### PR TITLE
chore(iq): freeze legacy SVG assets and verify provenance hashes

### DIFF
--- a/backend/scripts/iq/build_legacy_svg_provenance_manifest.php
+++ b/backend/scripts/iq/build_legacy_svg_provenance_manifest.php
@@ -1,0 +1,76 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_svg_provenance_lib.php';
+
+/**
+ * @return array<int, string>
+ */
+function iqBuildRequestedPackDirs(): array
+{
+    $options = getopt('', ['pack-dir::', 'check', 'stdout']);
+    $packDirs = $options['pack-dir'] ?? [];
+
+    if (is_string($packDirs) && $packDirs !== '') {
+        $packDirs = [$packDirs];
+    }
+
+    if (! is_array($packDirs) || $packDirs === []) {
+        $packDirs = iqSvgDefaultPackDirs();
+    }
+
+    return array_values(array_unique(array_map(
+        static fn (string $path): string => rtrim($path, '/'),
+        $packDirs
+    )));
+}
+
+function iqBuildFail(string $message, int $code = 1): never
+{
+    fwrite(STDERR, "[iq-svg-build] {$message}\n");
+    exit($code);
+}
+
+$options = getopt('', ['pack-dir::', 'check', 'stdout']);
+$packDirs = iqBuildRequestedPackDirs();
+$checkOnly = array_key_exists('check', $options);
+$stdout = array_key_exists('stdout', $options);
+
+if ($stdout && count($packDirs) !== 1) {
+    iqBuildFail('--stdout requires exactly one --pack-dir target.', 2);
+}
+
+try {
+    foreach ($packDirs as $packDir) {
+        $manifest = iqSvgBuildLegacyProvenanceManifest($packDir);
+        $encoded = iqSvgPrettyJson($manifest).PHP_EOL;
+        $targetPath = iqSvgDefaultManifestPath($packDir);
+
+        if ($stdout) {
+            fwrite(STDOUT, $encoded);
+
+            continue;
+        }
+
+        if ($checkOnly) {
+            $existing = is_file($targetPath) ? file_get_contents($targetPath) : false;
+            if (! is_string($existing) || $existing !== $encoded) {
+                iqBuildFail('manifest drift detected: '.iqSvgRelativePath($targetPath), 3);
+            }
+
+            fwrite(STDOUT, '[iq-svg-build] verified '.iqSvgRelativePath($targetPath).PHP_EOL);
+
+            continue;
+        }
+
+        if (file_put_contents($targetPath, $encoded) === false) {
+            iqBuildFail('failed to write manifest: '.iqSvgRelativePath($targetPath), 4);
+        }
+
+        fwrite(STDOUT, '[iq-svg-build] wrote '.iqSvgRelativePath($targetPath).PHP_EOL);
+    }
+} catch (Throwable $throwable) {
+    iqBuildFail($throwable->getMessage(), 10);
+}

--- a/backend/scripts/iq/iq_svg_provenance_lib.php
+++ b/backend/scripts/iq/iq_svg_provenance_lib.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+const IQ_SVG_PROVENANCE_SCHEMA_VERSION = 'fm.iq.svg_provenance_manifest.v1';
+const IQ_SVG_PROVENANCE_GENERATOR_VERSION = '2026.05.12';
+const IQ_LEGACY_PROTOTYPE_ZIP_PATH = '/Users/rainie/Desktop/iq_ui_prototype_30_svg_grid.zip';
+
+/**
+ * @return array<int, string>
+ */
+function iqSvgDefaultPackDirs(): array
+{
+    $repoRoot = iqSvgRepoRoot();
+
+    return [
+        $repoRoot.'/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO',
+        $repoRoot.'/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+    ];
+}
+
+function iqSvgRepoRoot(): string
+{
+    return dirname(__DIR__, 3);
+}
+
+function iqSvgRelativePath(string $path): string
+{
+    $repoRoot = iqSvgRepoRoot();
+    $normalizedPath = str_replace('\\', '/', $path);
+    $normalizedRoot = str_replace('\\', '/', $repoRoot);
+    $prefix = rtrim($normalizedRoot, '/').'/';
+
+    if (str_starts_with($normalizedPath, $prefix)) {
+        return substr($normalizedPath, strlen($prefix));
+    }
+
+    return $normalizedPath;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function iqSvgLoadJsonFile(string $path): array
+{
+    if (! is_file($path)) {
+        throw new RuntimeException('missing json file: '.$path);
+    }
+
+    $json = file_get_contents($path);
+    if (! is_string($json)) {
+        throw new RuntimeException('failed to read json file: '.$path);
+    }
+
+    $decoded = json_decode($json, true);
+    if (! is_array($decoded)) {
+        throw new RuntimeException('invalid json file: '.$path);
+    }
+
+    return $decoded;
+}
+
+function iqSvgSha256File(string $path): string
+{
+    if (! is_file($path)) {
+        throw new RuntimeException('missing file for sha256: '.$path);
+    }
+
+    $hash = hash_file('sha256', $path);
+    if (! is_string($hash) || $hash === '') {
+        throw new RuntimeException('failed to hash file: '.$path);
+    }
+
+    return 'sha256:'.$hash;
+}
+
+/**
+ * @param  mixed  $value
+ * @return mixed
+ */
+function iqSvgNormalizeValue($value)
+{
+    if (! is_array($value)) {
+        return $value;
+    }
+
+    if (iqSvgIsAssoc($value)) {
+        $normalized = [];
+        $keys = array_keys($value);
+        sort($keys, SORT_STRING);
+        foreach ($keys as $key) {
+            $normalized[$key] = iqSvgNormalizeValue($value[$key]);
+        }
+
+        return $normalized;
+    }
+
+    return array_map(
+        static fn ($item) => iqSvgNormalizeValue($item),
+        $value
+    );
+}
+
+function iqSvgStableJson(mixed $value): string
+{
+    $json = json_encode(
+        iqSvgNormalizeValue($value),
+        JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+    );
+
+    if (! is_string($json)) {
+        throw new RuntimeException('failed to encode stable json');
+    }
+
+    return $json;
+}
+
+function iqSvgPrettyJson(mixed $value): string
+{
+    $json = json_encode(
+        iqSvgNormalizeValue($value),
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+    );
+
+    if (! is_string($json)) {
+        throw new RuntimeException('failed to encode pretty json');
+    }
+
+    return $json;
+}
+
+function iqSvgSha256Json(mixed $value): string
+{
+    return 'sha256:'.hash('sha256', iqSvgStableJson($value));
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function iqSvgBuildLegacyProvenanceManifest(string $packDir): array
+{
+    if (! is_dir($packDir)) {
+        throw new RuntimeException('missing pack dir: '.$packDir);
+    }
+
+    $manifestPath = rtrim($packDir, '/').'/manifest.json';
+    $landingPath = rtrim($packDir, '/').'/meta/landing.json';
+    $questionsPath = rtrim($packDir, '/').'/questions.json';
+    $scoringPath = rtrim($packDir, '/').'/scoring_spec.json';
+    $versionPath = rtrim($packDir, '/').'/version.json';
+    $builderScriptPath = iqSvgRepoRoot().'/backend/scripts/iq/build_iq30_questions_from_prototype.php';
+
+    $manifest = iqSvgLoadJsonFile($manifestPath);
+    $landing = iqSvgLoadJsonFile($landingPath);
+    $questions = iqSvgLoadJsonFile($questionsPath);
+    $scoring = iqSvgLoadJsonFile($scoringPath);
+    $version = iqSvgLoadJsonFile($versionPath);
+
+    $questionItems = $questions['items'] ?? null;
+    if (! is_array($questionItems)) {
+        throw new RuntimeException('questions.items missing: '.$questionsPath);
+    }
+
+    $lifecycle = is_array($manifest['lifecycle'] ?? null) ? $manifest['lifecycle'] : [];
+    $landingLifecycle = is_array($landing['lifecycle'] ?? null) ? $landing['lifecycle'] : [];
+    $packDirRelative = iqSvgRelativePath($packDir);
+
+    $items = [];
+    foreach (array_values($questionItems) as $itemIndex => $question) {
+        if (! is_array($question)) {
+            throw new RuntimeException('question payload invalid at index '.$itemIndex);
+        }
+
+        $stemSvg = is_array($question['stem']['svg'] ?? null) ? $question['stem']['svg'] : [];
+        $options = is_array($question['options'] ?? null) ? $question['options'] : [];
+        $optionAssets = [];
+        foreach (array_values($options) as $optionIndex => $option) {
+            if (! is_array($option)) {
+                throw new RuntimeException('option payload invalid at index '.$itemIndex.':'.$optionIndex);
+            }
+
+            $optionSvg = is_array($option['svg'] ?? null) ? $option['svg'] : [];
+            $optionAssets[] = [
+                'code' => (string) ($option['code'] ?? ''),
+                'kind' => 'inline_svg',
+                'ref' => $packDirRelative.'/questions.json#items['.$itemIndex.'].options['.$optionIndex.'].svg',
+                'view_box' => (string) ($optionSvg['view_box'] ?? ''),
+                'path_count' => count(is_array($optionSvg['paths'] ?? null) ? $optionSvg['paths'] : []),
+                'sha256' => iqSvgSha256Json($optionSvg),
+            ];
+        }
+
+        $items[] = [
+            'question_id' => (string) ($question['question_id'] ?? ''),
+            'item_id' => null,
+            'status' => 'legacy_demo',
+            'order' => (int) ($question['order'] ?? ($itemIndex + 1)),
+            'section_code' => (string) ($question['section_code'] ?? ''),
+            'source_ref' => $packDirRelative.'/questions.json#items['.$itemIndex.']',
+            'source_question_slug' => (string) ($question['meta']['source_q'] ?? ''),
+            'source_html' => (string) ($question['meta']['source_html'] ?? ''),
+            'question_sha256' => iqSvgSha256Json($question),
+            'stem_asset' => [
+                'kind' => 'inline_svg',
+                'ref' => $packDirRelative.'/questions.json#items['.$itemIndex.'].stem.svg',
+                'view_box' => (string) ($stemSvg['view_box'] ?? ''),
+                'path_count' => count(is_array($stemSvg['paths'] ?? null) ? $stemSvg['paths'] : []),
+                'sha256' => iqSvgSha256Json($stemSvg),
+            ],
+            'option_assets' => $optionAssets,
+        ];
+    }
+
+    return [
+        'schema_version' => IQ_SVG_PROVENANCE_SCHEMA_VERSION,
+        'generator_version' => IQ_SVG_PROVENANCE_GENERATOR_VERSION,
+        'scale_code' => (string) ($manifest['scale_code'] ?? ''),
+        'pack_dir' => $packDirRelative,
+        'dir_version' => (string) ($version['dir_version'] ?? basename($packDir)),
+        'content_package_version' => (string) ($version['content_package_version'] ?? ($manifest['content_package_version'] ?? '')),
+        'lifecycle' => [
+            'status' => (string) ($lifecycle['status'] ?? ''),
+            'identity_role' => (string) ($lifecycle['identity_role'] ?? ''),
+            'legacy_scale_code' => $lifecycle['legacy_scale_code'] ?? null,
+            'canonical_scale_code' => $landingLifecycle['canonical_scale_code'] ?? null,
+            'legacy_demo_allowlisted' => ((string) ($lifecycle['status'] ?? '') === 'legacy_demo'),
+        ],
+        'runtime_policy' => [
+            'production_ready' => false,
+            'visual_output_changed' => false,
+            'asset_kind' => 'inline_svg_in_questions_json',
+            'legacy_identity_allowed' => ((string) ($lifecycle['status'] ?? '') === 'legacy_demo'),
+            'prototype_source_tracked_in_repo' => false,
+        ],
+        'source_files' => [
+            'questions_json' => iqSvgRelativePath($questionsPath),
+            'scoring_spec_json' => iqSvgRelativePath($scoringPath),
+            'manifest_json' => iqSvgRelativePath($manifestPath),
+            'landing_json' => iqSvgRelativePath($landingPath),
+            'version_json' => iqSvgRelativePath($versionPath),
+            'builder_script' => iqSvgRelativePath($builderScriptPath),
+        ],
+        'source_hashes' => [
+            'questions_json_sha256' => iqSvgSha256File($questionsPath),
+            'scoring_spec_json_sha256' => iqSvgSha256File($scoringPath),
+            'manifest_json_sha256' => iqSvgSha256File($manifestPath),
+            'landing_json_sha256' => iqSvgSha256File($landingPath),
+            'version_json_sha256' => iqSvgSha256File($versionPath),
+            'builder_script_sha256' => iqSvgSha256File($builderScriptPath),
+        ],
+        'recorded_generator_source' => [
+            'builder_script' => iqSvgRelativePath($builderScriptPath),
+            'prototype_zip_path' => IQ_LEGACY_PROTOTYPE_ZIP_PATH,
+            'prototype_zip_tracked_in_repo' => false,
+            'params_recorded' => false,
+            'seed_recorded' => false,
+            'version_recorded' => false,
+        ],
+        'scoring_contract_snapshot' => [
+            'scoring_mode' => (string) ($scoring['scoring_mode'] ?? ''),
+            'answer_key_version' => (string) ($scoring['answer_key_version'] ?? ''),
+            'item_bank_status' => (string) ($scoring['item_bank']['status'] ?? ''),
+            'item_count' => count($items),
+            'scored_items_declared' => count(is_array($scoring['items'] ?? null) ? $scoring['items'] : []),
+        ],
+        'item_count' => count($items),
+        'items' => $items,
+    ];
+}
+
+function iqSvgDefaultManifestPath(string $packDir): string
+{
+    return rtrim($packDir, '/').'/svg_provenance_manifest.json';
+}
+
+/**
+ * @param  array<int|string, mixed>  $value
+ */
+function iqSvgIsAssoc(array $value): bool
+{
+    if ($value === []) {
+        return false;
+    }
+
+    return array_keys($value) !== range(0, count($value) - 1);
+}

--- a/backend/scripts/iq/verify_legacy_svg_provenance.php
+++ b/backend/scripts/iq/verify_legacy_svg_provenance.php
@@ -1,0 +1,262 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_svg_provenance_lib.php';
+
+/**
+ * @return array<int, string>
+ */
+function iqVerifyRequestedPackDirs(): array
+{
+    $options = getopt('', ['pack-dir::', 'json']);
+    $packDirs = $options['pack-dir'] ?? [];
+
+    if (is_string($packDirs) && $packDirs !== '') {
+        $packDirs = [$packDirs];
+    }
+
+    if (! is_array($packDirs) || $packDirs === []) {
+        $packDirs = iqSvgDefaultPackDirs();
+    }
+
+    return array_values(array_unique(array_map(
+        static fn (string $path): string => rtrim($path, '/'),
+        $packDirs
+    )));
+}
+
+function iqVerifyFail(string $message, int $code = 1): never
+{
+    fwrite(STDERR, "[iq-svg-verify] {$message}\n");
+    exit($code);
+}
+
+/**
+ * @return array<string, array<string, mixed>>
+ */
+function iqManifestItemsByQuestionId(array $manifest): array
+{
+    $items = is_array($manifest['items'] ?? null) ? $manifest['items'] : [];
+    $indexed = [];
+
+    foreach ($items as $item) {
+        if (! is_array($item)) {
+            continue;
+        }
+
+        $questionId = (string) ($item['question_id'] ?? '');
+        if ($questionId === '') {
+            continue;
+        }
+
+        $indexed[$questionId] = $item;
+    }
+
+    return $indexed;
+}
+
+/**
+ * @return array<string, string>
+ */
+function iqOptionHashes(array $item): array
+{
+    $hashes = [];
+    $options = is_array($item['option_assets'] ?? null) ? $item['option_assets'] : [];
+
+    foreach ($options as $option) {
+        if (! is_array($option)) {
+            continue;
+        }
+
+        $code = (string) ($option['code'] ?? '');
+        $hash = (string) ($option['sha256'] ?? '');
+        if ($code === '') {
+            continue;
+        }
+
+        $hashes[$code] = $hash;
+    }
+
+    ksort($hashes, SORT_STRING);
+
+    return $hashes;
+}
+
+/**
+ * @return list<string>
+ */
+function iqCollectManifestViolations(array $recorded, array $expected): array
+{
+    $violations = [];
+
+    if (($recorded['item_count'] ?? null) !== ($expected['item_count'] ?? null)) {
+        $violations[] = 'item_count mismatch';
+    }
+
+    foreach ([
+        'questions_json_sha256',
+        'scoring_spec_json_sha256',
+        'manifest_json_sha256',
+        'landing_json_sha256',
+        'version_json_sha256',
+        'builder_script_sha256',
+    ] as $hashKey) {
+        $recordedHash = (string) ($recorded['source_hashes'][$hashKey] ?? '');
+        $expectedHash = (string) ($expected['source_hashes'][$hashKey] ?? '');
+        if ($recordedHash !== $expectedHash) {
+            $violations[] = 'source hash mismatch for '.$hashKey;
+        }
+    }
+
+    $recordedItems = iqManifestItemsByQuestionId($recorded);
+    $expectedItems = iqManifestItemsByQuestionId($expected);
+
+    foreach ($expectedItems as $questionId => $expectedItem) {
+        $recordedItem = $recordedItems[$questionId] ?? null;
+        if (! is_array($recordedItem)) {
+            $violations[] = 'missing question provenance entry for '.$questionId;
+
+            continue;
+        }
+
+        if ((string) ($recordedItem['question_sha256'] ?? '') !== (string) ($expectedItem['question_sha256'] ?? '')) {
+            $violations[] = 'question payload hash mismatch for '.$questionId;
+        }
+
+        if ((string) ($recordedItem['stem_asset']['sha256'] ?? '') !== (string) ($expectedItem['stem_asset']['sha256'] ?? '')) {
+            $violations[] = 'asset hash mismatch for '.$questionId.' stem';
+        }
+
+        $recordedOptionHashes = iqOptionHashes($recordedItem);
+        $expectedOptionHashes = iqOptionHashes($expectedItem);
+        foreach ($expectedOptionHashes as $code => $expectedHash) {
+            $recordedHash = $recordedOptionHashes[$code] ?? '';
+            if ($recordedHash !== $expectedHash) {
+                $violations[] = 'asset hash mismatch for '.$questionId.' option '.$code;
+            }
+        }
+    }
+
+    return $violations;
+}
+
+/**
+ * @return list<string>
+ */
+function iqCollectProductionContractViolations(string $packDir, array $manifest, array $scoring): array
+{
+    $violations = [];
+    $lifecycleStatus = strtolower(trim((string) ($manifest['lifecycle']['status'] ?? '')));
+    $scaleCode = strtoupper(trim((string) ($manifest['scale_code'] ?? '')));
+    $landingPath = rtrim($packDir, '/').'/meta/landing.json';
+    $landing = iqSvgLoadJsonFile($landingPath);
+    $canonicalPath = (string) ($landing['landing']['canonical_path'] ?? '');
+
+    if ($lifecycleStatus !== 'legacy_demo' && $scaleCode === 'IQ_RAVEN') {
+        $violations[] = 'production IQ metadata uses legacy scale_code IQ_RAVEN outside allowlist';
+    }
+
+    if ($lifecycleStatus !== 'legacy_demo' && str_contains($canonicalPath, '/test/iq-raven-demo')) {
+        $violations[] = 'production IQ metadata still exposes /test/iq-raven-demo as canonical path';
+    }
+
+    $bankStatus = strtolower(trim((string) ($scoring['item_bank']['status'] ?? '')));
+    $items = is_array($scoring['items'] ?? null) ? $scoring['items'] : [];
+    $productionItemsChecked = 0;
+
+    foreach ($items as $item) {
+        if (! is_array($item)) {
+            continue;
+        }
+
+        $itemStatus = strtolower(trim((string) ($item['status'] ?? '')));
+        $isLegacyDemo = $bankStatus === 'legacy_demo' || $itemStatus === 'legacy_demo';
+        if ($isLegacyDemo) {
+            continue;
+        }
+
+        $productionItemsChecked++;
+        $itemId = (string) ($item['item_id'] ?? 'missing_item_id');
+
+        foreach (['correct_answer', 'solution_rule', 'distractor_logic'] as $requiredField) {
+            $value = $item[$requiredField] ?? null;
+            if (! is_string($value) || trim($value) === '') {
+                $violations[] = 'production item missing '.$requiredField.': '.$itemId;
+            }
+        }
+
+        if (! is_array($item['asset_hashes'] ?? null) || ($item['asset_hashes'] ?? []) === []) {
+            $violations[] = 'production item missing asset_hashes: '.$itemId;
+        }
+
+        if (! is_array($item['generator_metadata'] ?? null) || ($item['generator_metadata'] ?? []) === []) {
+            $violations[] = 'production item missing generator_metadata: '.$itemId;
+        }
+    }
+
+    $manifest['production_items_checked'] = $productionItemsChecked;
+
+    return $violations;
+}
+
+$options = getopt('', ['pack-dir::', 'json']);
+$packDirs = iqVerifyRequestedPackDirs();
+$emitJson = array_key_exists('json', $options);
+
+$summary = [
+    'schema_version' => 'fm.iq.svg_provenance.verify.v1',
+    'ok' => true,
+    'packs' => [],
+];
+
+try {
+    foreach ($packDirs as $packDir) {
+        $manifestPath = iqSvgDefaultManifestPath($packDir);
+        $recorded = iqSvgLoadJsonFile($manifestPath);
+        $expected = iqSvgBuildLegacyProvenanceManifest($packDir);
+        $scoring = iqSvgLoadJsonFile(rtrim($packDir, '/').'/scoring_spec.json');
+        $violations = array_merge(
+            iqCollectManifestViolations($recorded, $expected),
+            iqCollectProductionContractViolations($packDir, $recorded, $scoring)
+        );
+
+        if ($violations !== []) {
+            iqVerifyFail(iqSvgRelativePath($packDir).' -> '.implode('; ', $violations), 20);
+        }
+
+        $summary['packs'][] = [
+            'pack_dir' => iqSvgRelativePath($packDir),
+            'scale_code' => (string) ($recorded['scale_code'] ?? ''),
+            'lifecycle_status' => (string) ($recorded['lifecycle']['status'] ?? ''),
+            'item_count' => (int) ($recorded['item_count'] ?? 0),
+            'legacy_demo_allowlisted' => (bool) ($recorded['lifecycle']['legacy_demo_allowlisted'] ?? false),
+            'scored_items_declared' => (int) ($recorded['scoring_contract_snapshot']['scored_items_declared'] ?? 0),
+        ];
+    }
+
+    if ($emitJson) {
+        fwrite(STDOUT, iqSvgPrettyJson($summary).PHP_EOL);
+    } else {
+        foreach ($summary['packs'] as $packSummary) {
+            if (! is_array($packSummary)) {
+                continue;
+            }
+
+            fwrite(
+                STDOUT,
+                sprintf(
+                    "[iq-svg-verify] ok pack=%s scale_code=%s lifecycle=%s items=%d scored_items=%d\n",
+                    $packSummary['pack_dir'],
+                    $packSummary['scale_code'],
+                    $packSummary['lifecycle_status'],
+                    $packSummary['item_count'],
+                    $packSummary['scored_items_declared']
+                )
+            );
+        }
+    }
+} catch (Throwable $throwable) {
+    iqVerifyFail($throwable->getMessage(), 10);
+}

--- a/backend/tests/Feature/Console/IqSvgProvenanceVerificationTest.php
+++ b/backend/tests/Feature/Console/IqSvgProvenanceVerificationTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+final class IqSvgProvenanceVerificationTest extends TestCase
+{
+    public function test_build_script_reproduces_committed_legacy_demo_manifests(): void
+    {
+        $process = new Process([
+            PHP_BINARY,
+            base_path('scripts/iq/build_legacy_svg_provenance_manifest.php'),
+            '--check',
+        ], base_path());
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            $process->getErrorOutput().$process->getOutput()
+        );
+    }
+
+    public function test_verify_script_accepts_committed_iq_legacy_demo_manifests(): void
+    {
+        $process = new Process([
+            PHP_BINARY,
+            base_path('scripts/iq/verify_legacy_svg_provenance.php'),
+            '--json',
+        ], base_path());
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            $process->getErrorOutput().$process->getOutput()
+        );
+
+        $payload = json_decode($process->getOutput(), true);
+        $this->assertIsArray($payload);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertCount(2, $payload['packs'] ?? []);
+        $this->assertSame(30, data_get($payload, 'packs.0.item_count'));
+        $this->assertSame(30, data_get($payload, 'packs.1.item_count'));
+    }
+
+    public function test_verify_script_detects_inline_svg_hash_mismatch_on_tampered_pack_copy(): void
+    {
+        $sourceDir = base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO');
+        $tempRoot = sys_get_temp_dir().'/iq_svg_provenance_'.bin2hex(random_bytes(4));
+        $tempPackDir = $tempRoot.'/IQ-RAVEN-CN-v0.3.0-DEMO';
+
+        $this->copyDirectory($sourceDir, $tempPackDir);
+
+        $questionsPath = $tempPackDir.'/questions.json';
+        $questions = json_decode((string) file_get_contents($questionsPath), true);
+        $this->assertIsArray($questions);
+        $questions['items'][0]['stem']['svg']['paths'][0]['d'] .= ' M0 0';
+        file_put_contents(
+            $questionsPath,
+            json_encode($questions, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
+        );
+
+        $process = new Process([
+            PHP_BINARY,
+            base_path('scripts/iq/verify_legacy_svg_provenance.php'),
+            '--pack-dir='.$tempPackDir,
+        ], base_path());
+        $process->run();
+
+        $this->assertFalse($process->isSuccessful());
+        $this->assertStringContainsString('asset hash mismatch', $process->getErrorOutput());
+
+        $this->removeDirectory($tempRoot);
+    }
+
+    private function copyDirectory(string $source, string $target): void
+    {
+        if (! is_dir($target) && ! mkdir($target, 0777, true) && ! is_dir($target)) {
+            $this->fail('failed to create temp directory: '.$target);
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            $destination = $target.DIRECTORY_SEPARATOR.$iterator->getSubPathName();
+            if ($item->isDir()) {
+                if (! is_dir($destination) && ! mkdir($destination, 0777, true) && ! is_dir($destination)) {
+                    $this->fail('failed to create copied directory: '.$destination);
+                }
+
+                continue;
+            }
+
+            if (! copy($item->getPathname(), $destination)) {
+                $this->fail('failed to copy file: '.$item->getPathname());
+            }
+        }
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            $target = $item->getPathname();
+            if ($item->isDir()) {
+                @rmdir($target);
+
+                continue;
+            }
+
+            @unlink($target);
+        }
+
+        @rmdir($path);
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/svg_provenance_manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/svg_provenance_manifest.json
@@ -1,0 +1,1944 @@
+{
+    "content_package_version": "v0.3.0-DEMO",
+    "dir_version": "IQ-RAVEN-CN-v0.3.0-DEMO",
+    "generator_version": "2026.05.12",
+    "item_count": 30,
+    "items": [
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[0].options[0].svg",
+                    "sha256": "sha256:30dadb4349313fddec5ac340c68f65d03cba70fb6a71cad408c6fa493a79beb6",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[0].options[1].svg",
+                    "sha256": "sha256:17923e0922a704f3b887e81a8e9f58a6ccb18f052a7f165973f70e6da0086138",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[0].options[2].svg",
+                    "sha256": "sha256:0544cee58ae668a3ab18c07fbf1cde20bcc461cb9a8b83d2a6e65ed21ca133e2",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[0].options[3].svg",
+                    "sha256": "sha256:ee26ddd60898f6307389aa8fef71c69635a3c7756febe6a2bc5afa07cae3a7ef",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[0].options[4].svg",
+                    "sha256": "sha256:229be094c30f046cf5e01b225fb47e62bbba0fa30f2f2fbc6b6e5851cf4d3f10",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 1,
+            "question_id": "MATRIX_Q01",
+            "question_sha256": "sha256:c60ba05d08ae14ff08a0bd754f3af66ab4fa211822bece75457c13e4b0492d82",
+            "section_code": "matrix",
+            "source_html": "matrix_q01.html",
+            "source_question_slug": "matrix_q01",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[0]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[0].stem.svg",
+                "sha256": "sha256:4c801e51d44fab632ebd64ed87b76418e022e8132c0f8017ef0f6d2d01f30f2f",
+                "view_box": "0 0 2200 2112"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[1].options[0].svg",
+                    "sha256": "sha256:61dae9713af71f2b9f9da720fdd1039025ea2af74994bc373f6bad0cdef5d894",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[1].options[1].svg",
+                    "sha256": "sha256:e76106fa1512bf2ff5d7906c947b7a6bff44b14ea02b7559a0f428ca01ddca7d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[1].options[2].svg",
+                    "sha256": "sha256:86b2c7200ee07defc48c87473199ac2d449da5d7e0565108ba369aa5513b222e",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[1].options[3].svg",
+                    "sha256": "sha256:ca8179f6621c2e2290afa0d663febcaa3b9cda4c5d7d8d8b5da91afc03499058",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[1].options[4].svg",
+                    "sha256": "sha256:5b0ea9dabe73a1ed90c0e846f7ffd6e7652a741e89b0d1c48bc0ef1cf2bd3c45",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 2,
+            "question_id": "MATRIX_Q02",
+            "question_sha256": "sha256:440ea11c282b495cdc961b65540ef8a597a64378862fc692846ef27545d09555",
+            "section_code": "matrix",
+            "source_html": "matrix_q02.html",
+            "source_question_slug": "matrix_q02",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[1]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[1].stem.svg",
+                "sha256": "sha256:c071492f5a3d21637936f18b979f538edf1cc166748de8151f9276ede5794eb8",
+                "view_box": "0 0 2200 2107"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[2].options[0].svg",
+                    "sha256": "sha256:e16c3592ec0ed159e0098b707b18bd501dc3f97eac1e2636719f4e23b662ca76",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[2].options[1].svg",
+                    "sha256": "sha256:7fdbd7f8f17e2522c48fd952f724095351dd13a859350ecfd8c6bbde8e9ddb05",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[2].options[2].svg",
+                    "sha256": "sha256:267bab8c68f92bce46a92133b2457762f6d109f194bc3937d6c6c01b3fa0181a",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[2].options[3].svg",
+                    "sha256": "sha256:6659e53a79dee92fb2997c1d3c4f5e7268c97031b5daec4baa6ef76675741e88",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[2].options[4].svg",
+                    "sha256": "sha256:762124df747234aadcb552a43ca2f36adb2c95365d477c93c76ea69d8c2a2dc0",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 3,
+            "question_id": "MATRIX_Q03",
+            "question_sha256": "sha256:a9b0aad3e20a6430c42bb8245a8e1c88ad3f33392cb430a9a6ed6f65ca438a2b",
+            "section_code": "matrix",
+            "source_html": "matrix_q03.html",
+            "source_question_slug": "matrix_q03",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[2]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[2].stem.svg",
+                "sha256": "sha256:580fe771dbc1d6b5a472c0603ddc2b357b4f8feaf3f80577be4e746b3352c9f0",
+                "view_box": "0 0 2200 2103"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[3].options[0].svg",
+                    "sha256": "sha256:40417c79d5bb0ca03f991a90dd2cc044fc5ec0f7f008709089f518c8816cc5c6",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[3].options[1].svg",
+                    "sha256": "sha256:f34ed792127ea9eb8f2bc80720d400148094725781a81855277e6bfc03e75bb5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[3].options[2].svg",
+                    "sha256": "sha256:bb39f46e1d62a0439e161463b2d6dcf57546fed0127dc03ca77d3c66e7add0cb",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[3].options[3].svg",
+                    "sha256": "sha256:3d3bc5838fec3bee375f345c0a8c8667180322c618e79e2ae5497bd0df24f524",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[3].options[4].svg",
+                    "sha256": "sha256:36458efa7dfe6ca98a07496637c649941a237f3c870e1e0424baef85c7449079",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 4,
+            "question_id": "MATRIX_Q04",
+            "question_sha256": "sha256:3317baa63981afd3a517232afacca4e4276c252389a5407f5d35ffb542e48726",
+            "section_code": "matrix",
+            "source_html": "matrix_q04.html",
+            "source_question_slug": "matrix_q04",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[3]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[3].stem.svg",
+                "sha256": "sha256:772090999d2b2e2acc01538824737716793078189d45e512b7abde814f78d696",
+                "view_box": "0 0 2200 2112"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[4].options[0].svg",
+                    "sha256": "sha256:bca52446e4ead0a59d47607b993d962460458f6c9142380ade9f5b4fda1212c4",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[4].options[1].svg",
+                    "sha256": "sha256:dfba3885e53f962eb86154abfd55ee3c38584772eac22579448500a0f30d69d5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[4].options[2].svg",
+                    "sha256": "sha256:e256c0ac76214911f9247d3736cf91afbca4764473fa68d67d080eb891ab86a3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[4].options[3].svg",
+                    "sha256": "sha256:57611bcd60e8428a4ea6730a5518c9e6f845376c81acde8c9a96446f9db185f2",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[4].options[4].svg",
+                    "sha256": "sha256:a178b3693ac077bbf4ae80effb7c5a5d4bc107042694553a9563eeb67d467933",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 5,
+            "question_id": "MATRIX_Q05",
+            "question_sha256": "sha256:68e0998fc3e91fd176ac25f78d8705e9a3491b6a7e4d390254d3b17c5322d790",
+            "section_code": "matrix",
+            "source_html": "matrix_q05.html",
+            "source_question_slug": "matrix_q05",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[4]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[4].stem.svg",
+                "sha256": "sha256:e49877a737b71474669eb676c1443e494ab92e9bd3566bce00e58ca720b82155",
+                "view_box": "0 0 2200 2103"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[5].options[0].svg",
+                    "sha256": "sha256:b6e45e2c34ae410f8fc4e363338becf9ad66d2aa5ccb71996f259f524469786a",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[5].options[1].svg",
+                    "sha256": "sha256:5d52c8952398fc394f572cedefc4235e7576b6e8e1d2988a70231d5b90123c9c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[5].options[2].svg",
+                    "sha256": "sha256:9fc296017a68bcf9da33c3aa975b2eefc6c0f1b930c62659036854dc81b05127",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[5].options[3].svg",
+                    "sha256": "sha256:827aad27fd877cd5a626bb1dab458919525f809276ee50b0def8e99871d47b11",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[5].options[4].svg",
+                    "sha256": "sha256:bc73e6a468bf6532501d3555fbcc5cd8a9432d9dbb4e22b3c6b9ec1d586f775a",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 6,
+            "question_id": "MATRIX_Q06",
+            "question_sha256": "sha256:98e776f9eb159c42894591272a609464b6342ed35cd1afb5a50ffe2b3c61b138",
+            "section_code": "matrix",
+            "source_html": "matrix_q06.html",
+            "source_question_slug": "matrix_q06",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[5]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[5].stem.svg",
+                "sha256": "sha256:c32ebfca2124e2cea19fafeecad44ca226bcf14d9f581fe84f1a07d851e6eecd",
+                "view_box": "0 0 2200 2107"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[6].options[0].svg",
+                    "sha256": "sha256:efc600d68d02b202ea0a35e960ff86b6e670b3b4d031575a3fa3c2070b3df02a",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[6].options[1].svg",
+                    "sha256": "sha256:a6bbae84a620c4f33a830a6ebfef9da7e2f03d90c955c6d6e14ecb52aac9ef0e",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[6].options[2].svg",
+                    "sha256": "sha256:55028c80b9cc797ddf53c2afd95cb413c3538009815732e507686979bd552223",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[6].options[3].svg",
+                    "sha256": "sha256:62bf8c019acd3dfea6770590192bccea08ac2fbcea41dd88626bbac9209eaacc",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[6].options[4].svg",
+                    "sha256": "sha256:3d895169d495fec00f8e5efe5913f5224aee6d830bd54d30ba2ba88ca5063f68",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 7,
+            "question_id": "MATRIX_Q07",
+            "question_sha256": "sha256:7578204f3da123e8df8737d4c3bc790c46f75ff4a723f9f1273cc2d478f1b08c",
+            "section_code": "matrix",
+            "source_html": "matrix_q07.html",
+            "source_question_slug": "matrix_q07",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[6]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[6].stem.svg",
+                "sha256": "sha256:506aa9a1f0cc5ef3ea7ce789d0bff846837a5e92f19ce2fc4cd6dba11c39db28",
+                "view_box": "0 0 2200 2103"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[7].options[0].svg",
+                    "sha256": "sha256:6936c693fc69ccc354d9b4a5446499382c910ac9b0b4ec875d12ce19d31c4e6c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[7].options[1].svg",
+                    "sha256": "sha256:54b5dec6b8d540c76c26539446ad94a5841e029cf4cde54eecd30ff5087d5c38",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[7].options[2].svg",
+                    "sha256": "sha256:cb7f692fb0d5c8245d5ab5742881dbc76212c47318d013d1b4e979ffa74e5f5f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[7].options[3].svg",
+                    "sha256": "sha256:733c96e1d8cb93dc0db88b1c0327e269e41a86f771683aa3d402922a1fdef400",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[7].options[4].svg",
+                    "sha256": "sha256:a91fce731ac9c5439e98a9ee036ea7341be18f57ee6f19d78f9eb3aa4fc9da5b",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 8,
+            "question_id": "MATRIX_Q08",
+            "question_sha256": "sha256:eaf5b5656c3f221878a6dd17591ee36cbffdbdd1a895b75e7f4552bc80d1ff01",
+            "section_code": "matrix",
+            "source_html": "matrix_q08.html",
+            "source_question_slug": "matrix_q08",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[7]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[7].stem.svg",
+                "sha256": "sha256:5b413c73bf3f8edfb7f33883decfa319b3a2ee03e9bb20a4415ce525cfc27b68",
+                "view_box": "0 0 2200 2112"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[8].options[0].svg",
+                    "sha256": "sha256:1ba927f66a8fd35782414ed6f0b36502bf2fefc1d2cc4d2ddc103dadf43ec67d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[8].options[1].svg",
+                    "sha256": "sha256:c95de2d55d1192f25310bbfe5d9ba409bc9b05c0dc7ef61f7db6c1c94979dd7e",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[8].options[2].svg",
+                    "sha256": "sha256:3329f8a7c4d665daa2999dc935de3d2cf8bedebab0247c24c765b57401cff748",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[8].options[3].svg",
+                    "sha256": "sha256:9158f0d40f571ab6cd8925dbd4199c6fa04addbfd76511378ec9416f9733efec",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[8].options[4].svg",
+                    "sha256": "sha256:31303dff29084ba371a8e63d3af4e96bf62b64112da2ff096eebc541d0d38b4b",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 9,
+            "question_id": "MATRIX_Q09",
+            "question_sha256": "sha256:d8855b05223d8b2670d167d655f87fe4a361a1b754dfc4f135872c18c1a8c15f",
+            "section_code": "matrix",
+            "source_html": "matrix_q09.html",
+            "source_question_slug": "matrix_q09",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[8]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[8].stem.svg",
+                "sha256": "sha256:bd6c0ab6e3f461bc9e12107aad2ea1a1109de051b2a5d8aab7efae6774a2421d",
+                "view_box": "0 0 2200 2112"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[9].options[0].svg",
+                    "sha256": "sha256:d031f1b25302092d3c3687ca193805110b25b1c61a9588a05f611f2343a84d77",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[9].options[1].svg",
+                    "sha256": "sha256:1fe3a8580ef219e850efbc94f04abf997457d0d6ac59e3bd45c511e6151c6110",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[9].options[2].svg",
+                    "sha256": "sha256:e28628faaa3e43f3ec996d616f23b0c1c73aa2733b3b41fa9c9709750e091349",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[9].options[3].svg",
+                    "sha256": "sha256:de803c1517d6848ad48b0ced15cc594d2945844fbf8e2fdd1464df4527d603e8",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[9].options[4].svg",
+                    "sha256": "sha256:58c92423c16a202dbcb9d65550974a985aaa7fc00bc23e6c6356d632cc030c2f",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 10,
+            "question_id": "ODD_Q01",
+            "question_sha256": "sha256:473cf360b632ea7ff8a4702352865cd0f41c43c92504fb759e5bf5914f6fc00b",
+            "section_code": "odd",
+            "source_html": "odd_q01.html",
+            "source_question_slug": "odd_q01",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[9]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[9].stem.svg",
+                "sha256": "sha256:e095fbc5675a1d51c9549ccd11dbb166ca34c273a6e565747e922b1ab16bd978",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[10].options[0].svg",
+                    "sha256": "sha256:363afa3807c6fa1b11f9b82f02569199eaca75b348e278dc7f78f4104e63c848",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[10].options[1].svg",
+                    "sha256": "sha256:94bf1bd9bbaab59855757f721203189fcedde36b6dbd5617b49850518705b6f9",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[10].options[2].svg",
+                    "sha256": "sha256:12949d0d4869c00791d39071a2c743b60ae434bbe250b8a39ac7fe75147c12ff",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[10].options[3].svg",
+                    "sha256": "sha256:17a5098c48c849e3838f572411052037389adcaece9a0fd59b1b94009c2fa8d6",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[10].options[4].svg",
+                    "sha256": "sha256:39f272d1a7a7f6cfba18b67fa967a359742e9f0fed810fda97917570fc637ff7",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 11,
+            "question_id": "ODD_Q02",
+            "question_sha256": "sha256:2b4bdae3ff18917a2d637bfcbea5494d04810848243bb3a39d2e1fc19c1d6b51",
+            "section_code": "odd",
+            "source_html": "odd_q02.html",
+            "source_question_slug": "odd_q02",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[10]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[10].stem.svg",
+                "sha256": "sha256:cce7337dd27b33c1eea2c130b5d486720613e39348d16f327b33b2f3477c644b",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[11].options[0].svg",
+                    "sha256": "sha256:30cf83ee9863f2f7f0c329abb041d17ffd1d8e23640ec3cc176c2d5f2b6aef1d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[11].options[1].svg",
+                    "sha256": "sha256:1d011271ce1ded14228bac2b020b9c860be8f4fe5616d654b8aad9a786f83504",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[11].options[2].svg",
+                    "sha256": "sha256:7163872615f99c72468b16255b2c819ebf839a14f1ab852ee08385279138ff4f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[11].options[3].svg",
+                    "sha256": "sha256:d8b537af06f82a92f3ac4cc70b9d05687df689b5c5fe328f795e95c5a4a02663",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[11].options[4].svg",
+                    "sha256": "sha256:bb156be0dc5f192208c16ff1e4a55a9d718d5506585a6d2be64a72063898fd43",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 12,
+            "question_id": "ODD_Q03",
+            "question_sha256": "sha256:c97bd4945b5840358eea78d4b67f23251f525de03a1dde5c1e064d25054b077d",
+            "section_code": "odd",
+            "source_html": "odd_q03.html",
+            "source_question_slug": "odd_q03",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[11]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[11].stem.svg",
+                "sha256": "sha256:0efee51e121ad989c96776a10de30d45868ae0e8b76b6dc1ce66013cc78b5c17",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[12].options[0].svg",
+                    "sha256": "sha256:061e1471d506575e7bbb886c370f645f908b5d0253be49fa37fa573191511b51",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[12].options[1].svg",
+                    "sha256": "sha256:3242ce19dda4ca1bf06e09471da3b3c33a317d0ae254866add3369e3bd2151ff",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[12].options[2].svg",
+                    "sha256": "sha256:d8c2080e5ef0c562a987a83a70d4c75e1a3062d05fbe2df3f1f69773d2b0a3fa",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[12].options[3].svg",
+                    "sha256": "sha256:f10473519f7a96be7f933448f781128e7e9c8df49195427cf3bb1de4e04c2e10",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[12].options[4].svg",
+                    "sha256": "sha256:228d265b81097d32426a68039c2fdbf9e7db5e12bc380eca969507520cf30f58",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 13,
+            "question_id": "ODD_Q04",
+            "question_sha256": "sha256:881794b97bc8630be3806653c10f3627c6e37dab3a5917412cb4149e87b50704",
+            "section_code": "odd",
+            "source_html": "odd_q04.html",
+            "source_question_slug": "odd_q04",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[12]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[12].stem.svg",
+                "sha256": "sha256:29be10b48eb41978b30e11cc1d4bc7b9b9724db82e14c720afcfa89c8e9e63ba",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[13].options[0].svg",
+                    "sha256": "sha256:f574d19f7e030dfadc79717e4f1702b6e5b5dde58e42ac7c88bf5b3e44b9174f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[13].options[1].svg",
+                    "sha256": "sha256:2e09fe0ba385ff6f69d47dd5c94783a4ebd40ce4f4b9ae5b1d6f36b94a2a5d16",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[13].options[2].svg",
+                    "sha256": "sha256:7d6b327d7b49863bb6f07d51a0d80f4080be2d21245e6cb555a49e958c6955ca",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[13].options[3].svg",
+                    "sha256": "sha256:bffcbb72fe37ce771e8da91c35a26214bb47d995209183109677c9f61ba30082",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[13].options[4].svg",
+                    "sha256": "sha256:56a1dc6bbfa5dc06000434a81a958fa22401bfff21ae49c3213bd36773f5dbea",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 14,
+            "question_id": "ODD_Q05",
+            "question_sha256": "sha256:ae12d4057e300bae19ff9bdc3475a4749b64e0258e3aa6d445786a2b7b3e3db1",
+            "section_code": "odd",
+            "source_html": "odd_q05.html",
+            "source_question_slug": "odd_q05",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[13]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[13].stem.svg",
+                "sha256": "sha256:c835e92d242ea676bf87429486cc899ad067a868707a74a990a03ddd624b039f",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[14].options[0].svg",
+                    "sha256": "sha256:16c03369020aac6bee2812a721c13deac41c54667d775c51825737f3c2b8f41b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[14].options[1].svg",
+                    "sha256": "sha256:98d9e3ccc226dd91323660e0ed03d68f86600f02689c5e287c1a58c91f4c10b0",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[14].options[2].svg",
+                    "sha256": "sha256:f9dc5d98b867fb1b763c856c715a37aab273ec216f91b8c6b4f4cedcaf8599aa",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[14].options[3].svg",
+                    "sha256": "sha256:fa6eac05e95be5da05117f4fc94528dcfd213dad4528274434e46675cbbbf4bf",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[14].options[4].svg",
+                    "sha256": "sha256:3757a4e7d7e57a37766cf309dcccdcb41974b07063042742f27d75ab906562cd",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 15,
+            "question_id": "ODD_Q06",
+            "question_sha256": "sha256:08b56c8b7d73100a8aeaee6f08cac3b1965330ae95cfd6025f12ef725a490ab2",
+            "section_code": "odd",
+            "source_html": "odd_q06.html",
+            "source_question_slug": "odd_q06",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[14]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[14].stem.svg",
+                "sha256": "sha256:4b0a5efabf72fe83179de7e6e3fdf948d64613879dbd89a289abe968869c56ab",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[15].options[0].svg",
+                    "sha256": "sha256:7aa4104ec8deeae80c03962665fd50279415a32bb7466a7cc2aff7788cefc594",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[15].options[1].svg",
+                    "sha256": "sha256:894645d6b48b4309961c1e1fea184f3d6954aa637ac327e3b5dbe8296ccdf68f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[15].options[2].svg",
+                    "sha256": "sha256:0414de1e9c9b535bfd84d1c0e85e6b8a4cbb3f1702256e99c11b353e13b48eaf",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[15].options[3].svg",
+                    "sha256": "sha256:0d0e863c68950d93e85a0b3f0547af17178e2480f8abc1eff09a8ce407383e0c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[15].options[4].svg",
+                    "sha256": "sha256:b70d390f08d738f60ac806c85728f79ecd9d392e4be273bf4e883c72b96e5bf3",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 16,
+            "question_id": "ODD_Q07",
+            "question_sha256": "sha256:49704f38f26f3af1b288ba2e6ce581115feb9d31dc2cd391e98483d053cf8a86",
+            "section_code": "odd",
+            "source_html": "odd_q07.html",
+            "source_question_slug": "odd_q07",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[15]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[15].stem.svg",
+                "sha256": "sha256:36da6f9b39fb6644c3e67dbcf2357ca551b44c9f510b6f4cd9df7ad75b0ecdee",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[16].options[0].svg",
+                    "sha256": "sha256:877a21e3de03ac94ba37fbda4b0df54875ea6e7c3a69c3720c2b9703617b9fa7",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[16].options[1].svg",
+                    "sha256": "sha256:9595945a5ebfef6660f7a2ac592d8b45fef62eeadd2632b87d895620b07d750c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[16].options[2].svg",
+                    "sha256": "sha256:af9703e4fa33fd3329f1623b19b46d9653ee75d9c877a73f679ef9e64dbe1738",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[16].options[3].svg",
+                    "sha256": "sha256:a8c100f0ced2806867d449040770e79a095a3a31b9b86781d9d5af4a6f4000cf",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[16].options[4].svg",
+                    "sha256": "sha256:4d3e89016cfb244a32d4a8806952aff86dd562713f448a9b3ab8b3a4ffa171e0",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 17,
+            "question_id": "ODD_Q08",
+            "question_sha256": "sha256:aea3821d7c5b79be65974060d3134135f4c468c21e54059da09ff520a718d48c",
+            "section_code": "odd",
+            "source_html": "odd_q08.html",
+            "source_question_slug": "odd_q08",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[16]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[16].stem.svg",
+                "sha256": "sha256:9a4eb4c83c63d2b6098e810d1c23ba6c138ca599001920307b9d97bb10da0c86",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[17].options[0].svg",
+                    "sha256": "sha256:3e114228d84b8e95450a4ab1e1df8334fb23a72dcee8631a9f7b29503a37b00b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[17].options[1].svg",
+                    "sha256": "sha256:17c5093223250c5ac8c0430401e47129586eb3496bc3ae27924ec9049d79b8ac",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[17].options[2].svg",
+                    "sha256": "sha256:f32fb146b2c4266665ab5c6337f4ab9d06a75d6991965073bec5f658c4f67dfb",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[17].options[3].svg",
+                    "sha256": "sha256:a96740c3d65b90f737817c41a572943be179b4fe68f9f1a5d84d08484c53b614",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[17].options[4].svg",
+                    "sha256": "sha256:c67d59f3da53a13914fdb1ae9fe08f71f1d0155d102f7de7e701d4625efa8bd1",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 18,
+            "question_id": "ODD_Q09",
+            "question_sha256": "sha256:7039bec613cd90f5d712fe59185e34726a613b47e0082e129094cbd73421681d",
+            "section_code": "odd",
+            "source_html": "odd_q09.html",
+            "source_question_slug": "odd_q09",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[17]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[17].stem.svg",
+                "sha256": "sha256:7ccc0beef5154f4ea7fd91f91eeca71351f16babe3df7424b939c1f60b06a056",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[18].options[0].svg",
+                    "sha256": "sha256:16e774f863e4faa43d693255ebd05f2d821c932fc79be41f3f3793cb1903abcb",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[18].options[1].svg",
+                    "sha256": "sha256:83ee45e21a1f15c878b4530ce55fbc1f3a49276a36823a7f632bd47b512cb17b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[18].options[2].svg",
+                    "sha256": "sha256:72bf71eacb96b52cba4d82cad1f0507b007627e69b8606bc4e60ab846b46b936",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[18].options[3].svg",
+                    "sha256": "sha256:1a76ab801fb34fc6463cef54d2b95e086b1b58c4de1870acf076e66f03870c6d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[18].options[4].svg",
+                    "sha256": "sha256:248ac9c1aff54b4c7bfa67e2d489d77e553d1ce9acf09a5ca8e5cb1551f47f51",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 19,
+            "question_id": "ODD_Q10",
+            "question_sha256": "sha256:cfd5afd3fd3a59e66f15ae421cef30864336e45f71563c42f3612b2d825f02cb",
+            "section_code": "odd",
+            "source_html": "odd_q10.html",
+            "source_question_slug": "odd_q10",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[18]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[18].stem.svg",
+                "sha256": "sha256:6f3a6703f8f981ee12a4484ceb6a7f7f9fea85d5d33d244a164670267e860af1",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[19].options[0].svg",
+                    "sha256": "sha256:aa25ea54f8c082f6d702260904e2d3f22450be4170a9f9b9382730591e796cd0",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[19].options[1].svg",
+                    "sha256": "sha256:575f06b635b2e1b36519d5ad29a0c844bb9866f61085262f58878dae7df0d8a3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[19].options[2].svg",
+                    "sha256": "sha256:285a781e85efccce7536206587e01ca3549c8842aa0e20c34515d8e956bed69c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[19].options[3].svg",
+                    "sha256": "sha256:bcc1f7f335723697256692819407fd4da6f9180a4c768012c25fc7fea29a2a19",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[19].options[4].svg",
+                    "sha256": "sha256:3e8ac596fe8da5eb17c95618f2828bf7460e20ebb3d14d84a07f0cc185401bb8",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[19].options[5].svg",
+                    "sha256": "sha256:455d8855d50fe10377df1ac4f7f1e6faa962282bfff07fc48fd797fefab461f7",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 20,
+            "question_id": "SERIES_Q01",
+            "question_sha256": "sha256:9dc362134b37e1342afed73549cdbfbf9a2098b308cd0e8f4fb4882f648e14a2",
+            "section_code": "series",
+            "source_html": "series_q01.html",
+            "source_question_slug": "series_q01",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[19]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[19].stem.svg",
+                "sha256": "sha256:a8aa6552133321f4435dcd5e1e8140f01f9676f5034d6fdcae2169d04776c010",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[20].options[0].svg",
+                    "sha256": "sha256:e52f939766c4085524f7bdfbe1a56d25cd929c1514be60785f357ee5066273ed",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[20].options[1].svg",
+                    "sha256": "sha256:48d88c84b0a997c7a7633d86f40822453a0cf978f9779fed0dee7dbe9265a8cc",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[20].options[2].svg",
+                    "sha256": "sha256:fc75679e20678ce2d42a3af6613aa2736aece2c6edffe69915213c01e4cebab3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[20].options[3].svg",
+                    "sha256": "sha256:df1047ec9b813d2c657c921196fe35119c5dba54253b696f2f3d7ddfbd30df55",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[20].options[4].svg",
+                    "sha256": "sha256:9009a67023d35745867088f2c6e489d9e83c0c4a7cf3042b4b4e6d265a7561de",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[20].options[5].svg",
+                    "sha256": "sha256:4f584332af50ed559b29a70b26ede3b2059874498a67957be91f16c502f299e1",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 21,
+            "question_id": "SERIES_Q02",
+            "question_sha256": "sha256:ca7e424f0fca31b5ce04aed8c5ba0170b0b9ef6323e7077aeb9d050b024a25e0",
+            "section_code": "series",
+            "source_html": "series_q02.html",
+            "source_question_slug": "series_q02",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[20]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[20].stem.svg",
+                "sha256": "sha256:10974428fc03e51808f3a77775c1c64c29521ade756a4e4261b51211319e3266",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[21].options[0].svg",
+                    "sha256": "sha256:4e9a05e36477894de0ffdbe15a3d1bf8c30242233db58fb473700e8db784f9dd",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[21].options[1].svg",
+                    "sha256": "sha256:2b90c925e57e5f1533f0f619e3290bce59bb6e7ba953dbb98f024ae646754413",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[21].options[2].svg",
+                    "sha256": "sha256:586536b82abb39bdbb66d87db954f846d750e83b49153d86c9237ac980757f31",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[21].options[3].svg",
+                    "sha256": "sha256:03c7aabdf7fb4685a4f751f457792bc8b9a3c11c6738c3aab3012d45e9804e81",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[21].options[4].svg",
+                    "sha256": "sha256:e454ddf94566f5198b05aa277bc09b26fe4f81094ffe168a4c4872daf53cb23c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[21].options[5].svg",
+                    "sha256": "sha256:4cd88e1366fe62c6948115c34b1b28f59153f40cba0923f6924d79edd4ee9e9e",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 22,
+            "question_id": "SERIES_Q03",
+            "question_sha256": "sha256:b597b1e78075208cf2171edd5be9f9d0c3f9ba26e38ff6ca4a010a6e760e05a5",
+            "section_code": "series",
+            "source_html": "series_q03.html",
+            "source_question_slug": "series_q03",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[21]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[21].stem.svg",
+                "sha256": "sha256:fce6c4a56400bd3ba6c2b4c3052ee59c3437eac4a45dd6f83452f79e4a4df15b",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[22].options[0].svg",
+                    "sha256": "sha256:5207f443488907d9372eeaf9cbf0073f7f754d98f792413d32e8d4bab7882d2b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[22].options[1].svg",
+                    "sha256": "sha256:f838bcbd60ce03e26951b41d9a12eb1c261c9c81143ec4dfd0ca88ae2d82a34b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[22].options[2].svg",
+                    "sha256": "sha256:33f7e2bcd00cb6760f772ee4574638f831bd1b9a86804c1e40386e5c1db98fc5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[22].options[3].svg",
+                    "sha256": "sha256:ac7361492b011e536eb13d88744ce38b0357b4cbc6afeb2f3ab182ba7d11f7d9",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[22].options[4].svg",
+                    "sha256": "sha256:4ae238291241643918597026bbe0432a299e048edc9f34a97097a70b54bce6ef",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[22].options[5].svg",
+                    "sha256": "sha256:a3839035887c24b92b5af98edfa5263e341d213000f563fcaad3e1285ea3ae58",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 23,
+            "question_id": "SERIES_Q04",
+            "question_sha256": "sha256:948016e3326e1b02bcd9f978d7a45d7788aab5b7e8f7214b1e85a10a685310ab",
+            "section_code": "series",
+            "source_html": "series_q04.html",
+            "source_question_slug": "series_q04",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[22]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[22].stem.svg",
+                "sha256": "sha256:7990540db01d7f610854b9fc9de8efc3fe6eb050ae758bff412f6e1791d51f84",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[23].options[0].svg",
+                    "sha256": "sha256:46477ddf8e76bd9a6e04d47fdeb32e5db264411643f2b9d1678dd107be94bdae",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[23].options[1].svg",
+                    "sha256": "sha256:f5e8eddf84605ca13f598dc980701009c18baa0ebf0d8ec05d3d237d20342796",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[23].options[2].svg",
+                    "sha256": "sha256:429f0e4b75bdb89e07e79928d102759acf24db9a2f2900bbaf62f93c540374db",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[23].options[3].svg",
+                    "sha256": "sha256:534713686e839b774543436a63dfa974357ef8d7d076e20fb5ffd194d03f0b77",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[23].options[4].svg",
+                    "sha256": "sha256:5840a461b6e9f46b69bc031a3febc687ec3af6cf92a997682534920dacc73c5f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[23].options[5].svg",
+                    "sha256": "sha256:93090f022ec2146bff95522dee2d28e812c941996532a368f2815f1304cf4912",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 24,
+            "question_id": "SERIES_Q05",
+            "question_sha256": "sha256:62e2844d6961cd81be327fa6b92c0ab320fa1a1256a0ce4bde453997966b7ff2",
+            "section_code": "series",
+            "source_html": "series_q05.html",
+            "source_question_slug": "series_q05",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[23]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[23].stem.svg",
+                "sha256": "sha256:1c0dea3a7488ee9586a6ced17533a12a36c34074d34a27690242c9ca9d1c457a",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[24].options[0].svg",
+                    "sha256": "sha256:2d4682e1a25256d5d26231923e11b9b14c4ec09278911cdb1b1d337386433fdc",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[24].options[1].svg",
+                    "sha256": "sha256:767c7bcf43a42352e8e385f49c19ed5d761269144c3a8cfa2765270d99ec13b5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[24].options[2].svg",
+                    "sha256": "sha256:90f72931b7e50061b204bdecbd0dd42158f63ad53934ad11b345a6bd5cef42c8",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[24].options[3].svg",
+                    "sha256": "sha256:6f6ad0ae446ae45ffff1f8d3af46aec8048fd1df9f900127bd68ba86017ca270",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[24].options[4].svg",
+                    "sha256": "sha256:a9d8021f58ba6c2ab693e856dfa5aa2214e898cd6655a0a041d475381fdd0f8c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[24].options[5].svg",
+                    "sha256": "sha256:55955c436319588e6558833133d1e9fbc8d7cd9b2ce083a67819b152793f02f3",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 25,
+            "question_id": "SERIES_Q06",
+            "question_sha256": "sha256:0b31114f29b9c084cc6c068223eaed7613ef2211a66be08754d8b30302ce4c6b",
+            "section_code": "series",
+            "source_html": "series_q06.html",
+            "source_question_slug": "series_q06",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[24]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[24].stem.svg",
+                "sha256": "sha256:604dc9fe7052c5852c1896c7debe74922d3e19095f0b99a00a09a9617ddaa75f",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[25].options[0].svg",
+                    "sha256": "sha256:9de08b6ee92b5fd030f8c487d27ad668f384d4ca34f0a5795afd65f5bb8394ce",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[25].options[1].svg",
+                    "sha256": "sha256:b6b65b6257379c576aa5190ee2d0f5681be0c7d84d217e55d1dc62fc64e89ec3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[25].options[2].svg",
+                    "sha256": "sha256:6768e9367226ddb3e7f4a8532810489390fc6773ecfc51648c8967dc1a303bfc",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[25].options[3].svg",
+                    "sha256": "sha256:425e05d1897e4d0b6a8fcaefccb5fad54187a26a108cfdb629f0737331adf578",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[25].options[4].svg",
+                    "sha256": "sha256:75a5992d973251c51f875cfa0fdbcac516736e5e33aa24e00b2a8662cc509aa0",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[25].options[5].svg",
+                    "sha256": "sha256:6bf6a06257cf6203e46617fba0fce2a02addc6f80c3c395aff607aca96437502",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 26,
+            "question_id": "SERIES_Q07",
+            "question_sha256": "sha256:57f83d173443f9540cba11805a6513abfa9eb5caff0f8ef71427d6d35997fb15",
+            "section_code": "series",
+            "source_html": "series_q07.html",
+            "source_question_slug": "series_q07",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[25]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[25].stem.svg",
+                "sha256": "sha256:26217eda8e63a8b3ed5e0be8c1a2795522f1e759f46e1ae96bc2457711518e68",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[26].options[0].svg",
+                    "sha256": "sha256:2fe7b514911c7e94fbc418d9b3f5bc937765a79dae6d763683060689bd3bd21f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[26].options[1].svg",
+                    "sha256": "sha256:dded6bf764b5835ca94a4cc1b26b570e535d4ebf4a1593afcc04c853d6862b11",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[26].options[2].svg",
+                    "sha256": "sha256:f20aaababbe41eb2ff7ee4f9c925b586d53be9938a28908d374547e3baec8c6c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[26].options[3].svg",
+                    "sha256": "sha256:322b18793140d5fb8dcded5838694968c03117e869bf0b0ff7ad1f7496c2c68f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[26].options[4].svg",
+                    "sha256": "sha256:a254996e376d667e77ccd5a8a053f6bff93072e2972a81683755b14862ffa5fd",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[26].options[5].svg",
+                    "sha256": "sha256:a7cd0595243bd9f8ddcae1f0eef3bba1777836b9be997fce2e121e79844d03f0",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 27,
+            "question_id": "SERIES_Q08",
+            "question_sha256": "sha256:75043befdaae4213262b239b24a304990d5ba36b27481e51265d65994e9c2935",
+            "section_code": "series",
+            "source_html": "series_q08.html",
+            "source_question_slug": "series_q08",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[26]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[26].stem.svg",
+                "sha256": "sha256:c214eb38bec2461a4f038044579aa8ae11b8c5bc5a2d9d650c01ea6223c24eea",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[27].options[0].svg",
+                    "sha256": "sha256:eab1abdc92e68646d8f2de3f7caab6abcda2d7f27e41244d4bb2a22d4c29ca28",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[27].options[1].svg",
+                    "sha256": "sha256:cb6f043b6262573694046278f1378d268de79cae68db279d591608f2f27ce350",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[27].options[2].svg",
+                    "sha256": "sha256:4254c93240b70207c104e90ac0b4289fe7d894776ef08ffe7e405f5e579e70fe",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[27].options[3].svg",
+                    "sha256": "sha256:cd74ffe0cf5204b6021a757949ee4679c92cdaf014a981f9bd04774277f36bb5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[27].options[4].svg",
+                    "sha256": "sha256:6e7a6c31234819a10a4bb60e1d9e493f1d5bad960c8ad9a86bef5df1700a550c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[27].options[5].svg",
+                    "sha256": "sha256:4f003792f8ea68b2fea61c9996e061e1a0a1abf25c750e4169e91d375f6fa75e",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 28,
+            "question_id": "SERIES_Q09",
+            "question_sha256": "sha256:783cc418734b2060bb87da89f583433ae0f2a1ffa7147ecc587a26d353973f0d",
+            "section_code": "series",
+            "source_html": "series_q09.html",
+            "source_question_slug": "series_q09",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[27]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[27].stem.svg",
+                "sha256": "sha256:23cccef8e6dd18f07e692dc4ee8847b3735945cc03f75f59e7bf60bedf45bc22",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[28].options[0].svg",
+                    "sha256": "sha256:a394e5b964084addc99470349d68de6e43a480f1da8a55414e2b108ae6b0c0f3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[28].options[1].svg",
+                    "sha256": "sha256:d398fd7ffbb3d61f719500d1a7fb852394cf673de3791fd9139bac11bc3f6264",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[28].options[2].svg",
+                    "sha256": "sha256:46ba630168ef34e7d291d76359fc42a4e12ba6f6a981930022697d2f27beb8a5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[28].options[3].svg",
+                    "sha256": "sha256:43c97d7d5dc5512b78604c3ae7b9f0d8145c5eb860edb87590cb78a6c4f508f1",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[28].options[4].svg",
+                    "sha256": "sha256:4a8b154ed88edac98b0d6e79753c3fae1309429aeb430b36118eb62cb1688175",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[28].options[5].svg",
+                    "sha256": "sha256:4fef00b166154ea1f8efe620969baa583d80308b23b09705d14a8bbf8860883e",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 29,
+            "question_id": "SERIES_Q10",
+            "question_sha256": "sha256:c6ce4093dffa87e4f1a987447dd3d8201e135b8be2c18c2f087c9c81c49aeff6",
+            "section_code": "series",
+            "source_html": "series_q10.html",
+            "source_question_slug": "series_q10",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[28]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[28].stem.svg",
+                "sha256": "sha256:9fdd62e70f2f2f6f06628a098a2f83efce4013d81f78fc25e7a92c2f58e03bf3",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[29].options[0].svg",
+                    "sha256": "sha256:35a696574824d4509ab1bc846da1113fe958e623ba18da0859253c00f0f70d3c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[29].options[1].svg",
+                    "sha256": "sha256:f5ef63ef3f528b3e879914ce3c3d53bb1cb77857980c04235cb7ee51636d742d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[29].options[2].svg",
+                    "sha256": "sha256:6aa44172f23ce06e577165141b8a5b2da5f3ff71c046aca502f11ff6cf0ed620",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[29].options[3].svg",
+                    "sha256": "sha256:173220ad10ecd2eb3a092ab6f6f74d895b48ce03ae494a4bdb0fc935cc705a0e",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[29].options[4].svg",
+                    "sha256": "sha256:638fe86c963b43f4840b6dc92222c23499a471c8dde279c0baa309127415da3f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[29].options[5].svg",
+                    "sha256": "sha256:ee2977c5c49a78b3a84fba9fd85ddcc94730806daa58ab04b880626d2966d1af",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 30,
+            "question_id": "SERIES_Q11",
+            "question_sha256": "sha256:552fbc777ca18b2bfdd896ad86e4b062cf069f6910601de989b9dd6934939b97",
+            "section_code": "series",
+            "source_html": "series_q11.html",
+            "source_question_slug": "series_q11",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[29]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json#items[29].stem.svg",
+                "sha256": "sha256:bb605dfde69cbad7cedce12d8024fc2b9426010dd2ad7ebf3af9654096e5f6dd",
+                "view_box": "0 0 2400 523"
+            }
+        }
+    ],
+    "lifecycle": {
+        "canonical_scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+        "identity_role": "",
+        "legacy_demo_allowlisted": true,
+        "legacy_scale_code": null,
+        "status": "legacy_demo"
+    },
+    "pack_dir": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO",
+    "recorded_generator_source": {
+        "builder_script": "backend/scripts/iq/build_iq30_questions_from_prototype.php",
+        "params_recorded": false,
+        "prototype_zip_path": "/Users/rainie/Desktop/iq_ui_prototype_30_svg_grid.zip",
+        "prototype_zip_tracked_in_repo": false,
+        "seed_recorded": false,
+        "version_recorded": false
+    },
+    "runtime_policy": {
+        "asset_kind": "inline_svg_in_questions_json",
+        "legacy_identity_allowed": true,
+        "production_ready": false,
+        "prototype_source_tracked_in_repo": false,
+        "visual_output_changed": false
+    },
+    "scale_code": "IQ_RAVEN",
+    "schema_version": "fm.iq.svg_provenance_manifest.v1",
+    "scoring_contract_snapshot": {
+        "answer_key_version": "legacy_demo_answer_key_not_available",
+        "item_bank_status": "legacy_demo",
+        "item_count": 30,
+        "scored_items_declared": 0,
+        "scoring_mode": "scored"
+    },
+    "source_files": {
+        "builder_script": "backend/scripts/iq/build_iq30_questions_from_prototype.php",
+        "landing_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/meta/landing.json",
+        "manifest_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/manifest.json",
+        "questions_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/questions.json",
+        "scoring_spec_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/scoring_spec.json",
+        "version_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/version.json"
+    },
+    "source_hashes": {
+        "builder_script_sha256": "sha256:3a71dd29744804ee105d8c4929c02953ad857381b47fa8aa29de574c5ba441e8",
+        "landing_json_sha256": "sha256:9259a7ca25f5f4b7e3d0e6c893ffff476321f2bb68f71ee833d1972c21d49ab7",
+        "manifest_json_sha256": "sha256:f58e707fbcbae7398a190466f7eeb9dae72bfe7b14123999cc95c77bf9211055",
+        "questions_json_sha256": "sha256:3da004dddfa7df46673efb9e1496cf142f32fcf15b55b0b978dded02fbcef51c",
+        "scoring_spec_json_sha256": "sha256:e5d8bfd3566bc71f60eda571bbc189e80fd46e6811d85ec461de22d2f90bc505",
+        "version_json_sha256": "sha256:e70d39ce306a2234b166cf5ce7d03ac972d04e796ea9c67c6914354241819cfa"
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/svg_provenance_manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/svg_provenance_manifest.json
@@ -1,0 +1,1944 @@
+{
+    "content_package_version": "v0.3.0-DEMO",
+    "dir_version": "IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO",
+    "generator_version": "2026.05.12",
+    "item_count": 30,
+    "items": [
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[0].options[0].svg",
+                    "sha256": "sha256:30dadb4349313fddec5ac340c68f65d03cba70fb6a71cad408c6fa493a79beb6",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[0].options[1].svg",
+                    "sha256": "sha256:17923e0922a704f3b887e81a8e9f58a6ccb18f052a7f165973f70e6da0086138",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[0].options[2].svg",
+                    "sha256": "sha256:0544cee58ae668a3ab18c07fbf1cde20bcc461cb9a8b83d2a6e65ed21ca133e2",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[0].options[3].svg",
+                    "sha256": "sha256:ee26ddd60898f6307389aa8fef71c69635a3c7756febe6a2bc5afa07cae3a7ef",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[0].options[4].svg",
+                    "sha256": "sha256:229be094c30f046cf5e01b225fb47e62bbba0fa30f2f2fbc6b6e5851cf4d3f10",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 1,
+            "question_id": "MATRIX_Q01",
+            "question_sha256": "sha256:c60ba05d08ae14ff08a0bd754f3af66ab4fa211822bece75457c13e4b0492d82",
+            "section_code": "matrix",
+            "source_html": "matrix_q01.html",
+            "source_question_slug": "matrix_q01",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[0]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[0].stem.svg",
+                "sha256": "sha256:4c801e51d44fab632ebd64ed87b76418e022e8132c0f8017ef0f6d2d01f30f2f",
+                "view_box": "0 0 2200 2112"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[1].options[0].svg",
+                    "sha256": "sha256:61dae9713af71f2b9f9da720fdd1039025ea2af74994bc373f6bad0cdef5d894",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[1].options[1].svg",
+                    "sha256": "sha256:e76106fa1512bf2ff5d7906c947b7a6bff44b14ea02b7559a0f428ca01ddca7d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[1].options[2].svg",
+                    "sha256": "sha256:86b2c7200ee07defc48c87473199ac2d449da5d7e0565108ba369aa5513b222e",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[1].options[3].svg",
+                    "sha256": "sha256:ca8179f6621c2e2290afa0d663febcaa3b9cda4c5d7d8d8b5da91afc03499058",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[1].options[4].svg",
+                    "sha256": "sha256:5b0ea9dabe73a1ed90c0e846f7ffd6e7652a741e89b0d1c48bc0ef1cf2bd3c45",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 2,
+            "question_id": "MATRIX_Q02",
+            "question_sha256": "sha256:440ea11c282b495cdc961b65540ef8a597a64378862fc692846ef27545d09555",
+            "section_code": "matrix",
+            "source_html": "matrix_q02.html",
+            "source_question_slug": "matrix_q02",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[1]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[1].stem.svg",
+                "sha256": "sha256:c071492f5a3d21637936f18b979f538edf1cc166748de8151f9276ede5794eb8",
+                "view_box": "0 0 2200 2107"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[2].options[0].svg",
+                    "sha256": "sha256:e16c3592ec0ed159e0098b707b18bd501dc3f97eac1e2636719f4e23b662ca76",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[2].options[1].svg",
+                    "sha256": "sha256:7fdbd7f8f17e2522c48fd952f724095351dd13a859350ecfd8c6bbde8e9ddb05",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[2].options[2].svg",
+                    "sha256": "sha256:267bab8c68f92bce46a92133b2457762f6d109f194bc3937d6c6c01b3fa0181a",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[2].options[3].svg",
+                    "sha256": "sha256:6659e53a79dee92fb2997c1d3c4f5e7268c97031b5daec4baa6ef76675741e88",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[2].options[4].svg",
+                    "sha256": "sha256:762124df747234aadcb552a43ca2f36adb2c95365d477c93c76ea69d8c2a2dc0",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 3,
+            "question_id": "MATRIX_Q03",
+            "question_sha256": "sha256:a9b0aad3e20a6430c42bb8245a8e1c88ad3f33392cb430a9a6ed6f65ca438a2b",
+            "section_code": "matrix",
+            "source_html": "matrix_q03.html",
+            "source_question_slug": "matrix_q03",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[2]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[2].stem.svg",
+                "sha256": "sha256:580fe771dbc1d6b5a472c0603ddc2b357b4f8feaf3f80577be4e746b3352c9f0",
+                "view_box": "0 0 2200 2103"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[3].options[0].svg",
+                    "sha256": "sha256:40417c79d5bb0ca03f991a90dd2cc044fc5ec0f7f008709089f518c8816cc5c6",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[3].options[1].svg",
+                    "sha256": "sha256:f34ed792127ea9eb8f2bc80720d400148094725781a81855277e6bfc03e75bb5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[3].options[2].svg",
+                    "sha256": "sha256:bb39f46e1d62a0439e161463b2d6dcf57546fed0127dc03ca77d3c66e7add0cb",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[3].options[3].svg",
+                    "sha256": "sha256:3d3bc5838fec3bee375f345c0a8c8667180322c618e79e2ae5497bd0df24f524",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[3].options[4].svg",
+                    "sha256": "sha256:36458efa7dfe6ca98a07496637c649941a237f3c870e1e0424baef85c7449079",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 4,
+            "question_id": "MATRIX_Q04",
+            "question_sha256": "sha256:3317baa63981afd3a517232afacca4e4276c252389a5407f5d35ffb542e48726",
+            "section_code": "matrix",
+            "source_html": "matrix_q04.html",
+            "source_question_slug": "matrix_q04",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[3]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[3].stem.svg",
+                "sha256": "sha256:772090999d2b2e2acc01538824737716793078189d45e512b7abde814f78d696",
+                "view_box": "0 0 2200 2112"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[4].options[0].svg",
+                    "sha256": "sha256:bca52446e4ead0a59d47607b993d962460458f6c9142380ade9f5b4fda1212c4",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[4].options[1].svg",
+                    "sha256": "sha256:dfba3885e53f962eb86154abfd55ee3c38584772eac22579448500a0f30d69d5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[4].options[2].svg",
+                    "sha256": "sha256:e256c0ac76214911f9247d3736cf91afbca4764473fa68d67d080eb891ab86a3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[4].options[3].svg",
+                    "sha256": "sha256:57611bcd60e8428a4ea6730a5518c9e6f845376c81acde8c9a96446f9db185f2",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[4].options[4].svg",
+                    "sha256": "sha256:a178b3693ac077bbf4ae80effb7c5a5d4bc107042694553a9563eeb67d467933",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 5,
+            "question_id": "MATRIX_Q05",
+            "question_sha256": "sha256:68e0998fc3e91fd176ac25f78d8705e9a3491b6a7e4d390254d3b17c5322d790",
+            "section_code": "matrix",
+            "source_html": "matrix_q05.html",
+            "source_question_slug": "matrix_q05",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[4]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[4].stem.svg",
+                "sha256": "sha256:e49877a737b71474669eb676c1443e494ab92e9bd3566bce00e58ca720b82155",
+                "view_box": "0 0 2200 2103"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[5].options[0].svg",
+                    "sha256": "sha256:b6e45e2c34ae410f8fc4e363338becf9ad66d2aa5ccb71996f259f524469786a",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[5].options[1].svg",
+                    "sha256": "sha256:5d52c8952398fc394f572cedefc4235e7576b6e8e1d2988a70231d5b90123c9c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[5].options[2].svg",
+                    "sha256": "sha256:9fc296017a68bcf9da33c3aa975b2eefc6c0f1b930c62659036854dc81b05127",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[5].options[3].svg",
+                    "sha256": "sha256:827aad27fd877cd5a626bb1dab458919525f809276ee50b0def8e99871d47b11",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[5].options[4].svg",
+                    "sha256": "sha256:bc73e6a468bf6532501d3555fbcc5cd8a9432d9dbb4e22b3c6b9ec1d586f775a",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 6,
+            "question_id": "MATRIX_Q06",
+            "question_sha256": "sha256:98e776f9eb159c42894591272a609464b6342ed35cd1afb5a50ffe2b3c61b138",
+            "section_code": "matrix",
+            "source_html": "matrix_q06.html",
+            "source_question_slug": "matrix_q06",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[5]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[5].stem.svg",
+                "sha256": "sha256:c32ebfca2124e2cea19fafeecad44ca226bcf14d9f581fe84f1a07d851e6eecd",
+                "view_box": "0 0 2200 2107"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[6].options[0].svg",
+                    "sha256": "sha256:efc600d68d02b202ea0a35e960ff86b6e670b3b4d031575a3fa3c2070b3df02a",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[6].options[1].svg",
+                    "sha256": "sha256:a6bbae84a620c4f33a830a6ebfef9da7e2f03d90c955c6d6e14ecb52aac9ef0e",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[6].options[2].svg",
+                    "sha256": "sha256:55028c80b9cc797ddf53c2afd95cb413c3538009815732e507686979bd552223",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[6].options[3].svg",
+                    "sha256": "sha256:62bf8c019acd3dfea6770590192bccea08ac2fbcea41dd88626bbac9209eaacc",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[6].options[4].svg",
+                    "sha256": "sha256:3d895169d495fec00f8e5efe5913f5224aee6d830bd54d30ba2ba88ca5063f68",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 7,
+            "question_id": "MATRIX_Q07",
+            "question_sha256": "sha256:7578204f3da123e8df8737d4c3bc790c46f75ff4a723f9f1273cc2d478f1b08c",
+            "section_code": "matrix",
+            "source_html": "matrix_q07.html",
+            "source_question_slug": "matrix_q07",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[6]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[6].stem.svg",
+                "sha256": "sha256:506aa9a1f0cc5ef3ea7ce789d0bff846837a5e92f19ce2fc4cd6dba11c39db28",
+                "view_box": "0 0 2200 2103"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[7].options[0].svg",
+                    "sha256": "sha256:6936c693fc69ccc354d9b4a5446499382c910ac9b0b4ec875d12ce19d31c4e6c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[7].options[1].svg",
+                    "sha256": "sha256:54b5dec6b8d540c76c26539446ad94a5841e029cf4cde54eecd30ff5087d5c38",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[7].options[2].svg",
+                    "sha256": "sha256:cb7f692fb0d5c8245d5ab5742881dbc76212c47318d013d1b4e979ffa74e5f5f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[7].options[3].svg",
+                    "sha256": "sha256:733c96e1d8cb93dc0db88b1c0327e269e41a86f771683aa3d402922a1fdef400",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[7].options[4].svg",
+                    "sha256": "sha256:a91fce731ac9c5439e98a9ee036ea7341be18f57ee6f19d78f9eb3aa4fc9da5b",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 8,
+            "question_id": "MATRIX_Q08",
+            "question_sha256": "sha256:eaf5b5656c3f221878a6dd17591ee36cbffdbdd1a895b75e7f4552bc80d1ff01",
+            "section_code": "matrix",
+            "source_html": "matrix_q08.html",
+            "source_question_slug": "matrix_q08",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[7]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[7].stem.svg",
+                "sha256": "sha256:5b413c73bf3f8edfb7f33883decfa319b3a2ee03e9bb20a4415ce525cfc27b68",
+                "view_box": "0 0 2200 2112"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[8].options[0].svg",
+                    "sha256": "sha256:1ba927f66a8fd35782414ed6f0b36502bf2fefc1d2cc4d2ddc103dadf43ec67d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[8].options[1].svg",
+                    "sha256": "sha256:c95de2d55d1192f25310bbfe5d9ba409bc9b05c0dc7ef61f7db6c1c94979dd7e",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[8].options[2].svg",
+                    "sha256": "sha256:3329f8a7c4d665daa2999dc935de3d2cf8bedebab0247c24c765b57401cff748",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[8].options[3].svg",
+                    "sha256": "sha256:9158f0d40f571ab6cd8925dbd4199c6fa04addbfd76511378ec9416f9733efec",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[8].options[4].svg",
+                    "sha256": "sha256:31303dff29084ba371a8e63d3af4e96bf62b64112da2ff096eebc541d0d38b4b",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 9,
+            "question_id": "MATRIX_Q09",
+            "question_sha256": "sha256:d8855b05223d8b2670d167d655f87fe4a361a1b754dfc4f135872c18c1a8c15f",
+            "section_code": "matrix",
+            "source_html": "matrix_q09.html",
+            "source_question_slug": "matrix_q09",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[8]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[8].stem.svg",
+                "sha256": "sha256:bd6c0ab6e3f461bc9e12107aad2ea1a1109de051b2a5d8aab7efae6774a2421d",
+                "view_box": "0 0 2200 2112"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[9].options[0].svg",
+                    "sha256": "sha256:d031f1b25302092d3c3687ca193805110b25b1c61a9588a05f611f2343a84d77",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[9].options[1].svg",
+                    "sha256": "sha256:1fe3a8580ef219e850efbc94f04abf997457d0d6ac59e3bd45c511e6151c6110",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[9].options[2].svg",
+                    "sha256": "sha256:e28628faaa3e43f3ec996d616f23b0c1c73aa2733b3b41fa9c9709750e091349",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[9].options[3].svg",
+                    "sha256": "sha256:de803c1517d6848ad48b0ced15cc594d2945844fbf8e2fdd1464df4527d603e8",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[9].options[4].svg",
+                    "sha256": "sha256:58c92423c16a202dbcb9d65550974a985aaa7fc00bc23e6c6356d632cc030c2f",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 10,
+            "question_id": "ODD_Q01",
+            "question_sha256": "sha256:473cf360b632ea7ff8a4702352865cd0f41c43c92504fb759e5bf5914f6fc00b",
+            "section_code": "odd",
+            "source_html": "odd_q01.html",
+            "source_question_slug": "odd_q01",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[9]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[9].stem.svg",
+                "sha256": "sha256:e095fbc5675a1d51c9549ccd11dbb166ca34c273a6e565747e922b1ab16bd978",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[10].options[0].svg",
+                    "sha256": "sha256:363afa3807c6fa1b11f9b82f02569199eaca75b348e278dc7f78f4104e63c848",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[10].options[1].svg",
+                    "sha256": "sha256:94bf1bd9bbaab59855757f721203189fcedde36b6dbd5617b49850518705b6f9",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[10].options[2].svg",
+                    "sha256": "sha256:12949d0d4869c00791d39071a2c743b60ae434bbe250b8a39ac7fe75147c12ff",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[10].options[3].svg",
+                    "sha256": "sha256:17a5098c48c849e3838f572411052037389adcaece9a0fd59b1b94009c2fa8d6",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[10].options[4].svg",
+                    "sha256": "sha256:39f272d1a7a7f6cfba18b67fa967a359742e9f0fed810fda97917570fc637ff7",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 11,
+            "question_id": "ODD_Q02",
+            "question_sha256": "sha256:2b4bdae3ff18917a2d637bfcbea5494d04810848243bb3a39d2e1fc19c1d6b51",
+            "section_code": "odd",
+            "source_html": "odd_q02.html",
+            "source_question_slug": "odd_q02",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[10]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[10].stem.svg",
+                "sha256": "sha256:cce7337dd27b33c1eea2c130b5d486720613e39348d16f327b33b2f3477c644b",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[11].options[0].svg",
+                    "sha256": "sha256:30cf83ee9863f2f7f0c329abb041d17ffd1d8e23640ec3cc176c2d5f2b6aef1d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[11].options[1].svg",
+                    "sha256": "sha256:1d011271ce1ded14228bac2b020b9c860be8f4fe5616d654b8aad9a786f83504",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[11].options[2].svg",
+                    "sha256": "sha256:7163872615f99c72468b16255b2c819ebf839a14f1ab852ee08385279138ff4f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[11].options[3].svg",
+                    "sha256": "sha256:d8b537af06f82a92f3ac4cc70b9d05687df689b5c5fe328f795e95c5a4a02663",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[11].options[4].svg",
+                    "sha256": "sha256:bb156be0dc5f192208c16ff1e4a55a9d718d5506585a6d2be64a72063898fd43",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 12,
+            "question_id": "ODD_Q03",
+            "question_sha256": "sha256:c97bd4945b5840358eea78d4b67f23251f525de03a1dde5c1e064d25054b077d",
+            "section_code": "odd",
+            "source_html": "odd_q03.html",
+            "source_question_slug": "odd_q03",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[11]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[11].stem.svg",
+                "sha256": "sha256:0efee51e121ad989c96776a10de30d45868ae0e8b76b6dc1ce66013cc78b5c17",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[12].options[0].svg",
+                    "sha256": "sha256:061e1471d506575e7bbb886c370f645f908b5d0253be49fa37fa573191511b51",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[12].options[1].svg",
+                    "sha256": "sha256:3242ce19dda4ca1bf06e09471da3b3c33a317d0ae254866add3369e3bd2151ff",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[12].options[2].svg",
+                    "sha256": "sha256:d8c2080e5ef0c562a987a83a70d4c75e1a3062d05fbe2df3f1f69773d2b0a3fa",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[12].options[3].svg",
+                    "sha256": "sha256:f10473519f7a96be7f933448f781128e7e9c8df49195427cf3bb1de4e04c2e10",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[12].options[4].svg",
+                    "sha256": "sha256:228d265b81097d32426a68039c2fdbf9e7db5e12bc380eca969507520cf30f58",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 13,
+            "question_id": "ODD_Q04",
+            "question_sha256": "sha256:881794b97bc8630be3806653c10f3627c6e37dab3a5917412cb4149e87b50704",
+            "section_code": "odd",
+            "source_html": "odd_q04.html",
+            "source_question_slug": "odd_q04",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[12]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[12].stem.svg",
+                "sha256": "sha256:29be10b48eb41978b30e11cc1d4bc7b9b9724db82e14c720afcfa89c8e9e63ba",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[13].options[0].svg",
+                    "sha256": "sha256:f574d19f7e030dfadc79717e4f1702b6e5b5dde58e42ac7c88bf5b3e44b9174f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[13].options[1].svg",
+                    "sha256": "sha256:2e09fe0ba385ff6f69d47dd5c94783a4ebd40ce4f4b9ae5b1d6f36b94a2a5d16",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[13].options[2].svg",
+                    "sha256": "sha256:7d6b327d7b49863bb6f07d51a0d80f4080be2d21245e6cb555a49e958c6955ca",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[13].options[3].svg",
+                    "sha256": "sha256:bffcbb72fe37ce771e8da91c35a26214bb47d995209183109677c9f61ba30082",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[13].options[4].svg",
+                    "sha256": "sha256:56a1dc6bbfa5dc06000434a81a958fa22401bfff21ae49c3213bd36773f5dbea",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 14,
+            "question_id": "ODD_Q05",
+            "question_sha256": "sha256:ae12d4057e300bae19ff9bdc3475a4749b64e0258e3aa6d445786a2b7b3e3db1",
+            "section_code": "odd",
+            "source_html": "odd_q05.html",
+            "source_question_slug": "odd_q05",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[13]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[13].stem.svg",
+                "sha256": "sha256:c835e92d242ea676bf87429486cc899ad067a868707a74a990a03ddd624b039f",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[14].options[0].svg",
+                    "sha256": "sha256:16c03369020aac6bee2812a721c13deac41c54667d775c51825737f3c2b8f41b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[14].options[1].svg",
+                    "sha256": "sha256:98d9e3ccc226dd91323660e0ed03d68f86600f02689c5e287c1a58c91f4c10b0",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[14].options[2].svg",
+                    "sha256": "sha256:f9dc5d98b867fb1b763c856c715a37aab273ec216f91b8c6b4f4cedcaf8599aa",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[14].options[3].svg",
+                    "sha256": "sha256:fa6eac05e95be5da05117f4fc94528dcfd213dad4528274434e46675cbbbf4bf",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[14].options[4].svg",
+                    "sha256": "sha256:3757a4e7d7e57a37766cf309dcccdcb41974b07063042742f27d75ab906562cd",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 15,
+            "question_id": "ODD_Q06",
+            "question_sha256": "sha256:08b56c8b7d73100a8aeaee6f08cac3b1965330ae95cfd6025f12ef725a490ab2",
+            "section_code": "odd",
+            "source_html": "odd_q06.html",
+            "source_question_slug": "odd_q06",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[14]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[14].stem.svg",
+                "sha256": "sha256:4b0a5efabf72fe83179de7e6e3fdf948d64613879dbd89a289abe968869c56ab",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[15].options[0].svg",
+                    "sha256": "sha256:7aa4104ec8deeae80c03962665fd50279415a32bb7466a7cc2aff7788cefc594",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[15].options[1].svg",
+                    "sha256": "sha256:894645d6b48b4309961c1e1fea184f3d6954aa637ac327e3b5dbe8296ccdf68f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[15].options[2].svg",
+                    "sha256": "sha256:0414de1e9c9b535bfd84d1c0e85e6b8a4cbb3f1702256e99c11b353e13b48eaf",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[15].options[3].svg",
+                    "sha256": "sha256:0d0e863c68950d93e85a0b3f0547af17178e2480f8abc1eff09a8ce407383e0c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[15].options[4].svg",
+                    "sha256": "sha256:b70d390f08d738f60ac806c85728f79ecd9d392e4be273bf4e883c72b96e5bf3",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 16,
+            "question_id": "ODD_Q07",
+            "question_sha256": "sha256:49704f38f26f3af1b288ba2e6ce581115feb9d31dc2cd391e98483d053cf8a86",
+            "section_code": "odd",
+            "source_html": "odd_q07.html",
+            "source_question_slug": "odd_q07",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[15]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[15].stem.svg",
+                "sha256": "sha256:36da6f9b39fb6644c3e67dbcf2357ca551b44c9f510b6f4cd9df7ad75b0ecdee",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[16].options[0].svg",
+                    "sha256": "sha256:877a21e3de03ac94ba37fbda4b0df54875ea6e7c3a69c3720c2b9703617b9fa7",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[16].options[1].svg",
+                    "sha256": "sha256:9595945a5ebfef6660f7a2ac592d8b45fef62eeadd2632b87d895620b07d750c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[16].options[2].svg",
+                    "sha256": "sha256:af9703e4fa33fd3329f1623b19b46d9653ee75d9c877a73f679ef9e64dbe1738",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[16].options[3].svg",
+                    "sha256": "sha256:a8c100f0ced2806867d449040770e79a095a3a31b9b86781d9d5af4a6f4000cf",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[16].options[4].svg",
+                    "sha256": "sha256:4d3e89016cfb244a32d4a8806952aff86dd562713f448a9b3ab8b3a4ffa171e0",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 17,
+            "question_id": "ODD_Q08",
+            "question_sha256": "sha256:aea3821d7c5b79be65974060d3134135f4c468c21e54059da09ff520a718d48c",
+            "section_code": "odd",
+            "source_html": "odd_q08.html",
+            "source_question_slug": "odd_q08",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[16]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[16].stem.svg",
+                "sha256": "sha256:9a4eb4c83c63d2b6098e810d1c23ba6c138ca599001920307b9d97bb10da0c86",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[17].options[0].svg",
+                    "sha256": "sha256:3e114228d84b8e95450a4ab1e1df8334fb23a72dcee8631a9f7b29503a37b00b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[17].options[1].svg",
+                    "sha256": "sha256:17c5093223250c5ac8c0430401e47129586eb3496bc3ae27924ec9049d79b8ac",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[17].options[2].svg",
+                    "sha256": "sha256:f32fb146b2c4266665ab5c6337f4ab9d06a75d6991965073bec5f658c4f67dfb",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[17].options[3].svg",
+                    "sha256": "sha256:a96740c3d65b90f737817c41a572943be179b4fe68f9f1a5d84d08484c53b614",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[17].options[4].svg",
+                    "sha256": "sha256:c67d59f3da53a13914fdb1ae9fe08f71f1d0155d102f7de7e701d4625efa8bd1",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 18,
+            "question_id": "ODD_Q09",
+            "question_sha256": "sha256:7039bec613cd90f5d712fe59185e34726a613b47e0082e129094cbd73421681d",
+            "section_code": "odd",
+            "source_html": "odd_q09.html",
+            "source_question_slug": "odd_q09",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[17]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[17].stem.svg",
+                "sha256": "sha256:7ccc0beef5154f4ea7fd91f91eeca71351f16babe3df7424b939c1f60b06a056",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[18].options[0].svg",
+                    "sha256": "sha256:16e774f863e4faa43d693255ebd05f2d821c932fc79be41f3f3793cb1903abcb",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[18].options[1].svg",
+                    "sha256": "sha256:83ee45e21a1f15c878b4530ce55fbc1f3a49276a36823a7f632bd47b512cb17b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[18].options[2].svg",
+                    "sha256": "sha256:72bf71eacb96b52cba4d82cad1f0507b007627e69b8606bc4e60ab846b46b936",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[18].options[3].svg",
+                    "sha256": "sha256:1a76ab801fb34fc6463cef54d2b95e086b1b58c4de1870acf076e66f03870c6d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[18].options[4].svg",
+                    "sha256": "sha256:248ac9c1aff54b4c7bfa67e2d489d77e553d1ce9acf09a5ca8e5cb1551f47f51",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 19,
+            "question_id": "ODD_Q10",
+            "question_sha256": "sha256:cfd5afd3fd3a59e66f15ae421cef30864336e45f71563c42f3612b2d825f02cb",
+            "section_code": "odd",
+            "source_html": "odd_q10.html",
+            "source_question_slug": "odd_q10",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[18]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[18].stem.svg",
+                "sha256": "sha256:6f3a6703f8f981ee12a4484ceb6a7f7f9fea85d5d33d244a164670267e860af1",
+                "view_box": "0 0 2400 432"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[19].options[0].svg",
+                    "sha256": "sha256:aa25ea54f8c082f6d702260904e2d3f22450be4170a9f9b9382730591e796cd0",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[19].options[1].svg",
+                    "sha256": "sha256:575f06b635b2e1b36519d5ad29a0c844bb9866f61085262f58878dae7df0d8a3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[19].options[2].svg",
+                    "sha256": "sha256:285a781e85efccce7536206587e01ca3549c8842aa0e20c34515d8e956bed69c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[19].options[3].svg",
+                    "sha256": "sha256:bcc1f7f335723697256692819407fd4da6f9180a4c768012c25fc7fea29a2a19",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[19].options[4].svg",
+                    "sha256": "sha256:3e8ac596fe8da5eb17c95618f2828bf7460e20ebb3d14d84a07f0cc185401bb8",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[19].options[5].svg",
+                    "sha256": "sha256:455d8855d50fe10377df1ac4f7f1e6faa962282bfff07fc48fd797fefab461f7",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 20,
+            "question_id": "SERIES_Q01",
+            "question_sha256": "sha256:9dc362134b37e1342afed73549cdbfbf9a2098b308cd0e8f4fb4882f648e14a2",
+            "section_code": "series",
+            "source_html": "series_q01.html",
+            "source_question_slug": "series_q01",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[19]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[19].stem.svg",
+                "sha256": "sha256:a8aa6552133321f4435dcd5e1e8140f01f9676f5034d6fdcae2169d04776c010",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[20].options[0].svg",
+                    "sha256": "sha256:e52f939766c4085524f7bdfbe1a56d25cd929c1514be60785f357ee5066273ed",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[20].options[1].svg",
+                    "sha256": "sha256:48d88c84b0a997c7a7633d86f40822453a0cf978f9779fed0dee7dbe9265a8cc",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[20].options[2].svg",
+                    "sha256": "sha256:fc75679e20678ce2d42a3af6613aa2736aece2c6edffe69915213c01e4cebab3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[20].options[3].svg",
+                    "sha256": "sha256:df1047ec9b813d2c657c921196fe35119c5dba54253b696f2f3d7ddfbd30df55",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[20].options[4].svg",
+                    "sha256": "sha256:9009a67023d35745867088f2c6e489d9e83c0c4a7cf3042b4b4e6d265a7561de",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[20].options[5].svg",
+                    "sha256": "sha256:4f584332af50ed559b29a70b26ede3b2059874498a67957be91f16c502f299e1",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 21,
+            "question_id": "SERIES_Q02",
+            "question_sha256": "sha256:ca7e424f0fca31b5ce04aed8c5ba0170b0b9ef6323e7077aeb9d050b024a25e0",
+            "section_code": "series",
+            "source_html": "series_q02.html",
+            "source_question_slug": "series_q02",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[20]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[20].stem.svg",
+                "sha256": "sha256:10974428fc03e51808f3a77775c1c64c29521ade756a4e4261b51211319e3266",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[21].options[0].svg",
+                    "sha256": "sha256:4e9a05e36477894de0ffdbe15a3d1bf8c30242233db58fb473700e8db784f9dd",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[21].options[1].svg",
+                    "sha256": "sha256:2b90c925e57e5f1533f0f619e3290bce59bb6e7ba953dbb98f024ae646754413",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[21].options[2].svg",
+                    "sha256": "sha256:586536b82abb39bdbb66d87db954f846d750e83b49153d86c9237ac980757f31",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[21].options[3].svg",
+                    "sha256": "sha256:03c7aabdf7fb4685a4f751f457792bc8b9a3c11c6738c3aab3012d45e9804e81",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[21].options[4].svg",
+                    "sha256": "sha256:e454ddf94566f5198b05aa277bc09b26fe4f81094ffe168a4c4872daf53cb23c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[21].options[5].svg",
+                    "sha256": "sha256:4cd88e1366fe62c6948115c34b1b28f59153f40cba0923f6924d79edd4ee9e9e",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 22,
+            "question_id": "SERIES_Q03",
+            "question_sha256": "sha256:b597b1e78075208cf2171edd5be9f9d0c3f9ba26e38ff6ca4a010a6e760e05a5",
+            "section_code": "series",
+            "source_html": "series_q03.html",
+            "source_question_slug": "series_q03",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[21]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[21].stem.svg",
+                "sha256": "sha256:fce6c4a56400bd3ba6c2b4c3052ee59c3437eac4a45dd6f83452f79e4a4df15b",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[22].options[0].svg",
+                    "sha256": "sha256:5207f443488907d9372eeaf9cbf0073f7f754d98f792413d32e8d4bab7882d2b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[22].options[1].svg",
+                    "sha256": "sha256:f838bcbd60ce03e26951b41d9a12eb1c261c9c81143ec4dfd0ca88ae2d82a34b",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[22].options[2].svg",
+                    "sha256": "sha256:33f7e2bcd00cb6760f772ee4574638f831bd1b9a86804c1e40386e5c1db98fc5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[22].options[3].svg",
+                    "sha256": "sha256:ac7361492b011e536eb13d88744ce38b0357b4cbc6afeb2f3ab182ba7d11f7d9",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[22].options[4].svg",
+                    "sha256": "sha256:4ae238291241643918597026bbe0432a299e048edc9f34a97097a70b54bce6ef",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[22].options[5].svg",
+                    "sha256": "sha256:a3839035887c24b92b5af98edfa5263e341d213000f563fcaad3e1285ea3ae58",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 23,
+            "question_id": "SERIES_Q04",
+            "question_sha256": "sha256:948016e3326e1b02bcd9f978d7a45d7788aab5b7e8f7214b1e85a10a685310ab",
+            "section_code": "series",
+            "source_html": "series_q04.html",
+            "source_question_slug": "series_q04",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[22]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[22].stem.svg",
+                "sha256": "sha256:7990540db01d7f610854b9fc9de8efc3fe6eb050ae758bff412f6e1791d51f84",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[23].options[0].svg",
+                    "sha256": "sha256:46477ddf8e76bd9a6e04d47fdeb32e5db264411643f2b9d1678dd107be94bdae",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[23].options[1].svg",
+                    "sha256": "sha256:f5e8eddf84605ca13f598dc980701009c18baa0ebf0d8ec05d3d237d20342796",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[23].options[2].svg",
+                    "sha256": "sha256:429f0e4b75bdb89e07e79928d102759acf24db9a2f2900bbaf62f93c540374db",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[23].options[3].svg",
+                    "sha256": "sha256:534713686e839b774543436a63dfa974357ef8d7d076e20fb5ffd194d03f0b77",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[23].options[4].svg",
+                    "sha256": "sha256:5840a461b6e9f46b69bc031a3febc687ec3af6cf92a997682534920dacc73c5f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[23].options[5].svg",
+                    "sha256": "sha256:93090f022ec2146bff95522dee2d28e812c941996532a368f2815f1304cf4912",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 24,
+            "question_id": "SERIES_Q05",
+            "question_sha256": "sha256:62e2844d6961cd81be327fa6b92c0ab320fa1a1256a0ce4bde453997966b7ff2",
+            "section_code": "series",
+            "source_html": "series_q05.html",
+            "source_question_slug": "series_q05",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[23]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[23].stem.svg",
+                "sha256": "sha256:1c0dea3a7488ee9586a6ced17533a12a36c34074d34a27690242c9ca9d1c457a",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[24].options[0].svg",
+                    "sha256": "sha256:2d4682e1a25256d5d26231923e11b9b14c4ec09278911cdb1b1d337386433fdc",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[24].options[1].svg",
+                    "sha256": "sha256:767c7bcf43a42352e8e385f49c19ed5d761269144c3a8cfa2765270d99ec13b5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[24].options[2].svg",
+                    "sha256": "sha256:90f72931b7e50061b204bdecbd0dd42158f63ad53934ad11b345a6bd5cef42c8",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[24].options[3].svg",
+                    "sha256": "sha256:6f6ad0ae446ae45ffff1f8d3af46aec8048fd1df9f900127bd68ba86017ca270",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[24].options[4].svg",
+                    "sha256": "sha256:a9d8021f58ba6c2ab693e856dfa5aa2214e898cd6655a0a041d475381fdd0f8c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[24].options[5].svg",
+                    "sha256": "sha256:55955c436319588e6558833133d1e9fbc8d7cd9b2ce083a67819b152793f02f3",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 25,
+            "question_id": "SERIES_Q06",
+            "question_sha256": "sha256:0b31114f29b9c084cc6c068223eaed7613ef2211a66be08754d8b30302ce4c6b",
+            "section_code": "series",
+            "source_html": "series_q06.html",
+            "source_question_slug": "series_q06",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[24]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[24].stem.svg",
+                "sha256": "sha256:604dc9fe7052c5852c1896c7debe74922d3e19095f0b99a00a09a9617ddaa75f",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[25].options[0].svg",
+                    "sha256": "sha256:9de08b6ee92b5fd030f8c487d27ad668f384d4ca34f0a5795afd65f5bb8394ce",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[25].options[1].svg",
+                    "sha256": "sha256:b6b65b6257379c576aa5190ee2d0f5681be0c7d84d217e55d1dc62fc64e89ec3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[25].options[2].svg",
+                    "sha256": "sha256:6768e9367226ddb3e7f4a8532810489390fc6773ecfc51648c8967dc1a303bfc",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[25].options[3].svg",
+                    "sha256": "sha256:425e05d1897e4d0b6a8fcaefccb5fad54187a26a108cfdb629f0737331adf578",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[25].options[4].svg",
+                    "sha256": "sha256:75a5992d973251c51f875cfa0fdbcac516736e5e33aa24e00b2a8662cc509aa0",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[25].options[5].svg",
+                    "sha256": "sha256:6bf6a06257cf6203e46617fba0fce2a02addc6f80c3c395aff607aca96437502",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 26,
+            "question_id": "SERIES_Q07",
+            "question_sha256": "sha256:57f83d173443f9540cba11805a6513abfa9eb5caff0f8ef71427d6d35997fb15",
+            "section_code": "series",
+            "source_html": "series_q07.html",
+            "source_question_slug": "series_q07",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[25]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[25].stem.svg",
+                "sha256": "sha256:26217eda8e63a8b3ed5e0be8c1a2795522f1e759f46e1ae96bc2457711518e68",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[26].options[0].svg",
+                    "sha256": "sha256:2fe7b514911c7e94fbc418d9b3f5bc937765a79dae6d763683060689bd3bd21f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[26].options[1].svg",
+                    "sha256": "sha256:dded6bf764b5835ca94a4cc1b26b570e535d4ebf4a1593afcc04c853d6862b11",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[26].options[2].svg",
+                    "sha256": "sha256:f20aaababbe41eb2ff7ee4f9c925b586d53be9938a28908d374547e3baec8c6c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[26].options[3].svg",
+                    "sha256": "sha256:322b18793140d5fb8dcded5838694968c03117e869bf0b0ff7ad1f7496c2c68f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[26].options[4].svg",
+                    "sha256": "sha256:a254996e376d667e77ccd5a8a053f6bff93072e2972a81683755b14862ffa5fd",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[26].options[5].svg",
+                    "sha256": "sha256:a7cd0595243bd9f8ddcae1f0eef3bba1777836b9be997fce2e121e79844d03f0",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 27,
+            "question_id": "SERIES_Q08",
+            "question_sha256": "sha256:75043befdaae4213262b239b24a304990d5ba36b27481e51265d65994e9c2935",
+            "section_code": "series",
+            "source_html": "series_q08.html",
+            "source_question_slug": "series_q08",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[26]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[26].stem.svg",
+                "sha256": "sha256:c214eb38bec2461a4f038044579aa8ae11b8c5bc5a2d9d650c01ea6223c24eea",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[27].options[0].svg",
+                    "sha256": "sha256:eab1abdc92e68646d8f2de3f7caab6abcda2d7f27e41244d4bb2a22d4c29ca28",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[27].options[1].svg",
+                    "sha256": "sha256:cb6f043b6262573694046278f1378d268de79cae68db279d591608f2f27ce350",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[27].options[2].svg",
+                    "sha256": "sha256:4254c93240b70207c104e90ac0b4289fe7d894776ef08ffe7e405f5e579e70fe",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[27].options[3].svg",
+                    "sha256": "sha256:cd74ffe0cf5204b6021a757949ee4679c92cdaf014a981f9bd04774277f36bb5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[27].options[4].svg",
+                    "sha256": "sha256:6e7a6c31234819a10a4bb60e1d9e493f1d5bad960c8ad9a86bef5df1700a550c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[27].options[5].svg",
+                    "sha256": "sha256:4f003792f8ea68b2fea61c9996e061e1a0a1abf25c750e4169e91d375f6fa75e",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 28,
+            "question_id": "SERIES_Q09",
+            "question_sha256": "sha256:783cc418734b2060bb87da89f583433ae0f2a1ffa7147ecc587a26d353973f0d",
+            "section_code": "series",
+            "source_html": "series_q09.html",
+            "source_question_slug": "series_q09",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[27]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[27].stem.svg",
+                "sha256": "sha256:23cccef8e6dd18f07e692dc4ee8847b3735945cc03f75f59e7bf60bedf45bc22",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[28].options[0].svg",
+                    "sha256": "sha256:a394e5b964084addc99470349d68de6e43a480f1da8a55414e2b108ae6b0c0f3",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[28].options[1].svg",
+                    "sha256": "sha256:d398fd7ffbb3d61f719500d1a7fb852394cf673de3791fd9139bac11bc3f6264",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[28].options[2].svg",
+                    "sha256": "sha256:46ba630168ef34e7d291d76359fc42a4e12ba6f6a981930022697d2f27beb8a5",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[28].options[3].svg",
+                    "sha256": "sha256:43c97d7d5dc5512b78604c3ae7b9f0d8145c5eb860edb87590cb78a6c4f508f1",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[28].options[4].svg",
+                    "sha256": "sha256:4a8b154ed88edac98b0d6e79753c3fae1309429aeb430b36118eb62cb1688175",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[28].options[5].svg",
+                    "sha256": "sha256:4fef00b166154ea1f8efe620969baa583d80308b23b09705d14a8bbf8860883e",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 29,
+            "question_id": "SERIES_Q10",
+            "question_sha256": "sha256:c6ce4093dffa87e4f1a987447dd3d8201e135b8be2c18c2f087c9c81c49aeff6",
+            "section_code": "series",
+            "source_html": "series_q10.html",
+            "source_question_slug": "series_q10",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[28]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[28].stem.svg",
+                "sha256": "sha256:9fdd62e70f2f2f6f06628a098a2f83efce4013d81f78fc25e7a92c2f58e03bf3",
+                "view_box": "0 0 2400 523"
+            }
+        },
+        {
+            "item_id": null,
+            "option_assets": [
+                {
+                    "code": "A",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[29].options[0].svg",
+                    "sha256": "sha256:35a696574824d4509ab1bc846da1113fe958e623ba18da0859253c00f0f70d3c",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "B",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[29].options[1].svg",
+                    "sha256": "sha256:f5ef63ef3f528b3e879914ce3c3d53bb1cb77857980c04235cb7ee51636d742d",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "C",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[29].options[2].svg",
+                    "sha256": "sha256:6aa44172f23ce06e577165141b8a5b2da5f3ff71c046aca502f11ff6cf0ed620",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "D",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[29].options[3].svg",
+                    "sha256": "sha256:173220ad10ecd2eb3a092ab6f6f74d895b48ce03ae494a4bdb0fc935cc705a0e",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "E",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[29].options[4].svg",
+                    "sha256": "sha256:638fe86c963b43f4840b6dc92222c23499a471c8dde279c0baa309127415da3f",
+                    "view_box": "0 0 1024 1024"
+                },
+                {
+                    "code": "F",
+                    "kind": "inline_svg",
+                    "path_count": 1,
+                    "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[29].options[5].svg",
+                    "sha256": "sha256:ee2977c5c49a78b3a84fba9fd85ddcc94730806daa58ab04b880626d2966d1af",
+                    "view_box": "0 0 1024 1024"
+                }
+            ],
+            "order": 30,
+            "question_id": "SERIES_Q11",
+            "question_sha256": "sha256:552fbc777ca18b2bfdd896ad86e4b062cf069f6910601de989b9dd6934939b97",
+            "section_code": "series",
+            "source_html": "series_q11.html",
+            "source_question_slug": "series_q11",
+            "source_ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[29]",
+            "status": "legacy_demo",
+            "stem_asset": {
+                "kind": "inline_svg",
+                "path_count": 1,
+                "ref": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json#items[29].stem.svg",
+                "sha256": "sha256:bb605dfde69cbad7cedce12d8024fc2b9426010dd2ad7ebf3af9654096e5f6dd",
+                "view_box": "0 0 2400 523"
+            }
+        }
+    ],
+    "lifecycle": {
+        "canonical_scale_code": null,
+        "identity_role": "canonical_v2",
+        "legacy_demo_allowlisted": true,
+        "legacy_scale_code": "IQ_RAVEN",
+        "status": "legacy_demo"
+    },
+    "pack_dir": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO",
+    "recorded_generator_source": {
+        "builder_script": "backend/scripts/iq/build_iq30_questions_from_prototype.php",
+        "params_recorded": false,
+        "prototype_zip_path": "/Users/rainie/Desktop/iq_ui_prototype_30_svg_grid.zip",
+        "prototype_zip_tracked_in_repo": false,
+        "seed_recorded": false,
+        "version_recorded": false
+    },
+    "runtime_policy": {
+        "asset_kind": "inline_svg_in_questions_json",
+        "legacy_identity_allowed": true,
+        "production_ready": false,
+        "prototype_source_tracked_in_repo": false,
+        "visual_output_changed": false
+    },
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "schema_version": "fm.iq.svg_provenance_manifest.v1",
+    "scoring_contract_snapshot": {
+        "answer_key_version": "legacy_demo_answer_key_not_available",
+        "item_bank_status": "legacy_demo",
+        "item_count": 30,
+        "scored_items_declared": 0,
+        "scoring_mode": "scored"
+    },
+    "source_files": {
+        "builder_script": "backend/scripts/iq/build_iq30_questions_from_prototype.php",
+        "landing_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/meta/landing.json",
+        "manifest_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/manifest.json",
+        "questions_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/questions.json",
+        "scoring_spec_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/scoring_spec.json",
+        "version_json": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/version.json"
+    },
+    "source_hashes": {
+        "builder_script_sha256": "sha256:3a71dd29744804ee105d8c4929c02953ad857381b47fa8aa29de574c5ba441e8",
+        "landing_json_sha256": "sha256:9eea84f9e5351e70c693da29f6de06853c6000c4a9eb923bb56e6d446746fb0f",
+        "manifest_json_sha256": "sha256:7f3dd586cd680f6a1e92d0c8b9d6ecbd1905ea1b3ba0b3f44f87b9244fbf6c1f",
+        "questions_json_sha256": "sha256:3da004dddfa7df46673efb9e1496cf142f32fcf15b55b0b978dded02fbcef51c",
+        "scoring_spec_json_sha256": "sha256:ec2037c353b7c43bac8cb1adb059ebc719e5c8dc173b7284cf5046300b3edddf",
+        "version_json_sha256": "sha256:c6c2b8c98491607d72fc4eac6eb0575033546c595c8e06d25cb5a469f9b7027c"
+    }
+}

--- a/docs/audits/iq/04_pr5_svg_freeze_notes.md
+++ b/docs/audits/iq/04_pr5_svg_freeze_notes.md
@@ -1,0 +1,42 @@
+# PR5 Notes — SVG Freeze And Provenance Verification
+
+## Scope
+
+- freeze the current IQ legacy demo SVG corpus without changing visual output
+- add deterministic per-item / per-option hash manifests for both IQ pack directories
+- add verifier scripts that enforce explicit legacy-demo allowlisting and future production asset metadata requirements
+
+## Added files
+
+- `backend/scripts/iq/iq_svg_provenance_lib.php`
+- `backend/scripts/iq/build_legacy_svg_provenance_manifest.php`
+- `backend/scripts/iq/verify_legacy_svg_provenance.php`
+- `backend/tests/Feature/Console/IqSvgProvenanceVerificationTest.php`
+- `content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/svg_provenance_manifest.json`
+- `content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/svg_provenance_manifest.json`
+
+## What changed
+
+- IQ legacy demo questions remain inline SVG payloads inside `questions.json`; no SVG geometry was edited.
+- The new provenance manifests freeze:
+  - `question_sha256`
+  - `stem_asset.sha256`
+  - `option_assets[*].sha256`
+  - source file hashes for `questions.json`, `scoring_spec.json`, `manifest.json`, `meta/landing.json`, `version.json`
+- The verifier now fails if:
+  - a committed provenance manifest drifts from the current inline SVG payloads
+  - a production IQ pack uses `IQ_RAVEN` as active identity outside explicit `legacy_demo` allowlisting
+  - a production IQ scored item lacks `asset_hashes`
+  - a production IQ scored item lacks `generator_metadata`
+
+## Explicit non-changes
+
+- no scoring math changes
+- no answer key added to legacy 30
+- no report builder changes
+- no payment / unlock changes
+- no frontend changes
+
+## Remaining external blocker
+
+- The original prototype zip source remains external to the repo. This PR records the source path and freezes deterministic hashes, but it does not vendor the prototype archive into git.

--- a/docs/codex/sidecar/iq-foundation-sidecar-issues.md
+++ b/docs/codex/sidecar/iq-foundation-sidecar-issues.md
@@ -49,3 +49,28 @@
 - PR2 formalizes a scored contract and explicit answer-key gate, but no validated `norm_table_version` exists yet.
 - Runtime now reports `unavailable_without_norm_table` instead of fabricating IQ estimates or percentiles.
 - Identity/scoring/report/SVG provenance work can continue without a production norm table.
+
+## IQ-SIDECAR-PROTOTYPE-ZIP-EXTERNAL-001
+
+| Field | Value |
+|---|---|
+| sidecar_id | `IQ-SIDECAR-PROTOTYPE-ZIP-EXTERNAL-001` |
+| title | `note(iq): prototype zip source remains external to git while legacy SVG hashes are frozen` |
+| owner_repo | `fap-api` |
+| scope_relation | `external_to_current_pr` |
+| introduced_by_current_pr | `false` |
+| affected_area | `svg_provenance_source_of_truth` |
+| affected_files | `backend/scripts/iq/build_iq30_questions_from_prototype.php`, `content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/svg_provenance_manifest.json`, `content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/svg_provenance_manifest.json` |
+| affected_scale_codes | `IQ_INTELLIGENCE_QUOTIENT`, `IQ_RAVEN` |
+| affected_routes | `api/v0.3/scales/{scale_code}/questions` |
+| severity | `low` |
+| proposed_owner_pr | `iq-showcase12-beta50-item-bank-import` |
+| next_goal | `Move future production-ready IQ banks onto repo-tracked generator metadata and reproducible source assets.` |
+| may_continue_train | `true` |
+| resume_condition | `A future IQ bank ships with repo-tracked generator metadata or source assets, making prototype reproduction independent of the external zip archive.` |
+
+### Evidence
+
+- `backend/scripts/iq/build_iq30_questions_from_prototype.php` records an absolute prototype zip path outside the repository.
+- PR5 freezes deterministic hashes for the current legacy demo assets, so train scope can continue without vendoring the external archive.
+- Future production banks should not depend on an external untracked prototype zip.


### PR DESCRIPTION
## Summary
- freeze legacy IQ demo inline SVG assets with deterministic per-item and per-option provenance manifests
- add build/verify scripts and coverage tests for IQ SVG provenance and future production asset metadata enforcement
- record the external prototype zip as a sidecar issue without changing scoring, report, payment, or frontend behavior

## Guardrails
- legacy demo assets remain legacy_demo
- no visual output changes intended
- no scoring changes
- no report builder changes
- no payment or commerce implementation
- no frontend changes

## Verification
- `php backend/scripts/iq/build_legacy_svg_provenance_manifest.php --check`
- `php backend/scripts/iq/verify_legacy_svg_provenance.php --json`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/IqSvgProvenanceVerificationTest.php`
- `cd backend && php artisan route:list --no-ansi | rg 'api/v0.3/(scales|attempts|orders|webhooks/payment|results/lookup-by-email)'`
- `cd backend && php artisan migrate` (local mysql unavailable: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO)`)
- `bash backend/scripts/ci_verify_mbti.sh`

## Next
- next PR is `iq-showcase12-beta50-item-bank-import` after this provenance PR merges
