### PR TITLE
feat(api): add career canonical eligibility audit schema

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRow.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRow.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityAuditRow
+{
+    /**
+     * @param  list<string>  $reasons
+     * @param  list<mixed>  $evidence
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $locale,
+        public readonly string $sourceScope,
+        public readonly CareerCanonicalEligibilityLayerStatus $entityStatus,
+        public readonly CareerCanonicalEligibilityLayerStatus $baselineStatus,
+        public readonly CareerCanonicalEligibilityLayerStatus $indexStatus,
+        public readonly CareerCanonicalEligibilityLayerStatus $runtimeStatus,
+        public readonly CareerCanonicalEligibilityLayerStatus $seoGeoStatus,
+        public readonly CareerCanonicalEligibilityLayerStatus $surfaceStatus,
+        public readonly CareerCanonicalEligibilityLayerStatus $safetyStatus,
+        public readonly string $overallStatus,
+        public readonly string $severity,
+        public readonly array $reasons = [],
+        public readonly array $evidence = [],
+        public readonly array $sidecars = [],
+    ) {
+        self::assertNonEmptyString($this->slug, 'slug');
+        self::assertNonEmptyString($this->locale, 'locale');
+        CareerCanonicalEligibilityScope::assertValid($this->sourceScope);
+        CareerCanonicalEligibilityStatus::assertValid($this->overallStatus);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertList('reasons', $this->reasons);
+        self::assertList('evidence', $this->evidence);
+        self::assertSidecars($this->sidecars);
+
+        self::assertLayer($this->entityStatus, CareerCanonicalEligibilityLayer::ENTITY, 'entity_status');
+        self::assertLayer($this->baselineStatus, CareerCanonicalEligibilityLayer::BASELINE, 'baseline_status');
+        self::assertLayer($this->indexStatus, CareerCanonicalEligibilityLayer::INDEX, 'index_status');
+        self::assertLayer($this->runtimeStatus, CareerCanonicalEligibilityLayer::RUNTIME, 'runtime_status');
+        self::assertLayer($this->seoGeoStatus, CareerCanonicalEligibilityLayer::SEO_GEO, 'seo_geo_status');
+        self::assertLayer($this->surfaceStatus, CareerCanonicalEligibilityLayer::SURFACE, 'surface_status');
+        self::assertLayer($this->safetyStatus, CareerCanonicalEligibilityLayer::SAFETY, 'safety_status');
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public static function fromArray(array $value): self
+    {
+        return new self(
+            slug: self::requiredString($value, 'slug'),
+            locale: self::requiredString($value, 'locale'),
+            sourceScope: self::requiredString($value, 'source_scope'),
+            entityStatus: self::requiredLayerStatus($value, 'entity_status', CareerCanonicalEligibilityLayer::ENTITY),
+            baselineStatus: self::requiredLayerStatus($value, 'baseline_status', CareerCanonicalEligibilityLayer::BASELINE),
+            indexStatus: self::requiredLayerStatus($value, 'index_status', CareerCanonicalEligibilityLayer::INDEX),
+            runtimeStatus: self::requiredLayerStatus($value, 'runtime_status', CareerCanonicalEligibilityLayer::RUNTIME),
+            seoGeoStatus: self::requiredLayerStatus($value, 'seo_geo_status', CareerCanonicalEligibilityLayer::SEO_GEO),
+            surfaceStatus: self::requiredLayerStatus($value, 'surface_status', CareerCanonicalEligibilityLayer::SURFACE),
+            safetyStatus: self::requiredLayerStatus($value, 'safety_status', CareerCanonicalEligibilityLayer::SAFETY),
+            overallStatus: self::requiredString($value, 'overall_status'),
+            severity: self::requiredString($value, 'severity'),
+            reasons: self::optionalList($value, 'reasons'),
+            evidence: self::optionalList($value, 'evidence'),
+            sidecars: self::optionalSidecars($value, 'sidecars'),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'slug' => $this->slug,
+            'locale' => $this->locale,
+            'source_scope' => $this->sourceScope,
+            'entity_status' => $this->entityStatus->toArray(),
+            'baseline_status' => $this->baselineStatus->toArray(),
+            'index_status' => $this->indexStatus->toArray(),
+            'runtime_status' => $this->runtimeStatus->toArray(),
+            'seo_geo_status' => $this->seoGeoStatus->toArray(),
+            'surface_status' => $this->surfaceStatus->toArray(),
+            'safety_status' => $this->safetyStatus->toArray(),
+            'overall_status' => $this->overallStatus,
+            'severity' => $this->severity,
+            'reasons' => $this->reasons,
+            'evidence' => $this->evidence,
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    private static function assertLayer(CareerCanonicalEligibilityLayerStatus $status, string $expectedLayer, string $field): void
+    {
+        if ($status->layer !== $expectedLayer) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility row [%s] must use layer [%s].', $field, $expectedLayer));
+        }
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    private static function requiredString(array $value, string $key): string
+    {
+        if (! array_key_exists($key, $value) || ! is_string($value[$key]) || trim($value[$key]) === '') {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility row requires non-empty [%s].', $key));
+        }
+
+        return $value[$key];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    private static function requiredLayerStatus(array $value, string $key, string $layer): CareerCanonicalEligibilityLayerStatus
+    {
+        if (! array_key_exists($key, $value) || ! is_array($value[$key])) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility row requires layer status [%s].', $key));
+        }
+
+        $status = CareerCanonicalEligibilityLayerStatus::fromArray($value[$key]);
+        self::assertLayer($status, $layer, $key);
+
+        return $status;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return list<mixed>
+     */
+    private static function optionalList(array $value, string $key): array
+    {
+        if (! array_key_exists($key, $value)) {
+            return [];
+        }
+
+        if (! is_array($value[$key])) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility row [%s] must be a list.', $key));
+        }
+
+        self::assertList($key, $value[$key]);
+
+        return $value[$key];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return list<CareerCanonicalEligibilitySidecar>
+     */
+    private static function optionalSidecars(array $value, string $key): array
+    {
+        if (! array_key_exists($key, $value)) {
+            return [];
+        }
+
+        if (! is_array($value[$key]) || ! array_is_list($value[$key])) {
+            throw new InvalidArgumentException('Career canonical eligibility row sidecars must be a list.');
+        }
+
+        return array_map(static function (mixed $sidecar): CareerCanonicalEligibilitySidecar {
+            if ($sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                return $sidecar;
+            }
+
+            if (! is_array($sidecar)) {
+                throw new InvalidArgumentException('Career canonical eligibility row sidecar item must be an object.');
+            }
+
+            return CareerCanonicalEligibilitySidecar::fromArray($sidecar);
+        }, $value[$key]);
+    }
+
+    private static function assertList(string $key, array $value): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career canonical eligibility row sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career canonical eligibility row sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityCheckProtocol.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityCheckProtocol.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityCheckProtocol
+{
+    public const STATE_PENDING = 'pending';
+
+    public const STATE_FAILED = 'failed';
+
+    public const STATE_GREEN = 'green';
+
+    public const ACTION_WAIT_OR_POLL = 'wait_or_poll';
+
+    public const ACTION_INSPECT_FAILURE = 'inspect_failure';
+
+    public const ACTION_CONTINUE = 'continue';
+
+    public const TRAIN_CONTINUE_YES = 'YES';
+
+    public const TRAIN_CONTINUE_WAITING_FOR_CHECKS = 'WAITING_FOR_CHECKS';
+
+    /**
+     * @return list<string>
+     */
+    public static function states(): array
+    {
+        return [
+            self::STATE_PENDING,
+            self::STATE_FAILED,
+            self::STATE_GREEN,
+        ];
+    }
+
+    public static function actionForState(string $state): string
+    {
+        return match (self::assertValidState($state)) {
+            self::STATE_PENDING => self::ACTION_WAIT_OR_POLL,
+            self::STATE_FAILED => self::ACTION_INSPECT_FAILURE,
+            self::STATE_GREEN => self::ACTION_CONTINUE,
+        };
+    }
+
+    public static function isImmediateStop(string $state): bool
+    {
+        self::assertValidState($state);
+
+        return false;
+    }
+
+    public static function trainContinueForState(string $state): string
+    {
+        return match (self::assertValidState($state)) {
+            self::STATE_PENDING => self::TRAIN_CONTINUE_WAITING_FOR_CHECKS,
+            self::STATE_GREEN => self::TRAIN_CONTINUE_YES,
+            self::STATE_FAILED => self::ACTION_INSPECT_FAILURE,
+        };
+    }
+
+    public static function assertValidState(string $state): string
+    {
+        if (! in_array($state, self::states(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career canonical eligibility check state [%s].', $state));
+        }
+
+        return $state;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayer.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityLayer
+{
+    public const ENTITY = 'entity';
+
+    public const BASELINE = 'baseline';
+
+    public const INDEX = 'index';
+
+    public const RUNTIME = 'runtime';
+
+    public const SEO_GEO = 'seo_geo';
+
+    public const SURFACE = 'surface';
+
+    public const SAFETY = 'safety';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return [
+            self::ENTITY,
+            self::BASELINE,
+            self::INDEX,
+            self::RUNTIME,
+            self::SEO_GEO,
+            self::SURFACE,
+            self::SAFETY,
+        ];
+    }
+
+    public static function assertValid(string $value): string
+    {
+        if (! in_array($value, self::values(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career canonical eligibility layer [%s].', $value));
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayerStatus.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayerStatus.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityLayerStatus
+{
+    /**
+     * @param  list<string>  $reasons
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $layer,
+        public readonly string $status,
+        public readonly array $reasons = [],
+        public readonly array $evidence = [],
+        public readonly ?string $source = null,
+    ) {
+        CareerCanonicalEligibilityLayer::assertValid($this->layer);
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        self::assertList('reasons', $this->reasons);
+        self::assertList('evidence', $this->evidence);
+
+        if ($this->source !== null && trim($this->source) === '') {
+            throw new InvalidArgumentException('Career canonical eligibility layer source must be null or a non-empty string.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public static function fromArray(array $value): self
+    {
+        return new self(
+            layer: self::requiredString($value, 'layer'),
+            status: self::requiredString($value, 'status'),
+            reasons: self::optionalList($value, 'reasons'),
+            evidence: self::optionalList($value, 'evidence'),
+            source: array_key_exists('source', $value) ? self::nullableString($value['source'], 'source') : null,
+        );
+    }
+
+    /**
+     * @return array{layer: string, status: string, reasons: list<string>, evidence: list<mixed>, source: string|null}
+     */
+    public function toArray(): array
+    {
+        return [
+            'layer' => $this->layer,
+            'status' => $this->status,
+            'reasons' => $this->reasons,
+            'evidence' => $this->evidence,
+            'source' => $this->source,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    private static function requiredString(array $value, string $key): string
+    {
+        if (! array_key_exists($key, $value) || ! is_string($value[$key]) || trim($value[$key]) === '') {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility layer status requires non-empty [%s].', $key));
+        }
+
+        return $value[$key];
+    }
+
+    private static function nullableString(mixed $value, string $key): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility layer status [%s] must be null or a non-empty string.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return list<mixed>
+     */
+    private static function optionalList(array $value, string $key): array
+    {
+        if (! array_key_exists($key, $value)) {
+            return [];
+        }
+
+        if (! is_array($value[$key])) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility layer status [%s] must be a list.', $key));
+        }
+
+        self::assertList($key, $value[$key]);
+
+        return $value[$key];
+    }
+
+    private static function assertList(string $key, array $value): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility layer status [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityReport.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityReport.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityReport
+{
+    /**
+     * @param  array<string, int>  $byReason
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly string $scope,
+        public readonly int $expectedOccupations,
+        public readonly int $auditedOccupations,
+        public readonly int $eligibleCount,
+        public readonly int $blockedCount,
+        public readonly array $byReason = [],
+        public readonly array $rows = [],
+        public readonly array $sidecars = [],
+    ) {
+        self::assertReportStatus($this->status);
+        CareerCanonicalEligibilityScope::assertValid($this->scope);
+        self::assertNonNegativeInt($this->expectedOccupations, 'expected_occupations');
+        self::assertNonNegativeInt($this->auditedOccupations, 'audited_occupations');
+        self::assertNonNegativeInt($this->eligibleCount, 'eligible_count');
+        self::assertNonNegativeInt($this->blockedCount, 'blocked_count');
+        self::assertByReason($this->byReason);
+        self::assertRows($this->rows);
+        self::assertSidecars($this->sidecars);
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public static function fromArray(array $value): self
+    {
+        return new self(
+            status: self::requiredString($value, 'status'),
+            scope: self::requiredString($value, 'scope'),
+            expectedOccupations: self::requiredInt($value, 'expected_occupations'),
+            auditedOccupations: self::requiredInt($value, 'audited_occupations'),
+            eligibleCount: self::requiredInt($value, 'eligible_count'),
+            blockedCount: self::requiredInt($value, 'blocked_count'),
+            byReason: self::optionalByReason($value, 'by_reason'),
+            rows: self::optionalRows($value, 'rows'),
+            sidecars: self::optionalSidecars($value, 'sidecars'),
+        );
+    }
+
+    /**
+     * @return array{status: string, scope: string, expected_occupations: int, audited_occupations: int, eligible_count: int, blocked_count: int, by_reason: array<string, int>, rows: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'scope' => $this->scope,
+            'expected_occupations' => $this->expectedOccupations,
+            'audited_occupations' => $this->auditedOccupations,
+            'eligible_count' => $this->eligibleCount,
+            'blocked_count' => $this->blockedCount,
+            'by_reason' => $this->byReason,
+            'rows' => array_map(
+                static fn (CareerCanonicalEligibilityAuditRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    /**
+     * @return list<CareerCanonicalEligibilitySidecar>
+     */
+    public function sidecarsThatBlockTrain(): array
+    {
+        return array_values(array_filter(
+            $this->sidecars,
+            static fn (CareerCanonicalEligibilitySidecar $sidecar): bool => ! $sidecar->canContinueTrain()
+        ));
+    }
+
+    public function canContinueTrain(): bool
+    {
+        return $this->sidecarsThatBlockTrain() === [];
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     * @return array<string, int>
+     */
+    public static function byReasonFromRows(array $rows): array
+    {
+        self::assertRows($rows);
+
+        $counts = [];
+        foreach ($rows as $row) {
+            foreach ($row->reasons as $reason) {
+                if (! is_string($reason) || trim($reason) === '') {
+                    throw new InvalidArgumentException('Career canonical eligibility row reasons must contain non-empty strings.');
+                }
+
+                $counts[$reason] = ($counts[$reason] ?? 0) + 1;
+            }
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    private static function assertReportStatus(string $value): void
+    {
+        if (! in_array($value, [
+            CareerCanonicalEligibilityStatus::PASS,
+            CareerCanonicalEligibilityStatus::FAIL,
+            CareerCanonicalEligibilityStatus::BLOCKED,
+        ], true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career canonical eligibility report status [%s].', $value));
+        }
+    }
+
+    private static function assertNonNegativeInt(int $value, string $key): void
+    {
+        if ($value < 0) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility report [%s] must be non-negative.', $key));
+        }
+    }
+
+    /**
+     * @param  array<string, int>  $byReason
+     */
+    private static function assertByReason(array $byReason): void
+    {
+        if (array_is_list($byReason) && $byReason !== []) {
+            throw new InvalidArgumentException('Career canonical eligibility report by_reason must be an object map.');
+        }
+
+        foreach ($byReason as $reason => $count) {
+            if (! is_string($reason) || trim($reason) === '' || ! is_int($count) || $count < 0) {
+                throw new InvalidArgumentException('Career canonical eligibility report by_reason must map non-empty reasons to non-negative integer counts.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career canonical eligibility report rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerCanonicalEligibilityAuditRow) {
+                throw new InvalidArgumentException('Career canonical eligibility report rows must contain audit row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career canonical eligibility report sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career canonical eligibility report sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    private static function requiredString(array $value, string $key): string
+    {
+        if (! array_key_exists($key, $value) || ! is_string($value[$key]) || trim($value[$key]) === '') {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility report requires non-empty [%s].', $key));
+        }
+
+        return $value[$key];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    private static function requiredInt(array $value, string $key): int
+    {
+        if (! array_key_exists($key, $value) || ! is_int($value[$key])) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility report requires integer [%s].', $key));
+        }
+
+        return $value[$key];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return array<string, int>
+     */
+    private static function optionalByReason(array $value, string $key): array
+    {
+        if (! array_key_exists($key, $value)) {
+            return [];
+        }
+
+        if (! is_array($value[$key])) {
+            throw new InvalidArgumentException('Career canonical eligibility report by_reason must be an object map.');
+        }
+
+        self::assertByReason($value[$key]);
+
+        return $value[$key];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return list<CareerCanonicalEligibilityAuditRow>
+     */
+    private static function optionalRows(array $value, string $key): array
+    {
+        if (! array_key_exists($key, $value)) {
+            return [];
+        }
+
+        if (! is_array($value[$key]) || ! array_is_list($value[$key])) {
+            throw new InvalidArgumentException('Career canonical eligibility report rows must be a list.');
+        }
+
+        return array_map(static function (mixed $row): CareerCanonicalEligibilityAuditRow {
+            if ($row instanceof CareerCanonicalEligibilityAuditRow) {
+                return $row;
+            }
+
+            if (! is_array($row)) {
+                throw new InvalidArgumentException('Career canonical eligibility report row item must be an object.');
+            }
+
+            return CareerCanonicalEligibilityAuditRow::fromArray($row);
+        }, $value[$key]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return list<CareerCanonicalEligibilitySidecar>
+     */
+    private static function optionalSidecars(array $value, string $key): array
+    {
+        if (! array_key_exists($key, $value)) {
+            return [];
+        }
+
+        if (! is_array($value[$key]) || ! array_is_list($value[$key])) {
+            throw new InvalidArgumentException('Career canonical eligibility report sidecars must be a list.');
+        }
+
+        return array_map(static function (mixed $sidecar): CareerCanonicalEligibilitySidecar {
+            if ($sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                return $sidecar;
+            }
+
+            if (! is_array($sidecar)) {
+                throw new InvalidArgumentException('Career canonical eligibility report sidecar item must be an object.');
+            }
+
+            return CareerCanonicalEligibilitySidecar::fromArray($sidecar);
+        }, $value[$key]);
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityScope.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityScope.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityScope
+{
+    public const ALL = 'all';
+
+    public const BATCH = 'batch';
+
+    public const SLUGS = 'slugs';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return [
+            self::ALL,
+            self::BATCH,
+            self::SLUGS,
+        ];
+    }
+
+    public static function assertValid(string $value): string
+    {
+        if (! in_array($value, self::values(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career canonical eligibility scope [%s].', $value));
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySeverity.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySeverity.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilitySeverity
+{
+    public const INFO = 'info';
+
+    public const LOW = 'low';
+
+    public const MEDIUM = 'medium';
+
+    public const HIGH = 'high';
+
+    public const BLOCKER_FOR_PUBLICATION = 'blocker_for_publication';
+
+    public const BLOCKER_FOR_FULL_2786_CLAIM = 'blocker_for_full_2786_claim';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return [
+            self::INFO,
+            self::LOW,
+            self::MEDIUM,
+            self::HIGH,
+            self::BLOCKER_FOR_PUBLICATION,
+            self::BLOCKER_FOR_FULL_2786_CLAIM,
+        ];
+    }
+
+    public static function assertValid(string $value): string
+    {
+        if (! in_array($value, self::values(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career canonical eligibility severity [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    public static function blocksInsideCurrentPr(string $value): bool
+    {
+        self::assertValid($value);
+
+        return in_array($value, [
+            self::HIGH,
+            self::BLOCKER_FOR_PUBLICATION,
+            self::BLOCKER_FOR_FULL_2786_CLAIM,
+        ], true);
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySidecar.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySidecar.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilitySidecar
+{
+    public const OWNER_REPO_FAP_API = 'fap-api';
+
+    public const OWNER_REPO_FAP_WEB = 'fap-web';
+
+    public const OWNER_REPO_EXTERNAL = 'external';
+
+    public const SCOPE_RELATION_EXTERNAL = 'external_to_current_pr';
+
+    public const SCOPE_RELATION_INSIDE = 'inside_current_pr';
+
+    /**
+     * @param  list<string>  $affectedSlugs
+     * @param  list<string>  $affectedLocales
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $sidecarId,
+        public readonly string $title,
+        public readonly string $ownerRepo,
+        public readonly string $scopeRelation,
+        public readonly bool $introducedByCurrentPr,
+        public readonly array $affectedSlugs,
+        public readonly array $affectedLocales,
+        public readonly array $evidence,
+        public readonly string $severity,
+        public readonly string $nextGoal,
+        public readonly bool $mayContinueTrain,
+    ) {
+        self::assertNonEmptyString($this->sidecarId, 'sidecar_id');
+        self::assertNonEmptyString($this->title, 'title');
+        self::assertValidOwnerRepo($this->ownerRepo);
+        self::assertValidScopeRelation($this->scopeRelation);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->nextGoal, 'next_goal');
+        self::assertListOfStrings('affected_slugs', $this->affectedSlugs);
+        self::assertListOfStrings('affected_locales', $this->affectedLocales);
+        self::assertList('evidence', $this->evidence);
+
+        if ($this->severity !== CareerCanonicalEligibilitySeverity::INFO && $this->evidence === []) {
+            throw new InvalidArgumentException('Career canonical eligibility sidecar evidence is required for non-info severity.');
+        }
+
+        if ($this->introducedByCurrentPr && $this->mayContinueTrain) {
+            throw new InvalidArgumentException('Career canonical eligibility sidecar introduced by the current PR cannot continue the train.');
+        }
+
+        if (
+            $this->scopeRelation === self::SCOPE_RELATION_INSIDE
+            && CareerCanonicalEligibilitySeverity::blocksInsideCurrentPr($this->severity)
+            && $this->mayContinueTrain
+        ) {
+            throw new InvalidArgumentException('Career canonical eligibility sidecar inside the current PR with high/blocker severity cannot continue the train.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public static function fromArray(array $value): self
+    {
+        return new self(
+            sidecarId: self::requiredString($value, 'sidecar_id'),
+            title: self::requiredString($value, 'title'),
+            ownerRepo: self::requiredString($value, 'owner_repo'),
+            scopeRelation: self::requiredString($value, 'scope_relation'),
+            introducedByCurrentPr: self::requiredBool($value, 'introduced_by_current_pr'),
+            affectedSlugs: self::requiredListOfStrings($value, 'affected_slugs'),
+            affectedLocales: self::requiredListOfStrings($value, 'affected_locales'),
+            evidence: self::requiredList($value, 'evidence'),
+            severity: self::requiredString($value, 'severity'),
+            nextGoal: self::requiredString($value, 'next_goal'),
+            mayContinueTrain: self::requiredBool($value, 'may_continue_train'),
+        );
+    }
+
+    /**
+     * @return array{sidecar_id: string, title: string, owner_repo: string, scope_relation: string, introduced_by_current_pr: bool, affected_slugs: list<string>, affected_locales: list<string>, evidence: list<mixed>, severity: string, next_goal: string, may_continue_train: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'sidecar_id' => $this->sidecarId,
+            'title' => $this->title,
+            'owner_repo' => $this->ownerRepo,
+            'scope_relation' => $this->scopeRelation,
+            'introduced_by_current_pr' => $this->introducedByCurrentPr,
+            'affected_slugs' => $this->affectedSlugs,
+            'affected_locales' => $this->affectedLocales,
+            'evidence' => $this->evidence,
+            'severity' => $this->severity,
+            'next_goal' => $this->nextGoal,
+            'may_continue_train' => $this->mayContinueTrain,
+        ];
+    }
+
+    public function canContinueTrain(): bool
+    {
+        return $this->mayContinueTrain;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function ownerRepos(): array
+    {
+        return [
+            self::OWNER_REPO_FAP_API,
+            self::OWNER_REPO_FAP_WEB,
+            self::OWNER_REPO_EXTERNAL,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function scopeRelations(): array
+    {
+        return [
+            self::SCOPE_RELATION_EXTERNAL,
+            self::SCOPE_RELATION_INSIDE,
+        ];
+    }
+
+    private static function assertValidOwnerRepo(string $value): void
+    {
+        if (! in_array($value, self::ownerRepos(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career canonical eligibility sidecar owner_repo [%s].', $value));
+        }
+    }
+
+    private static function assertValidScopeRelation(string $value): void
+    {
+        if (! in_array($value, self::scopeRelations(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career canonical eligibility sidecar scope_relation [%s].', $value));
+        }
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility sidecar requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    private static function requiredString(array $value, string $key): string
+    {
+        if (! array_key_exists($key, $value) || ! is_string($value[$key]) || trim($value[$key]) === '') {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility sidecar requires non-empty [%s].', $key));
+        }
+
+        return $value[$key];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    private static function requiredBool(array $value, string $key): bool
+    {
+        if (! array_key_exists($key, $value) || ! is_bool($value[$key])) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility sidecar requires boolean [%s].', $key));
+        }
+
+        return $value[$key];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return list<string>
+     */
+    private static function requiredListOfStrings(array $value, string $key): array
+    {
+        if (! array_key_exists($key, $value) || ! is_array($value[$key])) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility sidecar requires list [%s].', $key));
+        }
+
+        self::assertListOfStrings($key, $value[$key]);
+
+        return $value[$key];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return list<mixed>
+     */
+    private static function requiredList(array $value, string $key): array
+    {
+        if (! array_key_exists($key, $value) || ! is_array($value[$key])) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility sidecar requires list [%s].', $key));
+        }
+
+        self::assertList($key, $value[$key]);
+
+        return $value[$key];
+    }
+
+    private static function assertList(string $key, array $value): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career canonical eligibility sidecar [%s] must be a list.', $key));
+        }
+    }
+
+    private static function assertListOfStrings(string $key, array $value): void
+    {
+        self::assertList($key, $value);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career canonical eligibility sidecar [%s] must contain only non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityStatus.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityStatus.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityStatus
+{
+    public const PASS = 'pass';
+
+    public const FAIL = 'fail';
+
+    public const BLOCKED = 'blocked';
+
+    public const WARNING = 'warning';
+
+    public const UNVERIFIED = 'unverified';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return [
+            self::PASS,
+            self::FAIL,
+            self::BLOCKED,
+            self::WARNING,
+            self::UNVERIFIED,
+        ];
+    }
+
+    public static function assertValid(string $value): string
+    {
+        if (! in_array($value, self::values(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career canonical eligibility status [%s].', $value));
+        }
+
+        return $value;
+    }
+}

--- a/backend/docs/career/audits/canonical_eligibility_audit_schema.md
+++ b/backend/docs/career/audits/canonical_eligibility_audit_schema.md
@@ -1,0 +1,194 @@
+# Career Canonical Eligibility Audit Schema
+
+## Purpose
+
+AUDIT-1 defines the stable schema layer for the Career 2786 canonical eligibility audit train. It gives later AUDIT PRs a typed JSON contract for layer statuses, audit rows, report totals, sidecars, severity values, and train continuation decisions.
+
+AUDIT-1 is schema-only. It does not inspect production data, read the 2786 planner artifact, query the database, or claim that the full 2786 public resolution is complete.
+
+## Non-goals
+
+- No `career:audit-canonical-eligibility` command.
+- No 2786 public-resolution source resolver.
+- No occupation DB inventory.
+- No manifest train generator.
+- No live HTML validation.
+- No deployment, SSH, production mutation, backfill, rollback, quarantine, or Batch-001 apply action.
+
+## Row Schema
+
+Each row represents one slug/locale eligibility decision. The stable JSON key order is:
+
+```json
+{
+  "slug": "actuaries",
+  "locale": "en",
+  "source_scope": "batch",
+  "entity_status": {},
+  "baseline_status": {},
+  "index_status": {},
+  "runtime_status": {},
+  "seo_geo_status": {},
+  "surface_status": {},
+  "safety_status": {},
+  "overall_status": "pass",
+  "severity": "info",
+  "reasons": [],
+  "evidence": [],
+  "sidecars": []
+}
+```
+
+Layer status objects use:
+
+```json
+{
+  "layer": "entity",
+  "status": "pass",
+  "reasons": [],
+  "evidence": [],
+  "source": "db"
+}
+```
+
+`source_scope` values are `all`, `batch`, and `slugs`.
+
+## Layers
+
+- `entity`: the occupation entity exists and is addressable.
+- `baseline`: baseline/display metadata needed by public surfaces exists.
+- `index`: index-state authority allows publication or explains the hold.
+- `runtime`: backend runtime projection/truth is eligible.
+- `seo_geo`: sitemap, llms, canonical, and search metadata are eligible.
+- `surface`: API and frontend consumption surfaces are ready.
+- `safety`: policy, governance, and train-safety checks do not block continuation.
+
+## Status And Severity
+
+Status values are:
+
+- `pass`
+- `fail`
+- `blocked`
+- `warning`
+- `unverified`
+
+Severity values are:
+
+- `info`
+- `low`
+- `medium`
+- `high`
+- `blocker_for_publication`
+- `blocker_for_full_2786_claim`
+
+## Sidecar Schema
+
+Sidecars record blockers or external facts without mixing them into AUDIT-1 scope:
+
+```json
+{
+  "sidecar_id": "AUDIT-1-EXTERNAL-FAP-WEB-LIVE-ACCEPTANCE",
+  "title": "fap-web live HTML deploy pending",
+  "owner_repo": "fap-web",
+  "scope_relation": "external_to_current_pr",
+  "introduced_by_current_pr": false,
+  "affected_slugs": [],
+  "affected_locales": [],
+  "evidence": [
+    "AUDIT-1 is schema-only and does not deploy fap-web."
+  ],
+  "severity": "blocker_for_full_2786_claim",
+  "next_goal": "Complete frontend deployment and live acceptance outside AUDIT-1.",
+  "may_continue_train": true
+}
+```
+
+Allowed `owner_repo` values are `fap-api`, `fap-web`, and `external`. Allowed `scope_relation` values are `external_to_current_pr` and `inside_current_pr`.
+
+Validation rules:
+
+- `sidecar_id`, `title`, `owner_repo`, `scope_relation`, `severity`, and `next_goal` are required.
+- `introduced_by_current_pr` and `may_continue_train` must be booleans.
+- `affected_slugs`, `affected_locales`, and `evidence` must be lists.
+- Non-`info` sidecars must include evidence.
+- If `introduced_by_current_pr=true`, `may_continue_train` must be `false`.
+- If `scope_relation=inside_current_pr` and severity is `high`, `blocker_for_publication`, or `blocker_for_full_2786_claim`, `may_continue_train` must be `false`.
+
+## Report Schema
+
+The top-level report contract is:
+
+```json
+{
+  "status": "pass",
+  "scope": "all",
+  "expected_occupations": 2786,
+  "audited_occupations": 2786,
+  "eligible_count": 0,
+  "blocked_count": 0,
+  "by_reason": {},
+  "rows": [],
+  "sidecars": []
+}
+```
+
+AUDIT-1 only defines the shape. AUDIT-2+ will populate this contract from resolved sources and later inventory checks.
+
+## Continue And Stop Protocol
+
+External blockers can continue the train only when all of these are true:
+
+- They were not introduced by the current PR.
+- They are outside AUDIT-1 scope.
+- AUDIT-1 scope validation is green.
+- AUDIT-1 local tests pass.
+- Complete sidecar evidence exists.
+
+Current PR blockers cannot continue the train. Inside-current-PR high or blocker severity sidecars cannot continue the train.
+
+## Pending And Failed Checks
+
+Pending checks are a wait/poll state:
+
+- `CHECK_STATE=pending`
+- `ACTION=wait_or_poll`
+- `TRAIN_CONTINUE=WAITING_FOR_CHECKS`
+
+Failed checks require inspection, not an immediate stop:
+
+- `CHECK_STATE=failed`
+- `ACTION=inspect_failure`
+- If introduced by AUDIT-1, fix within AUDIT-1 scope, push, and wait again.
+- If pre-existing or external, record a complete sidecar and continue only when scope validation is green.
+
+## AUDIT-2+ Consumption
+
+AUDIT-2 should resolve the 2786 public-resolution source and then feed resolved slug/locale candidates into this schema. Later PRs should add inventory and eligibility logic by producing `CareerCanonicalEligibilityAuditRow` objects and rolling them into `CareerCanonicalEligibilityReport`.
+
+Later PRs must not change the JSON key order or value taxonomy without an explicit schema migration.
+
+## Sidecar Examples
+
+Example external blocker that may continue AUDIT-1:
+
+- `sidecar_id`: `AUDIT-1-EXTERNAL-FAP-WEB-LIVE-ACCEPTANCE`
+- `owner_repo`: `fap-web`
+- `scope_relation`: `external_to_current_pr`
+- `introduced_by_current_pr`: `false`
+- `severity`: `blocker_for_full_2786_claim`
+- `may_continue_train`: `true`
+
+Example AUDIT-2-owned blocker:
+
+- `sidecar_id`: `AUDIT-1-EXTERNAL-2786-PLANNER-SOURCE`
+- `owner_repo`: `external`
+- `scope_relation`: `external_to_current_pr`
+- `introduced_by_current_pr`: `false`
+- `severity`: `medium`
+- `next_goal`: `AUDIT-2 2786 public-resolution source resolver`
+- `may_continue_train`: `true`
+
+## Warning
+
+AUDIT-1 does not claim 2786 readiness. It only creates a stable schema, sidecar validation contract, continuation policy, and unit tests for future canonical eligibility audits.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerCanonicalEligibilityAuditSchemaTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerCanonicalEligibilityAuditSchemaTest.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityCheckProtocol;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayerStatus;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityScope;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySidecar;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class CareerCanonicalEligibilityAuditSchemaTest extends TestCase
+{
+    public function test_layer_status_serializes_to_stable_json(): void
+    {
+        $status = new CareerCanonicalEligibilityLayerStatus(
+            layer: CareerCanonicalEligibilityLayer::ENTITY,
+            status: CareerCanonicalEligibilityStatus::PASS,
+            source: 'db',
+        );
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "layer": "entity",
+    "status": "pass",
+    "reasons": [],
+    "evidence": [],
+    "source": "db"
+}
+JSON,
+            json_encode($status->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_sidecar_serializes_to_stable_json(): void
+    {
+        $sidecar = $this->externalSidecar();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "sidecar_id": "AUDIT-1-EXTERNAL-FAP-WEB-LIVE-ACCEPTANCE",
+    "title": "fap-web live HTML deploy pending",
+    "owner_repo": "fap-web",
+    "scope_relation": "external_to_current_pr",
+    "introduced_by_current_pr": false,
+    "affected_slugs": [],
+    "affected_locales": [],
+    "evidence": [
+        "AUDIT-1 is schema-only and does not deploy fap-web."
+    ],
+    "severity": "blocker_for_full_2786_claim",
+    "next_goal": "Complete frontend deployment and live acceptance outside AUDIT-1.",
+    "may_continue_train": true
+}
+JSON,
+            json_encode($sidecar->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_complete_external_sidecar_can_continue_train(): void
+    {
+        $this->assertTrue($this->externalSidecar()->canContinueTrain());
+    }
+
+    public function test_current_pr_blocker_cannot_continue_train(): void
+    {
+        $sidecar = new CareerCanonicalEligibilitySidecar(
+            sidecarId: 'AUDIT-1-CURRENT-PR-BLOCKER',
+            title: 'Current PR introduced schema blocker',
+            ownerRepo: CareerCanonicalEligibilitySidecar::OWNER_REPO_FAP_API,
+            scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_INSIDE,
+            introducedByCurrentPr: true,
+            affectedSlugs: [],
+            affectedLocales: [],
+            evidence: ['The current PR introduced the blocker.'],
+            severity: CareerCanonicalEligibilitySeverity::HIGH,
+            nextGoal: 'Fix inside AUDIT-1 before continuing.',
+            mayContinueTrain: false,
+        );
+
+        $this->assertFalse($sidecar->canContinueTrain());
+    }
+
+    public function test_missing_evidence_fails_validation_for_non_info_sidecar(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('evidence is required');
+
+        new CareerCanonicalEligibilitySidecar(
+            sidecarId: 'AUDIT-1-MISSING-EVIDENCE',
+            title: 'Missing evidence',
+            ownerRepo: CareerCanonicalEligibilitySidecar::OWNER_REPO_EXTERNAL,
+            scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_EXTERNAL,
+            introducedByCurrentPr: false,
+            affectedSlugs: [],
+            affectedLocales: [],
+            evidence: [],
+            severity: CareerCanonicalEligibilitySeverity::LOW,
+            nextGoal: 'Add evidence.',
+            mayContinueTrain: true,
+        );
+    }
+
+    public function test_audit_row_serializes_with_all_seven_layers(): void
+    {
+        $row = $this->passingRow();
+
+        $this->assertSame([
+            'slug',
+            'locale',
+            'source_scope',
+            'entity_status',
+            'baseline_status',
+            'index_status',
+            'runtime_status',
+            'seo_geo_status',
+            'surface_status',
+            'safety_status',
+            'overall_status',
+            'severity',
+            'reasons',
+            'evidence',
+            'sidecars',
+        ], array_keys($row->toArray()));
+
+        $this->assertSame(CareerCanonicalEligibilityLayer::ENTITY, $row->toArray()['entity_status']['layer']);
+        $this->assertSame(CareerCanonicalEligibilityLayer::BASELINE, $row->toArray()['baseline_status']['layer']);
+        $this->assertSame(CareerCanonicalEligibilityLayer::INDEX, $row->toArray()['index_status']['layer']);
+        $this->assertSame(CareerCanonicalEligibilityLayer::RUNTIME, $row->toArray()['runtime_status']['layer']);
+        $this->assertSame(CareerCanonicalEligibilityLayer::SEO_GEO, $row->toArray()['seo_geo_status']['layer']);
+        $this->assertSame(CareerCanonicalEligibilityLayer::SURFACE, $row->toArray()['surface_status']['layer']);
+        $this->assertSame(CareerCanonicalEligibilityLayer::SAFETY, $row->toArray()['safety_status']['layer']);
+    }
+
+    public function test_report_serializes_expected_top_level_schema(): void
+    {
+        $report = new CareerCanonicalEligibilityReport(
+            status: CareerCanonicalEligibilityStatus::PASS,
+            scope: CareerCanonicalEligibilityScope::ALL,
+            expectedOccupations: 2786,
+            auditedOccupations: 2786,
+            eligibleCount: 0,
+            blockedCount: 0,
+        );
+
+        $this->assertSame([
+            'status' => 'pass',
+            'scope' => 'all',
+            'expected_occupations' => 2786,
+            'audited_occupations' => 2786,
+            'eligible_count' => 0,
+            'blocked_count' => 0,
+            'by_reason' => [],
+            'rows' => [],
+            'sidecars' => [],
+        ], $report->toArray());
+    }
+
+    public function test_report_can_identify_train_blocking_sidecars(): void
+    {
+        $blocking = new CareerCanonicalEligibilitySidecar(
+            sidecarId: 'AUDIT-1-CURRENT-PR-BLOCKER',
+            title: 'Current PR introduced schema blocker',
+            ownerRepo: CareerCanonicalEligibilitySidecar::OWNER_REPO_FAP_API,
+            scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_INSIDE,
+            introducedByCurrentPr: true,
+            affectedSlugs: [],
+            affectedLocales: [],
+            evidence: ['The current PR introduced the blocker.'],
+            severity: CareerCanonicalEligibilitySeverity::HIGH,
+            nextGoal: 'Fix inside AUDIT-1 before continuing.',
+            mayContinueTrain: false,
+        );
+        $report = new CareerCanonicalEligibilityReport(
+            status: CareerCanonicalEligibilityStatus::BLOCKED,
+            scope: CareerCanonicalEligibilityScope::BATCH,
+            expectedOccupations: 58,
+            auditedOccupations: 58,
+            eligibleCount: 57,
+            blockedCount: 1,
+            sidecars: [$this->externalSidecar(), $blocking],
+        );
+
+        $this->assertFalse($report->canContinueTrain());
+        $this->assertSame([$blocking], $report->sidecarsThatBlockTrain());
+    }
+
+    public function test_schema_distinguishes_external_to_current_pr_vs_inside_current_pr(): void
+    {
+        $external = $this->externalSidecar();
+        $inside = new CareerCanonicalEligibilitySidecar(
+            sidecarId: 'AUDIT-1-INSIDE-LOW',
+            title: 'Inside current PR low severity note',
+            ownerRepo: CareerCanonicalEligibilitySidecar::OWNER_REPO_FAP_API,
+            scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_INSIDE,
+            introducedByCurrentPr: false,
+            affectedSlugs: [],
+            affectedLocales: [],
+            evidence: ['Scoped note has evidence.'],
+            severity: CareerCanonicalEligibilitySeverity::LOW,
+            nextGoal: 'Resolve within current PR if needed.',
+            mayContinueTrain: true,
+        );
+
+        $this->assertSame('external_to_current_pr', $external->scopeRelation);
+        $this->assertSame('inside_current_pr', $inside->scopeRelation);
+    }
+
+    public function test_severity_values_are_stable(): void
+    {
+        $this->assertSame([
+            'info',
+            'low',
+            'medium',
+            'high',
+            'blocker_for_publication',
+            'blocker_for_full_2786_claim',
+        ], CareerCanonicalEligibilitySeverity::values());
+    }
+
+    public function test_pending_check_state_is_not_treated_as_blocker(): void
+    {
+        $this->assertSame(
+            CareerCanonicalEligibilityCheckProtocol::ACTION_WAIT_OR_POLL,
+            CareerCanonicalEligibilityCheckProtocol::actionForState(CareerCanonicalEligibilityCheckProtocol::STATE_PENDING)
+        );
+        $this->assertFalse(CareerCanonicalEligibilityCheckProtocol::isImmediateStop(CareerCanonicalEligibilityCheckProtocol::STATE_PENDING));
+        $this->assertSame(
+            CareerCanonicalEligibilityCheckProtocol::TRAIN_CONTINUE_WAITING_FOR_CHECKS,
+            CareerCanonicalEligibilityCheckProtocol::trainContinueForState(CareerCanonicalEligibilityCheckProtocol::STATE_PENDING)
+        );
+    }
+
+    public function test_failed_check_state_requires_inspect_fix_loop_not_immediate_stop(): void
+    {
+        $this->assertSame(
+            CareerCanonicalEligibilityCheckProtocol::ACTION_INSPECT_FAILURE,
+            CareerCanonicalEligibilityCheckProtocol::actionForState(CareerCanonicalEligibilityCheckProtocol::STATE_FAILED)
+        );
+        $this->assertFalse(CareerCanonicalEligibilityCheckProtocol::isImmediateStop(CareerCanonicalEligibilityCheckProtocol::STATE_FAILED));
+    }
+
+    public function test_current_pr_introduced_failure_requires_may_continue_train_false(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('introduced by the current PR cannot continue');
+
+        new CareerCanonicalEligibilitySidecar(
+            sidecarId: 'AUDIT-1-CURRENT-PR-FAILURE',
+            title: 'Current PR introduced CI failure',
+            ownerRepo: CareerCanonicalEligibilitySidecar::OWNER_REPO_FAP_API,
+            scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_INSIDE,
+            introducedByCurrentPr: true,
+            affectedSlugs: [],
+            affectedLocales: [],
+            evidence: ['Failed check was introduced by this PR.'],
+            severity: CareerCanonicalEligibilitySeverity::HIGH,
+            nextGoal: 'Fix in AUDIT-1 and push a follow-up commit.',
+            mayContinueTrain: true,
+        );
+    }
+
+    public function test_external_pre_existing_failure_can_be_sidecar_continued_when_evidence_exists(): void
+    {
+        $sidecar = CareerCanonicalEligibilitySidecar::fromArray([
+            'sidecar_id' => 'AUDIT-1-EXTERNAL-PRE-EXISTING-CHECK',
+            'title' => 'Pre-existing external check failure',
+            'owner_repo' => 'external',
+            'scope_relation' => 'external_to_current_pr',
+            'introduced_by_current_pr' => false,
+            'affected_slugs' => [],
+            'affected_locales' => [],
+            'evidence' => ['The failure predates AUDIT-1 and does not touch schema scope.'],
+            'severity' => 'medium',
+            'next_goal' => 'Track externally while AUDIT-1 continues.',
+            'may_continue_train' => true,
+        ]);
+
+        $this->assertTrue($sidecar->canContinueTrain());
+    }
+
+    private function passingRow(): CareerCanonicalEligibilityAuditRow
+    {
+        return new CareerCanonicalEligibilityAuditRow(
+            slug: 'actuaries',
+            locale: 'en',
+            sourceScope: CareerCanonicalEligibilityScope::BATCH,
+            entityStatus: $this->layer(CareerCanonicalEligibilityLayer::ENTITY),
+            baselineStatus: $this->layer(CareerCanonicalEligibilityLayer::BASELINE),
+            indexStatus: $this->layer(CareerCanonicalEligibilityLayer::INDEX),
+            runtimeStatus: $this->layer(CareerCanonicalEligibilityLayer::RUNTIME),
+            seoGeoStatus: $this->layer(CareerCanonicalEligibilityLayer::SEO_GEO),
+            surfaceStatus: $this->layer(CareerCanonicalEligibilityLayer::SURFACE),
+            safetyStatus: $this->layer(CareerCanonicalEligibilityLayer::SAFETY),
+            overallStatus: CareerCanonicalEligibilityStatus::PASS,
+            severity: CareerCanonicalEligibilitySeverity::INFO,
+        );
+    }
+
+    private function layer(string $layer): CareerCanonicalEligibilityLayerStatus
+    {
+        return new CareerCanonicalEligibilityLayerStatus(
+            layer: $layer,
+            status: CareerCanonicalEligibilityStatus::PASS,
+            source: 'schema_fixture',
+        );
+    }
+
+    private function externalSidecar(): CareerCanonicalEligibilitySidecar
+    {
+        return new CareerCanonicalEligibilitySidecar(
+            sidecarId: 'AUDIT-1-EXTERNAL-FAP-WEB-LIVE-ACCEPTANCE',
+            title: 'fap-web live HTML deploy pending',
+            ownerRepo: CareerCanonicalEligibilitySidecar::OWNER_REPO_FAP_WEB,
+            scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_EXTERNAL,
+            introducedByCurrentPr: false,
+            affectedSlugs: [],
+            affectedLocales: [],
+            evidence: ['AUDIT-1 is schema-only and does not deploy fap-web.'],
+            severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_FULL_2786_CLAIM,
+            nextGoal: 'Complete frontend deployment and live acceptance outside AUDIT-1.',
+            mayContinueTrain: true,
+        );
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -251,6 +251,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_canonical_eligibility_audit_schema_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRow.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityCheckProtocol.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayer.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayerStatus.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityReport.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityScope.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySeverity.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySidecar.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityStatus.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -849,6 +866,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerCanonicalEligibilityAuditSchemaFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1097,6 +1118,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthValidator.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php',
+        ], true);
+    }
+
+    private function isCareerCanonicalEligibilityAuditSchemaFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRow.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityCheckProtocol.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayer.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayerStatus.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityReport.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityScope.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySeverity.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySidecar.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityStatus.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1048,6 +1048,7 @@
         "backend/app/Domain/Career/Audit/*",
         "backend/tests/Unit/Domain/Career/Audit/*",
         "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-12T14:33:39+08:00",
+  "updated_at": "2026-05-12T16:44:41+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -1036,6 +1036,41 @@
       "depends_on": [
         "iq-svg-asset-freeze-hash-verification"
       ]
+    },
+    "AUDIT-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-audit-schema-audit1-202605121641",
+      "title": "feat(api): add career canonical eligibility audit schema",
+      "name": "Career Canonical Eligibility Audit Schema + Sidecar Schema",
+      "status": "in_progress",
+      "scope_type": "schema_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no audit command",
+        "no 2786 resolver",
+        "no DB inventory",
+        "no manifest train generator",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized registering AUDIT-1 in docs/codex/pr-train.yaml and docs/codex/pr-train-state.json only."
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-2 2786 public-resolution source resolver",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -483,10 +483,12 @@ prs:
       - Add sidecar validation for continuation and stop logic.
       - Document AUDIT-1 schema and PR train policy.
       - Add unit tests proving JSON stability and sidecar continuation logic.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-1 schema-only Career audit files.
     allowed_paths:
       - backend/app/Domain/Career/Audit/*
       - backend/tests/Unit/Domain/Career/Audit/*
       - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -472,3 +472,36 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-1
+    repo: fap-api
+    branch: fix/career-audit-schema-audit1-202605121641
+    title: "feat(api): add career canonical eligibility audit schema"
+    name: "Career Canonical Eligibility Audit Schema + Sidecar Schema"
+    scope_type: schema_only
+    scope:
+      - Add Career canonical eligibility audit row, layer status, report, sidecar, status, severity, layer, scope, and check protocol schema contracts.
+      - Add sidecar validation for continuation and stop logic.
+      - Document AUDIT-1 schema and PR train policy.
+      - Add unit tests proving JSON stability and sidecar continuation logic.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add a career canonical eligibility audit command.
+      - Add a 2786 public-resolution resolver.
+      - Add DB inventory.
+      - Add a manifest train generator.
+      - Mutate production data.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - bash backend/scripts/ci_verify_mbti.sh
+    next_pr: "AUDIT-2 2786 public-resolution source resolver"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary

- Adds the AUDIT-1 schema-only Career canonical eligibility audit namespace.
- Defines stable DTO/value-set contracts for audit rows, layer statuses, reports, sidecars, statuses, severities, layers, scopes, and check handling.
- Adds sidecar train policy validation and unit coverage for continuation/stop logic.
- Documents the schema contract and AUDIT-1 PR train policy.
- Updates `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json` with explicit user authorization.
- Adds a scoped BigFive runtime freeze classifier allowlist entry for the AUDIT-1 schema-only Career audit files after GitHub CI identified them as current-PR runtime-path noise.

## Scope boundaries

- Schema-only.
- No DB mutation.
- No production commands.
- No 2786 resolver yet.
- No audit command yet.
- No deployment.
- No fap-web changes.
- Batch-001 full live acceptance has passed.
- Next PR is AUDIT-2 public-resolution source resolver.

## Train checks protocol

- Sidecar train policy included.
- Pending checks are wait/poll state, not blockers.
- Failed checks are inspect/fix/push/wait loop, not immediate stop.

## Validation

- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` - PASS, 14 tests / 28 assertions.
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_paths_have_no_uncommitted_diff|career_canonical_eligibility_audit_schema" --display-warnings --no-ansi` - PASS, 2 tests / 4 assertions.
- `vendor/bin/pint --test` - PASS, 3055 files.
- `git diff --check` - PASS.
- `php artisan route:list --no-ansi` - PASS, 197 routes.
- `bash backend/scripts/ci_verify_mbti.sh` - PASS.

## Notes

- Default `php artisan migrate` was not run because AUDIT-1 explicitly forbids DB mutation. The MBTI CI chain used its own SQLite `/tmp/fap-ci.sqlite` database.
