### PR TITLE
feat(iq): import showcase and beta item banks

### DIFF
--- a/backend/scripts/iq/build_showcase12_beta_bank.php
+++ b/backend/scripts/iq/build_showcase12_beta_bank.php
@@ -1,0 +1,50 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_showcase12_bank_lib.php';
+
+function iqShowcase12BuildFail(string $message, int $code = 1): never
+{
+    fwrite(STDERR, "[iq-showcase12-build] {$message}\n");
+    exit($code);
+}
+
+$options = getopt('', ['check']);
+$checkOnly = array_key_exists('check', $options);
+$fileMap = iqShowcase12FileMap();
+$payloads = iqShowcase12BankPayloads();
+
+if (! is_dir(iqShowcase12BankDir()) && ! mkdir(iqShowcase12BankDir(), 0777, true) && ! is_dir(iqShowcase12BankDir())) {
+    iqShowcase12BuildFail('failed to create bank dir: '.iqShowcase12BankDir(), 2);
+}
+
+try {
+    foreach ($payloads as $key => $payload) {
+        $targetPath = $fileMap[$key] ?? null;
+        if (! is_string($targetPath) || $targetPath === '') {
+            iqShowcase12BuildFail('missing target path for payload: '.$key, 3);
+        }
+
+        $encoded = iqSvgPrettyJson($payload).PHP_EOL;
+        if ($checkOnly) {
+            $existing = is_file($targetPath) ? file_get_contents($targetPath) : false;
+            if (! is_string($existing) || $existing !== $encoded) {
+                iqShowcase12BuildFail('bank artifact drift detected: '.iqSvgRelativePath($targetPath), 4);
+            }
+
+            fwrite(STDOUT, '[iq-showcase12-build] verified '.iqSvgRelativePath($targetPath).PHP_EOL);
+
+            continue;
+        }
+
+        if (file_put_contents($targetPath, $encoded) === false) {
+            iqShowcase12BuildFail('failed to write artifact: '.iqSvgRelativePath($targetPath), 5);
+        }
+
+        fwrite(STDOUT, '[iq-showcase12-build] wrote '.iqSvgRelativePath($targetPath).PHP_EOL);
+    }
+} catch (Throwable $throwable) {
+    iqShowcase12BuildFail($throwable->getMessage(), 10);
+}

--- a/backend/scripts/iq/iq_showcase12_bank_lib.php
+++ b/backend/scripts/iq/iq_showcase12_bank_lib.php
@@ -1,0 +1,767 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_svg_provenance_lib.php';
+
+const IQ_SHOWCASE12_SCHEMA_VERSION = 'fm.iq.item_bank_manifest.v1';
+const IQ_SHOWCASE12_ITEM_SCHEMA_VERSION = 'fm.iq.item_bank.items.v1';
+const IQ_SHOWCASE12_ANSWER_KEY_SCHEMA_VERSION = 'fm.iq.answer_key.v1';
+const IQ_SHOWCASE12_BANK_ID = 'IQ_SHOWCASE_12_BETA';
+const IQ_SHOWCASE12_GENERATOR_VERSION = 'iq_showcase12_generator_v1';
+const IQ_SHOWCASE12_THEME_VERSION = 'iq_showcase12_theme_v1';
+
+function iqShowcase12BankDir(): string
+{
+    return iqSvgRepoRoot().'/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/'.IQ_SHOWCASE12_BANK_ID;
+}
+
+/**
+ * @return array<string, string>
+ */
+function iqShowcase12FileMap(): array
+{
+    $bankDir = iqShowcase12BankDir();
+
+    return [
+        'manifest' => $bankDir.'/manifest.json',
+        'items' => $bankDir.'/items.json',
+        'answer_key' => $bankDir.'/answer_key.json',
+        'scoring_spec' => $bankDir.'/scoring_spec.json',
+    ];
+}
+
+/**
+ * @return array<string, string>
+ */
+function iqShowcase12DimensionNames(): array
+{
+    return [
+        'VSPR' => '视觉空间模式推理',
+        'VSI' => '视觉空间洞察',
+        'NPR' => '数字规律推理',
+    ];
+}
+
+function iqShowcase12Escape(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES | ENT_XML1, 'UTF-8');
+}
+
+function iqShowcase12Asset(string $viewBox, array $elements): array
+{
+    $markup = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="'.$viewBox.'" fill="none">'
+        .implode('', $elements)
+        .'</svg>';
+
+    return [
+        'kind' => 'inline_svg_markup',
+        'mime_type' => 'image/svg+xml',
+        'view_box' => $viewBox,
+        'svg_markup' => $markup,
+    ];
+}
+
+function iqShowcase12Rect(
+    int $x,
+    int $y,
+    int $width,
+    int $height,
+    string $fill = 'none',
+    string $stroke = '#111111',
+    int $strokeWidth = 4,
+    int $radius = 0
+): string {
+    return sprintf(
+        '<rect x="%d" y="%d" width="%d" height="%d" rx="%d" fill="%s" stroke="%s" stroke-width="%d"/>',
+        $x,
+        $y,
+        $width,
+        $height,
+        $radius,
+        iqShowcase12Escape($fill),
+        iqShowcase12Escape($stroke),
+        $strokeWidth
+    );
+}
+
+function iqShowcase12Circle(
+    int $cx,
+    int $cy,
+    int $radius,
+    string $fill = 'none',
+    string $stroke = '#111111',
+    int $strokeWidth = 4
+): string {
+    return sprintf(
+        '<circle cx="%d" cy="%d" r="%d" fill="%s" stroke="%s" stroke-width="%d"/>',
+        $cx,
+        $cy,
+        $radius,
+        iqShowcase12Escape($fill),
+        iqShowcase12Escape($stroke),
+        $strokeWidth
+    );
+}
+
+function iqShowcase12Line(
+    int $x1,
+    int $y1,
+    int $x2,
+    int $y2,
+    string $stroke = '#111111',
+    int $strokeWidth = 4
+): string {
+    return sprintf(
+        '<line x1="%d" y1="%d" x2="%d" y2="%d" stroke="%s" stroke-width="%d" stroke-linecap="round"/>',
+        $x1,
+        $y1,
+        $x2,
+        $y2,
+        iqShowcase12Escape($stroke),
+        $strokeWidth
+    );
+}
+
+function iqShowcase12Polygon(
+    string $points,
+    string $fill = 'none',
+    string $stroke = '#111111',
+    int $strokeWidth = 4
+): string {
+    return sprintf(
+        '<polygon points="%s" fill="%s" stroke="%s" stroke-width="%d" stroke-linejoin="round"/>',
+        iqShowcase12Escape($points),
+        iqShowcase12Escape($fill),
+        iqShowcase12Escape($stroke),
+        $strokeWidth
+    );
+}
+
+function iqShowcase12Text(
+    int $x,
+    int $y,
+    string $text,
+    int $fontSize = 14,
+    string $weight = '600',
+    string $anchor = 'middle'
+): string {
+    return sprintf(
+        '<text x="%d" y="%d" font-size="%d" font-family="Arial, sans-serif" font-weight="%s" text-anchor="%s" fill="#111111">%s</text>',
+        $x,
+        $y,
+        $fontSize,
+        iqShowcase12Escape($weight),
+        iqShowcase12Escape($anchor),
+        iqShowcase12Escape($text)
+    );
+}
+
+function iqShowcase12SquareCountAsset(int $count): array
+{
+    $elements = [];
+    for ($index = 0; $index < $count; $index++) {
+        $elements[] = iqShowcase12Rect(12 + ($index * 20), 44, 14, 14, '#111111', '#111111', 2, 2);
+    }
+
+    return iqShowcase12Asset('0 0 120 120', $elements);
+}
+
+function iqShowcase12ArrowAsset(int $rotationDegrees): array
+{
+    $elements = [
+        sprintf(
+            '<g transform="rotate(%d 60 60)">%s%s</g>',
+            $rotationDegrees,
+            iqShowcase12Line(24, 60, 92, 60, '#111111', 6),
+            iqShowcase12Polygon('92,60 74,48 74,72', '#111111', '#111111', 2)
+        ),
+    ];
+
+    return iqShowcase12Asset('0 0 120 120', $elements);
+}
+
+function iqShowcase12CornerDotAsset(string $corner): array
+{
+    $positions = [
+        'TL' => [28, 28],
+        'TR' => [92, 28],
+        'BR' => [92, 92],
+        'BL' => [28, 92],
+    ];
+
+    [$cx, $cy] = $positions[$corner];
+
+    return iqShowcase12Asset('0 0 120 120', [
+        iqShowcase12Rect(16, 16, 88, 88, 'none', '#111111', 4, 6),
+        iqShowcase12Circle($cx, $cy, 10, '#111111', '#111111', 2),
+    ]);
+}
+
+function iqShowcase12OutlineShapeAsset(string $shape, bool $filled): array
+{
+    $fill = $filled ? '#111111' : 'none';
+    $strokeWidth = $filled ? 2 : 4;
+
+    return match ($shape) {
+        'circle' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Circle(60, 60, 26, $fill, '#111111', $strokeWidth),
+        ]),
+        'square' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Rect(32, 32, 56, 56, $fill, '#111111', $strokeWidth, 4),
+        ]),
+        'triangle' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Polygon('60,24 92,88 28,88', $fill, '#111111', $strokeWidth),
+        ]),
+        default => throw new RuntimeException('unsupported shape: '.$shape),
+    };
+}
+
+function iqShowcase12HiddenShapeOption(string $variant): array
+{
+    return match ($variant) {
+        'correct' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Line(28, 28, 28, 88),
+            iqShowcase12Line(28, 88, 88, 88),
+            iqShowcase12Line(28, 58, 88, 58),
+        ]),
+        'rotated' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Line(28, 28, 88, 28),
+            iqShowcase12Line(88, 28, 88, 88),
+            iqShowcase12Line(58, 28, 58, 88),
+        ]),
+        'mirror' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Line(88, 28, 88, 88),
+            iqShowcase12Line(28, 88, 88, 88),
+            iqShowcase12Line(28, 58, 88, 58),
+        ]),
+        'other' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Line(28, 28, 88, 88),
+            iqShowcase12Line(88, 28, 28, 88),
+        ]),
+        default => throw new RuntimeException('unsupported hidden-shape variant: '.$variant),
+    };
+}
+
+function iqShowcase12PolyominoAsset(string $transform): array
+{
+    $base = [
+        iqShowcase12Rect(34, 34, 20, 20, '#111111', '#111111', 2, 3),
+        iqShowcase12Rect(34, 56, 20, 20, '#111111', '#111111', 2, 3),
+        iqShowcase12Rect(56, 56, 20, 20, '#111111', '#111111', 2, 3),
+    ];
+
+    return iqShowcase12Asset('0 0 120 120', [
+        sprintf('<g transform="%s">%s</g>', iqShowcase12Escape($transform), implode('', $base)),
+    ]);
+}
+
+function iqShowcase12AssemblyPieceAsset(string $piece): array
+{
+    return match ($piece) {
+        'small_square' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Rect(40, 40, 28, 28, '#111111', '#111111', 2, 3),
+        ]),
+        'vertical_bar' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Rect(46, 24, 20, 64, '#111111', '#111111', 2, 3),
+        ]),
+        'l_piece' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Rect(28, 28, 20, 52, '#111111', '#111111', 2, 3),
+            iqShowcase12Rect(48, 60, 28, 20, '#111111', '#111111', 2, 3),
+        ]),
+        'triangle' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Polygon('28,88 88,88 88,28', '#111111', '#111111', 2),
+        ]),
+        default => throw new RuntimeException('unsupported assembly piece: '.$piece),
+    };
+}
+
+function iqShowcase12PatternOption(string $variant): array
+{
+    return match ($variant) {
+        'cross' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Line(60, 20, 60, 100, '#111111', 8),
+            iqShowcase12Line(20, 60, 100, 60, '#111111', 8),
+        ]),
+        'x' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Line(24, 24, 96, 96, '#111111', 8),
+            iqShowcase12Line(96, 24, 24, 96, '#111111', 8),
+        ]),
+        'concentric' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Circle(60, 60, 28, 'none', '#111111', 6),
+            iqShowcase12Circle(60, 60, 10, '#111111', '#111111', 2),
+        ]),
+        'asymmetric' => iqShowcase12Asset('0 0 120 120', [
+            iqShowcase12Circle(42, 60, 12, '#111111', '#111111', 2),
+            iqShowcase12Circle(78, 42, 12, '#111111', '#111111', 2),
+            iqShowcase12Circle(78, 78, 12, '#111111', '#111111', 2),
+        ]),
+        default => throw new RuntimeException('unsupported pattern option: '.$variant),
+    };
+}
+
+function iqShowcase12NumberCardAsset(string $value): array
+{
+    return iqShowcase12Asset('0 0 120 120', [
+        iqShowcase12Rect(16, 20, 88, 80, '#F8FAFC', '#111111', 4, 8),
+        iqShowcase12Text(60, 72, $value, 26, '700'),
+    ]);
+}
+
+function iqShowcase12PromptCardAsset(array $lines): array
+{
+    $elements = [
+        iqShowcase12Rect(10, 14, 100, 92, '#F8FAFC', '#111111', 3, 8),
+    ];
+
+    foreach (array_values($lines) as $index => $line) {
+        $elements[] = iqShowcase12Text(60, 36 + ($index * 18), $line, 13, '600');
+    }
+
+    return iqShowcase12Asset('0 0 120 120', $elements);
+}
+
+/**
+ * @param  array<int, array<string, mixed>>  $optionAssets
+ * @param  array<string, mixed>  $params
+ * @return array<string, mixed>
+ */
+function iqShowcase12Item(
+    string $questionId,
+    string $itemId,
+    string $dimension,
+    string $itemFamily,
+    string $difficultyLevel,
+    string $correctAnswer,
+    string $templateKey,
+    string $solutionRule,
+    string $distractorLogic,
+    array $params,
+    array $stemAsset,
+    array $optionAssets
+): array {
+    $dimensionNames = iqShowcase12DimensionNames();
+    $assetHashes = [
+        'stem' => iqSvgSha256Json($stemAsset),
+        'options' => [],
+    ];
+
+    foreach ($optionAssets as $optionAsset) {
+        $code = (string) ($optionAsset['code'] ?? '');
+        $assetHashes['options'][$code] = iqSvgSha256Json($optionAsset['asset'] ?? []);
+    }
+
+    return [
+        'schema_version' => IQ_SHOWCASE12_ITEM_SCHEMA_VERSION,
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'bank_id' => IQ_SHOWCASE12_BANK_ID,
+        'status' => 'beta',
+        'question_id' => $questionId,
+        'item_id' => $itemId,
+        'dimension' => $dimension,
+        'dimension_name' => $dimensionNames[$dimension],
+        'item_family' => $itemFamily,
+        'difficulty_level' => $difficultyLevel,
+        'correct_answer' => $correctAnswer,
+        'solution_rule' => $solutionRule,
+        'distractor_logic' => $distractorLogic,
+        'option_count' => count($optionAssets),
+        'assets' => [
+            'stem' => $stemAsset,
+            'options' => $optionAssets,
+        ],
+        'asset_hashes' => $assetHashes,
+        'generator_metadata' => [
+            'generator_version' => IQ_SHOWCASE12_GENERATOR_VERSION,
+            'theme_version' => IQ_SHOWCASE12_THEME_VERSION,
+            'seed' => strtolower($questionId).'_seed',
+            'params_hash' => iqSvgSha256Json($params),
+            'template_key' => $templateKey,
+            'source_mode' => 'repo_generated',
+        ],
+    ];
+}
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function iqShowcase12Items(): array
+{
+    return [
+        iqShowcase12Item(
+            'IQS12_Q01',
+            'FM-IQ-VSPR-MX-L2-SH001',
+            'VSPR',
+            'matrix_reasoning',
+            'L2',
+            'A',
+            'matrix_square_count_v1',
+            'The square count increases by one across the sequence, so the next panel needs four filled squares.',
+            'The distractors keep the same visual style but use lower or higher square counts to catch undercounting.',
+            ['counts' => [1, 2, 3, 4]],
+            iqShowcase12PromptCardAsset(['1 square', '2 squares', '3 squares', 'next = ?']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12SquareCountAsset(4)],
+                ['code' => 'B', 'asset' => iqShowcase12SquareCountAsset(1)],
+                ['code' => 'C', 'asset' => iqShowcase12SquareCountAsset(5)],
+                ['code' => 'D', 'asset' => iqShowcase12SquareCountAsset(2)],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q02',
+            'FM-IQ-VSPR-MX-L2-SH002',
+            'VSPR',
+            'matrix_reasoning',
+            'L2',
+            'B',
+            'arrow_rotation_v1',
+            'The arrow rotates 90 degrees clockwise on each step, so the next state is the 270-degree orientation.',
+            'Distractors reuse prior orientations or partial rotations to test whether the rotation rule was tracked consistently.',
+            ['rotation_sequence' => [0, 90, 180, 270]],
+            iqShowcase12PromptCardAsset(['Rotate 90° each step', 'choose the next arrow']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12ArrowAsset(90)],
+                ['code' => 'B', 'asset' => iqShowcase12ArrowAsset(270)],
+                ['code' => 'C', 'asset' => iqShowcase12ArrowAsset(0)],
+                ['code' => 'D', 'asset' => iqShowcase12ArrowAsset(180)],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q03',
+            'FM-IQ-VSPR-SEQ-L3-SH003',
+            'VSPR',
+            'shape_sequence',
+            'L3',
+            'C',
+            'corner_dot_cycle_v1',
+            'The dot moves clockwise around the four corners of the square, so the missing position is bottom-left.',
+            'Distractors place the dot on earlier positions in the cycle or repeat the start position.',
+            ['corner_cycle' => ['TL', 'TR', 'BR', 'BL']],
+            iqShowcase12PromptCardAsset(['Dot moves clockwise', 'around the square']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12CornerDotAsset('TR')],
+                ['code' => 'B', 'asset' => iqShowcase12CornerDotAsset('BR')],
+                ['code' => 'C', 'asset' => iqShowcase12CornerDotAsset('BL')],
+                ['code' => 'D', 'asset' => iqShowcase12CornerDotAsset('TL')],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q04',
+            'FM-IQ-VSPR-ANL-L3-SH004',
+            'VSPR',
+            'shape_analogy',
+            'L3',
+            'D',
+            'outline_fill_analogy_v1',
+            'The left pair changes an outlined circle into a filled circle; applying the same rule to an outlined square yields a filled square.',
+            'Distractors preserve the wrong shape or fail to apply the fill transformation consistently.',
+            ['rule' => 'outline_to_filled', 'target_shape' => 'square'],
+            iqShowcase12PromptCardAsset(['Outline -> Filled', 'apply the same rule']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12OutlineShapeAsset('triangle', true)],
+                ['code' => 'B', 'asset' => iqShowcase12OutlineShapeAsset('square', false)],
+                ['code' => 'C', 'asset' => iqShowcase12OutlineShapeAsset('circle', true)],
+                ['code' => 'D', 'asset' => iqShowcase12OutlineShapeAsset('square', true)],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q05',
+            'FM-IQ-VSI-HS-L2-SH005',
+            'VSI',
+            'hidden_shape',
+            'L2',
+            'A',
+            'hidden_l_shape_v1',
+            'The target is the same L-shape orientation shown in the stem, and only option A contains that orientation unchanged.',
+            'The distractors mirror or rotate the target shape so they look similar without preserving the original orientation.',
+            ['target' => 'L', 'orientation' => 'upright'],
+            iqShowcase12PromptCardAsset(['Find the same', 'upright L-shape']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12HiddenShapeOption('correct')],
+                ['code' => 'B', 'asset' => iqShowcase12HiddenShapeOption('rotated')],
+                ['code' => 'C', 'asset' => iqShowcase12HiddenShapeOption('mirror')],
+                ['code' => 'D', 'asset' => iqShowcase12HiddenShapeOption('other')],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q06',
+            'FM-IQ-VSI-MR-L3-SH006',
+            'VSI',
+            'mental_rotation',
+            'L3',
+            'B',
+            'polyomino_rotation_v1',
+            'The base polyomino is rotated without mirroring, and only option B matches a pure 90-degree rotation.',
+            'Distractors mirror the shape or keep the original orientation, which is visually close but rule-inconsistent.',
+            ['rotation' => 90, 'mirror' => false],
+            iqShowcase12PromptCardAsset(['Choose the same shape', 'after rotation only']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12PolyominoAsset('translate(0 0) scale(-1 1) translate(-120 0)')],
+                ['code' => 'B', 'asset' => iqShowcase12PolyominoAsset('rotate(90 60 60)')],
+                ['code' => 'C', 'asset' => iqShowcase12PolyominoAsset('rotate(180 60 60) scale(-1 1) translate(-120 0)')],
+                ['code' => 'D', 'asset' => iqShowcase12PolyominoAsset('rotate(0 60 60)')],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q07',
+            'FM-IQ-VSI-ASM-L3-SH007',
+            'VSI',
+            'shape_assembly',
+            'L3',
+            'C',
+            'missing_piece_square_v1',
+            'The gap in the square needs one long vertical segment plus a short horizontal foot, which matches the L-shaped piece.',
+            'Distractors supply pieces with the wrong footprint, missing the horizontal foot or overfilling the gap.',
+            ['target_piece' => 'l_piece'],
+            iqShowcase12PromptCardAsset(['Fill the missing', 'corner piece']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12AssemblyPieceAsset('small_square')],
+                ['code' => 'B', 'asset' => iqShowcase12AssemblyPieceAsset('vertical_bar')],
+                ['code' => 'C', 'asset' => iqShowcase12AssemblyPieceAsset('l_piece')],
+                ['code' => 'D', 'asset' => iqShowcase12AssemblyPieceAsset('triangle')],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q08',
+            'FM-IQ-VSI-ODD-L4-SH008',
+            'VSI',
+            'odd_one_out',
+            'L4',
+            'D',
+            'symmetry_exception_v1',
+            'Three options are mirror-symmetric around at least one axis, while option D breaks that symmetry with an offset cluster.',
+            'The distractors all preserve simple reflection symmetry, so the odd one out is the only asymmetric pattern.',
+            ['symmetry_target' => 'mirror'],
+            iqShowcase12PromptCardAsset(['Which option is', 'different?']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12PatternOption('cross')],
+                ['code' => 'B', 'asset' => iqShowcase12PatternOption('x')],
+                ['code' => 'C', 'asset' => iqShowcase12PatternOption('concentric')],
+                ['code' => 'D', 'asset' => iqShowcase12PatternOption('asymmetric')],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q09',
+            'FM-IQ-NPR-NS-L2-SH009',
+            'NPR',
+            'number_sequence',
+            'L2',
+            'A',
+            'doubling_sequence_v1',
+            'Each term doubles the previous term, so the next value after 16 is 32.',
+            'Distractors include nearby even numbers and repeated powers to catch skipped or partial doubling.',
+            ['sequence' => [2, 4, 8, 16, 32]],
+            iqShowcase12PromptCardAsset(['2, 4, 8, 16, ?']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12NumberCardAsset('32')],
+                ['code' => 'B', 'asset' => iqShowcase12NumberCardAsset('24')],
+                ['code' => 'C', 'asset' => iqShowcase12NumberCardAsset('34')],
+                ['code' => 'D', 'asset' => iqShowcase12NumberCardAsset('36')],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q10',
+            'FM-IQ-NPR-GRD-L3-SH010',
+            'NPR',
+            'number_grid',
+            'L3',
+            'B',
+            'row_double_grid_v1',
+            'In each row the second number is double the first, so the row starting with 5 must end with 10.',
+            'Distractors keep the numbers close but break the row-doubling rule by under- or over-shooting the product.',
+            ['rows' => [[2, 4], [3, 6], [5, 10]]],
+            iqShowcase12PromptCardAsset(['2  4', '3  6', '5  ?']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12NumberCardAsset('8')],
+                ['code' => 'B', 'asset' => iqShowcase12NumberCardAsset('10')],
+                ['code' => 'C', 'asset' => iqShowcase12NumberCardAsset('12')],
+                ['code' => 'D', 'asset' => iqShowcase12NumberCardAsset('15')],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q11',
+            'FM-IQ-NPR-SYM-L3-SH011',
+            'NPR',
+            'symbol_operation',
+            'L3',
+            'C',
+            'symbol_value_addition_v1',
+            'The stem assigns values triangle=2 and circle=4, so adding them yields 6.',
+            'Distractors reuse one of the symbol values or add an extra step to test whether the mapping was applied cleanly.',
+            ['triangle' => 2, 'square' => 3, 'circle' => 4, 'target' => 'triangle+circle'],
+            iqShowcase12PromptCardAsset(['triangle = 2', 'square = 3', 'circle = 4', 'triangle + circle = ?']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12NumberCardAsset('4')],
+                ['code' => 'B', 'asset' => iqShowcase12NumberCardAsset('5')],
+                ['code' => 'C', 'asset' => iqShowcase12NumberCardAsset('6')],
+                ['code' => 'D', 'asset' => iqShowcase12NumberCardAsset('7')],
+            ]
+        ),
+        iqShowcase12Item(
+            'IQS12_Q12',
+            'FM-IQ-NPR-CNT-L4-SH012',
+            'NPR',
+            'shape_counting',
+            'L4',
+            'D',
+            'triangle_count_v1',
+            'The figure can be decomposed into eight distinct small triangles when counted systematically from top to bottom.',
+            'Distractors represent common under-counts that miss overlapping or edge triangles in the figure.',
+            ['triangle_count' => 8],
+            iqShowcase12PromptCardAsset(['Count all triangles', 'in the figure']),
+            [
+                ['code' => 'A', 'asset' => iqShowcase12NumberCardAsset('5')],
+                ['code' => 'B', 'asset' => iqShowcase12NumberCardAsset('6')],
+                ['code' => 'C', 'asset' => iqShowcase12NumberCardAsset('7')],
+                ['code' => 'D', 'asset' => iqShowcase12NumberCardAsset('8')],
+            ]
+        ),
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function iqShowcase12Manifest(array $items): array
+{
+    $answerDistribution = [];
+    $dimensionCounts = [];
+    $families = [];
+
+    foreach ($items as $item) {
+        $answer = (string) ($item['correct_answer'] ?? '');
+        $dimension = (string) ($item['dimension'] ?? '');
+        $family = (string) ($item['item_family'] ?? '');
+        $answerDistribution[$answer] = ($answerDistribution[$answer] ?? 0) + 1;
+        $dimensionCounts[$dimension] = ($dimensionCounts[$dimension] ?? 0) + 1;
+        $families[$family] = true;
+    }
+
+    ksort($answerDistribution, SORT_STRING);
+    ksort($dimensionCounts, SORT_STRING);
+
+    return [
+        'schema_version' => IQ_SHOWCASE12_SCHEMA_VERSION,
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'bank_id' => IQ_SHOWCASE12_BANK_ID,
+        'status' => 'beta',
+        'activation' => [
+            'runtime_bound' => false,
+            'reason' => 'showcase_only_until_beta50_and_norms_are_ready',
+        ],
+        'content_package_version' => 'v0.3.0-DEMO',
+        'bank_dir' => iqSvgRelativePath(iqShowcase12BankDir()),
+        'item_count' => count($items),
+        'dimension_counts' => $dimensionCounts,
+        'answer_distribution' => $answerDistribution,
+        'item_families' => array_values(array_keys($families)),
+        'files' => [
+            'items' => iqSvgRelativePath(iqShowcase12FileMap()['items']),
+            'answer_key' => iqSvgRelativePath(iqShowcase12FileMap()['answer_key']),
+            'scoring_spec' => iqSvgRelativePath(iqShowcase12FileMap()['scoring_spec']),
+        ],
+        'beta_50_status' => 'future_work',
+        'notes' => [
+            'showcase_12_imported' => true,
+            'beta_50_imported' => false,
+            'commerce_required' => false,
+            'norm_table_required_before_production' => true,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function iqShowcase12AnswerKey(array $items): array
+{
+    $entries = [];
+    foreach ($items as $item) {
+        $entries[] = [
+            'item_id' => (string) $item['item_id'],
+            'question_id' => (string) $item['question_id'],
+            'dimension' => (string) $item['dimension'],
+            'correct_answer' => (string) $item['correct_answer'],
+            'raw_points' => 1,
+        ];
+    }
+
+    return [
+        'schema_version' => IQ_SHOWCASE12_ANSWER_KEY_SCHEMA_VERSION,
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'bank_id' => IQ_SHOWCASE12_BANK_ID,
+        'answer_key_version' => 'showcase12.v1',
+        'status' => 'beta',
+        'items' => $entries,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function iqShowcase12ScoringSpec(array $items): array
+{
+    $scoringItems = [];
+    foreach ($items as $item) {
+        $scoringItems[] = [
+            'item_id' => (string) $item['item_id'],
+            'question_id' => (string) $item['question_id'],
+            'status' => 'beta',
+            'dimension' => (string) $item['dimension'],
+            'correct_answer' => (string) $item['correct_answer'],
+            'item_family' => (string) $item['item_family'],
+            'difficulty_level' => (string) $item['difficulty_level'],
+            'solution_rule' => (string) $item['solution_rule'],
+            'distractor_logic' => (string) $item['distractor_logic'],
+            'raw_points' => 1,
+            'asset_hashes' => $item['asset_hashes'],
+            'generator_metadata' => $item['generator_metadata'],
+        ];
+    }
+
+    return [
+        'version' => 'showcase12.v1',
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'scoring_mode' => 'scored',
+        'answer_key_version' => 'showcase12.v1',
+        'norm_table_version' => 'unavailable',
+        'scoring_engine_version' => 'iq_scoring_v2',
+        'item_bank' => [
+            'bank_id' => IQ_SHOWCASE12_BANK_ID,
+            'schema_version' => IQ_SHOWCASE12_ITEM_SCHEMA_VERSION,
+            'status' => 'beta',
+            'production_ready' => false,
+            'canonical_scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'item_count' => count($items),
+            'option_codes' => ['A', 'B', 'C', 'D'],
+            'dimensions' => ['VSPR', 'VSI', 'NPR'],
+        ],
+        'quality_rules' => [
+            'speeding_seconds_lt' => 30,
+            'straightlining_run_len_gte' => 8,
+            'abnormal_quality_policy' => 'review_with_caution',
+        ],
+        'items' => $scoringItems,
+    ];
+}
+
+/**
+ * @return array<string, array<string, mixed>>
+ */
+function iqShowcase12BankPayloads(): array
+{
+    $items = iqShowcase12Items();
+
+    return [
+        'manifest' => iqShowcase12Manifest($items),
+        'items' => [
+            'schema_version' => IQ_SHOWCASE12_ITEM_SCHEMA_VERSION,
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'bank_id' => IQ_SHOWCASE12_BANK_ID,
+            'status' => 'beta',
+            'items' => $items,
+        ],
+        'answer_key' => iqShowcase12AnswerKey($items),
+        'scoring_spec' => iqShowcase12ScoringSpec($items),
+    ];
+}

--- a/backend/scripts/iq/verify_showcase12_beta_bank.php
+++ b/backend/scripts/iq/verify_showcase12_beta_bank.php
@@ -1,0 +1,179 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_showcase12_bank_lib.php';
+
+function iqShowcase12VerifyFail(string $message, int $code = 1): never
+{
+    fwrite(STDERR, "[iq-showcase12-verify] {$message}\n");
+    exit($code);
+}
+
+/**
+ * @return list<string>
+ */
+function iqShowcase12CollectViolations(array $manifest, array $itemsPayload, array $answerKey, array $scoringSpec): array
+{
+    $violations = [];
+    $items = is_array($itemsPayload['items'] ?? null) ? $itemsPayload['items'] : [];
+    $answerEntries = is_array($answerKey['items'] ?? null) ? $answerKey['items'] : [];
+    $scoringItems = is_array($scoringSpec['items'] ?? null) ? $scoringSpec['items'] : [];
+
+    if ((string) ($manifest['scale_code'] ?? '') !== 'IQ_INTELLIGENCE_QUOTIENT') {
+        $violations[] = 'manifest scale_code must be IQ_INTELLIGENCE_QUOTIENT';
+    }
+
+    if ((string) ($manifest['bank_id'] ?? '') !== IQ_SHOWCASE12_BANK_ID) {
+        $violations[] = 'manifest bank_id mismatch';
+    }
+
+    if ((string) ($manifest['status'] ?? '') !== 'beta') {
+        $violations[] = 'manifest status must stay beta';
+    }
+
+    if ((bool) ($manifest['notes']['beta_50_imported'] ?? true) !== false) {
+        $violations[] = 'beta_50_imported must remain false for showcase-only import';
+    }
+
+    if (count($items) !== 12) {
+        $violations[] = 'expected 12 showcase items';
+    }
+
+    if (count($answerEntries) !== count($items)) {
+        $violations[] = 'answer_key item count mismatch';
+    }
+
+    if (count($scoringItems) !== count($items)) {
+        $violations[] = 'scoring_spec item count mismatch';
+    }
+
+    $dimensionCounts = [];
+    $answerDistribution = [];
+
+    foreach ($items as $item) {
+        if (! is_array($item)) {
+            $violations[] = 'invalid item payload entry';
+
+            continue;
+        }
+
+        $itemId = (string) ($item['item_id'] ?? 'missing_item_id');
+        $dimension = (string) ($item['dimension'] ?? '');
+        $dimensionCounts[$dimension] = ($dimensionCounts[$dimension] ?? 0) + 1;
+        $answer = (string) ($item['correct_answer'] ?? '');
+        $answerDistribution[$answer] = ($answerDistribution[$answer] ?? 0) + 1;
+
+        foreach (['correct_answer', 'solution_rule', 'distractor_logic'] as $field) {
+            $value = $item[$field] ?? null;
+            if (! is_string($value) || trim($value) === '') {
+                $violations[] = 'missing '.$field.' for '.$itemId;
+            }
+        }
+
+        if ((string) ($item['scale_code'] ?? '') !== 'IQ_INTELLIGENCE_QUOTIENT') {
+            $violations[] = 'non-canonical scale_code on '.$itemId;
+        }
+
+        if ((string) ($item['status'] ?? '') !== 'beta') {
+            $violations[] = 'item status must stay beta for '.$itemId;
+        }
+
+        $assetHashes = is_array($item['asset_hashes'] ?? null) ? $item['asset_hashes'] : [];
+        if ($assetHashes === []) {
+            $violations[] = 'missing asset_hashes for '.$itemId;
+        }
+
+        $generatorMetadata = is_array($item['generator_metadata'] ?? null) ? $item['generator_metadata'] : [];
+        if ($generatorMetadata === []) {
+            $violations[] = 'missing generator_metadata for '.$itemId;
+        }
+
+        $stemAsset = $item['assets']['stem'] ?? null;
+        if (! is_array($stemAsset) || (string) ($assetHashes['stem'] ?? '') !== iqSvgSha256Json($stemAsset)) {
+            $violations[] = 'stem asset hash mismatch for '.$itemId;
+        }
+
+        $options = is_array($item['assets']['options'] ?? null) ? $item['assets']['options'] : [];
+        if (count($options) !== 4) {
+            $violations[] = 'option count must be 4 for '.$itemId;
+        }
+
+        foreach ($options as $option) {
+            if (! is_array($option)) {
+                $violations[] = 'invalid option payload for '.$itemId;
+
+                continue;
+            }
+
+            $code = (string) ($option['code'] ?? '');
+            $asset = $option['asset'] ?? null;
+            if ($code === '' || ! is_array($asset)) {
+                $violations[] = 'invalid option asset for '.$itemId;
+
+                continue;
+            }
+
+            if ((string) (($assetHashes['options'] ?? [])[$code] ?? '') !== iqSvgSha256Json($asset)) {
+                $violations[] = 'option asset hash mismatch for '.$itemId.' '.$code;
+            }
+        }
+    }
+
+    foreach (['VSPR' => 4, 'VSI' => 4, 'NPR' => 4] as $dimension => $expectedCount) {
+        if (($dimensionCounts[$dimension] ?? 0) !== $expectedCount) {
+            $violations[] = 'dimension coverage mismatch for '.$dimension;
+        }
+    }
+
+    foreach (['A' => 3, 'B' => 3, 'C' => 3, 'D' => 3] as $answer => $expectedCount) {
+        if (($answerDistribution[$answer] ?? 0) !== $expectedCount) {
+            $violations[] = 'answer distribution mismatch for '.$answer;
+        }
+    }
+
+    return $violations;
+}
+
+$fileMap = iqShowcase12FileMap();
+
+try {
+    $expected = iqShowcase12BankPayloads();
+    $recorded = [
+        'manifest' => iqSvgLoadJsonFile($fileMap['manifest']),
+        'items' => iqSvgLoadJsonFile($fileMap['items']),
+        'answer_key' => iqSvgLoadJsonFile($fileMap['answer_key']),
+        'scoring_spec' => iqSvgLoadJsonFile($fileMap['scoring_spec']),
+    ];
+
+    foreach ($expected as $key => $payload) {
+        $encoded = iqSvgPrettyJson($payload).PHP_EOL;
+        $existing = file_get_contents($fileMap[$key]);
+        if (! is_string($existing) || $existing !== $encoded) {
+            iqShowcase12VerifyFail('artifact drift detected: '.iqSvgRelativePath($fileMap[$key]), 20);
+        }
+    }
+
+    $violations = iqShowcase12CollectViolations(
+        $recorded['manifest'],
+        $recorded['items'],
+        $recorded['answer_key'],
+        $recorded['scoring_spec']
+    );
+    if ($violations !== []) {
+        iqShowcase12VerifyFail(implode('; ', $violations), 21);
+    }
+
+    fwrite(STDOUT, iqSvgPrettyJson([
+        'ok' => true,
+        'bank_id' => IQ_SHOWCASE12_BANK_ID,
+        'bank_dir' => iqSvgRelativePath(iqShowcase12BankDir()),
+        'item_count' => 12,
+        'dimensions' => ['VSPR' => 4, 'VSI' => 4, 'NPR' => 4],
+        'answer_distribution' => ['A' => 3, 'B' => 3, 'C' => 3, 'D' => 3],
+        'beta_50_imported' => false,
+    ]).PHP_EOL);
+} catch (Throwable $throwable) {
+    iqShowcase12VerifyFail($throwable->getMessage(), 10);
+}

--- a/backend/tests/Feature/Content/IqShowcase12BetaBankImportTest.php
+++ b/backend/tests/Feature/Content/IqShowcase12BetaBankImportTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+final class IqShowcase12BetaBankImportTest extends TestCase
+{
+    public function test_build_script_reproduces_committed_showcase12_bank_artifacts(): void
+    {
+        $process = new Process([
+            PHP_BINARY,
+            base_path('scripts/iq/build_showcase12_beta_bank.php'),
+            '--check',
+        ], base_path());
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            $process->getErrorOutput().$process->getOutput()
+        );
+    }
+
+    public function test_verify_script_accepts_showcase12_bank_contract(): void
+    {
+        $process = new Process([
+            PHP_BINARY,
+            base_path('scripts/iq/verify_showcase12_beta_bank.php'),
+        ], base_path());
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            $process->getErrorOutput().$process->getOutput()
+        );
+
+        $payload = json_decode($process->getOutput(), true);
+        $this->assertIsArray($payload);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertSame('IQ_SHOWCASE_12_BETA', $payload['bank_id'] ?? null);
+        $this->assertSame(12, $payload['item_count'] ?? null);
+        $this->assertSame(4, data_get($payload, 'dimensions.VSPR'));
+        $this->assertSame(4, data_get($payload, 'dimensions.VSI'));
+        $this->assertSame(4, data_get($payload, 'dimensions.NPR'));
+        $this->assertFalse((bool) ($payload['beta_50_imported'] ?? true));
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/answer_key.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/answer_key.json
@@ -1,0 +1,93 @@
+{
+    "answer_key_version": "showcase12.v1",
+    "bank_id": "IQ_SHOWCASE_12_BETA",
+    "items": [
+        {
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "item_id": "FM-IQ-VSPR-MX-L2-SH001",
+            "question_id": "IQS12_Q01",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "B",
+            "dimension": "VSPR",
+            "item_id": "FM-IQ-VSPR-MX-L2-SH002",
+            "question_id": "IQS12_Q02",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "item_id": "FM-IQ-VSPR-SEQ-L3-SH003",
+            "question_id": "IQS12_Q03",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "item_id": "FM-IQ-VSPR-ANL-L3-SH004",
+            "question_id": "IQS12_Q04",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "A",
+            "dimension": "VSI",
+            "item_id": "FM-IQ-VSI-HS-L2-SH005",
+            "question_id": "IQS12_Q05",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "B",
+            "dimension": "VSI",
+            "item_id": "FM-IQ-VSI-MR-L3-SH006",
+            "question_id": "IQS12_Q06",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "C",
+            "dimension": "VSI",
+            "item_id": "FM-IQ-VSI-ASM-L3-SH007",
+            "question_id": "IQS12_Q07",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "D",
+            "dimension": "VSI",
+            "item_id": "FM-IQ-VSI-ODD-L4-SH008",
+            "question_id": "IQS12_Q08",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "A",
+            "dimension": "NPR",
+            "item_id": "FM-IQ-NPR-NS-L2-SH009",
+            "question_id": "IQS12_Q09",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "B",
+            "dimension": "NPR",
+            "item_id": "FM-IQ-NPR-GRD-L3-SH010",
+            "question_id": "IQS12_Q10",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "C",
+            "dimension": "NPR",
+            "item_id": "FM-IQ-NPR-SYM-L3-SH011",
+            "question_id": "IQS12_Q11",
+            "raw_points": 1
+        },
+        {
+            "correct_answer": "D",
+            "dimension": "NPR",
+            "item_id": "FM-IQ-NPR-CNT-L4-SH012",
+            "question_id": "IQS12_Q12",
+            "raw_points": 1
+        }
+    ],
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "schema_version": "fm.iq.answer_key.v1",
+    "status": "beta"
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/items.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/items.json
@@ -1,0 +1,956 @@
+{
+    "bank_id": "IQ_SHOWCASE_12_BETA",
+    "items": [
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:e32e83ffd91631a79ca5147569b76ec95b8169bd5e220a18caa17684aa8f46d8",
+                    "B": "sha256:611360163b760908cf7ac79c352bfa4d6cacee7ff698add431071d924ae47c25",
+                    "C": "sha256:2c503abc349886dacc0c701ed97b3d7c9f36d227e59d100aac2d091a01c9420c",
+                    "D": "sha256:78195b4d7b9e65950ef116754abd5662ec45f253eaba61c2af1f6099dc3faa06"
+                },
+                "stem": "sha256:a46c5261889c6a345bf08186950e0e69773ad97e4948fb20b1e1faf5f9ff936f"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"12\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"32\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"52\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"72\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"12\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"12\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"32\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"52\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"72\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"92\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"12\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"32\" y=\"44\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">1 square</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">2 squares</text><text x=\"60\" y=\"72\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">3 squares</text><text x=\"60\" y=\"90\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">next = ?</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "A",
+            "difficulty_level": "L2",
+            "dimension": "VSPR",
+            "dimension_name": "视觉空间模式推理",
+            "distractor_logic": "The distractors keep the same visual style but use lower or higher square counts to catch undercounting.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:11c9889f4d4fa4b5a4f3a90b6e94782252e0f44e3d7af49232a6604f330bcbc5",
+                "seed": "iqs12_q01_seed",
+                "source_mode": "repo_generated",
+                "template_key": "matrix_square_count_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "matrix_reasoning",
+            "item_id": "FM-IQ-VSPR-MX-L2-SH001",
+            "option_count": 4,
+            "question_id": "IQS12_Q01",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The square count increases by one across the sequence, so the next panel needs four filled squares.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:221a7d77d9752f17d9c6acfc634e7055b5c9260f50f25900da544483a0e47847",
+                    "B": "sha256:096f4ab1774ff98df61cab4b1fea2274a46fd1f99794f78e6e029754d9ed8128",
+                    "C": "sha256:bc11dd1bdd3f225863dc0243c364dbf79cc60ebff3fc29aeacb1c940f435b70b",
+                    "D": "sha256:1eed655959e09ae782df49e6a7d6da0c6b30051cc61f2319946223504085885e"
+                },
+                "stem": "sha256:a20b3828393702c890cda4aaae083073e074213769311d31a7a2dac426d93f41"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><g transform=\"rotate(90 60 60)\"><line x1=\"24\" y1=\"60\" x2=\"92\" y2=\"60\" stroke=\"#111111\" stroke-width=\"6\" stroke-linecap=\"round\"/><polygon points=\"92,60 74,48 74,72\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\" stroke-linejoin=\"round\"/></g></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><g transform=\"rotate(270 60 60)\"><line x1=\"24\" y1=\"60\" x2=\"92\" y2=\"60\" stroke=\"#111111\" stroke-width=\"6\" stroke-linecap=\"round\"/><polygon points=\"92,60 74,48 74,72\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\" stroke-linejoin=\"round\"/></g></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><g transform=\"rotate(0 60 60)\"><line x1=\"24\" y1=\"60\" x2=\"92\" y2=\"60\" stroke=\"#111111\" stroke-width=\"6\" stroke-linecap=\"round\"/><polygon points=\"92,60 74,48 74,72\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\" stroke-linejoin=\"round\"/></g></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><g transform=\"rotate(180 60 60)\"><line x1=\"24\" y1=\"60\" x2=\"92\" y2=\"60\" stroke=\"#111111\" stroke-width=\"6\" stroke-linecap=\"round\"/><polygon points=\"92,60 74,48 74,72\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\" stroke-linejoin=\"round\"/></g></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">Rotate 90° each step</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">choose the next arrow</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "B",
+            "difficulty_level": "L2",
+            "dimension": "VSPR",
+            "dimension_name": "视觉空间模式推理",
+            "distractor_logic": "Distractors reuse prior orientations or partial rotations to test whether the rotation rule was tracked consistently.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:f7bed9635d908207d1d32380249fb0f13dfe0b56f6544c24510cb45849058a64",
+                "seed": "iqs12_q02_seed",
+                "source_mode": "repo_generated",
+                "template_key": "arrow_rotation_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "matrix_reasoning",
+            "item_id": "FM-IQ-VSPR-MX-L2-SH002",
+            "option_count": 4,
+            "question_id": "IQS12_Q02",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The arrow rotates 90 degrees clockwise on each step, so the next state is the 270-degree orientation.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:591d651d9a398bc9eee6b31bd4c455a901fd5519c31b2cc8a07f721ca0188d49",
+                    "B": "sha256:fc4c47084fd154a5dae88d6957be861bf48b1bd3aaeace9b0b4d10d4eef7dc90",
+                    "C": "sha256:cf316b9777c120d099243f97ddad057f994d80affcfe17a39f8143dc548e36cb",
+                    "D": "sha256:fbe42f41ee75f1f49ca61f0435ae912c1acd9a3c76fdfe16538a484895e6db8a"
+                },
+                "stem": "sha256:f3c166570daf73fb6752695a1a7fa7bda102e58494b3cfef4b5216aad802d94c"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"16\" width=\"88\" height=\"88\" rx=\"6\" fill=\"none\" stroke=\"#111111\" stroke-width=\"4\"/><circle cx=\"92\" cy=\"28\" r=\"10\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"16\" width=\"88\" height=\"88\" rx=\"6\" fill=\"none\" stroke=\"#111111\" stroke-width=\"4\"/><circle cx=\"92\" cy=\"92\" r=\"10\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"16\" width=\"88\" height=\"88\" rx=\"6\" fill=\"none\" stroke=\"#111111\" stroke-width=\"4\"/><circle cx=\"28\" cy=\"92\" r=\"10\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"16\" width=\"88\" height=\"88\" rx=\"6\" fill=\"none\" stroke=\"#111111\" stroke-width=\"4\"/><circle cx=\"28\" cy=\"28\" r=\"10\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">Dot moves clockwise</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">around the square</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "C",
+            "difficulty_level": "L3",
+            "dimension": "VSPR",
+            "dimension_name": "视觉空间模式推理",
+            "distractor_logic": "Distractors place the dot on earlier positions in the cycle or repeat the start position.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:1a4909057305f14430de25af419e927977bbe507e90a14d94c276a6b0a5a3076",
+                "seed": "iqs12_q03_seed",
+                "source_mode": "repo_generated",
+                "template_key": "corner_dot_cycle_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "shape_sequence",
+            "item_id": "FM-IQ-VSPR-SEQ-L3-SH003",
+            "option_count": 4,
+            "question_id": "IQS12_Q03",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The dot moves clockwise around the four corners of the square, so the missing position is bottom-left.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:60ef09bdd6c07f38e25020d550473d408b088104d2a24ba85411c90785974f60",
+                    "B": "sha256:42dda0aa20cad4f3ecaab6431d02fd63533653a73bab269bd9f9b9a1f2448aa8",
+                    "C": "sha256:47e51d1896faa53156e8bb16742f1bd8a413dda0cb5499b6b40b9f44131e7c11",
+                    "D": "sha256:cab0c4dac524058382cea5b64be5af70446827abfbbca25f600f592adce1f794"
+                },
+                "stem": "sha256:660c48e026f9a17b1930e5498978115569b6da24b6c306b6e54c9f79126bba86"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><polygon points=\"60,24 92,88 28,88\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\" stroke-linejoin=\"round\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"32\" y=\"32\" width=\"56\" height=\"56\" rx=\"4\" fill=\"none\" stroke=\"#111111\" stroke-width=\"4\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><circle cx=\"60\" cy=\"60\" r=\"26\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"32\" y=\"32\" width=\"56\" height=\"56\" rx=\"4\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">Outline -&gt; Filled</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">apply the same rule</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "D",
+            "difficulty_level": "L3",
+            "dimension": "VSPR",
+            "dimension_name": "视觉空间模式推理",
+            "distractor_logic": "Distractors preserve the wrong shape or fail to apply the fill transformation consistently.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:368777543e06c4aa0996f43cc4a058323935f65823708350fb74ce43e7b5fac1",
+                "seed": "iqs12_q04_seed",
+                "source_mode": "repo_generated",
+                "template_key": "outline_fill_analogy_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "shape_analogy",
+            "item_id": "FM-IQ-VSPR-ANL-L3-SH004",
+            "option_count": 4,
+            "question_id": "IQS12_Q04",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The left pair changes an outlined circle into a filled circle; applying the same rule to an outlined square yields a filled square.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:be6d1e4fe9c6b464a2a3368ae2c7dd41deac5af696399f616f3d8d4fe5d42e7e",
+                    "B": "sha256:bc8d1f11d6440a05f1531fa5b6f788c4412bd484daf020c3f53590b6bdb8c3ce",
+                    "C": "sha256:40564ca992cd89d66eb8b377888b4a69554395e5f0d3a819a205a1edf3d993cc",
+                    "D": "sha256:75cb878d4649b9ff2fb940573fd3e2043663d945fbcab120029463234eeeaac2"
+                },
+                "stem": "sha256:65703ab2e5804bbb877cf297c8e8d76b13f5904edd61e1aabe93ea0607284911"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><line x1=\"28\" y1=\"28\" x2=\"28\" y2=\"88\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/><line x1=\"28\" y1=\"88\" x2=\"88\" y2=\"88\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/><line x1=\"28\" y1=\"58\" x2=\"88\" y2=\"58\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><line x1=\"28\" y1=\"28\" x2=\"88\" y2=\"28\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/><line x1=\"88\" y1=\"28\" x2=\"88\" y2=\"88\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/><line x1=\"58\" y1=\"28\" x2=\"58\" y2=\"88\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><line x1=\"88\" y1=\"28\" x2=\"88\" y2=\"88\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/><line x1=\"28\" y1=\"88\" x2=\"88\" y2=\"88\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/><line x1=\"28\" y1=\"58\" x2=\"88\" y2=\"58\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><line x1=\"28\" y1=\"28\" x2=\"88\" y2=\"88\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/><line x1=\"88\" y1=\"28\" x2=\"28\" y2=\"88\" stroke=\"#111111\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">Find the same</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">upright L-shape</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "A",
+            "difficulty_level": "L2",
+            "dimension": "VSI",
+            "dimension_name": "视觉空间洞察",
+            "distractor_logic": "The distractors mirror or rotate the target shape so they look similar without preserving the original orientation.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:a6df17ac264e51f60d8aae149d1f7b374ff20fe557507c6ab8b608189b47e374",
+                "seed": "iqs12_q05_seed",
+                "source_mode": "repo_generated",
+                "template_key": "hidden_l_shape_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "hidden_shape",
+            "item_id": "FM-IQ-VSI-HS-L2-SH005",
+            "option_count": 4,
+            "question_id": "IQS12_Q05",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The target is the same L-shape orientation shown in the stem, and only option A contains that orientation unchanged.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:9f6c3d821eb070979ccea8b23dc2c33828c8c4270a0b9c97b2b41c56ccd79208",
+                    "B": "sha256:618e2e14ca35217bacd44203603530b02f0262748aab15f777f7556bf09e0a0a",
+                    "C": "sha256:f22c168d0d5e3528cfe6ac26cdeb2cb64084236bb7c35913c11f6bec5eec8ab4",
+                    "D": "sha256:18d9d9dd0a6a040a50951bfe15aa466e89a76da78a41ca25522fee378dcc9be9"
+                },
+                "stem": "sha256:197b85cbc94e609855d66bfcd1e103fe64155ed3013ce5401a4ffbb459c75371"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><g transform=\"translate(0 0) scale(-1 1) translate(-120 0)\"><rect x=\"34\" y=\"34\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"34\" y=\"56\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"56\" y=\"56\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></g></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><g transform=\"rotate(90 60 60)\"><rect x=\"34\" y=\"34\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"34\" y=\"56\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"56\" y=\"56\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></g></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><g transform=\"rotate(180 60 60) scale(-1 1) translate(-120 0)\"><rect x=\"34\" y=\"34\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"34\" y=\"56\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"56\" y=\"56\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></g></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><g transform=\"rotate(0 60 60)\"><rect x=\"34\" y=\"34\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"34\" y=\"56\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"56\" y=\"56\" width=\"20\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></g></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">Choose the same shape</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">after rotation only</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "B",
+            "difficulty_level": "L3",
+            "dimension": "VSI",
+            "dimension_name": "视觉空间洞察",
+            "distractor_logic": "Distractors mirror the shape or keep the original orientation, which is visually close but rule-inconsistent.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:6fd1a7a15e95eb67419d7e6cd67f08d40b6e9f1c85746c7418dfe9360a07d917",
+                "seed": "iqs12_q06_seed",
+                "source_mode": "repo_generated",
+                "template_key": "polyomino_rotation_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "mental_rotation",
+            "item_id": "FM-IQ-VSI-MR-L3-SH006",
+            "option_count": 4,
+            "question_id": "IQS12_Q06",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The base polyomino is rotated without mirroring, and only option B matches a pure 90-degree rotation.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:35aee7e19f1d072e6f01419501e12ce1d0fd3c4590882296970285cbd06cd7fe",
+                    "B": "sha256:4be8a48ae51cbe43223c1aafe60b5c93ba333cbd18b469b14213327b9115a1e2",
+                    "C": "sha256:853a1aa6f7726ba09b8a3aa0f4a80e45edb935be53f3583a0d51bc9fc3914027",
+                    "D": "sha256:a65ac58d39aa2c773882105c9580656f0e52e8b420a40f6c0d5252f14b230ea3"
+                },
+                "stem": "sha256:2654025f8e72063d072a1c9afecdb92c8290faea8eab204810ac2b15058468b2"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"40\" y=\"40\" width=\"28\" height=\"28\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"46\" y=\"24\" width=\"20\" height=\"64\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"28\" y=\"28\" width=\"20\" height=\"52\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><rect x=\"48\" y=\"60\" width=\"28\" height=\"20\" rx=\"3\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><polygon points=\"28,88 88,88 88,28\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\" stroke-linejoin=\"round\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">Fill the missing</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">corner piece</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "C",
+            "difficulty_level": "L3",
+            "dimension": "VSI",
+            "dimension_name": "视觉空间洞察",
+            "distractor_logic": "Distractors supply pieces with the wrong footprint, missing the horizontal foot or overfilling the gap.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:605913ccf664c55a8ee813143284439824afbd8c452a2426044c9fabcbffe8ca",
+                "seed": "iqs12_q07_seed",
+                "source_mode": "repo_generated",
+                "template_key": "missing_piece_square_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "shape_assembly",
+            "item_id": "FM-IQ-VSI-ASM-L3-SH007",
+            "option_count": 4,
+            "question_id": "IQS12_Q07",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The gap in the square needs one long vertical segment plus a short horizontal foot, which matches the L-shaped piece.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:f7f859a730a169f861a60228b1d9dac2dc757fcf278f047a7c6ac7660c764792",
+                    "B": "sha256:76b3330b7d8c2ed969a912fe8c9d74d85cc89762790ef1d5020382cc5ff3912a",
+                    "C": "sha256:61d5cf2453fdfcd998bf9d3887cbd657818dbb5a41cc506039e693ba44c5523f",
+                    "D": "sha256:0ead8d5f5dd5a831a4af7743430c4d7ce35ca52444f742c15349c171568a0f3d"
+                },
+                "stem": "sha256:edc0c11bf6822bbc0b7eba6cd3b9a01a09c281726c6e1d7c3c0e170d23f00799"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><line x1=\"60\" y1=\"20\" x2=\"60\" y2=\"100\" stroke=\"#111111\" stroke-width=\"8\" stroke-linecap=\"round\"/><line x1=\"20\" y1=\"60\" x2=\"100\" y2=\"60\" stroke=\"#111111\" stroke-width=\"8\" stroke-linecap=\"round\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><line x1=\"24\" y1=\"24\" x2=\"96\" y2=\"96\" stroke=\"#111111\" stroke-width=\"8\" stroke-linecap=\"round\"/><line x1=\"96\" y1=\"24\" x2=\"24\" y2=\"96\" stroke=\"#111111\" stroke-width=\"8\" stroke-linecap=\"round\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><circle cx=\"60\" cy=\"60\" r=\"28\" fill=\"none\" stroke=\"#111111\" stroke-width=\"6\"/><circle cx=\"60\" cy=\"60\" r=\"10\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><circle cx=\"42\" cy=\"60\" r=\"12\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><circle cx=\"78\" cy=\"42\" r=\"12\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/><circle cx=\"78\" cy=\"78\" r=\"12\" fill=\"#111111\" stroke=\"#111111\" stroke-width=\"2\"/></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">Which option is</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">different?</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "D",
+            "difficulty_level": "L4",
+            "dimension": "VSI",
+            "dimension_name": "视觉空间洞察",
+            "distractor_logic": "The distractors all preserve simple reflection symmetry, so the odd one out is the only asymmetric pattern.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:c502c70cafc3d057a07ae96617ebadcf3d532c341e2dba72d29337ee7325076a",
+                "seed": "iqs12_q08_seed",
+                "source_mode": "repo_generated",
+                "template_key": "symmetry_exception_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "odd_one_out",
+            "item_id": "FM-IQ-VSI-ODD-L4-SH008",
+            "option_count": 4,
+            "question_id": "IQS12_Q08",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "Three options are mirror-symmetric around at least one axis, while option D breaks that symmetry with an offset cluster.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:76cd6a3255a86734431ab0f110c3a3c8e2e4653bc3f0b0bde30836451d511574",
+                    "B": "sha256:7ad74efdb5288984f686fcc5dcadc2c31c7c55984835a5add9c77c1b89c9919c",
+                    "C": "sha256:2bd4c01adbb7ceedc144748981712316cf86b506fc0ea75699dd92d98d4202bd",
+                    "D": "sha256:99b6f25c27d125a9fc291c418e908bdca98c7bbe6fc1edfe90c9a4f4ecd4dfaf"
+                },
+                "stem": "sha256:c9f6956e1afc3dac75e4bb42e66ab1da4c79de249b789f57f4212608a9db317c"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">32</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">24</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">34</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">36</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">2, 4, 8, 16, ?</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "A",
+            "difficulty_level": "L2",
+            "dimension": "NPR",
+            "dimension_name": "数字规律推理",
+            "distractor_logic": "Distractors include nearby even numbers and repeated powers to catch skipped or partial doubling.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:2b6a60c3d6bafc31eca3c2f80cbae3eef9132bad11fd2ba50079c72fbd0e068a",
+                "seed": "iqs12_q09_seed",
+                "source_mode": "repo_generated",
+                "template_key": "doubling_sequence_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "number_sequence",
+            "item_id": "FM-IQ-NPR-NS-L2-SH009",
+            "option_count": 4,
+            "question_id": "IQS12_Q09",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "Each term doubles the previous term, so the next value after 16 is 32.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:74aa182d9c17efe4288c38ade27360cbafc92c4610bd46abd869d658453975f7",
+                    "B": "sha256:015c2de4011cc043b645d97769ed0a0b662ca75b479485f7e31b0d3eea12cc93",
+                    "C": "sha256:737af3a89acf613f603e272d87844894b32f77140d9b4dffe602df566c82e6cb",
+                    "D": "sha256:94862ae363d9fcf29f960859f08ad1ed939547d2c6e54cb45a2d9cf43c9dc1ca"
+                },
+                "stem": "sha256:30422613ade45637e4d33f46c745ca1f171fae32900292337ecbde0307b39618"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">8</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">10</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">12</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">15</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">2  4</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">3  6</text><text x=\"60\" y=\"72\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">5  ?</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "B",
+            "difficulty_level": "L3",
+            "dimension": "NPR",
+            "dimension_name": "数字规律推理",
+            "distractor_logic": "Distractors keep the numbers close but break the row-doubling rule by under- or over-shooting the product.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:5dd2ca40a029e5eb576be1f326f16855b0b7e7574eabbd0944b72ac5b7cf0c73",
+                "seed": "iqs12_q10_seed",
+                "source_mode": "repo_generated",
+                "template_key": "row_double_grid_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "number_grid",
+            "item_id": "FM-IQ-NPR-GRD-L3-SH010",
+            "option_count": 4,
+            "question_id": "IQS12_Q10",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "In each row the second number is double the first, so the row starting with 5 must end with 10.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:f8d0c1491a4b6190395f8e67af2f5c2d6677b36657458166af2c3aff3f1bc4d8",
+                    "B": "sha256:3b872f92b834610fe427dd3c1bf3d53cc1b341ea4cfdbfff8cfdbbcf2b02b175",
+                    "C": "sha256:1ee0aefd125c62902db9556c03c6718b1fd8aaa266a9bd9ff17bb293b46bb3fc",
+                    "D": "sha256:bdfa60bee025b6745131326d97f9912dff513843521115cd3885259f5120806d"
+                },
+                "stem": "sha256:b73bb8b57527e21a2cde716e988b94d6eda5d71c2023a46a383ea188b34d1124"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">4</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">5</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">6</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">7</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">triangle = 2</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">square = 3</text><text x=\"60\" y=\"72\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">circle = 4</text><text x=\"60\" y=\"90\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">triangle + circle = ?</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "C",
+            "difficulty_level": "L3",
+            "dimension": "NPR",
+            "dimension_name": "数字规律推理",
+            "distractor_logic": "Distractors reuse one of the symbol values or add an extra step to test whether the mapping was applied cleanly.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:c8fcc5a9575d0e637db4d459754bd1f1129cdd7d1066d083c57a1ee2bb4c3161",
+                "seed": "iqs12_q11_seed",
+                "source_mode": "repo_generated",
+                "template_key": "symbol_value_addition_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "symbol_operation",
+            "item_id": "FM-IQ-NPR-SYM-L3-SH011",
+            "option_count": 4,
+            "question_id": "IQS12_Q11",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The stem assigns values triangle=2 and circle=4, so adding them yields 6.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:3b872f92b834610fe427dd3c1bf3d53cc1b341ea4cfdbfff8cfdbbcf2b02b175",
+                    "B": "sha256:1ee0aefd125c62902db9556c03c6718b1fd8aaa266a9bd9ff17bb293b46bb3fc",
+                    "C": "sha256:bdfa60bee025b6745131326d97f9912dff513843521115cd3885259f5120806d",
+                    "D": "sha256:74aa182d9c17efe4288c38ade27360cbafc92c4610bd46abd869d658453975f7"
+                },
+                "stem": "sha256:cbfe6d962ac9a23195bbedccf7c50cc4c439918b6023e71c33c9d0bb14ba1edc"
+            },
+            "assets": {
+                "options": [
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">5</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "A"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">6</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "B"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">7</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "C"
+                    },
+                    {
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"16\" y=\"20\" width=\"88\" height=\"80\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"4\"/><text x=\"60\" y=\"72\" font-size=\"26\" font-family=\"Arial, sans-serif\" font-weight=\"700\" text-anchor=\"middle\" fill=\"#111111\">8</text></svg>",
+                            "view_box": "0 0 120 120"
+                        },
+                        "code": "D"
+                    }
+                ],
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" fill=\"none\"><rect x=\"10\" y=\"14\" width=\"100\" height=\"92\" rx=\"8\" fill=\"#F8FAFC\" stroke=\"#111111\" stroke-width=\"3\"/><text x=\"60\" y=\"36\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">Count all triangles</text><text x=\"60\" y=\"54\" font-size=\"13\" font-family=\"Arial, sans-serif\" font-weight=\"600\" text-anchor=\"middle\" fill=\"#111111\">in the figure</text></svg>",
+                    "view_box": "0 0 120 120"
+                }
+            },
+            "bank_id": "IQ_SHOWCASE_12_BETA",
+            "correct_answer": "D",
+            "difficulty_level": "L4",
+            "dimension": "NPR",
+            "dimension_name": "数字规律推理",
+            "distractor_logic": "Distractors represent common under-counts that miss overlapping or edge triangles in the figure.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:11ee7013229bf08462ba79964887ac6944ef0f5f785cddc9925e27ea1f793033",
+                "seed": "iqs12_q12_seed",
+                "source_mode": "repo_generated",
+                "template_key": "triangle_count_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "shape_counting",
+            "item_id": "FM-IQ-NPR-CNT-L4-SH012",
+            "option_count": 4,
+            "question_id": "IQS12_Q12",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "schema_version": "fm.iq.item_bank.items.v1",
+            "solution_rule": "The figure can be decomposed into eight distinct small triangles when counted systematically from top to bottom.",
+            "status": "beta"
+        }
+    ],
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "schema_version": "fm.iq.item_bank.items.v1",
+    "status": "beta"
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/manifest.json
@@ -1,0 +1,49 @@
+{
+    "activation": {
+        "reason": "showcase_only_until_beta50_and_norms_are_ready",
+        "runtime_bound": false
+    },
+    "answer_distribution": {
+        "A": 3,
+        "B": 3,
+        "C": 3,
+        "D": 3
+    },
+    "bank_dir": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA",
+    "bank_id": "IQ_SHOWCASE_12_BETA",
+    "beta_50_status": "future_work",
+    "content_package_version": "v0.3.0-DEMO",
+    "dimension_counts": {
+        "NPR": 4,
+        "VSI": 4,
+        "VSPR": 4
+    },
+    "files": {
+        "answer_key": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/answer_key.json",
+        "items": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/items.json",
+        "scoring_spec": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/scoring_spec.json"
+    },
+    "item_count": 12,
+    "item_families": [
+        "matrix_reasoning",
+        "shape_sequence",
+        "shape_analogy",
+        "hidden_shape",
+        "mental_rotation",
+        "shape_assembly",
+        "odd_one_out",
+        "number_sequence",
+        "number_grid",
+        "symbol_operation",
+        "shape_counting"
+    ],
+    "notes": {
+        "beta_50_imported": false,
+        "commerce_required": false,
+        "norm_table_required_before_production": true,
+        "showcase_12_imported": true
+    },
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "schema_version": "fm.iq.item_bank_manifest.v1",
+    "status": "beta"
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/scoring_spec.json
@@ -1,0 +1,382 @@
+{
+    "answer_key_version": "showcase12.v1",
+    "item_bank": {
+        "bank_id": "IQ_SHOWCASE_12_BETA",
+        "canonical_scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+        "dimensions": [
+            "VSPR",
+            "VSI",
+            "NPR"
+        ],
+        "item_count": 12,
+        "option_codes": [
+            "A",
+            "B",
+            "C",
+            "D"
+        ],
+        "production_ready": false,
+        "schema_version": "fm.iq.item_bank.items.v1",
+        "status": "beta"
+    },
+    "items": [
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:e32e83ffd91631a79ca5147569b76ec95b8169bd5e220a18caa17684aa8f46d8",
+                    "B": "sha256:611360163b760908cf7ac79c352bfa4d6cacee7ff698add431071d924ae47c25",
+                    "C": "sha256:2c503abc349886dacc0c701ed97b3d7c9f36d227e59d100aac2d091a01c9420c",
+                    "D": "sha256:78195b4d7b9e65950ef116754abd5662ec45f253eaba61c2af1f6099dc3faa06"
+                },
+                "stem": "sha256:a46c5261889c6a345bf08186950e0e69773ad97e4948fb20b1e1faf5f9ff936f"
+            },
+            "correct_answer": "A",
+            "difficulty_level": "L2",
+            "dimension": "VSPR",
+            "distractor_logic": "The distractors keep the same visual style but use lower or higher square counts to catch undercounting.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:11c9889f4d4fa4b5a4f3a90b6e94782252e0f44e3d7af49232a6604f330bcbc5",
+                "seed": "iqs12_q01_seed",
+                "source_mode": "repo_generated",
+                "template_key": "matrix_square_count_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "matrix_reasoning",
+            "item_id": "FM-IQ-VSPR-MX-L2-SH001",
+            "question_id": "IQS12_Q01",
+            "raw_points": 1,
+            "solution_rule": "The square count increases by one across the sequence, so the next panel needs four filled squares.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:221a7d77d9752f17d9c6acfc634e7055b5c9260f50f25900da544483a0e47847",
+                    "B": "sha256:096f4ab1774ff98df61cab4b1fea2274a46fd1f99794f78e6e029754d9ed8128",
+                    "C": "sha256:bc11dd1bdd3f225863dc0243c364dbf79cc60ebff3fc29aeacb1c940f435b70b",
+                    "D": "sha256:1eed655959e09ae782df49e6a7d6da0c6b30051cc61f2319946223504085885e"
+                },
+                "stem": "sha256:a20b3828393702c890cda4aaae083073e074213769311d31a7a2dac426d93f41"
+            },
+            "correct_answer": "B",
+            "difficulty_level": "L2",
+            "dimension": "VSPR",
+            "distractor_logic": "Distractors reuse prior orientations or partial rotations to test whether the rotation rule was tracked consistently.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:f7bed9635d908207d1d32380249fb0f13dfe0b56f6544c24510cb45849058a64",
+                "seed": "iqs12_q02_seed",
+                "source_mode": "repo_generated",
+                "template_key": "arrow_rotation_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "matrix_reasoning",
+            "item_id": "FM-IQ-VSPR-MX-L2-SH002",
+            "question_id": "IQS12_Q02",
+            "raw_points": 1,
+            "solution_rule": "The arrow rotates 90 degrees clockwise on each step, so the next state is the 270-degree orientation.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:591d651d9a398bc9eee6b31bd4c455a901fd5519c31b2cc8a07f721ca0188d49",
+                    "B": "sha256:fc4c47084fd154a5dae88d6957be861bf48b1bd3aaeace9b0b4d10d4eef7dc90",
+                    "C": "sha256:cf316b9777c120d099243f97ddad057f994d80affcfe17a39f8143dc548e36cb",
+                    "D": "sha256:fbe42f41ee75f1f49ca61f0435ae912c1acd9a3c76fdfe16538a484895e6db8a"
+                },
+                "stem": "sha256:f3c166570daf73fb6752695a1a7fa7bda102e58494b3cfef4b5216aad802d94c"
+            },
+            "correct_answer": "C",
+            "difficulty_level": "L3",
+            "dimension": "VSPR",
+            "distractor_logic": "Distractors place the dot on earlier positions in the cycle or repeat the start position.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:1a4909057305f14430de25af419e927977bbe507e90a14d94c276a6b0a5a3076",
+                "seed": "iqs12_q03_seed",
+                "source_mode": "repo_generated",
+                "template_key": "corner_dot_cycle_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "shape_sequence",
+            "item_id": "FM-IQ-VSPR-SEQ-L3-SH003",
+            "question_id": "IQS12_Q03",
+            "raw_points": 1,
+            "solution_rule": "The dot moves clockwise around the four corners of the square, so the missing position is bottom-left.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:60ef09bdd6c07f38e25020d550473d408b088104d2a24ba85411c90785974f60",
+                    "B": "sha256:42dda0aa20cad4f3ecaab6431d02fd63533653a73bab269bd9f9b9a1f2448aa8",
+                    "C": "sha256:47e51d1896faa53156e8bb16742f1bd8a413dda0cb5499b6b40b9f44131e7c11",
+                    "D": "sha256:cab0c4dac524058382cea5b64be5af70446827abfbbca25f600f592adce1f794"
+                },
+                "stem": "sha256:660c48e026f9a17b1930e5498978115569b6da24b6c306b6e54c9f79126bba86"
+            },
+            "correct_answer": "D",
+            "difficulty_level": "L3",
+            "dimension": "VSPR",
+            "distractor_logic": "Distractors preserve the wrong shape or fail to apply the fill transformation consistently.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:368777543e06c4aa0996f43cc4a058323935f65823708350fb74ce43e7b5fac1",
+                "seed": "iqs12_q04_seed",
+                "source_mode": "repo_generated",
+                "template_key": "outline_fill_analogy_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "shape_analogy",
+            "item_id": "FM-IQ-VSPR-ANL-L3-SH004",
+            "question_id": "IQS12_Q04",
+            "raw_points": 1,
+            "solution_rule": "The left pair changes an outlined circle into a filled circle; applying the same rule to an outlined square yields a filled square.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:be6d1e4fe9c6b464a2a3368ae2c7dd41deac5af696399f616f3d8d4fe5d42e7e",
+                    "B": "sha256:bc8d1f11d6440a05f1531fa5b6f788c4412bd484daf020c3f53590b6bdb8c3ce",
+                    "C": "sha256:40564ca992cd89d66eb8b377888b4a69554395e5f0d3a819a205a1edf3d993cc",
+                    "D": "sha256:75cb878d4649b9ff2fb940573fd3e2043663d945fbcab120029463234eeeaac2"
+                },
+                "stem": "sha256:65703ab2e5804bbb877cf297c8e8d76b13f5904edd61e1aabe93ea0607284911"
+            },
+            "correct_answer": "A",
+            "difficulty_level": "L2",
+            "dimension": "VSI",
+            "distractor_logic": "The distractors mirror or rotate the target shape so they look similar without preserving the original orientation.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:a6df17ac264e51f60d8aae149d1f7b374ff20fe557507c6ab8b608189b47e374",
+                "seed": "iqs12_q05_seed",
+                "source_mode": "repo_generated",
+                "template_key": "hidden_l_shape_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "hidden_shape",
+            "item_id": "FM-IQ-VSI-HS-L2-SH005",
+            "question_id": "IQS12_Q05",
+            "raw_points": 1,
+            "solution_rule": "The target is the same L-shape orientation shown in the stem, and only option A contains that orientation unchanged.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:9f6c3d821eb070979ccea8b23dc2c33828c8c4270a0b9c97b2b41c56ccd79208",
+                    "B": "sha256:618e2e14ca35217bacd44203603530b02f0262748aab15f777f7556bf09e0a0a",
+                    "C": "sha256:f22c168d0d5e3528cfe6ac26cdeb2cb64084236bb7c35913c11f6bec5eec8ab4",
+                    "D": "sha256:18d9d9dd0a6a040a50951bfe15aa466e89a76da78a41ca25522fee378dcc9be9"
+                },
+                "stem": "sha256:197b85cbc94e609855d66bfcd1e103fe64155ed3013ce5401a4ffbb459c75371"
+            },
+            "correct_answer": "B",
+            "difficulty_level": "L3",
+            "dimension": "VSI",
+            "distractor_logic": "Distractors mirror the shape or keep the original orientation, which is visually close but rule-inconsistent.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:6fd1a7a15e95eb67419d7e6cd67f08d40b6e9f1c85746c7418dfe9360a07d917",
+                "seed": "iqs12_q06_seed",
+                "source_mode": "repo_generated",
+                "template_key": "polyomino_rotation_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "mental_rotation",
+            "item_id": "FM-IQ-VSI-MR-L3-SH006",
+            "question_id": "IQS12_Q06",
+            "raw_points": 1,
+            "solution_rule": "The base polyomino is rotated without mirroring, and only option B matches a pure 90-degree rotation.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:35aee7e19f1d072e6f01419501e12ce1d0fd3c4590882296970285cbd06cd7fe",
+                    "B": "sha256:4be8a48ae51cbe43223c1aafe60b5c93ba333cbd18b469b14213327b9115a1e2",
+                    "C": "sha256:853a1aa6f7726ba09b8a3aa0f4a80e45edb935be53f3583a0d51bc9fc3914027",
+                    "D": "sha256:a65ac58d39aa2c773882105c9580656f0e52e8b420a40f6c0d5252f14b230ea3"
+                },
+                "stem": "sha256:2654025f8e72063d072a1c9afecdb92c8290faea8eab204810ac2b15058468b2"
+            },
+            "correct_answer": "C",
+            "difficulty_level": "L3",
+            "dimension": "VSI",
+            "distractor_logic": "Distractors supply pieces with the wrong footprint, missing the horizontal foot or overfilling the gap.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:605913ccf664c55a8ee813143284439824afbd8c452a2426044c9fabcbffe8ca",
+                "seed": "iqs12_q07_seed",
+                "source_mode": "repo_generated",
+                "template_key": "missing_piece_square_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "shape_assembly",
+            "item_id": "FM-IQ-VSI-ASM-L3-SH007",
+            "question_id": "IQS12_Q07",
+            "raw_points": 1,
+            "solution_rule": "The gap in the square needs one long vertical segment plus a short horizontal foot, which matches the L-shaped piece.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:f7f859a730a169f861a60228b1d9dac2dc757fcf278f047a7c6ac7660c764792",
+                    "B": "sha256:76b3330b7d8c2ed969a912fe8c9d74d85cc89762790ef1d5020382cc5ff3912a",
+                    "C": "sha256:61d5cf2453fdfcd998bf9d3887cbd657818dbb5a41cc506039e693ba44c5523f",
+                    "D": "sha256:0ead8d5f5dd5a831a4af7743430c4d7ce35ca52444f742c15349c171568a0f3d"
+                },
+                "stem": "sha256:edc0c11bf6822bbc0b7eba6cd3b9a01a09c281726c6e1d7c3c0e170d23f00799"
+            },
+            "correct_answer": "D",
+            "difficulty_level": "L4",
+            "dimension": "VSI",
+            "distractor_logic": "The distractors all preserve simple reflection symmetry, so the odd one out is the only asymmetric pattern.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:c502c70cafc3d057a07ae96617ebadcf3d532c341e2dba72d29337ee7325076a",
+                "seed": "iqs12_q08_seed",
+                "source_mode": "repo_generated",
+                "template_key": "symmetry_exception_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "odd_one_out",
+            "item_id": "FM-IQ-VSI-ODD-L4-SH008",
+            "question_id": "IQS12_Q08",
+            "raw_points": 1,
+            "solution_rule": "Three options are mirror-symmetric around at least one axis, while option D breaks that symmetry with an offset cluster.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:76cd6a3255a86734431ab0f110c3a3c8e2e4653bc3f0b0bde30836451d511574",
+                    "B": "sha256:7ad74efdb5288984f686fcc5dcadc2c31c7c55984835a5add9c77c1b89c9919c",
+                    "C": "sha256:2bd4c01adbb7ceedc144748981712316cf86b506fc0ea75699dd92d98d4202bd",
+                    "D": "sha256:99b6f25c27d125a9fc291c418e908bdca98c7bbe6fc1edfe90c9a4f4ecd4dfaf"
+                },
+                "stem": "sha256:c9f6956e1afc3dac75e4bb42e66ab1da4c79de249b789f57f4212608a9db317c"
+            },
+            "correct_answer": "A",
+            "difficulty_level": "L2",
+            "dimension": "NPR",
+            "distractor_logic": "Distractors include nearby even numbers and repeated powers to catch skipped or partial doubling.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:2b6a60c3d6bafc31eca3c2f80cbae3eef9132bad11fd2ba50079c72fbd0e068a",
+                "seed": "iqs12_q09_seed",
+                "source_mode": "repo_generated",
+                "template_key": "doubling_sequence_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "number_sequence",
+            "item_id": "FM-IQ-NPR-NS-L2-SH009",
+            "question_id": "IQS12_Q09",
+            "raw_points": 1,
+            "solution_rule": "Each term doubles the previous term, so the next value after 16 is 32.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:74aa182d9c17efe4288c38ade27360cbafc92c4610bd46abd869d658453975f7",
+                    "B": "sha256:015c2de4011cc043b645d97769ed0a0b662ca75b479485f7e31b0d3eea12cc93",
+                    "C": "sha256:737af3a89acf613f603e272d87844894b32f77140d9b4dffe602df566c82e6cb",
+                    "D": "sha256:94862ae363d9fcf29f960859f08ad1ed939547d2c6e54cb45a2d9cf43c9dc1ca"
+                },
+                "stem": "sha256:30422613ade45637e4d33f46c745ca1f171fae32900292337ecbde0307b39618"
+            },
+            "correct_answer": "B",
+            "difficulty_level": "L3",
+            "dimension": "NPR",
+            "distractor_logic": "Distractors keep the numbers close but break the row-doubling rule by under- or over-shooting the product.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:5dd2ca40a029e5eb576be1f326f16855b0b7e7574eabbd0944b72ac5b7cf0c73",
+                "seed": "iqs12_q10_seed",
+                "source_mode": "repo_generated",
+                "template_key": "row_double_grid_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "number_grid",
+            "item_id": "FM-IQ-NPR-GRD-L3-SH010",
+            "question_id": "IQS12_Q10",
+            "raw_points": 1,
+            "solution_rule": "In each row the second number is double the first, so the row starting with 5 must end with 10.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:f8d0c1491a4b6190395f8e67af2f5c2d6677b36657458166af2c3aff3f1bc4d8",
+                    "B": "sha256:3b872f92b834610fe427dd3c1bf3d53cc1b341ea4cfdbfff8cfdbbcf2b02b175",
+                    "C": "sha256:1ee0aefd125c62902db9556c03c6718b1fd8aaa266a9bd9ff17bb293b46bb3fc",
+                    "D": "sha256:bdfa60bee025b6745131326d97f9912dff513843521115cd3885259f5120806d"
+                },
+                "stem": "sha256:b73bb8b57527e21a2cde716e988b94d6eda5d71c2023a46a383ea188b34d1124"
+            },
+            "correct_answer": "C",
+            "difficulty_level": "L3",
+            "dimension": "NPR",
+            "distractor_logic": "Distractors reuse one of the symbol values or add an extra step to test whether the mapping was applied cleanly.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:c8fcc5a9575d0e637db4d459754bd1f1129cdd7d1066d083c57a1ee2bb4c3161",
+                "seed": "iqs12_q11_seed",
+                "source_mode": "repo_generated",
+                "template_key": "symbol_value_addition_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "symbol_operation",
+            "item_id": "FM-IQ-NPR-SYM-L3-SH011",
+            "question_id": "IQS12_Q11",
+            "raw_points": 1,
+            "solution_rule": "The stem assigns values triangle=2 and circle=4, so adding them yields 6.",
+            "status": "beta"
+        },
+        {
+            "asset_hashes": {
+                "options": {
+                    "A": "sha256:3b872f92b834610fe427dd3c1bf3d53cc1b341ea4cfdbfff8cfdbbcf2b02b175",
+                    "B": "sha256:1ee0aefd125c62902db9556c03c6718b1fd8aaa266a9bd9ff17bb293b46bb3fc",
+                    "C": "sha256:bdfa60bee025b6745131326d97f9912dff513843521115cd3885259f5120806d",
+                    "D": "sha256:74aa182d9c17efe4288c38ade27360cbafc92c4610bd46abd869d658453975f7"
+                },
+                "stem": "sha256:cbfe6d962ac9a23195bbedccf7c50cc4c439918b6023e71c33c9d0bb14ba1edc"
+            },
+            "correct_answer": "D",
+            "difficulty_level": "L4",
+            "dimension": "NPR",
+            "distractor_logic": "Distractors represent common under-counts that miss overlapping or edge triangles in the figure.",
+            "generator_metadata": {
+                "generator_version": "iq_showcase12_generator_v1",
+                "params_hash": "sha256:11ee7013229bf08462ba79964887ac6944ef0f5f785cddc9925e27ea1f793033",
+                "seed": "iqs12_q12_seed",
+                "source_mode": "repo_generated",
+                "template_key": "triangle_count_v1",
+                "theme_version": "iq_showcase12_theme_v1"
+            },
+            "item_family": "shape_counting",
+            "item_id": "FM-IQ-NPR-CNT-L4-SH012",
+            "question_id": "IQS12_Q12",
+            "raw_points": 1,
+            "solution_rule": "The figure can be decomposed into eight distinct small triangles when counted systematically from top to bottom.",
+            "status": "beta"
+        }
+    ],
+    "norm_table_version": "unavailable",
+    "quality_rules": {
+        "abnormal_quality_policy": "review_with_caution",
+        "speeding_seconds_lt": 30,
+        "straightlining_run_len_gte": 8
+    },
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "scoring_engine_version": "iq_scoring_v2",
+    "scoring_mode": "scored",
+    "version": "showcase12.v1"
+}

--- a/docs/audits/iq/04_pr6_item_bank_import_notes.md
+++ b/docs/audits/iq/04_pr6_item_bank_import_notes.md
@@ -1,0 +1,58 @@
+# PR6 Notes — Showcase 12 Beta Bank Import
+
+## Scope
+
+- import a canonical `IQ_SHOWCASE_12_BETA` bank under `IQ_INTELLIGENCE_QUOTIENT`
+- keep the legacy 30-item demo untouched and unpromoted
+- keep commerce deferred
+- keep frontend out of scope
+
+## Imported bank
+
+- bank id: `IQ_SHOWCASE_12_BETA`
+- status: `beta`
+- activation: `runtime_bound=false`
+- item count: `12`
+- dimensions:
+  - `VSPR`: 4
+  - `VSI`: 4
+  - `NPR`: 4
+- answer distribution:
+  - `A`: 3
+  - `B`: 3
+  - `C`: 3
+  - `D`: 3
+
+## Files
+
+- `content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/manifest.json`
+- `content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/items.json`
+- `content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/answer_key.json`
+- `content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_SHOWCASE_12_BETA/scoring_spec.json`
+- `backend/scripts/iq/build_showcase12_beta_bank.php`
+- `backend/scripts/iq/verify_showcase12_beta_bank.php`
+- `backend/tests/Feature/Content/IqShowcase12BetaBankImportTest.php`
+
+## Guarantees
+
+- every imported item has:
+  - canonical `scale_code`
+  - `item_id`
+  - `dimension`
+  - `item_family`
+  - `difficulty_level`
+  - `correct_answer`
+  - `solution_rule`
+  - `distractor_logic`
+  - `assets`
+  - `asset_hashes`
+  - `generator_metadata`
+- `Beta 50` is still future work and is **not** claimed as imported in this PR
+- no legacy IQ demo SVG geometry was changed
+- no payment / unlock implementation was added
+
+## Remaining gap
+
+- `IQ_BETA_50` remains future work.
+- no production norm table was added.
+- runtime is still not switched from legacy demo to showcase bank.


### PR DESCRIPTION
Imported bank IDs: `IQ_SHOWCASE_12_BETA`

Summary:
- imports 12 canonical IQ items under `IQ_INTELLIGENCE_QUOTIENT`
- keeps legacy 30 demo items unchanged as legacy demo
- keeps commerce deferred
- keeps frontend out of scope

Details:
- item count: 12
- dimensions covered: VSPR=4, VSI=4, NPR=4
- answer distribution: A=3, B=3, C=3, D=3
- asset hash coverage: complete for all imported items
- generator metadata: present for all imported items
- bank activation: `runtime_bound=false`
- Beta 50 remains future work and is not imported in this PR

Not included:
- no commerce implementation
- no frontend implementation
- no legacy demo SVG geometry changes

Remaining sidecars:
- `IQ-SIDECAR-COMMERCE-DEFERRED-001`
- `IQ-SIDECAR-NORM-TABLE-DEFERRED-001`
- `IQ-SIDECAR-PROTOTYPE-ZIP-EXTERNAL-001`