### PR TITLE
feat(api): add career public resolution plan resolver

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerPublicResolutionPlan.php
+++ b/backend/app/Domain/Career/Audit/CareerPublicResolutionPlan.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerPublicResolutionPlan
+{
+    /**
+     * @param  list<CareerPublicResolutionPlanRow>  $rows
+     */
+    public function __construct(
+        public readonly string $sourcePath,
+        public readonly ?string $checksum,
+        public readonly array $rows,
+    ) {
+        if (trim($this->sourcePath) === '') {
+            throw new InvalidArgumentException('Career public resolution plan source_path is required.');
+        }
+
+        if (! array_is_list($this->rows)) {
+            throw new InvalidArgumentException('Career public resolution plan rows must be a list.');
+        }
+
+        foreach ($this->rows as $row) {
+            if (! $row instanceof CareerPublicResolutionPlanRow) {
+                throw new InvalidArgumentException('Career public resolution plan rows must contain row DTOs.');
+            }
+        }
+    }
+
+    public function foundRows(): int
+    {
+        return count($this->rows);
+    }
+
+    /**
+     * @return array{source_path: string, checksum: string|null, rows: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'source_path' => $this->sourcePath,
+            'checksum' => $this->checksum,
+            'rows' => array_map(
+                static fn (CareerPublicResolutionPlanRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanIssue.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerPublicResolutionPlanIssue
+{
+    public const PLAN_FILE_MISSING = 'plan_file_missing';
+
+    public const PLAN_JSON_INVALID = 'plan_json_invalid';
+
+    public const PLAN_ROWS_MISSING = 'plan_rows_missing';
+
+    public const PLAN_ROW_MALFORMED = 'plan_row_malformed';
+
+    public const CANONICAL_SLUG_MISSING = 'canonical_slug_missing';
+
+    public const CANONICAL_SLUG_DUPLICATE = 'canonical_slug_duplicate';
+
+    public const EXPECTED_ROW_COUNT_MISMATCH = 'expected_row_count_mismatch';
+
+    public const REQUIRED_FIELD_MISSING = 'required_field_missing';
+
+    public const UNSUPPORTED_PLAN_SHAPE = 'unsupported_plan_shape';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::MEDIUM,
+        public readonly ?int $rowIndex = null,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $jsonPath = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::PLAN_FILE_MISSING,
+            self::PLAN_JSON_INVALID,
+            self::PLAN_ROWS_MISSING,
+            self::PLAN_ROW_MALFORMED,
+            self::CANONICAL_SLUG_MISSING,
+            self::CANONICAL_SLUG_DUPLICATE,
+            self::EXPECTED_ROW_COUNT_MISMATCH,
+            self::REQUIRED_FIELD_MISSING,
+            self::UNSUPPORTED_PLAN_SHAPE,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career public resolution plan issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, row_index: int|null, canonical_slug: string|null, json_path: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'row_index' => $this->rowIndex,
+            'canonical_slug' => $this->canonicalSlug,
+            'json_path' => $this->jsonPath,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career public resolution plan issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career public resolution plan issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanResolver.php
+++ b/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanResolver.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerPublicResolutionPlanResolver
+{
+    public static function fromPath(string $path, ?int $expectedRows = null): CareerPublicResolutionPlanValidationResult
+    {
+        $sourcePath = trim($path);
+        if ($sourcePath === '' || ! is_file($sourcePath)) {
+            return CareerPublicResolutionPlanValidationResult::build(
+                expectedRows: $expectedRows,
+                sourcePath: $sourcePath === '' ? $path : $sourcePath,
+                plan: null,
+                issues: [
+                    new CareerPublicResolutionPlanIssue(
+                        reason: CareerPublicResolutionPlanIssue::PLAN_FILE_MISSING,
+                        message: 'Career public resolution planner JSON file was not found.',
+                        severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_FULL_2786_CLAIM,
+                        jsonPath: '$',
+                        evidence: [$path],
+                    ),
+                ],
+            );
+        }
+
+        $realPath = realpath($sourcePath);
+        $resolvedPath = is_string($realPath) && $realPath !== '' ? $realPath : $sourcePath;
+        $contents = file_get_contents($resolvedPath);
+        if (! is_string($contents)) {
+            return CareerPublicResolutionPlanValidationResult::build(
+                expectedRows: $expectedRows,
+                sourcePath: $resolvedPath,
+                plan: null,
+                issues: [
+                    new CareerPublicResolutionPlanIssue(
+                        reason: CareerPublicResolutionPlanIssue::PLAN_FILE_MISSING,
+                        message: 'Career public resolution planner JSON file could not be read.',
+                        severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_FULL_2786_CLAIM,
+                        jsonPath: '$',
+                        evidence: [$resolvedPath],
+                    ),
+                ],
+            );
+        }
+
+        $payload = json_decode($contents, true);
+        if (! is_array($payload)) {
+            return CareerPublicResolutionPlanValidationResult::build(
+                expectedRows: $expectedRows,
+                sourcePath: $resolvedPath,
+                plan: null,
+                issues: [
+                    new CareerPublicResolutionPlanIssue(
+                        reason: CareerPublicResolutionPlanIssue::PLAN_JSON_INVALID,
+                        message: 'Career public resolution planner JSON is not a parseable object.',
+                        severity: CareerCanonicalEligibilitySeverity::HIGH,
+                        jsonPath: '$',
+                        evidence: [json_last_error_msg()],
+                    ),
+                ],
+            );
+        }
+
+        $rowsSource = self::extractRows($payload);
+        if ($rowsSource['rows'] === null) {
+            return CareerPublicResolutionPlanValidationResult::build(
+                expectedRows: $expectedRows,
+                sourcePath: $resolvedPath,
+                plan: null,
+                issues: [
+                    new CareerPublicResolutionPlanIssue(
+                        reason: $rowsSource['reason'],
+                        message: $rowsSource['message'],
+                        severity: CareerCanonicalEligibilitySeverity::HIGH,
+                        jsonPath: $rowsSource['json_path'],
+                        evidence: ['Supported row paths: $.rows, $.workbook.rows, $.occupations, $.assets.'],
+                    ),
+                ],
+            );
+        }
+
+        $rows = [];
+        $issues = [];
+        $seenSlugs = [];
+        foreach ($rowsSource['rows'] as $index => $rawRow) {
+            if (! is_array($rawRow) || array_is_list($rawRow)) {
+                $issues[] = new CareerPublicResolutionPlanIssue(
+                    reason: CareerPublicResolutionPlanIssue::PLAN_ROW_MALFORMED,
+                    message: 'Career public resolution planner row must be a JSON object.',
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    rowIndex: $index,
+                    jsonPath: sprintf('%s.%d', $rowsSource['json_path'], $index),
+                    evidence: [$rawRow],
+                );
+
+                continue;
+            }
+
+            $row = CareerPublicResolutionPlanRow::fromRaw($rawRow);
+            $rows[] = $row;
+
+            if ($row->canonicalSlug === null) {
+                $issues[] = new CareerPublicResolutionPlanIssue(
+                    reason: CareerPublicResolutionPlanIssue::CANONICAL_SLUG_MISSING,
+                    message: 'Career public resolution planner row is missing canonical_slug, slug, or source_slug.',
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    rowIndex: $index,
+                    jsonPath: sprintf('%s.%d', $rowsSource['json_path'], $index),
+                    evidence: [$rawRow],
+                );
+            } elseif (array_key_exists($row->canonicalSlug, $seenSlugs)) {
+                $issues[] = new CareerPublicResolutionPlanIssue(
+                    reason: CareerPublicResolutionPlanIssue::CANONICAL_SLUG_DUPLICATE,
+                    message: 'Career public resolution planner row has a duplicate canonical_slug.',
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    rowIndex: $index,
+                    canonicalSlug: $row->canonicalSlug,
+                    jsonPath: sprintf('%s.%d.canonical_slug', $rowsSource['json_path'], $index),
+                    evidence: [
+                        [
+                            'first_index' => $seenSlugs[$row->canonicalSlug],
+                            'duplicate_index' => $index,
+                        ],
+                    ],
+                );
+            } else {
+                $seenSlugs[$row->canonicalSlug] = $index;
+            }
+
+            if ($row->rowNumber === null) {
+                $issues[] = new CareerPublicResolutionPlanIssue(
+                    reason: CareerPublicResolutionPlanIssue::REQUIRED_FIELD_MISSING,
+                    message: 'Career public resolution planner row is missing required row_number.',
+                    severity: CareerCanonicalEligibilitySeverity::MEDIUM,
+                    rowIndex: $index,
+                    canonicalSlug: $row->canonicalSlug,
+                    jsonPath: sprintf('%s.%d.row_number', $rowsSource['json_path'], $index),
+                    evidence: ['row_number'],
+                );
+            }
+
+            if ($row->publicResolutionState === null) {
+                $issues[] = new CareerPublicResolutionPlanIssue(
+                    reason: CareerPublicResolutionPlanIssue::REQUIRED_FIELD_MISSING,
+                    message: 'Career public resolution planner row is missing required status/public_resolution_state.',
+                    severity: CareerCanonicalEligibilitySeverity::MEDIUM,
+                    rowIndex: $index,
+                    canonicalSlug: $row->canonicalSlug,
+                    jsonPath: sprintf('%s.%d.status', $rowsSource['json_path'], $index),
+                    evidence: ['status', 'public_resolution_state', 'current_status'],
+                );
+            }
+        }
+
+        $declaredRows = self::normalizeInt($payload['workbook']['rows'] ?? null);
+        if ($declaredRows !== null && count($rows) !== $declaredRows) {
+            $issues[] = self::rowCountIssue(
+                expectedRows: $declaredRows,
+                foundRows: count($rows),
+                source: 'workbook.rows',
+            );
+        }
+
+        if ($expectedRows !== null && count($rows) !== $expectedRows) {
+            $issues[] = self::rowCountIssue(
+                expectedRows: $expectedRows,
+                foundRows: count($rows),
+                source: 'caller_expected_rows',
+            );
+        }
+
+        $checksum = hash_file('sha256', $resolvedPath);
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: $resolvedPath,
+            checksum: is_string($checksum) ? $checksum : null,
+            rows: $rows,
+        );
+
+        return CareerPublicResolutionPlanValidationResult::build(
+            expectedRows: $expectedRows,
+            sourcePath: $resolvedPath,
+            plan: $plan,
+            issues: $issues,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{rows: list<mixed>|null, json_path: string, reason: string, message: string}
+     */
+    private static function extractRows(array $payload): array
+    {
+        if (array_key_exists('rows', $payload)) {
+            return self::rowsAt($payload['rows'], '$.rows');
+        }
+
+        $workbook = $payload['workbook'] ?? null;
+        if (is_array($workbook) && array_key_exists('rows', $workbook) && is_array($workbook['rows'])) {
+            return self::rowsAt($workbook['rows'], '$.workbook.rows');
+        }
+
+        if (array_key_exists('occupations', $payload)) {
+            return self::rowsAt($payload['occupations'], '$.occupations');
+        }
+
+        if (array_key_exists('assets', $payload)) {
+            return self::rowsAt($payload['assets'], '$.assets');
+        }
+
+        return [
+            'rows' => null,
+            'json_path' => '$',
+            'reason' => CareerPublicResolutionPlanIssue::UNSUPPORTED_PLAN_SHAPE,
+            'message' => 'Career public resolution planner JSON does not expose a supported row list.',
+        ];
+    }
+
+    /**
+     * @return array{rows: list<mixed>|null, json_path: string, reason: string, message: string}
+     */
+    private static function rowsAt(mixed $value, string $jsonPath): array
+    {
+        if (! is_array($value) || ! array_is_list($value) || $value === []) {
+            return [
+                'rows' => null,
+                'json_path' => $jsonPath,
+                'reason' => CareerPublicResolutionPlanIssue::PLAN_ROWS_MISSING,
+                'message' => 'Career public resolution planner row path must contain a non-empty JSON array.',
+            ];
+        }
+
+        return [
+            'rows' => $value,
+            'json_path' => $jsonPath,
+            'reason' => '',
+            'message' => '',
+        ];
+    }
+
+    private static function rowCountIssue(int $expectedRows, int $foundRows, string $source): CareerPublicResolutionPlanIssue
+    {
+        return new CareerPublicResolutionPlanIssue(
+            reason: CareerPublicResolutionPlanIssue::EXPECTED_ROW_COUNT_MISMATCH,
+            message: 'Career public resolution planner row count does not match the expected count.',
+            severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_FULL_2786_CLAIM,
+            jsonPath: '$.rows',
+            evidence: [
+                [
+                    'source' => $source,
+                    'expected_rows' => $expectedRows,
+                    'found_rows' => $foundRows,
+                ],
+            ],
+        );
+    }
+
+    private static function normalizeInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanRow.php
+++ b/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanRow.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerPublicResolutionPlanRow
+{
+    /**
+     * @param  list<string>  $locales
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $rowNumber,
+        public readonly ?string $canonicalSlug,
+        public readonly ?string $publicResolutionState,
+        public readonly ?string $canonicalPublicType,
+        public readonly ?string $rolloutState,
+        public readonly ?string $projectionState,
+        public readonly ?string $indexStateHint,
+        public readonly ?string $titleEn,
+        public readonly ?string $titleZh,
+        public readonly ?string $sourceCode,
+        public readonly ?string $family,
+        public readonly ?string $batchId,
+        public readonly array $locales,
+        public readonly array $raw,
+    ) {
+        self::assertLocales($this->locales);
+    }
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public static function fromRaw(array $raw): self
+    {
+        return new self(
+            rowNumber: self::normalizeInt($raw['row_number'] ?? null),
+            canonicalSlug: self::normalizeSlug($raw['canonical_slug'] ?? null)
+                ?? self::normalizeSlug($raw['slug'] ?? null)
+                ?? self::normalizeSlug($raw['source_slug'] ?? null),
+            publicResolutionState: self::normalizeString($raw['public_resolution_state'] ?? null)
+                ?? self::normalizeString($raw['status'] ?? null)
+                ?? self::normalizeString($raw['current_status'] ?? null),
+            canonicalPublicType: self::normalizeString($raw['canonical_public_type'] ?? null)
+                ?? self::normalizeString($raw['public_resolution_type'] ?? null)
+                ?? self::normalizeString($raw['public_type'] ?? null),
+            rolloutState: self::normalizeString($raw['rollout_state'] ?? null),
+            projectionState: self::normalizeString($raw['projection_state'] ?? null),
+            indexStateHint: self::normalizeString($raw['index_state_hint'] ?? null)
+                ?? self::normalizeString($raw['indexability'] ?? null)
+                ?? self::normalizeString($raw['index_state'] ?? null),
+            titleEn: self::titleValue($raw, 'en'),
+            titleZh: self::titleValue($raw, 'zh'),
+            sourceCode: self::normalizeString($raw['source_code'] ?? null)
+                ?? self::normalizeString($raw['o_net_code'] ?? null)
+                ?? self::normalizeString($raw['onet_code'] ?? null),
+            family: self::normalizeString($raw['family'] ?? null)
+                ?? self::normalizeString($raw['career_family'] ?? null),
+            batchId: self::normalizeString($raw['batch_id'] ?? null)
+                ?? self::normalizeString($raw['batch'] ?? null),
+            locales: self::normalizeLocales($raw),
+            raw: $raw,
+        );
+    }
+
+    /**
+     * @return array{row_number: int|null, canonical_slug: string|null, public_resolution_state: string|null, canonical_public_type: string|null, rollout_state: string|null, projection_state: string|null, index_state_hint: string|null, title_en: string|null, title_zh: string|null, source_code: string|null, family: string|null, batch_id: string|null, locales: list<string>, raw: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'row_number' => $this->rowNumber,
+            'canonical_slug' => $this->canonicalSlug,
+            'public_resolution_state' => $this->publicResolutionState,
+            'canonical_public_type' => $this->canonicalPublicType,
+            'rollout_state' => $this->rolloutState,
+            'projection_state' => $this->projectionState,
+            'index_state_hint' => $this->indexStateHint,
+            'title_en' => $this->titleEn,
+            'title_zh' => $this->titleZh,
+            'source_code' => $this->sourceCode,
+            'family' => $this->family,
+            'batch_id' => $this->batchId,
+            'locales' => $this->locales,
+            'raw' => $this->raw,
+        ];
+    }
+
+    private static function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private static function normalizeSlug(mixed $value): ?string
+    {
+        $normalized = self::normalizeString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private static function normalizeInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    private static function titleValue(array $raw, string $locale): ?string
+    {
+        if ($locale === 'en') {
+            $direct = self::normalizeString($raw['title_en'] ?? null);
+            if ($direct !== null) {
+                return $direct;
+            }
+        }
+
+        if ($locale === 'zh') {
+            $direct = self::normalizeString($raw['title_zh'] ?? null)
+                ?? self::normalizeString($raw['title_zh_cn'] ?? null);
+            if ($direct !== null) {
+                return $direct;
+            }
+        }
+
+        $title = $raw['title'] ?? null;
+        if (! is_array($title)) {
+            return null;
+        }
+
+        return self::normalizeString($title[$locale] ?? null)
+            ?? ($locale === 'zh' ? self::normalizeString($title['zh-CN'] ?? null) : null);
+    }
+
+    /**
+     * @param  array<string, mixed>  $raw
+     * @return list<string>
+     */
+    private static function normalizeLocales(array $raw): array
+    {
+        $locales = $raw['locales'] ?? null;
+        if (is_array($locales) && array_is_list($locales)) {
+            $normalized = [];
+            foreach ($locales as $locale) {
+                $value = self::normalizeString($locale);
+                if ($value !== null) {
+                    $normalized[] = $value;
+                }
+            }
+
+            return array_values(array_unique($normalized));
+        }
+
+        $locale = self::normalizeString($raw['locale'] ?? null);
+
+        return $locale === null ? [] : [$locale];
+    }
+
+    /**
+     * @param  list<string>  $locales
+     */
+    private static function assertLocales(array $locales): void
+    {
+        if (! array_is_list($locales)) {
+            throw new InvalidArgumentException('Career public resolution plan row locales must be a list.');
+        }
+
+        foreach ($locales as $locale) {
+            if (! is_string($locale) || trim($locale) === '') {
+                throw new InvalidArgumentException('Career public resolution plan row locales must contain non-empty strings.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanValidationResult.php
+++ b/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanValidationResult.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerPublicResolutionPlanValidationResult
+{
+    /**
+     * @param  list<CareerPublicResolutionPlanIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly ?int $expectedRows,
+        public readonly string $sourcePath,
+        public readonly ?CareerPublicResolutionPlan $plan = null,
+        public readonly array $issues = [],
+    ) {
+        self::assertStatus($this->status);
+        if ($this->expectedRows !== null && $this->expectedRows < 0) {
+            throw new InvalidArgumentException('Career public resolution plan expected_rows must be non-negative.');
+        }
+
+        if (trim($this->sourcePath) === '') {
+            throw new InvalidArgumentException('Career public resolution plan validation source_path is required.');
+        }
+
+        if (! array_is_list($this->issues)) {
+            throw new InvalidArgumentException('Career public resolution plan issues must be a list.');
+        }
+
+        foreach ($this->issues as $issue) {
+            if (! $issue instanceof CareerPublicResolutionPlanIssue) {
+                throw new InvalidArgumentException('Career public resolution plan issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerPublicResolutionPlanIssue>  $issues
+     */
+    public static function build(?int $expectedRows, string $sourcePath, ?CareerPublicResolutionPlan $plan, array $issues): self
+    {
+        return new self(
+            status: self::statusForIssues($issues),
+            expectedRows: $expectedRows,
+            sourcePath: $sourcePath,
+            plan: $plan,
+            issues: $issues,
+        );
+    }
+
+    public function foundRows(): int
+    {
+        return $this->plan?->foundRows() ?? 0;
+    }
+
+    /**
+     * @return list<CareerPublicResolutionPlanRow>
+     */
+    public function rows(): array
+    {
+        return $this->plan?->rows ?? [];
+    }
+
+    public function checksum(): ?string
+    {
+        return $this->plan?->checksum;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, expected_rows: int|null, found_rows: int, source_path: string, checksum: string|null, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'expected_rows' => $this->expectedRows,
+            'found_rows' => $this->foundRows(),
+            'source_path' => $this->sourcePath,
+            'checksum' => $this->checksum(),
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerPublicResolutionPlanRow $row): array => $row->toArray(),
+                $this->rows()
+            ),
+            'issues' => array_map(
+                static fn (CareerPublicResolutionPlanIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerPublicResolutionPlanIssue>  $issues
+     */
+    private static function statusForIssues(array $issues): string
+    {
+        foreach ($issues as $issue) {
+            if ($issue->reason === CareerPublicResolutionPlanIssue::PLAN_FILE_MISSING) {
+                return CareerCanonicalEligibilityStatus::BLOCKED;
+            }
+        }
+
+        return $issues === []
+            ? CareerCanonicalEligibilityStatus::PASS
+            : CareerCanonicalEligibilityStatus::FAIL;
+    }
+
+    private static function assertStatus(string $status): void
+    {
+        if (! in_array($status, [
+            CareerCanonicalEligibilityStatus::PASS,
+            CareerCanonicalEligibilityStatus::FAIL,
+            CareerCanonicalEligibilityStatus::BLOCKED,
+        ], true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career public resolution plan validation status [%s].', $status));
+        }
+    }
+}

--- a/backend/docs/career/audits/public_resolution_source_resolver.md
+++ b/backend/docs/career/audits/public_resolution_source_resolver.md
@@ -1,0 +1,144 @@
+# Career Public Resolution Source Resolver
+
+AUDIT-2 adds a read-only resolver contract for the external Career 2786 public-resolution planner JSON. The resolver is intended for future AUDIT-3+ inventory checks and AUDIT-9 command integration. It does not run the canonical eligibility audit, query the database, backfill occupations, modify rollout state, write files, deploy, or claim 2786 readiness.
+
+## Purpose
+
+The Career full release ledger pipeline already accepts an external planner artifact for the 2786-row public-resolution model. AUDIT-2 makes that planner input explicit and reusable by validating the planner shape, normalizing rows, preserving raw row data, and returning structured issues instead of command-only exception strings.
+
+## Resolver Contract
+
+Primary API:
+
+```php
+CareerPublicResolutionPlanResolver::fromPath(
+    string $path,
+    ?int $expectedRows = null,
+): CareerPublicResolutionPlanValidationResult
+```
+
+The resolver:
+
+- accepts an explicit file path
+- reads JSON from that path only
+- validates that the file exists and JSON is parseable
+- extracts planner rows from a supported row path
+- normalizes rows into `CareerPublicResolutionPlanRow`
+- validates canonical slug presence and uniqueness
+- validates required planner fields used by the existing full release ledger planner path
+- validates expected row count when the caller supplies `expectedRows`
+- returns `pass`, `fail`, or `blocked`
+- does not query DB, write files, mutate rollout state, or require the production planner artifact in tests
+
+## Supported Input Shapes
+
+AUDIT-2 supports these row-list locations:
+
+- `$.rows`
+- `$.workbook.rows` when it is a JSON array
+- `$.occupations`
+- `$.assets`
+
+The current full release ledger command uses this production-oriented shape:
+
+```json
+{
+  "workbook": {
+    "path": "/absolute/path/to/career_full_upload_repaired.xlsx",
+    "sha256": "source-workbook-sha",
+    "sheet": "Career_Assets_v4_1",
+    "rows": 2786
+  },
+  "rows": []
+}
+```
+
+In that shape, `workbook.rows` is a declared row count and `rows` is the actual planner row list. If `workbook.rows` is present as a count and does not match the normalized row count, the resolver emits `expected_row_count_mismatch`.
+
+## Normalized Row Schema
+
+Each planner row is normalized to:
+
+```json
+{
+  "row_number": 2,
+  "canonical_slug": "actuaries",
+  "public_resolution_state": "upload_candidate",
+  "canonical_public_type": "public_canonical_job",
+  "rollout_state": null,
+  "projection_state": null,
+  "index_state_hint": null,
+  "title_en": "Actuaries",
+  "title_zh": "Jing suan shi",
+  "source_code": "15-2011.00",
+  "family": "math",
+  "batch_id": "batch-001",
+  "locales": ["en", "zh-CN"],
+  "raw": {}
+}
+```
+
+Field aliases:
+
+- `canonical_slug` falls back to `slug` and then `source_slug`.
+- `public_resolution_state` falls back to `status` and then `current_status`.
+- `canonical_public_type` falls back to `public_resolution_type` and then `public_type`.
+- `index_state_hint` falls back to `indexability` and then `index_state`.
+- `title_en` and `title_zh` may come from direct fields or a nested `title` object.
+
+Rows with missing fields are preserved in `raw` and reported through structured issues. The resolver does not silently drop malformed planner data.
+
+## Required Planner Fields
+
+The existing full release ledger planner path currently requires:
+
+- `row_number`
+- `slug` or `canonical_slug`
+- `status`
+
+AUDIT-2 keeps that requirement at the resolver layer while allowing future planner variants to supply equivalent normalized aliases.
+
+## Validation Reasons
+
+Structured issue reasons are stable:
+
+- `plan_file_missing`
+- `plan_json_invalid`
+- `plan_rows_missing`
+- `plan_row_malformed`
+- `canonical_slug_missing`
+- `canonical_slug_duplicate`
+- `expected_row_count_mismatch`
+- `required_field_missing`
+- `unsupported_plan_shape`
+
+`plan_file_missing` returns `blocked`. Other validation issues return `fail`. A resolver result with no issues returns `pass`.
+
+## Expected Row Count Semantics
+
+The resolver only requires 2786 rows when the caller passes `expectedRows: 2786` or when the planner itself declares a mismatching `workbook.rows` count. Tests use small synthetic fixtures and prove that 2786 can be represented as an expected count without requiring the real external planner artifact.
+
+## Consumption By AUDIT-3+
+
+Future AUDIT PRs should consume `CareerPublicResolutionPlanValidationResult` instead of rereading planner JSON:
+
+- AUDIT-3 should use normalized `canonical_slug` values for occupation entity inventory.
+- AUDIT-4 should join normalized slugs to baseline/display metadata checks.
+- AUDIT-9 should integrate the resolver into `career:audit-canonical-eligibility` without changing resolver behavior.
+
+Consumers should fail closed on `blocked` or `fail`, preserve `issues`, and avoid turning missing external planner input into a production mutation.
+
+## Non-Goals
+
+AUDIT-2 does not:
+
+- add the canonical eligibility audit command
+- implement DB inventory
+- backfill occupations
+- modify rollout state
+- generate a manifest train
+- run production validation
+- deploy
+- require the real 2786 planner artifact in tests
+
+AUDIT-2 does not claim 2786 readiness.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerPublicResolutionPlanResolverTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerPublicResolutionPlanResolverTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanIssue;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanResolver;
+use PHPUnit\Framework\TestCase;
+
+final class CareerPublicResolutionPlanResolverTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $paths = [];
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->paths) as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+
+            if (is_dir($path)) {
+                rmdir($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_missing_plan_file_returns_blocked_issue(): void
+    {
+        $result = CareerPublicResolutionPlanResolver::fromPath($this->tempPath('missing.json'), 2786);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(CareerPublicResolutionPlanIssue::PLAN_FILE_MISSING, $result->issues[0]->reason);
+        $this->assertSame(2786, $result->expectedRows);
+        $this->assertSame(0, $result->foundRows());
+    }
+
+    public function test_invalid_json_returns_plan_json_invalid(): void
+    {
+        $path = $this->writeRaw('{"rows": [');
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::FAIL, $result->status);
+        $this->assertSame(CareerPublicResolutionPlanIssue::PLAN_JSON_INVALID, $result->issues[0]->reason);
+    }
+
+    public function test_unsupported_shape_returns_shape_or_rows_issue(): void
+    {
+        $path = $this->writePlan(['workbook' => ['rows' => 2786]]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::FAIL, $result->status);
+        $this->assertContains($result->issues[0]->reason, [
+            CareerPublicResolutionPlanIssue::UNSUPPORTED_PLAN_SHAPE,
+            CareerPublicResolutionPlanIssue::PLAN_ROWS_MISSING,
+        ]);
+    }
+
+    public function test_valid_rows_shape_parses_into_normalized_rows(): void
+    {
+        $path = $this->writePlan([
+            'workbook' => ['rows' => 2],
+            'rows' => [
+                $this->row(2, 'Actuaries', 'upload_candidate', [
+                    'title' => ['en' => 'Actuaries', 'zh-CN' => 'Jing suan shi'],
+                    'source_code' => '15-2011.00',
+                    'family' => 'math',
+                    'batch_id' => 'batch-001',
+                    'locales' => ['en', 'zh-CN'],
+                ]),
+                $this->row(3, 'cn-proxy-sample', 'CN_proxy_hold'),
+            ],
+        ]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 2);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(2, $result->foundRows());
+        $this->assertSame('actuaries', $result->rows()[0]->canonicalSlug);
+        $this->assertSame('upload_candidate', $result->rows()[0]->publicResolutionState);
+        $this->assertSame('Actuaries', $result->rows()[0]->titleEn);
+        $this->assertSame('Jing suan shi', $result->rows()[0]->titleZh);
+        $this->assertSame(['en', 'zh-CN'], $result->rows()[0]->locales);
+    }
+
+    public function test_duplicate_canonical_slug_produces_duplicate_issue(): void
+    {
+        $path = $this->writePlan([
+            'rows' => [
+                $this->row(2, 'actuaries', 'upload_candidate'),
+                $this->row(3, 'actuaries', 'CN_proxy_hold'),
+            ],
+        ]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::FAIL, $result->status);
+        $this->assertSame(CareerPublicResolutionPlanIssue::CANONICAL_SLUG_DUPLICATE, $result->issues[0]->reason);
+        $this->assertSame('actuaries', $result->issues[0]->canonicalSlug);
+    }
+
+    public function test_missing_canonical_slug_produces_missing_slug_issue(): void
+    {
+        $path = $this->writePlan([
+            'rows' => [
+                [
+                    'row_number' => 2,
+                    'status' => 'upload_candidate',
+                ],
+            ],
+        ]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::FAIL, $result->status);
+        $this->assertSame(CareerPublicResolutionPlanIssue::CANONICAL_SLUG_MISSING, $result->issues[0]->reason);
+        $this->assertSame(['row_number' => 2, 'status' => 'upload_candidate'], $result->rows()[0]->raw);
+    }
+
+    public function test_expected_row_count_mismatch_produces_issue(): void
+    {
+        $path = $this->writePlan(['rows' => [$this->row(2, 'actuaries', 'upload_candidate')]]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 2);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::FAIL, $result->status);
+        $this->assertSame(CareerPublicResolutionPlanIssue::EXPECTED_ROW_COUNT_MISMATCH, $result->issues[0]->reason);
+        $this->assertSame(['expected_row_count_mismatch' => 1], $result->byReason());
+    }
+
+    public function test_expected_row_count_pass_works(): void
+    {
+        $path = $this->writePlan([
+            'rows' => [
+                $this->row(2, 'actuaries', 'upload_candidate'),
+                $this->row(3, 'cn-proxy-sample', 'CN_proxy_hold'),
+            ],
+        ]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 2);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(2, $result->expectedRows);
+        $this->assertSame([], $result->issues);
+    }
+
+    public function test_raw_row_is_preserved(): void
+    {
+        $raw = $this->row(2, 'actuaries', 'upload_candidate', ['custom_field' => ['nested' => true]]);
+        $path = $this->writePlan(['rows' => [$raw]]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 1);
+
+        $this->assertSame($raw, $result->rows()[0]->raw);
+        $this->assertSame(['nested' => true], $result->rows()[0]->raw['custom_field']);
+    }
+
+    public function test_resolver_does_not_hit_db(): void
+    {
+        $path = $this->writePlan(['rows' => [$this->row(2, 'actuaries', 'upload_candidate')]]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 1);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $path = $this->writePlan(['rows' => [$this->row(2, 'actuaries', 'upload_candidate')]]);
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 1)->toArray();
+        $result['source_path'] = '__PATH__';
+        $result['checksum'] = '__CHECKSUM__';
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "expected_rows": 1,
+    "found_rows": 1,
+    "source_path": "__PATH__",
+    "checksum": "__CHECKSUM__",
+    "by_reason": [],
+    "rows": [
+        {
+            "row_number": 2,
+            "canonical_slug": "actuaries",
+            "public_resolution_state": "upload_candidate",
+            "canonical_public_type": null,
+            "rollout_state": null,
+            "projection_state": null,
+            "index_state_hint": null,
+            "title_en": null,
+            "title_zh": null,
+            "source_code": null,
+            "family": null,
+            "batch_id": null,
+            "locales": [],
+            "raw": {
+                "row_number": 2,
+                "slug": "actuaries",
+                "status": "upload_candidate",
+                "canonical_slug": "actuaries",
+                "hold_reason": null,
+                "import_eligible": true
+            }
+        }
+    ],
+    "issues": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_by_reason_counts_issues_correctly(): void
+    {
+        $path = $this->writePlan([
+            'rows' => [
+                $this->row(2, 'actuaries', 'upload_candidate'),
+                $this->row(3, 'actuaries', 'CN_proxy_hold'),
+                ['row_number' => 4, 'status' => 'manual_hold'],
+            ],
+        ]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 2786);
+
+        $this->assertSame([
+            'canonical_slug_duplicate' => 1,
+            'canonical_slug_missing' => 1,
+            'expected_row_count_mismatch' => 1,
+        ], $result->byReason());
+    }
+
+    public function test_2786_expected_count_can_be_represented_without_actual_2786_fixture(): void
+    {
+        $path = $this->writePlan(['rows' => [$this->row(2, 'actuaries', 'upload_candidate')]]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 2786);
+
+        $this->assertSame(2786, $result->expectedRows);
+        $this->assertSame(1, $result->foundRows());
+        $this->assertSame(CareerPublicResolutionPlanIssue::EXPECTED_ROW_COUNT_MISMATCH, $result->issues[0]->reason);
+    }
+
+    public function test_small_synthetic_fixture_with_public_non_public_split_validates(): void
+    {
+        $path = $this->writePlan([
+            'workbook' => [
+                'path' => '/tmp/career_full_upload_repaired.xlsx',
+                'sha256' => 'fixture-workbook-sha',
+                'sheet' => 'Career_Assets_v4_1',
+                'rows' => 4,
+            ],
+            'rows' => [
+                $this->row(2, 'canonical-0001', 'already_imported_validated', ['canonical_public_type' => 'public_canonical_job']),
+                $this->row(3, 'canonical-0002', 'upload_candidate', ['canonical_public_type' => 'public_canonical_job']),
+                $this->row(4, 'cn-proxy-0001', 'CN_proxy_hold', ['canonical_public_type' => 'blocked_until_governance_approval']),
+                $this->row(5, 'manual-hold-0001', 'manual_hold', ['canonical_public_type' => 'keep_non_public_with_policy']),
+            ],
+        ]);
+
+        $result = CareerPublicResolutionPlanResolver::fromPath($path, 4);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame([
+            'public_canonical_job',
+            'public_canonical_job',
+            'blocked_until_governance_approval',
+            'keep_non_public_with_policy',
+        ], array_map(
+            static fn ($row): ?string => $row->canonicalPublicType,
+            $result->rows()
+        ));
+    }
+
+    private function tempPath(string $name): string
+    {
+        $dir = sys_get_temp_dir().'/career-public-resolution-plan-resolver-'.str_replace('.', '', uniqid('', true));
+        mkdir($dir);
+        $this->paths[] = $dir;
+
+        return $dir.'/'.$name;
+    }
+
+    private function writeRaw(string $contents): string
+    {
+        $path = $this->tempPath('plan.json');
+        file_put_contents($path, $contents);
+        $this->paths[] = $path;
+
+        return $path;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writePlan(array $payload): string
+    {
+        return $this->writeRaw((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function row(int $rowNumber, string $slug, string $status, array $overrides = []): array
+    {
+        return array_merge([
+            'row_number' => $rowNumber,
+            'slug' => $slug,
+            'status' => $status,
+            'canonical_slug' => $slug,
+            'hold_reason' => str_ends_with($status, '_hold') ? $status : null,
+            'import_eligible' => $status === 'upload_candidate',
+        ], $overrides);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -268,6 +268,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_public_resolution_plan_resolver_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlan.php',
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanIssue.php',
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanResolver.php',
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanRow.php',
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanValidationResult.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -870,6 +883,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerPublicResolutionPlanResolverFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1133,6 +1150,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySeverity.php',
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilitySidecar.php',
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityStatus.php',
+        ], true);
+    }
+
+    private function isCareerPublicResolutionPlanResolverFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlan.php',
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanIssue.php',
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanResolver.php',
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanRow.php',
+            'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanValidationResult.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-12T16:44:41+08:00",
+  "updated_at": "2026-05-12T18:04:55+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -1069,6 +1069,46 @@
       "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-2 2786 public-resolution source resolver",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "AUDIT-2": {
+      "repo": "fap-api",
+      "branch": "fix/career-public-resolution-source-resolver-audit2",
+      "title": "feat(api): add career public resolution plan resolver",
+      "name": "Career 2786 Public Resolution Source Resolver",
+      "status": "in_progress",
+      "scope_type": "source_resolver_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no audit command",
+        "no DB inventory",
+        "no backfill",
+        "no rollout",
+        "no manifest train generator",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly requested AUDIT-2 and authorized PR train manifest/state updates for this train item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-1 merged as 0c6dc52e9806242dc73cec405c7f09c05161d19b and origin/main contains the merge commit."
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-3 Occupation entity inventory audit",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1084,6 +1084,7 @@
         "backend/app/Domain/Career/Audit/*",
         "backend/tests/Unit/Domain/Career/Audit/*",
         "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -507,3 +507,39 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-2
+    repo: fap-api
+    branch: fix/career-public-resolution-source-resolver-audit2
+    title: "feat(api): add career public resolution plan resolver"
+    name: "Career 2786 Public Resolution Source Resolver"
+    scope_type: source_resolver_only
+    scope:
+      - Add a read-only Career public-resolution planner JSON resolver.
+      - Validate planner file existence, JSON parseability, supported row shape, required fields, canonical slug uniqueness, and optional expected row count.
+      - Normalize planner rows into stable DTOs while preserving raw rows.
+      - Return structured issue reasons for missing or malformed planner input.
+      - Document AUDIT-2 resolver contract and future AUDIT-3+ consumption policy.
+      - Add unit tests proving resolver stability without requiring the real 2786 planner artifact.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add a career canonical eligibility audit command.
+      - Add DB inventory.
+      - Backfill occupations.
+      - Modify rollout state.
+      - Add a manifest train generator.
+      - Mutate production data.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-3 Occupation entity inventory audit"
+    merge_policy:
+      github_checks_required: true
+      squash: true

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -520,10 +520,12 @@ prs:
       - Return structured issue reasons for missing or malformed planner input.
       - Document AUDIT-2 resolver contract and future AUDIT-3+ consumption policy.
       - Add unit tests proving resolver stability without requiring the real 2786 planner artifact.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-2 resolver-only Career audit files.
     allowed_paths:
       - backend/app/Domain/Career/Audit/*
       - backend/tests/Unit/Domain/Career/Audit/*
       - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:


### PR DESCRIPTION
## Summary

- Adds the AUDIT-2 read-only Career public-resolution planner JSON resolver.
- Validates planner file existence, JSON parseability, supported row shapes, required row fields, canonical slug uniqueness, and optional expected row count.
- Normalizes planner rows into stable DTOs while preserving raw row payloads.
- Adds structured issue reasons for missing/malformed external planner input.
- Documents the resolver contract and registers AUDIT-2 in the PR train manifest/state.
- Adds a scoped BigFive runtime freeze classifier allowlist entry for AUDIT-2 resolver-only Career audit files after GitHub CI identified them as current-PR runtime-path noise.

## Scope boundaries

- Resolver-only.
- No DB mutation.
- No production commands.
- No audit command yet.
- No rollout.
- No backfill.
- No manifest generator.
- Does not modify runtime projection/truth services.
- Does not claim 2786 readiness.
- Validates external planner artifact shape.
- Tests use synthetic fixtures and do not require the real 2786 planner artifact.
- Next PR is AUDIT-3 Occupation entity inventory audit.

## Validation

- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi` - PASS, 14 tests / 37 assertions.
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` - PASS, 14 tests / 28 assertions.
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_paths_have_no_uncommitted_diff|career_public_resolution_plan_resolver" --no-ansi` - PASS, 2 tests / 4 assertions.
- `vendor/bin/pint --test` - PASS, 3065 files.
- `git diff --check` - PASS.
- `php artisan route:list --no-ansi` - PASS, 197 routes.

## CI handling

- Initial GitHub `verify-mbti-legacy` and `verify-mbti-v2` failures were classified as `introduced_by_current_pr`.
- Failure cause: the BigFive runtime freeze classifier flagged the new resolver-only Career audit DTO files.
- Fix: scoped test-only owner allowlist update, with manifest/state allowed path updated.

## Notes

- Default `php artisan migrate` was not run because AUDIT-2 explicitly forbids DB mutation.
- `bash backend/scripts/ci_verify_mbti.sh` was not run locally because this AUDIT-2 validation set is resolver-only and DB mutation is explicitly forbidden; GitHub required checks run the MBTI gates.
