### PR TITLE
feat(api): add career occupation entity inventory audit

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryAuditor.php
@@ -1,0 +1,368 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use App\Models\Occupation;
+use Illuminate\Database\Eloquent\Model;
+use Throwable;
+
+final class CareerOccupationEntityInventoryAuditor
+{
+    /**
+     * Entity-level fields required to form future canonical eligibility rows.
+     *
+     * @var list<string>
+     */
+    private const REQUIRED_ENTITY_FIELDS = [
+        'id',
+        'canonical_slug',
+        'family_id',
+        'entity_level',
+        'truth_market',
+        'display_market',
+        'crosswalk_mode',
+        'canonical_title_en',
+        'canonical_title_zh',
+        'search_h1_zh',
+    ];
+
+    /**
+     * @param  class-string<Occupation>  $occupationModel
+     */
+    public function __construct(
+        private readonly string $occupationModel = Occupation::class,
+    ) {}
+
+    public function auditPlan(CareerPublicResolutionPlan $plan): CareerOccupationEntityInventoryResult
+    {
+        return $this->auditSlugs(
+            array_map(
+                static fn (CareerPublicResolutionPlanRow $row): ?string => $row->canonicalSlug,
+                $plan->rows
+            ),
+            'plan'
+        );
+    }
+
+    /**
+     * @param  list<string|null>  $slugs
+     */
+    public function auditSlugs(array $slugs, string $sourceScope = 'slugs'): CareerOccupationEntityInventoryResult
+    {
+        [$uniqueSlugs, $duplicateInputSlugs, $issues] = $this->normalizeInputSlugs($slugs);
+
+        if ($uniqueSlugs === []) {
+            return CareerOccupationEntityInventoryResult::build([], $issues, count($duplicateInputSlugs));
+        }
+
+        try {
+            $occupationsBySlug = $this->occupationsBySlug($uniqueSlugs);
+        } catch (Throwable $exception) {
+            $issue = new CareerOccupationEntityInventoryIssue(
+                reason: CareerOccupationEntityInventoryIssue::OCCUPATION_QUERY_FAILED,
+                message: 'Occupation entity inventory query failed.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                evidence: [[
+                    'exception' => $exception::class,
+                    'message' => $exception->getMessage(),
+                ]]
+            );
+
+            return CareerOccupationEntityInventoryResult::build(
+                rows: array_map(
+                    fn (string $slug): CareerOccupationEntityInventoryRow => $this->rowForQueryFailure($slug, $sourceScope, $issue),
+                    $uniqueSlugs
+                ),
+                issues: [...$issues, $issue],
+                duplicateInputCount: count($duplicateInputSlugs)
+            );
+        }
+
+        $rows = [];
+        foreach ($uniqueSlugs as $slug) {
+            $rows[] = $this->buildRow(
+                canonicalSlug: $slug,
+                sourceScope: $sourceScope,
+                duplicateInputSlug: array_key_exists($slug, $duplicateInputSlugs),
+                occupations: $occupationsBySlug[$slug] ?? []
+            );
+        }
+
+        return CareerOccupationEntityInventoryResult::build(
+            rows: $rows,
+            issues: [
+                ...$issues,
+                ...array_values(array_merge(...array_map(
+                    static fn (CareerOccupationEntityInventoryRow $row): array => $row->issues,
+                    $rows
+                ))),
+            ],
+            duplicateInputCount: count($duplicateInputSlugs)
+        );
+    }
+
+    /**
+     * @param  list<string|null>  $slugs
+     * @return array{0: list<string>, 1: array<string, true>, 2: list<CareerOccupationEntityInventoryIssue>}
+     */
+    private function normalizeInputSlugs(array $slugs): array
+    {
+        $issues = [];
+        $uniqueSlugs = [];
+        $seen = [];
+        $duplicateInputSlugs = [];
+
+        if ($slugs === []) {
+            $issues[] = new CareerOccupationEntityInventoryIssue(
+                reason: CareerOccupationEntityInventoryIssue::INPUT_SLUG_MISSING,
+                message: 'At least one canonical slug is required for occupation entity inventory.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                evidence: [['input_count' => 0]]
+            );
+        }
+
+        foreach ($slugs as $index => $slug) {
+            $canonicalSlug = $this->normalizeSlug($slug);
+
+            if ($canonicalSlug === null) {
+                $issues[] = new CareerOccupationEntityInventoryIssue(
+                    reason: CareerOccupationEntityInventoryIssue::INPUT_SLUG_MISSING,
+                    message: 'Input canonical slug is missing.',
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    evidence: [['input_index' => $index]]
+                );
+
+                continue;
+            }
+
+            if (isset($seen[$canonicalSlug])) {
+                $duplicateInputSlugs[$canonicalSlug] = true;
+
+                continue;
+            }
+
+            $seen[$canonicalSlug] = true;
+            $uniqueSlugs[] = $canonicalSlug;
+        }
+
+        return [$uniqueSlugs, $duplicateInputSlugs, $issues];
+    }
+
+    /**
+     * @param  list<string>  $canonicalSlugs
+     * @return array<string, list<Model>>
+     */
+    private function occupationsBySlug(array $canonicalSlugs): array
+    {
+        $model = $this->occupationModel;
+        $fields = self::REQUIRED_ENTITY_FIELDS;
+
+        /** @var iterable<Model> $occupations */
+        $occupations = $model::query()
+            ->whereIn('canonical_slug', $canonicalSlugs)
+            ->get($fields);
+
+        $bySlug = [];
+        foreach ($occupations as $occupation) {
+            $canonicalSlug = $this->normalizeSlug($occupation->getAttribute('canonical_slug'));
+            if ($canonicalSlug === null) {
+                continue;
+            }
+
+            $bySlug[$canonicalSlug] ??= [];
+            $bySlug[$canonicalSlug][] = $occupation;
+        }
+
+        return $bySlug;
+    }
+
+    /**
+     * @param  list<Model>  $occupations
+     */
+    private function buildRow(
+        string $canonicalSlug,
+        string $sourceScope,
+        bool $duplicateInputSlug,
+        array $occupations,
+    ): CareerOccupationEntityInventoryRow {
+        $issues = [];
+
+        if ($duplicateInputSlug) {
+            $issues[] = new CareerOccupationEntityInventoryIssue(
+                reason: CareerOccupationEntityInventoryIssue::CANONICAL_SLUG_DUPLICATE_IN_INPUT,
+                message: 'Input canonical slug appears more than once.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                evidence: [['canonical_slug' => $canonicalSlug]]
+            );
+        }
+
+        if ($occupations === []) {
+            $issues[] = new CareerOccupationEntityInventoryIssue(
+                reason: CareerOccupationEntityInventoryIssue::OCCUPATION_MISSING,
+                message: 'Occupation entity was not found for canonical slug.',
+                severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_FULL_2786_CLAIM,
+                canonicalSlug: $canonicalSlug,
+                evidence: [['canonical_slug' => $canonicalSlug]]
+            );
+
+            return $this->inventoryRow(
+                canonicalSlug: $canonicalSlug,
+                occupation: null,
+                sourceScope: $sourceScope,
+                duplicateInputSlug: $duplicateInputSlug,
+                duplicateEntitySlug: false,
+                missingEntityFields: [],
+                issues: $issues
+            );
+        }
+
+        $duplicateEntitySlug = count($occupations) > 1;
+        if ($duplicateEntitySlug) {
+            $issues[] = new CareerOccupationEntityInventoryIssue(
+                reason: CareerOccupationEntityInventoryIssue::CANONICAL_SLUG_DUPLICATE_IN_ENTITIES,
+                message: 'Occupation canonical slug matched more than one entity row.',
+                severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_FULL_2786_CLAIM,
+                canonicalSlug: $canonicalSlug,
+                evidence: [['entity_rows' => count($occupations)]]
+            );
+        }
+
+        $occupation = $occupations[0];
+        $missingEntityFields = $this->missingEntityFields($occupation);
+        foreach ($missingEntityFields as $field) {
+            $issues[] = new CareerOccupationEntityInventoryIssue(
+                reason: CareerOccupationEntityInventoryIssue::ENTITY_FIELD_MISSING,
+                message: 'Occupation entity is missing a required entity-level field.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                field: $field,
+                evidence: [['field' => $field]]
+            );
+        }
+
+        return $this->inventoryRow(
+            canonicalSlug: $canonicalSlug,
+            occupation: $occupation,
+            sourceScope: $sourceScope,
+            duplicateInputSlug: $duplicateInputSlug,
+            duplicateEntitySlug: $duplicateEntitySlug,
+            missingEntityFields: $missingEntityFields,
+            issues: $issues
+        );
+    }
+
+    /**
+     * @param  list<string>  $missingEntityFields
+     * @param  list<CareerOccupationEntityInventoryIssue>  $issues
+     */
+    private function inventoryRow(
+        string $canonicalSlug,
+        ?Model $occupation,
+        string $sourceScope,
+        bool $duplicateInputSlug,
+        bool $duplicateEntitySlug,
+        array $missingEntityFields,
+        array $issues,
+    ): CareerOccupationEntityInventoryRow {
+        $evidence = $occupation === null
+            ? [['canonical_slug' => $canonicalSlug]]
+            : [['occupation_id' => (string) $occupation->getAttribute('id')]];
+
+        if ($missingEntityFields !== []) {
+            $evidence[] = ['missing_entity_fields' => $missingEntityFields];
+        }
+
+        if ($duplicateEntitySlug) {
+            $evidence[] = ['duplicate_entity_slug' => true];
+        }
+
+        $reasons = array_values(array_unique(array_map(
+            static fn (CareerOccupationEntityInventoryIssue $issue): string => $issue->reason,
+            $issues
+        )));
+
+        return new CareerOccupationEntityInventoryRow(
+            canonicalSlug: $canonicalSlug,
+            occupationExists: $occupation !== null,
+            occupationId: $occupation === null ? null : (string) $occupation->getAttribute('id'),
+            duplicateInputSlug: $duplicateInputSlug,
+            duplicateEntitySlug: $duplicateEntitySlug,
+            entityStatus: new CareerCanonicalEligibilityLayerStatus(
+                layer: CareerCanonicalEligibilityLayer::ENTITY,
+                status: $this->layerStatusForRow($occupation !== null, $duplicateInputSlug, $duplicateEntitySlug, $missingEntityFields),
+                reasons: $reasons,
+                evidence: $evidence,
+                source: 'occupations'
+            ),
+            missingEntityFields: $missingEntityFields,
+            sourceScope: $sourceScope,
+            evidence: $evidence,
+            issues: $issues
+        );
+    }
+
+    private function rowForQueryFailure(
+        string $canonicalSlug,
+        string $sourceScope,
+        CareerOccupationEntityInventoryIssue $issue,
+    ): CareerOccupationEntityInventoryRow {
+        return $this->inventoryRow(
+            canonicalSlug: $canonicalSlug,
+            occupation: null,
+            sourceScope: $sourceScope,
+            duplicateInputSlug: false,
+            duplicateEntitySlug: false,
+            missingEntityFields: [],
+            issues: [$issue]
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function missingEntityFields(Model $occupation): array
+    {
+        $missing = [];
+        foreach (self::REQUIRED_ENTITY_FIELDS as $field) {
+            $value = $occupation->getAttribute($field);
+
+            if ($value === null || (is_string($value) && trim($value) === '')) {
+                $missing[] = $field;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * @param  list<string>  $missingEntityFields
+     */
+    private function layerStatusForRow(
+        bool $occupationExists,
+        bool $duplicateInputSlug,
+        bool $duplicateEntitySlug,
+        array $missingEntityFields,
+    ): string {
+        if (! $occupationExists || $duplicateEntitySlug || $missingEntityFields !== []) {
+            return CareerCanonicalEligibilityStatus::BLOCKED;
+        }
+
+        return $duplicateInputSlug
+            ? CareerCanonicalEligibilityStatus::WARNING
+            : CareerCanonicalEligibilityStatus::PASS;
+    }
+
+    private function normalizeSlug(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryIssue.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerOccupationEntityInventoryIssue
+{
+    public const OCCUPATION_MISSING = 'occupation_missing';
+
+    public const CANONICAL_SLUG_DUPLICATE_IN_INPUT = 'canonical_slug_duplicate_in_input';
+
+    public const CANONICAL_SLUG_DUPLICATE_IN_ENTITIES = 'canonical_slug_duplicate_in_entities';
+
+    public const ENTITY_FIELD_MISSING = 'entity_field_missing';
+
+    public const OCCUPATION_QUERY_FAILED = 'occupation_query_failed';
+
+    public const INPUT_SLUG_MISSING = 'input_slug_missing';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::MEDIUM,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $field = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->field !== null) {
+            self::assertNonEmptyString($this->field, 'field');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::OCCUPATION_MISSING,
+            self::CANONICAL_SLUG_DUPLICATE_IN_INPUT,
+            self::CANONICAL_SLUG_DUPLICATE_IN_ENTITIES,
+            self::ENTITY_FIELD_MISSING,
+            self::OCCUPATION_QUERY_FAILED,
+            self::INPUT_SLUG_MISSING,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career occupation entity inventory issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, canonical_slug: string|null, field: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'canonical_slug' => $this->canonicalSlug,
+            'field' => $this->field,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career occupation entity inventory issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career occupation entity inventory issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryResult.php
+++ b/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryResult.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerOccupationEntityInventoryResult
+{
+    /**
+     * @param  list<CareerOccupationEntityInventoryRow>  $rows
+     * @param  list<CareerOccupationEntityInventoryIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly int $expectedCount,
+        public readonly int $foundCount,
+        public readonly int $missingCount,
+        public readonly int $duplicateInputCount,
+        public readonly int $duplicateEntityCount,
+        public readonly int $missingEntityFieldCount,
+        public readonly array $rows,
+        public readonly array $issues = [],
+        public readonly array $sidecars = [],
+    ) {
+        if (! in_array($this->status, [
+            CareerCanonicalEligibilityStatus::PASS,
+            CareerCanonicalEligibilityStatus::FAIL,
+            CareerCanonicalEligibilityStatus::BLOCKED,
+        ], true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career occupation entity inventory status [%s].', $this->status));
+        }
+
+        foreach ([
+            'expected_count' => $this->expectedCount,
+            'found_count' => $this->foundCount,
+            'missing_count' => $this->missingCount,
+            'duplicate_input_count' => $this->duplicateInputCount,
+            'duplicate_entity_count' => $this->duplicateEntityCount,
+            'missing_entity_field_count' => $this->missingEntityFieldCount,
+        ] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career occupation entity inventory [%s] must be non-negative.', $key));
+            }
+        }
+
+        self::assertIssueList($this->issues);
+        self::assertRowList($this->rows);
+        self::assertSidecarList($this->sidecars);
+    }
+
+    /**
+     * @param  list<CareerOccupationEntityInventoryRow>  $rows
+     * @param  list<CareerOccupationEntityInventoryIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public static function build(array $rows, array $issues, int $duplicateInputCount, array $sidecars = []): self
+    {
+        self::assertRowList($rows);
+        self::assertIssueList($issues);
+        self::assertSidecarList($sidecars);
+
+        $missingEntityFieldCount = 0;
+        foreach ($rows as $row) {
+            $missingEntityFieldCount += count($row->missingEntityFields);
+        }
+
+        return new self(
+            status: self::statusForIssues($issues),
+            expectedCount: count($rows),
+            foundCount: count(array_filter($rows, static fn (CareerOccupationEntityInventoryRow $row): bool => $row->occupationExists)),
+            missingCount: count(array_filter($rows, static fn (CareerOccupationEntityInventoryRow $row): bool => ! $row->occupationExists)),
+            duplicateInputCount: $duplicateInputCount,
+            duplicateEntityCount: count(array_filter($rows, static fn (CareerOccupationEntityInventoryRow $row): bool => $row->duplicateEntitySlug)),
+            missingEntityFieldCount: $missingEntityFieldCount,
+            rows: $rows,
+            issues: $issues,
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, expected_count: int, found_count: int, missing_count: int, duplicate_input_count: int, duplicate_entity_count: int, missing_entity_field_count: int, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'expected_count' => $this->expectedCount,
+            'found_count' => $this->foundCount,
+            'missing_count' => $this->missingCount,
+            'duplicate_input_count' => $this->duplicateInputCount,
+            'duplicate_entity_count' => $this->duplicateEntityCount,
+            'missing_entity_field_count' => $this->missingEntityFieldCount,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerOccupationEntityInventoryRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerOccupationEntityInventoryIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerOccupationEntityInventoryIssue>  $issues
+     */
+    private static function statusForIssues(array $issues): string
+    {
+        return $issues === []
+            ? CareerCanonicalEligibilityStatus::PASS
+            : CareerCanonicalEligibilityStatus::BLOCKED;
+    }
+
+    /**
+     * @param  list<CareerOccupationEntityInventoryRow>  $rows
+     */
+    private static function assertRowList(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career occupation entity inventory rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerOccupationEntityInventoryRow) {
+                throw new InvalidArgumentException('Career occupation entity inventory rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerOccupationEntityInventoryIssue>  $issues
+     */
+    private static function assertIssueList(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career occupation entity inventory issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerOccupationEntityInventoryIssue) {
+                throw new InvalidArgumentException('Career occupation entity inventory issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecarList(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career occupation entity inventory sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career occupation entity inventory sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryRow.php
+++ b/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryRow.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerOccupationEntityInventoryRow
+{
+    /**
+     * @param  list<string>  $missingEntityFields
+     * @param  list<mixed>  $evidence
+     * @param  list<CareerOccupationEntityInventoryIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly bool $occupationExists,
+        public readonly ?string $occupationId,
+        public readonly bool $duplicateInputSlug,
+        public readonly bool $duplicateEntitySlug,
+        public readonly CareerCanonicalEligibilityLayerStatus $entityStatus,
+        public readonly array $missingEntityFields = [],
+        public readonly ?string $sourceScope = null,
+        public readonly array $evidence = [],
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertListOfStrings($this->missingEntityFields, 'missing_entity_fields');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->occupationId !== null) {
+            self::assertNonEmptyString($this->occupationId, 'occupation_id');
+        }
+
+        if ($this->sourceScope !== null) {
+            self::assertNonEmptyString($this->sourceScope, 'source_scope');
+        }
+
+        if (! array_is_list($this->issues)) {
+            throw new InvalidArgumentException('Career occupation entity inventory row issues must be a list.');
+        }
+
+        foreach ($this->issues as $issue) {
+            if (! $issue instanceof CareerOccupationEntityInventoryIssue) {
+                throw new InvalidArgumentException('Career occupation entity inventory row issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, occupation_exists: bool, occupation_id: string|null, duplicate_input_slug: bool, duplicate_entity_slug: bool, entity_status: array<string, mixed>, missing_entity_fields: list<string>, source_scope: string|null, evidence: list<mixed>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'occupation_exists' => $this->occupationExists,
+            'occupation_id' => $this->occupationId,
+            'duplicate_input_slug' => $this->duplicateInputSlug,
+            'duplicate_entity_slug' => $this->duplicateEntitySlug,
+            'entity_status' => $this->entityStatus->toArray(),
+            'missing_entity_fields' => $this->missingEntityFields,
+            'source_scope' => $this->sourceScope,
+            'evidence' => $this->evidence,
+            'issues' => array_map(
+                static fn (CareerOccupationEntityInventoryIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career occupation entity inventory row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career occupation entity inventory row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career occupation entity inventory row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/docs/career/audits/occupation_entity_inventory_audit.md
+++ b/backend/docs/career/audits/occupation_entity_inventory_audit.md
@@ -1,0 +1,144 @@
+# Career Occupation Entity Inventory Audit
+
+AUDIT-3 adds the read-only entity inventory layer for the Career 2786 Full Public Resolution program.
+
+The auditor consumes canonical slugs from AUDIT-2 public-resolution plan rows and checks whether matching `occupations` entities exist with the entity-level fields needed by later canonical eligibility rows. It emits stable JSON and AUDIT-1-compatible `entity` layer statuses.
+
+## Scope
+
+AUDIT-3 is entity-inventory-only.
+
+It does:
+
+- count expected canonical slugs from a normalized plan or explicit slug list
+- query `occupations` by `canonical_slug`
+- report missing occupation entities
+- detect duplicate canonical slugs in the input
+- defensively report duplicate entity rows if the database ever returns them
+- report missing entity-level fields required by future audit rows
+- emit `CareerCanonicalEligibilityLayerStatus` for the `entity` layer
+
+It does not:
+
+- create the `career:audit-canonical-eligibility` command
+- inspect baseline/display metadata
+- inspect index state
+- inspect runtime projection/truth state
+- inspect SEO/GEO or live surface HTML
+- backfill, create, update, or delete occupations
+- run production validation or deployment
+
+## Input Contract
+
+The primary input is `CareerPublicResolutionPlan`, produced by AUDIT-2:
+
+```php
+(new CareerOccupationEntityInventoryAuditor())->auditPlan($plan);
+```
+
+The auditor also accepts a direct slug list:
+
+```php
+(new CareerOccupationEntityInventoryAuditor())->auditSlugs(['actuaries']);
+```
+
+Slugs are normalized by trimming whitespace and lowercasing. Empty or non-scalar slugs are reported as `input_slug_missing`.
+
+The real 2786 planner artifact is not required for AUDIT-3 tests; synthetic plan rows are enough to prove the contract.
+
+## Entity Checks
+
+For each unique canonical slug, AUDIT-3 reads from `occupations` only. The required entity-level fields are:
+
+- `id`
+- `canonical_slug`
+- `family_id`
+- `entity_level`
+- `truth_market`
+- `display_market`
+- `crosswalk_mode`
+- `canonical_title_en`
+- `canonical_title_zh`
+- `search_h1_zh`
+
+These fields are intentionally limited to entity structure. Baseline metadata, display assets, index state, runtime projection/truth, and surface checks are reserved for later PRs.
+
+## Issue Reasons
+
+AUDIT-3 issue reasons are:
+
+- `occupation_missing`
+- `canonical_slug_duplicate_in_input`
+- `canonical_slug_duplicate_in_entities`
+- `entity_field_missing`
+- `occupation_query_failed`
+- `input_slug_missing`
+
+The `occupations.canonical_slug` column is unique in the current schema. Duplicate entity detection remains in the result contract as a defensive guard for schema drift, alternate stores, or future repository adapters.
+
+## Entity Layer Status
+
+Found occupation:
+
+```json
+{
+    "layer": "entity",
+    "status": "pass",
+    "reasons": [],
+    "evidence": [
+        {
+            "occupation_id": "..."
+        }
+    ],
+    "source": "occupations"
+}
+```
+
+Missing occupation:
+
+```json
+{
+    "layer": "entity",
+    "status": "blocked",
+    "reasons": [
+        "occupation_missing"
+    ],
+    "evidence": [
+        {
+            "canonical_slug": "..."
+        }
+    ],
+    "source": "occupations"
+}
+```
+
+Rows with missing entity fields or duplicate entity rows are also `blocked`. Rows that only have a duplicate input slug are marked `warning` at the layer level, while the result remains blocked because input duplication makes the inventory unreliable.
+
+## Result JSON
+
+The result contains:
+
+- `status`
+- `expected_count`
+- `found_count`
+- `missing_count`
+- `duplicate_input_count`
+- `duplicate_entity_count`
+- `missing_entity_field_count`
+- `by_reason`
+- `rows`
+- `issues`
+- `sidecars`
+
+Sidecars are available in the schema, but AUDIT-3 does not need sidecars for normal in-scope missing occupation rows. Missing baseline, index, runtime, SEO/GEO, or surface evidence belongs to AUDIT-4 through AUDIT-8.
+
+## Future Consumption
+
+AUDIT-4+ should consume AUDIT-3 output as the entity layer authority:
+
+- use `rows[*].entity_status` for AUDIT-1 layer status composition
+- use `occupation_id` only when `occupation_exists=true`
+- keep baseline/index/runtime/surface checks outside AUDIT-3
+- preserve `issues` and `by_reason` in later aggregate reports
+
+AUDIT-3 does not claim 2786 readiness. It only proves the read-only entity inventory contract for future canonical eligibility audits.

--- a/backend/tests/Feature/Domain/Career/Audit/CareerOccupationEntityInventoryAuditorTest.php
+++ b/backend/tests/Feature/Domain/Career/Audit/CareerOccupationEntityInventoryAuditorTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerOccupationEntityInventoryAuditor;
+use App\Domain\Career\Audit\CareerOccupationEntityInventoryIssue;
+use App\Domain\Career\Audit\CareerPublicResolutionPlan;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerOccupationEntityInventoryAuditorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_audit_slugs_reports_all_found_occupations(): void
+    {
+        $this->createOccupation('actuaries');
+        $this->createOccupation('financial-analysts');
+
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs([
+            'actuaries',
+            'financial-analysts',
+        ]);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(2, $result->expectedCount);
+        $this->assertSame(2, $result->foundCount);
+        $this->assertSame(0, $result->missingCount);
+        $this->assertSame([], $result->issues);
+    }
+
+    public function test_audit_slugs_reports_missing_occupations(): void
+    {
+        $this->createOccupation('actuaries');
+
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs([
+            'actuaries',
+            'missing-career',
+        ]);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(2, $result->expectedCount);
+        $this->assertSame(1, $result->foundCount);
+        $this->assertSame(1, $result->missingCount);
+        $this->assertSame(CareerOccupationEntityInventoryIssue::OCCUPATION_MISSING, $result->rows[1]->issues[0]->reason);
+    }
+
+    public function test_duplicate_input_slug_is_detected(): void
+    {
+        $this->createOccupation('actuaries');
+
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs([
+            'Actuaries',
+            'actuaries',
+        ]);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->duplicateInputCount);
+        $this->assertTrue($result->rows[0]->duplicateInputSlug);
+        $this->assertSame(CareerOccupationEntityInventoryIssue::CANONICAL_SLUG_DUPLICATE_IN_INPUT, $result->rows[0]->issues[0]->reason);
+    }
+
+    public function test_entity_layer_status_passes_for_found_occupation(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs(['actuaries']);
+        $status = $result->rows[0]->entityStatus;
+
+        $this->assertSame(CareerCanonicalEligibilityLayer::ENTITY, $status->layer);
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $status->status);
+        $this->assertSame([], $status->reasons);
+        $this->assertSame([['occupation_id' => $occupation->id]], $status->evidence);
+        $this->assertSame('occupations', $status->source);
+    }
+
+    public function test_entity_layer_status_blocks_for_missing_occupation(): void
+    {
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs(['missing-career']);
+        $status = $result->rows[0]->entityStatus;
+
+        $this->assertSame(CareerCanonicalEligibilityLayer::ENTITY, $status->layer);
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $status->status);
+        $this->assertSame([CareerOccupationEntityInventoryIssue::OCCUPATION_MISSING], $status->reasons);
+        $this->assertSame([['canonical_slug' => 'missing-career']], $status->evidence);
+    }
+
+    public function test_result_by_reason_counts_occupation_missing(): void
+    {
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs([
+            'missing-one',
+            'missing-two',
+        ]);
+
+        $this->assertSame([
+            CareerOccupationEntityInventoryIssue::OCCUPATION_MISSING => 2,
+        ], $result->byReason());
+    }
+
+    public function test_missing_entity_fields_are_reported(): void
+    {
+        $this->createOccupation('actuaries', ['canonical_title_zh' => '']);
+
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->missingEntityFieldCount);
+        $this->assertSame(['canonical_title_zh'], $result->rows[0]->missingEntityFields);
+        $this->assertSame(CareerOccupationEntityInventoryIssue::ENTITY_FIELD_MISSING, $result->rows[0]->issues[0]->reason);
+    }
+
+    public function test_audit_plan_consumes_public_resolution_plan_rows(): void
+    {
+        $this->createOccupation('actuaries');
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-audit-3-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'actuaries']),
+                CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'missing-career']),
+            ]
+        );
+
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditPlan($plan);
+
+        $this->assertSame(2, $result->expectedCount);
+        $this->assertSame('plan', $result->rows[0]->sourceScope);
+        $this->assertSame(1, $result->foundCount);
+        $this->assertSame(1, $result->missingCount);
+    }
+
+    public function test_empty_input_is_handled_explicitly(): void
+    {
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs([]);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(0, $result->expectedCount);
+        $this->assertSame([
+            CareerOccupationEntityInventoryIssue::INPUT_SLUG_MISSING => 1,
+        ], $result->byReason());
+    }
+
+    public function test_no_index_baseline_or_projection_logic_is_invoked(): void
+    {
+        $this->createOccupation('actuaries');
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        (new CareerOccupationEntityInventoryAuditor)->auditSlugs(['actuaries']);
+
+        $queries = json_encode(DB::getQueryLog(), JSON_UNESCAPED_SLASHES);
+
+        $this->assertIsString($queries);
+        $this->assertStringContainsString('occupations', $queries);
+        $this->assertStringNotContainsString('index_states', $queries);
+        $this->assertStringNotContainsString('career_job_display_assets', $queries);
+        $this->assertStringNotContainsString('occupation_truth_metrics', $queries);
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $this->createOccupation('actuaries', [
+            'id' => '00000000-0000-4000-8000-000000000001',
+        ]);
+
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs(['actuaries'])->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "expected_count": 1,
+    "found_count": 1,
+    "missing_count": 0,
+    "duplicate_input_count": 0,
+    "duplicate_entity_count": 0,
+    "missing_entity_field_count": 0,
+    "by_reason": [],
+    "rows": [
+        {
+            "canonical_slug": "actuaries",
+            "occupation_exists": true,
+            "occupation_id": "00000000-0000-4000-8000-000000000001",
+            "duplicate_input_slug": false,
+            "duplicate_entity_slug": false,
+            "entity_status": {
+                "layer": "entity",
+                "status": "pass",
+                "reasons": [],
+                "evidence": [
+                    {
+                        "occupation_id": "00000000-0000-4000-8000-000000000001"
+                    }
+                ],
+                "source": "occupations"
+            },
+            "missing_entity_fields": [],
+            "source_scope": "slugs",
+            "evidence": [
+                {
+                    "occupation_id": "00000000-0000-4000-8000-000000000001"
+                }
+            ],
+            "issues": []
+        }
+    ],
+    "issues": [],
+    "sidecars": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_auditor_does_not_mutate_database(): void
+    {
+        $this->createOccupation('actuaries');
+        $before = Occupation::query()->count();
+
+        (new CareerOccupationEntityInventoryAuditor)->auditSlugs(['actuaries', 'missing-career']);
+
+        $this->assertSame($before, Occupation::query()->count());
+    }
+
+    public function test_duplicate_entity_slug_detection_is_defensive_under_unique_schema(): void
+    {
+        $this->createOccupation('actuaries');
+
+        $result = (new CareerOccupationEntityInventoryAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame(0, $result->duplicateEntityCount);
+        $this->assertFalse($result->rows[0]->duplicateEntitySlug);
+        $this->assertSame([], array_filter(
+            $result->issues,
+            static fn (CareerOccupationEntityInventoryIssue $issue): bool => $issue->reason === CareerOccupationEntityInventoryIssue::CANONICAL_SLUG_DUPLICATE_IN_ENTITIES
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function createOccupation(string $slug, array $attributes = []): Occupation
+    {
+        $payload = array_merge([
+            'id' => (string) Str::uuid(),
+            'family_id' => $this->occupationFamily()->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'occupation',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'direct',
+            'canonical_title_en' => Str::title(str_replace('-', ' ', $slug)),
+            'canonical_title_zh' => Str::title(str_replace('-', ' ', $slug)),
+            'search_h1_zh' => Str::title(str_replace('-', ' ', $slug)),
+        ], $attributes);
+
+        /** @var Occupation $occupation */
+        $occupation = Occupation::query()->create($payload);
+
+        return $occupation;
+    }
+
+    private function occupationFamily(): OccupationFamily
+    {
+        /** @var OccupationFamily $family */
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'audit-3-family'],
+            [
+                'id' => '00000000-0000-4000-8000-000000000100',
+                'title_en' => 'Audit 3 Family',
+                'title_zh' => 'Audit 3 Family',
+            ]
+        );
+
+        return $family;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -281,6 +281,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_occupation_entity_inventory_audit_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryIssue.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryResult.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -887,6 +899,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerOccupationEntityInventoryAuditFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1161,6 +1177,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanResolver.php',
             'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanRow.php',
             'backend/app/Domain/Career/Audit/CareerPublicResolutionPlanValidationResult.php',
+        ], true);
+    }
+
+    private function isCareerOccupationEntityInventoryAuditFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryIssue.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryResult.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-12T18:04:55+08:00",
+  "updated_at": "2026-05-12T19:04:18+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -1110,6 +1110,88 @@
       "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-3 Occupation entity inventory audit",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "AUDIT-3": {
+      "repo": "fap-api",
+      "branch": "fix/career-occupation-entity-inventory-audit3",
+      "title": "feat(api): add career occupation entity inventory audit",
+      "name": "Career Occupation Entity Inventory Audit",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-2"
+      ],
+      "scope_type": "entity_inventory_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no audit command",
+        "no baseline metadata inventory",
+        "no index-state inventory",
+        "no runtime projection/truth audit",
+        "no SEO/GEO audit",
+        "no live HTML/surface audit",
+        "no rollout",
+        "no backfill",
+        "no manifest train generator",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly requested AUDIT-3 and authorized PR train manifest/state updates for this train item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-2 merged as 696462c4 and origin/main contains PR #1317."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Feature/Domain/Career/Audit, backend/docs/career/audits, and docs/codex train files."
+        },
+        "occupation_entity_inventory_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi",
+          "evidence": "13 tests passed, 45 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3070 files checked; pass after formatting the new AUDIT-3 feature test."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full MBTI CI chain exited 0; generated compiled artifacts were restored because they are outside AUDIT-3 scope."
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-4 Baseline/display metadata inventory audit",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-12T19:04:18+08:00",
+  "updated_at": "2026-05-12T19:19:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -1183,10 +1183,20 @@
           "status": "pass",
           "command": "git diff --check"
         },
+        "github_check_failure_classification": {
+          "status": "fixed",
+          "classification": "introduced_by_current_pr",
+          "evidence": "PR #1318 verify-mbti-legacy and verify-mbti-v2 failed in BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff because AUDIT-3 app/Domain/Career/Audit entity inventory files were not yet in the test-only runtime freeze classifier allowlist."
+        },
+        "runtime_freeze_allowlist_fix": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-3 CareerOccupationEntityInventory* files to the test-only freeze classifier allowlist; the failing gate now passes locally."
+        },
         "mbti_ci": {
           "status": "pass",
           "command": "bash backend/scripts/ci_verify_mbti.sh",
-          "evidence": "Full MBTI CI chain exited 0; generated compiled artifacts were restored because they are outside AUDIT-3 scope."
+          "evidence": "Full MBTI CI chain exited 0 after the test-only allowlist fix; generated compiled artifacts were restored because they are outside AUDIT-3 scope."
         }
       },
       "sidecar_issues": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -545,3 +545,46 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-3
+    repo: fap-api
+    depends_on:
+      - AUDIT-2
+    branch: fix/career-occupation-entity-inventory-audit3
+    title: "feat(api): add career occupation entity inventory audit"
+    name: "Career Occupation Entity Inventory Audit"
+    scope_type: entity_inventory_only
+    scope:
+      - Add a read-only Occupation entity inventory auditor for canonical slugs from AUDIT-2 plan rows.
+      - Query occupations by canonical_slug and report found, missing, duplicate input, defensive duplicate entity, and missing entity-field cases.
+      - Emit AUDIT-1-compatible entity layer statuses.
+      - Document AUDIT-3 entity inventory contract and future AUDIT-4+ consumption policy.
+      - Add focused tests proving stable JSON, read-only behavior, and no baseline/index/runtime/surface audit logic.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add a career canonical eligibility audit command.
+      - Add baseline metadata inventory.
+      - Add index-state inventory.
+      - Add runtime projection/truth audit.
+      - Add SEO/GEO or surface audit.
+      - Modify rollout state.
+      - Backfill occupations.
+      - Add a manifest train generator.
+      - Mutate production data.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-4 Baseline/display metadata inventory audit"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds AUDIT-3 entity-inventory-only Career audit service, DTOs, issue/result schema, docs, and tests.
- Consumes AUDIT-2 public-resolution plan rows or explicit canonical slug lists.
- Queries Occupation entities by canonical_slug read-only and emits AUDIT-1-compatible entity layer statuses.
- Registers AUDIT-3 in the PR train manifest/state with the authorized scope.

## Non-goals / safety
- No DB mutation.
- No production commands.
- No audit command yet.
- No baseline/index/runtime/surface audit yet.
- No rollout/backfill.
- No manifest generator.
- Does not require the real 2786 planner artifact in tests.

## Validation
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi` PASS: 13 tests, 45 assertions.
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi` PASS: 14 tests, 37 assertions.
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` PASS: 14 tests, 28 assertions.
- `vendor/bin/pint --test` PASS.
- `git diff --check` PASS.
- `bash backend/scripts/ci_verify_mbti.sh` PASS.

## PR train
- Pending checks are wait/poll state, not blockers.
- Failed checks are inspect/fix/push/wait loop, not immediate stop.
- Next PR: AUDIT-4 Baseline/display metadata inventory audit.
