### PR TITLE
RIASEC-TRAIN-01 — Measurement Contract + score_space_version + compare policy

### DIFF
--- a/backend/app/Services/Assessment/Drivers/RiasecDriver.php
+++ b/backend/app/Services/Assessment/Drivers/RiasecDriver.php
@@ -7,12 +7,14 @@ namespace App\Services\Assessment\Drivers;
 use App\Services\Assessment\ScoreResult;
 use App\Services\Assessment\Scorers\RiasecScorer;
 use App\Services\Content\RiasecPackLoader;
+use App\Services\Riasec\RiasecMeasurementContract;
 
 final class RiasecDriver implements DriverInterface
 {
     public function __construct(
         private readonly RiasecPackLoader $packLoader,
         private readonly RiasecScorer $scorer,
+        private readonly RiasecMeasurementContract $measurementContract,
     ) {}
 
     public function score(array $answers, array $spec, array $ctx): ScoreResult
@@ -36,11 +38,33 @@ final class RiasecDriver implements DriverInterface
             $scoringSpecVersion = (string) ($scorePayload['scoring_spec_version'] ?? 'riasec_standard_60_v1');
         }
 
+        $formCode = $this->measurementContract->canonicalFormCode(
+            (string) ($ctx['form_code'] ?? ($policy['form_code'] ?? ($scorePayload['form_code'] ?? ''))),
+            (int) ($scorePayload['answer_count'] ?? count($answers))
+        );
+        $measurementContract = $this->measurementContract->forFormCode(
+            $formCode,
+            (int) ($scorePayload['answer_count'] ?? count($answers))
+        );
+        $comparePolicy = is_array($measurementContract['compare_policy'] ?? null)
+            ? $measurementContract['compare_policy']
+            : $this->measurementContract->comparePolicyForFormCode($formCode);
+        $scoreSpaceVersion = (string) data_get($measurementContract, 'form.score_space_version', '');
+
+        $scorePayload['form_code'] = $formCode;
+        $scorePayload['score_space_version'] = $scoreSpaceVersion;
+        $scorePayload['compare_compatibility_group'] = (string) ($comparePolicy['compare_compatibility_group'] ?? '');
+        $scorePayload['cross_form_comparable'] = false;
+        $scorePayload['raw_score_delta_allowed'] = false;
+        $scorePayload['measurement_contract_v1'] = $measurementContract;
+        $scorePayload['compare_policy_v1'] = $comparePolicy;
         $scorePayload['version_snapshot'] = [
             'pack_id' => (string) ($ctx['pack_id'] ?? RiasecPackLoader::PACK_ID),
             'pack_version' => $version,
             'engine_version' => (string) ($scorePayload['engine_version'] ?? ($policy['engine_version'] ?? 'riasec_v1.0.0')),
             'scoring_spec_version' => $scoringSpecVersion,
+            'measurement_contract_version' => RiasecMeasurementContract::SCHEMA_VERSION,
+            'score_space_version' => $scoreSpaceVersion,
             'content_manifest_hash' => $manifestHash,
         ];
 

--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -107,6 +107,9 @@ class AttemptStartService
         $resolvedScoringSpecVersion = null;
         $resolvedQualityVersion = null;
         $resolvedQuestionCount = null;
+        $resolvedMeasurementContractVersion = null;
+        $resolvedScoreSpaceVersion = null;
+        $resolvedCompareCompatibilityGroup = null;
         $contentPackageVersion = '';
 
         if (strtoupper($scaleCode) === 'MBTI') {
@@ -163,6 +166,9 @@ class AttemptStartService
             $resolvedScoringSpecVersion = trim((string) ($resolvedForm['scoring_spec_version'] ?? ''));
             $resolvedQualityVersion = trim((string) ($resolvedForm['quality_version'] ?? ''));
             $resolvedQuestionCount = (int) ($resolvedForm['question_count'] ?? 0);
+            $resolvedMeasurementContractVersion = trim((string) ($resolvedForm['measurement_contract_version'] ?? ''));
+            $resolvedScoreSpaceVersion = trim((string) ($resolvedForm['score_space_version'] ?? ''));
+            $resolvedCompareCompatibilityGroup = trim((string) ($resolvedForm['compare_compatibility_group'] ?? ''));
         }
 
         if ($packId === '' || $dirVersion === '') {
@@ -281,6 +287,17 @@ class AttemptStartService
         }
         if ($resolvedQualityVersion !== null && $resolvedQualityVersion !== '') {
             $answersMeta['quality_version'] = $resolvedQualityVersion;
+        }
+        if ($resolvedMeasurementContractVersion !== null && $resolvedMeasurementContractVersion !== '') {
+            $answersMeta['measurement_contract_version'] = $resolvedMeasurementContractVersion;
+        }
+        if ($resolvedScoreSpaceVersion !== null && $resolvedScoreSpaceVersion !== '') {
+            $answersMeta['score_space_version'] = $resolvedScoreSpaceVersion;
+        }
+        if ($resolvedCompareCompatibilityGroup !== null && $resolvedCompareCompatibilityGroup !== '') {
+            $answersMeta['compare_compatibility_group'] = $resolvedCompareCompatibilityGroup;
+            $answersMeta['cross_form_comparable'] = false;
+            $answersMeta['raw_score_delta_allowed'] = false;
         }
         $manifestHash = $this->resolveScaleManifestHash($scaleCode, $dirVersion);
         if ($manifestHash !== '') {
@@ -686,7 +703,7 @@ class AttemptStartService
             $resumeExpiresAt = $resumeExpiresAt->format(\DateTimeInterface::ATOM);
         }
 
-        return [
+        $response = [
             'ok' => true,
             'org_id' => $orgId,
             'anon_id' => $anonId,
@@ -712,6 +729,20 @@ class AttemptStartService
             'resume_token' => (string) ($draft['token'] ?? ''),
             'resume_expires_at' => $resumeExpiresAt,
         ];
+
+        foreach ([
+            'measurement_contract_version',
+            'score_space_version',
+            'compare_compatibility_group',
+            'cross_form_comparable',
+            'raw_score_delta_allowed',
+        ] as $metaKey) {
+            if (data_get($attempt->answers_summary_json, 'meta.'.$metaKey) !== null) {
+                $response[$metaKey] = data_get($attempt->answers_summary_json, 'meta.'.$metaKey);
+            }
+        }
+
+        return $response;
     }
 
     private function eventRecorder(): EventRecorder

--- a/backend/app/Services/Riasec/RiasecCompareGuardService.php
+++ b/backend/app/Services/Riasec/RiasecCompareGuardService.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+use App\Models\Attempt;
+use App\Models\Result;
+
+final class RiasecCompareGuardService
+{
+    public const VERSION = 'riasec.compare_guard.v1';
+
+    public function __construct(
+        private readonly RiasecMeasurementContract $measurementContract,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function evaluate(
+        ?Attempt $attemptA,
+        ?Result $resultA,
+        ?Attempt $attemptB,
+        ?Result $resultB
+    ): array {
+        $basisA = $this->resolveBasis($attemptA, $resultA);
+        $basisB = $this->resolveBasis($attemptB, $resultB);
+
+        if (($basisA['scale_code'] ?? '') !== 'RIASEC' || ($basisB['scale_code'] ?? '') !== 'RIASEC') {
+            return $this->contract($basisA, $basisB, false, 'different_scale', 'riasec.compare.blocked_cross_scale');
+        }
+
+        if (($basisA['score_space_version'] ?? null) === null || ($basisB['score_space_version'] ?? null) === null) {
+            return $this->contract($basisA, $basisB, false, 'missing_score_space_version', 'riasec.compare.blocked_missing_basis');
+        }
+
+        $groupA = (string) ($basisA['compare_compatibility_group'] ?? '');
+        $groupB = (string) ($basisB['compare_compatibility_group'] ?? '');
+        $formA = (string) ($basisA['form_code'] ?? '');
+        $formB = (string) ($basisB['form_code'] ?? '');
+
+        if ($groupA !== '' && $groupA === $groupB && $formA !== '' && $formA === $formB) {
+            return $this->contract($basisA, $basisB, true, 'same_compare_compatibility_group', 'riasec.compare.allowed_same_form');
+        }
+
+        return $this->contract($basisA, $basisB, false, 'cross_form_score_space_mismatch', 'riasec.compare.blocked_cross_form');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function summarizeAttempt(?Attempt $attempt, ?Result $result): array
+    {
+        $basis = $this->resolveBasis($attempt, $result);
+
+        return [
+            'version' => self::VERSION,
+            'scale_code' => 'RIASEC',
+            'form_code' => $basis['form_code'],
+            'score_space_version' => $basis['score_space_version'],
+            'compare_compatibility_group' => $basis['compare_compatibility_group'],
+            'cross_form_comparable' => false,
+            'raw_score_delta_allowed' => false,
+            'reason' => ($basis['score_space_version'] ?? null) !== null
+                ? 'same_compare_compatibility_group'
+                : 'missing_score_space_version',
+            'copy_key' => ($basis['score_space_version'] ?? null) !== null
+                ? 'riasec.compare.allowed_same_form'
+                : 'riasec.compare.blocked_missing_basis',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolveBasis(?Attempt $attempt, ?Result $result): array
+    {
+        $payload = $this->decodeArray($result?->result_json);
+        $questionCount = (int) ($attempt?->question_count ?? data_get($payload, 'answer_count', 0));
+        $formCode = $this->stringOrNull(
+            data_get($payload, 'measurement_contract_v1.form.form_code')
+            ?? data_get($payload, 'form_code')
+            ?? data_get($attempt?->answers_summary_json, 'meta.form_code')
+        );
+        $formCode = $this->measurementContract->canonicalFormCode($formCode, $questionCount);
+        $scoreSpaceVersion = $this->stringOrNull(
+            data_get($payload, 'measurement_contract_v1.form.score_space_version')
+            ?? data_get($payload, 'score_space_version')
+            ?? data_get($attempt?->answers_summary_json, 'meta.score_space_version')
+        ) ?? $this->measurementContract->scoreSpaceVersion($formCode, $questionCount);
+        $compareGroup = $this->stringOrNull(
+            data_get($payload, 'measurement_contract_v1.compare_policy.compare_compatibility_group')
+            ?? data_get($payload, 'compare_policy_v1.compare_compatibility_group')
+            ?? data_get($payload, 'compare_compatibility_group')
+            ?? data_get($attempt?->answers_summary_json, 'meta.compare_compatibility_group')
+        ) ?? $this->measurementContract->compareCompatibilityGroup($formCode, $scoreSpaceVersion);
+
+        return [
+            'attempt_id' => $this->stringOrNull($attempt?->id ?? $result?->attempt_id),
+            'scale_code' => strtoupper(trim((string) ($attempt?->scale_code ?? $result?->scale_code ?? 'RIASEC'))),
+            'form_code' => $formCode,
+            'score_space_version' => $scoreSpaceVersion,
+            'compare_compatibility_group' => $compareGroup,
+            'cross_form_comparable' => false,
+            'raw_score_delta_allowed' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $basisA
+     * @param  array<string,mixed>  $basisB
+     * @return array<string,mixed>
+     */
+    private function contract(array $basisA, array $basisB, bool $canCompare, string $reason, string $copyKey): array
+    {
+        return [
+            'version' => self::VERSION,
+            'scale_code' => 'RIASEC',
+            'can_compare' => $canCompare,
+            'reason' => $reason,
+            'raw_score_delta_allowed' => false,
+            'attempt_a' => [
+                'attempt_id' => $basisA['attempt_id'],
+                'form_code' => $basisA['form_code'],
+                'score_space_version' => $basisA['score_space_version'],
+                'compare_compatibility_group' => $basisA['compare_compatibility_group'],
+            ],
+            'attempt_b' => [
+                'attempt_id' => $basisB['attempt_id'],
+                'form_code' => $basisB['form_code'],
+                'score_space_version' => $basisB['score_space_version'],
+                'compare_compatibility_group' => $basisB['compare_compatibility_group'],
+            ],
+            'copy_key' => $copyKey,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeArray(mixed $payload): array
+    {
+        if (is_array($payload)) {
+            return $payload;
+        }
+
+        if (! is_string($payload) || trim($payload) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($payload, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Services/Riasec/RiasecFormCatalog.php
+++ b/backend/app/Services/Riasec/RiasecFormCatalog.php
@@ -16,6 +16,7 @@ final class RiasecFormCatalog
 
     public function __construct(
         private readonly RiasecPackLoader $packLoader,
+        private readonly RiasecMeasurementContract $measurementContract,
     ) {}
 
     /**
@@ -27,6 +28,11 @@ final class RiasecFormCatalog
      *   norm_version:string,
      *   scoring_spec_version:string,
      *   quality_version:string,
+     *   measurement_contract_version:string,
+     *   score_space_version:string,
+     *   compare_compatibility_group:string,
+     *   cross_form_comparable:bool,
+     *   raw_score_delta_allowed:bool,
      *   question_count:int,
      *   form_kind:string
      * }
@@ -76,6 +82,7 @@ final class RiasecFormCatalog
         }
 
         $policy = is_array($policyCompiled['policy'] ?? null) ? $policyCompiled['policy'] : [];
+        $comparePolicy = $this->measurementContract->comparePolicyForFormCode($canonical, $questionCount);
         $resolved = [
             'form_code' => $canonical,
             'pack_id' => RiasecPackLoader::PACK_ID,
@@ -84,6 +91,11 @@ final class RiasecFormCatalog
             'norm_version' => '',
             'scoring_spec_version' => trim((string) ($policy['scoring_spec_version'] ?? ($manifest['scoring_spec_version'] ?? ''))),
             'quality_version' => trim((string) ($policy['quality_version'] ?? ($manifest['quality_version'] ?? ''))),
+            'measurement_contract_version' => RiasecMeasurementContract::SCHEMA_VERSION,
+            'score_space_version' => (string) ($comparePolicy['score_space_version'] ?? ''),
+            'compare_compatibility_group' => (string) ($comparePolicy['compare_compatibility_group'] ?? ''),
+            'cross_form_comparable' => false,
+            'raw_score_delta_allowed' => false,
             'question_count' => $questionCount,
             'form_kind' => trim((string) ($formConfig['form_kind'] ?? ($manifest['form_kind'] ?? ''))),
         ];

--- a/backend/app/Services/Riasec/RiasecMeasurementContract.php
+++ b/backend/app/Services/Riasec/RiasecMeasurementContract.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+final class RiasecMeasurementContract
+{
+    public const SCHEMA_VERSION = 'riasec.measurement_contract.v1';
+
+    public const COMPARE_POLICY_VERSION = 'riasec.compare_policy.v1';
+
+    public const STANDARD_60_SCORE_SPACE = 'riasec_60_likert5_activity_sum_space.v1';
+
+    public const ENHANCED_140_SCORE_SPACE = 'riasec_140_likert5_activity_context_space.v1';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function forFormCode(?string $formCode, ?int $questionCount = null): array
+    {
+        $canonical = $this->canonicalFormCode($formCode, $questionCount);
+        $isEnhanced = $canonical === 'riasec_140';
+        $scoreSpaceVersion = $isEnhanced ? self::ENHANCED_140_SCORE_SPACE : self::STANDARD_60_SCORE_SPACE;
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'scale_code' => 'RIASEC',
+            'measured_signal_kind' => 'career_interest',
+            'form' => [
+                'form_code' => $canonical,
+                'question_count' => $isEnhanced ? 140 : 60,
+                'form_kind' => $isEnhanced ? 'enhanced_contextual' : 'standard',
+                'score_space_version' => $scoreSpaceVersion,
+                'score_space_label' => $isEnhanced
+                    ? '140Q contextual daily-work interest signal'
+                    : '60Q career interest signal',
+            ],
+            'scoring' => [
+                'normalization_method' => $isEnhanced
+                    ? 'activity_environment_role_weighted_0_100'
+                    : 'raw_sum_per_dimension_min10_max50_to_0_100',
+                'raw_score_delta_allowed' => false,
+                'cross_form_raw_delta_allowed' => false,
+            ],
+            'quality' => [
+                'low_quality_strength' => $isEnhanced ? 'caution_flags_available' : 'not_available_for_strong_low_quality',
+                'quality_rule_status' => $isEnhanced ? 'quality_flags_available' : 'minimal_answer_completion_only',
+            ],
+            'claim_boundary' => [
+                'measures' => ['career_interest'],
+                'does_not_measure' => ['ability', 'personality', 'values', 'career_success_probability', 'job_fit'],
+                'occupation_examples_policy' => 'content_example_not_registry_match_without_reviewed_registry_source',
+            ],
+            'compare_policy' => $this->comparePolicyForFormCode($canonical, $questionCount),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function comparePolicyForFormCode(?string $formCode, ?int $questionCount = null): array
+    {
+        $canonical = $this->canonicalFormCode($formCode, $questionCount);
+        $scoreSpaceVersion = $canonical === 'riasec_140'
+            ? self::ENHANCED_140_SCORE_SPACE
+            : self::STANDARD_60_SCORE_SPACE;
+
+        return [
+            'version' => self::COMPARE_POLICY_VERSION,
+            'scale_code' => 'RIASEC',
+            'form_code' => $canonical,
+            'score_space_version' => $scoreSpaceVersion,
+            'compare_compatibility_group' => $this->compareCompatibilityGroup($canonical, $scoreSpaceVersion),
+            'cross_form_comparable' => false,
+            'raw_score_delta_allowed' => false,
+            'copy_key' => 'riasec.compare.same_form_only',
+        ];
+    }
+
+    public function scoreSpaceVersion(?string $formCode, ?int $questionCount = null): string
+    {
+        return (string) $this->comparePolicyForFormCode($formCode, $questionCount)['score_space_version'];
+    }
+
+    public function compareCompatibilityGroup(?string $formCode, ?string $scoreSpaceVersion = null): string
+    {
+        $canonical = $this->canonicalFormCode($formCode);
+        $space = trim((string) ($scoreSpaceVersion ?? $this->scoreSpaceVersion($canonical)));
+
+        return 'RIASEC:'.$canonical.':'.$space;
+    }
+
+    public function canonicalFormCode(?string $formCode, ?int $questionCount = null): string
+    {
+        $normalized = strtolower(trim((string) $formCode));
+        if (in_array($normalized, ['riasec_140', '140', 'enhanced', 'v1-enhanced-140'], true)) {
+            return 'riasec_140';
+        }
+
+        if (in_array($normalized, ['riasec_60', '60', 'standard', 'v1-standard-60'], true)) {
+            return 'riasec_60';
+        }
+
+        return ((int) ($questionCount ?? 0)) >= 140 ? 'riasec_140' : 'riasec_60';
+    }
+}

--- a/backend/app/Services/Riasec/RiasecPublicFormSummaryBuilder.php
+++ b/backend/app/Services/Riasec/RiasecPublicFormSummaryBuilder.php
@@ -9,6 +9,10 @@ use App\Models\Result;
 
 final class RiasecPublicFormSummaryBuilder
 {
+    public function __construct(
+        private readonly RiasecMeasurementContract $measurementContract,
+    ) {}
+
     public function build(?Attempt $attempt, ?Result $result = null): ?array
     {
         $formCode = trim((string) data_get($attempt?->answers_summary_json, 'meta.form_code', ''));
@@ -24,11 +28,24 @@ final class RiasecPublicFormSummaryBuilder
             $questionCount = str_contains($formCode, '140') ? 140 : 60;
         }
 
+        $formCode = $this->measurementContract->canonicalFormCode($formCode, $questionCount);
+        $measurementContract = $this->measurementContract->forFormCode($formCode, $questionCount);
+        $comparePolicy = is_array($measurementContract['compare_policy'] ?? null)
+            ? $measurementContract['compare_policy']
+            : $this->measurementContract->comparePolicyForFormCode($formCode, $questionCount);
+
         return [
             'form_code' => $formCode,
             'question_count' => $questionCount,
             'form_kind' => str_contains($formCode, '140') ? 'enhanced' : 'standard',
             'estimated_minutes' => str_contains($formCode, '140') ? 18 : 8,
+            'measurement_contract_version' => RiasecMeasurementContract::SCHEMA_VERSION,
+            'score_space_version' => (string) data_get($measurementContract, 'form.score_space_version', ''),
+            'compare_compatibility_group' => (string) ($comparePolicy['compare_compatibility_group'] ?? ''),
+            'cross_form_comparable' => false,
+            'raw_score_delta_allowed' => false,
+            'measurement_contract_v1' => $measurementContract,
+            'compare_policy_v1' => $comparePolicy,
         ];
     }
 }

--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -17,6 +17,10 @@ final class RiasecPublicProjectionService
         'C' => ['en' => 'Conventional', 'zh-CN' => '常规型'],
     ];
 
+    public function __construct(
+        private readonly RiasecMeasurementContract $measurementContract,
+    ) {}
+
     public function buildFromResult(Result $result, string $locale = 'zh-CN'): array
     {
         $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
@@ -29,6 +33,18 @@ final class RiasecPublicProjectionService
         $primary = trim((string) ($payload['primary_type'] ?? substr($topCode, 0, 1)));
         $secondary = trim((string) ($payload['secondary_type'] ?? substr($topCode, 1, 1)));
         $tertiary = trim((string) ($payload['tertiary_type'] ?? substr($topCode, 2, 1)));
+        $formCode = $this->measurementContract->canonicalFormCode(
+            (string) ($payload['form_code'] ?? data_get($payload, 'measurement_contract_v1.form.form_code', '')),
+            (int) ($payload['answer_count'] ?? 0)
+        );
+        $measurementContract = is_array($payload['measurement_contract_v1'] ?? null)
+            ? $payload['measurement_contract_v1']
+            : $this->measurementContract->forFormCode($formCode, (int) ($payload['answer_count'] ?? 0));
+        $comparePolicy = is_array($payload['compare_policy_v1'] ?? null)
+            ? $payload['compare_policy_v1']
+            : (is_array($measurementContract['compare_policy'] ?? null)
+                ? $measurementContract['compare_policy']
+                : $this->measurementContract->comparePolicyForFormCode($formCode, (int) ($payload['answer_count'] ?? 0)));
 
         return [
             'schema' => 'fap.riasec.public_projection.v1',
@@ -42,6 +58,15 @@ final class RiasecPublicProjectionService
             'quality_grade' => (string) ($payload['quality_grade'] ?? data_get($payload, 'quality.grade', 'A')),
             'quality_flags' => array_values(array_filter(array_map('strval', (array) ($payload['quality_flags'] ?? data_get($payload, 'quality.flags', []))))),
             'dimension_labels' => $this->dimensionLabels($locale),
+            'form' => [
+                'form_code' => $formCode,
+                'score_space_version' => (string) data_get($measurementContract, 'form.score_space_version', ''),
+                'compare_compatibility_group' => (string) ($comparePolicy['compare_compatibility_group'] ?? ''),
+                'cross_form_comparable' => false,
+                'raw_score_delta_allowed' => false,
+            ],
+            'measurement_contract_v1' => $measurementContract,
+            'compare_policy_v1' => $comparePolicy,
             'enhanced_breakdown' => [
                 'activity' => $this->prefixedScores($payload, 'activity_'),
                 'environment' => $this->prefixedScores($payload, 'env_'),

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -16,6 +16,7 @@ use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Report\InviteUnlockSummaryBuilder;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\Resolvers\OfferResolver;
+use App\Services\Riasec\RiasecCompareGuardService;
 use App\Services\Riasec\RiasecPublicFormSummaryBuilder;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
@@ -75,6 +76,7 @@ class MeAttemptsService
         private readonly EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
         private readonly EnneagramCompareGuardService $enneagramCompareGuardService,
         private readonly EnneagramObservationStateService $enneagramObservationStateService,
+        private readonly RiasecCompareGuardService $riasecCompareGuardService,
         private readonly RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
         private readonly InviteUnlockSummaryBuilder $inviteUnlockSummaryBuilder,
     ) {}
@@ -222,6 +224,7 @@ class MeAttemptsService
                 $presented['enneagram_form_v1'] = $this->enneagramPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
             } elseif (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'RIASEC') {
                 $presented['riasec_form_v1'] = $this->riasecPublicFormSummaryBuilder->build($attempt, $result);
+                $presented['compare_policy_v1'] = $this->riasecCompareGuardService->summarizeAttempt($attempt, $result);
             }
             $items[] = $presented;
         }
@@ -234,6 +237,8 @@ class MeAttemptsService
             $historyCompare = $this->buildBigFiveHistoryCompare($attemptModels, $resultByAttemptId);
         } elseif ($normalizedScaleCode === 'ENNEAGRAM') {
             $historyCompare = $this->buildEnneagramHistorySummary($attemptModels, $resultByAttemptId);
+        } elseif ($normalizedScaleCode === 'RIASEC') {
+            $historyCompare = $this->buildRiasecHistorySummary($attemptModels, $resultByAttemptId);
         }
 
         return [
@@ -582,6 +587,61 @@ class MeAttemptsService
     }
 
     /**
+     * @param  list<Attempt>  $attemptModels
+     * @param  array<string,Result>  $resultByAttemptId
+     * @return array<string,mixed>|null
+     */
+    private function buildRiasecHistorySummary(array $attemptModels, array $resultByAttemptId): ?array
+    {
+        if ($attemptModels === []) {
+            return null;
+        }
+
+        $latest = $attemptModels[0];
+        $latestId = (string) ($latest->id ?? '');
+        if ($latestId === '') {
+            return null;
+        }
+
+        $latestScore = $this->extractRiasecScoreResult($resultByAttemptId[$latestId] ?? null);
+        if ($latestScore === []) {
+            return null;
+        }
+
+        $payload = [
+            'scale_code' => 'RIASEC',
+            'current_attempt_id' => $latestId,
+            'current_top_code' => (string) ($latestScore['top_code'] ?? ''),
+            'current_primary_type' => (string) ($latestScore['primary_type'] ?? ''),
+            'current_compare_policy_v1' => $this->riasecCompareGuardService->summarizeAttempt($latest, $resultByAttemptId[$latestId] ?? null),
+        ];
+
+        $previous = $attemptModels[1] ?? null;
+        if ($previous instanceof Attempt) {
+            $previousId = (string) ($previous->id ?? '');
+            $previousScore = $this->extractRiasecScoreResult($resultByAttemptId[$previousId] ?? null);
+            if ($previousId !== '' && $previousScore !== []) {
+                $payload['previous_attempt_id'] = $previousId;
+                $payload['previous_top_code'] = (string) ($previousScore['top_code'] ?? '');
+                $payload['previous_primary_type'] = (string) ($previousScore['primary_type'] ?? '');
+                $payload['top_code_changed'] = $payload['previous_top_code'] !== $payload['current_top_code'];
+                $payload['previous_compare_policy_v1'] = $this->riasecCompareGuardService->summarizeAttempt(
+                    $previous,
+                    $resultByAttemptId[$previousId] ?? null
+                );
+                $payload['compare_guard_v1'] = $this->riasecCompareGuardService->evaluate(
+                    $latest,
+                    $resultByAttemptId[$latestId] ?? null,
+                    $previous,
+                    $resultByAttemptId[$previousId] ?? null
+                );
+            }
+        }
+
+        return $payload;
+    }
+
+    /**
      * @return array<string,float>
      */
     private function extractDomainsMean(mixed $resultJson): array
@@ -746,6 +806,39 @@ class MeAttemptsService
 
         foreach ($candidates as $candidate) {
             if (is_array($candidate) && strtoupper(trim((string) ($candidate['scale_code'] ?? ''))) === 'ENNEAGRAM') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractRiasecScoreResult(?Result $result): array
+    {
+        if (! $result instanceof Result) {
+            return [];
+        }
+
+        $resultJson = $this->decodeResultJson($result->result_json);
+        $candidates = [
+            $resultJson['normed_json'] ?? null,
+            $resultJson,
+            data_get($resultJson, 'breakdown_json.score_result'),
+            data_get($resultJson, 'axis_scores_json.score_result'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $hasRiasecShape = array_key_exists('scores_0_100', $candidate)
+                || array_key_exists('top_code', $candidate)
+                || strtoupper(trim((string) ($candidate['scale_code'] ?? ''))) === 'RIASEC';
+            if ($hasRiasecShape) {
                 return $candidate;
             }
         }

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -61,6 +61,9 @@ final class RiasecAssessmentFlowTest extends TestCase
         $start->assertJsonPath('dir_version', 'v1-standard-60');
         $start->assertJsonPath('question_count', 60);
         $start->assertJsonPath('scoring_spec_version', 'riasec_standard_60_v1');
+        $start->assertJsonPath('measurement_contract_version', 'riasec.measurement_contract.v1');
+        $start->assertJsonPath('score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $start->assertJsonPath('raw_score_delta_allowed', false);
 
         $attemptId = (string) $start->json('attempt_id');
         $answers = $this->answers(60);
@@ -84,6 +87,10 @@ final class RiasecAssessmentFlowTest extends TestCase
         $this->assertSame('RIASEC', (string) $stored->scale_code);
         $this->assertSame('v1-standard-60', (string) $stored->dir_version);
         $this->assertSame('RIA', (string) data_get($stored->result_json, 'top_code'));
+        $this->assertSame('riasec_60', (string) data_get($stored->result_json, 'form_code'));
+        $this->assertSame('riasec_60_likert5_activity_sum_space.v1', (string) data_get($stored->result_json, 'score_space_version'));
+        $this->assertSame('riasec.measurement_contract.v1', (string) data_get($stored->result_json, 'measurement_contract_v1.schema_version'));
+        $this->assertFalse((bool) data_get($stored->result_json, 'raw_score_delta_allowed'));
 
         $readback = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -95,6 +102,10 @@ final class RiasecAssessmentFlowTest extends TestCase
         $readback->assertJsonPath('result.top_code', 'RIA');
         $readback->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
         $readback->assertJsonPath('riasec_form_v1.form_code', 'riasec_60');
+        $readback->assertJsonPath('riasec_form_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $readback->assertJsonPath('riasec_form_v1.raw_score_delta_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v1.form.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $readback->assertJsonPath('riasec_public_projection_v1.measurement_contract_v1.claim_boundary.does_not_measure.0', 'ability');
 
         $report = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -107,6 +118,7 @@ final class RiasecAssessmentFlowTest extends TestCase
         $report->assertJsonPath('report.top_code', 'RIA');
         $report->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
         $report->assertJsonPath('riasec_form_v1.form_code', 'riasec_60');
+        $report->assertJsonPath('riasec_form_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
 
         $reportAccess = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -119,6 +131,7 @@ final class RiasecAssessmentFlowTest extends TestCase
         $reportAccess->assertJsonPath('payload.access_level', 'full');
         $reportAccess->assertJsonPath('payload.variant', 'full');
         $reportAccess->assertJsonPath('riasec_form_v1.form_code', 'riasec_60');
+        $reportAccess->assertJsonPath('riasec_form_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
 
         $share = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -147,6 +160,9 @@ final class RiasecAssessmentFlowTest extends TestCase
         $history->assertJsonPath('items.0.attempt_id', $attemptId);
         $history->assertJsonPath('items.0.riasec_form_v1.form_code', 'riasec_60');
         $history->assertJsonPath('items.0.riasec_form_v1.question_count', 60);
+        $history->assertJsonPath('items.0.compare_policy_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $history->assertJsonPath('items.0.compare_policy_v1.raw_score_delta_allowed', false);
+        $history->assertJsonPath('history_compare.current_compare_policy_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
     }
 
     public function test_riasec_enhanced_140_persists_quality_and_layer_scores(): void
@@ -185,6 +201,69 @@ final class RiasecAssessmentFlowTest extends TestCase
         $submit->assertJsonPath('result.env_R', 100);
         $submit->assertJsonPath('result.role_R', 100);
         $submit->assertJsonPath('result.quality_grade', 'A');
+    }
+
+    public function test_riasec_history_compare_guard_blocks_60_and_140_raw_delta(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_riasec_compare_guard';
+        $token = $this->issueAnonToken($anonId);
+
+        $standardStart = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'RIASEC',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => '60',
+        ]);
+        $standardStart->assertStatus(200);
+        $standardAttemptId = (string) $standardStart->json('attempt_id');
+        $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $standardAttemptId,
+            'answers' => $this->answers(60),
+            'duration_ms' => 180000,
+        ])->assertStatus(200);
+
+        $this->travel(1)->seconds();
+
+        $enhancedStart = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'RIASEC',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => '140',
+        ]);
+        $enhancedStart->assertStatus(200);
+        $enhancedAttemptId = (string) $enhancedStart->json('attempt_id');
+        $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $enhancedAttemptId,
+            'answers' => $this->answers(140),
+            'duration_ms' => 360000,
+        ])->assertStatus(200);
+
+        $history = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/me/attempts?scale=RIASEC');
+        $history->assertStatus(200);
+        $history->assertJsonPath('history_compare.current_attempt_id', $enhancedAttemptId);
+        $history->assertJsonPath('history_compare.previous_attempt_id', $standardAttemptId);
+        $history->assertJsonPath('history_compare.compare_guard_v1.can_compare', false);
+        $history->assertJsonPath('history_compare.compare_guard_v1.reason', 'cross_form_score_space_mismatch');
+        $history->assertJsonPath('history_compare.compare_guard_v1.raw_score_delta_allowed', false);
+        $history->assertJsonPath('history_compare.current_compare_policy_v1.score_space_version', 'riasec_140_likert5_activity_context_space.v1');
+        $history->assertJsonPath('history_compare.previous_compare_policy_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $this->assertNull($history->json('history_compare.raw_scores_delta'));
+        $this->assertNull($history->json('history_compare.domains_delta'));
+
+        $this->travelBack();
     }
 
     private function seedScales(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -447,6 +447,22 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_measurement_contract_compare_policy_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Assessment/Drivers/RiasecDriver.php',
+            'backend/app/Services/Attempts/AttemptStartService.php',
+            'backend/app/Services/Riasec/RiasecCompareGuardService.php',
+            'backend/app/Services/Riasec/RiasecFormCatalog.php',
+            'backend/app/Services/Riasec/RiasecMeasurementContract.php',
+            'backend/app/Services/Riasec/RiasecPublicFormSummaryBuilder.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+            'backend/app/Services/V0_3/Me/MeAttemptsService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -938,6 +954,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecMeasurementContractComparePolicyFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -1053,6 +1073,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isIqScoringContractFoundationFile(string $file): bool
     {
         return $file === 'backend/app/Services/Assessment/Drivers/IqTestDriver.php';
+    }
+
+    private function isRiasecMeasurementContractComparePolicyFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Assessment/Drivers/RiasecDriver.php',
+            'backend/app/Services/Attempts/AttemptStartService.php',
+            'backend/app/Services/Riasec/RiasecCompareGuardService.php',
+            'backend/app/Services/Riasec/RiasecFormCatalog.php',
+            'backend/app/Services/Riasec/RiasecMeasurementContract.php',
+            'backend/app/Services/Riasec/RiasecPublicFormSummaryBuilder.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+            'backend/app/Services/V0_3/Me/MeAttemptsService.php',
+        ], true);
     }
 
     private function isIqReportFoundationFile(string $file): bool

--- a/backend/tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Riasec\RiasecCompareGuardService;
+use App\Services\Riasec\RiasecMeasurementContract;
+use Tests\TestCase;
+
+final class RiasecCompareGuardContractTest extends TestCase
+{
+    public function test_compare_guard_allows_same_form_attempts(): void
+    {
+        $service = new RiasecCompareGuardService(new RiasecMeasurementContract);
+
+        $guard = $service->evaluate(
+            $this->attempt('attempt_a', 'riasec_60', 60),
+            $this->makeResult('attempt_a', 'riasec_60', 'riasec_60_likert5_activity_sum_space.v1'),
+            $this->attempt('attempt_b', 'riasec_60', 60),
+            $this->makeResult('attempt_b', 'riasec_60', 'riasec_60_likert5_activity_sum_space.v1')
+        );
+
+        $this->assertSame('RIASEC', $guard['scale_code']);
+        $this->assertTrue($guard['can_compare']);
+        $this->assertSame('same_compare_compatibility_group', $guard['reason']);
+        $this->assertSame('riasec.compare.allowed_same_form', $guard['copy_key']);
+        $this->assertFalse($guard['raw_score_delta_allowed']);
+    }
+
+    public function test_compare_guard_blocks_60q_and_140q_cross_form_delta(): void
+    {
+        $service = new RiasecCompareGuardService(new RiasecMeasurementContract);
+
+        $guard = $service->evaluate(
+            $this->attempt('attempt_a', 'riasec_60', 60),
+            $this->makeResult('attempt_a', 'riasec_60', 'riasec_60_likert5_activity_sum_space.v1'),
+            $this->attempt('attempt_b', 'riasec_140', 140),
+            $this->makeResult('attempt_b', 'riasec_140', 'riasec_140_likert5_activity_context_space.v1')
+        );
+
+        $this->assertFalse($guard['can_compare']);
+        $this->assertSame('cross_form_score_space_mismatch', $guard['reason']);
+        $this->assertSame('riasec.compare.blocked_cross_form', $guard['copy_key']);
+        $this->assertFalse($guard['raw_score_delta_allowed']);
+        $this->assertArrayNotHasKey('raw_scores_delta', $guard);
+        $this->assertArrayNotHasKey('domains_delta', $guard);
+    }
+
+    public function test_measurement_contract_keeps_claim_boundary_and_140q_contextual_label(): void
+    {
+        $contract = (new RiasecMeasurementContract)->forFormCode('riasec_140', 140);
+
+        $this->assertSame('riasec.measurement_contract.v1', $contract['schema_version']);
+        $this->assertSame('career_interest', $contract['measured_signal_kind']);
+        $this->assertSame('riasec_140_likert5_activity_context_space.v1', data_get($contract, 'form.score_space_version'));
+        $this->assertSame('140Q contextual daily-work interest signal', data_get($contract, 'form.score_space_label'));
+        $this->assertContains('ability', data_get($contract, 'claim_boundary.does_not_measure'));
+        $this->assertContains('career_success_probability', data_get($contract, 'claim_boundary.does_not_measure'));
+        $this->assertSame('content_example_not_registry_match_without_reviewed_registry_source', data_get($contract, 'claim_boundary.occupation_examples_policy'));
+        $this->assertFalse((bool) data_get($contract, 'scoring.raw_score_delta_allowed'));
+        $this->assertFalse((bool) data_get($contract, 'compare_policy.cross_form_comparable'));
+    }
+
+    private function attempt(string $id, string $formCode, int $questionCount): Attempt
+    {
+        $attempt = new Attempt;
+        $attempt->id = $id;
+        $attempt->org_id = 0;
+        $attempt->scale_code = 'RIASEC';
+        $attempt->question_count = $questionCount;
+        $attempt->answers_summary_json = [
+            'meta' => [
+                'form_code' => $formCode,
+            ],
+        ];
+
+        return $attempt;
+    }
+
+    private function makeResult(string $attemptId, string $formCode, string $scoreSpaceVersion): Result
+    {
+        $result = new Result;
+        $result->attempt_id = $attemptId;
+        $result->scale_code = 'RIASEC';
+        $result->result_json = [
+            'form_code' => $formCode,
+            'top_code' => 'RIA',
+            'measurement_contract_v1' => (new RiasecMeasurementContract)->forFormCode($formCode),
+            'score_space_version' => $scoreSpaceVersion,
+        ];
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## What changed
- Added backend-authoritative `RiasecMeasurementContract` and `RiasecCompareGuardService`.
- Added RIASEC `score_space_version`, compare compatibility group, raw-delta prohibition, and claim boundary metadata to the scorer output, form catalog, public projection, start response, result/report/report-access form summary, and history compare surface.
- Added tests proving 60Q and 140Q are separate score spaces and cannot expose raw score deltas.
- Updated the Big Five runtime freeze classifier with a precise RIASEC measurement-contract exception so this train item is not misclassified as a Big Five runtime change.

## Why
Trusted Result v1.5 needs an explicit measurement contract before projection v2, snapshot-bound report, share/PDF/history consistency, or V11 rendering work can safely land. This PR keeps the backend as authority and does not change RIASEC scoring math or content pack semantics.

## Validation commands
- `vendor/bin/pint --test app/Services/Riasec/RiasecMeasurementContract.php app/Services/Riasec/RiasecCompareGuardService.php app/Services/Riasec/RiasecFormCatalog.php app/Services/Riasec/RiasecPublicFormSummaryBuilder.php app/Services/Riasec/RiasecPublicProjectionService.php app/Services/Assessment/Drivers/RiasecDriver.php app/Services/Attempts/AttemptStartService.php app/Services/V0_3/Me/MeAttemptsService.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecAssessmentFlowTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecCompareGuardContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecScorerTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EnneagramCompareGuardContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_measurement_contract'`
- `git diff --check`

## Sidecar issues
- Broad local runbook filter command failed only on `Tests\Feature\V0_3\AttemptReportAccessReadTest` logging expectation assertions for missing invite snapshot/projection tables. Scoped RIASEC checks passed; this PR does not touch `AttemptReadController`, report-access repair logic, or those tests.

## Intentionally deferred
- Projection v2 minimal schema is deferred to `RIASEC-TRAIN-02`.
- Snapshot-bound formal report path is deferred to `RIASEC-TRAIN-03`.
- Share/PDF/history snapshot consistency is deferred to `RIASEC-TRAIN-04`.
- Technical Note, V11 copy governance, activity registry examples, feedback overlay, and analytics remain deferred to later train items.

## Invariants preserved
- No RIASEC scoring math changes.
- No content pack question semantic changes.
- 140Q is described as contextual daily-work interest signal, not a more accurate answer.
- 60Q/140Q raw score delta is explicitly blocked.
- No occupation matches, job-fit percentages, career recommendations, or success predictions.
- No frontend or AI-generated interpretation authority added.

## Rollback / compatibility
- Additive response fields only; existing `riasec_public_projection_v1` and `riasec_form_v1` keys remain compatible.
- Rollback is a straight revert of this PR if downstream consumers need to pause on the measurement contract.
