### PR TITLE
feat(api): add career baseline metadata inventory audit

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditor.php
@@ -1,0 +1,471 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerBaselineMetadataInventoryAuditor
+{
+    /**
+     * The zh baseline is the display source for these fields in AUDIT-4.
+     *
+     * @var list<string>
+     */
+    private const DEFAULT_REQUIRED_DISPLAY_FIELDS = [
+        'title',
+        'subtitle',
+        'excerpt',
+        'body_md',
+        'seo_meta',
+    ];
+
+    /**
+     * @param  list<string>|null  $manifestPaths
+     * @param  list<string>|null  $requiredDisplayFields
+     */
+    public function __construct(
+        private readonly ?string $zhBaselinePath = null,
+        private readonly ?string $enBaselinePath = null,
+        private readonly ?array $manifestPaths = null,
+        private readonly ?array $requiredDisplayFields = null,
+    ) {}
+
+    public function auditPlan(CareerPublicResolutionPlan $plan): CareerBaselineMetadataInventoryResult
+    {
+        return $this->auditRows($plan->rows);
+    }
+
+    /**
+     * @param  list<CareerPublicResolutionPlanRow>  $planRows
+     */
+    public function auditRows(array $planRows): CareerBaselineMetadataInventoryResult
+    {
+        $sources = $this->loadSources();
+        $rows = [];
+
+        foreach ($planRows as $planRow) {
+            $canonicalSlug = $this->normalizeSlug($planRow->canonicalSlug);
+            if ($canonicalSlug === null) {
+                continue;
+            }
+
+            $rows[] = $this->buildRow(
+                canonicalSlug: $canonicalSlug,
+                sourceScope: $planRow->batchId ?? 'plan',
+                zhRow: $sources['zh_rows'][$canonicalSlug] ?? null,
+                enRow: $sources['en_rows'][$canonicalSlug] ?? null,
+                manifestRow: $sources['manifest_rows'][$canonicalSlug] ?? null
+            );
+        }
+
+        return CareerBaselineMetadataInventoryResult::build(
+            sourcePaths: $this->sourcePaths(),
+            rows: $rows,
+            issues: $sources['issues']
+        );
+    }
+
+    /**
+     * @return array{zh_rows: array<string, array<string, mixed>>, en_rows: array<string, array<string, mixed>>, manifest_rows: array<string, array<string, mixed>>, issues: list<CareerBaselineMetadataInventoryIssue>}
+     */
+    private function loadSources(): array
+    {
+        $issues = [];
+        [$zhRows, $zhIssue] = $this->loadSlugRowsFromJson($this->resolvedZhBaselinePath(), 'zh_baseline');
+        [$enRows, $enIssue] = $this->loadSlugRowsFromJson($this->resolvedEnBaselinePath(), 'en_baseline');
+
+        if ($zhIssue !== null) {
+            $issues[] = $zhIssue;
+        }
+
+        if ($enIssue !== null) {
+            $issues[] = $enIssue;
+        }
+
+        $manifestRows = [];
+        foreach ($this->resolvedManifestPaths() as $manifestPath) {
+            [$rows, $issue] = $this->loadSlugRowsFromJson($manifestPath, 'batch_manifest');
+            if ($issue !== null) {
+                $issues[] = $issue;
+
+                continue;
+            }
+
+            $manifestRows = array_replace($manifestRows, $rows);
+        }
+
+        return [
+            'zh_rows' => $zhRows,
+            'en_rows' => $enRows,
+            'manifest_rows' => $manifestRows,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array{0: array<string, array<string, mixed>>, 1: CareerBaselineMetadataInventoryIssue|null}
+     */
+    private function loadSlugRowsFromJson(string $path, string $source): array
+    {
+        if (! is_file($path)) {
+            return [
+                [],
+                new CareerBaselineMetadataInventoryIssue(
+                    reason: CareerBaselineMetadataInventoryIssue::BASELINE_SOURCE_MISSING,
+                    message: sprintf('Career baseline metadata source [%s] was not found.', $source),
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    sourcePath: $path,
+                    evidence: [['source' => $source, 'path' => $path]]
+                ),
+            ];
+        }
+
+        $contents = file_get_contents($path);
+        $payload = is_string($contents) ? json_decode($contents, true) : null;
+        if (! is_array($payload)) {
+            return [
+                [],
+                new CareerBaselineMetadataInventoryIssue(
+                    reason: CareerBaselineMetadataInventoryIssue::BASELINE_JSON_INVALID,
+                    message: sprintf('Career baseline metadata source [%s] is not valid JSON.', $source),
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    sourcePath: $path,
+                    evidence: [['source' => $source, 'json_error' => json_last_error_msg()]]
+                ),
+            ];
+        }
+
+        return [$this->rowsBySlug($payload), null];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, array<string, mixed>>
+     */
+    private function rowsBySlug(array $payload): array
+    {
+        $rows = $this->extractRows($payload);
+        $bySlug = [];
+
+        foreach ($rows as $key => $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->normalizeSlug($row['canonical_slug'] ?? null)
+                ?? $this->normalizeSlug($row['slug'] ?? null)
+                ?? (is_string($key) ? $this->normalizeSlug($key) : null);
+
+            if ($slug !== null) {
+                $bySlug[$slug] = $row;
+            }
+        }
+
+        return $bySlug;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<mixed>|array<string, mixed>
+     */
+    private function extractRows(array $payload): array
+    {
+        foreach (['jobs', 'members', 'occupations', 'rows', 'assets'] as $key) {
+            if (array_key_exists($key, $payload) && is_array($payload[$key])) {
+                return $payload[$key];
+            }
+        }
+
+        $workbook = $payload['workbook'] ?? null;
+        if (is_array($workbook) && isset($workbook['rows']) && is_array($workbook['rows'])) {
+            return $workbook['rows'];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $zhRow
+     * @param  array<string, mixed>|null  $enRow
+     * @param  array<string, mixed>|null  $manifestRow
+     */
+    private function buildRow(
+        string $canonicalSlug,
+        string $sourceScope,
+        ?array $zhRow,
+        ?array $enRow,
+        ?array $manifestRow,
+    ): CareerBaselineMetadataInventoryRow {
+        $issues = [];
+        $missingDisplayFields = $this->missingDisplayFields($zhRow);
+        $titleZh = $this->titleForLocale($zhRow, 'zh');
+        [$titleEn, $titleEnSource] = $this->resolveTitleEn($canonicalSlug, $enRow, $manifestRow);
+
+        if ($zhRow === null) {
+            $issues[] = new CareerBaselineMetadataInventoryIssue(
+                reason: CareerBaselineMetadataInventoryIssue::ZH_BASELINE_MISSING,
+                message: 'Career zh-CN baseline row was not found for canonical slug.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                evidence: [['canonical_slug' => $canonicalSlug]]
+            );
+        }
+
+        foreach ($missingDisplayFields as $field) {
+            $issues[] = new CareerBaselineMetadataInventoryIssue(
+                reason: CareerBaselineMetadataInventoryIssue::REQUIRED_DISPLAY_FIELD_MISSING,
+                message: 'Career zh-CN baseline row is missing a required display field.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                field: $field,
+                evidence: [['field' => $field]]
+            );
+        }
+
+        if ($titleEnSource === CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED) {
+            $issues[] = new CareerBaselineMetadataInventoryIssue(
+                reason: CareerBaselineMetadataInventoryIssue::EN_TITLE_DERIVATION_REQUIRED,
+                message: 'Career English title was derived from canonical_slug because no baseline or manifest title was available.',
+                severity: CareerCanonicalEligibilitySeverity::LOW,
+                canonicalSlug: $canonicalSlug,
+                evidence: [['canonical_slug' => $canonicalSlug, 'title_en' => $titleEn]]
+            );
+        }
+
+        if ($titleEnSource === CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_MISSING) {
+            $issues[] = new CareerBaselineMetadataInventoryIssue(
+                reason: CareerBaselineMetadataInventoryIssue::EN_TITLE_MISSING,
+                message: 'Career English title is missing and could not be derived from canonical_slug.',
+                severity: CareerCanonicalEligibilitySeverity::MEDIUM,
+                canonicalSlug: $canonicalSlug,
+                evidence: [['canonical_slug' => $canonicalSlug]]
+            );
+        }
+
+        $evidence = [
+            [
+                'canonical_slug' => $canonicalSlug,
+                'zh_baseline_exists' => $zhRow !== null,
+                'title_en_source' => $titleEnSource,
+            ],
+        ];
+
+        if ($titleZh !== null) {
+            $evidence[] = ['title_zh' => $titleZh];
+        }
+
+        if ($titleEn !== null) {
+            $evidence[] = ['title_en' => $titleEn];
+        }
+
+        return new CareerBaselineMetadataInventoryRow(
+            canonicalSlug: $canonicalSlug,
+            zhBaselineExists: $zhRow !== null,
+            titleZh: $titleZh,
+            titleEn: $titleEn,
+            titleEnSource: $titleEnSource,
+            baselineStatus: $this->baselineLayerStatus($issues, $evidence),
+            missingDisplayFields: $missingDisplayFields,
+            sourceScope: $sourceScope,
+            evidence: $evidence,
+            issues: $issues
+        );
+    }
+
+    /**
+     * @param  list<CareerBaselineMetadataInventoryIssue>  $issues
+     * @param  list<mixed>  $evidence
+     */
+    private function baselineLayerStatus(array $issues, array $evidence): CareerCanonicalEligibilityLayerStatus
+    {
+        $reasons = array_values(array_unique(array_map(
+            static fn (CareerBaselineMetadataInventoryIssue $issue): string => $issue->reason,
+            $issues
+        )));
+
+        $status = CareerCanonicalEligibilityStatus::PASS;
+        foreach ($issues as $issue) {
+            if ($issue->reason === CareerBaselineMetadataInventoryIssue::EN_TITLE_DERIVATION_REQUIRED) {
+                $status = $status === CareerCanonicalEligibilityStatus::PASS
+                    ? CareerCanonicalEligibilityStatus::WARNING
+                    : $status;
+
+                continue;
+            }
+
+            $status = CareerCanonicalEligibilityStatus::BLOCKED;
+            break;
+        }
+
+        return new CareerCanonicalEligibilityLayerStatus(
+            layer: CareerCanonicalEligibilityLayer::BASELINE,
+            status: $status,
+            reasons: $reasons,
+            evidence: $evidence,
+            source: 'career_baselines'
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $row
+     * @return list<string>
+     */
+    private function missingDisplayFields(?array $row): array
+    {
+        if ($row === null) {
+            return $this->requiredDisplayFields();
+        }
+
+        $missing = [];
+        foreach ($this->requiredDisplayFields() as $field) {
+            if ($this->fieldValue($row, $field) === null) {
+                $missing[] = $field;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $enRow
+     * @param  array<string, mixed>|null  $manifestRow
+     * @return array{0: string|null, 1: string}
+     */
+    private function resolveTitleEn(string $canonicalSlug, ?array $enRow, ?array $manifestRow): array
+    {
+        $title = $this->titleForLocale($enRow, 'en');
+        if ($title !== null) {
+            return [$title, CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_EN_BASELINE];
+        }
+
+        $title = $this->titleForLocale($manifestRow, 'en');
+        if ($title !== null) {
+            return [$title, CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_BATCH_MANIFEST];
+        }
+
+        $derived = $this->deriveTitleEn($canonicalSlug);
+
+        return $derived === null
+            ? [null, CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_MISSING]
+            : [$derived, CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $row
+     */
+    private function titleForLocale(?array $row, string $locale): ?string
+    {
+        if ($row === null) {
+            return null;
+        }
+
+        if ($locale === 'en') {
+            return $this->normalizeString($row['title_en'] ?? null)
+                ?? $this->normalizeString($row['canonical_title_en'] ?? null)
+                ?? $this->normalizeString($row['title'] ?? null);
+        }
+
+        return $this->normalizeString($row['title_zh'] ?? null)
+            ?? $this->normalizeString($row['canonical_title_zh'] ?? null)
+            ?? $this->normalizeString($row['title'] ?? null);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function fieldValue(array $row, string $field): ?string
+    {
+        if (array_key_exists($field, $row)) {
+            return $this->normalizeString($row[$field]);
+        }
+
+        if ($field === 'title_zh') {
+            return $this->titleForLocale($row, 'zh');
+        }
+
+        return null;
+    }
+
+    private function deriveTitleEn(string $canonicalSlug): ?string
+    {
+        $words = preg_split('/[-_]+/', $canonicalSlug);
+        if (! is_array($words) || $words === []) {
+            return null;
+        }
+
+        $title = trim(implode(' ', array_map(
+            static fn (string $word): string => ucfirst(strtolower($word)),
+            array_filter($words, static fn (string $word): bool => $word !== '')
+        )));
+
+        return $title === '' ? null : $title;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredDisplayFields(): array
+    {
+        return $this->requiredDisplayFields ?? self::DEFAULT_REQUIRED_DISPLAY_FIELDS;
+    }
+
+    private function resolvedZhBaselinePath(): string
+    {
+        return $this->zhBaselinePath ?? $this->repoRoot().'/content_baselines/career_jobs/career_jobs.zh-CN.json';
+    }
+
+    private function resolvedEnBaselinePath(): string
+    {
+        return $this->enBaselinePath ?? $this->repoRoot().'/content_baselines/career_jobs/career_jobs.en.json';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolvedManifestPaths(): array
+    {
+        return $this->manifestPaths ?? [
+            $this->repoRoot().'/backend/docs/career/first_wave_manifest.json',
+            $this->repoRoot().'/backend/docs/career/batches/batch_2_manifest.json',
+            $this->repoRoot().'/backend/docs/career/batches/batch_3_manifest.json',
+            $this->repoRoot().'/backend/docs/career/batches/batch_4_manifest.json',
+        ];
+    }
+
+    /**
+     * @return array{zh_baseline: string|null, en_baseline: string|null, manifests: list<string>}
+     */
+    private function sourcePaths(): array
+    {
+        return [
+            'zh_baseline' => $this->resolvedZhBaselinePath(),
+            'en_baseline' => $this->resolvedEnBaselinePath(),
+            'manifests' => $this->resolvedManifestPaths(),
+        ];
+    }
+
+    private function repoRoot(): string
+    {
+        $root = realpath(dirname(__DIR__, 5));
+
+        return is_string($root) && $root !== '' ? $root : dirname(__DIR__, 5);
+    }
+
+    private function normalizeSlug(mixed $value): ?string
+    {
+        $normalized = $this->normalizeString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryIssue.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerBaselineMetadataInventoryIssue
+{
+    public const ZH_BASELINE_MISSING = 'zh_baseline_missing';
+
+    public const EN_TITLE_MISSING = 'en_title_missing';
+
+    public const EN_TITLE_DERIVATION_REQUIRED = 'en_title_derivation_required';
+
+    public const REQUIRED_DISPLAY_FIELD_MISSING = 'required_display_field_missing';
+
+    public const BASELINE_JSON_INVALID = 'baseline_json_invalid';
+
+    public const BASELINE_SOURCE_MISSING = 'baseline_source_missing';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::MEDIUM,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $field = null,
+        public readonly ?string $sourcePath = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->field !== null) {
+            self::assertNonEmptyString($this->field, 'field');
+        }
+
+        if ($this->sourcePath !== null) {
+            self::assertNonEmptyString($this->sourcePath, 'source_path');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::ZH_BASELINE_MISSING,
+            self::EN_TITLE_MISSING,
+            self::EN_TITLE_DERIVATION_REQUIRED,
+            self::REQUIRED_DISPLAY_FIELD_MISSING,
+            self::BASELINE_JSON_INVALID,
+            self::BASELINE_SOURCE_MISSING,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career baseline metadata inventory issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, canonical_slug: string|null, field: string|null, source_path: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'canonical_slug' => $this->canonicalSlug,
+            'field' => $this->field,
+            'source_path' => $this->sourcePath,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career baseline metadata inventory issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career baseline metadata inventory issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryResult.php
+++ b/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryResult.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerBaselineMetadataInventoryResult
+{
+    /**
+     * @param  list<CareerBaselineMetadataInventoryRow>  $rows
+     * @param  list<CareerBaselineMetadataInventoryIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     * @param  array{zh_baseline: string|null, en_baseline: string|null, manifests: list<string>}  $sourcePaths
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly int $expectedCount,
+        public readonly int $zhBaselineFoundCount,
+        public readonly int $zhBaselineMissingCount,
+        public readonly int $enTitleFoundCount,
+        public readonly int $enTitleDerivedCount,
+        public readonly int $missingDisplayFieldCount,
+        public readonly array $sourcePaths,
+        public readonly array $rows,
+        public readonly array $issues = [],
+        public readonly array $sidecars = [],
+    ) {
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        foreach ([
+            'expected_count' => $this->expectedCount,
+            'zh_baseline_found_count' => $this->zhBaselineFoundCount,
+            'zh_baseline_missing_count' => $this->zhBaselineMissingCount,
+            'en_title_found_count' => $this->enTitleFoundCount,
+            'en_title_derived_count' => $this->enTitleDerivedCount,
+            'missing_display_field_count' => $this->missingDisplayFieldCount,
+        ] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career baseline metadata inventory [%s] must be non-negative.', $key));
+            }
+        }
+
+        self::assertSourcePaths($this->sourcePaths);
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+        self::assertSidecars($this->sidecars);
+    }
+
+    /**
+     * @param  list<CareerBaselineMetadataInventoryRow>  $rows
+     * @param  list<CareerBaselineMetadataInventoryIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     * @param  array{zh_baseline: string|null, en_baseline: string|null, manifests: list<string>}  $sourcePaths
+     */
+    public static function build(array $sourcePaths, array $rows, array $issues = [], array $sidecars = []): self
+    {
+        $allIssues = [
+            ...$issues,
+            ...array_values(array_merge(...array_map(
+                static fn (CareerBaselineMetadataInventoryRow $row): array => $row->issues,
+                $rows
+            ))),
+        ];
+
+        return new self(
+            status: self::statusForIssues($allIssues),
+            expectedCount: count($rows),
+            zhBaselineFoundCount: count(array_filter(
+                $rows,
+                static fn (CareerBaselineMetadataInventoryRow $row): bool => $row->zhBaselineExists
+            )),
+            zhBaselineMissingCount: count(array_filter(
+                $rows,
+                static fn (CareerBaselineMetadataInventoryRow $row): bool => ! $row->zhBaselineExists
+            )),
+            enTitleFoundCount: count(array_filter(
+                $rows,
+                static fn (CareerBaselineMetadataInventoryRow $row): bool => $row->titleEn !== null
+                    && $row->titleEnSource !== CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED
+            )),
+            enTitleDerivedCount: count(array_filter(
+                $rows,
+                static fn (CareerBaselineMetadataInventoryRow $row): bool => $row->titleEnSource === CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED
+            )),
+            missingDisplayFieldCount: array_sum(array_map(
+                static fn (CareerBaselineMetadataInventoryRow $row): int => count($row->missingDisplayFields),
+                $rows
+            )),
+            sourcePaths: $sourcePaths,
+            rows: $rows,
+            issues: $allIssues,
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, expected_count: int, zh_baseline_found_count: int, zh_baseline_missing_count: int, en_title_found_count: int, en_title_derived_count: int, missing_display_field_count: int, by_reason: array<string, int>, source_paths: array<string, mixed>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'expected_count' => $this->expectedCount,
+            'zh_baseline_found_count' => $this->zhBaselineFoundCount,
+            'zh_baseline_missing_count' => $this->zhBaselineMissingCount,
+            'en_title_found_count' => $this->enTitleFoundCount,
+            'en_title_derived_count' => $this->enTitleDerivedCount,
+            'missing_display_field_count' => $this->missingDisplayFieldCount,
+            'by_reason' => $this->byReason(),
+            'source_paths' => $this->sourcePaths,
+            'rows' => array_map(
+                static fn (CareerBaselineMetadataInventoryRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerBaselineMetadataInventoryIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerBaselineMetadataInventoryIssue>  $issues
+     */
+    private static function statusForIssues(array $issues): string
+    {
+        if ($issues === []) {
+            return CareerCanonicalEligibilityStatus::PASS;
+        }
+
+        foreach ($issues as $issue) {
+            if ($issue->reason !== CareerBaselineMetadataInventoryIssue::EN_TITLE_DERIVATION_REQUIRED) {
+                return CareerCanonicalEligibilityStatus::BLOCKED;
+            }
+        }
+
+        return CareerCanonicalEligibilityStatus::WARNING;
+    }
+
+    /**
+     * @param  array{zh_baseline: string|null, en_baseline: string|null, manifests: list<string>}  $sourcePaths
+     */
+    private static function assertSourcePaths(array $sourcePaths): void
+    {
+        foreach (['zh_baseline', 'en_baseline', 'manifests'] as $key) {
+            if (! array_key_exists($key, $sourcePaths)) {
+                throw new InvalidArgumentException(sprintf('Career baseline metadata inventory source_paths missing [%s].', $key));
+            }
+        }
+
+        if (! is_array($sourcePaths['manifests']) || ! array_is_list($sourcePaths['manifests'])) {
+            throw new InvalidArgumentException('Career baseline metadata inventory source_paths manifests must be a list.');
+        }
+    }
+
+    /**
+     * @param  list<CareerBaselineMetadataInventoryRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career baseline metadata inventory rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerBaselineMetadataInventoryRow) {
+                throw new InvalidArgumentException('Career baseline metadata inventory rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerBaselineMetadataInventoryIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career baseline metadata inventory issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerBaselineMetadataInventoryIssue) {
+                throw new InvalidArgumentException('Career baseline metadata inventory issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career baseline metadata inventory sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career baseline metadata inventory sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryRow.php
+++ b/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryRow.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerBaselineMetadataInventoryRow
+{
+    public const TITLE_EN_SOURCE_EN_BASELINE = 'en_baseline';
+
+    public const TITLE_EN_SOURCE_BATCH_MANIFEST = 'batch_manifest';
+
+    public const TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED = 'canonical_slug_derived';
+
+    public const TITLE_EN_SOURCE_MISSING = 'missing';
+
+    /**
+     * @param  list<string>  $missingDisplayFields
+     * @param  list<mixed>  $evidence
+     * @param  list<CareerBaselineMetadataInventoryIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly bool $zhBaselineExists,
+        public readonly ?string $titleZh,
+        public readonly ?string $titleEn,
+        public readonly string $titleEnSource,
+        public readonly CareerCanonicalEligibilityLayerStatus $baselineStatus,
+        public readonly array $missingDisplayFields = [],
+        public readonly ?string $sourceScope = null,
+        public readonly array $evidence = [],
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertValidTitleEnSource($this->titleEnSource);
+        self::assertListOfStrings($this->missingDisplayFields, 'missing_display_fields');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->titleZh !== null) {
+            self::assertNonEmptyString($this->titleZh, 'title_zh');
+        }
+
+        if ($this->titleEn !== null) {
+            self::assertNonEmptyString($this->titleEn, 'title_en');
+        }
+
+        if ($this->sourceScope !== null) {
+            self::assertNonEmptyString($this->sourceScope, 'source_scope');
+        }
+
+        if (! array_is_list($this->issues)) {
+            throw new InvalidArgumentException('Career baseline metadata inventory row issues must be a list.');
+        }
+
+        foreach ($this->issues as $issue) {
+            if (! $issue instanceof CareerBaselineMetadataInventoryIssue) {
+                throw new InvalidArgumentException('Career baseline metadata inventory row issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function titleEnSources(): array
+    {
+        return [
+            self::TITLE_EN_SOURCE_EN_BASELINE,
+            self::TITLE_EN_SOURCE_BATCH_MANIFEST,
+            self::TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED,
+            self::TITLE_EN_SOURCE_MISSING,
+        ];
+    }
+
+    public static function assertValidTitleEnSource(string $value): string
+    {
+        if (! in_array($value, self::titleEnSources(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career baseline metadata title_en_source [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{canonical_slug: string, zh_baseline_exists: bool, title_zh: string|null, title_en: string|null, title_en_source: string, baseline_status: array<string, mixed>, missing_display_fields: list<string>, source_scope: string|null, evidence: list<mixed>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'zh_baseline_exists' => $this->zhBaselineExists,
+            'title_zh' => $this->titleZh,
+            'title_en' => $this->titleEn,
+            'title_en_source' => $this->titleEnSource,
+            'baseline_status' => $this->baselineStatus->toArray(),
+            'missing_display_fields' => $this->missingDisplayFields,
+            'source_scope' => $this->sourceScope,
+            'evidence' => $this->evidence,
+            'issues' => array_map(
+                static fn (CareerBaselineMetadataInventoryIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career baseline metadata inventory row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career baseline metadata inventory row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career baseline metadata inventory row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/docs/career/audits/baseline_metadata_inventory_audit.md
+++ b/backend/docs/career/audits/baseline_metadata_inventory_audit.md
@@ -1,0 +1,99 @@
+# Career Baseline Metadata Inventory Audit
+
+AUDIT-4 adds the read-only baseline/display metadata inventory layer for the Career 2786 canonical eligibility audit train.
+
+## Purpose
+
+The auditor consumes normalized AUDIT-2 public-resolution plan rows and verifies that each canonical slug has enough baseline/display metadata to support future eligibility rows.
+
+It checks:
+
+- `content_baselines/career_jobs/career_jobs.zh-CN.json`
+- `content_baselines/career_jobs/career_jobs.en.json`
+- existing Career batch manifests that expose canonical English titles
+- canonical slug title derivation as a documented fallback
+
+## Non-Goals
+
+AUDIT-4 does not:
+
+- query or mutate the database
+- backfill Occupations or display assets
+- audit Occupation entity inventory
+- audit index state
+- audit runtime projection/truth
+- audit SEO/GEO or live surfaces
+- run rollout, apply, rollback, quarantine, deployment, or production validation
+
+## Input Contract
+
+The primary input is `CareerPublicResolutionPlan`, produced by AUDIT-2. Each row contributes:
+
+- `canonical_slug`
+- optional `batch_id` as `source_scope`
+- raw planner metadata preserved by AUDIT-2
+
+The baseline auditor loads JSON sources from explicit paths supplied by the caller, or from the repo default baseline and manifest paths.
+
+Supported source row envelopes:
+
+- `jobs`
+- `members`
+- `occupations`
+- `rows`
+- `assets`
+- `workbook.rows`
+- slug-keyed objects
+
+## Row Output
+
+Each `CareerBaselineMetadataInventoryRow` serializes as:
+
+- `canonical_slug`
+- `zh_baseline_exists`
+- `title_zh`
+- `title_en`
+- `title_en_source`
+- `baseline_status`
+- `missing_display_fields`
+- `source_scope`
+- `evidence`
+- `issues`
+
+`title_en_source` is one of:
+
+- `en_baseline`
+- `batch_manifest`
+- `canonical_slug_derived`
+- `missing`
+
+## Issue Reasons
+
+AUDIT-4 emits these structured reasons:
+
+- `zh_baseline_missing`
+- `en_title_missing`
+- `en_title_derivation_required`
+- `required_display_field_missing`
+- `baseline_json_invalid`
+- `baseline_source_missing`
+
+`en_title_derivation_required` is a warning-level continuation signal. Missing zh baselines, invalid JSON, missing source files, and required display-field gaps block the baseline layer.
+
+## AUDIT-1 Layer Status
+
+Rows expose an AUDIT-1-compatible `CareerCanonicalEligibilityLayerStatus` with:
+
+- `layer=baseline`
+- `status=pass|warning|blocked`
+- `source=career_baselines`
+- `reasons` copied from baseline inventory issue reasons
+- `evidence` containing slug, zh baseline availability, and English title source
+
+## Consumption by AUDIT-5+
+
+Future audit layers should consume this result as a baseline-layer input only. AUDIT-5 must not infer index state from baseline metadata. AUDIT-6 must not infer runtime publish state from baseline metadata. AUDIT-9 will compose this result into the full command.
+
+## Readiness Warning
+
+AUDIT-4 is schema and read-only inventory logic only. It does not claim 2786 readiness and does not prove publication eligibility on its own.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditorTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerBaselineMetadataInventoryAuditor;
+use App\Domain\Career\Audit\CareerBaselineMetadataInventoryIssue;
+use App\Domain\Career\Audit\CareerBaselineMetadataInventoryRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerPublicResolutionPlan;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
+use PHPUnit\Framework\TestCase;
+
+final class CareerBaselineMetadataInventoryAuditorTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $paths = [];
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->paths) as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+
+            if (is_dir($path)) {
+                rmdir($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_zh_baseline_found_passes_baseline_layer(): void
+    {
+        $result = $this->auditor(
+            zhRows: [$this->baselineRow('actuaries', '精算师')],
+            enRows: [$this->baselineRow('actuaries', 'Actuaries')],
+        )->auditPlan($this->plan(['actuaries']));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(1, $result->zhBaselineFoundCount);
+        $this->assertSame(CareerCanonicalEligibilityLayer::BASELINE, $result->rows[0]->baselineStatus->layer);
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->rows[0]->baselineStatus->status);
+    }
+
+    public function test_zh_baseline_missing_is_reported(): void
+    {
+        $result = $this->auditor(
+            zhRows: [],
+            enRows: [$this->baselineRow('actuaries', 'Actuaries')],
+        )->auditPlan($this->plan(['actuaries']));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->zhBaselineMissingCount);
+        $this->assertSame(CareerBaselineMetadataInventoryIssue::ZH_BASELINE_MISSING, $result->rows[0]->issues[0]->reason);
+    }
+
+    public function test_en_title_from_en_baseline(): void
+    {
+        $result = $this->auditor(
+            zhRows: [$this->baselineRow('actuaries', '精算师')],
+            enRows: [$this->baselineRow('actuaries', 'Actuaries')],
+        )->auditPlan($this->plan(['actuaries']));
+
+        $this->assertSame('Actuaries', $result->rows[0]->titleEn);
+        $this->assertSame(CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_EN_BASELINE, $result->rows[0]->titleEnSource);
+    }
+
+    public function test_en_title_from_manifest_when_en_baseline_missing(): void
+    {
+        $result = $this->auditor(
+            zhRows: [$this->baselineRow('financial-analysts', '金融分析师')],
+            enRows: [],
+            manifestRows: [$this->manifestRow('financial-analysts', 'Financial Analysts')],
+        )->auditPlan($this->plan(['financial-analysts']));
+
+        $this->assertSame('Financial Analysts', $result->rows[0]->titleEn);
+        $this->assertSame(CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_BATCH_MANIFEST, $result->rows[0]->titleEnSource);
+    }
+
+    public function test_en_title_can_be_derived_from_canonical_slug(): void
+    {
+        $result = $this->auditor(
+            zhRows: [$this->baselineRow('software-developers', '软件开发人员')],
+            enRows: [],
+            manifestRows: [],
+        )->auditPlan($this->plan(['software-developers']));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::WARNING, $result->status);
+        $this->assertSame('Software Developers', $result->rows[0]->titleEn);
+        $this->assertSame(CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED, $result->rows[0]->titleEnSource);
+        $this->assertSame([
+            CareerBaselineMetadataInventoryIssue::EN_TITLE_DERIVATION_REQUIRED => 1,
+        ], $result->byReason());
+    }
+
+    public function test_display_field_missing_is_reported(): void
+    {
+        $result = $this->auditor(
+            zhRows: [
+                [
+                    'slug' => 'actuaries',
+                    'title' => '精算师',
+                ],
+            ],
+            enRows: [$this->baselineRow('actuaries', 'Actuaries')],
+        )->auditPlan($this->plan(['actuaries']));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(['excerpt'], $result->rows[0]->missingDisplayFields);
+        $this->assertSame(CareerBaselineMetadataInventoryIssue::REQUIRED_DISPLAY_FIELD_MISSING, $result->rows[0]->issues[0]->reason);
+    }
+
+    public function test_invalid_baseline_json_is_reported(): void
+    {
+        $zhPath = $this->writeRaw('zh.json', '{"jobs": [');
+        $enPath = $this->writeBaseline('en.json', ['jobs' => [$this->baselineRow('actuaries', 'Actuaries')]]);
+
+        $result = (new CareerBaselineMetadataInventoryAuditor(
+            zhBaselinePath: $zhPath,
+            enBaselinePath: $enPath,
+            manifestPaths: [],
+            requiredDisplayFields: ['title', 'excerpt'],
+        ))->auditPlan($this->plan(['actuaries']));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(CareerBaselineMetadataInventoryIssue::BASELINE_JSON_INVALID, $result->issues[0]->reason);
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $result = $this->auditor(
+            zhRows: [$this->baselineRow('actuaries', '精算师')],
+            enRows: [$this->baselineRow('actuaries', 'Actuaries')],
+        )->auditPlan($this->plan(['actuaries']))->toArray();
+        $result['source_paths'] = [
+            'zh_baseline' => '__ZH__',
+            'en_baseline' => '__EN__',
+            'manifests' => [],
+        ];
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "expected_count": 1,
+    "zh_baseline_found_count": 1,
+    "zh_baseline_missing_count": 0,
+    "en_title_found_count": 1,
+    "en_title_derived_count": 0,
+    "missing_display_field_count": 0,
+    "by_reason": [],
+    "source_paths": {
+        "zh_baseline": "__ZH__",
+        "en_baseline": "__EN__",
+        "manifests": []
+    },
+    "rows": [
+        {
+            "canonical_slug": "actuaries",
+            "zh_baseline_exists": true,
+            "title_zh": "精算师",
+            "title_en": "Actuaries",
+            "title_en_source": "en_baseline",
+            "baseline_status": {
+                "layer": "baseline",
+                "status": "pass",
+                "reasons": [],
+                "evidence": [
+                    {
+                        "canonical_slug": "actuaries",
+                        "zh_baseline_exists": true,
+                        "title_en_source": "en_baseline"
+                    },
+                    {
+                        "title_zh": "精算师"
+                    },
+                    {
+                        "title_en": "Actuaries"
+                    }
+                ],
+                "source": "career_baselines"
+            },
+            "missing_display_fields": [],
+            "source_scope": "plan",
+            "evidence": [
+                {
+                    "canonical_slug": "actuaries",
+                    "zh_baseline_exists": true,
+                    "title_en_source": "en_baseline"
+                },
+                {
+                    "title_zh": "精算师"
+                },
+                {
+                    "title_en": "Actuaries"
+                }
+            ],
+            "issues": []
+        }
+    ],
+    "issues": [],
+    "sidecars": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+        );
+    }
+
+    public function test_auditor_does_not_hit_db(): void
+    {
+        $result = $this->auditor(
+            zhRows: [$this->baselineRow('actuaries', '精算师')],
+            enRows: [$this->baselineRow('actuaries', 'Actuaries')],
+        )->auditPlan($this->plan(['actuaries']));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+    }
+
+    private function auditor(array $zhRows, array $enRows, array $manifestRows = []): CareerBaselineMetadataInventoryAuditor
+    {
+        return new CareerBaselineMetadataInventoryAuditor(
+            zhBaselinePath: $this->writeBaseline('zh.json', ['jobs' => $zhRows]),
+            enBaselinePath: $this->writeBaseline('en.json', ['jobs' => $enRows]),
+            manifestPaths: $manifestRows === [] ? [] : [
+                $this->writeBaseline('manifest.json', ['members' => $manifestRows]),
+            ],
+            requiredDisplayFields: ['title', 'excerpt'],
+        );
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function plan(array $slugs): CareerPublicResolutionPlan
+    {
+        return new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-audit-4-plan.json',
+            checksum: null,
+            rows: array_map(
+                static fn (string $slug): CareerPublicResolutionPlanRow => CareerPublicResolutionPlanRow::fromRaw([
+                    'canonical_slug' => $slug,
+                ]),
+                $slugs
+            )
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baselineRow(string $slug, string $title): array
+    {
+        return [
+            'slug' => $slug,
+            'title' => $title,
+            'excerpt' => $title.' overview.',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function manifestRow(string $slug, string $title): array
+    {
+        return [
+            'canonical_slug' => $slug,
+            'canonical_title_en' => $title,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeBaseline(string $name, array $payload): string
+    {
+        return $this->writeRaw($name, (string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+
+    private function writeRaw(string $name, string $contents): string
+    {
+        $dir = sys_get_temp_dir().'/career-baseline-metadata-inventory-'.str_replace('.', '', uniqid('', true));
+        mkdir($dir);
+        $this->paths[] = $dir;
+
+        $path = $dir.'/'.$name;
+        file_put_contents($path, $contents);
+        $this->paths[] = $path;
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -293,6 +293,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_baseline_metadata_inventory_audit_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryIssue.php',
+            'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryResult.php',
+            'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -903,6 +915,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerBaselineMetadataInventoryAuditFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1187,6 +1203,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryIssue.php',
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryResult.php',
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryRow.php',
+        ], true);
+    }
+
+    private function isCareerBaselineMetadataInventoryAuditFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryIssue.php',
+            'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryResult.php',
+            'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1205,6 +1205,115 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-4": {
+      "repo": "fap-api",
+      "branch": "fix/career-baseline-metadata-inventory-audit4",
+      "title": "feat(api): add career baseline metadata inventory audit",
+      "name": "Career Baseline/display Metadata Inventory Audit",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-3"
+      ],
+      "scope_type": "baseline_metadata_inventory_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no audit command",
+        "no Occupation entity inventory",
+        "no index-state inventory",
+        "no runtime projection/truth audit",
+        "no SEO/GEO audit",
+        "no live HTML/surface audit",
+        "no rollout",
+        "no display metadata backfill",
+        "no manifest train generator",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuing the Career 2786 audit PR train from AUDIT-4 through AUDIT-13 and authorized per-item PR train manifest/state updates."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-3 is present on main as PR #1318 merge fbc90e6d and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Unit/Domain/Career/Audit, backend/docs/career/audits, the test-only BigFive freeze classifier allowlist, and docs/codex train files."
+        },
+        "baseline_metadata_inventory_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi",
+          "evidence": "9 tests passed, 22 assertions."
+        },
+        "occupation_entity_inventory_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi",
+          "evidence": "13 tests passed, 45 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_allowlist_fix": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-4 CareerBaselineMetadataInventory* files to the test-only freeze classifier allowlist; the runtime path gate passes locally."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3075 files checked."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "mbti_ci": {
+          "status": "external_flaky_or_infrastructure",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "After the AUDIT-4 freeze allowlist fix, the full local chain failed in unrelated BigFive norm/content tests with SQLite /tmp/fap-ci.sqlite database locked DeadlockException. Scoped AUDIT-4 validation and the runtime freeze classifier gate pass."
+        }
+      },
+      "sidecar_issues": [
+        {
+          "sidecar_id": "AUDIT-4-SIDECAR-LOCAL-MBTI-SQLITE-LOCK",
+          "title": "Local MBTI CI chain hit SQLite database lock outside AUDIT-4 scope",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "bash backend/scripts/ci_verify_mbti.sh failed after AUDIT-4 allowlist fix in unrelated BigFive norm/content tests with SQLSTATE[HY000]: General error: 5 database is locked against /tmp/fap-ci.sqlite.",
+            "Scoped AUDIT-4 tests, AUDIT-1/2/3 regressions, pint, git diff --check, and BigFive runtime freeze path gate passed."
+          ],
+          "severity": "low",
+          "next_goal": "Let GitHub required checks run in isolated CI; inspect logs if the same failure appears there.",
+          "may_continue_train": true
+        }
+      ],
+      "failure_reason": null,
+      "next_pr": "AUDIT-5 Index-state authority audit",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -588,3 +588,48 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-4
+    repo: fap-api
+    depends_on:
+      - AUDIT-3
+    branch: fix/career-baseline-metadata-inventory-audit4
+    title: "feat(api): add career baseline metadata inventory audit"
+    name: "Career Baseline/display Metadata Inventory Audit"
+    scope_type: baseline_metadata_inventory_only
+    scope:
+      - Add a read-only baseline/display metadata inventory auditor for canonical slugs from AUDIT-2 plan rows.
+      - Load existing Career zh-CN/en baseline files and batch manifests from explicit or repo-default paths.
+      - Report zh baseline availability, English title source, required display field gaps, and structured baseline issues.
+      - Emit AUDIT-1-compatible baseline layer statuses.
+      - Document AUDIT-4 baseline inventory contract and future AUDIT-5+ consumption policy.
+      - Add focused tests proving stable JSON, read-only behavior, and no DB/runtime/index/surface audit logic.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-4 baseline metadata audit files.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add a career canonical eligibility audit command.
+      - Add Occupation entity inventory.
+      - Add index-state inventory.
+      - Add runtime projection/truth audit.
+      - Add SEO/GEO or surface audit.
+      - Modify rollout state.
+      - Backfill display metadata.
+      - Mutate production data.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-5 Index-state authority audit"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- AUDIT-4 baseline/display metadata inventory audit only.
- Adds read-only baseline metadata inventory DTOs/service for AUDIT-2 plan rows.
- Supports zh-CN/en baseline files, batch manifest English title sources, canonical slug title derivation, stable JSON, and AUDIT-1 baseline layer statuses.
- Updates PR train manifest/state for AUDIT-4 only.
- Adds the scoped test-only BigFive runtime freeze classifier allowlist for AUDIT-4 Career audit files.

## Non-goals / Safety
- No DB mutation.
- No production commands.
- No deploy.
- No audit command yet.
- No Occupation entity inventory changes.
- No index-state, runtime projection/truth, SEO/GEO, or surface audit yet.
- No rollout/backfill/apply/rollback/quarantine.
- Does not claim 2786 readiness.

## Validation
- `php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi` passed: 9 tests, 22 assertions.
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi` passed: 13 tests, 45 assertions.
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi` passed: 14 tests, 37 assertions.
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` passed: 14 tests, 28 assertions.
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi` passed.
- `vendor/bin/pint --test` passed: 3075 files checked.
- `git diff --check` passed.

## Sidecar / Local CI Note
- `bash backend/scripts/ci_verify_mbti.sh` was run locally after the AUDIT-4 allowlist fix.
- The introduced AUDIT-4 freeze-classifier failure was fixed and the focused gate now passes.
- The full local chain then failed in unrelated BigFive norm/content tests with SQLite `/tmp/fap-ci.sqlite` database locked `DeadlockException`; recorded as `AUDIT-4-SIDECAR-LOCAL-MBTI-SQLITE-LOCK`, external to AUDIT-4, `may_continue_train=true`.
- If GitHub checks show the same failure, inspect logs before classifying.

## PR Train Protocol
- Pending checks are wait/poll state, not blockers.
- Failed checks require inspect/fix/push/wait loop, not immediate stop.
- Next PR: AUDIT-5 Index-state authority audit.
