### PR TITLE
RIASEC-TRAIN-02 — Projection v2 minimal + evidence metadata

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -309,6 +309,12 @@ class AttemptReadController extends Controller
                 (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
             )
             : [];
+        $riasecProjectionV2 = $scaleCode === 'RIASEC'
+            ? $this->riasecPublicProjectionService->buildV2FromResult(
+                $result,
+                (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
+            )
+            : [];
 
         $mbtiEventMeta = $scaleCode === 'MBTI'
             ? $this->resolveMbtiResultViewEventMeta($request, $result, $attempt, $attemptId)
@@ -396,6 +402,9 @@ class AttemptReadController extends Controller
         }
         if ($riasecProjection !== []) {
             $responsePayload['riasec_public_projection_v1'] = $riasecProjection;
+        }
+        if ($riasecProjectionV2 !== []) {
+            $responsePayload['riasec_public_projection_v2'] = $riasecProjectionV2;
         }
         if (is_array($riasecFormSummary)) {
             $responsePayload['riasec_form_v1'] = $riasecFormSummary;
@@ -607,7 +616,15 @@ class AttemptReadController extends Controller
                     (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN'))
                 );
             }
+            $projectionV2 = data_get($responsePayload, 'report._meta.riasec_public_projection_v2');
+            if (! is_array($projectionV2)) {
+                $projectionV2 = $this->riasecPublicProjectionService->buildV2FromResult(
+                    $result,
+                    (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN'))
+                );
+            }
             $responsePayload['riasec_public_projection_v1'] = $projection;
+            $responsePayload['riasec_public_projection_v2'] = $projectionV2;
         }
 
         $effectiveMbtiPersonalization = $scaleCode === 'MBTI'

--- a/backend/app/Services/Assessment/Drivers/RiasecDriver.php
+++ b/backend/app/Services/Assessment/Drivers/RiasecDriver.php
@@ -37,6 +37,7 @@ final class RiasecDriver implements DriverInterface
         if ($scoringSpecVersion === '') {
             $scoringSpecVersion = (string) ($scorePayload['scoring_spec_version'] ?? 'riasec_standard_60_v1');
         }
+        $qualityRuleVersion = trim((string) ($ctx['quality_version'] ?? ($policy['quality_version'] ?? '')));
 
         $formCode = $this->measurementContract->canonicalFormCode(
             (string) ($ctx['form_code'] ?? ($policy['form_code'] ?? ($scorePayload['form_code'] ?? ''))),
@@ -56,6 +57,7 @@ final class RiasecDriver implements DriverInterface
         $scorePayload['compare_compatibility_group'] = (string) ($comparePolicy['compare_compatibility_group'] ?? '');
         $scorePayload['cross_form_comparable'] = false;
         $scorePayload['raw_score_delta_allowed'] = false;
+        $scorePayload['quality_rule_version'] = $qualityRuleVersion;
         $scorePayload['measurement_contract_v1'] = $measurementContract;
         $scorePayload['compare_policy_v1'] = $comparePolicy;
         $scorePayload['version_snapshot'] = [
@@ -63,6 +65,7 @@ final class RiasecDriver implements DriverInterface
             'pack_version' => $version,
             'engine_version' => (string) ($scorePayload['engine_version'] ?? ($policy['engine_version'] ?? 'riasec_v1.0.0')),
             'scoring_spec_version' => $scoringSpecVersion,
+            'quality_rule_version' => $qualityRuleVersion,
             'measurement_contract_version' => RiasecMeasurementContract::SCHEMA_VERSION,
             'score_space_version' => $scoreSpaceVersion,
             'content_manifest_hash' => $manifestHash,

--- a/backend/app/Services/Report/RiasecReportComposer.php
+++ b/backend/app/Services/Report/RiasecReportComposer.php
@@ -27,6 +27,7 @@ final class RiasecReportComposer
         }
 
         $projection = $this->projectionService->buildFromResult($result, $locale);
+        $projectionV2 = $this->projectionService->buildV2FromResult($result, $locale);
         $topCode = trim((string) ($projection['top_code'] ?? $result->type_code ?? ''));
         if ($topCode === '') {
             return [
@@ -62,6 +63,7 @@ final class RiasecReportComposer
                 'sections' => $this->buildSections($projection),
                 '_meta' => [
                     'riasec_public_projection_v1' => $projection,
+                    'riasec_public_projection_v2' => $projectionV2,
                 ],
                 'generated_at' => now()->toISOString(),
             ],

--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -76,6 +76,94 @@ final class RiasecPublicProjectionService
     }
 
     /**
+     * @return array<string,mixed>
+     */
+    public function buildV2FromResult(Result $result, string $locale = 'zh-CN'): array
+    {
+        $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $v1 = $this->buildFromResult($result, $locale);
+        $measurementContract = is_array($v1['measurement_contract_v1'] ?? null)
+            ? $v1['measurement_contract_v1']
+            : $this->measurementContract->forFormCode((string) data_get($v1, 'form.form_code', ''));
+        $comparePolicy = is_array($v1['compare_policy_v1'] ?? null)
+            ? $v1['compare_policy_v1']
+            : (is_array($measurementContract['compare_policy'] ?? null)
+                ? $measurementContract['compare_policy']
+                : $this->measurementContract->comparePolicyForFormCode((string) data_get($v1, 'form.form_code', '')));
+        $scoreSpaceVersion = (string) data_get($measurementContract, 'form.score_space_version', data_get($v1, 'form.score_space_version', ''));
+        $formCode = (string) data_get($measurementContract, 'form.form_code', data_get($v1, 'form.form_code', ''));
+
+        return [
+            'schema_version' => 'riasec.public_projection.v2',
+            'scale_code' => 'RIASEC',
+            'locale' => str_starts_with(strtolower($locale), 'zh') ? 'zh-CN' : 'en',
+            'holland_code' => [
+                'code' => (string) ($v1['top_code'] ?? ''),
+                'primary_type' => (string) ($v1['primary_type'] ?? ''),
+                'secondary_type' => (string) ($v1['secondary_type'] ?? ''),
+                'tertiary_type' => (string) ($v1['tertiary_type'] ?? ''),
+            ],
+            'scores' => [
+                'score_kind' => 'dimension_scores_0_100',
+                'dimensions' => $this->dimensionScoreRows(is_array($v1['scores_0_100'] ?? null) ? $v1['scores_0_100'] : [], $locale),
+            ],
+            'form' => [
+                'form_code' => $formCode,
+                'question_count' => (int) data_get($measurementContract, 'form.question_count', 0),
+                'form_kind' => (string) data_get($measurementContract, 'form.form_kind', ''),
+                'score_space_version' => $scoreSpaceVersion,
+                'compare_compatibility_group' => (string) ($comparePolicy['compare_compatibility_group'] ?? ''),
+                'cross_form_comparable' => false,
+                'raw_score_delta_allowed' => false,
+            ],
+            'measurement_evidence' => [
+                'measurement_contract_version' => (string) ($measurementContract['schema_version'] ?? RiasecMeasurementContract::SCHEMA_VERSION),
+                'scoring_spec_version' => $this->firstString([
+                    $result->scoring_spec_version ?? null,
+                    data_get($payload, 'version_snapshot.scoring_spec_version'),
+                    data_get($payload, 'scoring_spec_version'),
+                ]),
+                'form_version' => $this->firstString([
+                    $result->dir_version ?? null,
+                    data_get($payload, 'version_snapshot.pack_version'),
+                ]),
+                'content_package_version' => $this->firstString([
+                    $result->content_package_version ?? null,
+                    data_get($payload, 'version_snapshot.pack_version'),
+                ]),
+                'score_space_version' => $scoreSpaceVersion,
+                'normalization_method' => (string) data_get($measurementContract, 'scoring.normalization_method', ''),
+                'quality_rule_version' => $this->firstString([
+                    data_get($payload, 'version_snapshot.quality_rule_version'),
+                    data_get($payload, 'quality_rule_version'),
+                ]),
+                'quality_rule_status' => (string) data_get($measurementContract, 'quality.quality_rule_status', ''),
+                'interpretation_rule_version' => null,
+                'validation_status' => 'runtime_contract_defined_validation_pending',
+                'snapshot_bound' => false,
+            ],
+            'quality' => [
+                'grade' => (string) ($v1['quality_grade'] ?? ''),
+                'flags' => is_array($v1['quality_flags'] ?? null) ? array_values($v1['quality_flags']) : [],
+                'low_quality_strength' => (string) data_get($measurementContract, 'quality.low_quality_strength', ''),
+            ],
+            'indices' => [
+                'clarity_index' => (float) ($v1['clarity_index'] ?? 0),
+                'breadth_index' => (float) ($v1['breadth_index'] ?? 0),
+            ],
+            'claim_boundary' => is_array($measurementContract['claim_boundary'] ?? null) ? $measurementContract['claim_boundary'] : [],
+            'compare_policy_v1' => $comparePolicy,
+            'content_boundary' => [
+                'occupation_examples_policy' => (string) data_get(
+                    $measurementContract,
+                    'claim_boundary.occupation_examples_policy',
+                    'content_example_not_registry_match_without_reviewed_registry_source'
+                ),
+            ],
+        ];
+    }
+
+    /**
      * @param  array<string,mixed>  $scores
      * @return array<string,float>
      */
@@ -118,5 +206,43 @@ final class RiasecPublicProjectionService
         }
 
         return $out;
+    }
+
+    /**
+     * @param  array<string,mixed>  $scores
+     * @return list<array{code:string,label:string,score:float}>
+     */
+    private function dimensionScoreRows(array $scores, string $locale): array
+    {
+        $labels = $this->dimensionLabels($locale);
+        $out = [];
+        foreach ($this->normalizeScores($scores) as $code => $score) {
+            $out[] = [
+                'code' => $code,
+                'label' => (string) ($labels[$code] ?? $code),
+                'score' => $score,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  list<mixed>  $candidates
+     */
+    private function firstString(array $candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if (! is_scalar($candidate)) {
+                continue;
+            }
+
+            $normalized = trim((string) $candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -106,6 +106,15 @@ final class RiasecAssessmentFlowTest extends TestCase
         $readback->assertJsonPath('riasec_form_v1.raw_score_delta_allowed', false);
         $readback->assertJsonPath('riasec_public_projection_v1.form.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
         $readback->assertJsonPath('riasec_public_projection_v1.measurement_contract_v1.claim_boundary.does_not_measure.0', 'ability');
+        $readback->assertJsonPath('riasec_public_projection_v2.schema_version', 'riasec.public_projection.v2');
+        $readback->assertJsonPath('riasec_public_projection_v2.form.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.form.raw_score_delta_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.measurement_contract_version', 'riasec.measurement_contract.v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.scoring_spec_version', 'riasec_standard_60_v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.normalization_method', 'raw_sum_per_dimension_min10_max50_to_0_100');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.quality_rule_status', 'minimal_answer_completion_only');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.claim_boundary.does_not_measure.3', 'career_success_probability');
 
         $report = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -119,6 +128,8 @@ final class RiasecAssessmentFlowTest extends TestCase
         $report->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
         $report->assertJsonPath('riasec_form_v1.form_code', 'riasec_60');
         $report->assertJsonPath('riasec_form_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $report->assertJsonPath('report._meta.riasec_public_projection_v2.schema_version', 'riasec.public_projection.v2');
+        $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
 
         $reportAccess = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -201,6 +212,21 @@ final class RiasecAssessmentFlowTest extends TestCase
         $submit->assertJsonPath('result.env_R', 100);
         $submit->assertJsonPath('result.role_R', 100);
         $submit->assertJsonPath('result.quality_grade', 'A');
+
+        $stored = Result::query()->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($stored);
+        $this->assertSame('riasec_quality_v1', (string) data_get($stored->result_json, 'version_snapshot.quality_rule_version'));
+
+        $readback = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+        $readback->assertStatus(200);
+        $readback->assertJsonPath('riasec_public_projection_v2.schema_version', 'riasec.public_projection.v2');
+        $readback->assertJsonPath('riasec_public_projection_v2.form.score_space_version', 'riasec_140_likert5_activity_context_space.v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.normalization_method', 'activity_environment_role_weighted_0_100');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.quality_rule_version', 'riasec_quality_v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.quality_rule_status', 'quality_flags_available');
     }
 
     public function test_riasec_history_compare_guard_blocks_60_and_140_raw_delta(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -475,6 +475,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_projection_v2_minimal_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
+            'backend/app/Services/Assessment/Drivers/RiasecDriver.php',
+            'backend/app/Services/Report/RiasecReportComposer.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -974,6 +986,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecProjectionV2MinimalFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -1102,6 +1118,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Riasec/RiasecPublicFormSummaryBuilder.php',
             'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
             'backend/app/Services/V0_3/Me/MeAttemptsService.php',
+        ], true);
+    }
+
+    private function isRiasecProjectionV2MinimalFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
+            'backend/app/Services/Assessment/Drivers/RiasecDriver.php',
+            'backend/app/Services/Report/RiasecReportComposer.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
         ], true);
     }
 


### PR DESCRIPTION
## PR code
RIASEC-TRAIN-02

## Goal
Add a backend-authoritative RIASEC public projection v2 envelope with minimal evidence metadata while keeping projection v1 and existing result/report routes compatible.

## What changed
- Added `riasec_public_projection_v2` on RIASEC attempt result reads.
- Added `riasec_public_projection_v2` into RIASEC report `_meta` and top-level report responses.
- Added evidence fields for measurement contract version, scoring spec version, form/content versions, score space version, normalization method, quality rule status/version, validation status, and snapshot-bound status.
- Persisted RIASEC quality rule version from driver context/policy into the score payload/version snapshot.
- Added targeted RIASEC flow assertions for 60Q and 140Q projection v2 metadata.
- Added a precise Big Five runtime-freeze classifier exception for this RIASEC-only projection-v2 scope.

## Scope validation
In scope:
- RIASEC projection v2 minimal envelope.
- Evidence metadata surfaced from existing backend contract/result payloads.
- Compatibility with existing projection v1/result/report responses.

Out of scope:
- Snapshot-bound formal report identity (TRAIN-03).
- Share/PDF/history snapshot consistency (TRAIN-04).
- Technical Note and Method Boundary registry (TRAIN-05).
- Frontend result shell rendering (TRAIN-06).
- Career Activity Registry, career matching, or occupation source claims (TRAIN-07+).
- RIASEC scoring math, question semantics, or content pack edits.

Hard invariants preserved:
- No RIASEC scoring math changes.
- No RIASEC content pack question semantic changes.
- 140Q is not described as more accurate.
- 60Q/140Q raw score delta remains disallowed.
- No occupation Matches/job fit/career success prediction added.
- Frontend is not introduced as interpretation authority.
- Feedback does not modify measured Holland code or scores.
- No AI runtime report generation.

## Validation commands
Passed:
- `php -l backend/app/Services/Riasec/RiasecPublicProjectionService.php`
- `php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `php -l backend/app/Services/Report/RiasecReportComposer.php`
- `php -l backend/app/Services/Assessment/Drivers/RiasecDriver.php`
- `vendor/bin/pint --test app/Services/Riasec/RiasecPublicProjectionService.php app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/Report/RiasecReportComposer.php app/Services/Assessment/Drivers/RiasecDriver.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecAssessmentFlowTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_projection_v2|riasec_measurement_contract'`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecCompareGuardContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecScorerTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EnneagramCompareGuardContractTest`
- `git diff --check`

Sidecar local issue:
- `bash backend/scripts/ci_verify_mbti.sh` failed in the phone OTP acceptance stage after MBTI verification passed: `[ACCEPT_PHONE][FAIL] verify did not return token`. This PR does not touch phone auth/OTP paths; tracked as external to TRAIN-02 scope.

## Intentionally deferred
- Snapshot-bound formal report path remains TRAIN-03.
- Share/PDF/history reading snapshot remains TRAIN-04.
- Technical Note v0.1 and method-boundary copy remain TRAIN-05.
- User-facing result card/six-dimension rendering remains TRAIN-06.
- Career examples remain examples-only and are not registry matches in this PR.

## Rollback / compatibility
Projection v2 is additive alongside existing v1 payloads. Rollback is reverting this PR; existing projection v1/result/report consumers remain compatible.
