### PR TITLE
feat(api): add career index-state authority audit

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityAuditor.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use App\Domain\Career\IndexStateValue;
+use App\Models\IndexState;
+use App\Models\Occupation;
+
+final class CareerIndexStateAuthorityAuditor
+{
+    /**
+     * @param  class-string<Occupation>  $occupationModel
+     */
+    public function __construct(
+        private readonly string $occupationModel = Occupation::class,
+    ) {}
+
+    public function auditPlan(CareerPublicResolutionPlan $plan): CareerIndexStateAuthorityResult
+    {
+        return $this->auditSlugs(array_map(
+            static fn (CareerPublicResolutionPlanRow $row): ?string => $row->canonicalSlug,
+            $plan->rows
+        ));
+    }
+
+    public function auditEntityInventory(CareerOccupationEntityInventoryResult $result): CareerIndexStateAuthorityResult
+    {
+        return $this->auditSlugs(array_map(
+            static fn (CareerOccupationEntityInventoryRow $row): string => $row->canonicalSlug,
+            $result->rows
+        ));
+    }
+
+    /**
+     * @param  list<string|null>  $slugs
+     */
+    public function auditSlugs(array $slugs): CareerIndexStateAuthorityResult
+    {
+        $rows = [];
+        foreach ($this->occupationsBySlug($slugs) as $slug => $occupation) {
+            $rows[] = $this->rowForOccupation($slug, $occupation);
+        }
+
+        return CareerIndexStateAuthorityResult::build($rows);
+    }
+
+    /**
+     * @param  list<string|null>  $slugs
+     * @return array<string, Occupation|null>
+     */
+    private function occupationsBySlug(array $slugs): array
+    {
+        $normalized = [];
+        foreach ($slugs as $slug) {
+            $value = $this->normalizeSlug($slug);
+            if ($value !== null) {
+                $normalized[$value] = null;
+            }
+        }
+
+        if ($normalized === []) {
+            return [];
+        }
+
+        $model = $this->occupationModel;
+        /** @var iterable<Occupation> $occupations */
+        $occupations = $model::query()
+            ->whereIn('canonical_slug', array_keys($normalized))
+            ->with(['indexStates' => fn ($query) => $query
+                ->orderByDesc('changed_at')
+                ->orderByDesc('created_at')])
+            ->get();
+
+        foreach ($occupations as $occupation) {
+            $slug = $this->normalizeSlug($occupation->getAttribute('canonical_slug'));
+            if ($slug !== null && array_key_exists($slug, $normalized)) {
+                $normalized[$slug] = $occupation;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function rowForOccupation(string $canonicalSlug, ?Occupation $occupation): CareerIndexStateAuthorityRow
+    {
+        $indexState = $occupation?->indexStates->first();
+        $issues = $this->issuesFor($canonicalSlug, $indexState);
+        $evidence = $this->evidenceFor($canonicalSlug, $occupation, $indexState);
+
+        return new CareerIndexStateAuthorityRow(
+            canonicalSlug: $canonicalSlug,
+            occupationId: $this->normalizeString($occupation?->getAttribute('id')),
+            indexStateId: $this->normalizeString($indexState?->getAttribute('id')),
+            rawIndexState: $this->normalizeString($indexState?->getAttribute('index_state')),
+            publicIndexState: $indexState === null ? null : IndexStateValue::publicFacing(
+                (string) $indexState->getAttribute('index_state'),
+                (bool) $indexState->getAttribute('index_eligible')
+            ),
+            indexEligible: (bool) ($indexState?->getAttribute('index_eligible') ?? false),
+            changedAt: $this->normalizeString($indexState?->getAttribute('changed_at')?->toISOString()),
+            indexStatus: $this->indexLayerStatus($issues, $evidence),
+            reasonCodes: $this->reasonCodes($indexState),
+            evidence: $evidence,
+            issues: $issues
+        );
+    }
+
+    /**
+     * @return list<CareerIndexStateAuthorityIssue>
+     */
+    private function issuesFor(string $canonicalSlug, ?IndexState $indexState): array
+    {
+        if ($indexState === null) {
+            return [
+                new CareerIndexStateAuthorityIssue(
+                    reason: CareerIndexStateAuthorityIssue::INDEX_STATE_MISSING,
+                    message: 'Latest index_state authority row was not found for canonical slug.',
+                    severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_FULL_2786_CLAIM,
+                    canonicalSlug: $canonicalSlug,
+                    evidence: [['canonical_slug' => $canonicalSlug]]
+                ),
+            ];
+        }
+
+        $issues = [];
+        $rawState = strtolower(trim((string) $indexState->getAttribute('index_state')));
+        $indexEligible = (bool) $indexState->getAttribute('index_eligible');
+        $indexStateId = $this->normalizeString($indexState->getAttribute('id'));
+
+        if (! $indexEligible) {
+            $issues[] = new CareerIndexStateAuthorityIssue(
+                reason: CareerIndexStateAuthorityIssue::INDEX_ELIGIBLE_FALSE,
+                message: 'Latest index_state row is not index eligible.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                indexStateId: $indexStateId,
+                evidence: [['index_eligible' => false]]
+            );
+        }
+
+        if ($rawState === IndexStateValue::NOINDEX) {
+            $issues[] = new CareerIndexStateAuthorityIssue(
+                reason: CareerIndexStateAuthorityIssue::EXPLICIT_NOINDEX_BLOCK,
+                message: 'Latest index_state row explicitly marks the occupation noindex.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                indexStateId: $indexStateId,
+                evidence: [['index_state' => $rawState]]
+            );
+        }
+
+        if ($this->containsBlocker($rawState, $this->reasonCodes($indexState), 'quarantine')) {
+            $issues[] = new CareerIndexStateAuthorityIssue(
+                reason: CareerIndexStateAuthorityIssue::QUARANTINE_BLOCK,
+                message: 'Latest index_state row carries quarantine blocker evidence.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                indexStateId: $indexStateId,
+                evidence: [['index_state' => $rawState, 'reason_codes' => $this->reasonCodes($indexState)]]
+            );
+        }
+
+        if ($this->containsBlocker($rawState, $this->reasonCodes($indexState), 'rollback')) {
+            $issues[] = new CareerIndexStateAuthorityIssue(
+                reason: CareerIndexStateAuthorityIssue::ROLLBACK_BLOCK,
+                message: 'Latest index_state row carries rollback blocker evidence.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                indexStateId: $indexStateId,
+                evidence: [['index_state' => $rawState, 'reason_codes' => $this->reasonCodes($indexState)]]
+            );
+        }
+
+        if (! IndexStateValue::isIndexedLike($rawState, $indexEligible) && $issues === []) {
+            $issues[] = new CareerIndexStateAuthorityIssue(
+                reason: CareerIndexStateAuthorityIssue::INDEX_STATE_NOT_INDEXED_LIKE,
+                message: 'Latest index_state row is not indexed-like.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $canonicalSlug,
+                indexStateId: $indexStateId,
+                evidence: [['index_state' => $rawState, 'index_eligible' => $indexEligible]]
+            );
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  list<CareerIndexStateAuthorityIssue>  $issues
+     * @param  list<mixed>  $evidence
+     */
+    private function indexLayerStatus(array $issues, array $evidence): CareerCanonicalEligibilityLayerStatus
+    {
+        return new CareerCanonicalEligibilityLayerStatus(
+            layer: CareerCanonicalEligibilityLayer::INDEX,
+            status: $issues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            reasons: array_values(array_unique(array_map(
+                static fn (CareerIndexStateAuthorityIssue $issue): string => $issue->reason,
+                $issues
+            ))),
+            evidence: $evidence,
+            source: 'index_states'
+        );
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function evidenceFor(string $canonicalSlug, ?Occupation $occupation, ?IndexState $indexState): array
+    {
+        $evidence = [['canonical_slug' => $canonicalSlug]];
+
+        if ($occupation !== null) {
+            $evidence[] = ['occupation_id' => (string) $occupation->getAttribute('id')];
+        }
+
+        if ($indexState !== null) {
+            $evidence[] = [
+                'index_state_id' => (string) $indexState->getAttribute('id'),
+                'index_state' => (string) $indexState->getAttribute('index_state'),
+                'index_eligible' => (bool) $indexState->getAttribute('index_eligible'),
+            ];
+        }
+
+        return $evidence;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function reasonCodes(?IndexState $indexState): array
+    {
+        $reasonCodes = $indexState?->getAttribute('reason_codes');
+        if (! is_array($reasonCodes) || ! array_is_list($reasonCodes)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($reasonCodes as $reasonCode) {
+            $value = $this->normalizeString($reasonCode);
+            if ($value !== null) {
+                $normalized[] = $value;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @param  list<string>  $reasonCodes
+     */
+    private function containsBlocker(string $rawState, array $reasonCodes, string $needle): bool
+    {
+        if (str_contains($rawState, $needle)) {
+            return true;
+        }
+
+        foreach ($reasonCodes as $reasonCode) {
+            if (str_contains(strtolower($reasonCode), $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function normalizeSlug(mixed $value): ?string
+    {
+        $normalized = $this->normalizeString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityIssue.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerIndexStateAuthorityIssue
+{
+    public const INDEX_STATE_MISSING = 'index_state_missing';
+
+    public const INDEX_STATE_NOT_INDEXED_LIKE = 'index_state_not_indexed_like';
+
+    public const INDEX_ELIGIBLE_FALSE = 'index_eligible_false';
+
+    public const EXPLICIT_NOINDEX_BLOCK = 'explicit_noindex_block';
+
+    public const QUARANTINE_BLOCK = 'quarantine_block';
+
+    public const ROLLBACK_BLOCK = 'rollback_block';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::MEDIUM,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $indexStateId = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->indexStateId !== null) {
+            self::assertNonEmptyString($this->indexStateId, 'index_state_id');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::INDEX_STATE_MISSING,
+            self::INDEX_STATE_NOT_INDEXED_LIKE,
+            self::INDEX_ELIGIBLE_FALSE,
+            self::EXPLICIT_NOINDEX_BLOCK,
+            self::QUARANTINE_BLOCK,
+            self::ROLLBACK_BLOCK,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career index-state authority issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, canonical_slug: string|null, index_state_id: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'canonical_slug' => $this->canonicalSlug,
+            'index_state_id' => $this->indexStateId,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career index-state authority issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career index-state authority issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityResult.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityResult.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerIndexStateAuthorityResult
+{
+    /**
+     * @param  list<CareerIndexStateAuthorityRow>  $rows
+     * @param  list<CareerIndexStateAuthorityIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly int $expectedCount,
+        public readonly int $indexedLikeCount,
+        public readonly int $missingIndexStateCount,
+        public readonly int $blockedCount,
+        public readonly array $rows,
+        public readonly array $issues = [],
+        public readonly array $sidecars = [],
+    ) {
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        foreach ([
+            'expected_count' => $this->expectedCount,
+            'indexed_like_count' => $this->indexedLikeCount,
+            'missing_index_state_count' => $this->missingIndexStateCount,
+            'blocked_count' => $this->blockedCount,
+        ] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career index-state authority [%s] must be non-negative.', $key));
+            }
+        }
+
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+        self::assertSidecars($this->sidecars);
+    }
+
+    /**
+     * @param  list<CareerIndexStateAuthorityRow>  $rows
+     * @param  list<CareerIndexStateAuthorityIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public static function build(array $rows, array $issues = [], array $sidecars = []): self
+    {
+        $allIssues = [
+            ...$issues,
+            ...array_values(array_merge(...array_map(
+                static fn (CareerIndexStateAuthorityRow $row): array => $row->issues,
+                $rows
+            ))),
+        ];
+
+        return new self(
+            status: $allIssues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            expectedCount: count($rows),
+            indexedLikeCount: count(array_filter(
+                $rows,
+                static fn (CareerIndexStateAuthorityRow $row): bool => $row->issues === []
+            )),
+            missingIndexStateCount: count(array_filter(
+                $rows,
+                static fn (CareerIndexStateAuthorityRow $row): bool => $row->indexStateId === null
+            )),
+            blockedCount: count(array_filter(
+                $rows,
+                static fn (CareerIndexStateAuthorityRow $row): bool => $row->issues !== []
+            )),
+            rows: $rows,
+            issues: $allIssues,
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, expected_count: int, indexed_like_count: int, missing_index_state_count: int, blocked_count: int, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'expected_count' => $this->expectedCount,
+            'indexed_like_count' => $this->indexedLikeCount,
+            'missing_index_state_count' => $this->missingIndexStateCount,
+            'blocked_count' => $this->blockedCount,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerIndexStateAuthorityRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerIndexStateAuthorityIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerIndexStateAuthorityRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career index-state authority rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerIndexStateAuthorityRow) {
+                throw new InvalidArgumentException('Career index-state authority rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerIndexStateAuthorityIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career index-state authority issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerIndexStateAuthorityIssue) {
+                throw new InvalidArgumentException('Career index-state authority issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career index-state authority sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career index-state authority sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityRow.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityRow.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerIndexStateAuthorityRow
+{
+    /**
+     * @param  list<string>  $reasonCodes
+     * @param  list<mixed>  $evidence
+     * @param  list<CareerIndexStateAuthorityIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly ?string $occupationId,
+        public readonly ?string $indexStateId,
+        public readonly ?string $rawIndexState,
+        public readonly ?string $publicIndexState,
+        public readonly bool $indexEligible,
+        public readonly ?string $changedAt,
+        public readonly CareerCanonicalEligibilityLayerStatus $indexStatus,
+        public readonly array $reasonCodes = [],
+        public readonly array $evidence = [],
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertListOfStrings($this->reasonCodes, 'reason_codes');
+        self::assertList($this->evidence, 'evidence');
+
+        foreach (['occupation_id' => $this->occupationId, 'index_state_id' => $this->indexStateId, 'raw_index_state' => $this->rawIndexState, 'public_index_state' => $this->publicIndexState, 'changed_at' => $this->changedAt] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+
+        if (! array_is_list($this->issues)) {
+            throw new InvalidArgumentException('Career index-state authority row issues must be a list.');
+        }
+
+        foreach ($this->issues as $issue) {
+            if (! $issue instanceof CareerIndexStateAuthorityIssue) {
+                throw new InvalidArgumentException('Career index-state authority row issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, occupation_id: string|null, index_state_id: string|null, raw_index_state: string|null, public_index_state: string|null, index_eligible: bool, changed_at: string|null, index_status: array<string, mixed>, reason_codes: list<string>, evidence: list<mixed>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'occupation_id' => $this->occupationId,
+            'index_state_id' => $this->indexStateId,
+            'raw_index_state' => $this->rawIndexState,
+            'public_index_state' => $this->publicIndexState,
+            'index_eligible' => $this->indexEligible,
+            'changed_at' => $this->changedAt,
+            'index_status' => $this->indexStatus->toArray(),
+            'reason_codes' => $this->reasonCodes,
+            'evidence' => $this->evidence,
+            'issues' => array_map(
+                static fn (CareerIndexStateAuthorityIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career index-state authority row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career index-state authority row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career index-state authority row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/docs/career/audits/index_state_authority_audit.md
+++ b/backend/docs/career/audits/index_state_authority_audit.md
@@ -1,0 +1,69 @@
+# Career Index-State Authority Audit
+
+AUDIT-5 adds the read-only index-state authority layer for the Career 2786 canonical eligibility audit train.
+
+## Purpose
+
+The auditor consumes canonical slugs from AUDIT-2 plan rows or AUDIT-3 entity inventory output and verifies the latest `index_states` authority row for each occupation.
+
+## Checks
+
+For each canonical slug, AUDIT-5 checks:
+
+- latest `index_states` row exists
+- raw `index_state` is indexed-like: `indexable` or `indexed`
+- `IndexStateValue::publicFacing()` normalization is represented
+- `index_eligible=true`
+- explicit `noindex` blockers
+- quarantine blocker evidence in raw state or `reason_codes`
+- rollback blocker evidence in raw state or `reason_codes`
+
+## Issue Reasons
+
+AUDIT-5 emits:
+
+- `index_state_missing`
+- `index_state_not_indexed_like`
+- `index_eligible_false`
+- `explicit_noindex_block`
+- `quarantine_block`
+- `rollback_block`
+
+## Row Contract
+
+Each `CareerIndexStateAuthorityRow` serializes as:
+
+- `canonical_slug`
+- `occupation_id`
+- `index_state_id`
+- `raw_index_state`
+- `public_index_state`
+- `index_eligible`
+- `changed_at`
+- `index_status`
+- `reason_codes`
+- `evidence`
+- `issues`
+
+`index_status` is an AUDIT-1-compatible `CareerCanonicalEligibilityLayerStatus` with `layer=index` and `source=index_states`.
+
+## Non-Goals
+
+AUDIT-5 does not:
+
+- mutate or backfill `index_states`
+- create or update Occupations
+- inspect baseline/display metadata
+- inspect runtime projection/truth
+- inspect SEO/GEO or live surfaces
+- run rollout, apply, rollback, quarantine, deployment, or production validation
+
+Local PHPUnit DB usage is limited to normal Laravel test database conventions.
+
+## Consumption by AUDIT-6+
+
+AUDIT-6 should consume this result only as the index layer authority. Runtime publication and projection/truth checks must remain separate and must not be inferred from an indexed-like state alone.
+
+## Readiness Warning
+
+AUDIT-5 does not claim 2786 readiness. It proves only reusable index-state authority inventory behavior for future command integration.

--- a/backend/tests/Feature/Domain/Career/Audit/CareerIndexStateAuthorityAuditorTest.php
+++ b/backend/tests/Feature/Domain/Career/Audit/CareerIndexStateAuthorityAuditorTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerIndexStateAuthorityAuditor;
+use App\Domain\Career\Audit\CareerIndexStateAuthorityIssue;
+use App\Domain\Career\Audit\CareerPublicResolutionPlan;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
+use App\Domain\Career\IndexStateValue;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerIndexStateAuthorityAuditorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_indexed_state_is_accepted(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::INDEXED, true);
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(1, $result->indexedLikeCount);
+        $this->assertSame(IndexStateValue::INDEXABLE, $result->rows[0]->publicIndexState);
+    }
+
+    public function test_indexable_state_is_accepted(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::INDEXABLE, true);
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(IndexStateValue::INDEXABLE, $result->rows[0]->rawIndexState);
+    }
+
+    public function test_missing_index_state_blocks(): void
+    {
+        $this->createOccupation('actuaries');
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->missingIndexStateCount);
+        $this->assertSame(CareerIndexStateAuthorityIssue::INDEX_STATE_MISSING, $result->rows[0]->issues[0]->reason);
+    }
+
+    public function test_noindex_state_blocks(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::NOINDEX, false);
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertContains(CareerIndexStateAuthorityIssue::EXPLICIT_NOINDEX_BLOCK, $result->rows[0]->indexStatus->reasons);
+    }
+
+    public function test_index_eligible_false_blocks_even_when_raw_state_is_indexable(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::INDEXABLE, false);
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame([CareerIndexStateAuthorityIssue::INDEX_ELIGIBLE_FALSE], $result->rows[0]->indexStatus->reasons);
+    }
+
+    public function test_quarantine_and_rollback_reason_codes_block(): void
+    {
+        $quarantine = $this->createOccupation('quarantine-career');
+        $rollback = $this->createOccupation('rollback-career');
+        $this->createIndexState($quarantine, IndexStateValue::INDEXABLE, true, ['quarantine_on_failure']);
+        $this->createIndexState($rollback, IndexStateValue::INDEXABLE, true, ['rollback_required']);
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditSlugs([
+            'quarantine-career',
+            'rollback-career',
+        ]);
+
+        $this->assertSame([
+            CareerIndexStateAuthorityIssue::QUARANTINE_BLOCK => 1,
+            CareerIndexStateAuthorityIssue::ROLLBACK_BLOCK => 1,
+        ], $result->byReason());
+    }
+
+    public function test_latest_index_state_wins(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::NOINDEX, false, [], now()->subDay());
+        $this->createIndexState($occupation, IndexStateValue::INDEXABLE, true, [], now());
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(IndexStateValue::INDEXABLE, $result->rows[0]->rawIndexState);
+    }
+
+    public function test_audit_plan_consumes_public_resolution_rows(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::INDEXABLE, true);
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-audit-5-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'actuaries']),
+            ]
+        );
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditPlan($plan);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame('actuaries', $result->rows[0]->canonicalSlug);
+    }
+
+    public function test_index_layer_status_blocks_for_missing_state(): void
+    {
+        $this->createOccupation('actuaries');
+
+        $status = (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries'])->rows[0]->indexStatus;
+
+        $this->assertSame(CareerCanonicalEligibilityLayer::INDEX, $status->layer);
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $status->status);
+        $this->assertSame([CareerIndexStateAuthorityIssue::INDEX_STATE_MISSING], $status->reasons);
+        $this->assertSame('index_states', $status->source);
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $occupation = $this->createOccupation('actuaries', [
+            'id' => '00000000-0000-4000-8000-000000000001',
+        ]);
+        $this->createIndexState($occupation, IndexStateValue::INDEXABLE, true, [], Carbon::parse('2026-05-12T00:00:00Z'), [
+            'id' => '00000000-0000-4000-8000-000000000002',
+        ]);
+
+        $result = (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries'])->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "expected_count": 1,
+    "indexed_like_count": 1,
+    "missing_index_state_count": 0,
+    "blocked_count": 0,
+    "by_reason": [],
+    "rows": [
+        {
+            "canonical_slug": "actuaries",
+            "occupation_id": "00000000-0000-4000-8000-000000000001",
+            "index_state_id": "00000000-0000-4000-8000-000000000002",
+            "raw_index_state": "indexable",
+            "public_index_state": "indexable",
+            "index_eligible": true,
+            "changed_at": "2026-05-12T00:00:00.000000Z",
+            "index_status": {
+                "layer": "index",
+                "status": "pass",
+                "reasons": [],
+                "evidence": [
+                    {
+                        "canonical_slug": "actuaries"
+                    },
+                    {
+                        "occupation_id": "00000000-0000-4000-8000-000000000001"
+                    },
+                    {
+                        "index_state_id": "00000000-0000-4000-8000-000000000002",
+                        "index_state": "indexable",
+                        "index_eligible": true
+                    }
+                ],
+                "source": "index_states"
+            },
+            "reason_codes": [],
+            "evidence": [
+                {
+                    "canonical_slug": "actuaries"
+                },
+                {
+                    "occupation_id": "00000000-0000-4000-8000-000000000001"
+                },
+                {
+                    "index_state_id": "00000000-0000-4000-8000-000000000002",
+                    "index_state": "indexable",
+                    "index_eligible": true
+                }
+            ],
+            "issues": []
+        }
+    ],
+    "issues": [],
+    "sidecars": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_auditor_does_not_mutate_database(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::INDEXABLE, true);
+        $before = IndexState::query()->count();
+
+        (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries']);
+
+        $this->assertSame($before, IndexState::query()->count());
+    }
+
+    public function test_no_baseline_projection_or_surface_logic_is_invoked(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::INDEXABLE, true);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        (new CareerIndexStateAuthorityAuditor)->auditSlugs(['actuaries']);
+
+        $queries = json_encode(DB::getQueryLog(), JSON_UNESCAPED_SLASHES);
+
+        $this->assertIsString($queries);
+        $this->assertStringContainsString('index_states', $queries);
+        $this->assertStringNotContainsString('career_jobs', $queries);
+        $this->assertStringNotContainsString('career_job_display_assets', $queries);
+        $this->assertStringNotContainsString('runtime', $queries);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function createOccupation(string $slug, array $attributes = []): Occupation
+    {
+        $payload = array_merge([
+            'id' => (string) Str::uuid(),
+            'family_id' => $this->occupationFamily()->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'occupation',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'direct',
+            'canonical_title_en' => Str::title(str_replace('-', ' ', $slug)),
+            'canonical_title_zh' => Str::title(str_replace('-', ' ', $slug)),
+            'search_h1_zh' => Str::title(str_replace('-', ' ', $slug)),
+        ], $attributes);
+
+        /** @var Occupation $occupation */
+        $occupation = Occupation::query()->create($payload);
+
+        return $occupation;
+    }
+
+    /**
+     * @param  list<string>  $reasonCodes
+     * @param  array<string, mixed>  $attributes
+     */
+    private function createIndexState(
+        Occupation $occupation,
+        string $state,
+        bool $eligible,
+        array $reasonCodes = [],
+        ?Carbon $changedAt = null,
+        array $attributes = [],
+    ): IndexState {
+        /** @var IndexState $indexState */
+        $indexState = IndexState::query()->create(array_merge([
+            'occupation_id' => $occupation->id,
+            'index_state' => $state,
+            'index_eligible' => $eligible,
+            'canonical_path' => '/career/jobs/'.$occupation->canonical_slug,
+            'canonical_target' => '/career/jobs/'.$occupation->canonical_slug,
+            'reason_codes' => $reasonCodes,
+            'changed_at' => $changedAt ?? now(),
+        ], $attributes));
+
+        return $indexState;
+    }
+
+    private function occupationFamily(): OccupationFamily
+    {
+        /** @var OccupationFamily $family */
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'audit-5-family'],
+            [
+                'id' => '00000000-0000-4000-8000-000000000500',
+                'title_en' => 'Audit 5 Family',
+                'title_zh' => 'Audit 5 Family',
+            ]
+        );
+
+        return $family;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -305,6 +305,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_index_state_authority_audit_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityIssue.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityResult.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -947,6 +959,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerIndexStateAuthorityAuditFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1273,6 +1289,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryIssue.php',
             'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryResult.php',
             'backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryRow.php',
+        ], true);
+    }
+
+    private function isCareerIndexStateAuthorityAuditFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityIssue.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityResult.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1314,6 +1314,97 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-5": {
+      "repo": "fap-api",
+      "branch": "fix/career-index-state-authority-audit5",
+      "title": "feat(api): add career index-state authority audit",
+      "name": "Career Index-state Authority Audit",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-4"
+      ],
+      "scope_type": "index_state_authority_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no audit command",
+        "no baseline metadata inventory",
+        "no runtime projection/truth audit",
+        "no SEO/GEO audit",
+        "no live HTML/surface audit",
+        "no rollout",
+        "no index-state backfill",
+        "no manifest train generator",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuing the Career 2786 audit PR train from AUDIT-4 through AUDIT-13 and authorized per-item PR train manifest/state updates."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-4 merged as PR #1320 with merge commit 4d180ff31530a73417d982bb6fc448ac8ca4ca86 and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Feature/Domain/Career/Audit, backend/docs/career/audits, the test-only BigFive freeze classifier allowlist, and docs/codex train files."
+        },
+        "index_state_authority_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi",
+          "evidence": "12 tests passed, 28 assertions."
+        },
+        "baseline_metadata_inventory_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi",
+          "evidence": "9 tests passed, 22 assertions."
+        },
+        "occupation_entity_inventory_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi",
+          "evidence": "13 tests passed, 45 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_allowlist_fix": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-5 CareerIndexStateAuthority* files to the test-only freeze classifier allowlist; the runtime path gate passes locally."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3083 files checked after formatting the new auditor."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-6 Runtime projection/truth eligibility audit",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -633,3 +633,47 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-5
+    repo: fap-api
+    depends_on:
+      - AUDIT-4
+    branch: fix/career-index-state-authority-audit5
+    title: "feat(api): add career index-state authority audit"
+    name: "Career Index-state Authority Audit"
+    scope_type: index_state_authority_only
+    scope:
+      - Add a read-only index-state authority auditor for canonical slugs from AUDIT-2 plan rows or AUDIT-3 entity inventory rows.
+      - Query latest index_states rows and report missing, non-indexed-like, index_eligible=false, noindex, quarantine, and rollback blockers.
+      - Emit AUDIT-1-compatible index layer statuses.
+      - Document AUDIT-5 index-state authority contract and future AUDIT-6+ consumption policy.
+      - Add focused tests proving stable JSON, read-only behavior, latest-state selection, and no baseline/runtime/surface audit logic.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-5 index-state audit files.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add a career canonical eligibility audit command.
+      - Add baseline metadata inventory.
+      - Add runtime projection/truth audit.
+      - Add SEO/GEO or surface audit.
+      - Modify rollout state.
+      - Backfill index states.
+      - Mutate production data.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
+      - php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-6 Runtime projection/truth eligibility audit"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- AUDIT-5 index-state authority audit only.
- Adds a read-only index-state authority auditor for AUDIT-2 plan rows and AUDIT-3 entity inventory rows.
- Checks latest `index_states` authority rows for indexed-like state, `index_eligible=true`, explicit noindex, quarantine, and rollback blockers.
- Emits AUDIT-1-compatible index layer statuses and stable JSON.
- Updates PR train manifest/state for AUDIT-5 only.
- Adds the scoped test-only BigFive runtime freeze classifier allowlist for AUDIT-5 Career audit files.

## Non-goals / Safety
- No DB mutation beyond local PHPUnit test database usage.
- No production DB queries.
- No production commands.
- No deploy.
- No audit command yet.
- No baseline/runtime/projection/truth/SEO/GEO/surface audit changes.
- No rollout/backfill/apply/rollback/quarantine.
- Does not claim 2786 readiness.

## Validation
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi` passed: 12 tests, 28 assertions.
- `php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi` passed: 9 tests, 22 assertions.
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi` passed: 13 tests, 45 assertions.
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi` passed: 14 tests, 37 assertions.
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` passed: 14 tests, 28 assertions.
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi` passed.
- `vendor/bin/pint --test` passed: 3083 files checked.
- `git diff --check` passed.
- `jq empty docs/codex/pr-train-state.json` passed.
- YAML parse for `docs/codex/pr-train.yaml` passed.

## PR Train Protocol
- Pending checks are wait/poll state, not blockers.
- Failed checks require inspect/fix/push/wait loop, not immediate stop.
- Next PR: AUDIT-6 Runtime projection/truth eligibility audit.
