### PR TITLE
RIASEC-TRAIN-03 — Snapshot-bound formal report

### DIFF
--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -212,14 +212,52 @@ class ReportGatekeeper
         };
         $locked = $unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED;
 
-        $shouldUseSnapshot = in_array($scaleCode, [ReportAccess::SCALE_RIASEC], true)
-            ? false
+        $shouldUseSnapshot = $scaleCode === ReportAccess::SCALE_RIASEC
+            ? $hasFullAccess
             : $hasFullAccess && $this->offerResolver->modulesCoverOffered($modulesAllowed, $modulesOffered);
+        $requiresSnapshotBoundReport = $scaleCode === ReportAccess::SCALE_RIASEC
+            && $unlockStage !== ReportAccess::UNLOCK_STAGE_PARTIAL
+            && $shouldUseSnapshot;
         $snapshotStrictMode = in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true) ? false : $this->strictSnapshotModeEnabled();
         $shouldReadFromSnapshot = $unlockStage !== ReportAccess::UNLOCK_STAGE_PARTIAL
             && ($snapshotStrictMode || $shouldUseSnapshot);
         $allowLiveBuildFallbackForSnapshot = $scaleCode === ReportAccess::SCALE_ENNEAGRAM && ! $snapshotStrictMode;
-        if ($shouldReadFromSnapshot && ($snapshotStrictMode || ! $forceRefresh)) {
+        if ($requiresSnapshotBoundReport) {
+            $snapshotResult = $this->snapshotStore->createSnapshotForAttempt([
+                'org_id' => $effectiveOrgId,
+                'attempt_id' => $attemptId,
+                'trigger_source' => 'report_api_sync',
+                'order_no' => null,
+                'user_id' => $userId,
+                'anon_id' => $anonId,
+                'org_role' => $role,
+            ]);
+
+            if (! ($snapshotResult['ok'] ?? false)) {
+                return $this->responsePayload(
+                    $locked,
+                    $reportAccessLevel,
+                    $variant,
+                    $viewPolicy,
+                    [],
+                    $paywall,
+                    [
+                        'generating' => false,
+                        'snapshot_error' => true,
+                        'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
+                        'snapshot_status' => 'failed',
+                    ],
+                    $modulesAllowed,
+                    $modulesOffered,
+                    $modulesPreview,
+                    $normsPayload,
+                    $qualityPayload,
+                    $isMbtiContract
+                );
+            }
+        }
+
+        if ($shouldReadFromSnapshot && ($snapshotStrictMode || ! $forceRefresh || $requiresSnapshotBoundReport)) {
             $snapshotRow = DB::table('report_snapshots')
                 ->where('org_id', $effectiveOrgId)
                 ->where('attempt_id', $attemptId)

--- a/backend/app/Services/Report/ReportSnapshotStore.php
+++ b/backend/app/Services/Report/ReportSnapshotStore.php
@@ -27,6 +27,7 @@ class ReportSnapshotStore
         private Sds20ReportComposer $sds20ReportComposer,
         private Eq60ReportComposer $eq60ReportComposer,
         private EnneagramReportComposer $enneagramReportComposer,
+        private RiasecReportComposer $riasecReportComposer,
         private IqReportBuilder $iqReportBuilder,
         private GenericReportBuilder $genericReportBuilder,
         private EventRecorder $eventRecorder,
@@ -428,6 +429,27 @@ class ReportSnapshotStore
                     : ReportAccess::REPORT_ACCESS_FULL,
                 'modules_allowed' => $modulesAllowed,
                 'modules_preview' => $modulesPreview,
+            ]);
+            if (! ($composed['ok'] ?? false)) {
+                return null;
+            }
+            $report = $composed['report'] ?? null;
+
+            return is_array($report) ? $report : null;
+        }
+
+        if ($scaleCode === 'RIASEC') {
+            $composed = $this->riasecReportComposer->composeVariant($attempt, $result, $variant, [
+                'org_id' => (int) ($attempt->org_id ?? 0),
+                'variant' => $variant,
+                'report_access_level' => $variant === ReportAccess::VARIANT_FREE
+                    ? ReportAccess::REPORT_ACCESS_FREE
+                    : ReportAccess::REPORT_ACCESS_FULL,
+                'modules_allowed' => $modulesAllowed,
+                'modules_preview' => $modulesPreview,
+                'snapshot_bound' => true,
+                'snapshot_version' => self::SNAPSHOT_VERSION,
+                'report_engine_version' => self::REPORT_ENGINE_VERSION,
             ]);
             if (! ($composed['ok'] ?? false)) {
                 return null;

--- a/backend/app/Services/Report/RiasecReportComposer.php
+++ b/backend/app/Services/Report/RiasecReportComposer.php
@@ -26,8 +26,9 @@ final class RiasecReportComposer
             $locale = 'zh-CN';
         }
 
+        $snapshotBound = (bool) ($ctx['snapshot_bound'] ?? false);
         $projection = $this->projectionService->buildFromResult($result, $locale);
-        $projectionV2 = $this->projectionService->buildV2FromResult($result, $locale);
+        $projectionV2 = $this->projectionService->buildV2FromResult($result, $locale, $snapshotBound);
         $topCode = trim((string) ($projection['top_code'] ?? $result->type_code ?? ''));
         if ($topCode === '') {
             return [
@@ -61,12 +62,33 @@ final class RiasecReportComposer
                     'breadth_index' => (float) ($projection['breadth_index'] ?? 0),
                 ],
                 'sections' => $this->buildSections($projection),
-                '_meta' => [
+                '_meta' => array_filter([
                     'riasec_public_projection_v1' => $projection,
                     'riasec_public_projection_v2' => $projectionV2,
-                ],
+                    'snapshot_binding_v1' => $snapshotBound ? $this->buildSnapshotBinding($ctx, $projectionV2) : null,
+                ], static fn (mixed $value): bool => $value !== null),
                 'generated_at' => now()->toISOString(),
             ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     * @param  array<string,mixed>  $projectionV2
+     * @return array<string,mixed>
+     */
+    private function buildSnapshotBinding(array $ctx, array $projectionV2): array
+    {
+        return [
+            'schema_version' => 'riasec.snapshot_binding.v1',
+            'snapshot_bound' => true,
+            'snapshot_version' => trim((string) ($ctx['snapshot_version'] ?? 'v1')),
+            'report_engine_version' => trim((string) ($ctx['report_engine_version'] ?? 'v1.2')),
+            'measurement_contract_version' => data_get($projectionV2, 'measurement_evidence.measurement_contract_version'),
+            'scoring_spec_version' => data_get($projectionV2, 'measurement_evidence.scoring_spec_version'),
+            'score_space_version' => data_get($projectionV2, 'measurement_evidence.score_space_version'),
+            'form_code' => data_get($projectionV2, 'form.form_code'),
+            'validation_status' => data_get($projectionV2, 'measurement_evidence.validation_status'),
         ];
     }
 

--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -78,7 +78,7 @@ final class RiasecPublicProjectionService
     /**
      * @return array<string,mixed>
      */
-    public function buildV2FromResult(Result $result, string $locale = 'zh-CN'): array
+    public function buildV2FromResult(Result $result, string $locale = 'zh-CN', bool $snapshotBound = false): array
     {
         $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
         $v1 = $this->buildFromResult($result, $locale);
@@ -140,7 +140,7 @@ final class RiasecPublicProjectionService
                 'quality_rule_status' => (string) data_get($measurementContract, 'quality.quality_rule_status', ''),
                 'interpretation_rule_version' => null,
                 'validation_status' => 'runtime_contract_defined_validation_pending',
-                'snapshot_bound' => false,
+                'snapshot_bound' => $snapshotBound,
             ],
             'quality' => [
                 'grade' => (string) ($v1['quality_grade'] ?? ''),

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -130,6 +130,7 @@ final class RiasecAssessmentFlowTest extends TestCase
         $report->assertJsonPath('riasec_form_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
         $report->assertJsonPath('report._meta.riasec_public_projection_v2.schema_version', 'riasec.public_projection.v2');
         $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
 
         $reportAccess = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -174,6 +175,75 @@ final class RiasecAssessmentFlowTest extends TestCase
         $history->assertJsonPath('items.0.compare_policy_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
         $history->assertJsonPath('items.0.compare_policy_v1.raw_score_delta_allowed', false);
         $history->assertJsonPath('history_compare.current_compare_policy_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+    }
+
+    public function test_riasec_report_reads_from_snapshot_after_first_formal_report_build(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_riasec_snapshot_bound';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'RIASEC',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => 'riasec_60',
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->answers(60),
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+
+        $first = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+        $first->assertStatus(200);
+        $first->assertJsonPath('ok', true);
+        $first->assertJsonPath('locked', false);
+        $first->assertJsonPath('report.top_code', 'RIA');
+        $first->assertJsonPath('report._meta.riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
+        $first->assertJsonPath('report._meta.snapshot_binding_v1.schema_version', 'riasec.snapshot_binding.v1');
+        $first->assertJsonPath('report._meta.snapshot_binding_v1.snapshot_bound', true);
+
+        $snapshot = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($snapshot);
+        $this->assertSame('ready', (string) ($snapshot->status ?? ''));
+        $reportFull = json_decode((string) ($snapshot->report_full_json ?? '{}'), true);
+        $this->assertIsArray($reportFull);
+        $this->assertSame('RIA', (string) data_get($reportFull, 'top_code'));
+        $this->assertTrue((bool) data_get($reportFull, '_meta.riasec_public_projection_v2.measurement_evidence.snapshot_bound'));
+
+        /** @var Result $stored */
+        $stored = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+        $resultJson = is_array($stored->result_json) ? $stored->result_json : [];
+        data_set($resultJson, 'top_code', 'SEC');
+        data_set($resultJson, 'primary_type', 'Social');
+        $stored->type_code = 'SEC';
+        $stored->result_json = $resultJson;
+        $stored->save();
+
+        $second = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+        $second->assertStatus(200);
+        $second->assertJsonPath('ok', true);
+        $second->assertJsonPath('report.top_code', 'RIA');
+        $second->assertJsonPath('riasec_public_projection_v2.holland_code.code', 'RIA');
+        $second->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
+        $this->assertSame($first->json('report.generated_at'), $second->json('report.generated_at'));
+        $this->assertSame(1, DB::table('report_snapshots')->where('attempt_id', $attemptId)->count());
     }
 
     public function test_riasec_enhanced_140_persists_quality_and_layer_scores(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -499,6 +499,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_snapshot_bound_report_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Report/ReportGatekeeper.php',
+            'backend/app/Services/Report/ReportSnapshotStore.php',
+            'backend/app/Services/Report/RiasecReportComposer.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -1006,6 +1018,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecSnapshotBoundReportFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -1142,6 +1158,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
             'backend/app/Services/Assessment/Drivers/RiasecDriver.php',
+            'backend/app/Services/Report/RiasecReportComposer.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+        ], true);
+    }
+
+    private function isRiasecSnapshotBoundReportFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Report/ReportGatekeeper.php',
+            'backend/app/Services/Report/ReportSnapshotStore.php',
             'backend/app/Services/Report/RiasecReportComposer.php',
             'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
         ], true);


### PR DESCRIPTION
## PR code
RIASEC-TRAIN-03

## Goal
Make the RIASEC formal report path snapshot-bound while preserving existing v1/v2 projection compatibility and keeping share/PDF/history work deferred to TRAIN-04.

## What changed
- RIASEC report reads now synchronously create/refresh a ready `report_snapshots` row before returning the formal report.
- RIASEC formal report responses read the report payload back from `report_snapshots` instead of live-building as the response authority.
- `ReportSnapshotStore` now composes RIASEC snapshots through `RiasecReportComposer` instead of falling through to the generic builder.
- RIASEC projection v2 carries `measurement_evidence.snapshot_bound=true` when composed for a snapshot.
- RIASEC report `_meta` now includes `snapshot_binding_v1` for snapshot-bound reports.
- Added regression coverage proving a mutated live result does not change the formal report after the snapshot is created.
- Added a precise Big Five runtime-freeze classifier exception for this RIASEC snapshot-bound report scope.

## Scope validation
In scope:
- RIASEC formal report snapshot identity.
- Backend report snapshot generation/read path.
- Snapshot metadata in RIASEC report/projection v2.
- Compatibility with existing projection v1 and projection v2 fields.

Out of scope:
- Share/PDF/history snapshot read consistency; deferred to TRAIN-04.
- Technical Note and Method Boundary registry; deferred to TRAIN-05.
- Frontend result shell rendering; deferred to TRAIN-06.
- Career examples, registry matching, or occupation source claims; deferred to TRAIN-07+.
- RIASEC scoring math, question semantics, content packs, migrations, or frontend content authority.

Hard invariants preserved:
- No RIASEC scoring math changes.
- No RIASEC content pack changes.
- 140Q is not described as more accurate.
- 60Q/140Q raw score delta remains disallowed.
- No occupation Matches/job fit/career success prediction added.
- Frontend is not introduced as interpretation authority.
- Feedback does not modify measured Holland code or scores.
- Share/PDF raw feedback behavior is not changed in this PR.
- No AI runtime report generation.

## Validation commands
Passed:
- `php -l backend/app/Services/Report/ReportGatekeeper.php`
- `php -l backend/app/Services/Report/ReportSnapshotStore.php`
- `php -l backend/app/Services/Report/RiasecReportComposer.php`
- `php -l backend/app/Services/Riasec/RiasecPublicProjectionService.php`
- `php -l backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `vendor/bin/pint --test app/Services/Report/ReportGatekeeper.php app/Services/Report/ReportSnapshotStore.php app/Services/Report/RiasecReportComposer.php app/Services/Riasec/RiasecPublicProjectionService.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecAssessmentFlowTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ReportSnapshotStrictModeTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EnneagramReportSnapshotBindingTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ReportSnapshotStoreTenantIsolationTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=GenerateReportSnapshotJobTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecCompareGuardContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecScorerTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_snapshot_bound_report|riasec_projection_v2|riasec_measurement_contract'`
- `git diff --check`

Sidecar local issue:
- `bash backend/scripts/ci_verify_mbti.sh` passed the MBTI/Big Five tests and MBTI report/share smoke path, then failed in phone OTP acceptance with `[ACCEPT_PHONE][FAIL] verify did not return token`. This PR does not touch phone auth/OTP paths. Generated Big Five compiled artifact diffs from the script were restored and are not part of this PR.

## Intentionally deferred
- Share/PDF/history snapshot consistency remains TRAIN-04.
- Technical Note v0.1 and method-boundary copy remain TRAIN-05.
- User-facing 3-minute result shell remains TRAIN-06.
- Career Activity Registry examples-only work remains TRAIN-07.

## Rollback / compatibility
The report response remains compatible at the API envelope level and continues exposing existing RIASEC projection v1/v2 siblings. Rollback is reverting this PR; existing non-RIASEC snapshot behavior is not intentionally changed.
