### PR TITLE
feat(api): add career runtime projection truth eligibility audit

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditor.php
@@ -1,0 +1,527 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerRuntimeProjectionTruthEligibilityAuditor
+{
+    private const PUBLISHED = 'published';
+
+    private const PUBLIC_CANONICAL_JOB = 'public_canonical_job';
+
+    /**
+     * @param  list<mixed>  $planRows
+     * @param  list<string>  $locales
+     * @param  array<string, mixed>|list<array<string, mixed>>  $projection
+     * @param  array<string, mixed>|list<array<string, mixed>>  $truth
+     * @param  array<string, mixed>|list<array<string, mixed>>|null  $ledger
+     */
+    public function audit(
+        array $planRows,
+        array $locales,
+        array $projection,
+        array $truth,
+        ?array $ledger = null,
+    ): CareerRuntimeProjectionTruthEligibilityResult {
+        $expectedSlugs = $this->expectedSlugs($planRows);
+        $expectedLocales = $this->expectedLocales($locales);
+        $projectionRows = $this->rowsBySlugLocale($this->artifactRows($projection));
+        $truthRows = $this->rowsBySlugLocale($this->artifactRows($truth));
+        $ledgerSlugs = $ledger === null ? null : $this->ledgerSlugs($ledger);
+        $planTypes = $this->publicTypesBySlug($planRows);
+
+        $rows = [];
+        foreach ($expectedSlugs as $slug) {
+            foreach ($expectedLocales as $locale) {
+                $rows[] = $this->auditExpectedRow(
+                    slug: $slug,
+                    locale: $locale,
+                    projectionRow: $projectionRows[$this->rowKey($slug, $locale)] ?? null,
+                    truthRow: $truthRows[$this->rowKey($slug, $locale)] ?? null,
+                    ledgerMemberExists: $ledgerSlugs === null ? null : in_array($slug, $ledgerSlugs, true),
+                    planPublicType: $planTypes[$slug] ?? null,
+                );
+            }
+        }
+
+        return CareerRuntimeProjectionTruthEligibilityResult::build($rows);
+    }
+
+    public function auditPlan(
+        CareerPublicResolutionPlan $plan,
+        array $locales,
+        array $projection,
+        array $truth,
+        ?array $ledger = null,
+    ): CareerRuntimeProjectionTruthEligibilityResult {
+        return $this->audit($plan->rows, $locales, $projection, $truth, $ledger);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array<string, mixed>|list<array<string, mixed>>  $projection
+     * @param  array<string, mixed>|list<array<string, mixed>>  $truth
+     * @param  array<string, mixed>|list<array<string, mixed>>|null  $ledger
+     */
+    public function auditSlugs(
+        array $slugs,
+        array $locales,
+        array $projection,
+        array $truth,
+        ?array $ledger = null,
+    ): CareerRuntimeProjectionTruthEligibilityResult {
+        return $this->audit($slugs, $locales, $projection, $truth, $ledger);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function expectedSlugs(array $planRows): array
+    {
+        $slugs = [];
+        foreach ($planRows as $row) {
+            $slug = $this->slugForPlanRow($row);
+            if ($slug !== null && ! in_array($slug, $slugs, true)) {
+                $slugs[] = $slug;
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return list<string>
+     */
+    private function expectedLocales(array $locales): array
+    {
+        $normalized = [];
+        foreach ($locales as $locale) {
+            $value = $this->normalizeString($locale);
+            if ($value !== null) {
+                $value = strtolower($value);
+                if (! in_array($value, $normalized, true)) {
+                    $normalized[] = $value;
+                }
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function publicTypesBySlug(array $planRows): array
+    {
+        $types = [];
+        foreach ($planRows as $row) {
+            $slug = $this->slugForPlanRow($row);
+            $type = $this->publicTypeForRow($row);
+            if ($slug !== null && $type !== null) {
+                $types[$slug] = $type;
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $projectionRow
+     * @param  array<string, mixed>|null  $truthRow
+     */
+    private function auditExpectedRow(
+        string $slug,
+        string $locale,
+        ?array $projectionRow,
+        ?array $truthRow,
+        ?bool $ledgerMemberExists,
+        ?string $planPublicType,
+    ): CareerRuntimeProjectionTruthEligibilityRow {
+        $projectionState = $this->normalizeString($projectionRow['projection_state'] ?? null);
+        $runtimePublishState = $this->normalizeString($projectionRow['runtime_publish_state'] ?? null);
+        $truthState = $this->normalizeString(
+            $truthRow['truth_state']
+                ?? $truthRow['state']
+                ?? $truthRow['status']
+                ?? $truthRow['projection_state']
+                ?? null
+        );
+        $canonicalPublicType = $this->firstString([
+            $projectionRow['canonical_public_type'] ?? null,
+            $projectionRow['public_resolution_type'] ?? null,
+            $projectionRow['public_type'] ?? null,
+            $truthRow['canonical_public_type'] ?? null,
+            $truthRow['public_resolution_type'] ?? null,
+            $truthRow['public_type'] ?? null,
+            $planPublicType,
+        ]);
+
+        $issues = $this->issuesFor(
+            slug: $slug,
+            locale: $locale,
+            projectionRow: $projectionRow,
+            truthRow: $truthRow,
+            projectionState: $projectionState,
+            runtimePublishState: $runtimePublishState,
+            truthState: $truthState,
+            canonicalPublicType: $canonicalPublicType,
+            ledgerMemberExists: $ledgerMemberExists,
+        );
+        $evidence = $this->evidenceFor(
+            slug: $slug,
+            locale: $locale,
+            projectionState: $projectionState,
+            runtimePublishState: $runtimePublishState,
+            truthState: $truthState,
+            canonicalPublicType: $canonicalPublicType,
+            ledgerMemberExists: $ledgerMemberExists,
+        );
+
+        return new CareerRuntimeProjectionTruthEligibilityRow(
+            canonicalSlug: $slug,
+            locale: $locale,
+            ledgerMemberExists: $ledgerMemberExists,
+            projectionExists: $projectionRow !== null,
+            truthExists: $truthRow !== null,
+            projectionState: $projectionState,
+            runtimePublishState: $runtimePublishState,
+            truthState: $truthState,
+            canonicalPublicType: $canonicalPublicType,
+            runtimeStatus: $this->runtimeLayerStatus($issues, $evidence),
+            evidence: $evidence,
+            issues: $issues,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $projectionRow
+     * @param  array<string, mixed>|null  $truthRow
+     * @return list<CareerRuntimeProjectionTruthEligibilityIssue>
+     */
+    private function issuesFor(
+        string $slug,
+        string $locale,
+        ?array $projectionRow,
+        ?array $truthRow,
+        ?string $projectionState,
+        ?string $runtimePublishState,
+        ?string $truthState,
+        ?string $canonicalPublicType,
+        ?bool $ledgerMemberExists,
+    ): array {
+        $issues = [];
+        $rowEvidence = [['slug' => $slug, 'locale' => $locale]];
+
+        if ($ledgerMemberExists === false) {
+            $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
+                reason: CareerRuntimeProjectionTruthEligibilityIssue::LEDGER_MEMBER_MISSING,
+                message: 'Ledger input was provided but did not include the expected canonical slug.',
+                severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_FULL_2786_CLAIM,
+                canonicalSlug: $slug,
+                locale: $locale,
+                evidence: $rowEvidence,
+            );
+        }
+
+        if ($projectionRow === null && $truthRow === null) {
+            $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
+                reason: CareerRuntimeProjectionTruthEligibilityIssue::LOCALE_ROW_MISSING,
+                message: 'No runtime projection or truth row was found for the expected slug and locale.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $slug,
+                locale: $locale,
+                evidence: $rowEvidence,
+            );
+        }
+
+        if ($projectionRow === null) {
+            $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
+                reason: CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_ROW_MISSING,
+                message: 'Runtime publish projection row was not found for the expected slug and locale.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $slug,
+                locale: $locale,
+                evidence: $rowEvidence,
+            );
+        } elseif ($runtimePublishState !== null && $runtimePublishState !== self::PUBLISHED) {
+            $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
+                reason: CareerRuntimeProjectionTruthEligibilityIssue::RUNTIME_PUBLISH_STATE_NOT_PUBLISHED,
+                message: 'Runtime publish projection row is not published.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $slug,
+                locale: $locale,
+                evidence: [['runtime_publish_state' => $runtimePublishState]],
+            );
+        } elseif ($runtimePublishState === null && $projectionState !== null && $projectionState !== self::PUBLISHED) {
+            $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
+                reason: CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_STATE_NOT_PUBLISHED,
+                message: 'Projection row state is not published.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $slug,
+                locale: $locale,
+                evidence: [['projection_state' => $projectionState]],
+            );
+        }
+
+        if ($truthRow === null) {
+            $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
+                reason: CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_ROW_MISSING,
+                message: 'Canonical runtime truth row was not found for the expected slug and locale.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $slug,
+                locale: $locale,
+                evidence: $rowEvidence,
+            );
+        } elseif ($truthState !== null && $truthState !== self::PUBLISHED) {
+            $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
+                reason: CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_STATE_NOT_PUBLISHED,
+                message: 'Canonical runtime truth row state is not published.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $slug,
+                locale: $locale,
+                evidence: [['truth_state' => $truthState]],
+            );
+        }
+
+        if ($canonicalPublicType !== null && $canonicalPublicType !== self::PUBLIC_CANONICAL_JOB) {
+            $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
+                reason: CareerRuntimeProjectionTruthEligibilityIssue::CANONICAL_PUBLIC_TYPE_INVALID,
+                message: 'Runtime projection/truth row exposes a non-canonical public type.',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                canonicalSlug: $slug,
+                locale: $locale,
+                evidence: [['canonical_public_type' => $canonicalPublicType]],
+            );
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  list<CareerRuntimeProjectionTruthEligibilityIssue>  $issues
+     * @param  list<mixed>  $evidence
+     */
+    private function runtimeLayerStatus(array $issues, array $evidence): CareerCanonicalEligibilityLayerStatus
+    {
+        return new CareerCanonicalEligibilityLayerStatus(
+            layer: CareerCanonicalEligibilityLayer::RUNTIME,
+            status: $issues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            reasons: array_values(array_unique(array_map(
+                static fn (CareerRuntimeProjectionTruthEligibilityIssue $issue): string => $issue->reason,
+                $issues
+            ))),
+            evidence: $evidence,
+            source: 'runtime_projection_truth',
+        );
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function evidenceFor(
+        string $slug,
+        string $locale,
+        ?string $projectionState,
+        ?string $runtimePublishState,
+        ?string $truthState,
+        ?string $canonicalPublicType,
+        ?bool $ledgerMemberExists,
+    ): array {
+        $evidence = [['slug' => $slug, 'locale' => $locale]];
+
+        if ($ledgerMemberExists !== null) {
+            $evidence[] = ['ledger_member_exists' => $ledgerMemberExists];
+        }
+        if ($projectionState !== null) {
+            $evidence[] = ['projection_state' => $projectionState];
+        }
+        if ($runtimePublishState !== null) {
+            $evidence[] = ['runtime_publish_state' => $runtimePublishState];
+        }
+        if ($truthState !== null) {
+            $evidence[] = ['truth_state' => $truthState];
+        }
+        if ($canonicalPublicType !== null) {
+            $evidence[] = ['canonical_public_type' => $canonicalPublicType];
+        }
+
+        return $evidence;
+    }
+
+    /**
+     * @param  array<string, mixed>|list<array<string, mixed>>  $artifact
+     * @return list<array<string, mixed>>
+     */
+    private function artifactRows(array $artifact): array
+    {
+        $candidates = [
+            $artifact,
+            $artifact['items'] ?? null,
+            $artifact['rows'] ?? null,
+            $artifact['projection']['items'] ?? null,
+            $artifact['truth']['items'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && array_is_list($candidate)) {
+                return array_values(array_filter($candidate, static fn (mixed $row): bool => is_array($row)));
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, array<string, mixed>>
+     */
+    private function rowsBySlugLocale(array $rows): array
+    {
+        $indexed = [];
+        foreach ($rows as $row) {
+            $slug = $this->slugForArrayRow($row);
+            $locale = $this->normalizeString($row['locale'] ?? null);
+            if ($slug === null || $locale === null) {
+                continue;
+            }
+
+            $indexed[$this->rowKey($slug, strtolower($locale))] = $row;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @param  array<string, mixed>|list<array<string, mixed>>  $ledger
+     * @return list<string>
+     */
+    private function ledgerSlugs(array $ledger): array
+    {
+        $rows = $this->ledgerRows($ledger);
+        $slugs = [];
+        foreach ($rows as $row) {
+            $slug = $this->slugForArrayRow($row);
+            if ($slug !== null && ! in_array($slug, $slugs, true)) {
+                $slugs[] = $slug;
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  array<string, mixed>|list<array<string, mixed>>  $ledger
+     * @return list<array<string, mixed>>
+     */
+    private function ledgerRows(array $ledger): array
+    {
+        $candidates = [
+            $ledger,
+            $ledger['public_resolution']['rows'] ?? null,
+            $ledger['members'] ?? null,
+            $ledger['items'] ?? null,
+            $ledger['rows'] ?? null,
+            $ledger['ledger']['public_resolution']['rows'] ?? null,
+            $ledger['ledger']['members'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && array_is_list($candidate)) {
+                return array_values(array_filter($candidate, static fn (mixed $row): bool => is_array($row)));
+            }
+        }
+
+        return [];
+    }
+
+    private function slugForPlanRow(mixed $row): ?string
+    {
+        if ($row instanceof CareerPublicResolutionPlanRow) {
+            return $this->normalizeSlug($row->canonicalSlug);
+        }
+
+        if (is_string($row)) {
+            return $this->normalizeSlug($row);
+        }
+
+        if (is_array($row)) {
+            return $this->slugForArrayRow($row);
+        }
+
+        if (is_object($row) && property_exists($row, 'canonicalSlug')) {
+            return $this->normalizeSlug($row->canonicalSlug);
+        }
+
+        return null;
+    }
+
+    private function publicTypeForRow(mixed $row): ?string
+    {
+        if ($row instanceof CareerPublicResolutionPlanRow) {
+            return $this->normalizeString($row->canonicalPublicType);
+        }
+
+        if (is_array($row)) {
+            return $this->firstString([
+                $row['canonical_public_type'] ?? null,
+                $row['public_resolution_type'] ?? null,
+                $row['public_type'] ?? null,
+            ]);
+        }
+
+        if (is_object($row) && property_exists($row, 'canonicalPublicType')) {
+            return $this->normalizeString($row->canonicalPublicType);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function slugForArrayRow(array $row): ?string
+    {
+        return $this->normalizeSlug($row['canonical_slug'] ?? $row['source_slug'] ?? $row['slug'] ?? null);
+    }
+
+    /**
+     * @param  list<mixed>  $values
+     */
+    private function firstString(array $values): ?string
+    {
+        foreach ($values as $value) {
+            $normalized = $this->normalizeString($value);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function rowKey(string $slug, string $locale): string
+    {
+        return $slug.'|'.$locale;
+    }
+
+    private function normalizeSlug(mixed $value): ?string
+    {
+        $normalized = $this->normalizeString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityIssue.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerRuntimeProjectionTruthEligibilityIssue
+{
+    public const LEDGER_MEMBER_MISSING = 'ledger_member_missing';
+
+    public const PROJECTION_ROW_MISSING = 'projection_row_missing';
+
+    public const PROJECTION_STATE_NOT_PUBLISHED = 'projection_state_not_published';
+
+    public const RUNTIME_PUBLISH_STATE_NOT_PUBLISHED = 'runtime_publish_state_not_published';
+
+    public const TRUTH_ROW_MISSING = 'truth_row_missing';
+
+    public const TRUTH_STATE_NOT_PUBLISHED = 'truth_state_not_published';
+
+    public const CANONICAL_PUBLIC_TYPE_INVALID = 'canonical_public_type_invalid';
+
+    public const LOCALE_ROW_MISSING = 'locale_row_missing';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::MEDIUM,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $locale = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->locale !== null) {
+            self::assertNonEmptyString($this->locale, 'locale');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::LEDGER_MEMBER_MISSING,
+            self::PROJECTION_ROW_MISSING,
+            self::PROJECTION_STATE_NOT_PUBLISHED,
+            self::RUNTIME_PUBLISH_STATE_NOT_PUBLISHED,
+            self::TRUTH_ROW_MISSING,
+            self::TRUTH_STATE_NOT_PUBLISHED,
+            self::CANONICAL_PUBLIC_TYPE_INVALID,
+            self::LOCALE_ROW_MISSING,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career runtime projection/truth issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, canonical_slug: string|null, locale: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career runtime projection/truth issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career runtime projection/truth issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityResult.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityResult.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerRuntimeProjectionTruthEligibilityResult
+{
+    /**
+     * @param  list<CareerRuntimeProjectionTruthEligibilityRow>  $rows
+     * @param  list<CareerRuntimeProjectionTruthEligibilityIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly int $expectedRows,
+        public readonly int $foundProjectionRows,
+        public readonly int $foundTruthRows,
+        public readonly int $foundPublished,
+        public readonly int $missingProjectionRows,
+        public readonly int $missingTruthRows,
+        public readonly int $notPublishedRows,
+        public readonly int $invalidPublicTypeRows,
+        public readonly int $ledgerMissingRows,
+        public readonly array $rows,
+        public readonly array $issues = [],
+        public readonly array $sidecars = [],
+    ) {
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        foreach ([
+            'expected_rows' => $this->expectedRows,
+            'found_projection_rows' => $this->foundProjectionRows,
+            'found_truth_rows' => $this->foundTruthRows,
+            'found_published' => $this->foundPublished,
+            'missing_projection_rows' => $this->missingProjectionRows,
+            'missing_truth_rows' => $this->missingTruthRows,
+            'not_published_rows' => $this->notPublishedRows,
+            'invalid_public_type_rows' => $this->invalidPublicTypeRows,
+            'ledger_missing_rows' => $this->ledgerMissingRows,
+        ] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career runtime projection/truth [%s] must be non-negative.', $key));
+            }
+        }
+
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+        self::assertSidecars($this->sidecars);
+    }
+
+    /**
+     * @param  list<CareerRuntimeProjectionTruthEligibilityRow>  $rows
+     * @param  list<CareerRuntimeProjectionTruthEligibilityIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public static function build(array $rows, array $issues = [], array $sidecars = []): self
+    {
+        $allIssues = [
+            ...$issues,
+            ...array_values(array_merge(...array_map(
+                static fn (CareerRuntimeProjectionTruthEligibilityRow $row): array => $row->issues,
+                $rows
+            ))),
+        ];
+
+        return new self(
+            status: $allIssues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            expectedRows: count($rows),
+            foundProjectionRows: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => $row->projectionExists)),
+            foundTruthRows: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => $row->truthExists)),
+            foundPublished: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => $row->issues === [])),
+            missingProjectionRows: self::countRowsWithReason($rows, CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_ROW_MISSING),
+            missingTruthRows: self::countRowsWithReason($rows, CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_ROW_MISSING),
+            notPublishedRows: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => self::rowHasAnyReason($row, [
+                CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_STATE_NOT_PUBLISHED,
+                CareerRuntimeProjectionTruthEligibilityIssue::RUNTIME_PUBLISH_STATE_NOT_PUBLISHED,
+                CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_STATE_NOT_PUBLISHED,
+            ]))),
+            invalidPublicTypeRows: self::countRowsWithReason($rows, CareerRuntimeProjectionTruthEligibilityIssue::CANONICAL_PUBLIC_TYPE_INVALID),
+            ledgerMissingRows: self::countRowsWithReason($rows, CareerRuntimeProjectionTruthEligibilityIssue::LEDGER_MEMBER_MISSING),
+            rows: $rows,
+            issues: $allIssues,
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, expected_rows: int, found_projection_rows: int, found_truth_rows: int, found_published: int, missing_projection_rows: int, missing_truth_rows: int, not_published_rows: int, invalid_public_type_rows: int, ledger_missing_rows: int, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'expected_rows' => $this->expectedRows,
+            'found_projection_rows' => $this->foundProjectionRows,
+            'found_truth_rows' => $this->foundTruthRows,
+            'found_published' => $this->foundPublished,
+            'missing_projection_rows' => $this->missingProjectionRows,
+            'missing_truth_rows' => $this->missingTruthRows,
+            'not_published_rows' => $this->notPublishedRows,
+            'invalid_public_type_rows' => $this->invalidPublicTypeRows,
+            'ledger_missing_rows' => $this->ledgerMissingRows,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerRuntimeProjectionTruthEligibilityRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerRuntimeProjectionTruthEligibilityIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerRuntimeProjectionTruthEligibilityRow>  $rows
+     */
+    private static function countRowsWithReason(array $rows, string $reason): int
+    {
+        return count(array_filter(
+            $rows,
+            static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => self::rowHasAnyReason($row, [$reason])
+        ));
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     */
+    private static function rowHasAnyReason(CareerRuntimeProjectionTruthEligibilityRow $row, array $reasons): bool
+    {
+        foreach ($row->issues as $issue) {
+            if (in_array($issue->reason, $reasons, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<CareerRuntimeProjectionTruthEligibilityRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career runtime projection/truth rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerRuntimeProjectionTruthEligibilityRow) {
+                throw new InvalidArgumentException('Career runtime projection/truth rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerRuntimeProjectionTruthEligibilityIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career runtime projection/truth issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerRuntimeProjectionTruthEligibilityIssue) {
+                throw new InvalidArgumentException('Career runtime projection/truth issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career runtime projection/truth sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career runtime projection/truth sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityRow.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityRow.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerRuntimeProjectionTruthEligibilityRow
+{
+    /**
+     * @param  list<mixed>  $evidence
+     * @param  list<CareerRuntimeProjectionTruthEligibilityIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $locale,
+        public readonly ?bool $ledgerMemberExists,
+        public readonly bool $projectionExists,
+        public readonly bool $truthExists,
+        public readonly ?string $projectionState,
+        public readonly ?string $runtimePublishState,
+        public readonly ?string $truthState,
+        public readonly ?string $canonicalPublicType,
+        public readonly CareerCanonicalEligibilityLayerStatus $runtimeStatus,
+        public readonly array $evidence = [],
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertNonEmptyString($this->locale, 'locale');
+        self::assertList($this->evidence, 'evidence');
+
+        foreach ([
+            'projection_state' => $this->projectionState,
+            'runtime_publish_state' => $this->runtimePublishState,
+            'truth_state' => $this->truthState,
+            'canonical_public_type' => $this->canonicalPublicType,
+        ] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+
+        if (! array_is_list($this->issues)) {
+            throw new InvalidArgumentException('Career runtime projection/truth row issues must be a list.');
+        }
+
+        foreach ($this->issues as $issue) {
+            if (! $issue instanceof CareerRuntimeProjectionTruthEligibilityIssue) {
+                throw new InvalidArgumentException('Career runtime projection/truth row issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, locale: string, ledger_member_exists: bool|null, projection_exists: bool, truth_exists: bool, projection_state: string|null, runtime_publish_state: string|null, truth_state: string|null, canonical_public_type: string|null, runtime_status: array<string, mixed>, evidence: list<mixed>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'ledger_member_exists' => $this->ledgerMemberExists,
+            'projection_exists' => $this->projectionExists,
+            'truth_exists' => $this->truthExists,
+            'projection_state' => $this->projectionState,
+            'runtime_publish_state' => $this->runtimePublishState,
+            'truth_state' => $this->truthState,
+            'canonical_public_type' => $this->canonicalPublicType,
+            'runtime_status' => $this->runtimeStatus->toArray(),
+            'evidence' => $this->evidence,
+            'issues' => array_map(
+                static fn (CareerRuntimeProjectionTruthEligibilityIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career runtime projection/truth row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career runtime projection/truth row [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/docs/career/audits/runtime_projection_truth_eligibility_audit.md
+++ b/backend/docs/career/audits/runtime_projection_truth_eligibility_audit.md
@@ -1,0 +1,107 @@
+# Career Runtime Projection / Truth Eligibility Audit
+
+AUDIT-6 adds a read-only runtime eligibility layer for the Career 2786 canonical eligibility audit train. It checks whether normalized public-resolution plan rows can resolve through optional full release ledger membership, runtime publish projection rows, and canonical runtime truth rows.
+
+AUDIT-6 does not run rollout apply, publish rows, backfill data, mutate runtime state, inspect SEO/GEO surfaces, validate live HTML, or claim 2786 readiness.
+
+## Inputs
+
+The auditor accepts synthetic or artifact-derived arrays:
+
+- plan rows from AUDIT-2 normalized rows, array rows, or slug lists
+- expected locales such as `["en", "zh"]`
+- runtime publish projection arrays with rows under `items`
+- canonical runtime truth arrays with rows under `items`
+- optional full release ledger arrays with rows under `public_resolution.rows`, `members`, `items`, or `rows`
+
+Tests use synthetic arrays only. The real 2786 production planner, projection, truth, or ledger artifacts are not required.
+
+## Matching Rules
+
+Rows are matched by normalized lowercase `slug` or `canonical_slug` plus lowercase `locale`.
+
+Projection rows may expose either:
+
+- `runtime_publish_state`
+- `projection_state`
+
+Truth rows may expose:
+
+- `projection_state`
+- `truth_state`
+- `state`
+- `status`
+
+For AUDIT-6 eligibility, exposed runtime/truth state must be `published`. If a ledger artifact is provided, the slug must also exist in that ledger. If no ledger artifact is provided, ledger membership is not audited.
+
+The canonical public type is accepted only when it is absent or `public_canonical_job`. Any exposed non-canonical type is reported as an audit issue.
+
+## Result Shape
+
+The result reports:
+
+- `status`
+- `expected_rows`
+- `found_projection_rows`
+- `found_truth_rows`
+- `found_published`
+- `missing_projection_rows`
+- `missing_truth_rows`
+- `not_published_rows`
+- `invalid_public_type_rows`
+- `ledger_missing_rows`
+- `by_reason`
+- `rows`
+- `issues`
+- `sidecars`
+
+Each row includes an AUDIT-1-compatible runtime layer status:
+
+```json
+{
+  "layer": "runtime",
+  "status": "pass",
+  "reasons": [],
+  "evidence": [
+    {
+      "slug": "actuaries",
+      "locale": "en",
+      "runtime_publish_state": "published",
+      "truth_state": "published"
+    }
+  ],
+  "source": "runtime_projection_truth"
+}
+```
+
+Blocked rows use `status=blocked`, include reason codes, and keep the same `source`.
+
+## Issue Reasons
+
+- `ledger_member_missing`
+- `projection_row_missing`
+- `projection_state_not_published`
+- `runtime_publish_state_not_published`
+- `truth_row_missing`
+- `truth_state_not_published`
+- `canonical_public_type_invalid`
+- `locale_row_missing`
+
+## Non-Goals
+
+AUDIT-6 is runtime projection/truth only. It does not:
+
+- implement `career:audit-canonical-eligibility`
+- audit baseline metadata
+- audit index-state authority
+- audit SEO/GEO readiness
+- audit API or live HTML surfaces
+- generate manifests
+- apply rollout
+- backfill or mutate data
+- run production validation
+- deploy
+
+## Consumption By AUDIT-7+
+
+AUDIT-7 should consume AUDIT-6 output as the runtime layer prerequisite before checking SEO/GEO readiness. AUDIT-8 should treat AUDIT-6 runtime failures as upstream blockers rather than attempting to prove live surface readiness for rows that are missing projection or truth eligibility.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditorTest.php
@@ -1,0 +1,466 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerPublicResolutionPlan;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
+use App\Domain\Career\Audit\CareerRuntimeProjectionTruthEligibilityAuditor;
+use App\Domain\Career\Audit\CareerRuntimeProjectionTruthEligibilityIssue;
+use PHPUnit\Framework\TestCase;
+
+final class CareerRuntimeProjectionTruthEligibilityAuditorTest extends TestCase
+{
+    public function test_projection_truth_expected_rows_pass(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en', 'zh'],
+            projection: $this->projection([
+                $this->projectionRow('actuaries', 'en'),
+                $this->projectionRow('actuaries', 'zh'),
+            ]),
+            truth: $this->truth([
+                $this->truthRow('actuaries', 'en'),
+                $this->truthRow('actuaries', 'zh'),
+            ]),
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(2, $result->expectedRows);
+        $this->assertSame(2, $result->foundProjectionRows);
+        $this->assertSame(2, $result->foundTruthRows);
+        $this->assertSame(2, $result->foundPublished);
+    }
+
+    public function test_missing_projection_row_is_reported(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->missingProjectionRows);
+        $this->assertSame(CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_ROW_MISSING, $result->issues[0]->reason);
+    }
+
+    public function test_missing_truth_row_is_reported(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([]),
+        );
+
+        $this->assertSame(1, $result->missingTruthRows);
+        $this->assertSame(CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_ROW_MISSING, $result->issues[0]->reason);
+    }
+
+    public function test_projection_state_not_published_is_reported(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([
+                $this->projectionRow('actuaries', 'en', ['runtime_publish_state' => null, 'projection_state' => 'published_candidate']),
+            ]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        );
+
+        $this->assertSame(CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_STATE_NOT_PUBLISHED, $result->issues[0]->reason);
+        $this->assertSame(1, $result->notPublishedRows);
+    }
+
+    public function test_runtime_publish_state_not_published_is_reported(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en', ['runtime_publish_state' => 'published_candidate'])]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        );
+
+        $this->assertSame(CareerRuntimeProjectionTruthEligibilityIssue::RUNTIME_PUBLISH_STATE_NOT_PUBLISHED, $result->issues[0]->reason);
+        $this->assertSame(1, $result->notPublishedRows);
+    }
+
+    public function test_truth_not_published_is_reported_if_truth_state_exists(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en', ['projection_state' => 'published_candidate'])]),
+        );
+
+        $this->assertSame(CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_STATE_NOT_PUBLISHED, $result->issues[0]->reason);
+        $this->assertSame(1, $result->notPublishedRows);
+    }
+
+    public function test_invalid_canonical_public_type_is_reported(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: [['canonical_slug' => 'actuaries', 'canonical_public_type' => 'public_alias_redirect']],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en', ['public_resolution_type' => 'public_alias_redirect'])]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        );
+
+        $this->assertSame(CareerRuntimeProjectionTruthEligibilityIssue::CANONICAL_PUBLIC_TYPE_INVALID, $result->issues[0]->reason);
+        $this->assertSame(1, $result->invalidPublicTypeRows);
+    }
+
+    public function test_missing_locale_row_is_reported(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en', 'zh'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        );
+
+        $this->assertSame([
+            CareerRuntimeProjectionTruthEligibilityIssue::LOCALE_ROW_MISSING => 1,
+            CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_ROW_MISSING => 1,
+            CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_ROW_MISSING => 1,
+        ], $result->byReason());
+    }
+
+    public function test_optional_ledger_missing_member_is_reported_when_ledger_input_is_supplied(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+            ledger: ['public_resolution' => ['rows' => [['source_slug' => 'actors']]]],
+        );
+
+        $this->assertSame(CareerRuntimeProjectionTruthEligibilityIssue::LEDGER_MEMBER_MISSING, $result->issues[0]->reason);
+        $this->assertSame(1, $result->ledgerMissingRows);
+        $this->assertFalse($result->rows[0]->ledgerMemberExists);
+    }
+
+    public function test_no_ledger_issue_is_produced_when_ledger_input_is_null(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+            ledger: null,
+        );
+
+        $this->assertSame([], $result->issues);
+        $this->assertNull($result->rows[0]->ledgerMemberExists);
+    }
+
+    public function test_result_by_reason_counts_issues(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries', 'actors'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en', ['runtime_publish_state' => 'blocked'])]),
+            truth: $this->truth([]),
+        );
+
+        $this->assertSame([
+            CareerRuntimeProjectionTruthEligibilityIssue::LOCALE_ROW_MISSING => 1,
+            CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_ROW_MISSING => 1,
+            CareerRuntimeProjectionTruthEligibilityIssue::RUNTIME_PUBLISH_STATE_NOT_PUBLISHED => 1,
+            CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_ROW_MISSING => 2,
+        ], $result->byReason());
+    }
+
+    public function test_row_to_array_is_stable(): void
+    {
+        $row = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+            ledger: ['public_resolution' => ['rows' => [['source_slug' => 'actuaries']]]],
+        )->rows[0]->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "canonical_slug": "actuaries",
+    "locale": "en",
+    "ledger_member_exists": true,
+    "projection_exists": true,
+    "truth_exists": true,
+    "projection_state": null,
+    "runtime_publish_state": "published",
+    "truth_state": "published",
+    "canonical_public_type": "public_canonical_job",
+    "runtime_status": {
+        "layer": "runtime",
+        "status": "pass",
+        "reasons": [],
+        "evidence": [
+            {
+                "slug": "actuaries",
+                "locale": "en"
+            },
+            {
+                "ledger_member_exists": true
+            },
+            {
+                "runtime_publish_state": "published"
+            },
+            {
+                "truth_state": "published"
+            },
+            {
+                "canonical_public_type": "public_canonical_job"
+            }
+        ],
+        "source": "runtime_projection_truth"
+    },
+    "evidence": [
+        {
+            "slug": "actuaries",
+            "locale": "en"
+        },
+        {
+            "ledger_member_exists": true
+        },
+        {
+            "runtime_publish_state": "published"
+        },
+        {
+            "truth_state": "published"
+        },
+        {
+            "canonical_public_type": "public_canonical_job"
+        }
+    ],
+    "issues": []
+}
+JSON,
+            json_encode($row, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        )->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "expected_rows": 1,
+    "found_projection_rows": 1,
+    "found_truth_rows": 1,
+    "found_published": 1,
+    "missing_projection_rows": 0,
+    "missing_truth_rows": 0,
+    "not_published_rows": 0,
+    "invalid_public_type_rows": 0,
+    "ledger_missing_rows": 0,
+    "by_reason": [],
+    "rows": [
+        {
+            "canonical_slug": "actuaries",
+            "locale": "en",
+            "ledger_member_exists": null,
+            "projection_exists": true,
+            "truth_exists": true,
+            "projection_state": null,
+            "runtime_publish_state": "published",
+            "truth_state": "published",
+            "canonical_public_type": "public_canonical_job",
+            "runtime_status": {
+                "layer": "runtime",
+                "status": "pass",
+                "reasons": [],
+                "evidence": [
+                    {
+                        "slug": "actuaries",
+                        "locale": "en"
+                    },
+                    {
+                        "runtime_publish_state": "published"
+                    },
+                    {
+                        "truth_state": "published"
+                    },
+                    {
+                        "canonical_public_type": "public_canonical_job"
+                    }
+                ],
+                "source": "runtime_projection_truth"
+            },
+            "evidence": [
+                {
+                    "slug": "actuaries",
+                    "locale": "en"
+                },
+                {
+                    "runtime_publish_state": "published"
+                },
+                {
+                    "truth_state": "published"
+                },
+                {
+                    "canonical_public_type": "public_canonical_job"
+                }
+            ],
+            "issues": []
+        }
+    ],
+    "issues": [],
+    "sidecars": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_runtime_layer_status_pass_and_blocked_are_audit_one_compatible(): void
+    {
+        $pass = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        )->rows[0]->runtimeStatus;
+
+        $blocked = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([]),
+            truth: $this->truth([]),
+        )->rows[0]->runtimeStatus;
+
+        $this->assertSame(CareerCanonicalEligibilityLayer::RUNTIME, $pass->layer);
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $pass->status);
+        $this->assertSame(CareerCanonicalEligibilityLayer::RUNTIME, $blocked->layer);
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $blocked->status);
+        $this->assertContains(CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_ROW_MISSING, $blocked->reasons);
+    }
+
+    public function test_audit_plan_consumes_audit_two_plan_rows(): void
+    {
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: '__fixture__',
+            checksum: null,
+            rows: [CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'actuaries', 'canonical_public_type' => 'public_canonical_job'])],
+        );
+
+        $result = $this->auditor()->auditPlan(
+            plan: $plan,
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame('actuaries', $result->rows[0]->canonicalSlug);
+    }
+
+    public function test_no_db_mutation_or_dependency(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            projection: $this->projection([$this->projectionRow('actuaries', 'en')]),
+            truth: $this->truth([$this->truthRow('actuaries', 'en')]),
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+    }
+
+    private function auditor(): CareerRuntimeProjectionTruthEligibilityAuditor
+    {
+        return new CareerRuntimeProjectionTruthEligibilityAuditor;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function projection(array $items): array
+    {
+        return [
+            'projection_kind' => 'career_runtime_publish_projection',
+            'projection_version' => 'test',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function truth(array $items): array
+    {
+        return [
+            'truth_kind' => 'career_canonical_runtime_truth',
+            'truth_version' => 'test',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function projectionRow(string $slug, string $locale, array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'runtime_publish_state' => 'published',
+            'detail_route_enabled' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'canonical_self' => true,
+            'robots_indexable' => true,
+            'release_gate_pass' => true,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function truthRow(string $slug, string $locale, array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'projection_state' => 'published',
+            'route_exists' => true,
+            'final_200' => true,
+            'robots_indexable' => true,
+            'canonical_self' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'release_gate_pass' => true,
+            'fully_live' => true,
+        ], $overrides);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -317,6 +317,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_runtime_projection_truth_audit_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityIssue.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityResult.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -963,6 +975,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerRuntimeProjectionTruthAuditFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1299,6 +1315,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityIssue.php',
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityResult.php',
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityRow.php',
+        ], true);
+    }
+
+    private function isCareerRuntimeProjectionTruthAuditFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityIssue.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityResult.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1405,6 +1405,97 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-6": {
+      "repo": "fap-api",
+      "branch": "fix/career-runtime-projection-truth-audit6",
+      "title": "feat(api): add career runtime projection truth eligibility audit",
+      "name": "Career Runtime Projection Truth Eligibility Audit",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-5"
+      ],
+      "scope_type": "runtime_projection_truth_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no audit command",
+        "no baseline metadata audit",
+        "no index-state audit",
+        "no SEO/GEO audit",
+        "no surface audit",
+        "no rollout",
+        "no apply",
+        "no backfill",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuing AUDIT-6 from existing branch fix/career-runtime-projection-truth-audit6 and authorized per-item PR train manifest/state updates."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-5 passed GitHub checks, was squash-merged as PR #1322 with merge commit 2c13914c253aa532a1992b0e3d346a911f0ab65d, local main was synced, and the AUDIT-5 branch was cleaned up before AUDIT-6 implementation."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Unit/Domain/Career/Audit, backend/docs/career/audits, the test-only BigFive freeze classifier allowlist, and docs/codex train files."
+        },
+        "runtime_projection_truth_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi",
+          "evidence": "16 tests passed, 35 assertions."
+        },
+        "occupation_entity_inventory_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi",
+          "evidence": "13 tests passed, 45 assertions."
+        },
+        "index_state_authority_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi",
+          "evidence": "12 tests passed, 28 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_allowlist_fix": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-6 CareerRuntimeProjectionTruthEligibility* files to the test-only freeze classifier allowlist; the runtime path gate passes locally."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3088 files checked."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-7 SEO/GEO readiness audit",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -677,3 +677,49 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-6
+    repo: fap-api
+    depends_on:
+      - AUDIT-5
+    branch: fix/career-runtime-projection-truth-audit6
+    title: "feat(api): add career runtime projection truth eligibility audit"
+    name: "Career Runtime Projection Truth Eligibility Audit"
+    scope_type: runtime_projection_truth_only
+    scope:
+      - Add a read-only runtime projection/truth eligibility auditor for canonical slugs from AUDIT-2 plan rows or slug lists.
+      - Consume synthetic or artifact-derived runtime publish projection, canonical runtime truth, and optional full release ledger arrays.
+      - Report missing projection rows, missing truth rows, not-published states, invalid public types, missing locale rows, and optional ledger membership gaps.
+      - Emit AUDIT-1-compatible runtime layer statuses.
+      - Document AUDIT-6 runtime projection/truth contract and future AUDIT-7+ consumption policy.
+      - Add focused tests proving stable JSON, read-only behavior, optional ledger handling, and no DB/SEO/surface audit logic.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-6 runtime projection/truth audit files.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add a career canonical eligibility audit command.
+      - Add baseline metadata audit.
+      - Add index-state audit.
+      - Add SEO/GEO audit.
+      - Add surface audit.
+      - Modify rollout state.
+      - Apply rollout or backfill data.
+      - Mutate production data.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-7 SEO/GEO readiness audit"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds AUDIT-6 runtime projection/truth-only eligibility auditor and DTOs under Career Audit.
- Emits AUDIT-1-compatible runtime layer statuses from synthetic or artifact-derived projection, truth, and optional ledger arrays.
- Updates AUDIT-6 docs plus PR train manifest/state with explicit runtime_projection_truth_only scope.

## Guardrails
- Runtime projection/truth only.
- No DB mutation.
- No production commands.
- No audit command yet.
- No SEO/GEO audit yet.
- No surface audit yet.
- No rollout/apply/backfill.
- Uses synthetic artifacts in tests; no real 2786 planner, projection, truth, or ledger artifact required.
- Next PR is AUDIT-7 SEO/GEO readiness audit.

## Validation
- php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
- php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
- php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi
- vendor/bin/pint --test
- git diff --check
- jq empty docs/codex/pr-train-state.json
- ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'\n\n## Check protocol\nPending checks are wait/poll state, not blockers. Failed checks require inspect/classify/fix or sidecar before stopping.