### PR TITLE
RIASEC-TRAIN-04 — Share / PDF / History from snapshot

### DIFF
--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -43,6 +43,10 @@ final class ReportPdfDocumentService
     public function metadata(Attempt $attempt, array $gate = [], ?Result $result = null): array
     {
         $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($scaleCode === 'RIASEC') {
+            return $this->riasecMetadata($attempt, $gate);
+        }
+
         if ($scaleCode !== 'ENNEAGRAM') {
             return [
                 'pdf_surface_version' => 'report_pdf.surface.v1',
@@ -113,6 +117,58 @@ final class ReportPdfDocumentService
                 ?? data_get($snapshotBinding, 'compare_compatibility_group'),
             'cross_form_comparable' => data_get($projectionV2, 'methodology.cross_form_comparable')
                 ?? data_get($snapshotBinding, 'cross_form_comparable'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $gate
+     * @return array<string,mixed>
+     */
+    private function riasecMetadata(Attempt $attempt, array $gate): array
+    {
+        $report = is_array($gate['report'] ?? null) ? $gate['report'] : [];
+        if ($report === []) {
+            $snapshot = ReportSnapshot::query()
+                ->where('org_id', (int) ($attempt->org_id ?? 0))
+                ->where('attempt_id', (string) $attempt->id)
+                ->where('status', 'ready')
+                ->first();
+            if ($snapshot instanceof ReportSnapshot) {
+                $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+                if ($report === []) {
+                    $report = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+                }
+            }
+        }
+
+        $projectionV2 = is_array(data_get($report, '_meta.riasec_public_projection_v2'))
+            ? data_get($report, '_meta.riasec_public_projection_v2')
+            : [];
+        $snapshotBinding = $this->extractSnapshotBinding($report);
+        $formCode = trim((string) (
+            data_get($projectionV2, 'form.form_code')
+            ?? data_get($snapshotBinding, 'form_code')
+            ?? $attempt->form_code
+        ));
+        $date = $attempt->submitted_at?->format('Y-m-d')
+            ?? $attempt->created_at?->format('Y-m-d')
+            ?? now()->format('Y-m-d');
+
+        return [
+            'pdf_surface_version' => 'riasec.pdf_surface.v1',
+            'scale_code' => 'RIASEC',
+            'form_code' => $formCode !== '' ? $formCode : null,
+            'form_label' => $this->riasecFormLabel($formCode),
+            'filename_hint' => $this->riasecFileNameHint($formCode, $date),
+            'report_schema_version' => data_get($report, 'schema_version'),
+            'projection_version' => data_get($projectionV2, 'schema_version'),
+            'report_engine_version' => data_get($snapshotBinding, 'report_engine_version'),
+            'interpretation_context_id' => null,
+            'content_release_hash' => null,
+            'content_snapshot_status' => null,
+            'snapshot_binding_v1' => $snapshotBinding,
+            'compare_compatibility_group' => data_get($projectionV2, 'form.compare_compatibility_group'),
+            'cross_form_comparable' => false,
         ];
     }
 
@@ -318,6 +374,25 @@ final class ReportPdfDocumentService
             'enneagram_forced_choice_144' => 'FC144 深度版',
             default => null,
         };
+    }
+
+    private function riasecFormLabel(string $formCode): ?string
+    {
+        return match (trim($formCode)) {
+            'riasec_60' => 'RIASEC 60Q',
+            'riasec_140' => 'RIASEC 140Q',
+            default => null,
+        };
+    }
+
+    private function riasecFileNameHint(string $formCode, string $date): string
+    {
+        $suffix = match (trim($formCode)) {
+            'riasec_140' => '140q',
+            default => '60q',
+        };
+
+        return 'riasec_'.$suffix.'_report_'.$date.'.pdf';
     }
 
     private function enneagramFileNameHint(string $formCode, string $date): string

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -15,6 +15,7 @@ use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Report\InviteUnlockSummaryBuilder;
 use App\Services\Report\ReportAccess;
+use App\Services\Report\ReportSnapshotStore;
 use App\Services\Report\Resolvers\OfferResolver;
 use App\Services\Riasec\RiasecCompareGuardService;
 use App\Services\Riasec\RiasecPublicFormSummaryBuilder;
@@ -79,6 +80,7 @@ class MeAttemptsService
         private readonly RiasecCompareGuardService $riasecCompareGuardService,
         private readonly RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
         private readonly InviteUnlockSummaryBuilder $inviteUnlockSummaryBuilder,
+        private readonly ReportSnapshotStore $reportSnapshotStore,
     ) {}
 
     public function list(
@@ -205,6 +207,8 @@ class MeAttemptsService
             }
         }
 
+        $riasecSnapshotReportByAttemptId = $this->riasecSnapshotReportsByAttemptId($orgId, $attemptModels, $resultByAttemptId, $userId, $anonId);
+
         $items = [];
         foreach ($attemptModels as $attempt) {
             $attemptId = (string) ($attempt->id ?? '');
@@ -223,8 +227,29 @@ class MeAttemptsService
             } elseif (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM') {
                 $presented['enneagram_form_v1'] = $this->enneagramPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
             } elseif (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'RIASEC') {
+                $riasecSnapshotReport = $riasecSnapshotReportByAttemptId[$attemptId] ?? [];
                 $presented['riasec_form_v1'] = $this->riasecPublicFormSummaryBuilder->build($attempt, $result);
                 $presented['compare_policy_v1'] = $this->riasecCompareGuardService->summarizeAttempt($attempt, $result);
+                $projection = is_array(data_get($riasecSnapshotReport, '_meta.riasec_public_projection_v1'))
+                    ? data_get($riasecSnapshotReport, '_meta.riasec_public_projection_v1')
+                    : [];
+                $projectionV2 = is_array(data_get($riasecSnapshotReport, '_meta.riasec_public_projection_v2'))
+                    ? data_get($riasecSnapshotReport, '_meta.riasec_public_projection_v2')
+                    : [];
+                if ($projection !== []) {
+                    $presented['riasec_public_projection_v1'] = $projection;
+                    $snapshotTopCode = trim((string) ($projection['top_code'] ?? ''));
+                    if ($snapshotTopCode !== '') {
+                        $presented['type_code'] = $snapshotTopCode;
+                    }
+                }
+                if ($projectionV2 !== []) {
+                    $presented['riasec_public_projection_v2'] = $projectionV2;
+                }
+                $snapshotBinding = data_get($riasecSnapshotReport, '_meta.snapshot_binding_v1');
+                if (is_array($snapshotBinding)) {
+                    $presented['riasec_snapshot_binding_v1'] = $snapshotBinding;
+                }
             }
             $items[] = $presented;
         }
@@ -238,7 +263,7 @@ class MeAttemptsService
         } elseif ($normalizedScaleCode === 'ENNEAGRAM') {
             $historyCompare = $this->buildEnneagramHistorySummary($attemptModels, $resultByAttemptId);
         } elseif ($normalizedScaleCode === 'RIASEC') {
-            $historyCompare = $this->buildRiasecHistorySummary($attemptModels, $resultByAttemptId);
+            $historyCompare = $this->buildRiasecHistorySummary($attemptModels, $resultByAttemptId, $riasecSnapshotReportByAttemptId);
         }
 
         return [
@@ -591,7 +616,7 @@ class MeAttemptsService
      * @param  array<string,Result>  $resultByAttemptId
      * @return array<string,mixed>|null
      */
-    private function buildRiasecHistorySummary(array $attemptModels, array $resultByAttemptId): ?array
+    private function buildRiasecHistorySummary(array $attemptModels, array $resultByAttemptId, array $snapshotReportByAttemptId = []): ?array
     {
         if ($attemptModels === []) {
             return null;
@@ -603,7 +628,8 @@ class MeAttemptsService
             return null;
         }
 
-        $latestScore = $this->extractRiasecScoreResult($resultByAttemptId[$latestId] ?? null);
+        $latestScore = $this->extractRiasecScoreResultFromSnapshot($snapshotReportByAttemptId[$latestId] ?? [])
+            ?: $this->extractRiasecScoreResult($resultByAttemptId[$latestId] ?? null);
         if ($latestScore === []) {
             return null;
         }
@@ -619,7 +645,8 @@ class MeAttemptsService
         $previous = $attemptModels[1] ?? null;
         if ($previous instanceof Attempt) {
             $previousId = (string) ($previous->id ?? '');
-            $previousScore = $this->extractRiasecScoreResult($resultByAttemptId[$previousId] ?? null);
+            $previousScore = $this->extractRiasecScoreResultFromSnapshot($snapshotReportByAttemptId[$previousId] ?? [])
+                ?: $this->extractRiasecScoreResult($resultByAttemptId[$previousId] ?? null);
             if ($previousId !== '' && $previousScore !== []) {
                 $payload['previous_attempt_id'] = $previousId;
                 $payload['previous_top_code'] = (string) ($previousScore['top_code'] ?? '');
@@ -639,6 +666,105 @@ class MeAttemptsService
         }
 
         return $payload;
+    }
+
+    /**
+     * @param  list<Attempt>  $attemptModels
+     * @param  array<string,Result>  $resultByAttemptId
+     * @return array<string,array<string,mixed>>
+     */
+    private function riasecSnapshotReportsByAttemptId(
+        int $orgId,
+        array $attemptModels,
+        array $resultByAttemptId,
+        ?string $userId,
+        ?string $anonId
+    ): array {
+        $riasecAttemptIds = [];
+        foreach ($attemptModels as $attempt) {
+            if (! $attempt instanceof Attempt) {
+                continue;
+            }
+            if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== ReportAccess::SCALE_RIASEC) {
+                continue;
+            }
+            $attemptId = (string) ($attempt->id ?? '');
+            if ($attemptId !== '' && isset($resultByAttemptId[$attemptId])) {
+                $riasecAttemptIds[] = $attemptId;
+            }
+        }
+
+        if ($riasecAttemptIds === []) {
+            return [];
+        }
+
+        $reports = $this->readReadySnapshotReports($orgId, $riasecAttemptIds);
+        foreach ($attemptModels as $attempt) {
+            $attemptId = (string) ($attempt->id ?? '');
+            if (! in_array($attemptId, $riasecAttemptIds, true) || isset($reports[$attemptId])) {
+                continue;
+            }
+
+            $this->reportSnapshotStore->createSnapshotForAttempt([
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'trigger_source' => 'history_surface_sync',
+                'order_no' => null,
+                'user_id' => $userId,
+                'anon_id' => $anonId,
+                'org_role' => 'public',
+            ]);
+        }
+
+        return $this->readReadySnapshotReports($orgId, $riasecAttemptIds);
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     * @return array<string,array<string,mixed>>
+     */
+    private function readReadySnapshotReports(int $orgId, array $attemptIds): array
+    {
+        if ($attemptIds === []) {
+            return [];
+        }
+
+        $rows = ReportSnapshot::query()
+            ->where('org_id', $orgId)
+            ->whereIn('attempt_id', $attemptIds)
+            ->where('status', 'ready')
+            ->get();
+
+        $reports = [];
+        foreach ($rows as $snapshot) {
+            if (! $snapshot instanceof ReportSnapshot) {
+                continue;
+            }
+
+            $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+            if ($report === []) {
+                $report = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+            }
+            if ($report !== []) {
+                $reports[(string) $snapshot->attempt_id] = $report;
+            }
+        }
+
+        return $reports;
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function extractRiasecScoreResultFromSnapshot(array $report): array
+    {
+        $projection = data_get($report, '_meta.riasec_public_projection_v1');
+        if (is_array($projection) && $projection !== []) {
+            return $projection;
+        }
+
+        return $report;
     }
 
     /**

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -22,6 +22,7 @@ use App\Services\PublicSurface\PublicSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
+use App\Services\Report\ReportSnapshotStore;
 use App\Services\Riasec\RiasecPublicProjectionService;
 use App\Services\Scale\ScaleIdentityWriteProjector;
 use App\Services\Scale\ScaleRegistry;
@@ -35,6 +36,7 @@ class ShareService
     public function __construct(
         private readonly ScaleIdentityWriteProjector $identityProjector,
         private readonly ReportComposer $reportComposer,
+        private readonly ReportSnapshotStore $reportSnapshotStore,
         private readonly ScaleRegistry $scaleRegistry,
         private readonly PersonalityProfileService $personalityProfileService,
         private readonly MbtiPrivacyConsentContractService $mbtiPrivacyConsentContractService,
@@ -590,26 +592,16 @@ class ShareService
      */
     private function buildPublicSafeReportSnapshot(Attempt $attempt, Result $result): array
     {
-        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM') {
-            $snapshot = ReportSnapshot::query()
-                ->where('org_id', (int) ($attempt->org_id ?? 0))
-                ->where('attempt_id', (string) $attempt->id)
-                ->where('status', 'ready')
-                ->first();
-
-            if ($snapshot instanceof ReportSnapshot) {
-                $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
-                if ($report === []) {
-                    $report = is_array($snapshot->report_json) ? $snapshot->report_json : [];
-                }
-
-                return $report;
-            }
-
-            return [];
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($scaleCode === 'RIASEC') {
+            return $this->resolveRiasecSnapshotReport($attempt);
         }
 
-        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== 'MBTI') {
+        if ($scaleCode === 'ENNEAGRAM') {
+            return $this->readReadySnapshotReport($attempt);
+        }
+
+        if ($scaleCode !== 'MBTI') {
             return [];
         }
 
@@ -633,6 +625,50 @@ class ShareService
         }
 
         return $payload['report'];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolveRiasecSnapshotReport(Attempt $attempt): array
+    {
+        $report = $this->readReadySnapshotReport($attempt);
+        if ($report !== []) {
+            return $report;
+        }
+
+        $this->reportSnapshotStore->createSnapshotForAttempt([
+            'org_id' => (int) ($attempt->org_id ?? 0),
+            'attempt_id' => (string) $attempt->id,
+            'trigger_source' => 'share_surface_sync',
+            'order_no' => null,
+            'org_role' => 'system',
+        ]);
+
+        return $this->readReadySnapshotReport($attempt);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readReadySnapshotReport(Attempt $attempt): array
+    {
+        $snapshot = ReportSnapshot::query()
+            ->where('org_id', (int) ($attempt->org_id ?? 0))
+            ->where('attempt_id', (string) $attempt->id)
+            ->where('status', 'ready')
+            ->first();
+
+        if (! $snapshot instanceof ReportSnapshot) {
+            return [];
+        }
+
+        $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+        if ($report === []) {
+            $report = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+        }
+
+        return $report;
     }
 
     private function resolvePublicProfile(
@@ -1089,9 +1125,16 @@ class ShareService
                 true
             )
             : [];
-        $riasecProjection = $normalizedScaleCode === 'RIASEC'
-            ? $this->riasecPublicProjectionService->buildFromResult($result, $normalizedLocale)
-            : [];
+        $riasecProjection = [];
+        $riasecProjectionV2 = [];
+        if ($normalizedScaleCode === 'RIASEC') {
+            $riasecProjection = is_array(data_get($publicSafeReport, '_meta.riasec_public_projection_v1'))
+                ? data_get($publicSafeReport, '_meta.riasec_public_projection_v1')
+                : $this->riasecPublicProjectionService->buildFromResult($result, $normalizedLocale);
+            $riasecProjectionV2 = is_array(data_get($publicSafeReport, '_meta.riasec_public_projection_v2'))
+                ? data_get($publicSafeReport, '_meta.riasec_public_projection_v2')
+                : [];
+        }
         $summary = $this->buildShareSummary($share, $attempt, $result, $publicSafeReport, $big5Projection, $riasecProjection);
         $resolvedShareId = trim((string) $shareId);
         $locale = (string) ($summary['locale'] ?? 'zh-CN');
@@ -1182,6 +1225,13 @@ class ShareService
             }
         } elseif ($scaleCode === 'RIASEC' && $riasecProjection !== []) {
             $payload['riasec_public_projection_v1'] = $riasecProjection;
+            if ($riasecProjectionV2 !== []) {
+                $payload['riasec_public_projection_v2'] = $riasecProjectionV2;
+            }
+            $snapshotBinding = data_get($publicSafeReport, '_meta.snapshot_binding_v1');
+            if (is_array($snapshotBinding)) {
+                $payload['riasec_snapshot_binding_v1'] = $snapshotBinding;
+            }
         }
 
         $payload['public_surface_v1'] = $this->buildPublicSurfaceContract(

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -244,6 +244,38 @@ final class RiasecAssessmentFlowTest extends TestCase
         $second->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
         $this->assertSame($first->json('report.generated_at'), $second->json('report.generated_at'));
         $this->assertSame(1, DB::table('report_snapshots')->where('attempt_id', $attemptId)->count());
+
+        $share = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+        $share->assertStatus(200);
+        $share->assertJsonPath('type_code', 'RIA');
+        $share->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
+        $share->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
+        $share->assertJsonPath('riasec_snapshot_binding_v1.snapshot_bound', true);
+
+        $history = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/me/attempts?scale=RIASEC');
+        $history->assertStatus(200);
+        $history->assertJsonPath('items.0.type_code', 'RIA');
+        $history->assertJsonPath('items.0.riasec_public_projection_v1.top_code', 'RIA');
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
+        $history->assertJsonPath('items.0.riasec_snapshot_binding_v1.snapshot_bound', true);
+        $history->assertJsonPath('history_compare.current_top_code', 'RIA');
+
+        $pdf = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->get("/api/v0.3/attempts/{$attemptId}/report.pdf?inline=1");
+        $pdf->assertStatus(200);
+        $this->assertSame('riasec.pdf_surface.v1', $pdf->headers->get('X-Pdf-Surface-Version'));
+        $this->assertSame('riasec.report.v1', $pdf->headers->get('X-Report-Schema-Version'));
+        $this->assertSame('riasec.public_projection.v2', $pdf->headers->get('X-Projection-Version'));
+        $this->assertSame('riasec_60', $pdf->headers->get('X-Report-Form-Code'));
+        $this->assertSame('false', $pdf->headers->get('X-Cross-Form-Comparable'));
     }
 
     public function test_riasec_enhanced_140_persists_quality_and_layer_scores(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -523,6 +523,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_snapshot_surface_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Report/Pdf/ReportPdfDocumentService.php',
+            'backend/app/Services/V0_3/Me/MeAttemptsService.php',
+            'backend/app/Services/V0_3/ShareService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -1038,6 +1049,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecSnapshotSurfaceFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -1186,6 +1201,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Report/ReportSnapshotStore.php',
             'backend/app/Services/Report/RiasecReportComposer.php',
             'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+        ], true);
+    }
+
+    private function isRiasecSnapshotSurfaceFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Report/Pdf/ReportPdfDocumentService.php',
+            'backend/app/Services/V0_3/Me/MeAttemptsService.php',
+            'backend/app/Services/V0_3/ShareService.php',
         ], true);
     }
 


### PR DESCRIPTION
## Goal
RIASEC-TRAIN-04 makes public RIASEC share, PDF, and history surfaces read from the formal report snapshot once a snapshot exists, preserving the measured result identity across downstream surfaces.

## What changed
- Share payloads now resolve RIASEC public projection v1/v2 and snapshot binding metadata from a ready report snapshot, creating the snapshot synchronously only when the share surface has no ready snapshot yet.
- History list/compare payloads now use RIASEC snapshot projections and snapshot binding metadata instead of re-deriving the visible result from mutable live result rows.
- PDF metadata now exposes RIASEC snapshot/report/projection/form compatibility headers, with cross-form comparison explicitly disabled.
- Added RIASEC flow coverage proving formal report, share, history, and PDF remain bound to the original snapshot after the live result row is mutated.
- Added Big Five freeze classifier coverage so these RIASEC-only surface files do not trip unrelated MBTI/Big Five runtime freeze gates.

## Scope validation
- No RIASEC scoring math changed.
- No RIASEC content pack question semantics changed.
- No frontend result shell or CMS authority fallback added.
- No career examples, matches, fit scores, rankings, or occupational recommendation logic added.
- No 60Q/140Q raw score delta added.
- No claim that 140Q is more accurate.
- No feedback mutation path added.
- Non-RIASEC share/history/PDF behavior is preserved.

## Validation
- `php -l app/Services/V0_3/ShareService.php app/Services/V0_3/Me/MeAttemptsService.php app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `vendor/bin/pint --test app/Services/V0_3/ShareService.php app/Services/V0_3/Me/MeAttemptsService.php app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecAssessmentFlowTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_snapshot_surface|riasec_snapshot_bound_report|riasec_projection_v2|riasec_measurement_contract'`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ReportPdfCrossScaleDeliveryTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EnneagramPdfMetadataContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EnneagramHistorySummaryTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecCompareGuardContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ReportSnapshotStoreTenantIsolationTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ReportSnapshotStrictModeTest`
- `git diff --check`

## Sidecar issues
- `bash backend/scripts/ci_verify_mbti.sh` passes MBTI/Big Five tests, report/share smoke, and content verification, then fails in the existing local phone OTP acceptance step with `verify did not return token` / `INTERNAL_ERROR`. This is the same non-RIASEC local runbook sidecar observed earlier in the train.
- The full runbook rewrites compiled content-pack artifacts for BIG5/CLINICAL/SDS during verification; those generated diffs were restored and are not included in this PR.

## Deferred
- Technical Note and Method Boundary remain TRAIN-05.
- Trusted 3-minute shell renderer remains TRAIN-06.
- Career Activity Registry examples-only surface remains TRAIN-07.
- V11 CMS governance and fallback guard remain TRAIN-08.
- Exploration Feedback overlay remains TRAIN-09.
- Analytics, fixtures, and broader contract tests remain TRAIN-10.

## Rollback / compatibility
This keeps the existing API envelope and adds RIASEC snapshot metadata to public surfaces. Reverting this PR returns RIASEC share/history/PDF to live-result-derived behavior while leaving TRAIN-01 through TRAIN-03 measurement/projection/report snapshot contracts intact.
