### PR TITLE
RIASEC-TRAIN-05 — Technical Note v0.1 + Method Boundary

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ScalesController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesController.php
@@ -16,6 +16,7 @@ use App\Services\Enneagram\EnneagramFormCatalog;
 use App\Services\Enneagram\EnneagramTechnicalNoteService;
 use App\Services\Mbti\MbtiFormCatalog;
 use App\Services\Riasec\RiasecFormCatalog;
+use App\Services\Riasec\RiasecTechnicalNoteService;
 use App\Services\Scale\PublicScaleInputGuard;
 use App\Services\Scale\ScaleCodeInputGuard;
 use App\Services\Scale\ScaleCodeResponseProjector;
@@ -97,8 +98,12 @@ class ScalesController extends Controller
     /**
      * GET /api/v0.3/scales/{scale_code}/technical-note
      */
-    public function technicalNote(Request $request, string $scale_code, EnneagramTechnicalNoteService $technicalNoteService): JsonResponse
-    {
+    public function technicalNote(
+        Request $request,
+        string $scale_code,
+        EnneagramTechnicalNoteService $enneagramTechnicalNoteService,
+        RiasecTechnicalNoteService $riasecTechnicalNoteService
+    ): JsonResponse {
         $orgId = $this->orgContext->orgId();
         $code = $this->publicInputGuard->normalizeScaleCode($scale_code);
         if ($code === null) {
@@ -120,20 +125,23 @@ class ScalesController extends Controller
         }
 
         $resolvedScaleCode = strtoupper(trim((string) ($row['code'] ?? $code)));
-        if ($resolvedScaleCode !== 'ENNEAGRAM') {
+        if (! in_array($resolvedScaleCode, ['ENNEAGRAM', 'RIASEC'], true)) {
             return response()->json([
                 'ok' => false,
                 'error_code' => 'SCALE_NOT_SUPPORTED',
-                'message' => 'technical note contract is only available for ENNEAGRAM.',
+                'message' => 'technical note contract is only available for ENNEAGRAM or RIASEC.',
             ], 422);
         }
 
         $scaleCodeMeta = $this->buildScaleCodeMeta($code, $row);
+        $contract = $resolvedScaleCode === 'RIASEC'
+            ? $riasecTechnicalNoteService->contract()
+            : $enneagramTechnicalNoteService->contract();
 
         return response()->json(array_merge([
             'ok' => true,
             'scale_code' => $scaleCodeMeta['scale_code'],
-        ], $scaleCodeMeta, $technicalNoteService->contract()));
+        ], $scaleCodeMeta, $contract));
     }
 
     /**

--- a/backend/app/Services/Riasec/RiasecTechnicalNoteService.php
+++ b/backend/app/Services/Riasec/RiasecTechnicalNoteService.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+use Carbon\CarbonImmutable;
+
+final class RiasecTechnicalNoteService
+{
+    public const SCHEMA_VERSION = 'riasec.technical_note.v1';
+
+    public const TECHNICAL_NOTE_VERSION = 'riasec_technical_note.v0.1';
+
+    public const METHOD_BOUNDARY_VERSION = 'riasec.method_boundary.v0.1';
+
+    public function __construct(
+        private readonly RiasecMeasurementContract $measurementContract,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function contract(): array
+    {
+        $standard = $this->measurementContract->forFormCode('riasec_60', 60);
+        $enhanced = $this->measurementContract->forFormCode('riasec_140', 140);
+
+        return [
+            'technical_note_v1' => [
+                'schema_version' => self::SCHEMA_VERSION,
+                'scale_code' => 'RIASEC',
+                'technical_note_version' => self::TECHNICAL_NOTE_VERSION,
+                'measurement_contract_version' => RiasecMeasurementContract::SCHEMA_VERSION,
+                'method_boundary_version' => self::METHOD_BOUNDARY_VERSION,
+                'sections' => $this->sections(),
+                'method_boundaries' => $this->methodBoundaries(),
+                'form_contracts' => [
+                    'riasec_60' => [
+                        'form_code' => 'riasec_60',
+                        'question_count' => 60,
+                        'score_space_version' => data_get($standard, 'form.score_space_version'),
+                        'normalization_method' => data_get($standard, 'scoring.normalization_method'),
+                        'quality_rule_status' => data_get($standard, 'quality.quality_rule_status'),
+                        'low_quality_strength' => data_get($standard, 'quality.low_quality_strength'),
+                        'cross_form_comparable' => false,
+                        'raw_score_delta_allowed' => false,
+                    ],
+                    'riasec_140' => [
+                        'form_code' => 'riasec_140',
+                        'question_count' => 140,
+                        'score_space_version' => data_get($enhanced, 'form.score_space_version'),
+                        'normalization_method' => data_get($enhanced, 'scoring.normalization_method'),
+                        'quality_rule_status' => data_get($enhanced, 'quality.quality_rule_status'),
+                        'low_quality_strength' => data_get($enhanced, 'quality.low_quality_strength'),
+                        'cross_form_comparable' => false,
+                        'raw_score_delta_allowed' => false,
+                    ],
+                ],
+                'data_status_summary' => [
+                    'currently_operational' => [
+                        '60q_scoring_v1',
+                        'projection_v2_minimal',
+                        'score_space_version',
+                        'compare_policy',
+                        'snapshot_bound_report',
+                    ],
+                    'partial' => [
+                        'activity_explorer_v0_1',
+                        'pdf_share_history_snapshot_surfaces',
+                    ],
+                    'not_claimed' => [
+                        'ability',
+                        'personality',
+                        'values',
+                        'career_success_probability',
+                        'job_fit',
+                        'hiring_screening_suitability',
+                        'career_registry_match',
+                        'cross_form_raw_score_delta',
+                    ],
+                ],
+                'disclaimers' => $this->disclaimers(),
+                'generated_at' => CarbonImmutable::now()->toIso8601String(),
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function sections(): array
+    {
+        return [
+            [
+                'section_key' => 'test_goal',
+                'title' => '测试目标',
+                'body' => 'RIASEC 当前用于呈现职业兴趣线索，帮助用户理解自己更容易被哪些工作活动吸引。',
+                'data_status' => 'currently_operational',
+            ],
+            [
+                'section_key' => 'measurement_boundary',
+                'title' => '测量边界',
+                'body' => 'RIASEC 测职业兴趣，不测能力、人格、价值观、雇佣筛选结论或长期职业结果。',
+                'data_status' => 'currently_operational',
+            ],
+            [
+                'section_key' => 'score_space_boundary',
+                'title' => '分数空间',
+                'body' => '60Q 与 140Q 属于同一 RIASEC scale，但使用不同 score_space_version，不默认比较 raw score delta。',
+                'data_status' => 'currently_operational',
+            ],
+            [
+                'section_key' => 'riasec_140_context',
+                'title' => '140Q 边界',
+                'body' => '140Q 可表达更具体的工作日常情境化兴趣线索，但不能被写成更准确答案。',
+                'data_status' => 'currently_operational',
+            ],
+            [
+                'section_key' => 'quality_boundary',
+                'title' => '质量边界',
+                'body' => '60Q 当前只声明最小答题完成规则，不输出强 low_quality 判断。',
+                'data_status' => 'currently_operational',
+            ],
+            [
+                'section_key' => 'snapshot_boundary',
+                'title' => '报告快照',
+                'body' => '正式报告必须绑定生成时的 snapshot，后续 share、PDF、history 应读取同一份可审计结果。',
+                'data_status' => 'currently_operational',
+            ],
+            [
+                'section_key' => 'career_examples_boundary',
+                'title' => '职业例子边界',
+                'body' => '没有 reviewed registry source 时，职业例子只能作为 content_example_not_registry_match 展示，不是职业匹配。',
+                'data_status' => 'partial',
+            ],
+            [
+                'section_key' => 'feedback_boundary',
+                'title' => '反馈边界',
+                'body' => 'Exploration feedback 只能作为后续探索覆盖层，不能改写 measured_holland_code 或 RIASEC 分数。',
+                'data_status' => 'planned',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,array<string,string>>
+     */
+    private function methodBoundaries(): array
+    {
+        return [
+            'career_interest_only' => [
+                'label' => '职业兴趣信号',
+                'copy' => 'RIASEC 输出的是职业兴趣证据，不是能力、人格或价值观结论。',
+                'evidence_level' => 'runtime_contract',
+                'content_maturity' => 'v0.1',
+            ],
+            'not_career_recommendation' => [
+                'label' => '非职业推荐器',
+                'copy' => '结果页不能输出职业推荐、岗位适配评分、职业排名或长期职业结果判断。',
+                'evidence_level' => 'method_boundary',
+                'content_maturity' => 'v0.1',
+            ],
+            'same_scale_not_same_score_space' => [
+                'label' => '同一 scale，不同分数空间',
+                'copy' => 'riasec_60 与 riasec_140 同属 RIASEC，但 raw score space 不同，跨 form raw delta 默认关闭。',
+                'evidence_level' => 'measurement_contract',
+                'content_maturity' => 'v0.1',
+            ],
+            'riasec_140_contextual_not_more_accurate' => [
+                'label' => '140Q 情境化边界',
+                'copy' => '140Q 只能称为工作日常情境化兴趣线索，不能称为更准确答案。',
+                'evidence_level' => 'method_boundary',
+                'content_maturity' => 'v0.1',
+            ],
+            'content_examples_not_registry_match' => [
+                'label' => 'Examples only',
+                'copy' => '没有 reviewed registry source 时，occupation examples 必须标注 content_example_not_registry_match。',
+                'evidence_level' => 'content_boundary',
+                'content_maturity' => 'v0.1',
+            ],
+            'feedback_no_score_mutation' => [
+                'label' => '反馈不改写测量结果',
+                'copy' => '用户反馈只进入探索层，不会覆盖 measured_holland_code、维度分数或正式报告快照。',
+                'evidence_level' => 'method_boundary',
+                'content_maturity' => 'v0.1',
+            ],
+            'snapshot_bound_report' => [
+                'label' => '正式报告快照绑定',
+                'copy' => '正式报告、share、PDF、history 必须以 snapshot-bound report 为展示依据。',
+                'evidence_level' => 'runtime_contract',
+                'content_maturity' => 'v0.1',
+            ],
+            'quality_boundary_60q_minimal' => [
+                'label' => '60Q 质量边界',
+                'copy' => '60Q 当前没有强 low_quality rule，只能声明 minimal_answer_completion_only。',
+                'evidence_level' => 'measurement_contract',
+                'content_maturity' => 'v0.1',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function disclaimers(): array
+    {
+        return [
+            [
+                'key' => 'not_ability_or_personality',
+                'label' => '非能力/人格测量',
+                'copy' => 'RIASEC 不测能力、人格、价值观或长期职业结果。',
+            ],
+            [
+                'key' => 'not_hiring_screening',
+                'label' => '非招聘筛选用途',
+                'copy' => 'RIASEC 不用于招聘、晋升、淘汰或雇佣筛选。',
+            ],
+            [
+                'key' => 'no_cross_form_raw_delta',
+                'label' => '不比较跨 form raw delta',
+                'copy' => '60Q 与 140Q 不默认比较 raw score delta。',
+            ],
+            [
+                'key' => 'riasec_140_not_more_accurate',
+                'label' => '140Q 非更准确声明',
+                'copy' => '140Q 只能作为更具体的情境化兴趣线索。',
+            ],
+            [
+                'key' => 'examples_not_matches',
+                'label' => '职业例子不是匹配',
+                'copy' => '职业例子是内容示例，不是职业数据库匹配或岗位推荐。',
+            ],
+            [
+                'key' => 'feedback_overlay_boundary',
+                'label' => '反馈层边界',
+                'copy' => '反馈不会修改 measured_holland_code、分数或正式报告快照。',
+            ],
+        ];
+    }
+}

--- a/backend/tests/Feature/V0_3/RiasecTechnicalNoteContractTest.php
+++ b/backend/tests/Feature/V0_3/RiasecTechnicalNoteContractTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class RiasecTechnicalNoteContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_technical_note_route_returns_method_boundary_contract(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $response = $this->getJson('/api/v0.3/scales/RIASEC/technical-note');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('scale_code', 'RIASEC');
+        $response->assertJsonPath('technical_note_v1.schema_version', 'riasec.technical_note.v1');
+        $response->assertJsonPath('technical_note_v1.technical_note_version', 'riasec_technical_note.v0.1');
+        $response->assertJsonPath('technical_note_v1.measurement_contract_version', 'riasec.measurement_contract.v1');
+        $response->assertJsonPath('technical_note_v1.method_boundary_version', 'riasec.method_boundary.v0.1');
+        $response->assertJsonPath('technical_note_v1.form_contracts.riasec_60.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $response->assertJsonPath('technical_note_v1.form_contracts.riasec_60.quality_rule_status', 'minimal_answer_completion_only');
+        $response->assertJsonPath('technical_note_v1.form_contracts.riasec_140.score_space_version', 'riasec_140_likert5_activity_context_space.v1');
+        $response->assertJsonPath('technical_note_v1.form_contracts.riasec_140.cross_form_comparable', false);
+        $response->assertJsonPath('technical_note_v1.form_contracts.riasec_140.raw_score_delta_allowed', false);
+        $response->assertJsonPath('technical_note_v1.method_boundaries.same_scale_not_same_score_space.evidence_level', 'measurement_contract');
+        $response->assertJsonPath('technical_note_v1.method_boundaries.content_examples_not_registry_match.content_maturity', 'v0.1');
+
+        $sectionKeys = collect((array) $response->json('technical_note_v1.sections'))
+            ->map(static fn (array $entry): string => (string) ($entry['section_key'] ?? ''))
+            ->sort()
+            ->values()
+            ->all();
+
+        $this->assertSame([
+            'career_examples_boundary',
+            'feedback_boundary',
+            'measurement_boundary',
+            'quality_boundary',
+            'riasec_140_context',
+            'score_space_boundary',
+            'snapshot_boundary',
+            'test_goal',
+        ], $sectionKeys);
+
+        $this->assertContains(
+            'cross_form_raw_score_delta',
+            (array) $response->json('technical_note_v1.data_status_summary.not_claimed')
+        );
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -546,6 +546,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_technical_note_method_boundary_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/ScalesController.php',
+            'backend/app/Services/Riasec/RiasecTechnicalNoteService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -1069,6 +1079,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecTechnicalNoteMethodBoundaryFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -1226,6 +1240,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Report/Pdf/ReportPdfDocumentService.php',
             'backend/app/Services/V0_3/Me/MeAttemptsService.php',
             'backend/app/Services/V0_3/ShareService.php',
+        ], true);
+    }
+
+    private function isRiasecTechnicalNoteMethodBoundaryFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_3/ScalesController.php',
+            'backend/app/Services/Riasec/RiasecTechnicalNoteService.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/Riasec/RiasecTechnicalNoteBoundaryTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecTechnicalNoteBoundaryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Services\Riasec\RiasecTechnicalNoteService;
+use Tests\TestCase;
+
+final class RiasecTechnicalNoteBoundaryTest extends TestCase
+{
+    public function test_technical_note_includes_safe_method_boundaries_without_overclaims(): void
+    {
+        $contract = app(RiasecTechnicalNoteService::class)->contract();
+
+        $disclaimerKeys = collect((array) data_get($contract, 'technical_note_v1.disclaimers', []))
+            ->map(static fn (array $entry): string => (string) ($entry['key'] ?? ''))
+            ->all();
+
+        $this->assertSame([
+            'not_ability_or_personality',
+            'not_hiring_screening',
+            'no_cross_form_raw_delta',
+            'riasec_140_not_more_accurate',
+            'examples_not_matches',
+            'feedback_overlay_boundary',
+        ], $disclaimerKeys);
+
+        $body = collect((array) data_get($contract, 'technical_note_v1.sections', []))
+            ->map(static fn (array $entry): string => (string) ($entry['body'] ?? ''))
+            ->implode("\n");
+        $boundaryCopy = collect((array) data_get($contract, 'technical_note_v1.method_boundaries', []))
+            ->map(static fn (array $entry): string => (string) ($entry['copy'] ?? ''))
+            ->implode("\n");
+        $text = $body."\n".$boundaryCopy;
+
+        $this->assertStringContainsString('不默认比较 raw score delta', $text);
+        $this->assertStringContainsString('不能称为更准确答案', $text);
+        $this->assertStringContainsString('content_example_not_registry_match', $text);
+        $this->assertStringContainsString('不会覆盖 measured_holland_code', $text);
+        $this->assertStringContainsString('minimal_answer_completion_only', $text);
+        $this->assertStringNotContainsString('岗位匹配度', $text);
+        $this->assertStringNotContainsString('职业成功预测', $text);
+        $this->assertStringNotContainsString('更准确答案。140Q', $text);
+
+        $this->assertContains('career_success_probability', (array) data_get($contract, 'technical_note_v1.data_status_summary.not_claimed', []));
+        $this->assertContains('job_fit', (array) data_get($contract, 'technical_note_v1.data_status_summary.not_claimed', []));
+        $this->assertContains('cross_form_raw_score_delta', (array) data_get($contract, 'technical_note_v1.data_status_summary.not_claimed', []));
+    }
+}


### PR DESCRIPTION
## Goal
RIASEC-TRAIN-05 exposes a backend-authoritative RIASEC Technical Note v0.1 and method boundary contract through the existing scale technical-note route.

## What changed
- Added `RiasecTechnicalNoteService` with deterministic `riasec.technical_note.v1` payload.
- Extended `/api/v0.3/scales/{scale_code}/technical-note` to support RIASEC while preserving Enneagram behavior.
- Included 60Q/140Q form contracts derived from the existing RIASEC measurement contract and score-space versions.
- Added method boundary entries for career-interest-only interpretation, non-recommendation, same-scale/different-score-space policy, 140Q contextual boundary, Examples-only occupation policy, feedback no-score-mutation, snapshot-bound reports, and 60Q minimal quality boundary.
- Added route/unit tests for RIASEC technical note safety and Enneagram regression coverage.
- Added Big Five freeze classifier coverage for this RIASEC-only route/service change.

## Scope validation
- No RIASEC scoring math changed.
- No RIASEC content pack question semantics changed.
- No frontend content authority or local fallback added.
- No career registry ingestion, occupation matching, fit scoring, rankings, or recommendation logic added.
- No 60Q/140Q raw score delta added.
- No claim that 140Q is more accurate.
- No feedback mutation path added.
- Enneagram technical-note behavior remains covered by regression tests.

## Validation
- `php -l app/Services/Riasec/RiasecTechnicalNoteService.php app/Http/Controllers/API/V0_3/ScalesController.php tests/Feature/V0_3/RiasecTechnicalNoteContractTest.php tests/Unit/Services/Riasec/RiasecTechnicalNoteBoundaryTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `vendor/bin/pint --test app/Services/Riasec/RiasecTechnicalNoteService.php app/Http/Controllers/API/V0_3/ScalesController.php tests/Feature/V0_3/RiasecTechnicalNoteContractTest.php tests/Unit/Services/Riasec/RiasecTechnicalNoteBoundaryTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecTechnicalNoteContractTest.php tests/Unit/Services/Riasec/RiasecTechnicalNoteBoundaryTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/EnneagramTechnicalNoteContractTest.php tests/Unit/Services/Enneagram/EnneagramTechnicalNoteBoundaryTest.php tests/Unit/Services/Content/EnneagramMethodRegistryBoundaryTest.php tests/Unit/Services/Content/EnneagramTechnicalNoteRegistryContentTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecAssessmentFlowTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecCompareGuardContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_technical_note_method_boundary|riasec_snapshot_surface|riasec_snapshot_bound_report|riasec_projection_v2|riasec_measurement_contract'`
- `git diff --check`

## Sidecar issues
- `bash backend/scripts/ci_verify_mbti.sh` passes MBTI/Big Five tests, report/share smoke, and content verification, then fails in the existing local phone OTP acceptance step with `verify did not return token` / `INTERNAL_ERROR`. This is the same non-RIASEC local runbook sidecar observed earlier in the train.
- The full runbook rewrites compiled BIG5 content-pack artifacts during verification; generated diffs were restored and are not included in this PR.

## Deferred
- Trusted 3-minute result card and six-dimension renderer remain TRAIN-06.
- Career Activity Registry examples-only surface remains TRAIN-07.
- V11 copy CMS governance/fallback guard remains TRAIN-08.
- Exploration Feedback overlay remains TRAIN-09.
- Analytics, fixtures, and broader contract tests remain TRAIN-10.

## Rollback / compatibility
This reuses the existing technical-note route shape and does not alter scoring, report composition, or public projection payloads. Reverting this PR removes only the RIASEC technical-note contract and route support while preserving TRAIN-01 through TRAIN-04 runtime contracts.
