### PR TITLE
feat(api): add career seo geo readiness audit

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessAuditor.php
@@ -1,0 +1,437 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerSeoGeoReadinessAuditor
+{
+    /**
+     * @param  list<mixed>  $planRows
+     * @param  list<string>  $locales
+     * @param  array<string, mixed>|list<array<string, mixed>>  $seoGeo
+     */
+    public function audit(array $planRows, array $locales, array $seoGeo): CareerSeoGeoReadinessResult
+    {
+        $expectedSlugs = $this->expectedSlugs($planRows);
+        $expectedLocales = $this->expectedLocales($locales);
+        $rowsByKey = $this->rowsBySlugLocale($this->artifactRows($seoGeo));
+
+        $rows = [];
+        foreach ($expectedSlugs as $slug) {
+            foreach ($expectedLocales as $locale) {
+                $artifactRow = $rowsByKey[$this->rowKey($slug, $locale)] ?? [];
+                $rows[] = $this->auditExpectedRow($slug, $locale, $artifactRow);
+            }
+        }
+
+        return CareerSeoGeoReadinessResult::build($rows);
+    }
+
+    public function auditPlan(CareerPublicResolutionPlan $plan, array $locales, array $seoGeo): CareerSeoGeoReadinessResult
+    {
+        return $this->audit($plan->rows, $locales, $seoGeo);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array<string, mixed>|list<array<string, mixed>>  $seoGeo
+     */
+    public function auditSlugs(array $slugs, array $locales, array $seoGeo): CareerSeoGeoReadinessResult
+    {
+        return $this->audit($slugs, $locales, $seoGeo);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function auditExpectedRow(string $slug, string $locale, array $row): CareerSeoGeoReadinessRow
+    {
+        $canonicalPath = $this->canonicalPath($row);
+        $canonicalPathSelf = $canonicalPath !== null && $canonicalPath === $this->expectedCanonicalPath($slug, $locale);
+        $canonicalSelf = ($this->boolValue($row, ['canonical_self']) ?? $canonicalPathSelf) && $canonicalPathSelf;
+        $robotsPolicy = $this->normalizeString($row['robots_policy'] ?? $row['robots'] ?? null);
+        $robotsIndexable = $this->boolValue($row, ['robots_indexable', 'index_eligible'])
+            ?? ($robotsPolicy !== null && ! str_contains(strtolower($robotsPolicy), 'noindex'));
+        $sitemapEligible = $this->boolValue($row, ['sitemap_eligible', 'sitemap_live', 'sitemap']);
+        $llmsEligible = $this->boolValue($row, ['llms_eligible', 'llms_live', 'llms']);
+        $llmsFullEligible = $this->boolValue($row, ['llms_full_eligible', 'llms_full_live', 'llms_full']);
+        $structuredDataReady = $this->boolValue($row, ['structured_data_ready', 'structured_metadata_ready'])
+            ?? $this->nonEmptyArrayValue($row, ['structured_data', 'structured_data_json', 'jsonld']);
+        $datasetEligible = $this->boolValue($row, ['dataset_eligible', 'dataset_visible', 'dataset']);
+        $searchEligible = $this->boolValue($row, ['search_eligible', 'search_visible', 'search']);
+        $citationMetadataReady = $this->boolValue($row, ['citation_metadata_ready', 'ai_citation_metadata_ready'])
+            ?? $this->nonEmptyArrayValue($row, ['citation_metadata', 'ai_citation_metadata']);
+
+        $issues = $this->issuesFor(
+            slug: $slug,
+            locale: $locale,
+            canonicalPath: $canonicalPath,
+            canonicalSelf: $canonicalSelf,
+            robotsPolicy: $robotsPolicy,
+            robotsIndexable: $robotsIndexable,
+            sitemapEligible: $sitemapEligible,
+            llmsEligible: $llmsEligible,
+            llmsFullEligible: $llmsFullEligible,
+            structuredDataReady: $structuredDataReady,
+            datasetEligible: $datasetEligible,
+            searchEligible: $searchEligible,
+            citationMetadataReady: $citationMetadataReady,
+        );
+        $evidence = $this->evidenceFor(
+            slug: $slug,
+            locale: $locale,
+            canonicalPath: $canonicalPath,
+            canonicalSelf: $canonicalSelf,
+            robotsPolicy: $robotsPolicy,
+            robotsIndexable: $robotsIndexable,
+            sitemapEligible: $sitemapEligible,
+            llmsEligible: $llmsEligible,
+            llmsFullEligible: $llmsFullEligible,
+            structuredDataReady: $structuredDataReady,
+            datasetEligible: $datasetEligible,
+            searchEligible: $searchEligible,
+            citationMetadataReady: $citationMetadataReady,
+        );
+
+        return new CareerSeoGeoReadinessRow(
+            canonicalSlug: $slug,
+            locale: $locale,
+            canonicalPath: $canonicalPath,
+            canonicalSelf: $canonicalSelf,
+            robotsPolicy: $robotsPolicy,
+            robotsIndexable: $robotsIndexable,
+            sitemapEligible: $sitemapEligible ?? false,
+            llmsEligible: $llmsEligible ?? false,
+            llmsFullEligible: $llmsFullEligible ?? false,
+            structuredDataReady: $structuredDataReady ?? false,
+            datasetEligible: $datasetEligible ?? false,
+            searchEligible: $searchEligible ?? false,
+            citationMetadataReady: $citationMetadataReady ?? false,
+            seoGeoStatus: $this->seoGeoLayerStatus($issues, $evidence),
+            evidence: $evidence,
+            issues: $issues,
+        );
+    }
+
+    /**
+     * @return list<CareerSeoGeoReadinessIssue>
+     */
+    private function issuesFor(
+        string $slug,
+        string $locale,
+        ?string $canonicalPath,
+        bool $canonicalSelf,
+        ?string $robotsPolicy,
+        bool $robotsIndexable,
+        ?bool $sitemapEligible,
+        ?bool $llmsEligible,
+        ?bool $llmsFullEligible,
+        ?bool $structuredDataReady,
+        ?bool $datasetEligible,
+        ?bool $searchEligible,
+        ?bool $citationMetadataReady,
+    ): array {
+        $issues = [];
+        if (! $canonicalSelf) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::CANONICAL_NOT_SELF, 'Canonical path is missing or does not match the expected self path.', ['canonical_path' => $canonicalPath]);
+        }
+        if (! $robotsIndexable) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::ROBOTS_NOINDEX, 'Robots policy or indexability indicates noindex.', ['robots_policy' => $robotsPolicy, 'robots_indexable' => $robotsIndexable]);
+        }
+        if ($sitemapEligible !== true) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::SITEMAP_MISSING, 'Sitemap eligibility is missing or false.', ['sitemap_eligible' => $sitemapEligible]);
+        }
+        if ($llmsEligible !== true) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::LLMS_MISSING, 'LLMS eligibility is missing or false.', ['llms_eligible' => $llmsEligible]);
+        }
+        if ($llmsFullEligible !== true) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::LLMS_FULL_MISSING, 'LLMS-full eligibility is missing or false.', ['llms_full_eligible' => $llmsFullEligible]);
+        }
+        if ($structuredDataReady !== true) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::STRUCTURED_DATA_MISSING, 'Structured metadata readiness is missing or false.', ['structured_data_ready' => $structuredDataReady]);
+        }
+        if ($datasetEligible !== true) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::DATASET_MISSING, 'Dataset eligibility is missing or false.', ['dataset_eligible' => $datasetEligible]);
+        }
+        if ($searchEligible !== true) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::SEARCH_MISSING, 'Search eligibility is missing or false.', ['search_eligible' => $searchEligible]);
+        }
+        if ($citationMetadataReady !== true) {
+            $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::CITATION_METADATA_MISSING, 'AI citation metadata readiness is missing or false.', ['citation_metadata_ready' => $citationMetadataReady]);
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function issue(string $slug, string $locale, string $reason, string $message, array $evidence): CareerSeoGeoReadinessIssue
+    {
+        return new CareerSeoGeoReadinessIssue(
+            reason: $reason,
+            message: $message,
+            severity: CareerCanonicalEligibilitySeverity::HIGH,
+            canonicalSlug: $slug,
+            locale: $locale,
+            evidence: [$evidence],
+        );
+    }
+
+    /**
+     * @param  list<CareerSeoGeoReadinessIssue>  $issues
+     * @param  list<mixed>  $evidence
+     */
+    private function seoGeoLayerStatus(array $issues, array $evidence): CareerCanonicalEligibilityLayerStatus
+    {
+        return new CareerCanonicalEligibilityLayerStatus(
+            layer: CareerCanonicalEligibilityLayer::SEO_GEO,
+            status: $issues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            reasons: array_values(array_unique(array_map(
+                static fn (CareerSeoGeoReadinessIssue $issue): string => $issue->reason,
+                $issues
+            ))),
+            evidence: $evidence,
+            source: 'seo_geo_artifacts',
+        );
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function evidenceFor(
+        string $slug,
+        string $locale,
+        ?string $canonicalPath,
+        bool $canonicalSelf,
+        ?string $robotsPolicy,
+        bool $robotsIndexable,
+        ?bool $sitemapEligible,
+        ?bool $llmsEligible,
+        ?bool $llmsFullEligible,
+        ?bool $structuredDataReady,
+        ?bool $datasetEligible,
+        ?bool $searchEligible,
+        ?bool $citationMetadataReady,
+    ): array {
+        return [
+            ['slug' => $slug, 'locale' => $locale],
+            ['canonical_path' => $canonicalPath, 'canonical_self' => $canonicalSelf],
+            ['robots_policy' => $robotsPolicy, 'robots_indexable' => $robotsIndexable],
+            ['sitemap_eligible' => $sitemapEligible],
+            ['llms_eligible' => $llmsEligible],
+            ['llms_full_eligible' => $llmsFullEligible],
+            ['structured_data_ready' => $structuredDataReady],
+            ['dataset_eligible' => $datasetEligible],
+            ['search_eligible' => $searchEligible],
+            ['citation_metadata_ready' => $citationMetadataReady],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function expectedSlugs(array $planRows): array
+    {
+        $slugs = [];
+        foreach ($planRows as $row) {
+            $slug = $this->slugForPlanRow($row);
+            if ($slug !== null && ! in_array($slug, $slugs, true)) {
+                $slugs[] = $slug;
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return list<string>
+     */
+    private function expectedLocales(array $locales): array
+    {
+        $normalized = [];
+        foreach ($locales as $locale) {
+            $value = $this->normalizeString($locale);
+            if ($value !== null) {
+                $value = strtolower($value);
+                if (! in_array($value, $normalized, true)) {
+                    $normalized[] = $value;
+                }
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>|list<array<string, mixed>>  $artifact
+     * @return list<array<string, mixed>>
+     */
+    private function artifactRows(array $artifact): array
+    {
+        $candidates = [
+            $artifact,
+            $artifact['items'] ?? null,
+            $artifact['rows'] ?? null,
+            $artifact['seo_geo']['items'] ?? null,
+            $artifact['seo_geo']['rows'] ?? null,
+            $artifact['projection']['items'] ?? null,
+            $artifact['truth']['items'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && array_is_list($candidate)) {
+                return array_values(array_filter($candidate, static fn (mixed $row): bool => is_array($row)));
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, array<string, mixed>>
+     */
+    private function rowsBySlugLocale(array $rows): array
+    {
+        $indexed = [];
+        foreach ($rows as $row) {
+            $slug = $this->slugForArrayRow($row);
+            $locale = $this->normalizeString($row['locale'] ?? null);
+            if ($slug === null || $locale === null) {
+                continue;
+            }
+
+            $indexed[$this->rowKey($slug, strtolower($locale))] = $row;
+        }
+
+        return $indexed;
+    }
+
+    private function slugForPlanRow(mixed $row): ?string
+    {
+        if ($row instanceof CareerPublicResolutionPlanRow) {
+            return $this->normalizeSlug($row->canonicalSlug);
+        }
+
+        if (is_string($row)) {
+            return $this->normalizeSlug($row);
+        }
+
+        if (is_array($row)) {
+            return $this->slugForArrayRow($row);
+        }
+
+        if (is_object($row) && property_exists($row, 'canonicalSlug')) {
+            return $this->normalizeSlug($row->canonicalSlug);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function slugForArrayRow(array $row): ?string
+    {
+        return $this->normalizeSlug($row['canonical_slug'] ?? $row['source_slug'] ?? $row['slug'] ?? null);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @param  list<string>  $keys
+     */
+    private function boolValue(array $row, array $keys): ?bool
+    {
+        foreach ($keys as $key) {
+            if (! array_key_exists($key, $row)) {
+                continue;
+            }
+
+            $value = $row[$key];
+            if (is_bool($value)) {
+                return $value;
+            }
+            if (is_int($value)) {
+                return $value === 1;
+            }
+            if (is_string($value)) {
+                $normalized = strtolower(trim($value));
+                if (in_array($normalized, ['1', 'true', 'yes', 'present', 'ready', 'live', 'eligible', 'index,follow'], true)) {
+                    return true;
+                }
+                if (in_array($normalized, ['0', 'false', 'no', 'missing', 'not_ready', 'noindex,follow'], true)) {
+                    return false;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @param  list<string>  $keys
+     */
+    private function nonEmptyArrayValue(array $row, array $keys): ?bool
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $row)) {
+                return is_array($row[$key]) && $row[$key] !== [];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function canonicalPath(array $row): ?string
+    {
+        $path = $this->normalizeString($row['canonical_path'] ?? null);
+        if ($path !== null) {
+            return $path;
+        }
+
+        $url = $this->normalizeString($row['canonical_url'] ?? null);
+        if ($url === null) {
+            return null;
+        }
+
+        $parsedPath = parse_url($url, PHP_URL_PATH);
+
+        return is_string($parsedPath) && trim($parsedPath) !== '' ? $parsedPath : null;
+    }
+
+    private function expectedCanonicalPath(string $slug, string $locale): string
+    {
+        return '/'.$locale.'/career/jobs/'.$slug;
+    }
+
+    private function rowKey(string $slug, string $locale): string
+    {
+        return $slug.'|'.$locale;
+    }
+
+    private function normalizeSlug(mixed $value): ?string
+    {
+        $normalized = $this->normalizeString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessIssue.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSeoGeoReadinessIssue
+{
+    public const CANONICAL_NOT_SELF = 'canonical_not_self';
+
+    public const ROBOTS_NOINDEX = 'robots_noindex';
+
+    public const SITEMAP_MISSING = 'sitemap_missing';
+
+    public const LLMS_MISSING = 'llms_missing';
+
+    public const LLMS_FULL_MISSING = 'llms_full_missing';
+
+    public const STRUCTURED_DATA_MISSING = 'structured_data_missing';
+
+    public const DATASET_MISSING = 'dataset_missing';
+
+    public const SEARCH_MISSING = 'search_missing';
+
+    public const CITATION_METADATA_MISSING = 'citation_metadata_missing';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::MEDIUM,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $locale = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->locale !== null) {
+            self::assertNonEmptyString($this->locale, 'locale');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::CANONICAL_NOT_SELF,
+            self::ROBOTS_NOINDEX,
+            self::SITEMAP_MISSING,
+            self::LLMS_MISSING,
+            self::LLMS_FULL_MISSING,
+            self::STRUCTURED_DATA_MISSING,
+            self::DATASET_MISSING,
+            self::SEARCH_MISSING,
+            self::CITATION_METADATA_MISSING,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career SEO/GEO readiness issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, canonical_slug: string|null, locale: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career SEO/GEO readiness issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career SEO/GEO readiness issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessResult.php
+++ b/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessResult.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSeoGeoReadinessResult
+{
+    /**
+     * @param  list<CareerSeoGeoReadinessRow>  $rows
+     * @param  list<CareerSeoGeoReadinessIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly int $expectedRows,
+        public readonly int $readyRows,
+        public readonly int $blockedRows,
+        public readonly int $sitemapMissingRows,
+        public readonly int $llmsMissingRows,
+        public readonly int $llmsFullMissingRows,
+        public readonly int $structuredDataMissingRows,
+        public readonly int $datasetMissingRows,
+        public readonly int $searchMissingRows,
+        public readonly int $citationMetadataMissingRows,
+        public readonly array $rows,
+        public readonly array $issues = [],
+        public readonly array $sidecars = [],
+    ) {
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        foreach ([
+            'expected_rows' => $this->expectedRows,
+            'ready_rows' => $this->readyRows,
+            'blocked_rows' => $this->blockedRows,
+            'sitemap_missing_rows' => $this->sitemapMissingRows,
+            'llms_missing_rows' => $this->llmsMissingRows,
+            'llms_full_missing_rows' => $this->llmsFullMissingRows,
+            'structured_data_missing_rows' => $this->structuredDataMissingRows,
+            'dataset_missing_rows' => $this->datasetMissingRows,
+            'search_missing_rows' => $this->searchMissingRows,
+            'citation_metadata_missing_rows' => $this->citationMetadataMissingRows,
+        ] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career SEO/GEO readiness [%s] must be non-negative.', $key));
+            }
+        }
+
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+        self::assertSidecars($this->sidecars);
+    }
+
+    /**
+     * @param  list<CareerSeoGeoReadinessRow>  $rows
+     * @param  list<CareerSeoGeoReadinessIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public static function build(array $rows, array $issues = [], array $sidecars = []): self
+    {
+        $allIssues = [
+            ...$issues,
+            ...array_values(array_merge(...array_map(
+                static fn (CareerSeoGeoReadinessRow $row): array => $row->issues,
+                $rows
+            ))),
+        ];
+
+        return new self(
+            status: $allIssues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            expectedRows: count($rows),
+            readyRows: count(array_filter($rows, static fn (CareerSeoGeoReadinessRow $row): bool => $row->issues === [])),
+            blockedRows: count(array_filter($rows, static fn (CareerSeoGeoReadinessRow $row): bool => $row->issues !== [])),
+            sitemapMissingRows: self::countRowsWithReason($rows, CareerSeoGeoReadinessIssue::SITEMAP_MISSING),
+            llmsMissingRows: self::countRowsWithReason($rows, CareerSeoGeoReadinessIssue::LLMS_MISSING),
+            llmsFullMissingRows: self::countRowsWithReason($rows, CareerSeoGeoReadinessIssue::LLMS_FULL_MISSING),
+            structuredDataMissingRows: self::countRowsWithReason($rows, CareerSeoGeoReadinessIssue::STRUCTURED_DATA_MISSING),
+            datasetMissingRows: self::countRowsWithReason($rows, CareerSeoGeoReadinessIssue::DATASET_MISSING),
+            searchMissingRows: self::countRowsWithReason($rows, CareerSeoGeoReadinessIssue::SEARCH_MISSING),
+            citationMetadataMissingRows: self::countRowsWithReason($rows, CareerSeoGeoReadinessIssue::CITATION_METADATA_MISSING),
+            rows: $rows,
+            issues: $allIssues,
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, expected_rows: int, ready_rows: int, blocked_rows: int, sitemap_missing_rows: int, llms_missing_rows: int, llms_full_missing_rows: int, structured_data_missing_rows: int, dataset_missing_rows: int, search_missing_rows: int, citation_metadata_missing_rows: int, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'expected_rows' => $this->expectedRows,
+            'ready_rows' => $this->readyRows,
+            'blocked_rows' => $this->blockedRows,
+            'sitemap_missing_rows' => $this->sitemapMissingRows,
+            'llms_missing_rows' => $this->llmsMissingRows,
+            'llms_full_missing_rows' => $this->llmsFullMissingRows,
+            'structured_data_missing_rows' => $this->structuredDataMissingRows,
+            'dataset_missing_rows' => $this->datasetMissingRows,
+            'search_missing_rows' => $this->searchMissingRows,
+            'citation_metadata_missing_rows' => $this->citationMetadataMissingRows,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerSeoGeoReadinessRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerSeoGeoReadinessIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerSeoGeoReadinessRow>  $rows
+     */
+    private static function countRowsWithReason(array $rows, string $reason): int
+    {
+        return count(array_filter($rows, static function (CareerSeoGeoReadinessRow $row) use ($reason): bool {
+            foreach ($row->issues as $issue) {
+                if ($issue->reason === $reason) {
+                    return true;
+                }
+            }
+
+            return false;
+        }));
+    }
+
+    /**
+     * @param  list<CareerSeoGeoReadinessRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career SEO/GEO readiness rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerSeoGeoReadinessRow) {
+                throw new InvalidArgumentException('Career SEO/GEO readiness rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerSeoGeoReadinessIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career SEO/GEO readiness issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerSeoGeoReadinessIssue) {
+                throw new InvalidArgumentException('Career SEO/GEO readiness issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career SEO/GEO readiness sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career SEO/GEO readiness sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessRow.php
+++ b/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessRow.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSeoGeoReadinessRow
+{
+    /**
+     * @param  list<mixed>  $evidence
+     * @param  list<CareerSeoGeoReadinessIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $locale,
+        public readonly ?string $canonicalPath,
+        public readonly bool $canonicalSelf,
+        public readonly ?string $robotsPolicy,
+        public readonly bool $robotsIndexable,
+        public readonly bool $sitemapEligible,
+        public readonly bool $llmsEligible,
+        public readonly bool $llmsFullEligible,
+        public readonly bool $structuredDataReady,
+        public readonly bool $datasetEligible,
+        public readonly bool $searchEligible,
+        public readonly bool $citationMetadataReady,
+        public readonly CareerCanonicalEligibilityLayerStatus $seoGeoStatus,
+        public readonly array $evidence = [],
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertNonEmptyString($this->locale, 'locale');
+        self::assertList($this->evidence, 'evidence');
+
+        foreach (['canonical_path' => $this->canonicalPath, 'robots_policy' => $this->robotsPolicy] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+
+        if (! array_is_list($this->issues)) {
+            throw new InvalidArgumentException('Career SEO/GEO readiness row issues must be a list.');
+        }
+
+        foreach ($this->issues as $issue) {
+            if (! $issue instanceof CareerSeoGeoReadinessIssue) {
+                throw new InvalidArgumentException('Career SEO/GEO readiness row issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, locale: string, canonical_path: string|null, canonical_self: bool, robots_policy: string|null, robots_indexable: bool, sitemap_eligible: bool, llms_eligible: bool, llms_full_eligible: bool, structured_data_ready: bool, dataset_eligible: bool, search_eligible: bool, citation_metadata_ready: bool, seo_geo_status: array<string, mixed>, evidence: list<mixed>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'canonical_path' => $this->canonicalPath,
+            'canonical_self' => $this->canonicalSelf,
+            'robots_policy' => $this->robotsPolicy,
+            'robots_indexable' => $this->robotsIndexable,
+            'sitemap_eligible' => $this->sitemapEligible,
+            'llms_eligible' => $this->llmsEligible,
+            'llms_full_eligible' => $this->llmsFullEligible,
+            'structured_data_ready' => $this->structuredDataReady,
+            'dataset_eligible' => $this->datasetEligible,
+            'search_eligible' => $this->searchEligible,
+            'citation_metadata_ready' => $this->citationMetadataReady,
+            'seo_geo_status' => $this->seoGeoStatus->toArray(),
+            'evidence' => $this->evidence,
+            'issues' => array_map(
+                static fn (CareerSeoGeoReadinessIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career SEO/GEO readiness row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career SEO/GEO readiness row [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/docs/career/audits/seo_geo_readiness_audit.md
+++ b/backend/docs/career/audits/seo_geo_readiness_audit.md
@@ -1,0 +1,85 @@
+# Career SEO/GEO Readiness Audit
+
+AUDIT-7 adds a read-only static SEO/GEO readiness layer for the Career 2786 canonical eligibility audit train. It consumes backend artifact arrays and checks whether expected public-resolution rows carry the static signals needed for search, sitemap, LLMS, dataset/search, structured metadata, and AI citation readiness.
+
+AUDIT-7 does not fetch live HTML, modify fap-web, deploy, mutate DB state, apply rollout, backfill data, or implement the full `career:audit-canonical-eligibility` command.
+
+## Inputs
+
+The auditor accepts:
+
+- AUDIT-2 normalized plan rows, array rows, or slug lists
+- expected locales such as `["en", "zh"]`
+- backend artifact arrays with rows under `items`, `rows`, `seo_geo.items`, `seo_geo.rows`, `projection.items`, or `truth.items`
+
+Rows are matched by lowercase `slug` or `canonical_slug` plus lowercase `locale`. Tests use synthetic rows only.
+
+## Checks
+
+For each expected slug and locale, AUDIT-7 checks:
+
+- canonical self path
+- robots indexability
+- sitemap eligibility
+- LLMS eligibility
+- LLMS-full eligibility
+- structured metadata readiness
+- dataset eligibility
+- search eligibility
+- AI citation metadata readiness
+
+The canonical self path defaults to `/{locale}/career/jobs/{slug}`. The auditor can derive a path from `canonical_url` when `canonical_path` is not supplied.
+
+## Issue Reasons
+
+- `canonical_not_self`
+- `robots_noindex`
+- `sitemap_missing`
+- `llms_missing`
+- `llms_full_missing`
+- `structured_data_missing`
+- `dataset_missing`
+- `search_missing`
+- `citation_metadata_missing`
+
+## AUDIT-1 Layer Status
+
+Each row emits an AUDIT-1-compatible `seo_geo` layer status:
+
+```json
+{
+  "layer": "seo_geo",
+  "status": "pass",
+  "reasons": [],
+  "evidence": [
+    {
+      "slug": "actuaries",
+      "locale": "en"
+    },
+    {
+      "canonical_path": "/en/career/jobs/actuaries",
+      "canonical_self": true
+    }
+  ],
+  "source": "seo_geo_artifacts"
+}
+```
+
+Blocked rows use `status=blocked` and include the static readiness reason codes.
+
+## Non-Goals
+
+AUDIT-7 does not:
+
+- inspect live HTML
+- call fap-web
+- deploy
+- mutate DB or runtime state
+- run rollout apply/backfill/rollback/quarantine
+- audit API/live surfaces
+- generate expansion manifests
+- claim 2786 readiness
+
+## Consumption By AUDIT-8+
+
+AUDIT-8 should consume AUDIT-7 output as the static SEO/GEO prerequisite before API or optional live HTML surface checks. Missing SEO/GEO signals should remain distinct from surface mismatches so future reports can distinguish backend static readiness from runtime surface rendering.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerSeoGeoReadinessAuditorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerSeoGeoReadinessAuditorTest.php
@@ -1,0 +1,390 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerPublicResolutionPlan;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
+use App\Domain\Career\Audit\CareerSeoGeoReadinessAuditor;
+use App\Domain\Career\Audit\CareerSeoGeoReadinessIssue;
+use PHPUnit\Framework\TestCase;
+
+final class CareerSeoGeoReadinessAuditorTest extends TestCase
+{
+    public function test_canonical_self_and_static_seo_geo_readiness_pass(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            seoGeo: $this->artifact([$this->row('actuaries', 'en')]),
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(1, $result->readyRows);
+        $this->assertSame(CareerCanonicalEligibilityLayer::SEO_GEO, $result->rows[0]->seoGeoStatus->layer);
+    }
+
+    public function test_canonical_not_self_is_reported(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([
+            $this->row('actuaries', 'en', ['canonical_path' => '/en/career/jobs/actors']),
+        ]));
+
+        $this->assertSame(CareerSeoGeoReadinessIssue::CANONICAL_NOT_SELF, $result->issues[0]->reason);
+    }
+
+    public function test_robots_noindex_is_reported(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([
+            $this->row('actuaries', 'en', ['robots_policy' => 'noindex,follow', 'robots_indexable' => false]),
+        ]));
+
+        $this->assertSame(CareerSeoGeoReadinessIssue::ROBOTS_NOINDEX, $result->issues[0]->reason);
+    }
+
+    public function test_sitemap_llms_and_llms_full_missing_are_reported(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([
+            $this->row('actuaries', 'en', [
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ]),
+        ]));
+
+        $this->assertSame([
+            CareerSeoGeoReadinessIssue::LLMS_FULL_MISSING => 1,
+            CareerSeoGeoReadinessIssue::LLMS_MISSING => 1,
+            CareerSeoGeoReadinessIssue::SITEMAP_MISSING => 1,
+        ], $result->byReason());
+        $this->assertSame(1, $result->sitemapMissingRows);
+        $this->assertSame(1, $result->llmsMissingRows);
+        $this->assertSame(1, $result->llmsFullMissingRows);
+    }
+
+    public function test_structured_data_dataset_search_and_citation_missing_are_reported(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([
+            $this->row('actuaries', 'en', [
+                'structured_data_ready' => false,
+                'dataset_eligible' => false,
+                'search_eligible' => false,
+                'citation_metadata_ready' => false,
+            ]),
+        ]));
+
+        $this->assertSame([
+            CareerSeoGeoReadinessIssue::CITATION_METADATA_MISSING => 1,
+            CareerSeoGeoReadinessIssue::DATASET_MISSING => 1,
+            CareerSeoGeoReadinessIssue::SEARCH_MISSING => 1,
+            CareerSeoGeoReadinessIssue::STRUCTURED_DATA_MISSING => 1,
+        ], $result->byReason());
+    }
+
+    public function test_missing_artifact_row_reports_all_static_readiness_issues(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([]));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(9, count($result->issues));
+    }
+
+    public function test_audit_plan_consumes_public_resolution_plan_rows(): void
+    {
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: '__fixture__',
+            checksum: null,
+            rows: [CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'actuaries'])],
+        );
+
+        $result = $this->auditor()->auditPlan($plan, ['en'], $this->artifact([$this->row('actuaries', 'en')]));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame('actuaries', $result->rows[0]->canonicalSlug);
+    }
+
+    public function test_row_to_array_is_stable(): void
+    {
+        $row = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([$this->row('actuaries', 'en')]))->rows[0]->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "canonical_slug": "actuaries",
+    "locale": "en",
+    "canonical_path": "/en/career/jobs/actuaries",
+    "canonical_self": true,
+    "robots_policy": "index,follow",
+    "robots_indexable": true,
+    "sitemap_eligible": true,
+    "llms_eligible": true,
+    "llms_full_eligible": true,
+    "structured_data_ready": true,
+    "dataset_eligible": true,
+    "search_eligible": true,
+    "citation_metadata_ready": true,
+    "seo_geo_status": {
+        "layer": "seo_geo",
+        "status": "pass",
+        "reasons": [],
+        "evidence": [
+            {
+                "slug": "actuaries",
+                "locale": "en"
+            },
+            {
+                "canonical_path": "/en/career/jobs/actuaries",
+                "canonical_self": true
+            },
+            {
+                "robots_policy": "index,follow",
+                "robots_indexable": true
+            },
+            {
+                "sitemap_eligible": true
+            },
+            {
+                "llms_eligible": true
+            },
+            {
+                "llms_full_eligible": true
+            },
+            {
+                "structured_data_ready": true
+            },
+            {
+                "dataset_eligible": true
+            },
+            {
+                "search_eligible": true
+            },
+            {
+                "citation_metadata_ready": true
+            }
+        ],
+        "source": "seo_geo_artifacts"
+    },
+    "evidence": [
+        {
+            "slug": "actuaries",
+            "locale": "en"
+        },
+        {
+            "canonical_path": "/en/career/jobs/actuaries",
+            "canonical_self": true
+        },
+        {
+            "robots_policy": "index,follow",
+            "robots_indexable": true
+        },
+        {
+            "sitemap_eligible": true
+        },
+        {
+            "llms_eligible": true
+        },
+        {
+            "llms_full_eligible": true
+        },
+        {
+            "structured_data_ready": true
+        },
+        {
+            "dataset_eligible": true
+        },
+        {
+            "search_eligible": true
+        },
+        {
+            "citation_metadata_ready": true
+        }
+    ],
+    "issues": []
+}
+JSON,
+            json_encode($row, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([$this->row('actuaries', 'en')]))->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "expected_rows": 1,
+    "ready_rows": 1,
+    "blocked_rows": 0,
+    "sitemap_missing_rows": 0,
+    "llms_missing_rows": 0,
+    "llms_full_missing_rows": 0,
+    "structured_data_missing_rows": 0,
+    "dataset_missing_rows": 0,
+    "search_missing_rows": 0,
+    "citation_metadata_missing_rows": 0,
+    "by_reason": [],
+    "rows": [
+        {
+            "canonical_slug": "actuaries",
+            "locale": "en",
+            "canonical_path": "/en/career/jobs/actuaries",
+            "canonical_self": true,
+            "robots_policy": "index,follow",
+            "robots_indexable": true,
+            "sitemap_eligible": true,
+            "llms_eligible": true,
+            "llms_full_eligible": true,
+            "structured_data_ready": true,
+            "dataset_eligible": true,
+            "search_eligible": true,
+            "citation_metadata_ready": true,
+            "seo_geo_status": {
+                "layer": "seo_geo",
+                "status": "pass",
+                "reasons": [],
+                "evidence": [
+                    {
+                        "slug": "actuaries",
+                        "locale": "en"
+                    },
+                    {
+                        "canonical_path": "/en/career/jobs/actuaries",
+                        "canonical_self": true
+                    },
+                    {
+                        "robots_policy": "index,follow",
+                        "robots_indexable": true
+                    },
+                    {
+                        "sitemap_eligible": true
+                    },
+                    {
+                        "llms_eligible": true
+                    },
+                    {
+                        "llms_full_eligible": true
+                    },
+                    {
+                        "structured_data_ready": true
+                    },
+                    {
+                        "dataset_eligible": true
+                    },
+                    {
+                        "search_eligible": true
+                    },
+                    {
+                        "citation_metadata_ready": true
+                    }
+                ],
+                "source": "seo_geo_artifacts"
+            },
+            "evidence": [
+                {
+                    "slug": "actuaries",
+                    "locale": "en"
+                },
+                {
+                    "canonical_path": "/en/career/jobs/actuaries",
+                    "canonical_self": true
+                },
+                {
+                    "robots_policy": "index,follow",
+                    "robots_indexable": true
+                },
+                {
+                    "sitemap_eligible": true
+                },
+                {
+                    "llms_eligible": true
+                },
+                {
+                    "llms_full_eligible": true
+                },
+                {
+                    "structured_data_ready": true
+                },
+                {
+                    "dataset_eligible": true
+                },
+                {
+                    "search_eligible": true
+                },
+                {
+                    "citation_metadata_ready": true
+                }
+            ],
+            "issues": []
+        }
+    ],
+    "issues": [],
+    "sidecars": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_seo_geo_layer_status_blocks_when_readiness_fails(): void
+    {
+        $status = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([
+            $this->row('actuaries', 'en', ['robots_indexable' => false]),
+        ]))->rows[0]->seoGeoStatus;
+
+        $this->assertSame(CareerCanonicalEligibilityLayer::SEO_GEO, $status->layer);
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $status->status);
+        $this->assertContains(CareerSeoGeoReadinessIssue::ROBOTS_NOINDEX, $status->reasons);
+    }
+
+    public function test_no_db_mutation_or_live_html_fetch(): void
+    {
+        $result = $this->auditor()->auditSlugs(['actuaries'], ['en'], $this->artifact([$this->row('actuaries', 'en')]));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+    }
+
+    private function auditor(): CareerSeoGeoReadinessAuditor
+    {
+        return new CareerSeoGeoReadinessAuditor;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function artifact(array $items): array
+    {
+        return [
+            'seo_geo_kind' => 'career_static_seo_geo_readiness',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function row(string $slug, string $locale, array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => $slug,
+            'locale' => $locale,
+            'canonical_path' => '/'.$locale.'/career/jobs/'.$slug,
+            'canonical_self' => true,
+            'robots_policy' => 'index,follow',
+            'robots_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'llms_full_eligible' => true,
+            'structured_data_ready' => true,
+            'dataset_eligible' => true,
+            'search_eligible' => true,
+            'citation_metadata_ready' => true,
+        ], $overrides);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -329,6 +329,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_seo_geo_readiness_audit_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessIssue.php',
+            'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessResult.php',
+            'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -1002,6 +1014,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerSeoGeoReadinessAuditFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1375,6 +1391,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityIssue.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityRow.php',
+        ], true);
+    }
+
+    private function isCareerSeoGeoReadinessAuditFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessIssue.php',
+            'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessResult.php',
+            'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1496,6 +1496,101 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-7": {
+      "repo": "fap-api",
+      "branch": "fix/career-seo-geo-readiness-audit7",
+      "title": "feat(api): add career seo geo readiness audit",
+      "name": "Career SEO/GEO Readiness Audit",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-6"
+      ],
+      "scope_type": "seo_geo_readiness_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no audit command",
+        "no surface audit",
+        "no live HTML fetch",
+        "no rollout",
+        "no apply",
+        "no backfill",
+        "no DB mutation",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuous autonomous execution of remaining Career 2786 canonical eligibility audit PR train items."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-6 merged as PR #1324 with merge commit d847a6bf7899389ec591e63e8e0de8d6209d38f2 and local main was synced before AUDIT-7 branch creation."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Unit/Domain/Career/Audit, backend/docs/career/audits, the test-only BigFive freeze classifier allowlist, and docs/codex train files."
+        },
+        "seo_geo_readiness_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi",
+          "evidence": "11 tests passed, 20 assertions."
+        },
+        "runtime_projection_truth_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi",
+          "evidence": "16 tests passed, 35 assertions."
+        },
+        "occupation_entity_inventory_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi",
+          "evidence": "13 tests passed, 45 assertions."
+        },
+        "index_state_authority_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi",
+          "evidence": "12 tests passed, 28 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_allowlist_fix": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-7 CareerSeoGeoReadiness* files to the test-only freeze classifier allowlist; the runtime path gate passes locally."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3093 files checked."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-8 Surface readiness audit",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -723,3 +723,46 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-7
+    repo: fap-api
+    depends_on:
+      - AUDIT-6
+    branch: fix/career-seo-geo-readiness-audit7
+    title: "feat(api): add career seo geo readiness audit"
+    name: "Career SEO/GEO Readiness Audit"
+    scope_type: seo_geo_readiness_only
+    scope:
+      - Add a read-only static SEO/GEO readiness auditor for canonical slugs from AUDIT-2 plan rows or slug lists.
+      - Consume synthetic or backend artifact arrays for canonical self path, robots indexability, sitemap, LLMS, LLMS-full, structured metadata, dataset, search, and citation metadata readiness.
+      - Emit AUDIT-1-compatible seo_geo layer statuses.
+      - Document AUDIT-7 SEO/GEO readiness contract and future AUDIT-8+ consumption policy.
+      - Add focused tests proving stable JSON, read-only behavior, no live HTML fetch, and no DB mutation.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-7 SEO/GEO audit files.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add a career canonical eligibility audit command.
+      - Add surface audit or live HTML fetch.
+      - Add rollout/apply/backfill behavior.
+      - Modify fap-web.
+      - Mutate DB or production data.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-8 Surface readiness audit"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds AUDIT-7 static SEO/GEO readiness auditor and DTOs under Career Audit.
- Emits AUDIT-1-compatible seo_geo layer statuses from synthetic or backend artifact arrays.
- Checks canonical self, robots indexability, sitemap, LLMS, LLMS-full, structured metadata, dataset/search, and citation metadata readiness.
- Updates AUDIT-7 docs plus PR train manifest/state.

## Guardrails
- SEO/GEO readiness only.
- No DB mutation.
- No production commands.
- No audit command yet.
- No surface audit or live HTML fetch.
- No rollout/apply/backfill.
- Uses synthetic artifacts in tests.
- Next PR is AUDIT-8 Surface readiness audit.

## Validation
- php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
- php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
- php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
- php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi
- vendor/bin/pint --test
- git diff --check
- jq empty docs/codex/pr-train-state.json
- ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'\n\n## Check protocol\nPending checks are wait/poll state, not blockers. Failed checks require inspect/classify/fix or sidecar before stopping.