### PR TITLE
feat(api): add career surface readiness audit

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerSurfaceReadinessAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceReadinessAuditor.php
@@ -1,0 +1,401 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerSurfaceReadinessAuditor
+{
+    /**
+     * @param  list<mixed>  $planRows
+     * @param  list<string>  $locales
+     * @param  array<string, mixed>|list<array<string, mixed>>  $apiArtifact
+     * @param  array<string, string>|null  $liveHtmlByKey
+     */
+    public function audit(
+        array $planRows,
+        array $locales,
+        array $apiArtifact,
+        bool $includeLiveHtml = false,
+        ?string $baseUrl = null,
+        ?array $liveHtmlByKey = null,
+    ): CareerSurfaceReadinessResult {
+        $apiRows = $this->rowsBySlugLocale($this->artifactRows($apiArtifact));
+        $rows = [];
+
+        foreach ($this->expectedSlugs($planRows) as $slug) {
+            foreach ($this->expectedLocales($locales) as $locale) {
+                $key = $this->rowKey($slug, $locale);
+                $rows[] = $this->auditExpectedRow(
+                    slug: $slug,
+                    locale: $locale,
+                    apiRow: $apiRows[$key] ?? [],
+                    includeLiveHtml: $includeLiveHtml,
+                    baseUrl: $baseUrl,
+                    liveHtml: $liveHtmlByKey[$key] ?? null,
+                );
+            }
+        }
+
+        return CareerSurfaceReadinessResult::build($rows);
+    }
+
+    public function auditPlan(
+        CareerPublicResolutionPlan $plan,
+        array $locales,
+        array $apiArtifact,
+        bool $includeLiveHtml = false,
+        ?string $baseUrl = null,
+        ?array $liveHtmlByKey = null,
+    ): CareerSurfaceReadinessResult {
+        return $this->audit($plan->rows, $locales, $apiArtifact, $includeLiveHtml, $baseUrl, $liveHtmlByKey);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    public function auditSlugs(
+        array $slugs,
+        array $locales,
+        array $apiArtifact,
+        bool $includeLiveHtml = false,
+        ?string $baseUrl = null,
+        ?array $liveHtmlByKey = null,
+    ): CareerSurfaceReadinessResult {
+        return $this->audit($slugs, $locales, $apiArtifact, $includeLiveHtml, $baseUrl, $liveHtmlByKey);
+    }
+
+    /**
+     * @param  array<string, mixed>  $apiRow
+     */
+    private function auditExpectedRow(
+        string $slug,
+        string $locale,
+        array $apiRow,
+        bool $includeLiveHtml,
+        ?string $baseUrl,
+        ?string $liveHtml,
+    ): CareerSurfaceReadinessRow {
+        $expectedPath = $this->expectedCanonicalPath($slug, $locale);
+        $apiCanonicalPath = $this->canonicalPath($apiRow);
+        $apiIndexable = $this->apiIndexable($apiRow);
+        $live = $includeLiveHtml && $baseUrl !== null && $liveHtml !== null
+            ? $this->parseLiveHtml($liveHtml)
+            : null;
+        $liveCanonicalPath = $live['canonical_path'] ?? null;
+        $liveRobotsPolicy = $live['robots_policy'] ?? null;
+        $ctaPresent = $live['cta_present'] ?? null;
+        $issues = $this->issuesFor(
+            slug: $slug,
+            locale: $locale,
+            expectedPath: $expectedPath,
+            apiCanonicalPath: $apiCanonicalPath,
+            apiIndexable: $apiIndexable,
+            includeLiveHtml: $includeLiveHtml,
+            baseUrl: $baseUrl,
+            liveHtml: $liveHtml,
+            liveCanonicalPath: $liveCanonicalPath,
+            liveRobotsPolicy: $liveRobotsPolicy,
+            ctaPresent: $ctaPresent,
+        );
+        $status = $this->surfaceLayerStatus(
+            issues: $issues,
+            evidence: $this->evidenceFor($slug, $locale, $apiCanonicalPath, $apiIndexable, $includeLiveHtml, $liveCanonicalPath, $liveRobotsPolicy, $ctaPresent),
+            unverified: $includeLiveHtml && ($baseUrl === null || $liveHtml === null),
+        );
+
+        return new CareerSurfaceReadinessRow(
+            canonicalSlug: $slug,
+            locale: $locale,
+            apiCanonicalPath: $apiCanonicalPath,
+            apiIndexable: $apiIndexable,
+            liveHtmlRequested: $includeLiveHtml,
+            liveHtmlVerified: $live !== null,
+            liveCanonicalPath: $liveCanonicalPath,
+            liveRobotsPolicy: $liveRobotsPolicy,
+            ctaPresent: $ctaPresent,
+            surfaceStatus: $status,
+            evidence: $status->evidence,
+            issues: $issues,
+        );
+    }
+
+    /**
+     * @return list<CareerSurfaceReadinessIssue>
+     */
+    private function issuesFor(
+        string $slug,
+        string $locale,
+        string $expectedPath,
+        ?string $apiCanonicalPath,
+        bool $apiIndexable,
+        bool $includeLiveHtml,
+        ?string $baseUrl,
+        ?string $liveHtml,
+        ?string $liveCanonicalPath,
+        ?string $liveRobotsPolicy,
+        ?bool $ctaPresent,
+    ): array {
+        $issues = [];
+        if ($apiCanonicalPath !== $expectedPath) {
+            $issues[] = $this->issue($slug, $locale, CareerSurfaceReadinessIssue::API_CANONICAL_NOT_SELF, 'API canonical path is missing or does not match expected self path.', ['api_canonical_path' => $apiCanonicalPath, 'expected_path' => $expectedPath]);
+        }
+        if (! $apiIndexable) {
+            $issues[] = $this->issue($slug, $locale, CareerSurfaceReadinessIssue::API_NOINDEX_PRESENT, 'API surface reports noindex or non-indexable state.', ['api_indexable' => false]);
+        }
+
+        if (! $includeLiveHtml) {
+            return $issues;
+        }
+
+        if ($baseUrl === null) {
+            $issues[] = $this->issue($slug, $locale, CareerSurfaceReadinessIssue::VALIDATOR_CONTEXT_MISSING, 'Live HTML validation was requested without a base URL.', ['base_url' => null]);
+
+            return $issues;
+        }
+        if ($liveHtml === null) {
+            $issues[] = $this->issue($slug, $locale, CareerSurfaceReadinessIssue::SURFACE_VERIFIER_MISSING, 'Live HTML validation was requested but no verifier HTML was supplied.', ['base_url' => $baseUrl]);
+
+            return $issues;
+        }
+
+        if ($liveCanonicalPath !== $expectedPath) {
+            $issues[] = $this->issue($slug, $locale, CareerSurfaceReadinessIssue::LIVE_CANONICAL_NOT_SELF, 'Live canonical path is missing or does not match expected self path.', ['live_canonical_path' => $liveCanonicalPath, 'expected_path' => $expectedPath]);
+        }
+        if ($liveRobotsPolicy !== null && str_contains(strtolower($liveRobotsPolicy), 'noindex')) {
+            $issues[] = $this->issue($slug, $locale, CareerSurfaceReadinessIssue::LIVE_NOINDEX_PRESENT, 'Live HTML contains a noindex robots directive.', ['live_robots_policy' => $liveRobotsPolicy]);
+        }
+        if ($ctaPresent !== true) {
+            $issues[] = $this->issue($slug, $locale, CareerSurfaceReadinessIssue::CTA_MISSING_OR_UNATTRIBUTED, 'Live HTML is missing an attributable career CTA marker.', ['cta_present' => $ctaPresent]);
+        }
+        if ($apiCanonicalPath !== null && $liveCanonicalPath !== null && $apiCanonicalPath !== $liveCanonicalPath) {
+            $issues[] = $this->issue($slug, $locale, CareerSurfaceReadinessIssue::REAL_SURFACE_MISMATCH, 'API and live HTML canonical surfaces disagree.', ['api_canonical_path' => $apiCanonicalPath, 'live_canonical_path' => $liveCanonicalPath]);
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function issue(string $slug, string $locale, string $reason, string $message, array $evidence): CareerSurfaceReadinessIssue
+    {
+        return new CareerSurfaceReadinessIssue(
+            reason: $reason,
+            message: $message,
+            severity: CareerCanonicalEligibilitySeverity::HIGH,
+            canonicalSlug: $slug,
+            locale: $locale,
+            evidence: [$evidence],
+        );
+    }
+
+    /**
+     * @param  list<CareerSurfaceReadinessIssue>  $issues
+     * @param  list<mixed>  $evidence
+     */
+    private function surfaceLayerStatus(array $issues, array $evidence, bool $unverified): CareerCanonicalEligibilityLayerStatus
+    {
+        return new CareerCanonicalEligibilityLayerStatus(
+            layer: CareerCanonicalEligibilityLayer::SURFACE,
+            status: $issues === [] ? CareerCanonicalEligibilityStatus::PASS : ($unverified ? CareerCanonicalEligibilityStatus::UNVERIFIED : CareerCanonicalEligibilityStatus::BLOCKED),
+            reasons: array_values(array_unique(array_map(
+                static fn (CareerSurfaceReadinessIssue $issue): string => $issue->reason,
+                $issues
+            ))),
+            evidence: $evidence,
+            source: 'surface_artifacts',
+        );
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function evidenceFor(string $slug, string $locale, ?string $apiCanonicalPath, bool $apiIndexable, bool $includeLiveHtml, ?string $liveCanonicalPath, ?string $liveRobotsPolicy, ?bool $ctaPresent): array
+    {
+        return [
+            ['slug' => $slug, 'locale' => $locale],
+            ['api_canonical_path' => $apiCanonicalPath, 'api_indexable' => $apiIndexable],
+            ['live_html_requested' => $includeLiveHtml],
+            ['live_canonical_path' => $liveCanonicalPath],
+            ['live_robots_policy' => $liveRobotsPolicy],
+            ['cta_present' => $ctaPresent],
+        ];
+    }
+
+    /**
+     * @return array{canonical_path: string|null, robots_policy: string|null, cta_present: bool}
+     */
+    private function parseLiveHtml(string $html): array
+    {
+        $canonical = null;
+        if (preg_match("~<link[^>]+rel=[\"']canonical[\"'][^>]+href=[\"']([^\"']+)[\"']~i", $html, $matches) === 1
+            || preg_match("~<link[^>]+href=[\"']([^\"']+)[\"'][^>]+rel=[\"']canonical[\"']~i", $html, $matches) === 1) {
+            $canonical = $this->pathFromUrl($matches[1]);
+        }
+
+        $robots = null;
+        if (preg_match("~<meta[^>]+name=[\"']robots[\"'][^>]+content=[\"']([^\"']+)[\"']~i", $html, $matches) === 1
+            || preg_match("~<meta[^>]+content=[\"']([^\"']+)[\"'][^>]+name=[\"']robots[\"']~i", $html, $matches) === 1) {
+            $robots = trim($matches[1]);
+        }
+
+        return [
+            'canonical_path' => $canonical,
+            'robots_policy' => $robots,
+            'cta_present' => str_contains($html, 'data-career-cta') || str_contains($html, 'career-cta'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|list<array<string, mixed>>  $artifact
+     * @return list<array<string, mixed>>
+     */
+    private function artifactRows(array $artifact): array
+    {
+        $candidates = [$artifact, $artifact['items'] ?? null, $artifact['rows'] ?? null, $artifact['api']['items'] ?? null, $artifact['api']['rows'] ?? null];
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && array_is_list($candidate)) {
+                return array_values(array_filter($candidate, static fn (mixed $row): bool => is_array($row)));
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, array<string, mixed>>
+     */
+    private function rowsBySlugLocale(array $rows): array
+    {
+        $indexed = [];
+        foreach ($rows as $row) {
+            $slug = $this->slugForArrayRow($row);
+            $locale = $this->normalizeString($row['locale'] ?? null);
+            if ($slug !== null && $locale !== null) {
+                $indexed[$this->rowKey($slug, strtolower($locale))] = $row;
+            }
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function expectedSlugs(array $planRows): array
+    {
+        $slugs = [];
+        foreach ($planRows as $row) {
+            $slug = $this->slugForPlanRow($row);
+            if ($slug !== null && ! in_array($slug, $slugs, true)) {
+                $slugs[] = $slug;
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return list<string>
+     */
+    private function expectedLocales(array $locales): array
+    {
+        $normalized = [];
+        foreach ($locales as $locale) {
+            $value = $this->normalizeString($locale);
+            if ($value !== null) {
+                $value = strtolower($value);
+                if (! in_array($value, $normalized, true)) {
+                    $normalized[] = $value;
+                }
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function apiIndexable(array $row): bool
+    {
+        $indexable = $row['api_indexable'] ?? $row['indexable'] ?? $row['robots_indexable'] ?? null;
+        if (is_bool($indexable)) {
+            return $indexable;
+        }
+
+        $robots = $this->normalizeString($row['api_robots_policy'] ?? $row['robots_policy'] ?? $row['robots'] ?? null);
+
+        return $robots !== null && ! str_contains(strtolower($robots), 'noindex');
+    }
+
+    private function canonicalPath(array $row): ?string
+    {
+        $path = $this->normalizeString($row['api_canonical_path'] ?? $row['canonical_path'] ?? null);
+        if ($path !== null) {
+            return $path;
+        }
+
+        $url = $this->normalizeString($row['api_canonical_url'] ?? $row['canonical_url'] ?? null);
+
+        return $url === null ? null : $this->pathFromUrl($url);
+    }
+
+    private function pathFromUrl(string $url): ?string
+    {
+        $parsedPath = parse_url($url, PHP_URL_PATH);
+
+        return is_string($parsedPath) && trim($parsedPath) !== '' ? $parsedPath : null;
+    }
+
+    private function slugForPlanRow(mixed $row): ?string
+    {
+        if ($row instanceof CareerPublicResolutionPlanRow) {
+            return $this->normalizeSlug($row->canonicalSlug);
+        }
+        if (is_string($row)) {
+            return $this->normalizeSlug($row);
+        }
+        if (is_array($row)) {
+            return $this->slugForArrayRow($row);
+        }
+        if (is_object($row) && property_exists($row, 'canonicalSlug')) {
+            return $this->normalizeSlug($row->canonicalSlug);
+        }
+
+        return null;
+    }
+
+    private function slugForArrayRow(array $row): ?string
+    {
+        return $this->normalizeSlug($row['canonical_slug'] ?? $row['source_slug'] ?? $row['slug'] ?? null);
+    }
+
+    private function expectedCanonicalPath(string $slug, string $locale): string
+    {
+        return '/'.$locale.'/career/jobs/'.$slug;
+    }
+
+    private function rowKey(string $slug, string $locale): string
+    {
+        return $slug.'|'.$locale;
+    }
+
+    private function normalizeSlug(mixed $value): ?string
+    {
+        $normalized = $this->normalizeString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSurfaceReadinessIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceReadinessIssue.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSurfaceReadinessIssue
+{
+    public const API_CANONICAL_NOT_SELF = 'api_canonical_not_self';
+
+    public const API_NOINDEX_PRESENT = 'api_noindex_present';
+
+    public const LIVE_CANONICAL_NOT_SELF = 'live_canonical_not_self';
+
+    public const LIVE_NOINDEX_PRESENT = 'live_noindex_present';
+
+    public const CTA_MISSING_OR_UNATTRIBUTED = 'cta_missing_or_unattributed';
+
+    public const SURFACE_VERIFIER_MISSING = 'surface_verifier_missing';
+
+    public const VALIDATOR_CONTEXT_MISSING = 'validator_context_missing';
+
+    public const UNEXPECTED_EXPOSURE = 'unexpected_exposure';
+
+    public const REAL_SURFACE_MISMATCH = 'real_surface_mismatch';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::MEDIUM,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $locale = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->locale !== null) {
+            self::assertNonEmptyString($this->locale, 'locale');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::API_CANONICAL_NOT_SELF,
+            self::API_NOINDEX_PRESENT,
+            self::LIVE_CANONICAL_NOT_SELF,
+            self::LIVE_NOINDEX_PRESENT,
+            self::CTA_MISSING_OR_UNATTRIBUTED,
+            self::SURFACE_VERIFIER_MISSING,
+            self::VALIDATOR_CONTEXT_MISSING,
+            self::UNEXPECTED_EXPOSURE,
+            self::REAL_SURFACE_MISMATCH,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career surface readiness issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, canonical_slug: string|null, locale: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career surface readiness issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career surface readiness issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSurfaceReadinessResult.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceReadinessResult.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSurfaceReadinessResult
+{
+    /**
+     * @param  list<CareerSurfaceReadinessRow>  $rows
+     * @param  list<CareerSurfaceReadinessIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly int $expectedRows,
+        public readonly int $readyRows,
+        public readonly int $blockedRows,
+        public readonly int $unverifiedRows,
+        public readonly int $surfaceMismatchRows,
+        public readonly array $rows,
+        public readonly array $issues = [],
+        public readonly array $sidecars = [],
+    ) {
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        foreach ([
+            'expected_rows' => $this->expectedRows,
+            'ready_rows' => $this->readyRows,
+            'blocked_rows' => $this->blockedRows,
+            'unverified_rows' => $this->unverifiedRows,
+            'surface_mismatch_rows' => $this->surfaceMismatchRows,
+        ] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career surface readiness [%s] must be non-negative.', $key));
+            }
+        }
+
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+        self::assertSidecars($this->sidecars);
+    }
+
+    /**
+     * @param  list<CareerSurfaceReadinessRow>  $rows
+     * @param  list<CareerSurfaceReadinessIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public static function build(array $rows, array $issues = [], array $sidecars = []): self
+    {
+        $allIssues = [
+            ...$issues,
+            ...array_values(array_merge(...array_map(
+                static fn (CareerSurfaceReadinessRow $row): array => $row->issues,
+                $rows
+            ))),
+        ];
+        $unverifiedRows = count(array_filter($rows, static fn (CareerSurfaceReadinessRow $row): bool => $row->surfaceStatus->status === CareerCanonicalEligibilityStatus::UNVERIFIED));
+        $blockingRows = count(array_filter($rows, static fn (CareerSurfaceReadinessRow $row): bool => $row->surfaceStatus->status === CareerCanonicalEligibilityStatus::BLOCKED));
+
+        return new self(
+            status: $blockingRows > 0 ? CareerCanonicalEligibilityStatus::BLOCKED : ($unverifiedRows > 0 ? CareerCanonicalEligibilityStatus::UNVERIFIED : CareerCanonicalEligibilityStatus::PASS),
+            expectedRows: count($rows),
+            readyRows: count(array_filter($rows, static fn (CareerSurfaceReadinessRow $row): bool => $row->issues === [])),
+            blockedRows: $blockingRows,
+            unverifiedRows: $unverifiedRows,
+            surfaceMismatchRows: self::countRowsWithReason($rows, CareerSurfaceReadinessIssue::REAL_SURFACE_MISMATCH),
+            rows: $rows,
+            issues: $allIssues,
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, expected_rows: int, ready_rows: int, blocked_rows: int, unverified_rows: int, surface_mismatch_rows: int, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'expected_rows' => $this->expectedRows,
+            'ready_rows' => $this->readyRows,
+            'blocked_rows' => $this->blockedRows,
+            'unverified_rows' => $this->unverifiedRows,
+            'surface_mismatch_rows' => $this->surfaceMismatchRows,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerSurfaceReadinessRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerSurfaceReadinessIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerSurfaceReadinessRow>  $rows
+     */
+    private static function countRowsWithReason(array $rows, string $reason): int
+    {
+        return count(array_filter($rows, static function (CareerSurfaceReadinessRow $row) use ($reason): bool {
+            foreach ($row->issues as $issue) {
+                if ($issue->reason === $reason) {
+                    return true;
+                }
+            }
+
+            return false;
+        }));
+    }
+
+    /**
+     * @param  list<CareerSurfaceReadinessRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career surface readiness rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerSurfaceReadinessRow) {
+                throw new InvalidArgumentException('Career surface readiness rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerSurfaceReadinessIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career surface readiness issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerSurfaceReadinessIssue) {
+                throw new InvalidArgumentException('Career surface readiness issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career surface readiness sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career surface readiness sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSurfaceReadinessRow.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceReadinessRow.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSurfaceReadinessRow
+{
+    /**
+     * @param  list<mixed>  $evidence
+     * @param  list<CareerSurfaceReadinessIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $locale,
+        public readonly ?string $apiCanonicalPath,
+        public readonly bool $apiIndexable,
+        public readonly bool $liveHtmlRequested,
+        public readonly bool $liveHtmlVerified,
+        public readonly ?string $liveCanonicalPath,
+        public readonly ?string $liveRobotsPolicy,
+        public readonly ?bool $ctaPresent,
+        public readonly CareerCanonicalEligibilityLayerStatus $surfaceStatus,
+        public readonly array $evidence = [],
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertNonEmptyString($this->locale, 'locale');
+        self::assertList($this->evidence, 'evidence');
+
+        foreach ([
+            'api_canonical_path' => $this->apiCanonicalPath,
+            'live_canonical_path' => $this->liveCanonicalPath,
+            'live_robots_policy' => $this->liveRobotsPolicy,
+        ] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+
+        if (! array_is_list($this->issues)) {
+            throw new InvalidArgumentException('Career surface readiness row issues must be a list.');
+        }
+
+        foreach ($this->issues as $issue) {
+            if (! $issue instanceof CareerSurfaceReadinessIssue) {
+                throw new InvalidArgumentException('Career surface readiness row issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, locale: string, api_canonical_path: string|null, api_indexable: bool, live_html_requested: bool, live_html_verified: bool, live_canonical_path: string|null, live_robots_policy: string|null, cta_present: bool|null, surface_status: array<string, mixed>, evidence: list<mixed>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'api_canonical_path' => $this->apiCanonicalPath,
+            'api_indexable' => $this->apiIndexable,
+            'live_html_requested' => $this->liveHtmlRequested,
+            'live_html_verified' => $this->liveHtmlVerified,
+            'live_canonical_path' => $this->liveCanonicalPath,
+            'live_robots_policy' => $this->liveRobotsPolicy,
+            'cta_present' => $this->ctaPresent,
+            'surface_status' => $this->surfaceStatus->toArray(),
+            'evidence' => $this->evidence,
+            'issues' => array_map(
+                static fn (CareerSurfaceReadinessIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career surface readiness row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career surface readiness row [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/docs/career/audits/surface_readiness_audit.md
+++ b/backend/docs/career/audits/surface_readiness_audit.md
@@ -1,0 +1,82 @@
+# Career Surface Readiness Audit
+
+AUDIT-8 adds a read-only surface readiness layer for the Career 2786 canonical eligibility audit train. It validates backend API surface artifacts and can optionally validate synthetic live HTML when a caller supplies a base URL and HTML content.
+
+AUDIT-8 does not fetch production HTML by itself, deploy, modify fap-web, mutate DB state, apply rollout, backfill data, or implement the full canonical eligibility audit command.
+
+## Inputs
+
+The auditor accepts:
+
+- AUDIT-2 normalized plan rows, array rows, or slug lists
+- expected locales such as `["en", "zh"]`
+- API artifact arrays with rows under `items`, `rows`, `api.items`, or `api.rows`
+- optional live HTML strings keyed by `{slug}|{locale}`
+- optional base URL when live HTML mode is requested
+
+## Checks
+
+API artifact mode checks:
+
+- API canonical path matches `/{locale}/career/jobs/{slug}`
+- API surface is indexable and does not expose noindex
+
+Optional live HTML mode checks:
+
+- base URL/context is present
+- verifier HTML is supplied
+- live canonical path matches expected self path
+- live robots policy does not include noindex
+- attributable career CTA marker is present
+- API and live canonical paths agree
+
+Missing live verifier/context is reported as `unverified`, not pass.
+
+## Issue Reasons
+
+- `api_canonical_not_self`
+- `api_noindex_present`
+- `live_canonical_not_self`
+- `live_noindex_present`
+- `cta_missing_or_unattributed`
+- `surface_verifier_missing`
+- `validator_context_missing`
+- `unexpected_exposure`
+- `real_surface_mismatch`
+
+## AUDIT-1 Layer Status
+
+Each row emits an AUDIT-1-compatible `surface` layer status:
+
+```json
+{
+  "layer": "surface",
+  "status": "pass",
+  "reasons": [],
+  "evidence": [
+    {
+      "slug": "actuaries",
+      "locale": "en"
+    }
+  ],
+  "source": "surface_artifacts"
+}
+```
+
+Rows with missing optional live verifier context emit `status=unverified`. Rows with API or verified live mismatches emit `status=blocked`.
+
+## Non-Goals
+
+AUDIT-8 does not:
+
+- change frontend code
+- perform production fetches
+- deploy
+- mutate backend state
+- run rollout apply/backfill/rollback/quarantine
+- generate expansion manifests
+- claim 2786 readiness
+
+## Consumption By AUDIT-9+
+
+AUDIT-9 should wire AUDIT-8 as an optional surface layer in the read-only command. Live HTML mode must remain opt-in and require explicit base URL/context.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerSurfaceReadinessAuditorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerSurfaceReadinessAuditorTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerSurfaceReadinessAuditor;
+use App\Domain\Career\Audit\CareerSurfaceReadinessIssue;
+use PHPUnit\Framework\TestCase;
+
+final class CareerSurfaceReadinessAuditorTest extends TestCase
+{
+    public function test_api_artifact_canonical_and_noindex_pass(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->api([$this->apiRow('actuaries', 'en')]));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(CareerCanonicalEligibilityLayer::SURFACE, $result->rows[0]->surfaceStatus->layer);
+    }
+
+    public function test_api_canonical_mismatch_blocks(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->api([
+            $this->apiRow('actuaries', 'en', ['api_canonical_path' => '/en/career/jobs/actors']),
+        ]));
+
+        $this->assertSame(CareerSurfaceReadinessIssue::API_CANONICAL_NOT_SELF, $result->issues[0]->reason);
+    }
+
+    public function test_api_noindex_blocks(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->api([
+            $this->apiRow('actuaries', 'en', ['api_indexable' => false]),
+        ]));
+
+        $this->assertSame(CareerSurfaceReadinessIssue::API_NOINDEX_PRESENT, $result->issues[0]->reason);
+    }
+
+    public function test_live_html_synthetic_canonical_noindex_and_cta_pass(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            apiArtifact: $this->api([$this->apiRow('actuaries', 'en')]),
+            includeLiveHtml: true,
+            baseUrl: 'https://fermatmind.com',
+            liveHtmlByKey: [
+                'actuaries|en' => $this->html('/en/career/jobs/actuaries'),
+            ],
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertTrue($result->rows[0]->liveHtmlVerified);
+        $this->assertTrue($result->rows[0]->ctaPresent);
+    }
+
+    public function test_live_html_mismatch_reports_real_surface_mismatch(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            apiArtifact: $this->api([$this->apiRow('actuaries', 'en')]),
+            includeLiveHtml: true,
+            baseUrl: 'https://fermatmind.com',
+            liveHtmlByKey: [
+                'actuaries|en' => $this->html('/en/career/jobs/actors'),
+            ],
+        );
+
+        $this->assertSame(1, $result->surfaceMismatchRows);
+        $this->assertContains(CareerSurfaceReadinessIssue::REAL_SURFACE_MISMATCH, array_keys($result->byReason()));
+    }
+
+    public function test_missing_live_verifier_reports_unverified_not_pass(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            apiArtifact: $this->api([$this->apiRow('actuaries', 'en')]),
+            includeLiveHtml: true,
+            baseUrl: 'https://fermatmind.com',
+            liveHtmlByKey: [],
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::UNVERIFIED, $result->status);
+        $this->assertSame(CareerCanonicalEligibilityStatus::UNVERIFIED, $result->rows[0]->surfaceStatus->status);
+        $this->assertSame(CareerSurfaceReadinessIssue::SURFACE_VERIFIER_MISSING, $result->issues[0]->reason);
+    }
+
+    public function test_live_html_without_base_url_reports_validator_context_missing(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            apiArtifact: $this->api([$this->apiRow('actuaries', 'en')]),
+            includeLiveHtml: true,
+            baseUrl: null,
+            liveHtmlByKey: ['actuaries|en' => $this->html('/en/career/jobs/actuaries')],
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::UNVERIFIED, $result->status);
+        $this->assertSame(CareerSurfaceReadinessIssue::VALIDATOR_CONTEXT_MISSING, $result->issues[0]->reason);
+    }
+
+    public function test_live_html_noindex_and_missing_cta_are_reported(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: ['actuaries'],
+            locales: ['en'],
+            apiArtifact: $this->api([$this->apiRow('actuaries', 'en')]),
+            includeLiveHtml: true,
+            baseUrl: 'https://fermatmind.com',
+            liveHtmlByKey: [
+                'actuaries|en' => '<html><head><link rel="canonical" href="https://fermatmind.com/en/career/jobs/actuaries"><meta name="robots" content="noindex,follow"></head><body></body></html>',
+            ],
+        );
+
+        $this->assertSame([
+            CareerSurfaceReadinessIssue::CTA_MISSING_OR_UNATTRIBUTED => 1,
+            CareerSurfaceReadinessIssue::LIVE_NOINDEX_PRESENT => 1,
+        ], $result->byReason());
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->api([$this->apiRow('actuaries', 'en')]))->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "expected_rows": 1,
+    "ready_rows": 1,
+    "blocked_rows": 0,
+    "unverified_rows": 0,
+    "surface_mismatch_rows": 0,
+    "by_reason": [],
+    "rows": [
+        {
+            "canonical_slug": "actuaries",
+            "locale": "en",
+            "api_canonical_path": "/en/career/jobs/actuaries",
+            "api_indexable": true,
+            "live_html_requested": false,
+            "live_html_verified": false,
+            "live_canonical_path": null,
+            "live_robots_policy": null,
+            "cta_present": null,
+            "surface_status": {
+                "layer": "surface",
+                "status": "pass",
+                "reasons": [],
+                "evidence": [
+                    {
+                        "slug": "actuaries",
+                        "locale": "en"
+                    },
+                    {
+                        "api_canonical_path": "/en/career/jobs/actuaries",
+                        "api_indexable": true
+                    },
+                    {
+                        "live_html_requested": false
+                    },
+                    {
+                        "live_canonical_path": null
+                    },
+                    {
+                        "live_robots_policy": null
+                    },
+                    {
+                        "cta_present": null
+                    }
+                ],
+                "source": "surface_artifacts"
+            },
+            "evidence": [
+                {
+                    "slug": "actuaries",
+                    "locale": "en"
+                },
+                {
+                    "api_canonical_path": "/en/career/jobs/actuaries",
+                    "api_indexable": true
+                },
+                {
+                    "live_html_requested": false
+                },
+                {
+                    "live_canonical_path": null
+                },
+                {
+                    "live_robots_policy": null
+                },
+                {
+                    "cta_present": null
+                }
+            ],
+            "issues": []
+        }
+    ],
+    "issues": [],
+    "sidecars": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_no_db_mutation_or_live_fetch_is_required(): void
+    {
+        $result = $this->auditor()->auditSlugs(['actuaries'], ['en'], $this->api([$this->apiRow('actuaries', 'en')]));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+    }
+
+    private function auditor(): CareerSurfaceReadinessAuditor
+    {
+        return new CareerSurfaceReadinessAuditor;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function api(array $items): array
+    {
+        return ['items' => $items];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function apiRow(string $slug, string $locale, array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => $slug,
+            'locale' => $locale,
+            'api_canonical_path' => '/'.$locale.'/career/jobs/'.$slug,
+            'api_indexable' => true,
+        ], $overrides);
+    }
+
+    private function html(string $canonicalPath): string
+    {
+        return '<html><head><link rel="canonical" href="https://fermatmind.com'.$canonicalPath.'"><meta name="robots" content="index,follow"></head><body><a data-career-cta="primary" href="/en/career/jobs">Explore</a></body></html>';
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -341,6 +341,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_surface_readiness_audit_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerSurfaceReadinessAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceReadinessIssue.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceReadinessResult.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceReadinessRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -1028,6 +1040,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerSurfaceReadinessAuditFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1423,6 +1439,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessResult.php',
             'backend/app/Domain/Career/Audit/CareerSeoGeoReadinessRow.php',
+        ], true);
+    }
+
+    private function isCareerSurfaceReadinessAuditFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerSurfaceReadinessAuditor.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceReadinessIssue.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceReadinessResult.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceReadinessRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1591,6 +1591,96 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-8": {
+      "repo": "fap-api",
+      "branch": "fix/career-surface-readiness-audit8",
+      "title": "feat(api): add career surface readiness audit",
+      "name": "Career Surface Readiness Audit",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-7"
+      ],
+      "scope_type": "surface_readiness_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no audit command",
+        "no frontend code changes",
+        "no production live HTML fetch",
+        "no rollout",
+        "no apply",
+        "no backfill",
+        "no DB mutation",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuous autonomous execution of remaining Career 2786 canonical eligibility audit PR train items."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-7 merged as PR #1327 with merge commit 422f5e3fd548eb0aa0a20bc9f1918f4cbab69741 and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Unit/Domain/Career/Audit, backend/docs/career/audits, the test-only BigFive freeze classifier allowlist, and docs/codex train files."
+        },
+        "surface_readiness_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi",
+          "evidence": "10 tests passed, 17 assertions."
+        },
+        "seo_geo_readiness_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi",
+          "evidence": "11 tests passed, 20 assertions."
+        },
+        "runtime_projection_truth_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi",
+          "evidence": "16 tests passed, 35 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_allowlist_fix": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-8 CareerSurfaceReadiness* files to the test-only freeze classifier allowlist; the runtime path gate passes locally."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3101 files checked."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-9 career:audit-canonical-eligibility command integration",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -766,3 +766,46 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-8
+    repo: fap-api
+    depends_on:
+      - AUDIT-7
+    branch: fix/career-surface-readiness-audit8
+    title: "feat(api): add career surface readiness audit"
+    name: "Career Surface Readiness Audit"
+    scope_type: surface_readiness_only
+    scope:
+      - Add a read-only surface readiness auditor for canonical slugs from AUDIT-2 plan rows or slug lists.
+      - Support API artifact mode for canonical/noindex readiness.
+      - Support optional synthetic live HTML validation only when base URL and verifier HTML are supplied.
+      - Report surface mismatches, noindex, missing CTA attribution, and unverified live verifier/context.
+      - Emit AUDIT-1-compatible surface layer statuses.
+      - Document AUDIT-8 surface readiness contract and future AUDIT-9 command consumption policy.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-8 surface audit files.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add a career canonical eligibility audit command.
+      - Change frontend code.
+      - Fetch production live HTML.
+      - Add rollout/apply/backfill behavior.
+      - Mutate DB or production data.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-9 career:audit-canonical-eligibility command integration"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds AUDIT-8 surface readiness auditor and DTOs under Career Audit.
- Supports API artifact mode and optional synthetic live HTML validation when base URL and verifier HTML are supplied.
- Emits AUDIT-1-compatible surface layer statuses, including unverified live context states.
- Updates AUDIT-8 docs plus PR train manifest/state.

## Guardrails
- Surface readiness only.
- No DB mutation.
- No production commands.
- No frontend changes.
- No production live HTML fetch.
- No audit command yet.
- No rollout/apply/backfill.
- Uses synthetic artifacts/HTML in tests.
- Next PR is AUDIT-9 career:audit-canonical-eligibility command integration.

## Validation
- php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
- php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
- php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi
- vendor/bin/pint --test
- git diff --check
- jq empty docs/codex/pr-train-state.json
- ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'\n\n## Check protocol\nPending checks are wait/poll state, not blockers. Failed checks require inspect/classify/fix or sidecar before stopping.