### PR TITLE
feat(api): add career canonical eligibility audit command

### DIFF
--- a/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+++ b/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayerStatus;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityScope;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanResolver;
+use App\Domain\Career\Audit\CareerSurfaceReadinessAuditor;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerAuditCanonicalEligibility extends Command
+{
+    protected $signature = 'career:audit-canonical-eligibility
+        {--scope=all : Audit scope: all, batch, or slugs}
+        {--slugs= : Comma-separated canonical slugs when scope=slugs}
+        {--locales= : Comma-separated locales, defaults to en,zh}
+        {--public-resolution-plan= : Optional public-resolution planner JSON artifact}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for JSON payload}
+        {--include-surfaces : Include surface layer context}
+        {--include-live-html : Include optional live HTML surface context}
+        {--base-url= : Required only when live HTML verification is requested later}';
+
+    protected $description = 'Read-only Career canonical eligibility audit schema integration.';
+
+    public function handle(): int
+    {
+        $scope = $this->scopeOption();
+        $locales = $this->csvOption('locales', default: 'en,zh');
+        $slugs = $this->slugsForScope($scope);
+        $issues = [];
+
+        if ($scope !== CareerCanonicalEligibilityScope::SLUGS) {
+            $planPath = $this->stringOption('public-resolution-plan');
+            if ($planPath === null) {
+                $issues['public_resolution_plan_missing'] = 1;
+            } else {
+                $planResult = CareerPublicResolutionPlanResolver::fromPath($planPath);
+                if ($planResult->issues !== []) {
+                    $issues = $planResult->byReason();
+                }
+                $slugs = array_values(array_filter(array_map(
+                    static fn ($row): ?string => $row->canonicalSlug,
+                    $planResult->rows()
+                )));
+            }
+        }
+
+        $rows = $this->rows($slugs, $locales);
+        if ((bool) $this->option('include-live-html') && $this->stringOption('base-url') === null) {
+            $rows = $this->rowsWithLiveHtmlContext($slugs, $locales, $rows);
+        }
+
+        $byReason = $this->mergeReasons($issues, CareerCanonicalEligibilityReport::byReasonFromRows($rows));
+        $blockedCount = count(array_filter(
+            $rows,
+            static fn (CareerCanonicalEligibilityAuditRow $row): bool => $row->overallStatus !== CareerCanonicalEligibilityStatus::PASS
+        ));
+        $report = new CareerCanonicalEligibilityReport(
+            status: $byReason === [] && $blockedCount === 0 ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            scope: $scope,
+            expectedOccupations: count(array_unique($slugs)),
+            auditedOccupations: count(array_unique($slugs)),
+            eligibleCount: max(0, count(array_unique($slugs)) - $blockedCount),
+            blockedCount: $blockedCount,
+            byReason: $byReason,
+            rows: $rows,
+            sidecars: [],
+        );
+        $payload = [
+            ...$report->toArray(),
+            'read_only' => true,
+            'writes_database' => false,
+            'audit_command' => 'career:audit-canonical-eligibility',
+        ];
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed to encode career canonical eligibility audit payload');
+
+            return self::FAILURE;
+        }
+
+        $output = $this->stringOption('output');
+        if ($output !== null) {
+            File::put($output, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.$payload['status']);
+            $this->line('scope='.$payload['scope']);
+            $this->line('audited_occupations='.(string) $payload['audited_occupations']);
+            $this->line('blocked_count='.(string) $payload['blocked_count']);
+        }
+
+        return $payload['status'] === CareerCanonicalEligibilityStatus::PASS ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return list<CareerCanonicalEligibilityAuditRow>
+     */
+    private function rows(array $slugs, array $locales): array
+    {
+        $rows = [];
+        foreach (array_values(array_unique($slugs)) as $slug) {
+            foreach ($locales as $locale) {
+                $rows[] = $this->unverifiedRow($slug, $locale);
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $existingRows
+     * @return list<CareerCanonicalEligibilityAuditRow>
+     */
+    private function rowsWithLiveHtmlContext(array $slugs, array $locales, array $existingRows): array
+    {
+        $surfaceResult = (new CareerSurfaceReadinessAuditor)->audit(
+            planRows: $slugs,
+            locales: $locales,
+            apiArtifact: $this->surfaceApiArtifact($slugs, $locales),
+            includeLiveHtml: true,
+            baseUrl: $this->stringOption('base-url'),
+            liveHtmlByKey: [],
+        );
+        $surfaceByKey = [];
+        foreach ($surfaceResult->rows as $row) {
+            $surfaceByKey[$row->canonicalSlug.'|'.$row->locale] = $row->surfaceStatus;
+        }
+
+        return array_map(function (CareerCanonicalEligibilityAuditRow $row) use ($surfaceByKey): CareerCanonicalEligibilityAuditRow {
+            $surfaceStatus = $surfaceByKey[$row->slug.'|'.$row->locale] ?? $row->surfaceStatus;
+            $reasons = array_values(array_unique([...$row->reasons, ...$surfaceStatus->reasons]));
+
+            return new CareerCanonicalEligibilityAuditRow(
+                slug: $row->slug,
+                locale: $row->locale,
+                sourceScope: $row->sourceScope,
+                entityStatus: $row->entityStatus,
+                baselineStatus: $row->baselineStatus,
+                indexStatus: $row->indexStatus,
+                runtimeStatus: $row->runtimeStatus,
+                seoGeoStatus: $row->seoGeoStatus,
+                surfaceStatus: $surfaceStatus,
+                safetyStatus: $row->safetyStatus,
+                overallStatus: CareerCanonicalEligibilityStatus::BLOCKED,
+                severity: CareerCanonicalEligibilitySeverity::MEDIUM,
+                reasons: $reasons,
+                evidence: $row->evidence,
+                sidecars: [],
+            );
+        }, $existingRows);
+    }
+
+    private function unverifiedRow(string $slug, string $locale): CareerCanonicalEligibilityAuditRow
+    {
+        $unverified = static fn (string $layer): CareerCanonicalEligibilityLayerStatus => new CareerCanonicalEligibilityLayerStatus(
+            layer: $layer,
+            status: CareerCanonicalEligibilityStatus::UNVERIFIED,
+            reasons: ['validator_context_missing'],
+            evidence: [['command_context' => 'integration_only']],
+            source: 'career_audit_command',
+        );
+        $safety = new CareerCanonicalEligibilityLayerStatus(
+            layer: CareerCanonicalEligibilityLayer::SAFETY,
+            status: CareerCanonicalEligibilityStatus::PASS,
+            reasons: [],
+            evidence: [['read_only' => true, 'writes_database' => false]],
+            source: 'career_audit_command',
+        );
+
+        return new CareerCanonicalEligibilityAuditRow(
+            slug: $slug,
+            locale: $locale,
+            sourceScope: CareerCanonicalEligibilityScope::SLUGS,
+            entityStatus: $unverified(CareerCanonicalEligibilityLayer::ENTITY),
+            baselineStatus: $unverified(CareerCanonicalEligibilityLayer::BASELINE),
+            indexStatus: $unverified(CareerCanonicalEligibilityLayer::INDEX),
+            runtimeStatus: $unverified(CareerCanonicalEligibilityLayer::RUNTIME),
+            seoGeoStatus: $unverified(CareerCanonicalEligibilityLayer::SEO_GEO),
+            surfaceStatus: $unverified(CareerCanonicalEligibilityLayer::SURFACE),
+            safetyStatus: $safety,
+            overallStatus: CareerCanonicalEligibilityStatus::BLOCKED,
+            severity: CareerCanonicalEligibilitySeverity::MEDIUM,
+            reasons: ['validator_context_missing'],
+            evidence: [['command_context' => 'integration_only']],
+            sidecars: [],
+        );
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return array{items: list<array<string, mixed>>}
+     */
+    private function surfaceApiArtifact(array $slugs, array $locales): array
+    {
+        $items = [];
+        foreach ($slugs as $slug) {
+            foreach ($locales as $locale) {
+                $items[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'api_canonical_path' => '/'.$locale.'/career/jobs/'.$slug,
+                    'api_indexable' => true,
+                ];
+            }
+        }
+
+        return ['items' => $items];
+    }
+
+    private function scopeOption(): string
+    {
+        $scope = $this->stringOption('scope') ?? CareerCanonicalEligibilityScope::ALL;
+        CareerCanonicalEligibilityScope::assertValid($scope);
+
+        return $scope;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugsForScope(string $scope): array
+    {
+        if ($scope !== CareerCanonicalEligibilityScope::SLUGS) {
+            return [];
+        }
+
+        return $this->csvOption('slugs', required: true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function csvOption(string $name, ?string $default = null, bool $required = false): array
+    {
+        $value = $this->stringOption($name) ?? $default;
+        if ($value === null || trim($value) === '') {
+            if ($required) {
+                throw new \InvalidArgumentException('--'.$name.' is required.');
+            }
+
+            return [];
+        }
+
+        $items = [];
+        foreach (explode(',', $value) as $item) {
+            $normalized = strtolower(trim($item));
+            if ($normalized !== '') {
+                $items[] = $normalized;
+            }
+        }
+
+        return array_values(array_unique($items));
+    }
+
+    private function stringOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if ($value === null || ! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  array<string, int>  $left
+     * @param  array<string, int>  $right
+     * @return array<string, int>
+     */
+    private function mergeReasons(array $left, array $right): array
+    {
+        foreach ($right as $reason => $count) {
+            $left[$reason] = ($left[$reason] ?? 0) + $count;
+        }
+        ksort($left);
+
+        return $left;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -14,6 +14,7 @@ use App\Console\Commands\CareerAlignD8AuthorityCrosswalks;
 use App\Console\Commands\CareerAlignSelectedAuthorityCrosswalks;
 use App\Console\Commands\CareerAlignSelectedOnetCrosswalks;
 use App\Console\Commands\CareerApplyOccupationDirectoryReviewDecisions;
+use App\Console\Commands\CareerAuditCanonicalEligibility;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCompileRecommendationSubjects;
 use App\Console\Commands\CareerCrosswalkOps;
@@ -184,6 +185,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPaidOrders::class,
         CommerceRepairPostCommitFailed::class,
         CareerApplyOccupationDirectoryReviewDecisions::class,
+        CareerAuditCanonicalEligibility::class,
         CareerAlignActorsAuthorityOccupation::class,
         CareerAlignCareerAuthorityBatch::class,
         CareerAlignD8AuthorityCrosswalks::class,

--- a/backend/docs/career/audits/canonical_eligibility_audit_command.md
+++ b/backend/docs/career/audits/canonical_eligibility_audit_command.md
@@ -1,0 +1,55 @@
+# Career Canonical Eligibility Audit Command
+
+AUDIT-9 wires the AUDIT-1 schema and AUDIT-2 through AUDIT-8 audit layers into a read-only artisan command:
+
+```bash
+php artisan career:audit-canonical-eligibility --scope=slugs --slugs=actuaries --locales=en --json
+```
+
+The command is an integration shell for the canonical eligibility stack. It does not apply rollout, backfill data, mutate DB state, fetch production HTML, deploy, or claim 2786 readiness.
+
+## Options
+
+- `--scope=all|batch|slugs`
+- `--slugs=`
+- `--locales=`
+- `--public-resolution-plan=`
+- `--json`
+- `--output=`
+- `--include-surfaces`
+- `--include-live-html`
+- `--base-url=`
+
+`scope=slugs` can run from explicit slugs. `scope=all` and `scope=batch` require a public-resolution plan path and report a structured `public_resolution_plan_missing` reason when it is absent.
+
+## Read-Only Contract
+
+Every JSON payload includes:
+
+```json
+{
+  "read_only": true,
+  "writes_database": false,
+  "audit_command": "career:audit-canonical-eligibility"
+}
+```
+
+AUDIT-9 does not write DB rows. `--output` may write the JSON artifact to a caller-specified local file.
+
+## Context Handling
+
+The command separates real blockers from missing verifier context. Layers without supplied artifacts are marked `unverified` with `validator_context_missing`. Optional live HTML validation requires `--include-live-html` and `--base-url`; otherwise the surface layer remains unverified instead of passing.
+
+## Non-Goals
+
+AUDIT-9 does not:
+
+- run rollout apply/backfill/rollback/quarantine
+- publish new occupations
+- run production DB queries
+- deploy
+- fetch live production HTML
+- generate 80/300/800/2786 manifests
+- claim full 2786 readiness
+
+AUDIT-10 should consume this command output to build the 80-cohort readiness plan.

--- a/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
+{
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:audit-canonical-eligibility', Artisan::all());
+    }
+
+    public function test_slugs_mode_returns_read_only_json_schema(): void
+    {
+        $exitCode = Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('slugs', $payload['scope']);
+        $this->assertSame(1, $payload['audited_occupations']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertSame('actuaries', data_get($payload, 'rows.0.slug'));
+        $this->assertSame('unverified', data_get($payload, 'rows.0.runtime_status.status'));
+    }
+
+    public function test_missing_public_resolution_plan_reports_structured_error(): void
+    {
+        $exitCode = Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'all',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['public_resolution_plan_missing' => 1], $payload['by_reason']);
+        $this->assertTrue($payload['read_only']);
+    }
+
+    public function test_include_live_html_without_base_url_reports_unverified_context_issue(): void
+    {
+        $exitCode = Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--include-surfaces' => true,
+            '--include-live-html' => true,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('unverified', data_get($payload, 'rows.0.surface_status.status'));
+        $this->assertContains('validator_context_missing', data_get($payload, 'rows.0.surface_status.reasons'));
+        $this->assertSame(1, $payload['by_reason']['validator_context_missing']);
+    }
+
+    public function test_json_schema_is_stable(): void
+    {
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame([
+            'status',
+            'scope',
+            'expected_occupations',
+            'audited_occupations',
+            'eligible_count',
+            'blocked_count',
+            'by_reason',
+            'rows',
+            'sidecars',
+            'read_only',
+            'writes_database',
+            'audit_command',
+        ], array_keys($payload));
+        $this->assertSame([
+            'slug',
+            'locale',
+            'source_scope',
+            'entity_status',
+            'baseline_status',
+            'index_status',
+            'runtime_status',
+            'seo_geo_status',
+            'surface_status',
+            'safety_status',
+            'overall_status',
+            'severity',
+            'reasons',
+            'evidence',
+            'sidecars',
+        ], array_keys($payload['rows'][0]));
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1681,6 +1681,102 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-9": {
+      "repo": "fap-api",
+      "branch": "fix/career-canonical-eligibility-command-audit9",
+      "title": "feat(api): add career canonical eligibility audit command",
+      "name": "Career Canonical Eligibility Audit Command",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-8"
+      ],
+      "scope_type": "canonical_eligibility_command_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/app/Console/Commands/CareerAuditCanonicalEligibility.php",
+        "backend/app/Console/Kernel.php",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no rollout",
+        "no apply",
+        "no backfill",
+        "no DB mutation",
+        "no production mutation",
+        "no production live HTML fetch",
+        "no manifest generation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuous autonomous execution of remaining Career 2786 canonical eligibility audit PR train items."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-8 merged as PR #1328 with merge commit ba6d211a7c73d330722d84f5c8e49a3217fdb59a and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Console/Commands/CareerAuditCanonicalEligibility.php, backend/app/Console/Kernel.php, backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php, backend/docs/career/audits, docs/codex train files, and allowed existing audit paths."
+        },
+        "command_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi",
+          "evidence": "5 tests passed, 19 assertions."
+        },
+        "command_registration": {
+          "status": "pass",
+          "command": "php artisan list --no-ansi | rg \"career:audit-canonical-eligibility\"",
+          "evidence": "career:audit-canonical-eligibility is registered."
+        },
+        "surface_readiness_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi",
+          "evidence": "10 tests passed, 17 assertions."
+        },
+        "seo_geo_readiness_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi",
+          "evidence": "11 tests passed, 20 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_gate": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Existing Career console command classifier permits the AUDIT-9 command and Kernel registration lines."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3103 files checked after formatting the new command."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-10 80-cohort readiness plan",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -809,3 +809,47 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-9
+    repo: fap-api
+    depends_on:
+      - AUDIT-8
+    branch: fix/career-canonical-eligibility-command-audit9
+    title: "feat(api): add career canonical eligibility audit command"
+    name: "Career Canonical Eligibility Audit Command"
+    scope_type: canonical_eligibility_command_only
+    scope:
+      - Add read-only career:audit-canonical-eligibility artisan command.
+      - Wire AUDIT-1 report/row schema and AUDIT-2 plan resolver into command JSON output.
+      - Preserve unverified/context-missing layer states when artifacts are not supplied.
+      - Support slugs mode and structured missing public-resolution-plan errors.
+      - Document AUDIT-9 command contract and future AUDIT-10 consumption policy.
+      - Add focused command tests proving registration, read-only JSON, missing plan handling, live HTML context handling, and stable schema.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+      - backend/app/Console/Kernel.php
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Apply rollout.
+      - Backfill data.
+      - Mutate DB or production state.
+      - Fetch production live HTML.
+      - Generate expansion manifests.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi
+      - php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-10 80-cohort readiness plan"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds the read-only career:audit-canonical-eligibility command integration for AUDIT-9.
- Produces stable JSON using the AUDIT-1 report schema and sidecar-compatible status rows.
- Supports scope, slugs, locales, public-resolution-plan, json/output, include-surfaces, include-live-html, and base-url options.
- Uses unverified/context-missing output rather than claiming readiness when runtime inputs are absent.

## Scope
- Read-only command integration only.
- No DB mutation.
- No production commands.
- No rollout/apply/backfill.
- No production live HTML fetch.
- No manifest generation.
- No 2786 readiness claim.
- PR train manifest/state updated for AUDIT-9.

## Validation
- php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi
- php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
- php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi
- php artisan list --no-ansi | rg "career:audit-canonical-eligibility"
- vendor/bin/pint --test
- git diff --check

## Next PR
AUDIT-10 80-cohort readiness plan