### PR TITLE
feat(api): add career 80 cohort readiness plan

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonical80CohortReadinessIssue
+{
+    public const COHORT_SIZE_NOT_MET = 'cohort_size_not_met';
+
+    public const ELIGIBILITY_ROW_MISSING = 'eligibility_row_missing';
+
+    public const ELIGIBILITY_BLOCKED = 'eligibility_blocked';
+
+    public const SIDECAR_BLOCKS_TRAIN = 'sidecar_blocks_train';
+
+    public const DUPLICATE_CANDIDATE_SLUG = 'duplicate_candidate_slug';
+
+    private const REASONS = [
+        self::COHORT_SIZE_NOT_MET,
+        self::ELIGIBILITY_ROW_MISSING,
+        self::ELIGIBILITY_BLOCKED,
+        self::SIDECAR_BLOCKS_TRAIN,
+        self::DUPLICATE_CANDIDATE_SLUG,
+    ];
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $canonicalSlug,
+        public readonly string $severity,
+        public readonly array $evidence = [],
+    ) {
+        self::assertReason($this->reason);
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        if (! array_is_list($this->evidence)) {
+            throw new InvalidArgumentException('Career 80-cohort readiness issue evidence must be a list.');
+        }
+    }
+
+    /**
+     * @return array{reason: string, canonical_slug: string, severity: string, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'canonical_slug' => $this->canonicalSlug,
+            'severity' => $this->severity,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    public static function assertReason(string $reason): void
+    {
+        if (! in_array($reason, self::REASONS, true)) {
+            throw new InvalidArgumentException(sprintf('Invalid Career 80-cohort readiness issue reason [%s].', $reason));
+        }
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career 80-cohort readiness issue requires non-empty [%s].', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonical80CohortReadinessPlanner
+{
+    public const DEFAULT_TARGET_COUNT = 80;
+
+    /**
+     * @param  list<string>|null  $candidateSlugs
+     */
+    public function plan(CareerCanonicalEligibilityReport $report, ?array $candidateSlugs = null, int $targetCount = self::DEFAULT_TARGET_COUNT): CareerCanonical80CohortReadinessResult
+    {
+        if ($targetCount <= 0) {
+            throw new InvalidArgumentException('Career 80-cohort readiness target_count must be positive.');
+        }
+
+        $candidates = $this->candidateSlugs($report, $candidateSlugs);
+        $rowsBySlug = $this->rowsBySlug($report->rows);
+        $readinessRows = [];
+        $issues = [];
+        $seen = [];
+        $selectedCount = 0;
+
+        foreach ($candidates as $slug) {
+            $duplicate = array_key_exists($slug, $seen);
+            $seen[$slug] = true;
+            $slugRows = $rowsBySlug[$slug] ?? [];
+            $rowIssues = [];
+            $reasons = [];
+            $evidence = [['canonical_slug' => $slug]];
+
+            if ($duplicate) {
+                $rowIssues[] = new CareerCanonical80CohortReadinessIssue(
+                    reason: CareerCanonical80CohortReadinessIssue::DUPLICATE_CANDIDATE_SLUG,
+                    canonicalSlug: $slug,
+                    severity: CareerCanonicalEligibilitySeverity::MEDIUM,
+                    evidence: [['canonical_slug' => $slug]],
+                );
+                $reasons[] = CareerCanonical80CohortReadinessIssue::DUPLICATE_CANDIDATE_SLUG;
+            }
+
+            if ($slugRows === []) {
+                $rowIssues[] = new CareerCanonical80CohortReadinessIssue(
+                    reason: CareerCanonical80CohortReadinessIssue::ELIGIBILITY_ROW_MISSING,
+                    canonicalSlug: $slug,
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    evidence: [['canonical_slug' => $slug]],
+                );
+                $reasons[] = CareerCanonical80CohortReadinessIssue::ELIGIBILITY_ROW_MISSING;
+            }
+
+            foreach ($slugRows as $eligibilityRow) {
+                $evidence[] = [
+                    'locale' => $eligibilityRow->locale,
+                    'overall_status' => $eligibilityRow->overallStatus,
+                    'severity' => $eligibilityRow->severity,
+                ];
+                if ($eligibilityRow->overallStatus !== CareerCanonicalEligibilityStatus::PASS) {
+                    $rowReasons = $eligibilityRow->reasons === []
+                        ? [CareerCanonical80CohortReadinessIssue::ELIGIBILITY_BLOCKED]
+                        : $eligibilityRow->reasons;
+                    $rowIssues[] = new CareerCanonical80CohortReadinessIssue(
+                        reason: CareerCanonical80CohortReadinessIssue::ELIGIBILITY_BLOCKED,
+                        canonicalSlug: $slug,
+                        severity: $eligibilityRow->severity,
+                        evidence: [$eligibilityRow->toArray()],
+                    );
+                    $reasons = [...$reasons, ...$rowReasons];
+                }
+            }
+
+            $selected = $rowIssues === [] && $selectedCount < $targetCount;
+            if ($selected) {
+                $selectedCount++;
+            }
+
+            $readinessRows[] = new CareerCanonical80CohortReadinessRow(
+                canonicalSlug: $slug,
+                cohortPosition: $selected ? $selectedCount : 0,
+                selected: $selected,
+                eligibilityStatus: $rowIssues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+                reasons: array_values(array_unique($reasons)),
+                evidence: $evidence,
+                issues: $rowIssues,
+            );
+        }
+
+        if ($selectedCount < $targetCount) {
+            $issues[] = new CareerCanonical80CohortReadinessIssue(
+                reason: CareerCanonical80CohortReadinessIssue::COHORT_SIZE_NOT_MET,
+                canonicalSlug: '__cohort__',
+                severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_PUBLICATION,
+                evidence: [[
+                    'target_count' => $targetCount,
+                    'planned_count' => $selectedCount,
+                    'candidate_count' => count($candidates),
+                ]],
+            );
+        }
+
+        return CareerCanonical80CohortReadinessResult::build(
+            targetCount: $targetCount,
+            candidateSlugs: $candidates,
+            rows: $readinessRows,
+            issues: $issues,
+            sidecars: $report->sidecars,
+        );
+    }
+
+    /**
+     * @param  list<string>|null  $candidateSlugs
+     * @return list<string>
+     */
+    private function candidateSlugs(CareerCanonicalEligibilityReport $report, ?array $candidateSlugs): array
+    {
+        if ($candidateSlugs !== null) {
+            return $this->normalizeSlugs($candidateSlugs);
+        }
+
+        return $this->normalizeSlugs(array_map(
+            static fn (CareerCanonicalEligibilityAuditRow $row): string => $row->slug,
+            $report->rows
+        ));
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return list<string>
+     */
+    private function normalizeSlugs(array $slugs): array
+    {
+        if (! array_is_list($slugs)) {
+            throw new InvalidArgumentException('Career 80-cohort readiness candidate slugs must be a list.');
+        }
+
+        return array_values(array_map(static function (string $slug): string {
+            $slug = trim($slug);
+            if ($slug === '') {
+                throw new InvalidArgumentException('Career 80-cohort readiness candidate slugs must be non-empty strings.');
+            }
+
+            return $slug;
+        }, $slugs));
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     * @return array<string, list<CareerCanonicalEligibilityAuditRow>>
+     */
+    private function rowsBySlug(array $rows): array
+    {
+        $bySlug = [];
+        foreach ($rows as $row) {
+            $bySlug[$row->slug] ??= [];
+            $bySlug[$row->slug][] = $row;
+        }
+
+        return $bySlug;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonical80CohortReadinessResult
+{
+    /**
+     * @param  list<string>  $candidateSlugs
+     * @param  list<string>  $readySlugs
+     * @param  list<string>  $blockedSlugs
+     * @param  list<CareerCanonical80CohortReadinessRow>  $rows
+     * @param  list<CareerCanonical80CohortReadinessIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly int $targetCount,
+        public readonly int $candidateCount,
+        public readonly int $plannedCount,
+        public readonly int $eligibleCount,
+        public readonly int $blockedCount,
+        public readonly bool $rolloutAllowed,
+        public readonly array $candidateSlugs,
+        public readonly array $readySlugs,
+        public readonly array $blockedSlugs,
+        public readonly array $rows,
+        public readonly array $issues = [],
+        public readonly array $sidecars = [],
+    ) {
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        foreach ([
+            'target_count' => $this->targetCount,
+            'candidate_count' => $this->candidateCount,
+            'planned_count' => $this->plannedCount,
+            'eligible_count' => $this->eligibleCount,
+            'blocked_count' => $this->blockedCount,
+        ] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career 80-cohort readiness [%s] must be non-negative.', $key));
+            }
+        }
+
+        self::assertListOfStrings($this->candidateSlugs, 'candidate_slugs');
+        self::assertListOfStrings($this->readySlugs, 'ready_slugs');
+        self::assertListOfStrings($this->blockedSlugs, 'blocked_slugs');
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+        self::assertSidecars($this->sidecars);
+    }
+
+    /**
+     * @param  list<CareerCanonical80CohortReadinessRow>  $rows
+     * @param  list<CareerCanonical80CohortReadinessIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     * @param  list<string>  $candidateSlugs
+     */
+    public static function build(int $targetCount, array $candidateSlugs, array $rows, array $issues = [], array $sidecars = []): self
+    {
+        self::assertRows($rows);
+        self::assertIssues($issues);
+        self::assertSidecars($sidecars);
+        self::assertListOfStrings($candidateSlugs, 'candidate_slugs');
+
+        $allIssues = [
+            ...$issues,
+            ...array_values(array_merge(...array_map(
+                static fn (CareerCanonical80CohortReadinessRow $row): array => $row->issues,
+                $rows
+            ))),
+        ];
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar->canContinueTrain()) {
+                $allIssues[] = new CareerCanonical80CohortReadinessIssue(
+                    reason: CareerCanonical80CohortReadinessIssue::SIDECAR_BLOCKS_TRAIN,
+                    canonicalSlug: '__sidecar__',
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    evidence: [$sidecar->toArray()],
+                );
+            }
+        }
+
+        $readySlugs = array_values(array_map(
+            static fn (CareerCanonical80CohortReadinessRow $row): string => $row->canonicalSlug,
+            array_filter($rows, static fn (CareerCanonical80CohortReadinessRow $row): bool => $row->selected)
+        ));
+        $blockedSlugs = array_values(array_map(
+            static fn (CareerCanonical80CohortReadinessRow $row): string => $row->canonicalSlug,
+            array_filter($rows, static fn (CareerCanonical80CohortReadinessRow $row): bool => ! $row->selected)
+        ));
+        $status = $allIssues === [] && count($readySlugs) === $targetCount
+            ? CareerCanonicalEligibilityStatus::PASS
+            : CareerCanonicalEligibilityStatus::BLOCKED;
+
+        return new self(
+            status: $status,
+            targetCount: $targetCount,
+            candidateCount: count($candidateSlugs),
+            plannedCount: count($readySlugs),
+            eligibleCount: count($readySlugs),
+            blockedCount: count($blockedSlugs),
+            rolloutAllowed: $status === CareerCanonicalEligibilityStatus::PASS,
+            candidateSlugs: $candidateSlugs,
+            readySlugs: $readySlugs,
+            blockedSlugs: $blockedSlugs,
+            rows: $rows,
+            issues: $allIssues,
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, target_count: int, candidate_count: int, planned_count: int, eligible_count: int, blocked_count: int, rollout_allowed: bool, candidate_slugs: list<string>, ready_slugs: list<string>, blocked_slugs: list<string>, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'target_count' => $this->targetCount,
+            'candidate_count' => $this->candidateCount,
+            'planned_count' => $this->plannedCount,
+            'eligible_count' => $this->eligibleCount,
+            'blocked_count' => $this->blockedCount,
+            'rollout_allowed' => $this->rolloutAllowed,
+            'candidate_slugs' => $this->candidateSlugs,
+            'ready_slugs' => $this->readySlugs,
+            'blocked_slugs' => $this->blockedSlugs,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerCanonical80CohortReadinessRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerCanonical80CohortReadinessIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerCanonical80CohortReadinessRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career 80-cohort readiness rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerCanonical80CohortReadinessRow) {
+                throw new InvalidArgumentException('Career 80-cohort readiness rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonical80CohortReadinessIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career 80-cohort readiness issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerCanonical80CohortReadinessIssue) {
+                throw new InvalidArgumentException('Career 80-cohort readiness issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career 80-cohort readiness sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career 80-cohort readiness sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career 80-cohort readiness [%s] must be a list.', $key));
+        }
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career 80-cohort readiness [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessRow.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessRow.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonical80CohortReadinessRow
+{
+    /**
+     * @param  list<string>  $reasons
+     * @param  list<mixed>  $evidence
+     * @param  list<CareerCanonical80CohortReadinessIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly int $cohortPosition,
+        public readonly bool $selected,
+        public readonly string $eligibilityStatus,
+        public readonly array $reasons = [],
+        public readonly array $evidence = [],
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        if ($this->cohortPosition < 0) {
+            throw new InvalidArgumentException('Career 80-cohort readiness row cohort_position must be non-negative.');
+        }
+        CareerCanonicalEligibilityStatus::assertValid($this->eligibilityStatus);
+        self::assertListOfStrings($this->reasons, 'reasons');
+        self::assertList($this->evidence, 'evidence');
+        self::assertIssues($this->issues);
+    }
+
+    /**
+     * @return array{canonical_slug: string, cohort_position: int, selected: bool, eligibility_status: string, reasons: list<string>, evidence: list<mixed>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'cohort_position' => $this->cohortPosition,
+            'selected' => $this->selected,
+            'eligibility_status' => $this->eligibilityStatus,
+            'reasons' => $this->reasons,
+            'evidence' => $this->evidence,
+            'issues' => array_map(
+                static fn (CareerCanonical80CohortReadinessIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career 80-cohort readiness row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career 80-cohort readiness row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career 80-cohort readiness row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonical80CohortReadinessIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career 80-cohort readiness row issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerCanonical80CohortReadinessIssue) {
+                throw new InvalidArgumentException('Career 80-cohort readiness row issues must contain issue DTOs.');
+            }
+        }
+    }
+}

--- a/backend/docs/career/audits/80_cohort_readiness_plan.md
+++ b/backend/docs/career/audits/80_cohort_readiness_plan.md
@@ -1,0 +1,66 @@
+# AUDIT-10 Career 80-Cohort Readiness Plan
+
+AUDIT-10 adds a read-only readiness planner for the first canonical 80-cohort expansion candidate set. It consumes AUDIT-1 canonical eligibility report rows and produces a stable readiness-only plan that later manifest generation can use.
+
+## Purpose
+
+- Select up to 80 eligible canonical slugs from a configured candidate set or from report row order.
+- Require every selected slug to have passing canonical eligibility rows.
+- Carry canonical eligibility sidecars into the readiness result.
+- Keep `rollout_allowed=false` unless the target cohort is fully eligible and no blocking sidecar exists.
+
+## Non-Goals
+
+- No rollout apply.
+- No publication or backfill.
+- No DB mutation.
+- No production commands.
+- No manifest train generation.
+- No 80/300/800/2786 expansion execution.
+- No 2786 readiness claim.
+
+## Input Contract
+
+The planner accepts a `CareerCanonicalEligibilityReport` and optional candidate slug list:
+
+- If candidate slugs are supplied, their order controls cohort order.
+- If no candidate slugs are supplied, unique slugs are read from report rows in report order.
+- The default target count is 80.
+- Tests use synthetic eligibility reports; the real 2786 planner artifact is not required.
+
+## Output Contract
+
+The result serializes as:
+
+```json
+{
+  "status": "pass|blocked",
+  "target_count": 80,
+  "candidate_count": 80,
+  "planned_count": 80,
+  "eligible_count": 80,
+  "blocked_count": 0,
+  "rollout_allowed": true,
+  "candidate_slugs": [],
+  "ready_slugs": [],
+  "blocked_slugs": [],
+  "by_reason": {},
+  "rows": [],
+  "issues": [],
+  "sidecars": []
+}
+```
+
+`rollout_allowed` is informational for future tooling. AUDIT-10 does not run rollout.
+
+## Issue Reasons
+
+- `cohort_size_not_met`: fewer than the target count can be selected.
+- `eligibility_row_missing`: a configured candidate has no eligibility row.
+- `eligibility_blocked`: a candidate has a non-pass eligibility row.
+- `sidecar_blocks_train`: a sidecar from the eligibility report cannot continue the train.
+- `duplicate_candidate_slug`: the configured candidate set repeats a slug.
+
+## AUDIT-11 Consumption
+
+AUDIT-11 should consume `ready_slugs` and `rollout_allowed`. It must not generate expansion manifests unless `status=pass`, `rollout_allowed=true`, and the expected cohort size is met.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerCanonical80CohortReadinessPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerCanonical80CohortReadinessPlannerTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonical80CohortReadinessIssue;
+use App\Domain\Career\Audit\CareerCanonical80CohortReadinessPlanner;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayerStatus;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityScope;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySidecar;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use PHPUnit\Framework\TestCase;
+
+final class CareerCanonical80CohortReadinessPlannerTest extends TestCase
+{
+    public function test_generates_default_80_cohort_from_eligible_rows(): void
+    {
+        $result = $this->planner()->plan($this->report($this->eligibleRows(80)));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertTrue($result->rolloutAllowed);
+        $this->assertSame(80, $result->targetCount);
+        $this->assertSame(80, $result->plannedCount);
+        $this->assertSame('slug-080', $result->readySlugs[79]);
+    }
+
+    public function test_configured_candidate_set_controls_order_and_size(): void
+    {
+        $result = $this->planner()->plan(
+            $this->report($this->eligibleRows(3)),
+            candidateSlugs: ['slug-003', 'slug-001'],
+            targetCount: 2,
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(['slug-003', 'slug-001'], $result->readySlugs);
+        $this->assertSame(1, $result->rows[0]->cohortPosition);
+        $this->assertSame(2, $result->rows[1]->cohortPosition);
+    }
+
+    public function test_blocks_when_eligibility_fails(): void
+    {
+        $result = $this->planner()->plan(
+            $this->report([
+                $this->row('actuaries', status: CareerCanonicalEligibilityStatus::BLOCKED, reasons: ['runtime_publish_state_not_published']),
+            ]),
+            candidateSlugs: ['actuaries'],
+            targetCount: 1,
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertFalse($result->rolloutAllowed);
+        $this->assertSame([
+            CareerCanonical80CohortReadinessIssue::COHORT_SIZE_NOT_MET => 1,
+            CareerCanonical80CohortReadinessIssue::ELIGIBILITY_BLOCKED => 1,
+        ], $result->byReason());
+    }
+
+    public function test_blocks_when_candidate_has_no_eligibility_row(): void
+    {
+        $result = $this->planner()->plan(
+            $this->report([]),
+            candidateSlugs: ['missing-slug'],
+            targetCount: 1,
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame([
+            CareerCanonical80CohortReadinessIssue::COHORT_SIZE_NOT_MET => 1,
+            CareerCanonical80CohortReadinessIssue::ELIGIBILITY_ROW_MISSING => 1,
+        ], $result->byReason());
+    }
+
+    public function test_duplicate_candidate_slug_is_reported(): void
+    {
+        $result = $this->planner()->plan(
+            $this->report([$this->row('actuaries')]),
+            candidateSlugs: ['actuaries', 'actuaries'],
+            targetCount: 1,
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->byReason()[CareerCanonical80CohortReadinessIssue::DUPLICATE_CANDIDATE_SLUG]);
+        $this->assertSame(['actuaries'], $result->readySlugs);
+        $this->assertSame(['actuaries'], $result->blockedSlugs);
+    }
+
+    public function test_sidecars_are_included_and_block_rollout_when_train_blocking(): void
+    {
+        $result = $this->planner()->plan(
+            $this->report(
+                [$this->row('actuaries')],
+                [new CareerCanonicalEligibilitySidecar(
+                    sidecarId: 'audit10-current-pr-blocker',
+                    title: 'Current PR blocker',
+                    ownerRepo: 'fap-api',
+                    scopeRelation: 'inside_current_pr',
+                    introducedByCurrentPr: true,
+                    affectedSlugs: ['actuaries'],
+                    affectedLocales: [],
+                    evidence: [['source' => 'unit-test']],
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    nextGoal: 'Fix current PR blocker',
+                    mayContinueTrain: false,
+                )],
+            ),
+            candidateSlugs: ['actuaries'],
+            targetCount: 1,
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertFalse($result->rolloutAllowed);
+        $this->assertSame(1, $result->byReason()[CareerCanonical80CohortReadinessIssue::SIDECAR_BLOCKS_TRAIN]);
+        $this->assertSame('audit10-current-pr-blocker', $result->toArray()['sidecars'][0]['sidecar_id']);
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $result = $this->planner()->plan(
+            $this->report([$this->row('actuaries'), $this->row('actors')]),
+            candidateSlugs: ['actuaries', 'actors'],
+            targetCount: 2,
+        )->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "target_count": 2,
+    "candidate_count": 2,
+    "planned_count": 2,
+    "eligible_count": 2,
+    "blocked_count": 0,
+    "rollout_allowed": true,
+    "candidate_slugs": [
+        "actuaries",
+        "actors"
+    ],
+    "ready_slugs": [
+        "actuaries",
+        "actors"
+    ],
+    "blocked_slugs": [],
+    "by_reason": [],
+    "rows": [
+        {
+            "canonical_slug": "actuaries",
+            "cohort_position": 1,
+            "selected": true,
+            "eligibility_status": "pass",
+            "reasons": [],
+            "evidence": [
+                {
+                    "canonical_slug": "actuaries"
+                },
+                {
+                    "locale": "en",
+                    "overall_status": "pass",
+                    "severity": "info"
+                }
+            ],
+            "issues": []
+        },
+        {
+            "canonical_slug": "actors",
+            "cohort_position": 2,
+            "selected": true,
+            "eligibility_status": "pass",
+            "reasons": [],
+            "evidence": [
+                {
+                    "canonical_slug": "actors"
+                },
+                {
+                    "locale": "en",
+                    "overall_status": "pass",
+                    "severity": "info"
+                }
+            ],
+            "issues": []
+        }
+    ],
+    "issues": [],
+    "sidecars": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_no_db_dependency_is_required(): void
+    {
+        $this->assertSame(
+            CareerCanonicalEligibilityStatus::PASS,
+            $this->planner()->plan($this->report($this->eligibleRows(1)), ['slug-001'], 1)->status,
+        );
+    }
+
+    private function planner(): CareerCanonical80CohortReadinessPlanner
+    {
+        return new CareerCanonical80CohortReadinessPlanner;
+    }
+
+    /**
+     * @return list<CareerCanonicalEligibilityAuditRow>
+     */
+    private function eligibleRows(int $count): array
+    {
+        $rows = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $rows[] = $this->row(sprintf('slug-%03d', $i));
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private function report(array $rows, array $sidecars = []): CareerCanonicalEligibilityReport
+    {
+        return new CareerCanonicalEligibilityReport(
+            status: $rows === [] ? CareerCanonicalEligibilityStatus::BLOCKED : CareerCanonicalEligibilityStatus::PASS,
+            scope: CareerCanonicalEligibilityScope::SLUGS,
+            expectedOccupations: count(array_unique(array_map(static fn (CareerCanonicalEligibilityAuditRow $row): string => $row->slug, $rows))),
+            auditedOccupations: count(array_unique(array_map(static fn (CareerCanonicalEligibilityAuditRow $row): string => $row->slug, $rows))),
+            eligibleCount: count(array_filter($rows, static fn (CareerCanonicalEligibilityAuditRow $row): bool => $row->overallStatus === CareerCanonicalEligibilityStatus::PASS)),
+            blockedCount: count(array_filter($rows, static fn (CareerCanonicalEligibilityAuditRow $row): bool => $row->overallStatus !== CareerCanonicalEligibilityStatus::PASS)),
+            byReason: CareerCanonicalEligibilityReport::byReasonFromRows($rows),
+            rows: $rows,
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     */
+    private function row(
+        string $slug,
+        string $status = CareerCanonicalEligibilityStatus::PASS,
+        array $reasons = [],
+    ): CareerCanonicalEligibilityAuditRow {
+        $passStatus = new CareerCanonicalEligibilityLayerStatus(
+            layer: CareerCanonicalEligibilityLayer::ENTITY,
+            status: CareerCanonicalEligibilityStatus::PASS,
+            reasons: [],
+            evidence: [['slug' => $slug]],
+            source: 'unit_test',
+        );
+
+        return new CareerCanonicalEligibilityAuditRow(
+            slug: $slug,
+            locale: 'en',
+            sourceScope: CareerCanonicalEligibilityScope::SLUGS,
+            entityStatus: $passStatus,
+            baselineStatus: new CareerCanonicalEligibilityLayerStatus(CareerCanonicalEligibilityLayer::BASELINE, CareerCanonicalEligibilityStatus::PASS, [], [['slug' => $slug]], 'unit_test'),
+            indexStatus: new CareerCanonicalEligibilityLayerStatus(CareerCanonicalEligibilityLayer::INDEX, CareerCanonicalEligibilityStatus::PASS, [], [['slug' => $slug]], 'unit_test'),
+            runtimeStatus: new CareerCanonicalEligibilityLayerStatus(CareerCanonicalEligibilityLayer::RUNTIME, CareerCanonicalEligibilityStatus::PASS, [], [['slug' => $slug]], 'unit_test'),
+            seoGeoStatus: new CareerCanonicalEligibilityLayerStatus(CareerCanonicalEligibilityLayer::SEO_GEO, CareerCanonicalEligibilityStatus::PASS, [], [['slug' => $slug]], 'unit_test'),
+            surfaceStatus: new CareerCanonicalEligibilityLayerStatus(CareerCanonicalEligibilityLayer::SURFACE, CareerCanonicalEligibilityStatus::PASS, [], [['slug' => $slug]], 'unit_test'),
+            safetyStatus: new CareerCanonicalEligibilityLayerStatus(CareerCanonicalEligibilityLayer::SAFETY, CareerCanonicalEligibilityStatus::PASS, [], [['read_only' => true]], 'unit_test'),
+            overallStatus: $status,
+            severity: $status === CareerCanonicalEligibilityStatus::PASS ? CareerCanonicalEligibilitySeverity::INFO : CareerCanonicalEligibilitySeverity::HIGH,
+            reasons: $reasons,
+            evidence: [['slug' => $slug]],
+            sidecars: [],
+        );
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -353,6 +353,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_80_cohort_readiness_plan_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -1044,6 +1056,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareer80CohortReadinessPlanFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1449,6 +1465,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerSurfaceReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerSurfaceReadinessResult.php',
             'backend/app/Domain/Career/Audit/CareerSurfaceReadinessRow.php',
+        ], true);
+    }
+
+    private function isCareer80CohortReadinessPlanFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1777,6 +1777,99 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-10": {
+      "repo": "fap-api",
+      "branch": "fix/career-80-cohort-readiness-audit10",
+      "title": "feat(api): add career 80 cohort readiness plan",
+      "name": "Career 80-Cohort Readiness Plan",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-9"
+      ],
+      "scope_type": "80_cohort_readiness_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no rollout",
+        "no apply",
+        "no backfill",
+        "no DB mutation",
+        "no production mutation",
+        "no manifest generation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuous autonomous execution of remaining Career 2786 canonical eligibility audit PR train items."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-9 merged as PR #1329 with merge commit 70ec4c20e5252a2871c29f3bf4676f516a1ebc4e and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Unit/Domain/Career/Audit, backend/docs/career/audits, the scoped Big Five freeze classifier allowlist, and docs/codex train files."
+        },
+        "readiness_planner_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonical80CohortReadinessPlanner --no-ansi",
+          "evidence": "8 tests passed, 24 assertions."
+        },
+        "command_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi",
+          "evidence": "5 tests passed, 19 assertions."
+        },
+        "surface_readiness_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi",
+          "evidence": "10 tests passed, 17 assertions."
+        },
+        "seo_geo_readiness_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi",
+          "evidence": "11 tests passed, 20 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_gate": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-10 CareerCanonical80CohortReadiness* files to the test-only freeze classifier allowlist; runtime path gate passed with 1 test and 3 assertions."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3108 files checked."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-11 Manifest train generator",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -853,3 +853,47 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-10
+    repo: fap-api
+    depends_on:
+      - AUDIT-9
+    branch: fix/career-80-cohort-readiness-audit10
+    title: "feat(api): add career 80 cohort readiness plan"
+    name: "Career 80-Cohort Readiness Plan"
+    scope_type: 80_cohort_readiness_only
+    scope:
+      - Add a read-only 80-cohort readiness planner that consumes AUDIT-1 canonical eligibility reports.
+      - Select configured candidate slugs or report-order slugs into an 80-slug ready cohort.
+      - Block rollout_allowed unless the target cohort is fully eligible and sidecars do not block the train.
+      - Preserve sidecars and stable by_reason output for future manifest generation.
+      - Document AUDIT-10 readiness-only contract and future AUDIT-11 consumption policy.
+      - Add focused unit tests proving eligible planning, blockers, sidecars, stable JSON, and no DB dependency.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-10 readiness plan files.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Apply rollout.
+      - Publish occupations.
+      - Backfill data.
+      - Mutate DB or production state.
+      - Generate expansion manifests.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerCanonical80CohortReadinessPlanner --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi
+      - php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-11 Manifest train generator"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds the AUDIT-10 read-only 80-cohort readiness planner.
- Consumes AUDIT-1 canonical eligibility reports and plans configured or report-order candidate slugs.
- Blocks rollout_allowed unless the target cohort is fully eligible and no train-blocking sidecar exists.
- Preserves stable JSON, by_reason, sidecars, ready_slugs, and blocked_slugs for AUDIT-11 manifest generation.

## Scope
- Readiness-plan only.
- No DB mutation.
- No production commands.
- No rollout/apply/backfill.
- No publishing.
- No manifest generation.
- No 80/300/800/2786 expansion execution.
- No 2786 readiness claim.
- PR train manifest/state updated for AUDIT-10.

## Validation
- php artisan test --filter=CareerCanonical80CohortReadinessPlanner --no-ansi
- php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi
- php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
- php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi
- vendor/bin/pint --test
- git diff --check

## Next PR
AUDIT-11 Manifest train generator