### PR TITLE
feat(api): add career canonical expansion manifest train generator

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainBatch.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainBatch.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalExpansionManifestTrainBatch
+{
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  list<string>  $rollbackGroup
+     * @param  list<CareerCanonicalExpansionManifestTrainIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $stage,
+        public readonly string $batchId,
+        public readonly int $batchSize,
+        public readonly array $slugs,
+        public readonly array $locales,
+        public readonly array $rollbackGroup,
+        public readonly string $readinessGate,
+        public readonly string $rolloutState,
+        public readonly bool $releaseGateRequired,
+        public readonly bool $surfaceEqualityRequired,
+        public readonly bool $dryRunOnly,
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->stage, 'stage');
+        self::assertNonEmptyString($this->batchId, 'batch_id');
+        if ($this->batchSize < 1) {
+            throw new InvalidArgumentException('Career manifest train batch_size must be positive.');
+        }
+        self::assertListOfStrings($this->slugs, 'slugs');
+        self::assertListOfStrings($this->locales, 'locales');
+        self::assertListOfStrings($this->rollbackGroup, 'rollback_group');
+        CareerCanonicalEligibilityStatus::assertValid($this->readinessGate);
+        self::assertNonEmptyString($this->rolloutState, 'rollout_state');
+        self::assertIssues($this->issues);
+    }
+
+    /**
+     * @return array{stage: string, readiness_gate: string, dry_run_only: bool, issues: list<array<string, mixed>>, manifest: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'stage' => $this->stage,
+            'readiness_gate' => $this->readinessGate,
+            'dry_run_only' => $this->dryRunOnly,
+            'issues' => array_map(
+                static fn (CareerCanonicalExpansionManifestTrainIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'manifest' => [
+                'batch_id' => $this->batchId,
+                'batch_size' => $this->batchSize,
+                'slugs' => $this->slugs,
+                'locales' => $this->locales,
+                'projection_state' => 'published_candidate',
+                'release_gate_required' => $this->releaseGateRequired,
+                'surface_equality_required' => $this->surfaceEqualityRequired,
+                'rollback_group' => $this->rollbackGroup,
+                'rollout_state' => $this->rolloutState,
+                'candidate_route_semantics' => 'expected_pre_route',
+                'candidate_release_gate_applicability' => 'not_applicable_before_promotion',
+            ],
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career manifest train batch requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career manifest train batch [%s] must be a list.', $key));
+        }
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career manifest train batch [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalExpansionManifestTrainIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career manifest train batch issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerCanonicalExpansionManifestTrainIssue) {
+                throw new InvalidArgumentException('Career manifest train batch issues must contain issue DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainGenerator.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainGenerator.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalExpansionManifestTrainGenerator
+{
+    public const TRAIN_KIND = 'career_canonical_expansion_manifest_train';
+
+    public const TRAIN_VERSION = 'career.canonical_expansion_manifest_train.v1';
+
+    /**
+     * @var list<int>
+     */
+    public const DEFAULT_STAGE_TARGETS = [80, 300, 800, 2786];
+
+    /**
+     * @param  list<int>  $stageTargets
+     * @param  list<string>  $locales
+     */
+    public function generate(
+        ?CareerCanonical80CohortReadinessResult $readiness,
+        array $stageTargets = self::DEFAULT_STAGE_TARGETS,
+        array $locales = ['en', 'zh'],
+    ): CareerCanonicalExpansionManifestTrainResult {
+        $this->assertStageTargets($stageTargets);
+        $locales = $this->normalizeStrings($locales, 'locales');
+
+        if ($readiness === null) {
+            return new CareerCanonicalExpansionManifestTrainResult(
+                status: CareerCanonicalEligibilityStatus::BLOCKED,
+                trainKind: self::TRAIN_KIND,
+                trainVersion: self::TRAIN_VERSION,
+                readinessStatus: CareerCanonicalEligibilityStatus::BLOCKED,
+                publishingAllowed: false,
+                mutationAllowed: false,
+                stageTargets: $stageTargets,
+                readySlugCount: 0,
+                batches: [],
+                issues: [new CareerCanonicalExpansionManifestTrainIssue(
+                    reason: CareerCanonicalExpansionManifestTrainIssue::READINESS_MISSING,
+                    stage: '__train__',
+                    severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_PUBLICATION,
+                    evidence: [['readiness_result' => null]],
+                )],
+                sidecars: [],
+            );
+        }
+
+        $readySlugs = $this->normalizeStrings($readiness->readySlugs, 'ready_slugs');
+        $issues = [];
+        if (count(array_unique($readySlugs)) !== count($readySlugs)) {
+            $issues[] = new CareerCanonicalExpansionManifestTrainIssue(
+                reason: CareerCanonicalExpansionManifestTrainIssue::DUPLICATE_READY_SLUG,
+                stage: '__train__',
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                evidence: [['ready_slugs' => $readySlugs]],
+            );
+        }
+
+        if ($readiness->status !== CareerCanonicalEligibilityStatus::PASS || ! $readiness->rolloutAllowed) {
+            $issues[] = new CareerCanonicalExpansionManifestTrainIssue(
+                reason: CareerCanonicalExpansionManifestTrainIssue::READINESS_NOT_PASS,
+                stage: '__train__',
+                severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_PUBLICATION,
+                evidence: [$readiness->toArray()],
+            );
+        }
+
+        foreach ($readiness->sidecars as $sidecar) {
+            if (! $sidecar->canContinueTrain()) {
+                $issues[] = new CareerCanonicalExpansionManifestTrainIssue(
+                    reason: CareerCanonicalExpansionManifestTrainIssue::SIDECAR_BLOCKS_TRAIN,
+                    stage: '__train__',
+                    severity: CareerCanonicalEligibilitySeverity::HIGH,
+                    evidence: [$sidecar->toArray()],
+                );
+            }
+        }
+
+        $batches = [];
+        foreach ($stageTargets as $target) {
+            $stage = 'canonical-'.$target;
+            $slugs = array_slice($readySlugs, 0, min($target, count($readySlugs)));
+            $batchIssues = [];
+            if (count($slugs) < $target) {
+                $batchIssues[] = new CareerCanonicalExpansionManifestTrainIssue(
+                    reason: CareerCanonicalExpansionManifestTrainIssue::INSUFFICIENT_READY_SLUGS,
+                    stage: $stage,
+                    severity: CareerCanonicalEligibilitySeverity::BLOCKER_FOR_PUBLICATION,
+                    evidence: [[
+                        'stage_target' => $target,
+                        'ready_slug_count' => count($readySlugs),
+                    ]],
+                );
+            }
+
+            $issues = [...$issues, ...$batchIssues];
+            $batches[] = new CareerCanonicalExpansionManifestTrainBatch(
+                stage: $stage,
+                batchId: 'career-canonical-'.$target,
+                batchSize: $target,
+                slugs: $slugs,
+                locales: $locales,
+                rollbackGroup: $slugs,
+                readinessGate: $batchIssues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+                rolloutState: $batchIssues === [] ? 'published_candidate' : 'blocked',
+                releaseGateRequired: true,
+                surfaceEqualityRequired: true,
+                dryRunOnly: true,
+                issues: $batchIssues,
+            );
+        }
+
+        return new CareerCanonicalExpansionManifestTrainResult(
+            status: $issues === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            trainKind: self::TRAIN_KIND,
+            trainVersion: self::TRAIN_VERSION,
+            readinessStatus: $readiness->status,
+            publishingAllowed: false,
+            mutationAllowed: false,
+            stageTargets: $stageTargets,
+            readySlugCount: count($readySlugs),
+            batches: $batches,
+            issues: $issues,
+            sidecars: $readiness->sidecars,
+        );
+    }
+
+    /**
+     * @param  list<int>  $stageTargets
+     */
+    private function assertStageTargets(array $stageTargets): void
+    {
+        if (! array_is_list($stageTargets) || $stageTargets === []) {
+            throw new InvalidArgumentException('Career manifest train stage targets must be a non-empty list.');
+        }
+
+        foreach ($stageTargets as $target) {
+            if (! is_int($target) || $target < 1) {
+                throw new InvalidArgumentException('Career manifest train stage targets must contain positive integers.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function normalizeStrings(array $values, string $key): array
+    {
+        if (! array_is_list($values)) {
+            throw new InvalidArgumentException(sprintf('Career manifest train [%s] must be a list.', $key));
+        }
+
+        return array_values(array_map(static function (string $value) use ($key): string {
+            $value = trim($value);
+            if ($value === '') {
+                throw new InvalidArgumentException(sprintf('Career manifest train [%s] must contain non-empty strings.', $key));
+            }
+
+            return $value;
+        }, $values));
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainIssue.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalExpansionManifestTrainIssue
+{
+    public const READINESS_MISSING = 'readiness_missing';
+
+    public const READINESS_NOT_PASS = 'readiness_not_pass';
+
+    public const INSUFFICIENT_READY_SLUGS = 'insufficient_ready_slugs';
+
+    public const DUPLICATE_READY_SLUG = 'duplicate_ready_slug';
+
+    public const STAGE_SIZE_INVALID = 'stage_size_invalid';
+
+    public const SIDECAR_BLOCKS_TRAIN = 'sidecar_blocks_train';
+
+    private const REASONS = [
+        self::READINESS_MISSING,
+        self::READINESS_NOT_PASS,
+        self::INSUFFICIENT_READY_SLUGS,
+        self::DUPLICATE_READY_SLUG,
+        self::STAGE_SIZE_INVALID,
+        self::SIDECAR_BLOCKS_TRAIN,
+    ];
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $stage,
+        public readonly string $severity,
+        public readonly array $evidence = [],
+    ) {
+        self::assertReason($this->reason);
+        self::assertNonEmptyString($this->stage, 'stage');
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        if (! array_is_list($this->evidence)) {
+            throw new InvalidArgumentException('Career manifest train issue evidence must be a list.');
+        }
+    }
+
+    /**
+     * @return array{reason: string, stage: string, severity: string, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'stage' => $this->stage,
+            'severity' => $this->severity,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    public static function assertReason(string $reason): void
+    {
+        if (! in_array($reason, self::REASONS, true)) {
+            throw new InvalidArgumentException(sprintf('Invalid Career manifest train issue reason [%s].', $reason));
+        }
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career manifest train issue requires non-empty [%s].', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainResult.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainResult.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalExpansionManifestTrainResult
+{
+    /**
+     * @param  list<int>  $stageTargets
+     * @param  list<CareerCanonicalExpansionManifestTrainBatch>  $batches
+     * @param  list<CareerCanonicalExpansionManifestTrainIssue>  $issues
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly string $trainKind,
+        public readonly string $trainVersion,
+        public readonly string $readinessStatus,
+        public readonly bool $publishingAllowed,
+        public readonly bool $mutationAllowed,
+        public readonly array $stageTargets,
+        public readonly int $readySlugCount,
+        public readonly array $batches,
+        public readonly array $issues = [],
+        public readonly array $sidecars = [],
+    ) {
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        self::assertNonEmptyString($this->trainKind, 'train_kind');
+        self::assertNonEmptyString($this->trainVersion, 'train_version');
+        CareerCanonicalEligibilityStatus::assertValid($this->readinessStatus);
+        self::assertStageTargets($this->stageTargets);
+        if ($this->readySlugCount < 0) {
+            throw new InvalidArgumentException('Career manifest train ready_slug_count must be non-negative.');
+        }
+        self::assertBatches($this->batches);
+        self::assertIssues($this->issues);
+        self::assertSidecars($this->sidecars);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{status: string, train_kind: string, train_version: string, readiness_status: string, publishing_allowed: bool, mutation_allowed: bool, stage_targets: list<int>, ready_slug_count: int, by_reason: array<string, int>, batches: list<array<string, mixed>>, issues: list<array<string, mixed>>, sidecars: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'train_kind' => $this->trainKind,
+            'train_version' => $this->trainVersion,
+            'readiness_status' => $this->readinessStatus,
+            'publishing_allowed' => $this->publishingAllowed,
+            'mutation_allowed' => $this->mutationAllowed,
+            'stage_targets' => $this->stageTargets,
+            'ready_slug_count' => $this->readySlugCount,
+            'by_reason' => $this->byReason(),
+            'batches' => array_map(
+                static fn (CareerCanonicalExpansionManifestTrainBatch $batch): array => $batch->toArray(),
+                $this->batches
+            ),
+            'issues' => array_map(
+                static fn (CareerCanonicalExpansionManifestTrainIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career manifest train result requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<int>  $stageTargets
+     */
+    private static function assertStageTargets(array $stageTargets): void
+    {
+        if (! array_is_list($stageTargets)) {
+            throw new InvalidArgumentException('Career manifest train stage_targets must be a list.');
+        }
+
+        foreach ($stageTargets as $target) {
+            if (! is_int($target) || $target < 1) {
+                throw new InvalidArgumentException('Career manifest train stage_targets must contain positive integers.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalExpansionManifestTrainBatch>  $batches
+     */
+    private static function assertBatches(array $batches): void
+    {
+        if (! array_is_list($batches)) {
+            throw new InvalidArgumentException('Career manifest train batches must be a list.');
+        }
+
+        foreach ($batches as $batch) {
+            if (! $batch instanceof CareerCanonicalExpansionManifestTrainBatch) {
+                throw new InvalidArgumentException('Career manifest train batches must contain batch DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalExpansionManifestTrainIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career manifest train issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerCanonicalExpansionManifestTrainIssue) {
+                throw new InvalidArgumentException('Career manifest train issues must contain issue DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career manifest train sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career manifest train sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+}

--- a/backend/docs/career/audits/expansion_manifest_train_generator.md
+++ b/backend/docs/career/audits/expansion_manifest_train_generator.md
@@ -1,0 +1,81 @@
+# AUDIT-11 Career Canonical Expansion Manifest Train Generator
+
+AUDIT-11 adds a read-only manifest train generator for the Career canonical expansion path. It consumes the AUDIT-10 readiness result and emits staged manifest payloads for the 80/300/800/2786 train.
+
+## Purpose
+
+- Generate staged manifest payloads from already eligible readiness slugs.
+- Keep rollback groups as explicit slug lists.
+- Attach readiness gates to each stage.
+- Preserve sidecars for train decisions.
+- Keep publishing and mutation disabled in the generated train result.
+
+## Non-Goals
+
+- No rollout apply.
+- No production mutation.
+- No publication.
+- No backfill.
+- No deployment.
+- No command integration in AUDIT-11.
+- No 2786 readiness claim.
+
+## Input Contract
+
+The generator accepts a `CareerCanonical80CohortReadinessResult`. By default it creates stages for:
+
+- 80
+- 300
+- 800
+- 2786
+
+Tests use synthetic readiness results, so no real 2786 planner artifact or production state is required.
+
+## Output Contract
+
+The result serializes as:
+
+```json
+{
+  "status": "pass|blocked",
+  "train_kind": "career_canonical_expansion_manifest_train",
+  "train_version": "career.canonical_expansion_manifest_train.v1",
+  "readiness_status": "pass|blocked",
+  "publishing_allowed": false,
+  "mutation_allowed": false,
+  "stage_targets": [80, 300, 800, 2786],
+  "ready_slug_count": 0,
+  "by_reason": {},
+  "batches": [],
+  "issues": [],
+  "sidecars": []
+}
+```
+
+Each batch contains a `manifest` object with:
+
+- `batch_id`
+- `batch_size`
+- `slugs`
+- `locales`
+- `projection_state=published_candidate`
+- `release_gate_required=true`
+- `surface_equality_required=true`
+- `rollback_group`
+- `rollout_state`
+- candidate route/release-gate semantics
+
+`rollback_group` must match the slug list. It must never be a batch id.
+
+## Issue Reasons
+
+- `readiness_missing`: no AUDIT-10 readiness result was supplied.
+- `readiness_not_pass`: readiness status is not pass or rollout is not allowed.
+- `insufficient_ready_slugs`: a stage target has fewer ready slugs than required.
+- `duplicate_ready_slug`: the readiness slug list contains duplicates.
+- `stage_size_invalid`: reserved for invalid stage size handling.
+- `sidecar_blocks_train`: a readiness sidecar cannot continue the train.
+
+## AUDIT-12 Consumption
+
+AUDIT-12 should consume generated manifest payloads in read-only validation mode. It must not apply rollout or publish rows.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainGeneratorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainGeneratorTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonical80CohortReadinessResult;
+use App\Domain\Career\Audit\CareerCanonical80CohortReadinessRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySidecar;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerCanonicalExpansionManifestTrainGenerator;
+use App\Domain\Career\Audit\CareerCanonicalExpansionManifestTrainIssue;
+use PHPUnit\Framework\TestCase;
+
+final class CareerCanonicalExpansionManifestTrainGeneratorTest extends TestCase
+{
+    public function test_rollback_group_uses_slug_list_not_batch_id(): void
+    {
+        $result = $this->generator()->generate($this->readiness(['actuaries', 'actors']), [2], ['en']);
+        $manifest = $result->toArray()['batches'][0]['manifest'];
+
+        $this->assertSame(['actuaries', 'actors'], $manifest['slugs']);
+        $this->assertSame(['actuaries', 'actors'], $manifest['rollback_group']);
+        $this->assertNotSame([$manifest['batch_id']], $manifest['rollback_group']);
+    }
+
+    public function test_generates_80_300_800_2786_staged_manifests_from_synthetic_readiness(): void
+    {
+        $result = $this->generator()->generate($this->readiness($this->slugs(2786)));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame([80, 300, 800, 2786], $result->stageTargets);
+        $this->assertSame([80, 300, 800, 2786], array_map(
+            static fn (array $batch): int => count($batch['manifest']['slugs']),
+            $result->toArray()['batches'],
+        ));
+        $this->assertFalse($result->publishingAllowed);
+        $this->assertFalse($result->mutationAllowed);
+    }
+
+    public function test_blocks_if_readiness_missing(): void
+    {
+        $result = $this->generator()->generate(null, [80]);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame([
+            CareerCanonicalExpansionManifestTrainIssue::READINESS_MISSING => 1,
+        ], $result->byReason());
+        $this->assertSame([], $result->batches);
+    }
+
+    public function test_blocks_when_readiness_not_pass(): void
+    {
+        $result = $this->generator()->generate($this->readiness(['actuaries'], status: CareerCanonicalEligibilityStatus::BLOCKED), [1]);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->byReason()[CareerCanonicalExpansionManifestTrainIssue::READINESS_NOT_PASS]);
+    }
+
+    public function test_blocks_when_stage_has_insufficient_ready_slugs(): void
+    {
+        $result = $this->generator()->generate($this->readiness(['actuaries']), [2]);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->byReason()[CareerCanonicalExpansionManifestTrainIssue::INSUFFICIENT_READY_SLUGS]);
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->toArray()['batches'][0]['readiness_gate']);
+        $this->assertSame('blocked', $result->toArray()['batches'][0]['manifest']['rollout_state']);
+    }
+
+    public function test_sidecars_are_preserved_and_block_train_when_needed(): void
+    {
+        $result = $this->generator()->generate($this->readiness(
+            ['actuaries'],
+            sidecars: [new CareerCanonicalEligibilitySidecar(
+                sidecarId: 'audit11-blocking-sidecar',
+                title: 'Blocking sidecar',
+                ownerRepo: 'fap-api',
+                scopeRelation: 'inside_current_pr',
+                introducedByCurrentPr: true,
+                affectedSlugs: ['actuaries'],
+                affectedLocales: [],
+                evidence: [['source' => 'unit-test']],
+                severity: CareerCanonicalEligibilitySeverity::HIGH,
+                nextGoal: 'Fix blocking sidecar',
+                mayContinueTrain: false,
+            )],
+        ), [1]);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result->status);
+        $this->assertSame(1, $result->byReason()[CareerCanonicalExpansionManifestTrainIssue::SIDECAR_BLOCKS_TRAIN]);
+        $this->assertSame('audit11-blocking-sidecar', $result->toArray()['sidecars'][0]['sidecar_id']);
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $result = $this->generator()->generate($this->readiness(['actuaries', 'actors']), [2], ['en'])->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "status": "pass",
+    "train_kind": "career_canonical_expansion_manifest_train",
+    "train_version": "career.canonical_expansion_manifest_train.v1",
+    "readiness_status": "pass",
+    "publishing_allowed": false,
+    "mutation_allowed": false,
+    "stage_targets": [
+        2
+    ],
+    "ready_slug_count": 2,
+    "by_reason": [],
+    "batches": [
+        {
+            "stage": "canonical-2",
+            "readiness_gate": "pass",
+            "dry_run_only": true,
+            "issues": [],
+            "manifest": {
+                "batch_id": "career-canonical-2",
+                "batch_size": 2,
+                "slugs": [
+                    "actuaries",
+                    "actors"
+                ],
+                "locales": [
+                    "en"
+                ],
+                "projection_state": "published_candidate",
+                "release_gate_required": true,
+                "surface_equality_required": true,
+                "rollback_group": [
+                    "actuaries",
+                    "actors"
+                ],
+                "rollout_state": "published_candidate",
+                "candidate_route_semantics": "expected_pre_route",
+                "candidate_release_gate_applicability": "not_applicable_before_promotion"
+            }
+        }
+    ],
+    "issues": [],
+    "sidecars": []
+}
+JSON,
+            json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    public function test_no_mutation_or_db_dependency_is_required(): void
+    {
+        $result = $this->generator()->generate($this->readiness(['actuaries']), [1]);
+
+        $this->assertFalse($result->publishingAllowed);
+        $this->assertFalse($result->mutationAllowed);
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+    }
+
+    private function generator(): CareerCanonicalExpansionManifestTrainGenerator
+    {
+        return new CareerCanonicalExpansionManifestTrainGenerator;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private function readiness(
+        array $slugs,
+        string $status = CareerCanonicalEligibilityStatus::PASS,
+        array $sidecars = [],
+    ): CareerCanonical80CohortReadinessResult {
+        $rows = [];
+        foreach ($slugs as $position => $slug) {
+            $rows[] = new CareerCanonical80CohortReadinessRow(
+                canonicalSlug: $slug,
+                cohortPosition: $position + 1,
+                selected: true,
+                eligibilityStatus: CareerCanonicalEligibilityStatus::PASS,
+                reasons: [],
+                evidence: [['canonical_slug' => $slug]],
+                issues: [],
+            );
+        }
+
+        return new CareerCanonical80CohortReadinessResult(
+            status: $status,
+            targetCount: count($slugs),
+            candidateCount: count($slugs),
+            plannedCount: $status === CareerCanonicalEligibilityStatus::PASS ? count($slugs) : 0,
+            eligibleCount: $status === CareerCanonicalEligibilityStatus::PASS ? count($slugs) : 0,
+            blockedCount: $status === CareerCanonicalEligibilityStatus::PASS ? 0 : count($slugs),
+            rolloutAllowed: $status === CareerCanonicalEligibilityStatus::PASS,
+            candidateSlugs: $slugs,
+            readySlugs: $status === CareerCanonicalEligibilityStatus::PASS ? $slugs : [],
+            blockedSlugs: $status === CareerCanonicalEligibilityStatus::PASS ? [] : $slugs,
+            rows: $rows,
+            issues: [],
+            sidecars: $sidecars,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('slug-%04d', $i);
+        }
+
+        return $slugs;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -365,6 +365,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_expansion_manifest_train_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainBatch.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainGenerator.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainIssue.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainResult.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -1070,6 +1082,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerExpansionManifestTrainFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1497,6 +1513,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessRow.php',
+        ], true);
+    }
+
+    private function isCareerExpansionManifestTrainFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainBatch.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainGenerator.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainIssue.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalExpansionManifestTrainResult.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1870,6 +1870,93 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-11": {
+      "repo": "fap-api",
+      "branch": "fix/career-expansion-manifest-train-audit11",
+      "title": "feat(api): add career canonical expansion manifest train generator",
+      "name": "Career Canonical Expansion Manifest Train Generator",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-10"
+      ],
+      "scope_type": "manifest_train_generator_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no rollout",
+        "no apply",
+        "no backfill",
+        "no DB mutation",
+        "no production mutation",
+        "no deployment"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuous autonomous execution of remaining Career 2786 canonical eligibility audit PR train items."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-10 merged as PR #1332 with merge commit 3728381923bb6ad18e32060db85bcf6e2c6ca080 and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Unit/Domain/Career/Audit, backend/docs/career/audits, the scoped Big Five freeze classifier allowlist, and docs/codex train files."
+        },
+        "manifest_train_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalExpansionManifestTrainGenerator --no-ansi",
+          "evidence": "8 tests passed, 24 assertions."
+        },
+        "readiness_planner_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonical80CohortReadinessPlanner --no-ansi",
+          "evidence": "8 tests passed, 24 assertions."
+        },
+        "command_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi",
+          "evidence": "5 tests passed, 19 assertions."
+        },
+        "public_resolution_resolver_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_gate": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-11 CareerCanonicalExpansionManifestTrain* files to the test-only freeze classifier allowlist; runtime path gate passed with 1 test and 3 assertions."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3115 files checked."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "AUDIT-12 Batch live acceptance v2",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -897,3 +897,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-11
+    repo: fap-api
+    depends_on:
+      - AUDIT-10
+    branch: fix/career-expansion-manifest-train-audit11
+    title: "feat(api): add career canonical expansion manifest train generator"
+    name: "Career Canonical Expansion Manifest Train Generator"
+    scope_type: manifest_train_generator_only
+    scope:
+      - Add a read-only canonical expansion manifest train generator that consumes AUDIT-10 readiness output.
+      - Generate staged 80/300/800/2786 manifest payloads with readiness gates.
+      - Ensure rollback_group is a slug list and matches manifest slugs.
+      - Preserve sidecars and stable by_reason output.
+      - Document AUDIT-11 generator contract and future AUDIT-12 consumption policy.
+      - Add focused unit tests proving staged generation, slug-list rollback groups, blocking gates, stable JSON, and no mutation.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-11 manifest train files.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Apply rollout.
+      - Publish occupations.
+      - Backfill data.
+      - Mutate DB or production state.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerCanonicalExpansionManifestTrainGenerator --no-ansi
+      - php artisan test --filter=CareerCanonical80CohortReadinessPlanner --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "AUDIT-12 Batch live acceptance v2"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds the AUDIT-11 read-only canonical expansion manifest train generator.
- Consumes AUDIT-10 readiness output and emits staged 80/300/800/2786 manifest payloads.
- Keeps rollback_group as an explicit slug list matching manifest slugs.
- Adds readiness gates, sidecars, by_reason, and stable JSON for AUDIT-12 consumption.

## Scope
- Manifest-train-generator only.
- No DB mutation.
- No production commands.
- No rollout/apply/backfill.
- No publishing.
- No deployment.
- No 2786 readiness claim.
- PR train manifest/state updated for AUDIT-11.

## Validation
- php artisan test --filter=CareerCanonicalExpansionManifestTrainGenerator --no-ansi
- php artisan test --filter=CareerCanonical80CohortReadinessPlanner --no-ansi
- php artisan test --filter=CareerAuditCanonicalEligibilityCommand --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi
- vendor/bin/pint --test
- git diff --check

## Next PR
AUDIT-12 Batch live acceptance v2