### PR TITLE
RIASEC-TRAIN-09 — Exploration Feedback Layer overlay

### DIFF
--- a/backend/app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php
+++ b/backend/app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+use App\Models\Result;
+
+final class RiasecExplorationFeedbackOverlayService
+{
+    private const SCHEMA_VERSION = 'riasec.exploration_feedback_overlay.v0.1';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function build(Result $result, array $projectionV2, bool $snapshotBound): array
+    {
+        $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'overlay_contract_only',
+            'feedback_stream_status' => 'not_connected_v0_1',
+            'scale_code' => 'RIASEC',
+            'snapshot_bound' => $snapshotBound,
+            'snapshot_identity' => [
+                'snapshot_required' => true,
+                'snapshot_bound' => $snapshotBound,
+                'identity_scope' => 'projection_snapshot',
+                'form_code' => (string) data_get($projectionV2, 'form.form_code', ''),
+                'score_space_version' => (string) data_get($projectionV2, 'form.score_space_version', ''),
+                'measured_holland_code' => (string) data_get($projectionV2, 'holland_code.code', ''),
+            ],
+            'measured_result_guard' => [
+                'measured_holland_code' => (string) data_get($projectionV2, 'holland_code.code', ''),
+                'scores_mutation_allowed' => false,
+                'holland_code_mutation_allowed' => false,
+                'report_snapshot_mutation_allowed' => false,
+                'measurement_evidence_mutation_allowed' => false,
+            ],
+            'feedback_scope' => [
+                'allowed' => [
+                    'activity_resonance',
+                    'task_interest_signal',
+                    'occupation_example_helpfulness',
+                    'exploration_next_step_interest',
+                ],
+                'not_allowed' => [
+                    'score_override',
+                    'holland_code_override',
+                    'career_recommendation',
+                    'job_fit_prediction',
+                    'career_success_prediction',
+                    'qualification_judgment',
+                ],
+            ],
+            'surface_policy' => [
+                'public_projection_allowed' => true,
+                'share_pdf_exposure_allowed' => false,
+                'raw_feedback_public_exposure_allowed' => false,
+                'formal_report_mutation_allowed' => false,
+            ],
+            'read_model' => [
+                'has_feedback' => false,
+                'feedback_count' => 0,
+                'latest_feedback_at' => null,
+                'summary_status' => 'not_available_without_feedback_stream',
+                'raw_feedback_included' => false,
+            ],
+            'claim_boundary' => [
+                'feedback_is_measurement' => false,
+                'feedback_changes_scores' => false,
+                'feedback_changes_measured_holland_code' => false,
+                'feedback_is_career_match' => false,
+                'feedback_is_success_prediction' => false,
+            ],
+            'context' => [
+                'form_code' => (string) ($payload['form_code'] ?? data_get($projectionV2, 'form.form_code', '')),
+                'score_space_version' => (string) ($payload['score_space_version'] ?? data_get($projectionV2, 'form.score_space_version', '')),
+            ],
+        ];
+    }
+}

--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -20,6 +20,7 @@ final class RiasecPublicProjectionService
     public function __construct(
         private readonly RiasecMeasurementContract $measurementContract,
         private readonly RiasecActivityExplorerService $activityExplorer,
+        private readonly RiasecExplorationFeedbackOverlayService $feedbackOverlay,
     ) {}
 
     public function buildFromResult(Result $result, string $locale = 'zh-CN'): array
@@ -94,7 +95,7 @@ final class RiasecPublicProjectionService
         $scoreSpaceVersion = (string) data_get($measurementContract, 'form.score_space_version', data_get($v1, 'form.score_space_version', ''));
         $formCode = (string) data_get($measurementContract, 'form.form_code', data_get($v1, 'form.form_code', ''));
 
-        return [
+        $projection = [
             'schema_version' => 'riasec.public_projection.v2',
             'scale_code' => 'RIASEC',
             'locale' => str_starts_with(strtolower($locale), 'zh') ? 'zh-CN' : 'en',
@@ -163,6 +164,9 @@ final class RiasecPublicProjectionService
             ],
             'activity_explorer_v0_1' => $this->activityExplorer->build((string) ($v1['top_code'] ?? ''), $locale),
         ];
+        $projection['exploration_feedback_overlay_v0_1'] = $this->feedbackOverlay->build($result, $projection, $snapshotBound);
+
+        return $projection;
     }
 
     /**

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -122,6 +122,16 @@ final class RiasecAssessmentFlowTest extends TestCase
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.boundary.fit_score_allowed', false);
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.dimension_activity_families.0.dimension', 'R');
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.code_activity_pack.status', 'not_available_for_code_v0_1');
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.schema_version', 'riasec.exploration_feedback_overlay.v0.1');
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.status', 'overlay_contract_only');
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.feedback_stream_status', 'not_connected_v0_1');
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.snapshot_identity.measured_holland_code', 'RIA');
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.snapshot_identity.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.measured_result_guard.scores_mutation_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.measured_result_guard.holland_code_mutation_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.surface_policy.raw_feedback_public_exposure_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.read_model.raw_feedback_included', false);
+        $this->assertNull($readback->json('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.attempt_id'));
 
         $report = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -139,6 +149,9 @@ final class RiasecAssessmentFlowTest extends TestCase
         $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
         $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
         $report->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.boundary.occupation_examples_policy', 'content_example_not_registry_match_without_reviewed_registry_source');
+        $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.snapshot_bound', true);
+        $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.surface_policy.formal_report_mutation_allowed', false);
+        $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.claim_boundary.feedback_changes_measured_holland_code', false);
 
         $reportAccess = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -262,6 +275,8 @@ final class RiasecAssessmentFlowTest extends TestCase
         $share->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
         $share->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
         $share->assertJsonPath('riasec_snapshot_binding_v1.snapshot_bound', true);
+        $share->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.read_model.raw_feedback_included', false);
+        $share->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.surface_policy.share_pdf_exposure_allowed', false);
 
         $history = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -272,6 +287,8 @@ final class RiasecAssessmentFlowTest extends TestCase
         $history->assertJsonPath('items.0.riasec_public_projection_v1.top_code', 'RIA');
         $history->assertJsonPath('items.0.riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
         $history->assertJsonPath('items.0.riasec_snapshot_binding_v1.snapshot_bound', true);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.exploration_feedback_overlay_v0_1.measured_result_guard.scores_mutation_allowed', false);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.exploration_feedback_overlay_v0_1.claim_boundary.feedback_is_career_match', false);
         $history->assertJsonPath('history_compare.current_top_code', 'RIA');
 
         $pdf = $this->withHeaders([

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -602,6 +602,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_exploration_feedback_overlay_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -1145,6 +1155,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecExplorationFeedbackOverlayFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -1317,6 +1331,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Services/Riasec/RiasecActivityExplorerService.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+        ], true);
+    }
+
+    private function isRiasecExplorationFeedbackOverlayFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php',
             'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
         ], true);
     }

--- a/backend/tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Models\Result;
+use App\Services\Riasec\RiasecExplorationFeedbackOverlayService;
+use Tests\TestCase;
+
+final class RiasecExplorationFeedbackOverlayServiceTest extends TestCase
+{
+    public function test_overlay_is_non_measuring_and_cannot_mutate_measured_result(): void
+    {
+        $result = new Result([
+            'scale_code' => 'RIASEC',
+            'type_code' => 'IAS',
+            'result_json' => [
+                'form_code' => 'riasec_60',
+                'score_space_version' => 'riasec_60_likert5_activity_sum_space.v1',
+            ],
+        ]);
+        $projection = [
+            'holland_code' => [
+                'code' => 'IAS',
+            ],
+            'form' => [
+                'form_code' => 'riasec_60',
+                'score_space_version' => 'riasec_60_likert5_activity_sum_space.v1',
+            ],
+        ];
+
+        $overlay = (new RiasecExplorationFeedbackOverlayService)->build($result, $projection, true);
+
+        $this->assertSame('riasec.exploration_feedback_overlay.v0.1', $overlay['schema_version']);
+        $this->assertSame('overlay_contract_only', $overlay['status']);
+        $this->assertSame('not_connected_v0_1', $overlay['feedback_stream_status']);
+        $this->assertTrue((bool) data_get($overlay, 'snapshot_identity.snapshot_required'));
+        $this->assertTrue((bool) data_get($overlay, 'snapshot_identity.snapshot_bound'));
+        $this->assertSame('projection_snapshot', data_get($overlay, 'snapshot_identity.identity_scope'));
+        $this->assertSame('IAS', data_get($overlay, 'snapshot_identity.measured_holland_code'));
+        $this->assertFalse((bool) data_get($overlay, 'measured_result_guard.scores_mutation_allowed'));
+        $this->assertFalse((bool) data_get($overlay, 'measured_result_guard.holland_code_mutation_allowed'));
+        $this->assertFalse((bool) data_get($overlay, 'measured_result_guard.report_snapshot_mutation_allowed'));
+        $this->assertFalse((bool) data_get($overlay, 'surface_policy.share_pdf_exposure_allowed'));
+        $this->assertFalse((bool) data_get($overlay, 'surface_policy.raw_feedback_public_exposure_allowed'));
+        $this->assertFalse((bool) data_get($overlay, 'read_model.raw_feedback_included'));
+        $this->assertFalse((bool) data_get($overlay, 'claim_boundary.feedback_is_measurement'));
+        $this->assertFalse((bool) data_get($overlay, 'claim_boundary.feedback_changes_scores'));
+        $this->assertFalse((bool) data_get($overlay, 'claim_boundary.feedback_changes_measured_holland_code'));
+        $this->assertContains('career_recommendation', data_get($overlay, 'feedback_scope.not_allowed'));
+        $this->assertContains('job_fit_prediction', data_get($overlay, 'feedback_scope.not_allowed'));
+        $this->assertArrayNotHasKey('attempt_id', $overlay);
+    }
+}


### PR DESCRIPTION
## What changed
- Added `RiasecExplorationFeedbackOverlayService` as a projection-only overlay contract.
- Attached `exploration_feedback_overlay_v0_1` to RIASEC public projection v2.
- Declared measured-result guards: feedback cannot mutate scores, measured Holland code, measurement evidence, or formal report snapshots.
- Declared read-model status as `not_connected_v0_1` with no raw feedback included.
- Extended RIASEC flow coverage for result/report/share/history snapshot-safe overlay exposure.
- Updated the Big Five runtime freeze classifier so this RIASEC-only service is not misclassified as Big Five/MBTI drift.

## Why
Trusted Result v1.5 needs an Exploration Feedback Layer boundary before frontend overlay work. This PR exposes the contract without adding a write stream, AI interpretation, score override, or recommendation runtime.

## Scope validation
- In scope: RIASEC projection v2 overlay contract, non-mutating guard fields, contract tests.
- Out of scope: feedback submit endpoint, migration/event stream, profile memory, AI generation, career recommendations, share/PDF raw feedback rendering.
- No scoring math changes, no content pack question semantic changes, no 140Q accuracy claim, no 60Q/140Q raw score delta, no occupation matches or job-fit/success prediction.
- `attempt_id` is intentionally not exposed inside the public overlay payload.

## Validation commands
- `php artisan route:list --path=api/v0.3/attempts`
- `php artisan test --filter=RiasecExplorationFeedbackOverlayServiceTest`
- `php artisan test --filter=RiasecAssessmentFlowTest`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest`
- `./vendor/bin/pint --test app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php app/Services/Riasec/RiasecPublicProjectionService.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh` *(sidecar failure below)*

## Sidecar issues
- Local `php artisan migrate --pretend` against the default `.env` is blocked by production guard, and `APP_ENV=testing` with default MySQL env cannot connect to local root/no-password MySQL. The sqlite in-memory pretend path succeeds.
- `bash scripts/ci_verify_mbti.sh` passes schema baseline, ENNEAGRAM gates, partner smoke, MBTI verify, content graph rollback, and events acceptance, then fails the existing phone OTP acceptance with `verify did not return token` / `INTERNAL_ERROR`. This is the same external legacy failure seen earlier in the train and is outside the RIASEC overlay scope.

## Deferred
- Feedback write stream and persisted read model.
- Any user feedback influence on content ordering.
- RIASEC-TRAIN-10 analytics, fixtures, and broader contract tests.

## Rollback / compatibility
Rollback removes the optional `exploration_feedback_overlay_v0_1` payload and service injection. Existing projection v1/v2 fields, snapshot-bound report, share/history/PDF paths, and scoring outputs remain unchanged.