### PR TITLE
feat(api): add career 2786 full audit artifact report

### DIFF
--- a/backend/app/Domain/Career/Audit/Career2786FullAuditArtifact.php
+++ b/backend/app/Domain/Career/Audit/Career2786FullAuditArtifact.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class Career2786FullAuditArtifact
+{
+    /**
+     * @param  array<string, int>  $byReason
+     * @param  array<string, array<string, int>>  $byLayer
+     * @param  list<array<string, mixed>>  $sections
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly int $totalExpected,
+        public readonly int $auditedCount,
+        public readonly int $eligibleCount,
+        public readonly int $blockedCount,
+        public readonly bool $readyForExpansion,
+        public readonly array $byReason,
+        public readonly array $byLayer,
+        public readonly array $sections,
+        public readonly array $sidecars = [],
+    ) {
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        foreach (['total_expected' => $this->totalExpected, 'audited_count' => $this->auditedCount, 'eligible_count' => $this->eligibleCount, 'blocked_count' => $this->blockedCount] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career 2786 audit artifact [%s] must be non-negative.', $key));
+            }
+        }
+        if (
+            (array_is_list($this->byReason) && $this->byReason !== [])
+            || (array_is_list($this->byLayer) && $this->byLayer !== [])
+            || ! array_is_list($this->sections)
+            || ! array_is_list($this->sidecars)
+        ) {
+            throw new InvalidArgumentException('Career 2786 audit artifact maps/lists are malformed.');
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'artifact_kind' => 'career_2786_canonical_eligibility_audit_report',
+            'artifact_version' => 'career.2786_canonical_eligibility_audit_report.v1',
+            'status' => $this->status,
+            'total_expected' => $this->totalExpected,
+            'audited_count' => $this->auditedCount,
+            'eligible_count' => $this->eligibleCount,
+            'blocked_count' => $this->blockedCount,
+            'ready_for_expansion' => $this->readyForExpansion,
+            'by_reason' => $this->byReason,
+            'by_layer' => $this->byLayer,
+            'sections' => $this->sections,
+            'sidecars' => array_map(static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(), $this->sidecars),
+            'read_only' => true,
+            'writes_database' => false,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Audit/Career2786FullAuditArtifactBuilder.php
+++ b/backend/app/Domain/Career/Audit/Career2786FullAuditArtifactBuilder.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class Career2786FullAuditArtifactBuilder
+{
+    public function build(
+        CareerCanonicalEligibilityReport $eligibilityReport,
+        ?CareerCanonical80CohortReadinessResult $readiness = null,
+        ?CareerCanonicalExpansionManifestTrainResult $manifestTrain = null,
+        ?CareerBatchLiveAcceptanceV2Result $batchAcceptance = null,
+        int $totalExpected = 2786,
+    ): Career2786FullAuditArtifact {
+        $sections = [];
+        $sidecars = $eligibilityReport->sidecars;
+        $byReason = $eligibilityReport->byReason;
+        $byLayer = $this->byLayer($eligibilityReport->rows);
+
+        $sections[] = ['section' => 'canonical_eligibility', 'status' => $eligibilityReport->status, 'summary' => $eligibilityReport->toArray()];
+
+        if ($readiness !== null) {
+            $sections[] = ['section' => '80_cohort_readiness', 'status' => $readiness->status, 'summary' => $readiness->toArray()];
+            $byReason = $this->mergeReasons($byReason, $readiness->byReason());
+            $sidecars = [...$sidecars, ...$readiness->sidecars];
+        }
+
+        if ($manifestTrain !== null) {
+            $sections[] = ['section' => 'manifest_train', 'status' => $manifestTrain->status, 'summary' => $manifestTrain->toArray()];
+            $byReason = $this->mergeReasons($byReason, $manifestTrain->byReason());
+            $sidecars = [...$sidecars, ...$manifestTrain->sidecars];
+        }
+
+        if ($batchAcceptance !== null) {
+            $sections[] = ['section' => 'batch_live_acceptance_v2', 'status' => $batchAcceptance->status, 'summary' => $batchAcceptance->toArray()];
+            $byReason = $this->mergeReasons($byReason, $batchAcceptance->byReason());
+            if ($batchAcceptance->status !== CareerCanonicalEligibilityStatus::PASS) {
+                $byLayer['surface']['blocked'] = ($byLayer['surface']['blocked'] ?? 0) + 1;
+            }
+        }
+
+        ksort($byReason);
+        ksort($byLayer);
+
+        $readyForExpansion = $eligibilityReport->status === CareerCanonicalEligibilityStatus::PASS
+            && $eligibilityReport->expectedOccupations === $totalExpected
+            && $eligibilityReport->auditedOccupations === $totalExpected
+            && $eligibilityReport->blockedCount === 0
+            && ($readiness === null || $readiness->status === CareerCanonicalEligibilityStatus::PASS)
+            && ($manifestTrain === null || $manifestTrain->status === CareerCanonicalEligibilityStatus::PASS)
+            && ($batchAcceptance === null || $batchAcceptance->status === CareerCanonicalEligibilityStatus::PASS);
+
+        return new Career2786FullAuditArtifact(
+            status: $readyForExpansion ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            totalExpected: $totalExpected,
+            auditedCount: $eligibilityReport->auditedOccupations,
+            eligibleCount: $eligibilityReport->eligibleCount,
+            blockedCount: $eligibilityReport->blockedCount,
+            readyForExpansion: $readyForExpansion,
+            byReason: $byReason,
+            byLayer: $byLayer,
+            sections: $sections,
+            sidecars: array_values($sidecars),
+        );
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     * @return array<string, array<string, int>>
+     */
+    private function byLayer(array $rows): array
+    {
+        $layers = [
+            'entity_status',
+            'baseline_status',
+            'index_status',
+            'runtime_status',
+            'seo_geo_status',
+            'surface_status',
+            'safety_status',
+        ];
+        $counts = [];
+
+        foreach ($rows as $row) {
+            foreach ($layers as $field) {
+                $status = $row->toArray()[$field]['status'];
+                $layer = str_replace('_status', '', $field);
+                $counts[$layer][$status] = ($counts[$layer][$status] ?? 0) + 1;
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param  array<string, int>  $left
+     * @param  array<string, int>  $right
+     * @return array<string, int>
+     */
+    private function mergeReasons(array $left, array $right): array
+    {
+        foreach ($right as $reason => $count) {
+            $left[$reason] = ($left[$reason] ?? 0) + $count;
+        }
+
+        return $left;
+    }
+}

--- a/backend/docs/career/audits/2786_full_audit_artifact_report.md
+++ b/backend/docs/career/audits/2786_full_audit_artifact_report.md
@@ -1,0 +1,40 @@
+# AUDIT-13 Career 2786 Full Audit Artifact Report
+
+AUDIT-13 adds the final read-only artifact builder for the Career 2786 canonical eligibility audit train.
+
+## Purpose
+
+- Summarize canonical eligibility totals.
+- Include by-reason and by-layer counts.
+- Carry sidecars.
+- Include readiness, manifest train, and batch live acceptance sections when supplied.
+- Produce a stable JSON artifact for the completed audit stack.
+
+## Non-Goals
+
+- No rollout apply.
+- No 2786 publication.
+- No DB mutation.
+- No deployment.
+- No automatic expansion start.
+
+## Output Contract
+
+The artifact contains:
+
+- `artifact_kind=career_2786_canonical_eligibility_audit_report`
+- `artifact_version`
+- `status`
+- `total_expected`
+- `audited_count`
+- `eligible_count`
+- `blocked_count`
+- `ready_for_expansion`
+- `by_reason`
+- `by_layer`
+- `sections`
+- `sidecars`
+- `read_only=true`
+- `writes_database=false`
+
+`ready_for_expansion` is true only when the expected count, audited count, blocked count, and supplied section statuses all pass. AUDIT-13 does not start expansion.

--- a/backend/tests/Unit/Domain/Career/Audit/Career2786FullAuditArtifactBuilderTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career2786FullAuditArtifactBuilderTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\Career2786FullAuditArtifactBuilder;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayerStatus;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityScope;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use PHPUnit\Framework\TestCase;
+
+final class Career2786FullAuditArtifactBuilderTest extends TestCase
+{
+    public function test_synthetic_2786_like_summary_can_pass_without_real_fixture(): void
+    {
+        $artifact = $this->builder()->build($this->report([$this->row('actuaries'), $this->row('actors')]), totalExpected: 2);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $artifact->status);
+        $this->assertTrue($artifact->readyForExpansion);
+        $this->assertSame(2, $artifact->totalExpected);
+        $this->assertSame(2, $artifact->eligibleCount);
+        $this->assertSame(0, $artifact->blockedCount);
+    }
+
+    public function test_blocked_rows_are_summarized_by_reason_and_layer(): void
+    {
+        $artifact = $this->builder()->build($this->report([
+            $this->row('actuaries'),
+            $this->row('actors', CareerCanonicalEligibilityStatus::BLOCKED, ['surface_mismatch']),
+        ]), totalExpected: 2)->toArray();
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $artifact['status']);
+        $this->assertFalse($artifact['ready_for_expansion']);
+        $this->assertSame(['surface_mismatch' => 1], $artifact['by_reason']);
+        $this->assertSame(2, $artifact['by_layer']['entity']['pass']);
+    }
+
+    public function test_artifact_to_array_is_stable(): void
+    {
+        $artifact = $this->builder()->build($this->report([$this->row('actuaries')]), totalExpected: 1)->toArray();
+
+        $this->assertSame(
+            <<<'JSON'
+{
+    "artifact_kind": "career_2786_canonical_eligibility_audit_report",
+    "artifact_version": "career.2786_canonical_eligibility_audit_report.v1",
+    "status": "pass",
+    "total_expected": 1,
+    "audited_count": 1,
+    "eligible_count": 1,
+    "blocked_count": 0,
+    "ready_for_expansion": true,
+    "by_reason": [],
+    "by_layer": {
+        "baseline": {
+            "pass": 1
+        },
+        "entity": {
+            "pass": 1
+        },
+        "index": {
+            "pass": 1
+        },
+        "runtime": {
+            "pass": 1
+        },
+        "safety": {
+            "pass": 1
+        },
+        "seo_geo": {
+            "pass": 1
+        },
+        "surface": {
+            "pass": 1
+        }
+    },
+    "sections": [
+        {
+            "section": "canonical_eligibility",
+            "status": "pass",
+            "summary": {
+                "status": "pass",
+                "scope": "slugs",
+                "expected_occupations": 1,
+                "audited_occupations": 1,
+                "eligible_count": 1,
+                "blocked_count": 0,
+                "by_reason": [],
+                "rows": [
+                    {
+                        "slug": "actuaries",
+                        "locale": "en",
+                        "source_scope": "slugs",
+                        "entity_status": {
+                            "layer": "entity",
+                            "status": "pass",
+                            "reasons": [],
+                            "evidence": [
+                                {
+                                    "slug": "actuaries"
+                                }
+                            ],
+                            "source": "unit_test"
+                        },
+                        "baseline_status": {
+                            "layer": "baseline",
+                            "status": "pass",
+                            "reasons": [],
+                            "evidence": [
+                                {
+                                    "slug": "actuaries"
+                                }
+                            ],
+                            "source": "unit_test"
+                        },
+                        "index_status": {
+                            "layer": "index",
+                            "status": "pass",
+                            "reasons": [],
+                            "evidence": [
+                                {
+                                    "slug": "actuaries"
+                                }
+                            ],
+                            "source": "unit_test"
+                        },
+                        "runtime_status": {
+                            "layer": "runtime",
+                            "status": "pass",
+                            "reasons": [],
+                            "evidence": [
+                                {
+                                    "slug": "actuaries"
+                                }
+                            ],
+                            "source": "unit_test"
+                        },
+                        "seo_geo_status": {
+                            "layer": "seo_geo",
+                            "status": "pass",
+                            "reasons": [],
+                            "evidence": [
+                                {
+                                    "slug": "actuaries"
+                                }
+                            ],
+                            "source": "unit_test"
+                        },
+                        "surface_status": {
+                            "layer": "surface",
+                            "status": "pass",
+                            "reasons": [],
+                            "evidence": [
+                                {
+                                    "slug": "actuaries"
+                                }
+                            ],
+                            "source": "unit_test"
+                        },
+                        "safety_status": {
+                            "layer": "safety",
+                            "status": "pass",
+                            "reasons": [],
+                            "evidence": [
+                                {
+                                    "read_only": true
+                                }
+                            ],
+                            "source": "unit_test"
+                        },
+                        "overall_status": "pass",
+                        "severity": "info",
+                        "reasons": [],
+                        "evidence": [
+                            {
+                                "slug": "actuaries"
+                            }
+                        ],
+                        "sidecars": []
+                    }
+                ],
+                "sidecars": []
+            }
+        }
+    ],
+    "sidecars": [],
+    "read_only": true,
+    "writes_database": false
+}
+JSON,
+            json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    private function builder(): Career2786FullAuditArtifactBuilder
+    {
+        return new Career2786FullAuditArtifactBuilder;
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     */
+    private function report(array $rows): CareerCanonicalEligibilityReport
+    {
+        $blocked = count(array_filter($rows, static fn (CareerCanonicalEligibilityAuditRow $row): bool => $row->overallStatus !== CareerCanonicalEligibilityStatus::PASS));
+
+        return new CareerCanonicalEligibilityReport(
+            status: $blocked === 0 ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            scope: CareerCanonicalEligibilityScope::SLUGS,
+            expectedOccupations: count($rows),
+            auditedOccupations: count($rows),
+            eligibleCount: count($rows) - $blocked,
+            blockedCount: $blocked,
+            byReason: CareerCanonicalEligibilityReport::byReasonFromRows($rows),
+            rows: $rows,
+            sidecars: [],
+        );
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     */
+    private function row(string $slug, string $status = CareerCanonicalEligibilityStatus::PASS, array $reasons = []): CareerCanonicalEligibilityAuditRow
+    {
+        $layer = static fn (string $layer, array $evidence): CareerCanonicalEligibilityLayerStatus => new CareerCanonicalEligibilityLayerStatus($layer, CareerCanonicalEligibilityStatus::PASS, [], $evidence, 'unit_test');
+
+        return new CareerCanonicalEligibilityAuditRow(
+            slug: $slug,
+            locale: 'en',
+            sourceScope: CareerCanonicalEligibilityScope::SLUGS,
+            entityStatus: $layer(CareerCanonicalEligibilityLayer::ENTITY, [['slug' => $slug]]),
+            baselineStatus: $layer(CareerCanonicalEligibilityLayer::BASELINE, [['slug' => $slug]]),
+            indexStatus: $layer(CareerCanonicalEligibilityLayer::INDEX, [['slug' => $slug]]),
+            runtimeStatus: $layer(CareerCanonicalEligibilityLayer::RUNTIME, [['slug' => $slug]]),
+            seoGeoStatus: $layer(CareerCanonicalEligibilityLayer::SEO_GEO, [['slug' => $slug]]),
+            surfaceStatus: $layer(CareerCanonicalEligibilityLayer::SURFACE, [['slug' => $slug]]),
+            safetyStatus: $layer(CareerCanonicalEligibilityLayer::SAFETY, [['read_only' => true]]),
+            overallStatus: $status,
+            severity: $status === CareerCanonicalEligibilityStatus::PASS ? CareerCanonicalEligibilitySeverity::INFO : CareerCanonicalEligibilitySeverity::HIGH,
+            reasons: $reasons,
+            evidence: [['slug' => $slug]],
+            sidecars: [],
+        );
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -389,6 +389,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_2786_full_audit_artifact_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/Career2786FullAuditArtifact.php',
+            'backend/app/Domain/Career/Audit/Career2786FullAuditArtifactBuilder.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -1126,6 +1136,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareer2786FullAuditArtifactFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -1593,6 +1607,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerBatchLiveAcceptanceV2Issue.php',
             'backend/app/Domain/Career/Audit/CareerBatchLiveAcceptanceV2Result.php',
             'backend/app/Domain/Career/Audit/CareerBatchLiveAcceptanceV2Row.php',
+        ], true);
+    }
+
+    private function isCareer2786FullAuditArtifactFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/Career2786FullAuditArtifact.php',
+            'backend/app/Domain/Career/Audit/Career2786FullAuditArtifactBuilder.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2107,6 +2107,89 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "AUDIT-13": {
+      "repo": "fap-api",
+      "branch": "fix/career-2786-full-audit-report-audit13",
+      "title": "feat(api): add career 2786 full audit artifact report",
+      "name": "Career 2786 Full Audit Artifact Report",
+      "status": "in_progress",
+      "depends_on": [
+        "AUDIT-12"
+      ],
+      "scope_type": "full_audit_artifact_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no rollout",
+        "no apply",
+        "no backfill",
+        "no DB mutation",
+        "no production mutation",
+        "no deployment",
+        "no automatic expansion start"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User requested continuous autonomous execution of remaining Career 2786 canonical eligibility audit PR train items."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-12 merged as PR #1335 with merge commit 28bdbcda4ceaf170581fda9615db1018fd110ffe and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend/app/Domain/Career/Audit, backend/tests/Unit/Domain/Career/Audit, backend/docs/career/audits, the scoped Big Five freeze classifier allowlist, and docs/codex train files."
+        },
+        "full_artifact_tests": {
+          "status": "pass",
+          "command": "php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi",
+          "evidence": "3 tests passed, 10 assertions."
+        },
+        "batch_live_acceptance_v2_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerBatchLiveAcceptanceV2Auditor --no-ansi",
+          "evidence": "7 tests passed, 20 assertions."
+        },
+        "manifest_train_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalExpansionManifestTrainGenerator --no-ansi",
+          "evidence": "8 tests passed, 24 assertions."
+        },
+        "canonical_schema_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "runtime_freeze_gate": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "evidence": "Added AUDIT-13 Career2786FullAuditArtifact* files to the test-only freeze classifier allowlist; runtime path gate passed with 1 test and 3 assertions."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3126 files checked."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "next_pr": "End of 2786 eligibility audit PR train",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1017,3 +1017,44 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: AUDIT-13
+    repo: fap-api
+    depends_on:
+      - AUDIT-12
+    branch: fix/career-2786-full-audit-report-audit13
+    title: "feat(api): add career 2786 full audit artifact report"
+    name: "Career 2786 Full Audit Artifact Report"
+    scope_type: full_audit_artifact_only
+    scope:
+      - Add a read-only final artifact builder for the Career 2786 canonical eligibility audit stack.
+      - Summarize total expected, audited, eligible, blocked, by_reason, by_layer, sections, and sidecars.
+      - Include readiness, manifest train, and batch live acceptance sections when supplied.
+      - Document that AUDIT-13 does not start expansion or publish occupations.
+      - Add focused unit tests proving synthetic 2786-like summary, blocked aggregation, and stable JSON.
+      - Update the Big Five runtime freeze classifier owner allowlist for AUDIT-13 artifact files.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Apply rollout.
+      - Publish occupations.
+      - Backfill data.
+      - Mutate DB or production state.
+      - Deploy.
+      - Start expansion.
+    validation:
+      - php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi
+      - php artisan test --filter=CareerBatchLiveAcceptanceV2Auditor --no-ansi
+      - php artisan test --filter=CareerCanonicalExpansionManifestTrainGenerator --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "End of 2786 eligibility audit PR train"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds the AUDIT-13 read-only final Career 2786 canonical eligibility audit artifact builder.
- Summarizes total expected, audited, eligible, blocked, by_reason, by_layer, sections, and sidecars.
- Includes readiness, manifest train, and batch live acceptance sections when supplied.
- Produces stable JSON with read_only=true and writes_database=false.

## Scope
- Full-audit-artifact only.
- No DB mutation.
- No production commands.
- No rollout/apply/backfill.
- No publishing.
- No deployment.
- Does not start 80/300/800/2786 expansion.
- PR train manifest/state updated for AUDIT-13.

## Validation
- php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi
- php artisan test --filter=CareerBatchLiveAcceptanceV2Auditor --no-ansi
- php artisan test --filter=CareerCanonicalExpansionManifestTrainGenerator --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi
- vendor/bin/pint --test
- git diff --check

## Next
End of 2786 eligibility audit PR train. Do not start expansion automatically.