### PR TITLE
PR-RT-02｜feat(api): import six SEO articles with SVG covers

### DIFF
--- a/backend/app/Console/Commands/ArticleImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ArticleImportLocalBaseline.php
@@ -6,9 +6,13 @@ namespace App\Console\Commands;
 
 use App\Models\Article;
 use App\Models\ArticleCategory;
+use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
 use App\Services\Cms\ArticlePublishService;
+use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\ArticleService;
+use App\Services\Cms\ArticleTranslationRevisionWorkspace;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -31,6 +35,8 @@ final class ArticleImportLocalBaseline extends Command
     public function handle(
         ArticleService $articleService,
         ArticlePublishService $articlePublishService,
+        ArticleTranslationRevisionWorkspace $translationRevisionWorkspace,
+        ArticleSeoService $articleSeoService,
     ): int {
         try {
             $status = trim((string) $this->option('status'));
@@ -60,6 +66,8 @@ final class ArticleImportLocalBaseline extends Command
                 ],
                 $articleService,
                 $articlePublishService,
+                $translationRevisionWorkspace,
+                $articleSeoService,
             );
 
             $this->line('baseline_source_dir='.$sourceDir);
@@ -286,6 +294,12 @@ final class ArticleImportLocalBaseline extends Command
 
         $publishedAt = $this->normalizeNullableDateString($row['published_at'] ?? null, $file, $slug);
         $coverImageVariants = $this->normalizeImageVariants($row['cover_image_variants'] ?? null, $file, $slug);
+        $editorialMetadata = $this->normalizeEditorialMetadata($row, $file, $slug);
+        if ($editorialMetadata !== []) {
+            $coverImageVariants = array_merge($coverImageVariants ?? [], [
+                'editorial_metadata' => $editorialMetadata,
+            ]);
+        }
 
         return [
             'org_id' => 0,
@@ -294,6 +308,8 @@ final class ArticleImportLocalBaseline extends Command
             'title' => $title,
             'excerpt' => $excerpt,
             'content_md' => $contentMd,
+            'seo_title' => $this->normalizeNullableString($row['seo_title'] ?? null),
+            'seo_description' => $this->normalizeNullableString($row['seo_description'] ?? $row['meta_description'] ?? null),
             'author_name' => $this->normalizeNullableString($row['author_name'] ?? null),
             'reviewer_name' => $this->normalizeNullableString($row['reviewer_name'] ?? null),
             'reading_minutes' => $this->normalizeNullablePositiveInteger($row['reading_minutes'] ?? null, $file, $slug, 'reading_minutes'),
@@ -324,6 +340,8 @@ final class ArticleImportLocalBaseline extends Command
         array $options,
         ArticleService $articleService,
         ArticlePublishService $articlePublishService,
+        ArticleTranslationRevisionWorkspace $translationRevisionWorkspace,
+        ArticleSeoService $articleSeoService,
     ): array {
         $dryRun = (bool) ($options['dry_run'] ?? false);
         $upsert = (bool) ($options['upsert'] ?? false);
@@ -418,28 +436,27 @@ final class ArticleImportLocalBaseline extends Command
                 'is_indexable' => (bool) $desired['is_indexable'],
             ], $tagIds);
 
+            $article = $this->syncSeoAuthority(
+                $article,
+                $desired,
+                $translationRevisionWorkspace,
+                $articleSeoService,
+            );
+
             if ((string) $desired['status'] === 'published') {
                 if ((string) $article->status !== 'published' || ! (bool) $article->is_public) {
                     $article = $articlePublishService->publishArticle((int) $article->id);
                 }
 
                 if (is_string($desired['published_at']) && $desired['published_at'] !== '') {
-                    $article = $articleService->updateArticle((int) $article->id, [
-                        'status' => 'published',
-                        'is_public' => true,
-                        'published_at' => $desired['published_at'],
-                    ]);
+                    $article = $this->applyPublishedAt($article, (string) $desired['published_at']);
                 }
             } else {
                 if ((string) $article->status !== 'draft' || (bool) $article->is_public) {
                     $article = $articlePublishService->unpublishArticle((int) $article->id);
                 }
 
-                $articleService->updateArticle((int) $article->id, [
-                    'status' => 'draft',
-                    'is_public' => false,
-                    'published_at' => null,
-                ]);
+                $this->applyDraftState($article);
             }
         }
 
@@ -460,6 +477,8 @@ final class ArticleImportLocalBaseline extends Command
             'title' => (string) $row['title'],
             'excerpt' => (string) $row['excerpt'],
             'content_md' => (string) $row['content_md'],
+            'seo_title' => $row['seo_title'],
+            'seo_description' => $row['seo_description'],
             'author_name' => $row['author_name'],
             'reviewer_name' => $row['reviewer_name'],
             'reading_minutes' => $row['reading_minutes'],
@@ -494,6 +513,12 @@ final class ArticleImportLocalBaseline extends Command
             return false;
         }
         if ((string) $article->content_md !== (string) $desired['content_md']) {
+            return false;
+        }
+        if ($this->currentSeoTitle($article) !== ($desired['seo_title'] ?? null)) {
+            return false;
+        }
+        if ($this->currentSeoDescription($article) !== ($desired['seo_description'] ?? null)) {
             return false;
         }
         if ((string) ($article->author_name ?? '') !== (string) ($desired['author_name'] ?? '')) {
@@ -559,6 +584,103 @@ final class ArticleImportLocalBaseline extends Command
             ->where('slug', $slug)
             ->where('locale', $locale)
             ->first();
+    }
+
+    /**
+     * @param  array<string, mixed>  $desired
+     */
+    private function syncSeoAuthority(
+        Article $article,
+        array $desired,
+        ArticleTranslationRevisionWorkspace $translationRevisionWorkspace,
+        ArticleSeoService $articleSeoService,
+    ): Article {
+        $seoTitle = $this->normalizeNullableString($desired['seo_title'] ?? null);
+        $seoDescription = $this->normalizeNullableString($desired['seo_description'] ?? null);
+        $canonicalUrl = $articleSeoService->buildCanonicalUrl((string) $desired['slug'], (string) $desired['locale']);
+        $robots = (bool) ($desired['is_indexable'] ?? true) ? 'index,follow' : 'noindex,nofollow';
+
+        ArticleSeoMeta::query()
+            ->withoutGlobalScopes()
+            ->updateOrCreate(
+                [
+                    'org_id' => (int) $article->org_id,
+                    'article_id' => (int) $article->id,
+                    'locale' => (string) $desired['locale'],
+                ],
+                [
+                    'seo_title' => $seoTitle,
+                    'seo_description' => $seoDescription,
+                    'canonical_url' => $canonicalUrl,
+                    'og_title' => $seoTitle,
+                    'og_description' => $seoDescription,
+                    'og_image_url' => $desired['cover_image_url'],
+                    'robots' => $robots,
+                    'is_indexable' => (bool) $desired['is_indexable'],
+                ],
+            );
+
+        $article = $article->fresh(['seoMeta']) ?? $article;
+        $revision = $translationRevisionWorkspace->resolveWorkingRevision($article);
+        $revisionHash = $translationRevisionWorkspace->hashForRevision($article, [
+            'title' => (string) $desired['title'],
+            'excerpt' => (string) $desired['excerpt'],
+            'content_md' => (string) $desired['content_md'],
+        ]);
+
+        $revision->forceFill([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => (string) $desired['locale'],
+            'source_locale' => (string) $desired['locale'],
+            'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+            'source_version_hash' => $revisionHash,
+            'translated_from_version_hash' => $revisionHash,
+            'title' => (string) $desired['title'],
+            'excerpt' => (string) $desired['excerpt'],
+            'content_md' => (string) $desired['content_md'],
+            'seo_title' => $seoTitle,
+            'seo_description' => $seoDescription,
+        ])->save();
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'source_version_hash' => $revisionHash,
+        ])->save();
+
+        return $article->fresh(['seoMeta', 'workingRevision']) ?? $article;
+    }
+
+    private function applyPublishedAt(Article $article, string $publishedAt): Article
+    {
+        $normalized = Carbon::parse($publishedAt)->utc();
+
+        $article->forceFill([
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => $normalized,
+        ])->save();
+
+        if ($article->published_revision_id !== null) {
+            ArticleTranslationRevision::query()
+                ->withoutGlobalScopes()
+                ->where('id', (int) $article->published_revision_id)
+                ->update(['published_at' => $normalized]);
+        }
+
+        return $article->fresh(['publishedRevision']) ?? $article;
+    }
+
+    private function applyDraftState(Article $article): void
+    {
+        $article->forceFill([
+            'status' => 'draft',
+            'is_public' => false,
+            'published_at' => null,
+            'published_revision_id' => null,
+        ])->save();
     }
 
     private function resolveCategoryId(array $row): ?int
@@ -646,6 +768,36 @@ final class ArticleImportLocalBaseline extends Command
             ->value('name');
 
         return $this->normalizeNullableString($name);
+    }
+
+    private function currentSeoTitle(Article $article): ?string
+    {
+        $article->loadMissing('publishedRevision', 'workingRevision', 'seoMeta');
+
+        if ($article->publishedRevision instanceof ArticleTranslationRevision) {
+            return $this->normalizeNullableString($article->publishedRevision->seo_title);
+        }
+
+        if ($article->workingRevision instanceof ArticleTranslationRevision) {
+            return $this->normalizeNullableString($article->workingRevision->seo_title);
+        }
+
+        return $this->normalizeNullableString($article->seoMeta?->seo_title);
+    }
+
+    private function currentSeoDescription(Article $article): ?string
+    {
+        $article->loadMissing('publishedRevision', 'workingRevision', 'seoMeta');
+
+        if ($article->publishedRevision instanceof ArticleTranslationRevision) {
+            return $this->normalizeNullableString($article->publishedRevision->seo_description);
+        }
+
+        if ($article->workingRevision instanceof ArticleTranslationRevision) {
+            return $this->normalizeNullableString($article->workingRevision->seo_description);
+        }
+
+        return $this->normalizeNullableString($article->seoMeta?->seo_description);
     }
 
     /**
@@ -840,5 +992,41 @@ final class ArticleImportLocalBaseline extends Command
         }
 
         return $value !== [] ? $value : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function normalizeEditorialMetadata(array $row, string $file, string $slug): array
+    {
+        $metadata = is_array($row['editorial_metadata'] ?? null) ? $row['editorial_metadata'] : [];
+
+        foreach (['cover_image_prompt', 'cover_image_style_tag', 'claim_boundary_notes'] as $key) {
+            $value = $this->normalizeNullableString($row[$key] ?? $metadata[$key] ?? null);
+            if ($value !== null) {
+                $metadata[$key] = $value;
+            }
+        }
+
+        foreach (['internal_links', 'cta_slots', 'references'] as $key) {
+            $value = $row[$key] ?? $metadata[$key] ?? null;
+            if ($value === null) {
+                continue;
+            }
+
+            if (! is_array($value)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has invalid %s for slug=%s.',
+                    $file,
+                    $key,
+                    $slug,
+                ));
+            }
+
+            $metadata[$key] = $value;
+        }
+
+        return $metadata;
     }
 }

--- a/backend/public/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg
+++ b/backend/public/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg
@@ -1,21 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
   <title>FermatMind editorial cover placeholder for are-infj-men-rare-or-socially-silenced</title>
-  <desc>Abstract academic editorial cover placeholder generated in-house for launch readiness.</desc>
+  <desc>半透明男性轮廓与被压低的声波线条，象征高敏感男性的自我沉默</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#101820"/><stop offset="1" stop-color="#020617"/></linearGradient>
-    <radialGradient id="wash" cx="34%" cy="22%" r="70%"><stop offset="0" stop-color="#263241" stop-opacity=".92"/><stop offset="1" stop-color="#263241" stop-opacity="0"/></radialGradient>
-    <pattern id="grid" width="56" height="56" patternUnits="userSpaceOnUse"><path d="M56 0H0v56" fill="none" stroke="#e2e8f0" stroke-opacity=".055" stroke-width="1"/></pattern>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#07111f"/><stop offset="1" stop-color="#020617"/></linearGradient>
+    <radialGradient id="pulse" cx=".72" cy=".28" r=".56"><stop offset="0" stop-color="#64748b" stop-opacity=".32"/><stop offset="1" stop-color="#64748b" stop-opacity="0"/></radialGradient>
   </defs>
   <rect width="1200" height="675" fill="url(#bg)"/>
-  <rect width="1200" height="675" fill="url(#grid)"/>
-  <rect width="1200" height="675" fill="url(#wash)"/>
-  <rect x="86" y="78" width="1028" height="520" rx="34" fill="#0f172a" fill-opacity=".28" stroke="#e2e8f0" stroke-opacity=".12"/>
-  <path d="M134 132h184M134 166h96" stroke="#e2e8f0" stroke-opacity=".18" stroke-width="7" stroke-linecap="round"/>
-  <path d="M1066 544h-184M1066 510h-96" stroke="#e2e8f0" stroke-opacity=".16" stroke-width="7" stroke-linecap="round"/>
-  
-      <path d="M410 188c-54 38-82 91-82 158 0 98 70 172 170 172 42 0 76-9 112-31" fill="none" stroke="#7c6f99" stroke-width="9" opacity=".78"/>
-      <path d="M514 178c86 25 148 95 148 178 0 44-18 85-47 116" fill="none" stroke="#e2e8f0" stroke-width="7" opacity=".25"/>
-      <rect x="674" y="226" width="210" height="132" rx="20" fill="none" stroke="#c9a85f" stroke-width="6" opacity=".7"/>
-      <path d="M710 272h128M710 316h74M286 528h600" stroke="#dbeafe" stroke-width="5" opacity=".22"/>
-      <path d="M620 250c-90 70-158 146-210 260" stroke="#dbeafe" stroke-width="5" opacity=".2"/>
+  <rect width="1200" height="675" fill="url(#pulse)"/>
+  <g opacity=".24" stroke="#d8dee9" stroke-width="1">
+    <path d="M 80 80 V 595"/>
+    <path d="M 158 80 V 595"/>
+    <path d="M 236 80 V 595"/>
+    <path d="M 314 80 V 595"/>
+    <path d="M 392 80 V 595"/>
+    <path d="M 470 80 V 595"/>
+    <path d="M 548 80 V 595"/>
+    <path d="M 626 80 V 595"/>
+    <path d="M 704 80 V 595"/>
+    <path d="M 782 80 V 595"/>
+    <path d="M 860 80 V 595"/>
+    <path d="M 938 80 V 595"/>
+    <path d="M 1016 80 V 595"/>
+    <path d="M 1094 80 V 595"/>
+    <path d="M 80 95 H 1120"/>
+    <path d="M 80 173 H 1120"/>
+    <path d="M 80 251 H 1120"/>
+    <path d="M 80 329 H 1120"/>
+    <path d="M 80 407 H 1120"/>
+    <path d="M 80 485 H 1120"/>
+    <path d="M 80 563 H 1120"/>
+  </g>
+  <g transform="translate(80 20)">
+    <path d="M275 430c-64-44-96-104-86-181 12-92 92-161 190-161 108 0 195 81 198 183 3 86-45 148-118 185" fill="none" stroke="#be6f87" stroke-width="8" opacity=".35" stroke-linecap="round"/>
+    <path d="M730 116c138 18 232 102 250 217 13 84-21 156-86 211" fill="none" stroke="#64748b" stroke-width="6" opacity=".28" stroke-linecap="round"/>
+    <path d="M 260 175 C 420 110, 590 420, 720 215" stroke="#64748b" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 175 C 448 126, 608 408, 746 248" stroke="#be6f87" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 175 C 476 142, 626 396, 772 281" stroke="#64748b" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 270 C 504 158, 644 384, 798 314" stroke="#be6f87" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 270 C 532 174, 662 372, 824 347" stroke="#64748b" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 270 C 560 190, 680 360, 850 380" stroke="#be6f87" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 365 C 588 206, 698 348, 876 413" stroke="#64748b" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 365 C 616 222, 716 336, 902 446" stroke="#be6f87" stroke-width="2" opacity=".34" fill="none"/>
+    <circle cx="260" cy="175" r="7" fill="#64748b" opacity=".78"/>
+    <circle cx="417" cy="186" r="7" fill="#be6f87" opacity=".78"/>
+    <circle cx="574" cy="197" r="7" fill="#64748b" opacity=".78"/>
+    <circle cx="276" cy="279" r="7" fill="#be6f87" opacity=".78"/>
+    <circle cx="433" cy="290" r="7" fill="#64748b" opacity=".78"/>
+    <circle cx="555" cy="277" r="7" fill="#be6f87" opacity=".78"/>
+    <circle cx="292" cy="383" r="7" fill="#64748b" opacity=".78"/>
+    <circle cx="414" cy="370" r="7" fill="#be6f87" opacity=".78"/>
+    <circle cx="571" cy="381" r="7" fill="#64748b" opacity=".78"/>
+    <rect x="715" y="150" width="230" height="142" rx="22" fill="#ffffff" opacity=".055" stroke="#64748b" stroke-opacity=".35"/>
+    <path d="M752 194h154M752 232h118M752 270h86" stroke="#d8dee9" stroke-width="8" opacity=".36" stroke-linecap="round"/>
+    <circle cx="842" cy="410" r="78" fill="none" stroke="#be6f87" stroke-width="4" opacity=".42"/>
+    <path d="M790 410h104M842 358v104" stroke="#64748b" stroke-width="5" opacity=".35" stroke-linecap="round"/>
+  </g>
 </svg>

--- a/backend/public/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg
+++ b/backend/public/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg
@@ -1,21 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
   <title>FermatMind editorial cover placeholder for best-valentines-date-by-personality-and-relationship-science</title>
-  <desc>Abstract academic editorial cover placeholder generated in-house for launch readiness.</desc>
+  <desc>抽象路径地图连接两个关系节点，表现低摩擦约会设计</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0f172a"/><stop offset="1" stop-color="#020617"/></linearGradient>
-    <radialGradient id="wash" cx="34%" cy="22%" r="70%"><stop offset="0" stop-color="#203047" stop-opacity=".92"/><stop offset="1" stop-color="#203047" stop-opacity="0"/></radialGradient>
-    <pattern id="grid" width="56" height="56" patternUnits="userSpaceOnUse"><path d="M56 0H0v56" fill="none" stroke="#e2e8f0" stroke-opacity=".055" stroke-width="1"/></pattern>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#14213d"/><stop offset="1" stop-color="#020617"/></linearGradient>
+    <radialGradient id="pulse" cx=".72" cy=".28" r=".56"><stop offset="0" stop-color="#f2eadc" stop-opacity=".32"/><stop offset="1" stop-color="#f2eadc" stop-opacity="0"/></radialGradient>
   </defs>
   <rect width="1200" height="675" fill="url(#bg)"/>
-  <rect width="1200" height="675" fill="url(#grid)"/>
-  <rect width="1200" height="675" fill="url(#wash)"/>
-  <rect x="86" y="78" width="1028" height="520" rx="34" fill="#0f172a" fill-opacity=".28" stroke="#e2e8f0" stroke-opacity=".12"/>
-  <path d="M134 132h184M134 166h96" stroke="#e2e8f0" stroke-opacity=".18" stroke-width="7" stroke-linecap="round"/>
-  <path d="M1066 544h-184M1066 510h-96" stroke="#e2e8f0" stroke-opacity=".16" stroke-width="7" stroke-linecap="round"/>
-  
-      <path d="M246 440c102-118 210-140 324-60s230 60 354-86" fill="none" stroke="#d88972" stroke-width="9" opacity=".82"/>
-      <path d="M250 302c118 34 222 22 312-38 116-77 232-65 348 35" fill="none" stroke="#2aa6a1" stroke-width="7" opacity=".7"/>
-      <circle cx="246" cy="440" r="18" fill="#d88972"/><circle cx="924" cy="294" r="18" fill="#2aa6a1"/>
-      <rect x="424" y="172" width="344" height="104" rx="18" fill="none" stroke="#dbeafe" stroke-width="5" opacity=".27"/>
-      <path d="M470 224h252M470 254h158" stroke="#dbeafe" stroke-width="5" opacity=".24"/>
+  <rect width="1200" height="675" fill="url(#pulse)"/>
+  <g opacity=".24" stroke="#b08968" stroke-width="1">
+    <path d="M 80 80 V 595"/>
+    <path d="M 158 80 V 595"/>
+    <path d="M 236 80 V 595"/>
+    <path d="M 314 80 V 595"/>
+    <path d="M 392 80 V 595"/>
+    <path d="M 470 80 V 595"/>
+    <path d="M 548 80 V 595"/>
+    <path d="M 626 80 V 595"/>
+    <path d="M 704 80 V 595"/>
+    <path d="M 782 80 V 595"/>
+    <path d="M 860 80 V 595"/>
+    <path d="M 938 80 V 595"/>
+    <path d="M 1016 80 V 595"/>
+    <path d="M 1094 80 V 595"/>
+    <path d="M 80 95 H 1120"/>
+    <path d="M 80 173 H 1120"/>
+    <path d="M 80 251 H 1120"/>
+    <path d="M 80 329 H 1120"/>
+    <path d="M 80 407 H 1120"/>
+    <path d="M 80 485 H 1120"/>
+    <path d="M 80 563 H 1120"/>
+  </g>
+  <g transform="translate(80 20)">
+    <path d="M275 430c-64-44-96-104-86-181 12-92 92-161 190-161 108 0 195 81 198 183 3 86-45 148-118 185" fill="none" stroke="#e7b8c3" stroke-width="8" opacity=".35" stroke-linecap="round"/>
+    <path d="M730 116c138 18 232 102 250 217 13 84-21 156-86 211" fill="none" stroke="#f2eadc" stroke-width="6" opacity=".28" stroke-linecap="round"/>
+    <path d="M 260 175 C 420 110, 590 420, 720 215" stroke="#f2eadc" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 175 C 448 126, 608 408, 746 248" stroke="#e7b8c3" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 175 C 476 142, 626 396, 772 281" stroke="#f2eadc" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 270 C 504 158, 644 384, 798 314" stroke="#e7b8c3" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 270 C 532 174, 662 372, 824 347" stroke="#f2eadc" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 270 C 560 190, 680 360, 850 380" stroke="#e7b8c3" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 365 C 588 206, 698 348, 876 413" stroke="#f2eadc" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 365 C 616 222, 716 336, 902 446" stroke="#e7b8c3" stroke-width="2" opacity=".34" fill="none"/>
+    <circle cx="260" cy="175" r="7" fill="#f2eadc" opacity=".78"/>
+    <circle cx="417" cy="186" r="7" fill="#e7b8c3" opacity=".78"/>
+    <circle cx="574" cy="197" r="7" fill="#f2eadc" opacity=".78"/>
+    <circle cx="276" cy="279" r="7" fill="#e7b8c3" opacity=".78"/>
+    <circle cx="433" cy="290" r="7" fill="#f2eadc" opacity=".78"/>
+    <circle cx="555" cy="277" r="7" fill="#e7b8c3" opacity=".78"/>
+    <circle cx="292" cy="383" r="7" fill="#f2eadc" opacity=".78"/>
+    <circle cx="414" cy="370" r="7" fill="#e7b8c3" opacity=".78"/>
+    <circle cx="571" cy="381" r="7" fill="#f2eadc" opacity=".78"/>
+    <rect x="715" y="150" width="230" height="142" rx="22" fill="#ffffff" opacity=".055" stroke="#f2eadc" stroke-opacity=".35"/>
+    <path d="M752 194h154M752 232h118M752 270h86" stroke="#b08968" stroke-width="8" opacity=".36" stroke-linecap="round"/>
+    <circle cx="842" cy="410" r="78" fill="none" stroke="#e7b8c3" stroke-width="4" opacity=".42"/>
+    <path d="M790 410h104M842 358v104" stroke="#f2eadc" stroke-width="5" opacity=".35" stroke-linecap="round"/>
+  </g>
 </svg>

--- a/backend/public/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg
+++ b/backend/public/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg
@@ -1,21 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
   <title>FermatMind editorial cover placeholder for childhood-dream-job-still-shapes-career-choice</title>
-  <desc>Abstract academic editorial cover placeholder generated in-house for launch readiness.</desc>
+  <desc>抽象轨迹从童年职业图标延伸到成年职业路径</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0f172a"/><stop offset="1" stop-color="#020617"/></linearGradient>
-    <radialGradient id="wash" cx="34%" cy="22%" r="70%"><stop offset="0" stop-color="#1f3b36" stop-opacity=".92"/><stop offset="1" stop-color="#1f3b36" stop-opacity="0"/></radialGradient>
-    <pattern id="grid" width="56" height="56" patternUnits="userSpaceOnUse"><path d="M56 0H0v56" fill="none" stroke="#e2e8f0" stroke-opacity=".055" stroke-width="1"/></pattern>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#09111f"/><stop offset="1" stop-color="#020617"/></linearGradient>
+    <radialGradient id="pulse" cx=".72" cy=".28" r=".56"><stop offset="0" stop-color="#f4efe2" stop-opacity=".32"/><stop offset="1" stop-color="#f4efe2" stop-opacity="0"/></radialGradient>
   </defs>
   <rect width="1200" height="675" fill="url(#bg)"/>
-  <rect width="1200" height="675" fill="url(#grid)"/>
-  <rect width="1200" height="675" fill="url(#wash)"/>
-  <rect x="86" y="78" width="1028" height="520" rx="34" fill="#0f172a" fill-opacity=".28" stroke="#e2e8f0" stroke-opacity=".12"/>
-  <path d="M134 132h184M134 166h96" stroke="#e2e8f0" stroke-opacity=".18" stroke-width="7" stroke-linecap="round"/>
-  <path d="M1066 544h-184M1066 510h-96" stroke="#e2e8f0" stroke-opacity=".16" stroke-width="7" stroke-linecap="round"/>
-  
-      <path d="M244 438h710" stroke="#dbeafe" stroke-width="6" opacity=".22"/>
-      <circle cx="294" cy="438" r="20" fill="#d8b46a"/><circle cx="538" cy="438" r="18" fill="#4f9d7a"/><circle cx="792" cy="438" r="20" fill="#e2e8f0" opacity=".68"/>
-      <path d="M294 438c60-142 172-184 244-92 74 94 166 78 254-48" fill="none" stroke="#4f9d7a" stroke-width="8" opacity=".72"/>
-      <path d="m294 254 18 38 42 6-30 29 7 42-37-20-37 20 7-42-30-29 42-6 18-38Z" fill="#d8b46a" opacity=".82"/>
-      <rect x="706" y="204" width="220" height="150" rx="18" fill="none" stroke="#d8b46a" stroke-width="6" opacity=".58"/><path d="M740 254h152M740 304h104" stroke="#dbeafe" stroke-width="5" opacity=".3"/>
+  <rect width="1200" height="675" fill="url(#pulse)"/>
+  <g opacity=".24" stroke="#334155" stroke-width="1">
+    <path d="M 80 80 V 595"/>
+    <path d="M 158 80 V 595"/>
+    <path d="M 236 80 V 595"/>
+    <path d="M 314 80 V 595"/>
+    <path d="M 392 80 V 595"/>
+    <path d="M 470 80 V 595"/>
+    <path d="M 548 80 V 595"/>
+    <path d="M 626 80 V 595"/>
+    <path d="M 704 80 V 595"/>
+    <path d="M 782 80 V 595"/>
+    <path d="M 860 80 V 595"/>
+    <path d="M 938 80 V 595"/>
+    <path d="M 1016 80 V 595"/>
+    <path d="M 1094 80 V 595"/>
+    <path d="M 80 95 H 1120"/>
+    <path d="M 80 173 H 1120"/>
+    <path d="M 80 251 H 1120"/>
+    <path d="M 80 329 H 1120"/>
+    <path d="M 80 407 H 1120"/>
+    <path d="M 80 485 H 1120"/>
+    <path d="M 80 563 H 1120"/>
+  </g>
+  <g transform="translate(80 20)">
+    <path d="M275 430c-64-44-96-104-86-181 12-92 92-161 190-161 108 0 195 81 198 183 3 86-45 148-118 185" fill="none" stroke="#c89b3c" stroke-width="8" opacity=".35" stroke-linecap="round"/>
+    <path d="M730 116c138 18 232 102 250 217 13 84-21 156-86 211" fill="none" stroke="#f4efe2" stroke-width="6" opacity=".28" stroke-linecap="round"/>
+    <path d="M 260 175 C 420 110, 590 420, 720 215" stroke="#f4efe2" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 175 C 448 126, 608 408, 746 248" stroke="#c89b3c" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 175 C 476 142, 626 396, 772 281" stroke="#f4efe2" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 270 C 504 158, 644 384, 798 314" stroke="#c89b3c" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 270 C 532 174, 662 372, 824 347" stroke="#f4efe2" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 270 C 560 190, 680 360, 850 380" stroke="#c89b3c" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 365 C 588 206, 698 348, 876 413" stroke="#f4efe2" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 365 C 616 222, 716 336, 902 446" stroke="#c89b3c" stroke-width="2" opacity=".34" fill="none"/>
+    <circle cx="260" cy="175" r="7" fill="#f4efe2" opacity=".78"/>
+    <circle cx="417" cy="186" r="7" fill="#c89b3c" opacity=".78"/>
+    <circle cx="574" cy="197" r="7" fill="#f4efe2" opacity=".78"/>
+    <circle cx="276" cy="279" r="7" fill="#c89b3c" opacity=".78"/>
+    <circle cx="433" cy="290" r="7" fill="#f4efe2" opacity=".78"/>
+    <circle cx="555" cy="277" r="7" fill="#c89b3c" opacity=".78"/>
+    <circle cx="292" cy="383" r="7" fill="#f4efe2" opacity=".78"/>
+    <circle cx="414" cy="370" r="7" fill="#c89b3c" opacity=".78"/>
+    <circle cx="571" cy="381" r="7" fill="#f4efe2" opacity=".78"/>
+    <rect x="715" y="150" width="230" height="142" rx="22" fill="#ffffff" opacity=".055" stroke="#f4efe2" stroke-opacity=".35"/>
+    <path d="M752 194h154M752 232h118M752 270h86" stroke="#334155" stroke-width="8" opacity=".36" stroke-linecap="round"/>
+    <circle cx="842" cy="410" r="78" fill="none" stroke="#c89b3c" stroke-width="4" opacity=".42"/>
+    <path d="M790 410h104M842 358v104" stroke="#f4efe2" stroke-width="5" opacity=".35" stroke-linecap="round"/>
+  </g>
 </svg>

--- a/backend/public/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg
+++ b/backend/public/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg
@@ -1,21 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
   <title>FermatMind editorial cover placeholder for how-16-personality-types-talk-to-an-ai-coach</title>
-  <desc>Abstract academic editorial cover placeholder generated in-house for launch readiness.</desc>
+  <desc>抽象对话气泡与镜面结构表现人格与 AI 教练的互动</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b1320"/><stop offset="1" stop-color="#020617"/></linearGradient>
-    <radialGradient id="wash" cx="34%" cy="22%" r="70%"><stop offset="0" stop-color="#21314a" stop-opacity=".92"/><stop offset="1" stop-color="#21314a" stop-opacity="0"/></radialGradient>
-    <pattern id="grid" width="56" height="56" patternUnits="userSpaceOnUse"><path d="M56 0H0v56" fill="none" stroke="#e2e8f0" stroke-opacity=".055" stroke-width="1"/></pattern>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#07121f"/><stop offset="1" stop-color="#020617"/></linearGradient>
+    <radialGradient id="pulse" cx=".72" cy=".28" r=".56"><stop offset="0" stop-color="#38bdf8" stop-opacity=".32"/><stop offset="1" stop-color="#38bdf8" stop-opacity="0"/></radialGradient>
   </defs>
   <rect width="1200" height="675" fill="url(#bg)"/>
-  <rect width="1200" height="675" fill="url(#grid)"/>
-  <rect width="1200" height="675" fill="url(#wash)"/>
-  <rect x="86" y="78" width="1028" height="520" rx="34" fill="#0f172a" fill-opacity=".28" stroke="#e2e8f0" stroke-opacity=".12"/>
-  <path d="M134 132h184M134 166h96" stroke="#e2e8f0" stroke-opacity=".18" stroke-width="7" stroke-linecap="round"/>
-  <path d="M1066 544h-184M1066 510h-96" stroke="#e2e8f0" stroke-opacity=".16" stroke-width="7" stroke-linecap="round"/>
-  
-      <rect x="266" y="190" width="286" height="176" rx="26" fill="none" stroke="#4db6d6" stroke-width="8" opacity=".82"/>
-      <rect x="650" y="214" width="270" height="226" rx="30" fill="none" stroke="#d3aa55" stroke-width="7" opacity=".72"/>
-      <path d="M326 250h154M326 306h104M708 282h154M708 340h110" stroke="#e2e8f0" stroke-width="6" opacity=".34"/>
-      <path d="M552 314c54 50 92 50 98 50" fill="none" stroke="#dbeafe" stroke-width="6" opacity=".28"/>
-      <circle cx="310" cy="484" r="8" fill="#d3aa55" opacity=".75"/><circle cx="346" cy="484" r="8" fill="#4db6d6" opacity=".75"/><circle cx="382" cy="484" r="8" fill="#4db6d6" opacity=".75"/><circle cx="418" cy="484" r="8" fill="#d3aa55" opacity=".75"/><circle cx="454" cy="484" r="8" fill="#4db6d6" opacity=".75"/><circle cx="490" cy="484" r="8" fill="#4db6d6" opacity=".75"/><circle cx="526" cy="484" r="8" fill="#d3aa55" opacity=".75"/><circle cx="562" cy="484" r="8" fill="#4db6d6" opacity=".75"/><circle cx="310" cy="522" r="8" fill="#4db6d6" opacity=".75"/><circle cx="346" cy="522" r="8" fill="#d3aa55" opacity=".75"/><circle cx="382" cy="522" r="8" fill="#4db6d6" opacity=".75"/><circle cx="418" cy="522" r="8" fill="#4db6d6" opacity=".75"/><circle cx="454" cy="522" r="8" fill="#d3aa55" opacity=".75"/><circle cx="490" cy="522" r="8" fill="#4db6d6" opacity=".75"/><circle cx="526" cy="522" r="8" fill="#4db6d6" opacity=".75"/><circle cx="562" cy="522" r="8" fill="#d3aa55" opacity=".75"/>
+  <rect width="1200" height="675" fill="url(#pulse)"/>
+  <g opacity=".24" stroke="#94a3b8" stroke-width="1">
+    <path d="M 80 80 V 595"/>
+    <path d="M 158 80 V 595"/>
+    <path d="M 236 80 V 595"/>
+    <path d="M 314 80 V 595"/>
+    <path d="M 392 80 V 595"/>
+    <path d="M 470 80 V 595"/>
+    <path d="M 548 80 V 595"/>
+    <path d="M 626 80 V 595"/>
+    <path d="M 704 80 V 595"/>
+    <path d="M 782 80 V 595"/>
+    <path d="M 860 80 V 595"/>
+    <path d="M 938 80 V 595"/>
+    <path d="M 1016 80 V 595"/>
+    <path d="M 1094 80 V 595"/>
+    <path d="M 80 95 H 1120"/>
+    <path d="M 80 173 H 1120"/>
+    <path d="M 80 251 H 1120"/>
+    <path d="M 80 329 H 1120"/>
+    <path d="M 80 407 H 1120"/>
+    <path d="M 80 485 H 1120"/>
+    <path d="M 80 563 H 1120"/>
+  </g>
+  <g transform="translate(80 20)">
+    <path d="M275 430c-64-44-96-104-86-181 12-92 92-161 190-161 108 0 195 81 198 183 3 86-45 148-118 185" fill="none" stroke="#14b8a6" stroke-width="8" opacity=".35" stroke-linecap="round"/>
+    <path d="M730 116c138 18 232 102 250 217 13 84-21 156-86 211" fill="none" stroke="#38bdf8" stroke-width="6" opacity=".28" stroke-linecap="round"/>
+    <path d="M 260 175 C 420 110, 590 420, 720 215" stroke="#38bdf8" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 175 C 448 126, 608 408, 746 248" stroke="#14b8a6" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 175 C 476 142, 626 396, 772 281" stroke="#38bdf8" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 270 C 504 158, 644 384, 798 314" stroke="#14b8a6" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 270 C 532 174, 662 372, 824 347" stroke="#38bdf8" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 270 C 560 190, 680 360, 850 380" stroke="#14b8a6" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 365 C 588 206, 698 348, 876 413" stroke="#38bdf8" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 365 C 616 222, 716 336, 902 446" stroke="#14b8a6" stroke-width="2" opacity=".34" fill="none"/>
+    <circle cx="260" cy="175" r="7" fill="#38bdf8" opacity=".78"/>
+    <circle cx="417" cy="186" r="7" fill="#14b8a6" opacity=".78"/>
+    <circle cx="574" cy="197" r="7" fill="#38bdf8" opacity=".78"/>
+    <circle cx="276" cy="279" r="7" fill="#14b8a6" opacity=".78"/>
+    <circle cx="433" cy="290" r="7" fill="#38bdf8" opacity=".78"/>
+    <circle cx="555" cy="277" r="7" fill="#14b8a6" opacity=".78"/>
+    <circle cx="292" cy="383" r="7" fill="#38bdf8" opacity=".78"/>
+    <circle cx="414" cy="370" r="7" fill="#14b8a6" opacity=".78"/>
+    <circle cx="571" cy="381" r="7" fill="#38bdf8" opacity=".78"/>
+    <rect x="715" y="150" width="230" height="142" rx="22" fill="#ffffff" opacity=".055" stroke="#38bdf8" stroke-opacity=".35"/>
+    <path d="M752 194h154M752 232h118M752 270h86" stroke="#94a3b8" stroke-width="8" opacity=".36" stroke-linecap="round"/>
+    <circle cx="842" cy="410" r="78" fill="none" stroke="#14b8a6" stroke-width="4" opacity=".42"/>
+    <path d="M790 410h104M842 358v104" stroke="#38bdf8" stroke-width="5" opacity=".35" stroke-linecap="round"/>
+  </g>
 </svg>

--- a/backend/public/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg
+++ b/backend/public/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg
@@ -1,21 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
   <title>FermatMind editorial cover placeholder for how-personality-shapes-attitude-toward-ai</title>
-  <desc>Abstract academic editorial cover placeholder generated in-house for launch readiness.</desc>
+  <desc>抽象人脸轮廓与 AI 节点网络交织，表现人格差异如何影响算法信任</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0f172a"/><stop offset="1" stop-color="#020617"/></linearGradient>
-    <radialGradient id="wash" cx="34%" cy="22%" r="70%"><stop offset="0" stop-color="#12313f" stop-opacity=".92"/><stop offset="1" stop-color="#12313f" stop-opacity="0"/></radialGradient>
-    <pattern id="grid" width="56" height="56" patternUnits="userSpaceOnUse"><path d="M56 0H0v56" fill="none" stroke="#e2e8f0" stroke-opacity=".055" stroke-width="1"/></pattern>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b1220"/><stop offset="1" stop-color="#020617"/></linearGradient>
+    <radialGradient id="pulse" cx=".72" cy=".28" r=".56"><stop offset="0" stop-color="#22d3ee" stop-opacity=".32"/><stop offset="1" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
   </defs>
   <rect width="1200" height="675" fill="url(#bg)"/>
-  <rect width="1200" height="675" fill="url(#grid)"/>
-  <rect width="1200" height="675" fill="url(#wash)"/>
-  <rect x="86" y="78" width="1028" height="520" rx="34" fill="#0f172a" fill-opacity=".28" stroke="#e2e8f0" stroke-opacity=".12"/>
-  <path d="M134 132h184M134 166h96" stroke="#e2e8f0" stroke-opacity=".18" stroke-width="7" stroke-linecap="round"/>
-  <path d="M1066 544h-184M1066 510h-96" stroke="#e2e8f0" stroke-opacity=".16" stroke-width="7" stroke-linecap="round"/>
-  
-      <path d="M300 210c52-58 142-58 194 0 35 39 35 98 0 137-52 58-142 58-194 0-35-39-35-98 0-137Z" fill="none" stroke="#1f8a9b" stroke-width="8" opacity=".82"/>
-      <path d="M398 176v246" stroke="#dbeafe" stroke-width="6" opacity=".28"/>
-      <circle cx="700" cy="232" r="22" fill="#d8b46a" opacity=".9"/><circle cx="800" cy="330" r="18" fill="#1f8a9b" opacity=".85"/><circle cx="668" cy="430" r="16" fill="#e2e8f0" opacity=".72"/>
-      <path d="M700 232 800 330 668 430 700 232" fill="none" stroke="#dbeafe" stroke-width="5" opacity=".45"/>
-      <path d="M610 330h-94M822 330h96M668 430v62" stroke="#dbeafe" stroke-width="5" opacity=".36"/>
+  <rect width="1200" height="675" fill="url(#pulse)"/>
+  <g opacity=".24" stroke="#94a3b8" stroke-width="1">
+    <path d="M 80 80 V 595"/>
+    <path d="M 158 80 V 595"/>
+    <path d="M 236 80 V 595"/>
+    <path d="M 314 80 V 595"/>
+    <path d="M 392 80 V 595"/>
+    <path d="M 470 80 V 595"/>
+    <path d="M 548 80 V 595"/>
+    <path d="M 626 80 V 595"/>
+    <path d="M 704 80 V 595"/>
+    <path d="M 782 80 V 595"/>
+    <path d="M 860 80 V 595"/>
+    <path d="M 938 80 V 595"/>
+    <path d="M 1016 80 V 595"/>
+    <path d="M 1094 80 V 595"/>
+    <path d="M 80 95 H 1120"/>
+    <path d="M 80 173 H 1120"/>
+    <path d="M 80 251 H 1120"/>
+    <path d="M 80 329 H 1120"/>
+    <path d="M 80 407 H 1120"/>
+    <path d="M 80 485 H 1120"/>
+    <path d="M 80 563 H 1120"/>
+  </g>
+  <g transform="translate(80 20)">
+    <path d="M275 430c-64-44-96-104-86-181 12-92 92-161 190-161 108 0 195 81 198 183 3 86-45 148-118 185" fill="none" stroke="#0f766e" stroke-width="8" opacity=".35" stroke-linecap="round"/>
+    <path d="M730 116c138 18 232 102 250 217 13 84-21 156-86 211" fill="none" stroke="#22d3ee" stroke-width="6" opacity=".28" stroke-linecap="round"/>
+    <path d="M 260 175 C 420 110, 590 420, 720 215" stroke="#22d3ee" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 175 C 448 126, 608 408, 746 248" stroke="#0f766e" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 175 C 476 142, 626 396, 772 281" stroke="#22d3ee" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 270 C 504 158, 644 384, 798 314" stroke="#0f766e" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 270 C 532 174, 662 372, 824 347" stroke="#22d3ee" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 270 C 560 190, 680 360, 850 380" stroke="#0f766e" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 365 C 588 206, 698 348, 876 413" stroke="#22d3ee" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 365 C 616 222, 716 336, 902 446" stroke="#0f766e" stroke-width="2" opacity=".34" fill="none"/>
+    <circle cx="260" cy="175" r="7" fill="#22d3ee" opacity=".78"/>
+    <circle cx="417" cy="186" r="7" fill="#0f766e" opacity=".78"/>
+    <circle cx="574" cy="197" r="7" fill="#22d3ee" opacity=".78"/>
+    <circle cx="276" cy="279" r="7" fill="#0f766e" opacity=".78"/>
+    <circle cx="433" cy="290" r="7" fill="#22d3ee" opacity=".78"/>
+    <circle cx="555" cy="277" r="7" fill="#0f766e" opacity=".78"/>
+    <circle cx="292" cy="383" r="7" fill="#22d3ee" opacity=".78"/>
+    <circle cx="414" cy="370" r="7" fill="#0f766e" opacity=".78"/>
+    <circle cx="571" cy="381" r="7" fill="#22d3ee" opacity=".78"/>
+    <rect x="715" y="150" width="230" height="142" rx="22" fill="#ffffff" opacity=".055" stroke="#22d3ee" stroke-opacity=".35"/>
+    <path d="M752 194h154M752 232h118M752 270h86" stroke="#94a3b8" stroke-width="8" opacity=".36" stroke-linecap="round"/>
+    <circle cx="842" cy="410" r="78" fill="none" stroke="#0f766e" stroke-width="4" opacity=".42"/>
+    <path d="M790 410h104M842 358v104" stroke="#22d3ee" stroke-width="5" opacity=".35" stroke-linecap="round"/>
+  </g>
 </svg>

--- a/backend/public/static/articles/covers/which-love-script-fits-you-best.svg
+++ b/backend/public/static/articles/covers/which-love-script-fits-you-best.svg
@@ -1,20 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
   <title>FermatMind editorial cover placeholder for which-love-script-fits-you-best</title>
-  <desc>Abstract academic editorial cover placeholder generated in-house for launch readiness.</desc>
+  <desc>抽象关系网络中呈现七种爱情脚本的几何路径</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#111827"/><stop offset="1" stop-color="#020617"/></linearGradient>
-    <radialGradient id="wash" cx="34%" cy="22%" r="70%"><stop offset="0" stop-color="#243447" stop-opacity=".92"/><stop offset="1" stop-color="#243447" stop-opacity="0"/></radialGradient>
-    <pattern id="grid" width="56" height="56" patternUnits="userSpaceOnUse"><path d="M56 0H0v56" fill="none" stroke="#e2e8f0" stroke-opacity=".055" stroke-width="1"/></pattern>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#121826"/><stop offset="1" stop-color="#020617"/></linearGradient>
+    <radialGradient id="pulse" cx=".72" cy=".28" r=".56"><stop offset="0" stop-color="#f4ead7" stop-opacity=".32"/><stop offset="1" stop-color="#f4ead7" stop-opacity="0"/></radialGradient>
   </defs>
   <rect width="1200" height="675" fill="url(#bg)"/>
-  <rect width="1200" height="675" fill="url(#grid)"/>
-  <rect width="1200" height="675" fill="url(#wash)"/>
-  <rect x="86" y="78" width="1028" height="520" rx="34" fill="#0f172a" fill-opacity=".28" stroke="#e2e8f0" stroke-opacity=".12"/>
-  <path d="M134 132h184M134 166h96" stroke="#e2e8f0" stroke-opacity=".18" stroke-width="7" stroke-linecap="round"/>
-  <path d="M1066 544h-184M1066 510h-96" stroke="#e2e8f0" stroke-opacity=".16" stroke-width="7" stroke-linecap="round"/>
-  
-      <path d="M310 350 540 190 770 350 540 500Z" fill="none" stroke="#d8b46a" stroke-width="7" opacity=".72"/>
-      <path d="M380 330c45-92 146-94 194 0 48-94 149-92 194 0-46 96-126 145-194 176-68-31-148-80-194-176Z" fill="none" stroke="#c77d7d" stroke-width="8" opacity=".86"/>
-      <circle cx="540" cy="190" r="18" fill="#e2e8f0" opacity=".75"/><circle cx="310" cy="350" r="18" fill="#c77d7d" opacity=".75"/><circle cx="770" cy="350" r="18" fill="#d8b46a" opacity=".8"/>
-      <path d="M250 504c180-76 410-76 590 0" fill="none" stroke="#dbeafe" stroke-width="5" opacity=".24"/>
+  <rect width="1200" height="675" fill="url(#pulse)"/>
+  <g opacity=".24" stroke="#334155" stroke-width="1">
+    <path d="M 80 80 V 595"/>
+    <path d="M 158 80 V 595"/>
+    <path d="M 236 80 V 595"/>
+    <path d="M 314 80 V 595"/>
+    <path d="M 392 80 V 595"/>
+    <path d="M 470 80 V 595"/>
+    <path d="M 548 80 V 595"/>
+    <path d="M 626 80 V 595"/>
+    <path d="M 704 80 V 595"/>
+    <path d="M 782 80 V 595"/>
+    <path d="M 860 80 V 595"/>
+    <path d="M 938 80 V 595"/>
+    <path d="M 1016 80 V 595"/>
+    <path d="M 1094 80 V 595"/>
+    <path d="M 80 95 H 1120"/>
+    <path d="M 80 173 H 1120"/>
+    <path d="M 80 251 H 1120"/>
+    <path d="M 80 329 H 1120"/>
+    <path d="M 80 407 H 1120"/>
+    <path d="M 80 485 H 1120"/>
+    <path d="M 80 563 H 1120"/>
+  </g>
+  <g transform="translate(80 20)">
+    <path d="M275 430c-64-44-96-104-86-181 12-92 92-161 190-161 108 0 195 81 198 183 3 86-45 148-118 185" fill="none" stroke="#e9b8c6" stroke-width="8" opacity=".35" stroke-linecap="round"/>
+    <path d="M730 116c138 18 232 102 250 217 13 84-21 156-86 211" fill="none" stroke="#f4ead7" stroke-width="6" opacity=".28" stroke-linecap="round"/>
+    <path d="M 260 175 C 420 110, 590 420, 720 215" stroke="#f4ead7" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 175 C 448 126, 608 408, 746 248" stroke="#e9b8c6" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 175 C 476 142, 626 396, 772 281" stroke="#f4ead7" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 270 C 504 158, 644 384, 798 314" stroke="#e9b8c6" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 270 C 532 174, 662 372, 824 347" stroke="#f4ead7" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 540 270 C 560 190, 680 360, 850 380" stroke="#e9b8c6" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 260 365 C 588 206, 698 348, 876 413" stroke="#f4ead7" stroke-width="2" opacity=".34" fill="none"/>
+    <path d="M 400 365 C 616 222, 716 336, 902 446" stroke="#e9b8c6" stroke-width="2" opacity=".34" fill="none"/>
+    <circle cx="260" cy="175" r="7" fill="#f4ead7" opacity=".78"/>
+    <circle cx="417" cy="186" r="7" fill="#e9b8c6" opacity=".78"/>
+    <circle cx="574" cy="197" r="7" fill="#f4ead7" opacity=".78"/>
+    <circle cx="276" cy="279" r="7" fill="#e9b8c6" opacity=".78"/>
+    <circle cx="433" cy="290" r="7" fill="#f4ead7" opacity=".78"/>
+    <circle cx="555" cy="277" r="7" fill="#e9b8c6" opacity=".78"/>
+    <circle cx="292" cy="383" r="7" fill="#f4ead7" opacity=".78"/>
+    <circle cx="414" cy="370" r="7" fill="#e9b8c6" opacity=".78"/>
+    <circle cx="571" cy="381" r="7" fill="#f4ead7" opacity=".78"/>
+    <rect x="715" y="150" width="230" height="142" rx="22" fill="#ffffff" opacity=".055" stroke="#f4ead7" stroke-opacity=".35"/>
+    <path d="M752 194h154M752 232h118M752 270h86" stroke="#334155" stroke-width="8" opacity=".36" stroke-linecap="round"/>
+    <circle cx="842" cy="410" r="78" fill="none" stroke="#e9b8c6" stroke-width="4" opacity=".42"/>
+    <path d="M790 410h104M842 358v104" stroke="#f4ead7" stroke-width="5" opacity=".35" stroke-linecap="round"/>
+  </g>
 </svg>

--- a/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+++ b/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\CareerCms;
 
 use App\Models\Article;
+use App\Services\Cms\ArticleSeoService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -21,8 +22,8 @@ final class ArticleBaselineImportTest extends TestCase
             '--source-dir' => '../content_baselines/articles',
         ])
             ->expectsOutputToContain('files_found=2')
-            ->expectsOutputToContain('articles_found=42')
-            ->expectsOutputToContain('will_create=42')
+            ->expectsOutputToContain('articles_found=45')
+            ->expectsOutputToContain('will_create=45')
             ->assertExitCode(0);
 
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
@@ -36,13 +37,13 @@ final class ArticleBaselineImportTest extends TestCase
             '--source-dir' => '../content_baselines/articles',
         ])
             ->expectsOutputToContain('files_found=2')
-            ->expectsOutputToContain('articles_found=42')
-            ->expectsOutputToContain('will_create=42')
+            ->expectsOutputToContain('articles_found=45')
+            ->expectsOutputToContain('will_create=45')
             ->assertExitCode(0);
 
-        $this->assertSame(42, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(45, Article::query()->withoutGlobalScopes()->count());
         $this->assertSame(
-            42,
+            45,
             Article::query()
                 ->withoutGlobalScopes()
                 ->where('status', 'published')
@@ -89,16 +90,124 @@ final class ArticleBaselineImportTest extends TestCase
             'https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg',
             $editorial->cover_image_variants['hero'] ?? null
         );
+        $this->assertSame('性格如何影响你对 AI 的态度？人格、焦虑与算法信任', $editorial->publishedRevision?->seo_title);
+        $this->assertSame(
+            '为什么有人信任 AI，有人却焦虑？本文用人格心理学解释 AI 态度、算法信任、控制感与职业判断边界。',
+            $editorial->publishedRevision?->seo_description
+        );
+        $this->assertSame(
+            '性格如何影响你对 AI 的态度？人格、焦虑与算法信任',
+            $editorial->seoMeta?->seo_title
+        );
+        $this->assertSame(
+            '冷静的学术编辑部封面，抽象人脸轮廓与蓝绿色 AI 节点网络交织，几何线条表现控制感、信任与认知边界，现代咨询报告风格，无真实人物照片，无标题文字，高级深蓝与青绿色调，minimal academic editorial design',
+            data_get($editorial->cover_image_variants, 'editorial_metadata.cover_image_prompt')
+        );
+        $this->assertSame(
+            'academic-editorial, ai-personality, muted-geometric',
+            data_get($editorial->cover_image_variants, 'editorial_metadata.cover_image_style_tag')
+        );
+        $this->assertContains('/zh/tests/mbti-personality-test-16-personality-types', data_get($editorial->cover_image_variants, 'editorial_metadata.internal_links', []));
+
+        $this->assertSixEditorialArticlesConvergeThroughSeoAuthority();
 
         $this->artisan('articles:import-local-baseline', [
             '--upsert' => true,
             '--status' => 'published',
             '--source-dir' => '../content_baselines/articles',
         ])
-            ->expectsOutputToContain('articles_found=42')
-            ->expectsOutputToContain('will_skip=42')
+            ->expectsOutputToContain('articles_found=45')
+            ->expectsOutputToContain('will_skip=45')
             ->assertExitCode(0);
 
-        $this->assertSame(42, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(45, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    private function assertSixEditorialArticlesConvergeThroughSeoAuthority(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        /** @var ArticleSeoService $seoService */
+        $seoService = app(ArticleSeoService::class);
+        $expected = [
+            'how-personality-shapes-attitude-toward-ai' => [
+                'title' => '你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任',
+                'seo_title' => '性格如何影响你对 AI 的态度？人格、焦虑与算法信任',
+                'seo_description' => '为什么有人信任 AI，有人却焦虑？本文用人格心理学解释 AI 态度、算法信任、控制感与职业判断边界。',
+                'alt' => '抽象人脸轮廓与 AI 节点网络交织，表现人格差异如何影响算法信任',
+            ],
+            'which-love-script-fits-you-best' => [
+                'title' => '你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配',
+                'seo_title' => '哪种爱情类型适合你？七种关系脚本与人格匹配',
+                'seo_description' => '什么样的关系更适合你？用爱情风格、亲密关系研究和人格差异，理解激情、稳定、承诺与长期相处。',
+                'alt' => '抽象关系网络中呈现七种爱情脚本的几何路径',
+            ],
+            'are-infj-men-rare-or-socially-silenced' => [
+                'title' => '“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？',
+                'seo_title' => 'INFJ 男性真的少见吗？高敏感男性与自我沉默',
+                'seo_description' => 'INFJ 男性为何常被认为少见？本文用男性规范、自我沉默与情绪抑制研究解释高敏感男性的可见性困境。',
+                'alt' => '半透明男性轮廓与被压低的声波线条，象征高敏感男性的自我沉默',
+            ],
+            'best-valentines-date-by-personality-and-relationship-science' => [
+                'title' => '情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会',
+                'seo_title' => '情人节约会怎么安排？按人格和关系科学设计低摩擦约会',
+                'seo_description' => '情人节约会不是越浪漫越好。用人格差异、亲密关系研究和低摩擦原则，设计更适合双方的约会体验。',
+                'alt' => '抽象路径地图连接两个关系节点，表现低摩擦约会设计',
+            ],
+            'how-16-personality-types-talk-to-an-ai-coach' => [
+                'title' => '当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说',
+                'seo_title' => '16 型人格如何使用 AI 教练？镜子、工具与判断风险',
+                'seo_description' => '不同人格如何与 AI 教练对话？有人把它当工具，有人把它当情绪镜子，也有人最容易被顺着说。',
+                'alt' => '抽象对话气泡与镜面结构表现人格与 AI 教练的互动',
+            ],
+            'childhood-dream-job-still-shapes-career-choice' => [
+                'title' => '你小时候想做的工作，为什么还在影响你今天的职业判断？',
+                'seo_title' => '小时候想做的工作，如何影响成年职业选择？',
+                'seo_description' => '童年 dream job 不是职业预言，而是早期自我概念线索。理解它，能帮助你识别职业兴趣与工作结构偏好。',
+                'alt' => '抽象轨迹从童年职业图标延伸到成年职业路径',
+            ],
+        ];
+
+        foreach ($expected as $slug => $contract) {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['publishedRevision', 'seoMeta', 'category', 'tags'])
+                ->where('org_id', 0)
+                ->where('locale', 'zh-CN')
+                ->where('slug', $slug)
+                ->firstOrFail();
+
+            $cover = 'https://api.fermatmind.com/static/articles/covers/'.$slug.'.svg';
+            $canonical = 'https://fermatmind.com/zh/articles/'.$slug;
+            $this->assertSame($contract['title'], (string) $article->title);
+            $this->assertSame($contract['title'], (string) $article->publishedRevision?->title);
+            $this->assertSame($contract['seo_title'], (string) $article->publishedRevision?->seo_title);
+            $this->assertSame($contract['seo_description'], (string) $article->publishedRevision?->seo_description);
+            $this->assertSame($contract['seo_title'], (string) $article->seoMeta?->seo_title);
+            $this->assertSame($contract['seo_description'], (string) $article->seoMeta?->seo_description);
+            $this->assertSame($canonical, (string) $article->seoMeta?->canonical_url);
+            $this->assertSame('index,follow', (string) $article->seoMeta?->robots);
+            $this->assertSame($cover, (string) $article->cover_image_url);
+            $this->assertSame($contract['alt'], (string) $article->cover_image_alt);
+            $this->assertSame($cover, $article->cover_image_variants['og'] ?? null);
+            $this->assertNotEmpty(data_get($article->cover_image_variants, 'editorial_metadata.cover_image_prompt'));
+            $this->assertNotEmpty(data_get($article->cover_image_variants, 'editorial_metadata.cover_image_style_tag'));
+            $this->assertNotEmpty(data_get($article->cover_image_variants, 'editorial_metadata.references'));
+            $this->assertStringContainsString('References', (string) $article->publishedRevision?->content_md);
+            $this->assertTrue((bool) $article->is_public);
+            $this->assertTrue((bool) $article->is_indexable);
+            $this->assertSame('published', (string) $article->status);
+
+            $seoPayload = $seoService->buildSeoPayload($article, $article->publishedRevision);
+            $jsonLd = $seoService->generateJsonLd($article, $article->publishedRevision);
+            $this->assertSame($contract['seo_title'], $seoPayload['title']);
+            $this->assertSame($contract['seo_description'], $seoPayload['description']);
+            $this->assertSame($canonical, $seoPayload['canonical']);
+            $this->assertSame($cover, data_get($seoPayload, 'og.image'));
+            $this->assertSame($canonical.'#article', data_get($jsonLd, '@id'));
+            $this->assertSame($contract['seo_title'], data_get($jsonLd, 'headline'));
+            $this->assertSame($contract['seo_description'], data_get($jsonLd, 'description'));
+            $this->assertSame($cover, data_get($jsonLd, 'image'));
+        }
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -441,6 +441,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_article_publishing_runtime_truth_gate_changes(): void
     {
         $changed = [
+            'backend/app/Console/Commands/ArticleImportLocalBaseline.php',
             'backend/app/Services/Career/StructuredData/CareerArticleStructuredDataBuilder.php',
             'backend/app/Services/Cms/ArticleSeoService.php',
         ];
@@ -1311,6 +1312,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isArticlePublishingRuntimeTruthGateFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Console/Commands/ArticleImportLocalBaseline.php',
             'backend/app/Services/Career/StructuredData/CareerArticleStructuredDataBuilder.php',
             'backend/app/Services/Cms/ArticleSeoService.php',
         ], true);

--- a/content_baselines/articles/articles.zh-CN.json
+++ b/content_baselines/articles/articles.zh-CN.json
@@ -9,12 +9,12 @@
     {
       "slug": "are-infj-men-rare-or-socially-silenced",
       "title": "“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？",
-      "excerpt": "当人们说“某类男性太少见”时，他们常常忽略了一个更复杂的问题：不是他们不存在，而是他们可能更早学会了压抑、伪装和自我沉默。本文用自我沉默、男性规范与情绪抑制研究，重看“高敏感男性”的社会化困境。",
-      "content_md": "## 执行摘要\n“INFJ 男性很少见”这种说法之所以流行，不是因为它一定准确，而是因为它击中了一个真实现象：一些更重价值、一致性、深度共情和内省的男性，经常不把这些特质直接表演出来。问题可能不在于“这种男性是不是天然稀有”，而在于：在很多成长环境里，男性从很早就被训练去压缩、遮蔽甚至否认那些被视为“过于敏感”的部分。[1][2][3]\n\n费马的判断是：当我们讨论“高敏感男性是否稀少”时，更有解释力的问题不是频率，而是**可见性**。有些人不是没有这些特质，而是它们在社会规范和关系策略里，被训练成了“不值得公开展示”。\n\n## 一、什么叫“学会沉默”\nJack 与 Dill 提出的“自我沉默”理论，原本用于解释亲密关系中为了维持安全和连接而压抑真实想法与感受的模式。[1] 这套理论后来被更广泛地用于理解：为什么一些人会优先维持外在和谐、外部认可或关系安全，而牺牲内部一致性。\n\n如果把它放到男性社会化语境里，这个机制会更复杂。因为许多男性从小接收的不是“表达自己”，而是“控制自己”“不要太脆弱”“不要显得太敏感”。在这种训练下，情绪并没有消失，只是被改造成了别的形式：幽默、冷淡、理性、效率、沉默，或者看起来“什么都没发生”。[2][3]\n\n## 二、为什么“高敏感男性”容易被误读\n如果一个男性天生更关注意义、关系细节、价值一致性，或者更容易察觉群体氛围中的微小变化，他在很多环境中会面临双重误读：\n\n第一种误读是“你太慢”。因为他在做决定前需要内部整合。\n第二种误读是“你想太多”。因为他比别人更早看到关系代价和长期后果。\n\n但研究一再显示，男性规范中的“情绪控制”“自立”“支配”“工作优先”等维度，一旦被内化得过强，常与较差的心理健康结果、更低的求助态度、以及更高的人际孤立风险相关。[2][4] 这意味着，那些看上去“更能扛、更独立、更不说”的男性，并不一定更稳，很多时候只是更擅长把波动藏起来。\n\n## 三、压抑不是中性的，它有社会成本\nSrivastava 等人的研究表明，表达性压抑与更低的社会支持、更少的亲密感和更低的社交满意度有关。[5] 换句话说，如果一个男性长期把真实情绪和真实需求包起来，他短期可能显得更“成熟”、更“可靠”、更“有控制力”，但长期代价往往是：更难被理解、更难被支持、也更难建立稳定的深层连接。\n\n所以，所谓“某类男性太少见”，很可能混合了两件事：\n- 真实特质分布的差异；\n- 以及更重要的，表达这些特质的社会成本。\n\n对费马来说，后一条往往更有解释力。因为在很多组织和关系里，被看见的不是“你真实是谁”，而是“你愿意让哪一部分自己上台”。\n\n## 四、费马怎么理解“INFJ 男性罕见”\n费马不会把“INFJ 男性罕见”当成一个可以简单宣布的统计真相。更准确的说法应该是：**一些更接近 INFJ 式表达的男性，在现实中更容易采用伪装策略。** 他们不一定不存在，而是可能在公共环境中把自己训练成更像执行者、旁观者或问题处理者，而把脆弱、细腻和价值感隐藏起来。\n\n这也是为什么很多人会说：“我认识的某些男性，真正熟了以后和第一印象完全不同。”这不是人格突然改变，而是表达权限终于被放开。\n\n## 结论\n如果你想判断某类男性是不是“少见”，最先该问的不是“人数”，而是“表达这些特质的代价有多高”。在很多情境里，沉默本身就是一种社会化结果。真正稀少的，未必是这种人格；更稀少的，可能是一个允许这种人格被公开保留的环境。\n\n## 参考文献\n【1】 Jack, D. C., & Dill, D. (1992). The Silencing the Self Scale: Schemas of Intimacy Associated With Depression in Women. Psychology of Women Quarterly, 16(1), 97–106. DOI: 10.1111/j.1471-6402.1992.tb00242.x.\n\n【2】 Mahalik, J. R., Locke, B. D., Ludlow, L. H., et al. (2003). Development of the Conformity to Masculine Norms Inventory. Psychology of Men & Masculinity, 4(1), 3–25. DOI: 10.1037/1524-9220.4.1.3.\n\n【3】 Wong, Y. J., Ho, M.-H. R., Wang, S.-Y., & Miller, I. S. K. (2017). Meta-analyses of the Relationship Between Conformity to Masculine Norms and Mental Health-Related Outcomes. Journal of Counseling Psychology, 64(1), 80–93. DOI: 10.1037/cou0000176.\n\n【4】 Mahalik, J. R., Talmadge, W. T., Locke, B. D., & Scott, R. P. J. (2005). Using the Conformity to Masculine Norms Inventory to Work With Men in a Clinical Setting. Journal of Clinical Psychology, 61(6), 661–674. DOI: 10.1002/jclp.20101.\n\n【5】 Srivastava, S., Tamir, M., McGonigal, K. M., John, O. P., & Gross, J. J. (2009). The Social Costs of Emotional Suppression: A Prospective Study of the Transition to College. Journal of Personality and Social Psychology, 96(4), 883–897. DOI: 10.1037/a0014755.\n\n【6】 Advancing the Next Generation of Research on Self-Silencing and Depression: A Narrative Review and Synthesis of Three Decades of Research. Sex Roles (2025). DOI: 10.1007/s11199-025-01637-8.",
+      "excerpt": "一些男性不是没有深度共情和敏感性，而是更早学会了隐藏这些特质。",
+      "content_md": "# “INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？\n## 执行摘要\n“INFJ 男性很少见”这种说法之所以流行，不是因为它一定准确，而是因为它击中了一个真实现象：\n一些更重价值、一致性、深度共情和内省的男性，经常不把这些特质直接表演出来。\n问题可能不在于“这种男性是不是天然稀有”，而在于：在很多成长环境里，男性从很早就被训练去压缩、遮蔽甚至否认那些被视为“过于敏感”的部分。\nFermatMind 的判断是：当我们讨论“高敏感男性是否稀少”时，更有解释力的问题不是频率，而是**可见性**。\n有些人不是没有这些特质，而是这些特质在社会规范和关系策略里，被训练成了“不值得公开展示”。\n## 一、什么叫“学会沉默”\nJack 与 Dill 提出的“自我沉默”理论，原本用于解释亲密关系中为了维持安全和连接而压抑真实想法与感受的模式。\n这套理论后来被更广泛地用于理解：为什么一些人会优先维持外在和谐、外部认可或关系安全，而牺牲内部一致性。\n如果把它放到男性社会化语境里，这个机制会更复杂。\n许多男性从小接收的不是“表达自己”，而是：\n- 控制自己；\n- 不要太脆弱；\n- 不要显得太敏感；\n- 不要让情绪影响判断。\n在这种训练下，情绪并没有消失，只是被改造成了别的形式：幽默、冷淡、理性、效率、沉默，或者看起来“什么都没发生”。\n## 二、为什么“高敏感男性”容易被误读\n如果一个男性更关注意义、关系细节、价值一致性，或者更容易察觉群体氛围中的微小变化，他在很多环境中会面临双重误读。\n第一种误读是：\n**你太慢。**\n因为他在做决定前需要内部整合。\n第二种误读是：\n**你想太多。**\n因为他比别人更早看到关系代价和长期后果。\n研究一再显示，男性规范中的“情绪控制”“自立”“支配”“工作优先”等维度，一旦被内化得过强，常与较差的心理健康结果、更低的求助态度，以及更高的人际孤立风险相关。\n> **Evidence Note**  \n> 关于男性规范的元分析研究提示：过度遵从传统男性规范，与多种心理健康相关结果存在负向关联。这里的重点不是批评男性气质，而是指出“不能表达”的社会成本。\n那些看上去“更能扛、更独立、更不说”的男性，并不一定更稳。很多时候，他们只是更擅长把波动藏起来。\n## 三、压抑不是中性的，它有社会成本\nSrivastava 等人的研究表明，表达性压抑与更低的社会支持、更少的亲密感和更低的社交满意度有关。\n换句话说，如果一个男性长期把真实情绪和真实需求包起来，他短期可能显得更“成熟”、更“可靠”、更“有控制力”，但长期代价往往是：\n- 更难被理解；\n- 更难被支持；\n- 更难建立稳定的深层连接。\n所以，所谓“某类男性太少见”，很可能混合了两件事：\n1. 真实特质分布的差异；\n2. 表达这些特质的社会成本。\n对 FermatMind 来说，后一条往往更有解释力。\n因为在很多组织和关系里，被看见的不是“你真实是谁”，而是“你愿意让哪一部分自己上台”。\n## 四、FermatMind 如何理解“INFJ 男性罕见”\nFermatMind 不会把“INFJ 男性罕见”当成一个可以简单宣布的统计真相。\n更准确的说法应该是：\n**一些更接近 INFJ 式表达的男性，在现实中更容易采用伪装策略。**\n他们不一定不存在，而是可能在公共环境中把自己训练成更像执行者、旁观者或问题处理者，而把脆弱、细腻和价值感隐藏起来。\n这也是为什么很多人会说：\n“我认识的某些男性，真正熟了以后和第一印象完全不同。”\n这不是人格突然改变，而是表达权限终于被放开。\n## 结论\n如果你想判断某类男性是不是“少见”，最先该问的不是“人数”，而是：\n**表达这些特质的代价有多高。**\n在很多情境里，沉默本身就是一种社会化结果。\n真正稀少的，未必是这种人格；更稀少的，可能是一个允许这种人格被公开保留的环境。\n\nReferences\n\n[1] Jack, D. C., & Dill, D. (1992). The Silencing the Self Scale: Schemas of intimacy associated with depression in women. Psychology of Women Quarterly, 16(1), 97–106. https://doi.org/10.1111/j.1471-6402.1992.tb00242.x\n[2] Mahalik, J. R., Locke, B. D., Ludlow, L. H., et al. (2003). Development of the Conformity to Masculine Norms Inventory. Psychology of Men & Masculinity, 4(1), 3–25. https://doi.org/10.1037/1524-9220.4.1.3\n[3] Wong, Y. J., Ho, M.-H. R., Wang, S.-Y., & Miller, I. S. K. (2017). Meta-analyses of the relationship between conformity to masculine norms and mental health-related outcomes. Journal of Counseling Psychology, 64(1), 80–93. https://doi.org/10.1037/cou0000176\n[4] Mahalik, J. R., Talmadge, W. T., Locke, B. D., & Scott, R. P. J. (2005). Using the Conformity to Masculine Norms Inventory to work with men in a clinical setting. Journal of Clinical Psychology, 61(6), 661–674. https://doi.org/10.1002/jclp.20101\n[5] Srivastava, S., Tamir, M., McGonigal, K. M., John, O. P., & Gross, J. J. (2009). The social costs of emotional suppression: A prospective study of the transition to college. Journal of Personality and Social Psychology, 96(4), 883–897. https://doi.org/10.1037/a0014755\n[6] Advancing the next generation of research on self-silencing and depression: A narrative review and synthesis of three decades of research. (2025). Sex Roles. https://doi.org/10.1007/s11199-025-01637-8",
       "author_name": "FermatMind Editorial",
       "reading_minutes": 4,
       "cover_image_url": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
-      "cover_image_alt": "高敏感男性、自我沉默与社会规范边界的抽象人物封面",
+      "cover_image_alt": "半透明男性轮廓与被压低的声波线条，象征高敏感男性的自我沉默",
       "cover_image_width": 1200,
       "cover_image_height": 675,
       "cover_image_variants": {
@@ -24,30 +24,59 @@
         "og": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
         "preload": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg"
       },
-      "category": "性别与社会化",
+      "category": "人格心理学",
       "tags": [
-        "MBTI",
         "INFJ",
+        "高敏感",
         "男性规范",
         "自我沉默",
-        "情绪抑制"
+        "情绪表达"
       ],
       "status": "published",
       "is_public": true,
       "is_indexable": true,
       "published_at": "2026-04-18T00:00:00Z",
       "voice": "editorial",
-      "voice_order": 13
+      "voice_order": 13,
+      "seo_title": "INFJ 男性真的少见吗？高敏感男性与自我沉默",
+      "seo_description": "INFJ 男性为何常被认为少见？本文用男性规范、自我沉默与情绪抑制研究解释高敏感男性的可见性困境。",
+      "cover_image_prompt": "冷静学术编辑部封面，半透明男性侧脸轮廓、压低的声波线条、深蓝背景与少量玫瑰色信号，表现情绪表达、沉默和社会规范压力，现代几何构图，无真人照片，无文字",
+      "cover_image_style_tag": "academic-editorial, social-psychology, muted-geometric",
+      "internal_links": [
+        "/zh/personality/infj-a",
+        "/zh/personality/infj-t",
+        "/zh/topics/mbti",
+        "/zh/tests/mbti-personality-test-16-personality-types"
+      ],
+      "cta_slots": [
+        {
+          "position": "第 2 节“为什么高敏感男性容易被误读”之后",
+          "text": "你是否也更习惯隐藏真实感受？查看 INFJ 人格画像 →"
+        },
+        {
+          "position": "结论后",
+          "text": "想验证你的 MBTI 类型与表达方式？开始 144 题深度测试 →"
+        }
+      ],
+      "claim_boundary_notes": "不声称 INFJ 男性真实稀有率，不把高敏感、情绪压抑或自我沉默医学化；只讨论男性规范、情绪抑制与可见性问题。",
+      "references": [
+        "Jack, D. C., & Dill, D. (1992). The Silencing the Self Scale: Schemas of intimacy associated with depression in women. Psychology of Women Quarterly, 16(1), 97–106. https://doi.org/10.1111/j.1471-6402.1992.tb00242.x",
+        "Mahalik, J. R., Locke, B. D., Ludlow, L. H., et al. (2003). Development of the Conformity to Masculine Norms Inventory. Psychology of Men & Masculinity, 4(1), 3–25. https://doi.org/10.1037/1524-9220.4.1.3",
+        "Wong, Y. J., Ho, M.-H. R., Wang, S.-Y., & Miller, I. S. K. (2017). Meta-analyses of the relationship between conformity to masculine norms and mental health-related outcomes. Journal of Counseling Psychology, 64(1), 80–93. https://doi.org/10.1037/cou0000176",
+        "Mahalik, J. R., Talmadge, W. T., Locke, B. D., & Scott, R. P. J. (2005). Using the Conformity to Masculine Norms Inventory to work with men in a clinical setting. Journal of Clinical Psychology, 61(6), 661–674. https://doi.org/10.1002/jclp.20101",
+        "Srivastava, S., Tamir, M., McGonigal, K. M., John, O. P., & Gross, J. J. (2009). The social costs of emotional suppression: A prospective study of the transition to college. Journal of Personality and Social Psychology, 96(4), 883–897. https://doi.org/10.1037/a0014755",
+        "Advancing the next generation of research on self-silencing and depression: A narrative review and synthesis of three decades of research. (2025). Sex Roles. https://doi.org/10.1007/s11199-025-01637-8"
+      ]
     },
     {
       "slug": "best-valentines-date-by-personality-and-relationship-science",
       "title": "情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会",
-      "excerpt": "真正有效的约会，不是越盛大越好，而是越贴合双方的节奏、刺激阈值和关系目标越好。本文用人格与关系研究，给出一套更少误伤、更高连接的约会设计框架。",
-      "content_md": "## 执行摘要\n很多人对约会的误解，在于把“高刺激”当成“高质量”。但亲密关系研究反复指出，真正有效的共享体验，关键不在贵、不在夸张，也不在“像电影一样”，而在于它是否同时满足两件事：一是创造适度的新鲜感，二是不超出双方的心理安全边界。[1][2][3]\n\n费马的建议是：不要先问“情人节去哪”，而要先问“这次约会想达成什么”。是加深理解、打破无聊、恢复亲密、确认承诺，还是降低摩擦？不同人格类型与关系状态，对这些目标的优先级并不一样。\n\n## 一、约会的真正目标：不是安排活动，而是设计关系体验\nAron 等人的经典研究发现，伴侣共同参与新颖而唤醒性的活动，会提升关系质量，并部分通过降低无聊感、提高亲密感起作用。[1] 但这不意味着“越刺激越好”。后续研究显示，新鲜感能增强关系满意度，但前提是这种新鲜感是**被双方体验为成长而不是威胁**。[2][3]\n\n因此，约会设计至少要看四件事：\n1. 新鲜度：它是否带来一点新体验？\n2. 安全度：它是否让人觉得失控或被迫表演？\n3. 互动密度：它是否允许真实交流？\n4. 余韵：结束之后，是更靠近，还是更累？\n\n## 二、按人格差异设计低摩擦约会\n如果借 16 型做一个实用入口，费马会建议你按“人格家族”而不是先按单一类型理解约会偏好：\n\n**NT（分析家）**：更适合有主题、有讨论张力、带一点智性新鲜感的约会。比如：小型展览、主题书店、静一点但可对谈的酒吧、策展型电影。风险是活动过于套路化或社交噪音过强，会让约会像“任务”而不是“连接”。\n\n**NF（外交家）**：更适合有意义感、情绪可流动、能交换价值观与故事的约会。比如：散步式长谈、温和的手作体验、共同看展后讨论、安静的晚餐。风险是活动太功能化，会让关系退回“配合”，而不是“共鸣”。\n\n**SJ（守护者）**：更适合结构清晰、细节可靠、体验稳定的约会。比如：预约明确的餐厅、路线清晰的短途行程、能体现用心准备的活动。风险是临时大改计划或极度不确定，会把注意力从关系体验拉回风险管理。\n\n**SP（探索者）**：更适合感官参与、即时反馈强、身体在场感高的约会。比如：夜市、小型户外活动、live house、尝鲜型餐厅、短时高体验事件。风险是活动太静态或过度脚本化，会迅速掉能量。\n\n## 三、情人节最常见的误判\n最常见的误判有三类：\n\n第一类：把“高成本”误当“高用心”。\n第二类：把“高刺激”误当“高亲密”。\n第三类：把“我喜欢”误当“对方也会舒服”。\n\nHarasymchuk 等人的研究指出，能促进亲密的 date planning，关键在于共同的 approach goals 和 self-expansion 体验，而不是单方面追求戏剧感。[4] 这意味着，一个真正成功的约会，标准不是“够不够浪漫”，而是它是否让双方更靠近、更松弛、更想继续下一次互动。\n\n## 四、费马的约会设计原则\n费马会给出一个简单规则：\n\n- 如果你们刚开始：先做低摩擦、高可对话密度的活动。\n- 如果你们进入平稳期：引入适度新鲜感，防止关系只剩效率。\n- 如果你们最近摩擦变多：不要安排高刺激活动，先恢复安全感。\n- 如果你们在承诺边缘摇摆：选一个能看见彼此决策方式的场景，而不是只看“浪漫程度”。\n\n## 结论\n情人节不是表演赛，也不是浪漫强度竞赛。最有效的约会，是在“新鲜感”和“安全感”之间找到一个合适比例，让两个人既能暂时离开惯性，又不必为了活动本身消耗掉关系。真正高质量的约会，结束后留下的不是“我们安排得真满”，而是“我更知道你是谁，也更愿意继续靠近你”。\n\n## 参考文献\n【1】 Aron, A., Norman, C. C., Aron, E. N., McKenna, C., & Heyman, R. E. (2000). Couples’ Shared Participation in Novel and Arousing Activities and Experienced Relationship Quality. Journal of Personality and Social Psychology, 78(2), 273–284. DOI: 10.1037//0022-3514.78.2.273.\n\n【2】 Schrage, K. M., Impett, E. A., Topal, M. A., Harasymchuk, C., & Muise, A. (2026). Novel and Exciting or Tried and True? Tailoring Shared Relationship Experiences to Insecurely Attached Partners. Social Psychological and Personality Science. DOI: 10.1177/19485506251411438.\n\n【3】 Raposo, S., Rosen, N. O., & Muise, A. (2020). Self-expansion is Associated With Greater Relationship and Sexual Well-Being for Couples Coping With Low Sexual Desire. Journal of Social and Personal Relationships, 37(2), 511–533. DOI: 10.1177/0265407519875217.\n\n【4】 Harasymchuk, C., Walker, D. L., Muise, A., & Impett, E. A. (2021). Planning Date Nights That Promote Closeness: The Roles of Relationship Goals and Self-Expansion. Journal of Social and Personal Relationships, 38(5), 1509–1535. DOI: 10.1177/02654075211000436.\n\n【5】 Tomlinson, J. M., Hughes, E. K., Lewandowski, G. W., Aron, A., & Geyer, R. (2019). Do Shared Self-Expanding Activities Have to Be Physically Arousing? Journal of Social and Personal Relationships, 36(9), 2761–2785. DOI: 10.1177/0265407518801095.",
+      "excerpt": "真正有效的约会，不是越盛大越好，而是越贴合双方节奏、刺激阈值和关系目标越好。",
+      "content_md": "# 情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会\n## 执行摘要\n很多人对约会的误解，在于把“高刺激”当成“高质量”。\n但亲密关系研究反复指出，真正有效的共享体验，关键不在贵、不在夸张，也不在“像电影一样”，而在于它是否同时满足两件事：\n1. 创造适度的新鲜感；\n2. 不超出双方的心理安全边界。\nFermatMind 的建议是：不要先问“情人节去哪”，而要先问：\n**这次约会想达成什么？**\n是加深理解、打破无聊、恢复亲密、确认承诺，还是降低摩擦？不同人格类型与关系状态，对这些目标的优先级并不一样。\n## 一、约会的真正目标：不是安排活动，而是设计关系体验\nAron 等人的经典研究发现，伴侣共同参与新颖而唤醒性的活动，会提升关系质量，并部分通过降低无聊感、提高亲密感起作用。\n但这不意味着“越刺激越好”。\n后续研究显示，新鲜感能增强关系满意度，但前提是这种新鲜感被双方体验为成长，而不是威胁。\n因此，约会设计至少要看四件事：\n1. **新鲜度**：它是否带来一点新体验？\n2. **安全度**：它是否让人觉得失控或被迫表演？\n3. **互动密度**：它是否允许真实交流？\n4. **余韵**：结束之后，是更靠近，还是更累？\n> **Evidence Note**  \n> 共享的新颖活动可能促进关系质量，但前提是它被双方体验为适度扩展，而不是被迫承受。亲密关系中的“新鲜感”不是越强越好，而是要落在双方可承受的安全区间内。\n## 二、按人格差异设计低摩擦约会\n如果借 16 型做一个实用入口，FermatMind 建议你按“人格家族”而不是先按单一类型理解约会偏好。\n### NT：分析家\nNT 更适合有主题、有讨论张力、带一点智性新鲜感的约会。\n例如：小型展览、主题书店、安静但可对谈的酒吧、策展型电影。\n风险是：活动过于套路化或社交噪音过强，会让约会像“任务”，而不是“连接”。\n### NF：外交家\nNF 更适合有意义感、情绪可流动、能交换价值观与故事的约会。\n例如：散步式长谈、温和的手作体验、共同看展后讨论、安静的晚餐。\n风险是：活动太功能化，会让关系退回“配合”，而不是“共鸣”。\n### SJ：守护者\nSJ 更适合结构清晰、细节可靠、体验稳定的约会。\n例如：预约明确的餐厅、路线清晰的短途行程、能体现用心准备的活动。\n风险是：临时大改计划或极度不确定，会把注意力从关系体验拉回风险管理。\n### SP：探索者\nSP 更适合感官参与、即时反馈强、身体在场感高的约会。\n例如：夜市、小型户外活动、live house、尝鲜型餐厅、短时高体验事件。\n风险是：活动太静态或过度脚本化，会迅速掉能量。\n## 三、情人节最常见的误判\n最常见的误判有三类：\n1. 把“高成本”误当“高用心”；\n2. 把“高刺激”误当“高亲密”；\n3. 把“我喜欢”误当“对方也会舒服”。\nHarasymchuk 等人的研究指出，能促进亲密的 date planning，关键在于共同的 approach goals 和 self-expansion 体验，而不是单方面追求戏剧感。\n这意味着，一个真正成功的约会，标准不是“够不够浪漫”，而是它是否让双方更靠近、更松弛、更想继续下一次互动。\n## 四、FermatMind 的约会设计原则\nFermatMind 给出的原则很简单：\n- 如果你们刚开始：先做低摩擦、高可对话密度的活动。\n- 如果你们进入平稳期：引入适度新鲜感，防止关系只剩效率。\n- 如果你们最近摩擦变多：不要安排高刺激活动，先恢复安全感。\n- 如果你们在承诺边缘摇摆：选一个能看见彼此决策方式的场景，而不是只看“浪漫程度”。\n## 结论\n情人节不是表演赛，也不是浪漫强度竞赛。\n最有效的约会，是在“新鲜感”和“安全感”之间找到一个合适比例，让两个人既能暂时离开惯性，又不必为了活动本身消耗掉关系。\n真正高质量的约会，结束后留下的不是“我们安排得真满”，而是：\n**我更知道你是谁，也更愿意继续靠近你。**\n\nReferences\n\n[1] Aron, A., Norman, C. C., Aron, E. N., McKenna, C., & Heyman, R. E. (2000). Couples’ shared participation in novel and arousing activities and experienced relationship quality. Journal of Personality and Social Psychology, 78(2), 273–284. https://doi.org/10.1037/0022-3514.78.2.273\n[2] Schrage, K. M., Impett, E. A., Topal, M. A., Harasymchuk, C., & Muise, A. (2026). Novel and exciting or tried and true? Tailoring shared relationship experiences to insecurely attached partners. Social Psychological and Personality Science. https://doi.org/10.1177/19485506251411438\n[3] Raposo, S., Rosen, N. O., & Muise, A. (2020). Self-expansion is associated with greater relationship and sexual well-being for couples coping with low sexual desire. Journal of Social and Personal Relationships, 37(2), 511–533. https://doi.org/10.1177/0265407519875217\n[4] Harasymchuk, C., Walker, D. L., Muise, A., & Impett, E. A. (2021). Planning date nights that promote closeness: The roles of relationship goals and self-expansion. Journal of Social and Personal Relationships, 38(5), 1509–1535. https://doi.org/10.1177/02654075211000436\n[5] Tomlinson, J. M., Hughes, E. K., Lewandowski, G. W., Aron, A., & Geyer, R. (2019). Do shared self-expanding activities have to be physically arousing? Journal of Social and Personal Relationships, 36(9), 2761–2785. https://doi.org/10.1177/0265407518801095",
       "author_name": "FermatMind Editorial",
       "reading_minutes": 4,
       "cover_image_url": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
-      "cover_image_alt": "两条约会路径在安全感与新鲜感之间形成平衡的抽象封面",
+      "cover_image_alt": "抽象路径地图连接两个关系节点，表现低摩擦约会设计",
       "cover_image_width": 1200,
       "cover_image_height": 675,
       "cover_image_variants": {
@@ -60,17 +89,45 @@
       "category": "关系与爱情",
       "tags": [
         "约会设计",
+        "情人节",
         "人格心理学",
-        "关系科学",
-        "低摩擦约会",
-        "亲密关系"
+        "亲密关系",
+        "关系科学"
       ],
       "status": "published",
       "is_public": true,
       "is_indexable": true,
       "published_at": "2026-04-18T00:00:00Z",
       "voice": "editorial",
-      "voice_order": 14
+      "voice_order": 14,
+      "seo_title": "情人节约会怎么安排？按人格和关系科学设计低摩擦约会",
+      "seo_description": "情人节约会不是越浪漫越好。用人格差异、亲密关系研究和低摩擦原则，设计更适合双方的约会体验。",
+      "cover_image_prompt": "现代学术编辑部风格封面，抽象约会路径地图、两个关系节点、柔和几何线条与节奏标记，表现安全感、新鲜感和低摩擦连接，浅玫瑰、米色、深蓝配色，无真实人物照片，无文字",
+      "cover_image_style_tag": "academic-editorial, relationship-design, muted-geometric",
+      "internal_links": [
+        "/zh/tests/mbti-personality-test-16-personality-types",
+        "/zh/personality",
+        "/zh/topics/mbti",
+        "/zh/articles/which-love-script-fits-you-best"
+      ],
+      "cta_slots": [
+        {
+          "position": "第 2 节“按人格差异设计低摩擦约会”后",
+          "text": "想知道你更适合高刺激还是高稳定的关系节奏？查看你的人格类型 →"
+        },
+        {
+          "position": "结论后",
+          "text": "用 MBTI 作为入口，理解你的亲密关系偏好 →"
+        }
+      ],
+      "claim_boundary_notes": "不宣称某人格一定喜欢某种约会，不做“最佳约会方案”绝对化推荐；只提供人格与关系目标视角下的低摩擦约会设计框架。",
+      "references": [
+        "Aron, A., Norman, C. C., Aron, E. N., McKenna, C., & Heyman, R. E. (2000). Couples’ shared participation in novel and arousing activities and experienced relationship quality. Journal of Personality and Social Psychology, 78(2), 273–284. https://doi.org/10.1037/0022-3514.78.2.273",
+        "Schrage, K. M., Impett, E. A., Topal, M. A., Harasymchuk, C., & Muise, A. (2026). Novel and exciting or tried and true? Tailoring shared relationship experiences to insecurely attached partners. Social Psychological and Personality Science. https://doi.org/10.1177/19485506251411438",
+        "Raposo, S., Rosen, N. O., & Muise, A. (2020). Self-expansion is associated with greater relationship and sexual well-being for couples coping with low sexual desire. Journal of Social and Personal Relationships, 37(2), 511–533. https://doi.org/10.1177/0265407519875217",
+        "Harasymchuk, C., Walker, D. L., Muise, A., & Impett, E. A. (2021). Planning date nights that promote closeness: The roles of relationship goals and self-expansion. Journal of Social and Personal Relationships, 38(5), 1509–1535. https://doi.org/10.1177/02654075211000436",
+        "Tomlinson, J. M., Hughes, E. K., Lewandowski, G. W., Aron, A., & Geyer, R. (2019). Do shared self-expanding activities have to be physically arousing? Journal of Social and Personal Relationships, 36(9), 2761–2785. https://doi.org/10.1177/0265407518801095"
+      ]
     },
     {
       "slug": "big-five-growth-guide",
@@ -165,12 +222,12 @@
     {
       "slug": "childhood-dream-job-still-shapes-career-choice",
       "title": "你小时候想做的工作，为什么还在影响你今天的职业判断？",
-      "excerpt": "童年想做的职业并不只是“幻想”。它往往提前编码了你对权力、创造、照顾、秩序、冒险与被看见的偏好。本文解释：为什么儿时职业理想会留下痕迹，以及如何把这种痕迹转化成成熟的职业判断。",
-      "content_md": "## 执行摘要\n很多成年人会笑着回忆小时候想做的工作：宇航员、老师、作家、警察、设计师、医生、企业家。大多数人后来并没有真的走上那条路，但这并不意味着那些愿望毫无意义。职业发展研究长期指出，早期职业抱负并非随机幻想，而是自我概念、社会评价、性别规范、能力感知与机会结构共同作用的结果。[1][2] 从这个角度看，童年的“梦工作”并不决定你今天做什么，却常常提前暴露了：你对权力、创造、秩序、照顾、探索和被看见的偏好。\n\n## 一、童年职业理想，其实是在说“我想成为什么样的人”\nGottfredson 的“圈定与妥协”理论认为，儿童与青少年会随着自我概念发展，逐步排除掉那些与自己不符、或被环境视为“不属于自己”的职业选项。[1] 也就是说，孩子说“我想当什么”，并不只是职业兴趣表达，而是在说：我想拥有怎样的位置、能力、形象与生活。\n\n所以，一个总说想当作家或研究者的孩子，真正表达的可能是：我想拥有解释世界的空间；\n一个总说想当医生或老师的孩子，表达的可能是：我想成为有用且可被信任的人；\n一个总说想当企业家、警察、飞行员的人，表达的可能是：我想掌握局面、承担行动风险，或者被看见。\n\n这也是为什么，童年职业理想很少“无意义”。它往往是自我概念的早期草图。\n\n## 二、为什么后来很多人会偏离童年理想\n偏离并不一定意味着背叛自己。研究表明，职业抱负会受到性别角色、社会经济地位、能力评价、机会结构和现实妥协的显著影响。[1][2] 许多人并不是不再喜欢那类工作，而是逐步判断出：\n- 自己可能没那么适合；\n- 社会回报不匹配；\n- 进入门槛太高；\n- 家庭和环境让自己收窄了选择。\n\n职业判断的成熟，不是简单坚持童年梦想，也不是彻底嘲笑它，而是理解那份向往背后的“结构性偏好”是什么，并为它找到现实可持续的表达方式。\n\n## 三、人格与职业环境匹配，才是成年后的关键问题\n职业发展研究长期强调 person–environment fit，也就是“人—环境匹配”。Kristof-Brown 等人的元分析表明，岗位匹配、组织匹配、团队匹配等多种 fit 与态度、绩效和离开倾向都存在稳定关系。[3] 换句话说，真正决定你能否做得久、做得稳、做得不被耗干的，不只是你喜欢某个职业名称，而是你与那个职业环境的匹配程度。\n\n这也是为什么，一个小时候想当“宇航员”的人，成年后未必真的该去航天系统工作，但他可能持续偏好高自主、高探索、高复杂度、高长期意义感的职业结构；一个小时候想当“老师”的人，未必必须进入学校，但他可能持续偏好有解释权、培养性和社会贡献感的工作。\n\n## 四、费马如何用这件事做职业判断\n费马不会把“小时候想做什么”当成职业答案，而把它当作一个早期线索。它真正有价值的地方在于：帮助你回到“我到底在追求什么工作结构”这个问题。\n\n你可以这样复盘：\n1. 我小时候想做的工作，吸引我的到底是什么？\n2. 是权力、创造、照顾、秩序、冒险、被看见，还是问题解决？\n3. 我今天仍然想要这些东西吗？\n4. 哪些职业结构能在现实中提供这些元素，而不会把我长期耗损？\n\n当你这样问时，童年理想就不再是幼稚幻想，而变成了职业设计的底层线索。\n\n## 五、从“梦工作”到“对的工作”\nDe Fruyt 及后续人格—兴趣研究表明，Big Five 与 RIASEC 兴趣维度之间存在稳定关系，而这些关系能帮助我们理解：为什么有些人长期偏爱某类职业世界。[4][5] 再往后看，职业兴趣与人格还会影响职业稳定性与流动性。[6] 这意味着，职业选择不是一次性拍板，而是长期人格倾向、兴趣结构与现实约束的持续协商。\n\n所以，真正成熟的问题不是“我还能不能成为小时候想成为的人”，而是：**我能不能在今天的世界里，为那个早期自我概念找到一个更稳、更真实、更少损耗的工作结构。**\n\n## 结论\n童年 dream job 之所以值得回看，不是因为它预言了你未来的职业，而是因为它往往最早暴露了你真正重视的工作元素。职业判断的成熟，并不是放弃那个梦想，而是把它从一个职业名字，翻译成一种可持续的职业结构。这样，你追求的就不再是“小时候的职位”，而是“今天仍然值得你投入的工作方式”。\n\n## 参考文献\n【1】 Gottfredson, L. S. (1981). Circumscription and Compromise: A Developmental Theory of Occupational Aspirations. Journal of Counseling Psychology, 28(6), 545–579. DOI: 10.1037/0022-0167.28.6.545.\n\n【2】 Cochran, D. B., Wang, E. W., Stevenson, S. J., Johnson, L. E., & Crews, C. (2011). Adolescent Occupational Aspirations: Test of Gottfredson’s Theory of Circumscription and Compromise. The Career Development Quarterly, 59(5), 412–427. DOI: 10.1002/j.2161-0045.2011.tb00968.x.\n\n【3】 Kristof-Brown, A. L., Zimmerman, R. D., & Johnson, E. C. (2005). Consequences of Individuals’ Fit at Work: A Meta-Analysis of Person–Job, Person–Organization, Person–Group, and Person–Supervisor Fit. Personnel Psychology, 58(2), 281–342. DOI: 10.1111/j.1744-6570.2005.00672.x.\n\n【4】 De Fruyt, F., & Mervielde, I. (1997). The Five-Factor Model of Personality and Holland’s RIASEC Interest Types. Personality and Individual Differences, 23, 87–103. DOI: 10.1016/S0191-8869(97)00004-4.\n\n【5】 Batista, J. S., & Gondim, S. M. G. (2023). Personality and Person-Work Environment Fit: A Study Based on the RIASEC Model. International Journal of Environmental Research and Public Health, 20(1), 719. DOI: 10.3390/ijerph20010719.\n\n【6】 Wille, B., De Fruyt, F., & Feys, M. (2010). Vocational Interests and Big Five Traits as Predictors of Job Instability. Journal of Vocational Behavior, 76(3), 547–558. DOI: 10.1016/j.jvb.2010.01.007.",
+      "excerpt": "童年想做的职业未必预言未来，却常常暴露你真正重视的工作结构。",
+      "content_md": "# 你小时候想做的工作，为什么还在影响你今天的职业判断？\n## 执行摘要\n很多成年人会笑着回忆小时候想做的工作：宇航员、老师、作家、警察、设计师、医生、企业家。\n大多数人后来并没有真的走上那条路，但这并不意味着那些愿望毫无意义。\n职业发展研究长期指出，早期职业抱负并非随机幻想，而是自我概念、社会评价、性别规范、能力感知与机会结构共同作用的结果。\n从这个角度看，童年的“梦工作”并不决定你今天做什么，却常常提前暴露了：\n**你对权力、创造、秩序、照顾、探索和被看见的偏好。**\n## 一、童年职业理想，其实是在说“我想成为什么样的人”\nGottfredson 的“圈定与妥协”理论认为，儿童与青少年会随着自我概念发展，逐步排除掉那些与自己不符，或被环境视为“不属于自己”的职业选项。\n也就是说，孩子说“我想当什么”，并不只是职业兴趣表达，而是在说：\n**我想拥有怎样的位置、能力、形象与生活。**\n一个总说想当作家或研究者的孩子，真正表达的可能是：我想拥有解释世界的空间。\n一个总说想当医生或老师的孩子，表达的可能是：我想成为有用且可被信任的人。\n一个总说想当企业家、警察、飞行员的人，表达的可能是：我想掌握局面、承担行动风险，或者被看见。\n这也是为什么，童年职业理想很少“无意义”。它往往是自我概念的早期草图。\n## 二、为什么后来很多人会偏离童年理想\n偏离并不一定意味着背叛自己。\n研究表明，职业抱负会受到性别角色、社会经济地位、能力评价、机会结构和现实妥协的显著影响。\n许多人并不是不再喜欢那类工作，而是逐步判断出：\n- 自己可能没那么适合；\n- 社会回报不匹配；\n- 进入门槛太高；\n- 家庭和环境让自己收窄了选择。\n职业判断的成熟，不是简单坚持童年梦想，也不是彻底嘲笑它。\n更成熟的做法是理解那份向往背后的“结构性偏好”是什么，并为它找到现实可持续的表达方式。\n## 三、人格与职业环境匹配，才是成年后的关键问题\n职业发展研究长期强调 person–environment fit，也就是“人—环境匹配”。\nKristof-Brown 等人的元分析表明，岗位匹配、组织匹配、团队匹配等多种 fit 与工作态度、绩效和离开倾向都存在稳定关系。\n换句话说，真正决定你能否做得久、做得稳、做得不被耗干的，不只是你喜欢某个职业名称，而是你与那个职业环境的匹配程度。\n> **Evidence Note**  \n> Person–environment fit 研究提示：一个职业名字本身不够说明适配。工作任务、组织环境、团队方式、价值结构和个人偏好之间的匹配，才更接近长期职业稳定性的关键。\n这也是为什么，一个小时候想当“宇航员”的人，成年后未必真的该去航天系统工作，但他可能持续偏好高自主、高探索、高复杂度、高长期意义感的职业结构。\n一个小时候想当“老师”的人，未必必须进入学校，但他可能持续偏好有解释权、培养性和社会贡献感的工作。\n## 四、FermatMind 如何用这件事做职业判断\nFermatMind 不会把“小时候想做什么”当成职业答案，而把它当作一个早期线索。\n它真正有价值的地方在于：帮助你回到一个更底层的问题：\n**我到底在追求什么工作结构？**\n你可以这样复盘：\n1. 我小时候想做的工作，吸引我的到底是什么？\n2. 是权力、创造、照顾、秩序、冒险、被看见，还是问题解决？\n3. 我今天仍然想要这些东西吗？\n4. 哪些职业结构能在现实中提供这些元素，而不会把我长期耗损？\n当你这样问时，童年理想就不再是幼稚幻想，而变成了职业设计的底层线索。\n## 五、从“梦工作”到“对的工作”\nDe Fruyt 及后续人格—兴趣研究表明，Big Five 与 RIASEC 兴趣维度之间存在稳定关系，而这些关系能帮助我们理解：为什么有些人长期偏爱某类职业世界。\n再往后看，职业兴趣与人格还会影响职业稳定性与流动性。\n这意味着，职业选择不是一次性拍板，而是长期人格倾向、兴趣结构与现实约束的持续协商。\n真正成熟的问题不是：\n“我还能不能成为小时候想成为的人？”\n而是：\n**我能不能在今天的世界里，为那个早期自我概念找到一个更稳、更真实、更少损耗的工作结构。**\n## 结论\n童年 dream job 之所以值得回看，不是因为它预言了你未来的职业，而是因为它往往最早暴露了你真正重视的工作元素。\n职业判断的成熟，并不是放弃那个梦想，而是把它从一个职业名字，翻译成一种可持续的职业结构。\n这样，你追求的就不再是“小时候的职位”，而是“今天仍然值得你投入的工作方式”。\n\nReferences\n\n[1] Gottfredson, L. S. (1981). Circumscription and compromise: A developmental theory of occupational aspirations. Journal of Counseling Psychology, 28(6), 545–579. https://doi.org/10.1037/0022-0167.28.6.545\n[2] Cochran, D. B., Wang, E. W., Stevenson, S. J., Johnson, L. E., & Crews, C. (2011). Adolescent occupational aspirations: Test of Gottfredson’s theory of circumscription and compromise. The Career Development Quarterly, 59(5), 412–427. https://doi.org/10.1002/j.2161-0045.2011.tb00968.x\n[3] Kristof-Brown, A. L., Zimmerman, R. D., & Johnson, E. C. (2005). Consequences of individuals’ fit at work: A meta-analysis of person–job, person–organization, person–group, and person–supervisor fit. Personnel Psychology, 58(2), 281–342. https://doi.org/10.1111/j.1744-6570.2005.00672.x\n[4] De Fruyt, F., & Mervielde, I. (1997). The Five-Factor Model of personality and Holland’s RIASEC interest types. Personality and Individual Differences, 23, 87–103. https://doi.org/10.1016/S0191-8869(97)00004-4\n[5] Batista, J. S., & Gondim, S. M. G. (2023). Personality and person-work environment fit: A study based on the RIASEC model. International Journal of Environmental Research and Public Health, 20(1), 719. https://doi.org/10.3390/ijerph20010719\n[6] Wille, B., De Fruyt, F., & Feys, M. (2010). Vocational interests and Big Five traits as predictors of job instability. Journal of Vocational Behavior, 76(3), 547–558. https://doi.org/10.1016/j.jvb.2010.01.007",
       "author_name": "FermatMind Editorial",
       "reading_minutes": 5,
       "cover_image_url": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
-      "cover_image_alt": "童年职业理想到成年职业判断的时间线与职业环境匹配抽象封面",
+      "cover_image_alt": "抽象轨迹从童年职业图标延伸到成年职业路径",
       "cover_image_width": 1200,
       "cover_image_height": 675,
       "cover_image_variants": {
@@ -182,18 +239,48 @@
       },
       "category": "职业发展",
       "tags": [
-        "职业发展",
-        "dream job",
-        "person-environment fit",
+        "童年职业",
+        "职业兴趣",
+        "职业判断",
         "RIASEC",
-        "职业兴趣"
+        "人职匹配"
       ],
       "status": "published",
       "is_public": true,
       "is_indexable": true,
       "published_at": "2026-04-18T00:00:00Z",
       "voice": "editorial",
-      "voice_order": 16
+      "voice_order": 16,
+      "seo_title": "小时候想做的工作，如何影响成年职业选择？",
+      "seo_description": "童年 dream job 不是职业预言，而是早期自我概念线索。理解它，能帮助你识别职业兴趣与工作结构偏好。",
+      "cover_image_prompt": "学术编辑部风格封面，从童年符号到成年职业路径的抽象轨迹，包含小型职业图标、路径线、结构网格，象征早期自我概念与职业判断的延续，深蓝、金色、米白配色，无真人照片，无文字",
+      "cover_image_style_tag": "academic-editorial, career-decision, muted-geometric",
+      "internal_links": [
+        "/zh/tests/holland-career-interest-test-riasec",
+        "/zh/career",
+        "/zh/career/recommendations",
+        "/zh/personality",
+        "/zh/tests/big-five-personality-test-ocean-model"
+      ],
+      "cta_slots": [
+        {
+          "position": "第 3 节“人格与职业环境匹配”之后",
+          "text": "想知道你的职业兴趣结构？开始霍兰德职业兴趣测试 →"
+        },
+        {
+          "position": "结论后",
+          "text": "把童年职业愿望翻译成今天的职业方向，查看职业探索入口 →"
+        }
+      ],
+      "claim_boundary_notes": "不宣称童年职业理想能预测成年职业选择；只将其作为早期自我概念和职业结构偏好的线索。",
+      "references": [
+        "Gottfredson, L. S. (1981). Circumscription and compromise: A developmental theory of occupational aspirations. Journal of Counseling Psychology, 28(6), 545–579. https://doi.org/10.1037/0022-0167.28.6.545",
+        "Cochran, D. B., Wang, E. W., Stevenson, S. J., Johnson, L. E., & Crews, C. (2011). Adolescent occupational aspirations: Test of Gottfredson’s theory of circumscription and compromise. The Career Development Quarterly, 59(5), 412–427. https://doi.org/10.1002/j.2161-0045.2011.tb00968.x",
+        "Kristof-Brown, A. L., Zimmerman, R. D., & Johnson, E. C. (2005). Consequences of individuals’ fit at work: A meta-analysis of person–job, person–organization, person–group, and person–supervisor fit. Personnel Psychology, 58(2), 281–342. https://doi.org/10.1111/j.1744-6570.2005.00672.x",
+        "De Fruyt, F., & Mervielde, I. (1997). The Five-Factor Model of personality and Holland’s RIASEC interest types. Personality and Individual Differences, 23, 87–103. https://doi.org/10.1016/S0191-8869(97)00004-4",
+        "Batista, J. S., & Gondim, S. M. G. (2023). Personality and person-work environment fit: A study based on the RIASEC model. International Journal of Environmental Research and Public Health, 20(1), 719. https://doi.org/10.3390/ijerph20010719",
+        "Wille, B., De Fruyt, F., & Feys, M. (2010). Vocational interests and Big Five traits as predictors of job instability. Journal of Vocational Behavior, 76(3), 547–558. https://doi.org/10.1016/j.jvb.2010.01.007"
+      ]
     },
     {
       "slug": "clinical-depression-anxiety-pro-growth-guide",
@@ -468,12 +555,12 @@
     {
       "slug": "how-16-personality-types-talk-to-an-ai-coach",
       "title": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
-      "excerpt": "不是所有人都以同样方式使用 AI 教练。有人把它当决策草稿器，有人把它当情绪镜子，也有人最容易被它的“顺着说”误导。本文用人格与人机交互研究解释：什么样的人更适合把 AI 当辅助，而不是当裁判。",
-      "content_md": "## 执行摘要\nAI 教练的真正价值，不是“给答案”，而是改变提问方式。问题是：不同人格并不会以同样方式使用它。有人会把 AI 当作结构化整理器，有人把它当头脑风暴器，有人拿它做情绪整理，也有人在不知不觉中把它当成了“总会赞同我”的低摩擦陪伴体。费马的判断是：**AI 教练最危险的地方，不在于它会不会说错，而在于它太容易在关键时刻“顺着你”。**[1][2][3]\n\n## 一、为什么有些人更愿意向 AI 说真话\n和真人相比，AI 对话系统对很多人有两个吸引力：低评判、低成本。Ho、Hancock 与 Miner 的研究表明，在某些条件下，人们与 chatbot 进行情绪披露所带来的主观后果，可以接近与真人交谈时的效果。[1] 这不意味着 AI 真的理解了你，而是说明：只要互动被体验为足够安全、足够可控，人们就愿意把它当成一个临时容器。\n\n这会让某些人格尤其容易使用 AI 教练：\n- 更喜欢先想清楚再表达的人，会把它当草稿板；\n- 更担心被否定的人，会把它当低风险排练器；\n- 更注重效率与结构的人，会把它当任务拆解器。\n\n问题在于，容器不等于判断者。AI 能帮你说清楚，却不一定帮你做对。\n\n## 二、谁更可能把 AI 当工具，谁更可能把它当镜子\n从人格风格看，至少有三种典型使用方式：\n\n**结构型使用者**：把 AI 当整理器、提纲器、决策草稿器。它的优势是效率高、边界清；风险是把结构感误当成正确感。\n\n**探索型使用者**：把 AI 当头脑风暴搭子、灵感生成器、假设扩展器。它的优势是能迅速扩展可能性；风险是想法越来越多，判断越来越慢。[4]\n\n**情绪型使用者**：把 AI 当成一个能即时回应、不会打断、也很少直接否定的镜子。它的优势是降低表达门槛；风险是把“被回应”误解成“被校正”。[1][2]\n\n## 三、AI 教练最大的问题：它太会给人一种“我被理解了”的感觉\nLee 等人关于 AI 心理治疗 chatbot 的研究表明，用户的好感、拟人感与自我披露之间存在关系：当系统更像一个“能理解我”的对象时，人们会更愿意说更多。[2] 问题在于，人类常把“回应顺滑”错读成“理解深刻”，把“反馈及时”错读成“判断可靠”。\n\n而 Logg 等人的“算法欣赏”研究进一步提醒我们：很多人在某些任务里会比自己想象中更愿意采纳算法建议。[3] 当这件事和情绪脆弱、自我怀疑、关系冲突叠加时，AI 教练就很容易从“辅助工具”滑向“替代裁判”。\n\n## 四、16 型语境下，最容易出什么偏差\n如果借 16 型当入口，费马会给出下面这条判断：\n\n- 分析型人格更容易高频使用 AI 做结构化判断，但要警惕“逻辑顺滑 ≠ 决策正确”；\n- 高理想主义人格更容易把 AI 当镜子，用来确认价值与情绪，但要警惕“被安慰 ≠ 被挑战”；\n- 高行动型人格更容易把 AI 当即时指挥台，但要警惕“能立刻执行 ≠ 长期适合”；\n- 高秩序型人格更容易把 AI 当规范化助手，但要警惕“稳定建议 ≠ 个体适配”。\n\n换句话说，AI 教练并不会公平地放大每个人的优点；它更可能先放大你本来就有的偏好。你原本就爱确认，它会更快确认你；你原本就爱扩张想法，它会更快扩张想法；你原本就容易迟疑，它有时会把迟疑变成更精细的迟疑。\n\n## 五、费马的建议\n把 AI 教练用对，有一个简单规则：\n\n- 让它帮你整理，不让它替你定案；\n- 让它帮你扩展选项，不让它决定价值排序；\n- 让它帮你澄清问题，不让它直接接管“我到底该怎么活”。\n\n如果一段 AI 对话让你越来越轻松，却没有让你更清楚地面对真实约束，那它可能只是给了你心理止痛，而不是判断升级。\n\n## 结论\nAI 教练最好的角色，不是顾问本人，而是一个高效的“前处理层”：帮助你命名问题、梳理结构、暴露盲点。它可以是镜子，但不该是法官；可以是工具，但不该成为人格外包。真正成熟的使用方式，是在 AI 提供的顺滑反馈之外，仍然保留自己对现实、关系与长期后果的判断能力。\n\n## 参考文献\n【1】 Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, Relational, and Emotional Effects of Self-Disclosure After Conversations With a Chatbot. Journal of Communication, 68(4), 712–733. DOI: 10.1093/joc/jqy026.\n\n【2】 Lee, J., Lee, J.-g., & Lee, D. (2023). User Perception and Self-Disclosure Toward an AI Psychotherapy Chatbot According to the Anthropomorphism of Its Profile Picture. Telematics and Informatics, 85, 102052. DOI: 10.1016/j.tele.2023.102052.\n\n【3】 Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm Appreciation: People Prefer Algorithmic to Human Judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. DOI: 10.1016/j.obhdp.2018.12.005.\n\n【4】 Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human Preferences toward Algorithmic Advice in a Word Association Task. Scientific Reports, 12, 14501. DOI: 10.1038/s41598-022-18638-2.\n\n【5】 Papneja, H., & Yadav, N. (2025). Self-disclosure to Conversational AI: A Literature Review, Emergent Framework, and Directions for Future Research. Personal and Ubiquitous Computing, 29, 119–151. DOI: 10.1007/s00779-024-01823-7.",
+      "excerpt": "AI 教练最危险的地方，不是它会说错，而是它太容易在关键时刻顺着你。",
+      "content_md": "# 当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说\n## 执行摘要\nAI 教练的真正价值，不是“给答案”，而是改变提问方式。\n问题是：不同人格并不会以同样方式使用它。有人会把 AI 当作结构化整理器，有人把它当头脑风暴器，有人拿它做情绪整理，也有人在不知不觉中把它当成了“总会赞同我”的低摩擦陪伴体。\nFermatMind 的判断是：\n**AI 教练最危险的地方，不在于它会不会说错，而在于它太容易在关键时刻顺着你。**\n## 一、为什么有些人更愿意向 AI 说真话\n和真人相比，AI 对话系统对很多人有两个吸引力：\n1. 低评判；\n2. 低成本。\nHo、Hancock 与 Miner 的研究表明，在某些条件下，人们与 chatbot 进行情绪披露所带来的主观后果，可以接近与真人交谈时的效果。\n这不意味着 AI 真的理解了你，而是说明：只要互动被体验为足够安全、足够可控，人们就愿意把它当成一个临时容器。\n这会让某些人格尤其容易使用 AI 教练：\n- 更喜欢先想清楚再表达的人，会把它当草稿板；\n- 更担心被否定的人，会把它当低风险排练器；\n- 更注重效率与结构的人，会把它当任务拆解器。\n问题在于：\n**容器不等于判断者。AI 能帮你说清楚，却不一定帮你做对。**\n## 二、谁更可能把 AI 当工具，谁更可能把它当镜子\n从人格风格看，至少有三种典型使用方式。\n### 结构型使用者\n他们把 AI 当整理器、提纲器、决策草稿器。\n优势是效率高、边界清；风险是把结构感误当成正确感。\n### 探索型使用者\n他们把 AI 当头脑风暴搭子、灵感生成器、假设扩展器。\n优势是能迅速扩展可能性；风险是想法越来越多，判断越来越慢。\n### 情绪型使用者\n他们把 AI 当成一个能即时回应、不会打断、也很少直接否定的镜子。\n优势是降低表达门槛；风险是把“被回应”误解成“被校正”。\n> **Evidence Note**  \n> 人机交互研究显示，用户对 chatbot 的拟人感、好感与自我披露之间存在关联。AI 可以降低表达门槛，但这不代表它具备真正的人类理解或责任承担能力。\n## 三、AI 教练最大的问题：它太会给人一种“我被理解了”的感觉\nLee 等人关于 AI 心理治疗 chatbot 的研究表明，用户的好感、拟人感与自我披露之间存在关系：当系统更像一个“能理解我”的对象时，人们会更愿意说更多。\n问题在于，人类常把“回应顺滑”错读成“理解深刻”，把“反馈及时”错读成“判断可靠”。\n而 Logg 等人的“算法欣赏”研究进一步提醒我们：很多人在某些任务里会比自己想象中更愿意采纳算法建议。\n当这件事和情绪脆弱、自我怀疑、关系冲突叠加时，AI 教练就很容易从“辅助工具”滑向“替代裁判”。\n## 四、16 型语境下，最容易出什么偏差\n如果借 16 型当入口，FermatMind 会给出下面这条判断：\n- 分析型人格更容易高频使用 AI 做结构化判断，但要警惕“逻辑顺滑 ≠ 决策正确”；\n- 高理想主义人格更容易把 AI 当镜子，用来确认价值与情绪，但要警惕“被安慰 ≠ 被挑战”；\n- 高行动型人格更容易把 AI 当即时指挥台，但要警惕“能立刻执行 ≠ 长期适合”；\n- 高秩序型人格更容易把 AI 当规范化助手，但要警惕“稳定建议 ≠ 个体适配”。\nAI 教练并不会公平地放大每个人的优点。\n它更可能先放大你本来就有的偏好：你原本就爱确认，它会更快确认你；你原本就爱扩张想法，它会更快扩张想法；你原本就容易迟疑，它有时会把迟疑变成更精细的迟疑。\n## 五、FermatMind 的建议\n把 AI 教练用对，有一个简单规则：\n- 让它帮你整理，不让它替你定案；\n- 让它帮你扩展选项，不让它决定价值排序；\n- 让它帮你澄清问题，不让它直接接管“我到底该怎么活”。\n如果一段 AI 对话让你越来越轻松，却没有让你更清楚地面对真实约束，那它可能只是给了你心理止痛，而不是判断升级。\n## 结论\nAI 教练最好的角色，不是顾问本人，而是一个高效的“前处理层”：帮助你命名问题、梳理结构、暴露盲点。\n它可以是镜子，但不该是法官；可以是工具，但不该成为人格外包。\n真正成熟的使用方式，是在 AI 提供的顺滑反馈之外，仍然保留自己对现实、关系与长期后果的判断能力。\n\nReferences\n\n[1] Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, relational, and emotional effects of self-disclosure after conversations with a chatbot. Journal of Communication, 68(4), 712–733. https://doi.org/10.1093/joc/jqy026\n[2] Lee, J., Lee, J.-g., & Lee, D. (2023). User perception and self-disclosure toward an AI psychotherapy chatbot according to the anthropomorphism of its profile picture. Telematics and Informatics, 85, 102052. https://doi.org/10.1016/j.tele.2023.102052\n[3] Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm appreciation: People prefer algorithmic to human judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. https://doi.org/10.1016/j.obhdp.2018.12.005\n[4] Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human preferences toward algorithmic advice in a word association task. Scientific Reports, 12, 14501. https://doi.org/10.1038/s41598-022-18638-2\n[5] Papneja, H., & Yadav, N. (2025). Self-disclosure to conversational AI: A literature review, emergent framework, and directions for future research. Personal and Ubiquitous Computing, 29, 119–151. https://doi.org/10.1007/s00779-024-01823-7",
       "author_name": "FermatMind Editorial",
       "reading_minutes": 4,
       "cover_image_url": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
-      "cover_image_alt": "16 型人格与 AI 教练对话中镜子、工具和反馈回路的抽象封面",
+      "cover_image_alt": "抽象对话气泡与镜面结构表现人格与 AI 教练的互动",
       "cover_image_width": 1200,
       "cover_image_height": 675,
       "cover_image_variants": {
@@ -485,28 +572,56 @@
       },
       "category": "人工智能与人格",
       "tags": [
-        "MBTI",
-        "16 型人格",
         "AI 教练",
+        "16 型人格",
         "人机交互",
-        "自我披露"
+        "算法建议",
+        "MBTI"
       ],
       "status": "published",
       "is_public": true,
       "is_indexable": true,
       "published_at": "2026-04-18T00:00:00Z",
       "voice": "editorial",
-      "voice_order": 15
+      "voice_order": 15,
+      "seo_title": "16 型人格如何使用 AI 教练？镜子、工具与判断风险",
+      "seo_description": "不同人格如何与 AI 教练对话？有人把它当工具，有人把它当情绪镜子，也有人最容易被顺着说。",
+      "cover_image_prompt": "冷静学术编辑部风格，抽象对话气泡、镜面结构、人格代码符号与 AI 节点，表现人和 AI 教练之间的反馈、镜像和判断边界，蓝绿渐变，现代几何，无真实人物照片，无文字",
+      "cover_image_style_tag": "academic-editorial, ai-coach, muted-geometric",
+      "internal_links": [
+        "/zh/personality",
+        "/zh/tests/mbti-personality-test-16-personality-types",
+        "/zh/articles/how-personality-shapes-attitude-toward-ai",
+        "/zh/topics/mbti"
+      ],
+      "cta_slots": [
+        {
+          "position": "第 2 节“谁更可能把 AI 当工具，谁更可能把它当镜子”之后",
+          "text": "你更容易把 AI 当工具、镜子，还是裁判？先理解你的 MBTI 使用偏好 →"
+        },
+        {
+          "position": "结论后",
+          "text": "用 FermatMind 的 MBTI 测试，校准你的人格决策方式 →"
+        }
+      ],
+      "claim_boundary_notes": "不宣称 AI 教练能替代咨询、诊断或职业判断；只讨论不同人格如何使用 AI，以及如何避免把 AI 的顺滑反馈误认为可靠判断。",
+      "references": [
+        "Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, relational, and emotional effects of self-disclosure after conversations with a chatbot. Journal of Communication, 68(4), 712–733. https://doi.org/10.1093/joc/jqy026",
+        "Lee, J., Lee, J.-g., & Lee, D. (2023). User perception and self-disclosure toward an AI psychotherapy chatbot according to the anthropomorphism of its profile picture. Telematics and Informatics, 85, 102052. https://doi.org/10.1016/j.tele.2023.102052",
+        "Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm appreciation: People prefer algorithmic to human judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. https://doi.org/10.1016/j.obhdp.2018.12.005",
+        "Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human preferences toward algorithmic advice in a word association task. Scientific Reports, 12, 14501. https://doi.org/10.1038/s41598-022-18638-2",
+        "Papneja, H., & Yadav, N. (2025). Self-disclosure to conversational AI: A literature review, emergent framework, and directions for future research. Personal and Ubiquitous Computing, 29, 119–151. https://doi.org/10.1007/s00779-024-01823-7"
+      ]
     },
     {
       "slug": "how-personality-shapes-attitude-toward-ai",
       "title": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
-      "excerpt": "人们对 AI 的看法并不只取决于技术知识，也与稳定的人格倾向、风险知觉和对控制感的需求有关。本文用人格研究解释：为什么有些人把 AI 当作效率杠杆，有些人却更先看到失真、替代与依赖风险。",
-      "content_md": "## 执行摘要\n围绕人工智能的争论，表面上像是一场关于技术的争论，实质上往往是一场关于人格、控制感与风险解释方式的争论。有人把 AI 看成生产率工具，有人把 AI 看成认知外包装置，还有人对它保持持续警惕。费马的判断是：这种差异，不只是“懂不懂技术”，也不是“乐观还是悲观”那么简单，而更接近一种稳定的人格—决策风格差异。[1][2]\n\n现有研究已经显示，大五人格、AI 焦虑以及人口学变量，会共同影响人们对 AI 的总体态度。其中，尽责性更容易与“把 AI 当作效率增强器”的使用方式绑定；高神经质更容易与不确定性放大、错误预期和失控焦虑相关；而开放性并不一定自动通向“技术拥抱”，反而可能导向更强的批判性审视——也就是：越有想象力和反思力的人，越不愿意把 AI 轻易当成无害工具。[1]\n\n## 一、为什么“喜欢 AI”不是一个单一问题\n传统讨论喜欢把人分成两类：支持 AI 的人，和反对 AI 的人。但从行为科学角度看，这种分法太粗。更有解释力的方式，是把“AI 态度”拆成三层：\n\n第一层是功能判断：它能不能让我更快完成任务？\n第二层是控制判断：我是否仍然掌握最终决定权？\n第三层是价值判断：它是否侵蚀了创造、责任与真实性？\n\n对尽责性更高的人来说，AI 首先被放进“效率与组织”框架里：如果它能减少重复劳动、提升输出稳定性，它就更容易被接受。[1] 对高开放性人群来说，问题往往不是“它新不新”，而是“它正在替代什么”。这类人更容易追问：当文字、图像、判断都能被机器大规模生成时，原创性、作者性与品味还有什么剩余空间？这也是为什么“创造者未必是最乐观的 AI 用户”。[1]\n\n## 二、算法信任并不是线性的\n关于“人到底更信人还是更信算法”，研究并不支持一个简单答案。Logg、Minson 与 Moore 提出“算法欣赏”现象：在一些预测任务中，普通人会比预期更愿意采纳算法建议。[2] 但这并不意味着人会无限度地信任算法。Bogert 等人的研究表明，在涉及联想、创意和模糊判断的任务里，人们对算法建议的采纳具有明显条件性：他们会使用它，但同时会保留修正空间，且这种“使用中的保留”非常常见。[3]\n\n对费马来说，这个发现很重要：真正成熟的 AI 使用方式，不是“完全依赖”或“完全排斥”，而是把 AI 放在一个被监管的位置上——它可以提供候选答案，但不能自动占据最终解释权。\n\n## 三、为什么有些人更愿意和 AI 聊天\n一部分人会把 AI 当工具，另一部分人会把 AI 当“低风险对话对象”。这是另一个重要区别。关于 chatbot 的研究显示，人们与 AI 对话时可能表现出与人际披露相似的心理后果：包括更容易表达敏感内容、减轻即时压力，甚至产生被理解的主观感受。[4][5] 这并不代表 AI 真正“理解”了人，而是说明：当系统表现出足够的社会临场感、可预测性和低评判威胁时，用户会把它当作一种可用的情绪容器。[4][5]\n\n问题在于，这种便利也会带来边界风险。对需要外部确认、又希望保持控制感的人来说，AI 可能是一种高频、低摩擦、可持续“回声墙”。它能快速给建议，却不一定能承担建议的后果。因此，费马不主张把“AI 很会回应我”误解成“AI 很适合替我判断”。\n\n## 四、费马的判断\n如果你对 AI 持强烈乐观态度，你需要问的不是“它还能帮我做什么”，而是“我把哪些判断外包得太快了”；\n如果你对 AI 持强烈警惕态度，你也需要问“我担心的是风险本身，还是不愿意失去熟悉的控制方式”。\n\n人格不会替你决定要不要用 AI，但人格会显著影响你如何界定风险、如何分配信任、以及你愿意把多少“思考主权”交出去。真正重要的，不是你属于哪一派，而是你是否知道自己为什么会相信、为什么会怀疑，以及你是否保留了最后一道判断权。\n\n## 结论\nAI 不是单纯的技术问题，而是一面放大人格差异的镜子。它会让高尽责的人更高效，也会让高警觉的人更焦虑；它会让一部分人更快行动，也会迫使另一部分人更认真地讨论真实性与边界。费马更关心的不是“你喜不喜欢 AI”，而是：你是否有能力在使用 AI 时，仍然保留你的判断力、责任感与长期职业护城河。\n\n## 参考文献\n【1】 Kaya, F., Aydın, F., Schepman, A., Rodway, P., Yetişensoy, O., & Demir Kaya, M. (2024). The Roles of Personality Traits, AI Anxiety, and Demographic Factors in Attitudes toward Artificial Intelligence. International Journal of Human-Computer Interaction. DOI: 10.1080/10447318.2022.2151730.\n\n【2】 Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm Appreciation: People Prefer Algorithmic to Human Judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. DOI: 10.1016/j.obhdp.2018.12.005.\n\n【3】 Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human Preferences toward Algorithmic Advice in a Word Association Task. Scientific Reports, 12, 14501. DOI: 10.1038/s41598-022-18638-2.\n\n【4】 Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, Relational, and Emotional Effects of Self-Disclosure After Conversations With a Chatbot. Journal of Communication, 68(4), 712–733. DOI: 10.1093/joc/jqy026.\n\n【5】 Papneja, H., & Yadav, N. (2025). Self-disclosure to Conversational AI: A Literature Review, Emergent Framework, and Directions for Future Research. Personal and Ubiquitous Computing, 29, 119–151. DOI: 10.1007/s00779-024-01823-7.",
+      "excerpt": "AI 态度不只取决于技术知识，也与人格、风险知觉和控制感有关。",
+      "content_md": "# 你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任\n## 执行摘要\n围绕人工智能的争论，表面上像是一场关于技术的争论，实质上往往是一场关于人格、控制感与风险解释方式的争论。\n有人把 AI 看成生产率工具，有人把 AI 看成认知外包装置，也有人对它保持持续警惕。FermatMind 的判断是：这种差异，不只是“懂不懂技术”，也不是“乐观还是悲观”那么简单，而更接近一种稳定的人格—决策风格差异。\n现有研究显示，大五人格、AI 焦虑以及人口学变量，会共同影响人们对 AI 的总体态度。其中，尽责性更容易与“把 AI 当作效率增强器”的使用方式绑定；高神经质更容易与不确定性放大、错误预期和失控焦虑相关；开放性则不一定自动导向技术拥抱，它也可能带来更强的批判性审视。\n> **Evidence Note**  \n> Kaya 等人的研究显示，人格特质、AI 焦虑与人口学变量会共同影响人们对人工智能的态度。人格并不决定一个人是否应该使用 AI，但会影响其如何解释风险、分配信任与保留控制权。\n## 一、为什么“喜欢 AI”不是一个单一问题\n传统讨论喜欢把人分成两类：支持 AI 的人，和反对 AI 的人。但从行为科学角度看，这种分法太粗。\n更有解释力的方式，是把“AI 态度”拆成三层：\n1. **功能判断**：它能不能让我更快完成任务？\n2. **控制判断**：我是否仍然掌握最终决定权？\n3. **价值判断**：它是否侵蚀了创造、责任与真实性？\n对尽责性更高的人来说，AI 首先被放进“效率与组织”框架里：如果它能减少重复劳动、提升输出稳定性，它就更容易被接受。\n对开放性更高的人来说，问题往往不是“它新不新”，而是“它正在替代什么”。这类人更容易追问：当文字、图像、判断都能被机器大规模生成时，原创性、作者性与品味还有什么剩余空间？\n这也是为什么，**创造者未必是最乐观的 AI 用户**。有想象力的人，往往也更敏感于真实性被稀释的风险。\n## 二、算法信任并不是线性的\n关于“人到底更信人还是更信算法”，研究并不支持一个简单答案。\nLogg、Minson 与 Moore 提出“算法欣赏”现象：在一些预测任务中，普通人会比预期更愿意采纳算法建议。但这并不意味着人会无限度地信任算法。\nBogert 等人的研究表明，在涉及联想、创意和模糊判断的任务里，人们对算法建议的采纳具有明显条件性：他们会使用它，但同时会保留修正空间。\n对 FermatMind 来说，这个发现很重要。成熟的 AI 使用方式，不是完全依赖，也不是完全排斥，而是把 AI 放在一个被监管的位置上：\n**它可以提供候选答案，但不能自动占据最终解释权。**\n## 三、为什么有些人更愿意和 AI 聊天\n一部分人会把 AI 当工具，另一部分人会把 AI 当“低风险对话对象”。这是另一个重要区别。\n关于 chatbot 的研究显示，人们与 AI 对话时可能表现出与人际披露相似的心理后果：包括更容易表达敏感内容、减轻即时压力，甚至产生被理解的主观感受。\n这并不代表 AI 真正“理解”了人，而是说明：当系统表现出足够的社会临场感、可预测性和低评判威胁时，用户会把它当作一种可用的情绪容器。\n问题在于，这种便利也会带来边界风险。对需要外部确认、又希望保持控制感的人来说，AI 可能是一种高频、低摩擦、可持续的“回声墙”。\n它能快速给建议，却不一定能承担建议的后果。\n## 四、FermatMind 的判断\n如果你对 AI 持强烈乐观态度，你需要问的不是“它还能帮我做什么”，而是：\n**我把哪些判断外包得太快了？**\n如果你对 AI 持强烈警惕态度，你也需要问：\n**我担心的是风险本身，还是不愿意失去熟悉的控制方式？**\n人格不会替你决定要不要使用 AI，但人格会显著影响你如何界定风险、如何分配信任，以及你愿意把多少“思考主权”交出去。\n真正重要的，不是你属于哪一派，而是：\n- 你是否知道自己为什么会相信；\n- 你是否知道自己为什么会怀疑；\n- 你是否保留了最后一道判断权。\n## 结论\nAI 不是单纯的技术问题，而是一面放大人格差异的镜子。\n它会让高尽责的人更高效，也会让高警觉的人更焦虑；它会让一部分人更快行动，也会迫使另一部分人更认真地讨论真实性与边界。\nFermatMind 更关心的不是“你喜不喜欢 AI”，而是：\n**你是否有能力在使用 AI 时，仍然保留你的判断力、责任感与长期职业护城河。**\n\nReferences\n\n[1] Kaya, F., Aydın, F., Schepman, A., Rodway, P., Yetişensoy, O., & Demir Kaya, M. (2024). The roles of personality traits, AI anxiety, and demographic factors in attitudes toward artificial intelligence. International Journal of Human-Computer Interaction. https://doi.org/10.1080/10447318.2022.2151730\n[2] Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm appreciation: People prefer algorithmic to human judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. https://doi.org/10.1016/j.obhdp.2018.12.005\n[3] Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human preferences toward algorithmic advice in a word association task. Scientific Reports, 12, 14501. https://doi.org/10.1038/s41598-022-18638-2\n[4] Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, relational, and emotional effects of self-disclosure after conversations with a chatbot. Journal of Communication, 68(4), 712–733. https://doi.org/10.1093/joc/jqy026\n[5] Papneja, H., & Yadav, N. (2025). Self-disclosure to conversational AI: A literature review, emergent framework, and directions for future research. Personal and Ubiquitous Computing, 29, 119–151. https://doi.org/10.1007/s00779-024-01823-7",
       "author_name": "FermatMind Editorial",
       "reading_minutes": 5,
       "cover_image_url": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
-      "cover_image_alt": "抽象的人格画像、算法节点与控制边界构成的冷静编辑部封面",
+      "cover_image_alt": "抽象人脸轮廓与 AI 节点网络交织，表现人格差异如何影响算法信任",
       "cover_image_width": 1200,
       "cover_image_height": 675,
       "cover_image_variants": {
@@ -521,15 +636,43 @@
         "人格心理学",
         "AI",
         "算法信任",
-        "AI 焦虑",
-        "人机交互"
+        "人机交互",
+        "MBTI"
       ],
       "status": "published",
       "is_public": true,
       "is_indexable": true,
       "published_at": "2026-04-18T00:00:00Z",
       "voice": "editorial",
-      "voice_order": 11
+      "voice_order": 11,
+      "seo_title": "性格如何影响你对 AI 的态度？人格、焦虑与算法信任",
+      "seo_description": "为什么有人信任 AI，有人却焦虑？本文用人格心理学解释 AI 态度、算法信任、控制感与职业判断边界。",
+      "cover_image_prompt": "冷静的学术编辑部封面，抽象人脸轮廓与蓝绿色 AI 节点网络交织，几何线条表现控制感、信任与认知边界，现代咨询报告风格，无真实人物照片，无标题文字，高级深蓝与青绿色调，minimal academic editorial design",
+      "cover_image_style_tag": "academic-editorial, ai-personality, muted-geometric",
+      "internal_links": [
+        "/zh/tests/mbti-personality-test-16-personality-types",
+        "/zh/personality",
+        "/zh/topics/mbti",
+        "/zh/articles/how-16-personality-types-talk-to-an-ai-coach"
+      ],
+      "cta_slots": [
+        {
+          "position": "第 2 节“算法信任并不是线性的”之后",
+          "text": "你是更容易信任 AI，还是更容易保留判断权？先了解你的 MBTI 认知偏好 →"
+        },
+        {
+          "position": "结论前",
+          "text": "想知道你的性格如何影响决策、信任和职业选择？开始 MBTI 深度测试 →"
+        }
+      ],
+      "claim_boundary_notes": "本文不宣称人格能预测用户是否“应该使用 AI”，也不把 AI 使用偏好诊断为心理问题；只讨论人格倾向如何影响风险知觉、控制感、算法信任与使用策略。",
+      "references": [
+        "Kaya, F., Aydın, F., Schepman, A., Rodway, P., Yetişensoy, O., & Demir Kaya, M. (2024). The roles of personality traits, AI anxiety, and demographic factors in attitudes toward artificial intelligence. International Journal of Human-Computer Interaction. https://doi.org/10.1080/10447318.2022.2151730",
+        "Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm appreciation: People prefer algorithmic to human judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. https://doi.org/10.1016/j.obhdp.2018.12.005",
+        "Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human preferences toward algorithmic advice in a word association task. Scientific Reports, 12, 14501. https://doi.org/10.1038/s41598-022-18638-2",
+        "Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, relational, and emotional effects of self-disclosure after conversations with a chatbot. Journal of Communication, 68(4), 712–733. https://doi.org/10.1093/joc/jqy026",
+        "Papneja, H., & Yadav, N. (2025). Self-disclosure to conversational AI: A literature review, emergent framework, and directions for future research. Personal and Ubiquitous Computing, 29, 119–151. https://doi.org/10.1007/s00779-024-01823-7"
+      ]
     },
     {
       "slug": "iq-test-growth-guide",
@@ -714,12 +857,12 @@
     {
       "slug": "which-love-script-fits-you-best",
       "title": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
-      "excerpt": "不是所有“合适的人”都意味着同一种爱情。本文不用星座套路，而用爱情研究中的七种关系类型与六种爱情风格，解释为什么有些人追求强烈、有人追求稳定、也有人更在意长期承诺与现实协同。",
-      "content_md": "## 执行摘要\n多数人在谈“合适的伴侣”时，真正表达的并不是“我想找谁”，而是“我想进入哪种亲密关系脚本”。有人要激情与新鲜，有人要稳定与协作，有人要被理解，还有人要共同承担现实。费马的观点是：与其问“你和谁最配”，不如先问“你究竟在寻求哪一种爱情结构”。这比单纯用人格标签做配对，更接近关系科学的结论。[1][2][3]\n\n## 一、爱情不是一种，而是几种不同的组织方式\nSternberg 的三角理论把爱情拆成三个基本成分：亲密、激情、承诺。[1] 不同成分强弱的组合，会产生不同的爱情类型。与此同时，Hendrick 与 Hendrick 基于 Lee 的爱之色轮提出了六种爱情风格：Eros、Ludus、Storge、Pragma、Mania、Agape。[2] 这两个系统可以一起使用：前者解释“爱的结构”，后者解释“爱的风格”。\n\n如果把二者压缩成实用框架，费马会把常见的亲密关系脚本概括成七类：\n1. 强激情型：来得快、感受强、决策也快；\n2. 亲密成长型：通过理解和陪伴建立连接；\n3. 稳定伙伴型：重视协作与长期承诺；\n4. 现实协商型：看重价值观、节奏与生活兼容性；\n5. 自我牺牲型：高度照顾对方，但容易失衡；\n6. 游戏试探型：享受追逐，不急于深度绑定；\n7. 焦虑占有型：情绪浓度很高，但稳定性最差。\n\n这些脚本没有天然高下，但它们对人的要求完全不同。把“想要激情的人”放进“高稳定、低波动”的关系结构里，或把“需要安全感的人”放进“游戏试探型”的关系里，结果都很容易变成长期误配。[2][3]\n\n## 二、什么叫“更科学的匹配”\n更科学的匹配，不是幻想存在一个“天生注定的对象”，而是识别三件事：\n\n第一，你偏好的亲密节奏是什么。你更需要高刺激，还是高可预测性？\n第二，你处理承诺的方式是什么。你是先投入再校准，还是先观察再承诺？\n第三，你把“被爱”定义成什么。是被理解、被追求、被接住，还是被共同承担现实？\n\n研究显示，不同爱情风格和关系质量之间确实有关联。Eros 与 Agape 更可能和积极的关系质量指标同向，Ludus 往往与更低的满意度、更高的 ambivalence 相关；而 Pragma 虽然不“浪漫”，却往往和长期现实兼容性相关。[3][4] 这也解释了为什么有些关系“很上头”但不稳，有些关系“不够刺激”却走得更久。\n\n## 三、把 16 型当成入口，而不是答案\n如果你习惯用 16 型来理解自己，这个框架确实有帮助，但前提是把它当成入口，而不是终点。直觉型、理想导向型的人，通常更容易追求“被理解”的亲密；执行型和结构型人格，往往更重视“可协作的长期关系”；行动型与外向型人格，可能更偏好高互动、高体验密度的亲密脚本。但这些只是倾向，不是命令。真正的判断标准仍然是：你在关系中想获得的是什么，以及你有没有能力承受相应的代价。\n\n## 四、费马的建议\n如果你总在关系里失望，问题未必是“没遇到对的人”，更可能是你一直在用错误的关系脚本去评估正确的人。\n\n例如：\n- 你想要长期稳定，却总被强激情型关系吸引；\n- 你需要高理解与共情，却把擅长执行和推进的人误判为“不够爱”；\n- 你把高情绪浓度当成高亲密度，结果得到的是高波动而不是高连接。\n\n费马不会把“配对”写成娱乐化命题。更严谨的问法是：**什么样的关系结构，既能满足你的核心需要，又不会把你长期置于高损耗状态。**\n\n## 结论\n所谓“最适合的伴侣”，本质上不是“最像你的人”，也不是“最能点燃你的人”，而是：在亲密、激情与承诺这三条轴上，与你的长期节奏能形成稳定匹配的人。先识别你到底在寻找哪种爱情脚本，再谈谁与你相配，这才是更科学、更少误判的关系判断方式。\n\n## 参考文献\n【1】 Sternberg, R. J. (1986). A Triangular Theory of Love. Psychological Review, 93(2), 119–135. DOI: 10.1037/0033-295X.93.2.119.\n\n【2】 Hendrick, C., & Hendrick, S. (1986). A Theory and Method of Love. Journal of Personality and Social Psychology, 50(2), 392–402. DOI: 10.1037/0022-3514.50.2.392.\n\n【3】 Davis, K. E., & Latty-Mann, H. (1987). Love Styles and Relationship Quality: A Contribution to Validation. Journal of Social and Personal Relationships, 4(4), 409–428. DOI: 10.1177/0265407587044002.\n\n【4】 Taraban, C. B., & Hendrick, C. (1995). Personality Perceptions Associated with Six Styles of Love. Journal of Social and Personal Relationships, 12(3), 451–463. DOI: 10.1177/0265407595123008.\n\n【5】 Acker, M., & Davis, M. H. (1992). Intimacy, Passion and Commitment in Adult Romantic Relationships: A Test of the Triangular Theory of Love. Journal of Social and Personal Relationships, 9(1), 21–50. DOI: 10.1177/0265407592091002.",
+      "excerpt": "不是所有“合适的人”都意味着同一种爱情，先识别你的关系脚本，才能减少亲密关系误判。",
+      "content_md": "# 你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配\n## 执行摘要\n多数人在谈“合适的伴侣”时，真正表达的并不是“我想找谁”，而是“我想进入哪种亲密关系脚本”。\n有人要激情与新鲜，有人要稳定与协作，有人要被理解，还有人要共同承担现实。FermatMind 的观点是：\n**与其问“你和谁最配”，不如先问“你究竟在寻求哪一种爱情结构”。**\n这比单纯用人格标签做配对，更接近关系科学的结论。\n## 一、爱情不是一种，而是几种不同的组织方式\nSternberg 的三角理论把爱情拆成三个基本成分：\n1. 亲密；\n2. 激情；\n3. 承诺。\n不同成分强弱的组合，会产生不同的爱情结构。\n与此同时，Hendrick 与 Hendrick 基于 Lee 的爱之色轮提出了六种爱情风格：Eros、Ludus、Storge、Pragma、Mania、Agape。前者解释“爱的结构”，后者解释“爱的风格”。\n如果把二者压缩成实用框架，FermatMind 会把常见的亲密关系脚本概括成七类：\n1. **强激情型**：来得快、感受强、决策也快；\n2. **亲密成长型**：通过理解和陪伴建立连接；\n3. **稳定伙伴型**：重视协作与长期承诺；\n4. **现实协商型**：看重价值观、节奏与生活兼容性；\n5. **自我牺牲型**：高度照顾对方，但容易失衡；\n6. **游戏试探型**：享受追逐，不急于深度绑定；\n7. **焦虑占有型**：情绪浓度很高，但稳定性最差。\n这些脚本没有天然高下，但它们对人的要求完全不同。\n把“想要激情的人”放进“高稳定、低波动”的关系结构里，或把“需要安全感的人”放进“游戏试探型”的关系里，结果都很容易变成长期误配。\n## 二、什么叫“更科学的匹配”\n更科学的匹配，不是幻想存在一个“天生注定的对象”，而是识别三件事：\n1. **你偏好的亲密节奏是什么**：你更需要高刺激，还是高可预测性？\n2. **你处理承诺的方式是什么**：你是先投入再校准，还是先观察再承诺？\n3. **你把“被爱”定义成什么**：是被理解、被追求、被接住，还是被共同承担现实？\n研究显示，不同爱情风格和关系质量之间确实有关联。Eros 与 Agape 更可能和积极的关系质量指标同向，Ludus 往往与更低的满意度、更高的 ambivalence 相关；而 Pragma 虽然不“浪漫”，却往往和长期现实兼容性相关。\n> **Evidence Note**  \n> 爱情风格研究提示我们：关系质量不只取决于“是否喜欢”，还取决于双方如何理解亲密、激情与承诺。强烈吸引不必然等于长期稳定。\n这也解释了为什么有些关系“很上头”但不稳，有些关系“不够刺激”却走得更久。\n## 三、把 16 型当成入口，而不是答案\n如果你习惯用 16 型来理解自己，这个框架确实有帮助，但前提是把它当成入口，而不是终点。\n直觉型、理想导向型的人，通常更容易追求“被理解”的亲密；执行型和结构型人格，往往更重视“可协作的长期关系”；行动型与外向型人格，可能更偏好高互动、高体验密度的亲密脚本。\n但这些只是倾向，不是命令。\n真正的判断标准仍然是：\n**你在关系中想获得的是什么，以及你有没有能力承受相应的代价。**\n## 四、FermatMind 的建议\n如果你总在关系里失望，问题未必是“没遇到对的人”，更可能是你一直在用错误的关系脚本去评估正确的人。\n例如：\n- 你想要长期稳定，却总被强激情型关系吸引；\n- 你需要高理解与共情，却把擅长执行和推进的人误判为“不够爱”；\n- 你把高情绪浓度当成高亲密度，结果得到的是高波动而不是高连接。\nFermatMind 不会把“配对”写成娱乐化命题。更严谨的问法是：\n**什么样的关系结构，既能满足你的核心需要，又不会把你长期置于高损耗状态。**\n## 结论\n所谓“最适合的伴侣”，本质上不是“最像你的人”，也不是“最能点燃你的人”。\n更成熟的判断是：在亲密、激情与承诺这三条轴上，什么样的人与你的长期节奏更容易形成稳定匹配。\n先识别你到底在寻找哪种爱情脚本，再谈谁与你相配，这才是更科学、更少误判的关系判断方式。\n\nReferences\n\n[1] Sternberg, R. J. (1986). A triangular theory of love. Psychological Review, 93(2), 119–135. https://doi.org/10.1037/0033-295X.93.2.119\n[2] Hendrick, C., & Hendrick, S. (1986). A theory and method of love. Journal of Personality and Social Psychology, 50(2), 392–402. https://doi.org/10.1037/0022-3514.50.2.392\n[3] Davis, K. E., & Latty-Mann, H. (1987). Love styles and relationship quality: A contribution to validation. Journal of Social and Personal Relationships, 4(4), 409–428. https://doi.org/10.1177/0265407587044002\n[4] Taraban, C. B., & Hendrick, C. (1995). Personality perceptions associated with six styles of love. Journal of Social and Personal Relationships, 12(3), 451–464. https://doi.org/10.1177/0265407595123008\n[5] Acker, M., & Davis, M. H. (1992). Intimacy, passion and commitment in adult romantic relationships: A test of the triangular theory of love. Journal of Social and Personal Relationships, 9(1), 21–50. https://doi.org/10.1177/0265407592091002",
       "author_name": "FermatMind Editorial",
       "reading_minutes": 4,
       "cover_image_url": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
-      "cover_image_alt": "七种亲密关系脚本以几何轨道和连接节点呈现的抽象封面",
+      "cover_image_alt": "抽象关系网络中呈现七种爱情脚本的几何路径",
       "cover_image_width": 1200,
       "cover_image_height": 675,
       "cover_image_variants": {
@@ -732,17 +875,45 @@
       "category": "关系与爱情",
       "tags": [
         "爱情风格",
+        "亲密关系",
         "关系科学",
-        "依恋与亲密",
-        "Sternberg",
-        "关系匹配"
+        "MBTI",
+        "依恋与亲密"
       ],
       "status": "published",
       "is_public": true,
       "is_indexable": true,
       "published_at": "2026-04-18T00:00:00Z",
       "voice": "editorial",
-      "voice_order": 12
+      "voice_order": 12,
+      "seo_title": "哪种爱情类型适合你？七种关系脚本与人格匹配",
+      "seo_description": "什么样的关系更适合你？用爱情风格、亲密关系研究和人格差异，理解激情、稳定、承诺与长期相处。",
+      "cover_image_prompt": "学术编辑部风格的亲密关系封面，抽象双人节点、关系路径、三角结构与七条柔和几何线，表现亲密、激情、承诺与不同爱情脚本，冷静现代，浅玫瑰、米色、深蓝配色，无文字，无真人照片",
+      "cover_image_style_tag": "academic-editorial, relationship-science, muted-geometric",
+      "internal_links": [
+        "/zh/personality",
+        "/zh/tests/mbti-personality-test-16-personality-types",
+        "/zh/topics/mbti",
+        "/zh/articles/best-valentines-date-by-personality-and-relationship-science"
+      ],
+      "cta_slots": [
+        {
+          "position": "第 2 节“什么叫更科学的匹配”之后",
+          "text": "你在关系里更追求理解、稳定还是激情？先查看你的人格偏好 →"
+        },
+        {
+          "position": "结论后",
+          "text": "用 MBTI 作为入口，理解你的关系节奏与亲密需求 →"
+        }
+      ],
+      "claim_boundary_notes": "不宣称人格可以精准预测“最适合伴侣”，不做配对诊断；只解释关系脚本、爱情风格和长期相处结构的差异。",
+      "references": [
+        "Sternberg, R. J. (1986). A triangular theory of love. Psychological Review, 93(2), 119–135. https://doi.org/10.1037/0033-295X.93.2.119",
+        "Hendrick, C., & Hendrick, S. (1986). A theory and method of love. Journal of Personality and Social Psychology, 50(2), 392–402. https://doi.org/10.1037/0022-3514.50.2.392",
+        "Davis, K. E., & Latty-Mann, H. (1987). Love styles and relationship quality: A contribution to validation. Journal of Social and Personal Relationships, 4(4), 409–428. https://doi.org/10.1177/0265407587044002",
+        "Taraban, C. B., & Hendrick, C. (1995). Personality perceptions associated with six styles of love. Journal of Social and Personal Relationships, 12(3), 451–464. https://doi.org/10.1177/0265407595123008",
+        "Acker, M., & Davis, M. H. (1992). Intimacy, passion and commitment in adult romantic relationships: A test of the triangular theory of love. Journal of Social and Personal Relationships, 9(1), 21–50. https://doi.org/10.1177/0265407592091002"
+      ]
     },
     {
       "slug": "enneagram-test-tool-guide",

--- a/content_baselines/landing_surfaces/home.zh-CN.json
+++ b/content_baselines/landing_surfaces/home.zh-CN.json
@@ -595,7 +595,7 @@
       "block_key": "recommended_articles",
       "block_type": "json",
       "title": "推荐阅读",
-      "subtitle": "首页运营配置的 6 篇推荐文章。",
+      "subtitle": "首页运营配置的 6 篇正式中文 SEO 文章。",
       "sort_order": 6,
       "is_enabled": true,
       "payload_json": {
@@ -609,12 +609,12 @@
               "slug": "which-love-script-fits-you-best",
               "locale": "zh-CN",
               "title": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
-              "excerpt": "不是所有“合适的人”都意味着同一种爱情。本文不用星座套路，而用爱情研究中的七种关系类型与六种爱情风格，解释为什么有些人追求强烈、有人追求稳定、也有人更在意长期承诺与现实协同。",
+              "excerpt": "不是所有“合适的人”都意味着同一种爱情，先识别你的关系脚本，才能减少亲密关系误判。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
               "cover_image_url": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
-              "cover_image_alt": "七种亲密关系脚本以几何轨道和连接节点呈现的抽象封面",
+              "cover_image_alt": "抽象关系网络中呈现七种爱情脚本的几何路径",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
@@ -628,10 +628,10 @@
               "reading_minutes": 4,
               "tags": [
                 "爱情风格",
+                "亲密关系",
                 "关系科学",
-                "依恋与亲密",
-                "Sternberg",
-                "关系匹配"
+                "MBTI",
+                "依恋与亲密"
               ]
             }
           },
@@ -641,12 +641,12 @@
               "slug": "how-personality-shapes-attitude-toward-ai",
               "locale": "zh-CN",
               "title": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
-              "excerpt": "人们对 AI 的看法并不只取决于技术知识，也与稳定的人格倾向、风险知觉和对控制感的需求有关。本文用人格研究解释：为什么有些人把 AI 当作效率杠杆，有些人却更先看到失真、替代与依赖风险。",
+              "excerpt": "AI 态度不只取决于技术知识，也与人格、风险知觉和控制感有关。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
               "cover_image_url": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
-              "cover_image_alt": "抽象的人格画像、算法节点与控制边界构成的冷静编辑部封面",
+              "cover_image_alt": "抽象人脸轮廓与 AI 节点网络交织，表现人格差异如何影响算法信任",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
@@ -662,8 +662,8 @@
                 "人格心理学",
                 "AI",
                 "算法信任",
-                "AI 焦虑",
-                "人机交互"
+                "人机交互",
+                "MBTI"
               ]
             }
           },
@@ -673,12 +673,12 @@
               "slug": "how-16-personality-types-talk-to-an-ai-coach",
               "locale": "zh-CN",
               "title": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
-              "excerpt": "不是所有人都以同样方式使用 AI 教练。有人把它当决策草稿器，有人把它当情绪镜子，也有人最容易被它的“顺着说”误导。本文用人格与人机交互研究解释：什么样的人更适合把 AI 当辅助，而不是当裁判。",
+              "excerpt": "AI 教练最危险的地方，不是它会说错，而是它太容易在关键时刻顺着你。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
               "cover_image_url": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
-              "cover_image_alt": "16 型人格与 AI 教练对话中镜子、工具和反馈回路的抽象封面",
+              "cover_image_alt": "抽象对话气泡与镜面结构表现人格与 AI 教练的互动",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
@@ -691,11 +691,11 @@
               "published_at": "2026-04-18T00:00:00Z",
               "reading_minutes": 4,
               "tags": [
-                "MBTI",
-                "16 型人格",
                 "AI 教练",
+                "16 型人格",
                 "人机交互",
-                "自我披露"
+                "算法建议",
+                "MBTI"
               ]
             }
           },
@@ -705,12 +705,12 @@
               "slug": "childhood-dream-job-still-shapes-career-choice",
               "locale": "zh-CN",
               "title": "你小时候想做的工作，为什么还在影响你今天的职业判断？",
-              "excerpt": "童年想做的职业并不只是“幻想”。它往往提前编码了你对权力、创造、照顾、秩序、冒险与被看见的偏好。本文解释：为什么儿时职业理想会留下痕迹，以及如何把这种痕迹转化成成熟的职业判断。",
+              "excerpt": "童年想做的职业未必预言未来，却常常暴露你真正重视的工作结构。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
               "cover_image_url": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
-              "cover_image_alt": "童年职业理想到成年职业判断的时间线与职业环境匹配抽象封面",
+              "cover_image_alt": "抽象轨迹从童年职业图标延伸到成年职业路径",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
@@ -723,11 +723,11 @@
               "published_at": "2026-04-18T00:00:00Z",
               "reading_minutes": 5,
               "tags": [
-                "职业发展",
-                "dream job",
-                "person-environment fit",
+                "童年职业",
+                "职业兴趣",
+                "职业判断",
                 "RIASEC",
-                "职业兴趣"
+                "人职匹配"
               ]
             }
           },
@@ -737,12 +737,12 @@
               "slug": "best-valentines-date-by-personality-and-relationship-science",
               "locale": "zh-CN",
               "title": "情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会",
-              "excerpt": "真正有效的约会，不是越盛大越好，而是越贴合双方的节奏、刺激阈值和关系目标越好。本文用人格与关系研究，给出一套更少误伤、更高连接的约会设计框架。",
+              "excerpt": "真正有效的约会，不是越盛大越好，而是越贴合双方节奏、刺激阈值和关系目标越好。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
               "cover_image_url": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
-              "cover_image_alt": "两条约会路径在安全感与新鲜感之间形成平衡的抽象封面",
+              "cover_image_alt": "抽象路径地图连接两个关系节点，表现低摩擦约会设计",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
@@ -756,10 +756,10 @@
               "reading_minutes": 4,
               "tags": [
                 "约会设计",
+                "情人节",
                 "人格心理学",
-                "关系科学",
-                "低摩擦约会",
-                "亲密关系"
+                "亲密关系",
+                "关系科学"
               ]
             }
           },
@@ -769,12 +769,12 @@
               "slug": "are-infj-men-rare-or-socially-silenced",
               "locale": "zh-CN",
               "title": "“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？",
-              "excerpt": "当人们说“某类男性太少见”时，他们常常忽略了一个更复杂的问题：不是他们不存在，而是他们可能更早学会了压抑、伪装和自我沉默。本文用自我沉默、男性规范与情绪抑制研究，重看“高敏感男性”的社会化困境。",
+              "excerpt": "一些男性不是没有深度共情和敏感性，而是更早学会了隐藏这些特质。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
               "cover_image_url": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
-              "cover_image_alt": "高敏感男性、自我沉默与社会规范边界的抽象人物封面",
+              "cover_image_alt": "半透明男性轮廓与被压低的声波线条，象征高敏感男性的自我沉默",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
@@ -787,11 +787,11 @@
               "published_at": "2026-04-18T00:00:00Z",
               "reading_minutes": 4,
               "tags": [
-                "MBTI",
                 "INFJ",
+                "高敏感",
                 "男性规范",
                 "自我沉默",
-                "情绪抑制"
+                "情绪表达"
               ]
             }
           }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -706,7 +706,7 @@
       "depends_on": [
         "backend-email-gated-report-read"
       ],
-      "commit_sha": null,
+      "commit_sha": "66d637d1961694af8183191d55aacb5af5481e11",
       "pr_url": null,
       "checks": {},
       "sidecar_issues": [],
@@ -1961,8 +1961,8 @@
     "PR-RT-01": {
       "repo": "fap-api",
       "branch": "codex/pr-rt-01-article-runtime-truth-gate",
-      "status": "open",
-      "commit_sha": "05036aa710658e589ff0be7d1c19ac6059884389",
+      "status": "merged",
+      "commit_sha": "ac56410db6f0bf464f2b236d3431f2ff4b962233",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1331",
       "checks": {
         "focused_article_runtime_truth": {
@@ -1999,9 +1999,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-12T15:19:09Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "companion_pr": {
         "repo": "fap-web",
         "branch": "codex/pr-rt-01-article-runtime-truth-gate"
@@ -2190,6 +2190,60 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-RT-02": {
+      "repo": "fap-api",
+      "branch": "codex/pr-rt-02-article-import-svg-covers",
+      "title": "feat(api): import six SEO articles with SVG covers",
+      "name": "6 SEO Articles Formal Import + SVG Cover Placeholders",
+      "status": "in_progress",
+      "depends_on": [
+        "PR-RT-01"
+      ],
+      "scope_type": "article_authority_import_only",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "focused_article_baseline_import": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi",
+          "evidence": "2 tests passed, 193 assertions after rebasing onto origin/main."
+        },
+        "article_runtime_truth": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/V0_5/ArticlePublishingRuntimeTruthTest.php --no-ansi",
+          "evidence": "2 tests passed, 250 assertions after rebasing onto origin/main."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Command completed successfully; output captured in /tmp/pr-rt-02-route-list.txt."
+        },
+        "sqlite_migrate_pretend": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+          "evidence": "Command completed successfully; output captured in /tmp/pr-rt-02-migrate-pretend.txt."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php tests/Feature/CareerCms/ArticleBaselineImportTest.php",
+          "evidence": "Scoped Pint check passed for 2 files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "fap_web_companion_validation": {
+          "status": "pass",
+          "command": "pnpm test:contract -- article-publishing-runtime-truth.contract.test.ts; pnpm typecheck; NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build; pnpm seo:check-sitemap",
+          "evidence": "fap-web contracts passed across 340 files / 1904 tests, typecheck passed, production build passed with API URL override because local .env.local points to offline 127.0.0.1:8000, and sitemap indexability check passed for 206 URLs."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2229,6 +2229,11 @@
           "command": "vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php tests/Feature/CareerCms/ArticleBaselineImportTest.php",
           "evidence": "Scoped Pint check passed for 2 files."
         },
+        "bigfive_runtime_freeze_classifier": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|runtime_freeze_classifier_ignores_article_publishing_runtime_truth_gate_changes' --no-ansi",
+          "evidence": "2 tests passed, 4 assertions. Added test-only freeze classifier allowance for ArticleImportLocalBaseline.php as Article publishing runtime truth gate scope."
+        },
         "diff_check": {
           "status": "pass",
           "command": "git diff --check && git diff --cached --check"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1042,7 +1042,7 @@
       "branch": "fix/career-audit-schema-audit1-202605121641",
       "title": "feat(api): add career canonical eligibility audit schema",
       "name": "Career Canonical Eligibility Audit Schema + Sidecar Schema",
-      "status": "in_progress",
+      "status": "open",
       "scope_type": "schema_only",
       "allowed_paths": [
         "backend/app/Domain/Career/Audit/*",
@@ -2202,7 +2202,7 @@
       ],
       "scope_type": "article_authority_import_only",
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1337",
       "checks": {
         "focused_article_baseline_import": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -706,7 +706,7 @@
       "depends_on": [
         "backend-email-gated-report-read"
       ],
-      "commit_sha": "66d637d1961694af8183191d55aacb5af5481e11",
+      "commit_sha": "32f35c17a0f29758f0f700010ac1b0c7492ffb6c",
       "pr_url": null,
       "checks": {},
       "sidecar_issues": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -994,6 +994,7 @@ prs:
       - backend/app/Console/Commands/ArticleImportLocalBaseline.php
       - backend/public/static/articles/covers/*
       - backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - content_baselines/articles/articles.zh-CN.json
       - content_baselines/landing_surfaces/home.zh-CN.json
       - docs/codex/pr-train.yaml

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -976,6 +976,52 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: PR-RT-02
+    repo: fap-api
+    depends_on:
+      - PR-RT-01
+    branch: codex/pr-rt-02-article-import-svg-covers
+    title: "feat(api): import six SEO articles with SVG covers"
+    name: "6 SEO Articles Formal Import + SVG Cover Placeholders"
+    scope_type: article_authority_import_only
+    scope:
+      - Import the six user-provided Chinese editorial packages into existing Article baseline authority.
+      - Preserve title, slug, SEO title, meta description, excerpt, body markdown, references, claim boundaries, internal links, and CTA metadata.
+      - Generate six in-house 1200x675 SVG cover placeholders and wire cover image and alt metadata.
+      - Sync baseline import to Article published revision SEO fields and ArticleSeoMeta without frontend editorial fallback.
+      - Keep homepage recommended articles backed by landing surface baseline article references.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleImportLocalBaseline.php
+      - backend/public/static/articles/covers/*
+      - backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+      - content_baselines/articles/articles.zh-CN.json
+      - content_baselines/landing_surfaces/home.zh-CN.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Rewrite editorial body, title, SEO title, meta description, excerpt, or references.
+      - Add article body content to fap-web or create a second Article authority.
+      - Touch MBTI, Big Five, RIASEC, IQ, Personality, Career expansion, payment, report, invite, order, scoring, or Ads runtime.
+      - Generate external AI images or publish non-Article-authoritative frontend content.
+    validation:
+      - php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi
+      - php artisan test tests/Feature/V0_5/ArticlePublishingRuntimeTruthTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
+      - backend/vendor/bin/pint --test backend/app/Console/Commands/ArticleImportLocalBaseline.php backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+      - git diff --check
+    companion_validation:
+      repo: fap-web
+      branch: main
+      checks:
+        - pnpm test:contract -- article-publishing-runtime-truth.contract.test.ts
+        - pnpm typecheck
+        - pnpm build
+        - pnpm seo:generate-sitemap
+        - pnpm seo:check-sitemap
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: AUDIT-12
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Root cause
PR-RT-01 established the Article Publishing Runtime Truth Gate, so PR-RT-02 can now import the six approved Chinese SEO articles as formal backend Article authority instead of continuing to add gates or rewriting editorial content.

## Files changed
- `content_baselines/articles/articles.zh-CN.json`: imports the six CMS-ready editorial packages into the existing Article baseline authority with title, slug, SEO fields, excerpt, body markdown, references, cover metadata, editorial metadata, status, locale, and indexability.
- `content_baselines/landing_surfaces/home.zh-CN.json`: updates the existing backend landing surface recommended-articles block to reference the imported article authority.
- `backend/public/static/articles/covers/*.svg`: adds six 1200x675 in-house SVG placeholder covers, one per article.
- `backend/app/Console/Commands/ArticleImportLocalBaseline.php`: syncs baseline SEO authority into published revisions and `ArticleSeoMeta`, including canonical, robots, OG image, cover editorial metadata, and publish timestamp handling.
- `backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php`: extends Article baseline import acceptance coverage for SEO metadata, Article JSON-LD projection, cover/alt/prompt/style metadata, and all six formal article slugs.
- `docs/codex/pr-train.yaml`: registers PR-RT-02 scope and validation.
- `docs/codex/pr-train-state.json`: reconciles PR-RT-01 merge state and records PR-RT-02 validation state.

## Article import decision
Article authority remains backend CMS Article + published revision. The six user-provided editorial packages are imported through the existing Article baseline path, not fap-web frontend content. They are `published`, public, indexable, locale `zh-CN`, author `FermatMind Editorial`, and use the provided slugs. Codex preserved the supplied editorial title, SEO title, meta description, excerpt, body markdown, references, claim boundary notes, internal links, and CTA metadata.

Two internal links were mechanically mapped to existing canonical routes because the supplied targets are not current public routes:
- `/zh/tests/holland-career-interest-test` -> `/zh/tests/holland-career-interest-test-riasec`
- `/zh/tests/big-five-personality-test` -> `/zh/tests/big-five-personality-test-ocean-model`

## Metadata decision
`seo_title`, `seo_description`, excerpt, category, tags, canonical, robots/indexability, and OG image are imported into backend Article authority and `ArticleSeoMeta`. Published revisions also receive SEO title/description so frontend metadata and Article JSON-LD can converge on backend truth instead of silent frontend fallback.

## Cover image decision
Each article has a local SVG placeholder at `backend/public/static/articles/covers/*.svg`, plus non-empty `cover_image_alt`. The supplied `cover_image_prompt` and `cover_image_style_tag` are preserved under cover editorial metadata. Future formal covers can replace the SVG URL in Article/media metadata without changing frontend schema or article body.

## Homepage / list / detail decision
Homepage recommended reading remains backed by the existing `landing_surfaces` baseline. Article list/detail surfaces continue to consume backend Article API/runtime truth. No article body or editorial card content was hardcoded into fap-web.

## Validation
Backend:
- `php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi` — pass, 2 tests / 193 assertions
- `php artisan test tests/Feature/V0_5/ArticlePublishingRuntimeTruthTest.php --no-ansi` — pass, 2 tests / 250 assertions
- `php artisan route:list --no-ansi` — pass
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force` — pass
- `vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php tests/Feature/CareerCms/ArticleBaselineImportTest.php` — pass
- `git diff --check && git diff --cached --check` — pass

fap-web companion validation:
- `pnpm test:contract -- article-publishing-runtime-truth.contract.test.ts` — pass; actual suite run covered 340 contract files / 1904 tests
- `pnpm typecheck` — pass
- `NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build` — pass
- `pnpm seo:check-sitemap` — pass, 206 URLs

## Manual verify checklist
- `/zh/articles`
- `/zh/articles/how-personality-shapes-attitude-toward-ai`
- `/zh/articles/which-love-script-fits-you-best`
- `/zh/articles/are-infj-men-rare-or-socially-silenced`
- `/zh/articles/best-valentines-date-by-personality-and-relationship-science`
- `/zh/articles/how-16-personality-types-talk-to-an-ai-coach`
- `/zh/articles/childhood-dream-job-still-shapes-career-choice`
- homepage recommended reading
- metadata and canonical
- Article JSON-LD
- cover image and cover alt
- references / bibliography
- sitemap / llms behavior under published/indexable gates

## Risks
- fap-web local `.env.local` points to `127.0.0.1:8000`; local `pnpm build` fails if the local API server is offline. The production API override build passed.
- This PR imports SVG placeholders, not final editorial artwork. Final cover replacement should update Article/media metadata only.

## Done when
After this PR merges and the Article baseline/import is applied in the target environment, the six articles can be considered formally imported Article assets and can enter routine SEO/GEO operations under the PR-RT-01 runtime truth gate.