### PR TITLE
fix(api): make career audit run context explicit

### DIFF
--- a/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+++ b/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
@@ -6,6 +6,10 @@ namespace App\Console\Commands;
 
 use App\Domain\Career\Audit\CareerBaselineMetadataInventoryAuditor;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRunContext;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRunContextApprovalGate;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRunContextRequirement;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRunContextStatus;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityLayerStatus;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
@@ -37,6 +41,7 @@ final class CareerAuditCanonicalEligibility extends Command
         {--ledger= : Optional full release ledger JSON artifact}
         {--json : Emit JSON output}
         {--output= : Optional output path for JSON payload}
+        {--context-output= : Optional output path for run context requirements JSON}
         {--include-surfaces : Include surface layer context}
         {--include-live-html : Include optional live HTML surface context}
         {--base-url= : Required only when live HTML verification is requested later}';
@@ -92,8 +97,24 @@ final class CareerAuditCanonicalEligibility extends Command
             rows: $rows,
             sidecars: $sidecars,
         );
+        $runContext = $this->runContext(
+            scope: $scope,
+            planRows: $planRows,
+            slugs: $slugs,
+            locales: $locales,
+            byReason: $byReason
+        );
+        $contextPayload = [
+            'context_summary' => $runContext->summary(),
+            'run_context' => $runContext->toArray(),
+            'read_only' => true,
+            'writes_database' => false,
+            'audit_command' => 'career:audit-canonical-eligibility',
+        ];
         $payload = [
             ...$report->toArray(),
+            'context_summary' => $contextPayload['context_summary'],
+            'run_context' => $contextPayload['run_context'],
             'read_only' => true,
             'writes_database' => false,
             'audit_command' => 'career:audit-canonical-eligibility',
@@ -110,6 +131,18 @@ final class CareerAuditCanonicalEligibility extends Command
             File::put($output, $encoded.PHP_EOL);
         }
 
+        $contextOutput = $this->stringOption('context-output');
+        if ($contextOutput !== null) {
+            $contextEncoded = json_encode($contextPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($contextEncoded)) {
+                $this->error('failed to encode career canonical eligibility audit context payload');
+
+                return self::FAILURE;
+            }
+
+            File::put($contextOutput, $contextEncoded.PHP_EOL);
+        }
+
         if ((bool) $this->option('json')) {
             $this->line($encoded);
         } else {
@@ -120,6 +153,327 @@ final class CareerAuditCanonicalEligibility extends Command
         }
 
         return $payload['status'] === CareerCanonicalEligibilityStatus::PASS ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  list<CareerPublicResolutionPlanRow>  $planRows
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array<string, int>  $byReason
+     */
+    private function runContext(string $scope, array $planRows, array $slugs, array $locales, array $byReason): CareerCanonicalEligibilityAuditRunContext
+    {
+        $planPath = $this->stringOption('public-resolution-plan');
+        $projectionPath = $this->stringOption('projection');
+        $truthPath = $this->stringOption('truth');
+        $ledgerPath = $this->stringOption('ledger');
+        $includeSurfaces = (bool) $this->option('include-surfaces') || (bool) $this->option('include-live-html');
+        $includeLiveHtml = (bool) $this->option('include-live-html');
+        $baseUrl = $this->stringOption('base-url');
+
+        $requirements = [
+            $this->contextRequirement(
+                contextId: 'public_resolution_plan',
+                label: 'Public resolution planner JSON',
+                status: $planPath !== null || $scope === CareerCanonicalEligibilityScope::SLUGS
+                    ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                    : CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+                requiredForMeaningfulRerun: $scope !== CareerCanonicalEligibilityScope::SLUGS,
+                blocks80Readiness: true,
+                requiresApproval: false,
+                approvalGateId: null,
+                suppliedInput: $planPath,
+                requiredInput: '--public-resolution-plan=/path/to/plan.json',
+                reason: $scope === CareerCanonicalEligibilityScope::SLUGS
+                    ? 'Explicit slug scope was supplied; full 2786 rerun still requires the planner artifact.'
+                    : 'The full 2786 audit must start from the authorized public-resolution planner JSON.',
+                evidence: [['scope' => $scope, 'found_rows' => count($planRows)]]
+            ),
+            $this->contextRequirement(
+                contextId: 'entity_db_context',
+                label: 'Occupation entity read-only DB context',
+                status: $this->reasonPresent($byReason, 'entity_db_context_missing')
+                    ? CareerCanonicalEligibilityAuditRunContextStatus::MISSING
+                    : CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED,
+                requiredForMeaningfulRerun: true,
+                blocks80Readiness: true,
+                requiresApproval: $this->reasonPresent($byReason, 'entity_db_context_missing'),
+                approvalGateId: $this->reasonPresent($byReason, 'entity_db_context_missing') ? 'production_readonly_db_context' : null,
+                suppliedInput: $this->reasonPresent($byReason, 'entity_db_context_missing') ? null : 'configured read-only DB connection',
+                requiredInput: 'approved read-only DB context for occupations',
+                reason: 'Entity inventory cannot distinguish missing Occupation rows from unavailable DB context until a read-only DB context is supplied.',
+                evidence: [['row_reason_count' => $byReason['entity_db_context_missing'] ?? 0]]
+            ),
+            $this->contextRequirement(
+                contextId: 'index_state_context',
+                label: 'Index-state read-only DB context',
+                status: $this->reasonPresent($byReason, 'index_state_context_missing')
+                    ? CareerCanonicalEligibilityAuditRunContextStatus::MISSING
+                    : CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED,
+                requiredForMeaningfulRerun: true,
+                blocks80Readiness: true,
+                requiresApproval: $this->reasonPresent($byReason, 'index_state_context_missing'),
+                approvalGateId: $this->reasonPresent($byReason, 'index_state_context_missing') ? 'production_readonly_db_context' : null,
+                suppliedInput: $this->reasonPresent($byReason, 'index_state_context_missing') ? null : 'configured read-only DB connection',
+                requiredInput: 'approved read-only DB context for index_states',
+                reason: 'Index-state authority cannot be proven until the audit can read occupations and index_states.',
+                evidence: [['row_reason_count' => $byReason['index_state_context_missing'] ?? 0]]
+            ),
+            $this->contextRequirement(
+                contextId: 'runtime_projection_context',
+                label: 'Runtime publish projection artifact',
+                status: $projectionPath !== null && is_file($projectionPath)
+                    ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                    : CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+                requiredForMeaningfulRerun: true,
+                blocks80Readiness: true,
+                requiresApproval: $projectionPath === null,
+                approvalGateId: $projectionPath === null ? 'production_runtime_projection_export' : null,
+                suppliedInput: $projectionPath,
+                requiredInput: '--projection=/path/to/runtime_projection.json',
+                reason: 'Runtime projection eligibility must be audited from a read-only projection artifact before readiness planning.',
+                evidence: [['row_reason_count' => $byReason['runtime_projection_context_missing'] ?? 0]]
+            ),
+            $this->contextRequirement(
+                contextId: 'runtime_truth_context',
+                label: 'Canonical runtime truth artifact',
+                status: $truthPath !== null && is_file($truthPath)
+                    ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                    : CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+                requiredForMeaningfulRerun: true,
+                blocks80Readiness: true,
+                requiresApproval: $truthPath === null,
+                approvalGateId: $truthPath === null ? 'production_truth_export' : null,
+                suppliedInput: $truthPath,
+                requiredInput: '--truth=/path/to/runtime_truth.json',
+                reason: 'Canonical runtime truth must be supplied as a read-only artifact before runtime readiness can be interpreted.',
+                evidence: [['row_reason_count' => $byReason['runtime_truth_context_missing'] ?? 0]]
+            ),
+            $this->contextRequirement(
+                contextId: 'surface_context',
+                label: 'Surface readiness artifact mode',
+                status: $includeSurfaces
+                    ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                    : CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+                requiredForMeaningfulRerun: true,
+                blocks80Readiness: true,
+                requiresApproval: false,
+                approvalGateId: null,
+                suppliedInput: $includeSurfaces ? '--include-surfaces' : null,
+                requiredInput: '--include-surfaces',
+                reason: 'Surface readiness is grouped as one context-level requirement; missing surface context is not 5572 independent data defects.',
+                evidence: [['row_reason_count' => $byReason['surface_context_missing'] ?? 0]]
+            ),
+            $this->contextRequirement(
+                contextId: 'live_html_context',
+                label: 'Optional live HTML verification context',
+                status: $includeLiveHtml && $baseUrl !== null
+                    ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                    : ($includeLiveHtml ? CareerCanonicalEligibilityAuditRunContextStatus::MISSING : CareerCanonicalEligibilityAuditRunContextStatus::NOT_REQUESTED),
+                requiredForMeaningfulRerun: false,
+                blocks80Readiness: $includeLiveHtml && $baseUrl === null,
+                requiresApproval: $includeLiveHtml && $baseUrl === null,
+                approvalGateId: $includeLiveHtml && $baseUrl === null ? 'live_html_crawl' : null,
+                suppliedInput: $baseUrl,
+                requiredInput: '--base-url=https://example.com',
+                reason: 'Live HTML checks are optional and require an explicit base URL plus approval before production-scale crawling.',
+                evidence: [['include_live_html' => $includeLiveHtml]]
+            ),
+        ];
+
+        $staticSources = $this->staticSourceContext($byReason);
+
+        return new CareerCanonicalEligibilityAuditRunContext(
+            planner: [
+                'status' => $planPath !== null || $scope === CareerCanonicalEligibilityScope::SLUGS
+                    ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                    : CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+                'public_resolution_plan_path' => $planPath,
+                'expected_rows' => count(array_unique($slugs)),
+                'found_rows' => count($planRows),
+                'source_type' => $planPath !== null ? 'public_resolution_plan_json' : ($scope === CareerCanonicalEligibilityScope::SLUGS ? 'explicit_slugs' : 'missing'),
+            ],
+            entity: [
+                'entity_db_context' => $requirements[1]->status,
+                'local_db_available' => ! $this->reasonPresent($byReason, 'entity_db_context_missing'),
+                'production_readonly_db_needed' => $this->reasonPresent($byReason, 'entity_db_context_missing'),
+            ],
+            index: [
+                'index_state_context' => $requirements[2]->status,
+                'local_db_available' => ! $this->reasonPresent($byReason, 'index_state_context_missing'),
+                'production_readonly_db_needed' => $this->reasonPresent($byReason, 'index_state_context_missing'),
+            ],
+            runtime: [
+                'ledger_path' => $ledgerPath,
+                'projection_path' => $projectionPath,
+                'truth_path' => $truthPath,
+                'runtime_projection_context' => $requirements[3]->status,
+                'runtime_truth_context' => $requirements[4]->status,
+            ],
+            surface: [
+                'include_surfaces' => $includeSurfaces,
+                'include_live_html' => $includeLiveHtml,
+                'base_url' => $baseUrl,
+                'surface_context' => $requirements[5]->status,
+                'live_html_context' => $requirements[6]->status,
+            ],
+            staticSources: $staticSources,
+            requirements: $requirements,
+            approvalGates: $this->approvalGates(),
+            suggestedRerunModes: [
+                'planner_only',
+                'planner_plus_local_db',
+                'planner_plus_runtime_artifacts',
+                'planner_plus_surface_base_url',
+                'full_readonly_context',
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string, int>  $byReason
+     * @return array<string, mixed>
+     */
+    private function staticSourceContext(array $byReason): array
+    {
+        $repoRoot = dirname(base_path());
+        $zhBaseline = $repoRoot.'/content_baselines/career_jobs/career_jobs.zh-CN.json';
+        $enBaseline = $repoRoot.'/content_baselines/career_jobs/career_jobs.en.json';
+
+        return [
+            'baseline_sources' => [
+                'zh_baseline_path' => $zhBaseline,
+                'zh_baseline_exists' => is_file($zhBaseline),
+                'en_baseline_path' => $enBaseline,
+                'en_baseline_exists' => is_file($enBaseline),
+            ],
+            'seo_geo_sources' => [
+                'sitemap_source_available' => ! $this->reasonPresent($byReason, 'sitemap_missing'),
+                'llms_source_available' => ! $this->reasonPresent($byReason, 'llms_missing'),
+                'llms_full_source_available' => ! $this->reasonPresent($byReason, 'llms_full_missing'),
+                'structured_data_source_available' => ! $this->reasonPresent($byReason, 'structured_data_missing'),
+                'citation_metadata_source_available' => ! $this->reasonPresent($byReason, 'citation_metadata_missing'),
+            ],
+            'context_note' => 'Static source gaps are artifact/metadata blockers, not approval to mutate DB or publish.',
+        ];
+    }
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    private function contextRequirement(
+        string $contextId,
+        string $label,
+        string $status,
+        bool $requiredForMeaningfulRerun,
+        bool $blocks80Readiness,
+        bool $requiresApproval,
+        ?string $approvalGateId,
+        ?string $suppliedInput,
+        ?string $requiredInput,
+        string $reason,
+        array $evidence,
+    ): CareerCanonicalEligibilityAuditRunContextRequirement {
+        return new CareerCanonicalEligibilityAuditRunContextRequirement(
+            contextId: $contextId,
+            label: $label,
+            status: $status,
+            requiredForMeaningfulRerun: $requiredForMeaningfulRerun,
+            blocks80Readiness: $blocks80Readiness,
+            requiresApproval: $requiresApproval,
+            approvalGateId: $approvalGateId,
+            suppliedInput: $suppliedInput,
+            requiredInput: $requiredInput,
+            reason: $reason,
+            evidence: $evidence,
+        );
+    }
+
+    /**
+     * @return list<CareerCanonicalEligibilityAuditRunContextApprovalGate>
+     */
+    private function approvalGates(): array
+    {
+        return [
+            new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                gateId: 'production_readonly_db_context',
+                title: 'Approved read-only DB context for Career 2786 audit',
+                required: true,
+                reason: 'Entity and index-state findings cannot be interpreted as production data defects until an approved read-only DB context is supplied.',
+                approvalPhraseTemplate: 'I approve a read-only Career 2786 audit DB query against <environment> using <credential/profile>, with no writes.',
+                allowedAction: 'Read-only audit queries for occupations and index_states.',
+                forbiddenActions: ['insert', 'update', 'delete', 'backfill', 'apply', 'rollback', 'quarantine'],
+                preconditions: ['read-only credentials', 'no mutation command flags', 'output path outside production storage'],
+            ),
+            new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                gateId: 'production_runtime_projection_export',
+                title: 'Approved read-only runtime projection artifact export',
+                required: true,
+                reason: 'Runtime projection must be supplied as an artifact; export approval must not imply rollout apply.',
+                approvalPhraseTemplate: 'I approve read-only runtime projection export for Career 2786 audit; no apply or publish is approved.',
+                allowedAction: 'Read-only export of runtime projection JSON.',
+                forbiddenActions: ['rollout apply', 'publish', 'backfill', 'production mutation'],
+                preconditions: ['export command inspected', 'artifact output path selected', 'no apply flags'],
+            ),
+            new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                gateId: 'production_truth_export',
+                title: 'Approved read-only canonical runtime truth artifact export',
+                required: true,
+                reason: 'Canonical runtime truth must be supplied as an artifact before runtime eligibility can be interpreted.',
+                approvalPhraseTemplate: 'I approve read-only canonical runtime truth export for Career 2786 audit; no apply or publish is approved.',
+                allowedAction: 'Read-only export of canonical runtime truth JSON.',
+                forbiddenActions: ['rollout apply', 'publish', 'backfill', 'production mutation'],
+                preconditions: ['export command inspected', 'artifact output path selected', 'no apply flags'],
+            ),
+            new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                gateId: 'live_html_crawl',
+                title: 'Approved live HTML verification crawl',
+                required: false,
+                reason: 'Live HTML verification can create external traffic and must be explicitly scoped before use.',
+                approvalPhraseTemplate: 'I approve read-only live HTML verification for Career 2786 against <base-url> with rate limit <limit>; no deploy is approved.',
+                allowedAction: 'Read-only live HTML fetches within the approved rate limit.',
+                forbiddenActions: ['deploy', 'frontend mutation', 'rollout apply', 'publication'],
+                preconditions: ['base URL confirmed', 'rate limit defined', 'small-sample verifier passed'],
+            ),
+            new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                gateId: 'db_backfill_apply',
+                title: 'DB backfill apply approval',
+                required: false,
+                reason: 'Backfills mutate DB state and are outside this command run context PR.',
+                approvalPhraseTemplate: 'I approve Career 2786 DB backfill apply for reviewed artifact <path> in <environment>.',
+                allowedAction: 'Apply the reviewed DB remediation plan only.',
+                forbiddenActions: ['unreviewed slug mutation', 'rollout apply', 'deploy'],
+                preconditions: ['reviewed dry-run artifact', 'explicit slug list', 'rollback plan'],
+            ),
+            new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                gateId: 'index_state_apply',
+                title: 'Index-state apply approval',
+                required: false,
+                reason: 'Index-state writes can change public eligibility and require a reviewed plan.',
+                approvalPhraseTemplate: 'I approve index_state remediation apply for reviewed slugs <path> in <environment>.',
+                allowedAction: 'Apply reviewed index_state changes only.',
+                forbiddenActions: ['unreviewed index changes', 'rollout apply', 'deploy'],
+                preconditions: ['previous-state snapshot', 'reviewed dry-run artifact', 'explicit slug list'],
+            ),
+            new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                gateId: 'rollout_apply',
+                title: 'Expansion rollout apply approval',
+                required: false,
+                reason: 'Expansion apply publishes/exposes occupations and must wait for eligibility proof.',
+                approvalPhraseTemplate: 'I approve Career canonical expansion apply for batch <80|300|800|2786> using manifest <path>.',
+                allowedAction: 'Apply only the reviewed expansion manifest.',
+                forbiddenActions: ['unreviewed publication', 'implicit deploy', 'implicit backfill'],
+                preconditions: ['full audit pass or approved sidecars', 'manifest reviewed', 'rollback group slug list reviewed'],
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string, int>  $byReason
+     */
+    private function reasonPresent(array $byReason, string $reason): bool
+    {
+        return ($byReason[$reason] ?? 0) > 0;
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContext.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContext.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityAuditRunContext
+{
+    /**
+     * @param  array<string, mixed>  $planner
+     * @param  array<string, mixed>  $entity
+     * @param  array<string, mixed>  $index
+     * @param  array<string, mixed>  $runtime
+     * @param  array<string, mixed>  $surface
+     * @param  array<string, mixed>  $staticSources
+     * @param  list<CareerCanonicalEligibilityAuditRunContextRequirement>  $requirements
+     * @param  list<CareerCanonicalEligibilityAuditRunContextApprovalGate>  $approvalGates
+     * @param  list<string>  $suggestedRerunModes
+     */
+    public function __construct(
+        public readonly array $planner,
+        public readonly array $entity,
+        public readonly array $index,
+        public readonly array $runtime,
+        public readonly array $surface,
+        public readonly array $staticSources,
+        public readonly array $requirements,
+        public readonly array $approvalGates,
+        public readonly array $suggestedRerunModes,
+    ) {
+        self::assertMap($this->planner, 'planner');
+        self::assertMap($this->entity, 'entity');
+        self::assertMap($this->index, 'index');
+        self::assertMap($this->runtime, 'runtime');
+        self::assertMap($this->surface, 'surface');
+        self::assertMap($this->staticSources, 'static_sources');
+        self::assertRequirements($this->requirements);
+        self::assertApprovalGates($this->approvalGates);
+        self::assertListOfStrings($this->suggestedRerunModes, 'suggested_rerun_modes');
+    }
+
+    /**
+     * @return array{planner: array<string, mixed>, entity: array<string, mixed>, index: array<string, mixed>, runtime: array<string, mixed>, surface: array<string, mixed>, static_sources: array<string, mixed>, missing_contexts: list<array<string, mixed>>, unverified_contexts: list<array<string, mixed>>, approval_gates: list<array<string, mixed>>, next_required_inputs: list<array<string, mixed>>, suggested_rerun_modes: list<string>}
+     */
+    public function toArray(): array
+    {
+        $requirements = array_map(
+            static fn (CareerCanonicalEligibilityAuditRunContextRequirement $requirement): array => $requirement->toArray(),
+            $this->requirements
+        );
+
+        return [
+            'planner' => $this->planner,
+            'entity' => $this->entity,
+            'index' => $this->index,
+            'runtime' => $this->runtime,
+            'surface' => $this->surface,
+            'static_sources' => $this->staticSources,
+            'missing_contexts' => array_values(array_filter(
+                $requirements,
+                static fn (array $requirement): bool => in_array($requirement['status'], [
+                    CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+                    CareerCanonicalEligibilityAuditRunContextStatus::REQUIRES_APPROVAL,
+                ], true)
+            )),
+            'unverified_contexts' => array_values(array_filter(
+                $requirements,
+                static fn (array $requirement): bool => $requirement['status'] !== CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+            )),
+            'approval_gates' => array_map(
+                static fn (CareerCanonicalEligibilityAuditRunContextApprovalGate $gate): array => $gate->toArray(),
+                $this->approvalGates
+            ),
+            'next_required_inputs' => array_values(array_filter(
+                $requirements,
+                static fn (array $requirement): bool => $requirement['required_for_meaningful_rerun'] === true
+                    && $requirement['status'] !== CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+            )),
+            'suggested_rerun_modes' => $this->suggestedRerunModes,
+        ];
+    }
+
+    /**
+     * @return array{planner_supplied: bool, entity_db_context: string, index_state_context: string, runtime_projection_context: string, runtime_truth_context: string, surface_context: string, live_html_context: string, required_next_action: string}
+     */
+    public function summary(): array
+    {
+        $requirements = $this->requirementsById();
+
+        return [
+            'planner_supplied' => ($this->planner['status'] ?? null) === CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED,
+            'entity_db_context' => $requirements['entity_db_context']->status ?? CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+            'index_state_context' => $requirements['index_state_context']->status ?? CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+            'runtime_projection_context' => $requirements['runtime_projection_context']->status ?? CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+            'runtime_truth_context' => $requirements['runtime_truth_context']->status ?? CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+            'surface_context' => $requirements['surface_context']->status ?? CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+            'live_html_context' => $requirements['live_html_context']->status ?? CareerCanonicalEligibilityAuditRunContextStatus::NOT_REQUESTED,
+            'required_next_action' => $this->requiredNextAction(),
+        ];
+    }
+
+    private function requiredNextAction(): string
+    {
+        foreach ($this->requirements as $requirement) {
+            if ($requirement->requiredForMeaningfulRerun && $requirement->status !== CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED) {
+                return 'provide_read_only_context_bundle';
+            }
+        }
+
+        return 'review_layer_blockers';
+    }
+
+    /**
+     * @return array<string, CareerCanonicalEligibilityAuditRunContextRequirement>
+     */
+    private function requirementsById(): array
+    {
+        $requirements = [];
+        foreach ($this->requirements as $requirement) {
+            $requirements[$requirement->contextId] = $requirement;
+        }
+
+        return $requirements;
+    }
+
+    private static function assertMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career audit run context [%s] must be an object map.', $key));
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRunContextRequirement>  $requirements
+     */
+    private static function assertRequirements(array $requirements): void
+    {
+        if (! array_is_list($requirements)) {
+            throw new InvalidArgumentException('Career audit run context requirements must be a list.');
+        }
+
+        foreach ($requirements as $requirement) {
+            if (! $requirement instanceof CareerCanonicalEligibilityAuditRunContextRequirement) {
+                throw new InvalidArgumentException('Career audit run context requirements must contain requirement DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRunContextApprovalGate>  $approvalGates
+     */
+    private static function assertApprovalGates(array $approvalGates): void
+    {
+        if (! array_is_list($approvalGates)) {
+            throw new InvalidArgumentException('Career audit run context approval gates must be a list.');
+        }
+
+        foreach ($approvalGates as $gate) {
+            if (! $gate instanceof CareerCanonicalEligibilityAuditRunContextApprovalGate) {
+                throw new InvalidArgumentException('Career audit run context approval gates must contain approval gate DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private static function assertListOfStrings(array $values, string $key): void
+    {
+        if (! array_is_list($values)) {
+            throw new InvalidArgumentException(sprintf('Career audit run context [%s] must be a list.', $key));
+        }
+
+        foreach ($values as $value) {
+            if (! is_string($value) || trim($value) === '') {
+                throw new InvalidArgumentException(sprintf('Career audit run context [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextApprovalGate.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextApprovalGate.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityAuditRunContextApprovalGate
+{
+    /**
+     * @param  list<string>  $forbiddenActions
+     * @param  list<string>  $preconditions
+     */
+    public function __construct(
+        public readonly string $gateId,
+        public readonly string $title,
+        public readonly bool $required,
+        public readonly string $reason,
+        public readonly string $approvalPhraseTemplate,
+        public readonly string $allowedAction,
+        public readonly array $forbiddenActions,
+        public readonly array $preconditions,
+    ) {
+        self::assertNonEmptyString($this->gateId, 'gate_id');
+        self::assertNonEmptyString($this->title, 'title');
+        self::assertNonEmptyString($this->reason, 'reason');
+        self::assertNonEmptyString($this->approvalPhraseTemplate, 'approval_phrase_template');
+        self::assertNonEmptyString($this->allowedAction, 'allowed_action');
+        self::assertListOfStrings($this->forbiddenActions, 'forbidden_actions');
+        self::assertListOfStrings($this->preconditions, 'preconditions');
+    }
+
+    /**
+     * @return array{gate_id: string, title: string, required: bool, reason: string, approval_phrase_template: string, allowed_action: string, forbidden_actions: list<string>, preconditions: list<string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'gate_id' => $this->gateId,
+            'title' => $this->title,
+            'required' => $this->required,
+            'reason' => $this->reason,
+            'approval_phrase_template' => $this->approvalPhraseTemplate,
+            'allowed_action' => $this->allowedAction,
+            'forbidden_actions' => $this->forbiddenActions,
+            'preconditions' => $this->preconditions,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career audit run context approval gate requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private static function assertListOfStrings(array $values, string $key): void
+    {
+        if (! array_is_list($values)) {
+            throw new InvalidArgumentException(sprintf('Career audit run context approval gate [%s] must be a list.', $key));
+        }
+
+        foreach ($values as $value) {
+            if (! is_string($value) || trim($value) === '') {
+                throw new InvalidArgumentException(sprintf('Career audit run context approval gate [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextRequirement.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextRequirement.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityAuditRunContextRequirement
+{
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $contextId,
+        public readonly string $label,
+        public readonly string $status,
+        public readonly bool $requiredForMeaningfulRerun,
+        public readonly bool $blocks80Readiness,
+        public readonly bool $requiresApproval,
+        public readonly ?string $approvalGateId,
+        public readonly ?string $suppliedInput,
+        public readonly ?string $requiredInput,
+        public readonly string $reason,
+        public readonly array $evidence = [],
+    ) {
+        self::assertNonEmptyString($this->contextId, 'context_id');
+        self::assertNonEmptyString($this->label, 'label');
+        CareerCanonicalEligibilityAuditRunContextStatus::assertValid($this->status);
+        self::assertNonEmptyString($this->reason, 'reason');
+        self::assertOptionalNonEmptyString($this->approvalGateId, 'approval_gate_id');
+        self::assertOptionalNonEmptyString($this->suppliedInput, 'supplied_input');
+        self::assertOptionalNonEmptyString($this->requiredInput, 'required_input');
+
+        if ($this->requiresApproval && $this->approvalGateId === null) {
+            throw new InvalidArgumentException('Career audit run context requirement that requires approval must include approval_gate_id.');
+        }
+
+        if (! array_is_list($this->evidence)) {
+            throw new InvalidArgumentException('Career audit run context requirement evidence must be a list.');
+        }
+    }
+
+    /**
+     * @return array{context_id: string, label: string, status: string, required_for_meaningful_rerun: bool, blocks_80_readiness: bool, requires_approval: bool, approval_gate_id: string|null, supplied_input: string|null, required_input: string|null, reason: string, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'context_id' => $this->contextId,
+            'label' => $this->label,
+            'status' => $this->status,
+            'required_for_meaningful_rerun' => $this->requiredForMeaningfulRerun,
+            'blocks_80_readiness' => $this->blocks80Readiness,
+            'requires_approval' => $this->requiresApproval,
+            'approval_gate_id' => $this->approvalGateId,
+            'supplied_input' => $this->suppliedInput,
+            'required_input' => $this->requiredInput,
+            'reason' => $this->reason,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career audit run context requirement requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertOptionalNonEmptyString(?string $value, string $key): void
+    {
+        if ($value !== null && trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career audit run context requirement optional [%s] cannot be empty.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextStatus.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextStatus.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonicalEligibilityAuditRunContextStatus
+{
+    public const SUPPLIED = 'supplied';
+
+    public const MISSING = 'missing';
+
+    public const OPTIONAL = 'optional';
+
+    public const NOT_REQUESTED = 'not_requested';
+
+    public const REQUIRES_APPROVAL = 'requires_approval';
+
+    public const UNVERIFIED = 'unverified';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return [
+            self::SUPPLIED,
+            self::MISSING,
+            self::OPTIONAL,
+            self::NOT_REQUESTED,
+            self::REQUIRES_APPROVAL,
+            self::UNVERIFIED,
+        ];
+    }
+
+    public static function assertValid(string $value): void
+    {
+        if (! in_array($value, self::values(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career audit run context status [%s].', $value));
+        }
+    }
+}

--- a/backend/docs/career/audits/audit_run_context.md
+++ b/backend/docs/career/audits/audit_run_context.md
@@ -1,0 +1,116 @@
+# Career 2786 Audit Run Context
+
+REPAIR-RUN-CTX-1 adds an explicit run-context contract to `career:audit-canonical-eligibility`.
+
+The audit result can still contain row-level `*_context_missing` reasons, but those reasons are now also grouped as top-level context requirements. Operators should read context-level blockers as missing inputs, not as thousands of independent production data defects.
+
+## Command Outputs
+
+Every JSON audit payload includes:
+
+```json
+{
+  "context_summary": {
+    "planner_supplied": true,
+    "entity_db_context": "missing",
+    "index_state_context": "missing",
+    "runtime_projection_context": "missing",
+    "runtime_truth_context": "missing",
+    "surface_context": "missing",
+    "live_html_context": "not_requested",
+    "required_next_action": "provide_read_only_context_bundle"
+  },
+  "run_context": {
+    "planner": {},
+    "entity": {},
+    "index": {},
+    "runtime": {},
+    "surface": {},
+    "static_sources": {},
+    "missing_contexts": [],
+    "unverified_contexts": [],
+    "approval_gates": [],
+    "next_required_inputs": [],
+    "suggested_rerun_modes": []
+  }
+}
+```
+
+Use `--context-output=/tmp/career_2786_audit_run_context_requirements.json` to write only the context artifact.
+
+## Rerun Modes
+
+- `planner_only`: validates planner rows and static artifact-derived layers only.
+- `planner_plus_local_db`: adds local/read-only DB context for Occupation and index-state layers.
+- `planner_plus_runtime_artifacts`: adds `--projection`, `--truth`, and optionally `--ledger`.
+- `planner_plus_surface_base_url`: adds surface verification context; live HTML requires `--include-live-html` and `--base-url`.
+- `full_readonly_context`: planner, read-only DB context, runtime artifacts, and surface context are all supplied.
+
+## Context Interpretation
+
+Context-level reasons are aggregated:
+
+- `entity_db_context_missing`: Occupation entity queries could not be interpreted from the current DB context.
+- `index_state_context_missing`: index-state authority could not be interpreted from the current DB context.
+- `runtime_projection_context_missing`: `--projection` artifact is absent.
+- `runtime_truth_context_missing`: `--truth` artifact is absent.
+- `surface_context_missing`: surface artifact mode was not requested.
+- `surface_live_html_context_missing`: live HTML verification was requested without a base URL.
+
+These blockers prevent 80-readiness planning from being meaningful. They do not authorize DB mutation, rollout apply, publication, or deployment.
+
+## Approval Gates
+
+The command emits approval gate templates for:
+
+- `production_readonly_db_context`
+- `production_runtime_projection_export`
+- `production_truth_export`
+- `live_html_crawl`
+- `db_backfill_apply`
+- `index_state_apply`
+- `rollout_apply`
+
+Only the read-only context/export gates are relevant for the next RUN-1 rerun. Backfill, index apply, and rollout apply remain forbidden until a later approved remediation/apply goal.
+
+## RUN-1 Rerun Shape
+
+Planner-only rerun:
+
+```bash
+php -d memory_limit=512M artisan career:audit-canonical-eligibility \
+  --scope=all \
+  --public-resolution-plan=/tmp/career_2786_public_resolution_plan_from_d23b.json \
+  --locales=en,zh \
+  --json \
+  --output=/tmp/career_2786_canonical_eligibility_audit_with_context.json \
+  --context-output=/tmp/career_2786_audit_run_context_requirements.json
+```
+
+Full read-only context rerun, after explicit approvals/artifacts:
+
+```bash
+php -d memory_limit=512M artisan career:audit-canonical-eligibility \
+  --scope=all \
+  --public-resolution-plan=/tmp/career_2786_public_resolution_plan_from_d23b.json \
+  --projection=/tmp/career_2786_runtime_projection.json \
+  --truth=/tmp/career_2786_runtime_truth.json \
+  --ledger=/tmp/career_2786_full_release_ledger.json \
+  --locales=en,zh \
+  --include-surfaces \
+  --json \
+  --output=/tmp/career_2786_canonical_eligibility_audit_with_context.json \
+  --context-output=/tmp/career_2786_audit_run_context_requirements.json
+```
+
+## Non-Goals
+
+This context layer does not:
+
+- mutate DB state
+- run backfill/apply/rollback/quarantine
+- generate or apply rollout manifests
+- deploy
+- fetch live HTML unless a later run explicitly supplies live context
+- claim 2786 readiness
+- run 80 readiness while context blockers remain unresolved

--- a/backend/docs/career/audits/canonical_eligibility_audit_command.md
+++ b/backend/docs/career/audits/canonical_eligibility_audit_command.md
@@ -19,6 +19,7 @@ The command is an integration shell for the canonical eligibility stack. It does
 - `--ledger=`
 - `--json`
 - `--output=`
+- `--context-output=`
 - `--include-surfaces`
 - `--include-live-html`
 - `--base-url=`
@@ -38,6 +39,7 @@ Every JSON payload includes:
 ```
 
 AUDIT-9 does not write DB rows. `--output` may write the JSON artifact to a caller-specified local file.
+`--context-output` writes only the run-context requirements artifact and does not mutate DB state.
 
 ## Layer Orchestration
 
@@ -63,6 +65,14 @@ The command separates real blockers from missing verifier context. Missing requi
 - `surface_live_html_context_missing`
 
 Missing runtime projection/truth artifacts mark the runtime layer as `unverified`; they do not fabricate runtime pass/fail results. Optional live HTML validation requires `--include-live-html` and `--base-url`; if live verification context is absent, the surface layer is unverified and the report includes a sidecar. The command remains read-only and does not fetch live HTML by itself.
+
+## Run Context Contract
+
+REPAIR-RUN-CTX-1 adds top-level `context_summary` and `run_context` sections. They explain which inputs were supplied, which contexts are missing, which missing contexts block 80-readiness planning, which contexts require explicit approval, and what artifact/input is needed for a meaningful rerun.
+
+The context layer intentionally groups row-wide context blockers. For example, `runtime_projection_context_missing` across 5,572 slug/locale rows is one missing `--projection` artifact requirement, not 5,572 separate data defects.
+
+See `backend/docs/career/audits/audit_run_context.md` for rerun modes and approval gate templates.
 
 ## Non-Goals
 

--- a/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
@@ -35,6 +35,9 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertArrayNotHasKey('validator_context_missing', $payload['by_reason']);
         $this->assertArrayHasKey('runtime_projection_context_missing', $payload['by_reason']);
         $this->assertArrayHasKey('runtime_truth_context_missing', $payload['by_reason']);
+        $this->assertSame('missing', $payload['context_summary']['runtime_projection_context']);
+        $this->assertSame('missing', $payload['context_summary']['runtime_truth_context']);
+        $this->assertSame('provide_read_only_context_bundle', $payload['context_summary']['required_next_action']);
     }
 
     public function test_missing_public_resolution_plan_reports_structured_error(): void
@@ -49,6 +52,8 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertSame('blocked', $payload['status']);
         $this->assertSame(['public_resolution_plan_missing' => 1], $payload['by_reason']);
         $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['context_summary']['planner_supplied']);
+        $this->assertContains('public_resolution_plan', array_column($payload['run_context']['next_required_inputs'], 'context_id'));
     }
 
     public function test_include_live_html_without_base_url_reports_unverified_context_issue(): void
@@ -68,6 +73,8 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertContains('validator_context_missing', data_get($payload, 'rows.0.surface_status.reasons'));
         $this->assertSame(1, $payload['by_reason']['validator_context_missing']);
         $this->assertContains('surface_live_html_context_missing', array_column($payload['sidecars'], 'sidecar_id'));
+        $this->assertSame('missing', $payload['context_summary']['live_html_context']);
+        $this->assertContains('live_html_context', array_column($payload['run_context']['unverified_contexts'], 'context_id'));
     }
 
     public function test_valid_public_resolution_plan_runs_layer_specific_audit_reasons(): void
@@ -91,6 +98,9 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertArrayNotHasKey('validator_context_missing', $payload['by_reason']);
         $this->assertArrayHasKey('runtime_projection_context_missing', $payload['by_reason']);
         $this->assertNotSame(['validator_context_missing' => count($payload['rows'])], $payload['by_reason']);
+        $this->assertTrue($payload['context_summary']['planner_supplied']);
+        $this->assertSame('public_resolution_plan_json', $payload['run_context']['planner']['source_type']);
+        $this->assertSame(2, $payload['run_context']['planner']['found_rows']);
     }
 
     public function test_projection_truth_artifacts_drive_runtime_layer_status(): void
@@ -119,6 +129,8 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertSame('pass', data_get($payload, 'rows.0.runtime_status.status'));
         $this->assertArrayNotHasKey('runtime_projection_context_missing', $payload['by_reason']);
         $this->assertArrayNotHasKey('runtime_truth_context_missing', $payload['by_reason']);
+        $this->assertSame('supplied', $payload['context_summary']['runtime_projection_context']);
+        $this->assertSame('supplied', $payload['context_summary']['runtime_truth_context']);
     }
 
     public function test_command_writes_output_json_when_requested(): void
@@ -136,6 +148,127 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertFileExists($outputPath);
         $payload = json_decode((string) file_get_contents($outputPath), true, flags: JSON_THROW_ON_ERROR);
         $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_command_output_includes_run_context_and_context_summary(): void
+    {
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('context_summary', $payload);
+        $this->assertArrayHasKey('run_context', $payload);
+        $this->assertSame([
+            'planner_supplied',
+            'entity_db_context',
+            'index_state_context',
+            'runtime_projection_context',
+            'runtime_truth_context',
+            'surface_context',
+            'live_html_context',
+            'required_next_action',
+        ], array_keys($payload['context_summary']));
+        $this->assertSame([
+            'planner',
+            'entity',
+            'index',
+            'runtime',
+            'surface',
+            'static_sources',
+            'missing_contexts',
+            'unverified_contexts',
+            'approval_gates',
+            'next_required_inputs',
+            'suggested_rerun_modes',
+        ], array_keys($payload['run_context']));
+    }
+
+    public function test_missing_contexts_are_aggregated_as_context_requirements(): void
+    {
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries,actors',
+            '--locales' => 'en,zh',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+        $missingContextIds = array_column($payload['run_context']['missing_contexts'], 'context_id');
+        $runtimeProjection = collect($payload['run_context']['missing_contexts'])->firstWhere('context_id', 'runtime_projection_context');
+        $runtimeTruth = collect($payload['run_context']['missing_contexts'])->firstWhere('context_id', 'runtime_truth_context');
+        $surface = collect($payload['run_context']['missing_contexts'])->firstWhere('context_id', 'surface_context');
+
+        $this->assertContains('runtime_projection_context', $missingContextIds);
+        $this->assertContains('runtime_truth_context', $missingContextIds);
+        $this->assertContains('surface_context', $missingContextIds);
+        $this->assertSame(4, data_get($runtimeProjection, 'evidence.0.row_reason_count'));
+        $this->assertSame(4, data_get($runtimeTruth, 'evidence.0.row_reason_count'));
+        $this->assertSame(4, data_get($surface, 'evidence.0.row_reason_count'));
+        $this->assertSame('provide_read_only_context_bundle', $payload['context_summary']['required_next_action']);
+    }
+
+    public function test_approval_gates_are_emitted_for_read_only_db_and_runtime_artifacts(): void
+    {
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+        $gateIds = array_column($payload['run_context']['approval_gates'], 'gate_id');
+
+        $this->assertContains('production_readonly_db_context', $gateIds);
+        $this->assertContains('production_runtime_projection_export', $gateIds);
+        $this->assertContains('production_truth_export', $gateIds);
+        $this->assertContains('live_html_crawl', $gateIds);
+        $this->assertContains('db_backfill_apply', $gateIds);
+        $this->assertContains('index_state_apply', $gateIds);
+        $this->assertContains('rollout_apply', $gateIds);
+    }
+
+    public function test_context_output_writes_stable_json(): void
+    {
+        $contextPath = sys_get_temp_dir().'/career-audit-command-context-'.bin2hex(random_bytes(4)).'.json';
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--json' => true,
+            '--context-output' => $contextPath,
+        ]);
+        $payload = json_decode((string) file_get_contents($contextPath), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertFileExists($contextPath);
+        $this->assertSame([
+            'context_summary',
+            'run_context',
+            'read_only',
+            'writes_database',
+            'audit_command',
+        ], array_keys($payload));
+        $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertContains('full_readonly_context', $payload['run_context']['suggested_rerun_modes']);
+    }
+
+    public function test_output_recommends_context_bundle_not_rollout_apply(): void
+    {
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('provide_read_only_context_bundle', $payload['context_summary']['required_next_action']);
+        $this->assertArrayNotHasKey('rollout_allowed', $payload);
         $this->assertFalse($payload['writes_database']);
     }
 
@@ -175,6 +308,8 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
             'by_reason',
             'rows',
             'sidecars',
+            'context_summary',
+            'run_context',
             'read_only',
             'writes_database',
             'audit_command',

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -255,6 +255,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRow.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContext.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextApprovalGate.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextRequirement.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextStatus.php',
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityCheckProtocol.php',
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayer.php',
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayerStatus.php',
@@ -1500,6 +1504,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRow.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContext.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextApprovalGate.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextRequirement.php',
+            'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityAuditRunContextStatus.php',
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityCheckProtocol.php',
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayer.php',
             'backend/app/Domain/Career/Audit/CareerCanonicalEligibilityLayerStatus.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T04:42:09.976Z",
+  "updated_at": "2026-05-13T12:56:06+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2453,6 +2453,38 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "REPAIR-RUN-CTX-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-2786-audit-run-context",
+      "title": "fix(api): make career audit run context explicit",
+      "name": "Make 2786 audit run context explicit and reproducible",
+      "status": "in_progress",
+      "depends_on": [
+        "CMD-FIX-1"
+      ],
+      "scope_type": "audit_run_context_only",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided REPAIR-RUN-CTX-1 execution goal and authorized updating PR train manifest/state."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "CMD-FIX-1 is merged as PR #1339 and current main contains 22cd24d5564afb277a710c89b02d205b7d034045."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to audit command/context DTOs, audit tests/docs, PR train state, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1229,3 +1229,51 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-RUN-CTX-1
+    repo: fap-api
+    depends_on:
+      - CMD-FIX-1
+    branch: fix/career-2786-audit-run-context
+    title: "fix(api): make career audit run context explicit"
+    name: "Make 2786 audit run context explicit and reproducible"
+    scope_type: audit_run_context_only
+    scope:
+      - Add explicit run_context and context_summary output to career:audit-canonical-eligibility.
+      - Add a context-output artifact for rerun requirements and approval gates.
+      - Aggregate row-wide missing context reasons into context-level requirements.
+      - Preserve read-only behavior and avoid remediation/apply behavior.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Mutate DB or production state.
+      - Run production commands.
+      - Apply rollout.
+      - Backfill data.
+      - Run 80 readiness.
+      - Deploy.
+      - Fabricate planner data.
+    validation:
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi
+      - php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
+      - php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
+      - php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "RUN-1 rerun with explicit context, then remediation PR train based on actual blockers"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds explicit `run_context` and `context_summary` output to `career:audit-canonical-eligibility`.
- Adds `--context-output=` to write a reproducible context/requirements artifact.
- Aggregates missing context blockers so operators can distinguish context-level gaps from per-row data defects.
- Registers REPAIR-RUN-CTX-1 in the PR train manifest/state.

## Safety
- No DB mutation.
- No production commands.
- No rollout/backfill/apply/quarantine/rollback.
- No 80 readiness execution.
- Does not claim 2786 readiness.

## Optional real planner rerun
Ran read-only against `/tmp/career_2786_public_resolution_plan_from_d23b.json` with `--context-output=/tmp/career_2786_audit_run_context_requirements.json`.

Result remains blocked, as expected, but now includes explicit context sections:
- `planner_supplied=true`
- `entity_db_context=missing`
- `index_state_context=missing`
- `runtime_projection_context=missing`
- `runtime_truth_context=missing`
- `surface_context=missing`
- `live_html_context=not_requested`
- `required_next_action=provide_read_only_context_bundle`

Audit artifact: `/tmp/career_2786_canonical_eligibility_audit_with_context.json`
Context artifact: `/tmp/career_2786_audit_run_context_requirements.json`

## Validation
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi`
- `php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi`
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi`
- `php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi`
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi`
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-repair-run-ctx-skill.sqlite php artisan migrate --force --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`

## Notes
Work was isolated in `/tmp/fap-api-repair-run-ctx` because the original workspace had unrelated RIASEC changes on another branch. Those unrelated files were not staged or modified by this PR.

## Next action
RUN-1 rerun with explicit context and authorized read-only artifacts.
