### PR TITLE
fix(api): add career audit entity index context inputs

### DIFF
--- a/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+++ b/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
@@ -17,8 +17,17 @@ use App\Domain\Career\Audit\CareerCanonicalEligibilityScope;
 use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
 use App\Domain\Career\Audit\CareerCanonicalEligibilitySidecar;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerEntityContextArtifact;
+use App\Domain\Career\Audit\CareerEntityContextArtifactIssue;
+use App\Domain\Career\Audit\CareerEntityContextArtifactReader;
 use App\Domain\Career\Audit\CareerIndexStateAuthorityAuditor;
+use App\Domain\Career\Audit\CareerIndexStateAuthorityIssue;
+use App\Domain\Career\Audit\CareerIndexStateContextArtifact;
+use App\Domain\Career\Audit\CareerIndexStateContextArtifactIssue;
+use App\Domain\Career\Audit\CareerIndexStateContextArtifactReader;
+use App\Domain\Career\Audit\CareerIndexStateContextArtifactRow;
 use App\Domain\Career\Audit\CareerOccupationEntityInventoryAuditor;
+use App\Domain\Career\Audit\CareerOccupationEntityInventoryIssue;
 use App\Domain\Career\Audit\CareerPublicResolutionPlan;
 use App\Domain\Career\Audit\CareerPublicResolutionPlanResolver;
 use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
@@ -36,6 +45,8 @@ final class CareerAuditCanonicalEligibility extends Command
         {--slugs= : Comma-separated canonical slugs when scope=slugs}
         {--locales= : Comma-separated locales, defaults to en,zh}
         {--public-resolution-plan= : Optional public-resolution planner JSON artifact}
+        {--entity-context= : Optional read-only entity context JSON artifact}
+        {--index-state-context= : Optional read-only index-state context JSON artifact}
         {--projection= : Optional runtime publish projection JSON artifact}
         {--truth= : Optional canonical runtime truth JSON artifact}
         {--ledger= : Optional full release ledger JSON artifact}
@@ -164,6 +175,8 @@ final class CareerAuditCanonicalEligibility extends Command
     private function runContext(string $scope, array $planRows, array $slugs, array $locales, array $byReason): CareerCanonicalEligibilityAuditRunContext
     {
         $planPath = $this->stringOption('public-resolution-plan');
+        $entityContextPath = $this->stringOption('entity-context');
+        $indexStateContextPath = $this->stringOption('index-state-context');
         $projectionPath = $this->stringOption('projection');
         $truthPath = $this->stringOption('truth');
         $ledgerPath = $this->stringOption('ledger');
@@ -191,32 +204,40 @@ final class CareerAuditCanonicalEligibility extends Command
             ),
             $this->contextRequirement(
                 contextId: 'entity_db_context',
-                label: 'Occupation entity read-only DB context',
-                status: $this->reasonPresent($byReason, 'entity_db_context_missing')
+                label: 'Occupation entity read-only context',
+                status: $entityContextPath !== null
+                    ? ($this->entityContextSupplied($entityContextPath, $byReason)
+                        ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                        : CareerCanonicalEligibilityAuditRunContextStatus::MISSING)
+                    : ($this->reasonPresent($byReason, 'entity_db_context_missing')
                     ? CareerCanonicalEligibilityAuditRunContextStatus::MISSING
-                    : CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED,
+                    : CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED),
                 requiredForMeaningfulRerun: true,
                 blocks80Readiness: true,
-                requiresApproval: $this->reasonPresent($byReason, 'entity_db_context_missing'),
-                approvalGateId: $this->reasonPresent($byReason, 'entity_db_context_missing') ? 'production_readonly_db_context' : null,
-                suppliedInput: $this->reasonPresent($byReason, 'entity_db_context_missing') ? null : 'configured read-only DB connection',
-                requiredInput: 'approved read-only DB context for occupations',
-                reason: 'Entity inventory cannot distinguish missing Occupation rows from unavailable DB context until a read-only DB context is supplied.',
+                requiresApproval: $entityContextPath === null && $this->reasonPresent($byReason, 'entity_db_context_missing'),
+                approvalGateId: $entityContextPath === null && $this->reasonPresent($byReason, 'entity_db_context_missing') ? 'production_readonly_db_context' : null,
+                suppliedInput: $entityContextPath ?? ($this->reasonPresent($byReason, 'entity_db_context_missing') ? null : 'configured read-only DB connection'),
+                requiredInput: '--entity-context=/path/to/entity_context.json',
+                reason: 'Entity inventory can be satisfied by an approved read-only entity context artifact or by a configured read-only DB context.',
                 evidence: [['row_reason_count' => $byReason['entity_db_context_missing'] ?? 0]]
             ),
             $this->contextRequirement(
                 contextId: 'index_state_context',
-                label: 'Index-state read-only DB context',
-                status: $this->reasonPresent($byReason, 'index_state_context_missing')
+                label: 'Index-state read-only context',
+                status: $indexStateContextPath !== null
+                    ? ($this->indexContextSupplied($indexStateContextPath, $byReason)
+                        ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                        : CareerCanonicalEligibilityAuditRunContextStatus::MISSING)
+                    : ($this->reasonPresent($byReason, 'index_state_context_missing')
                     ? CareerCanonicalEligibilityAuditRunContextStatus::MISSING
-                    : CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED,
+                    : CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED),
                 requiredForMeaningfulRerun: true,
                 blocks80Readiness: true,
-                requiresApproval: $this->reasonPresent($byReason, 'index_state_context_missing'),
-                approvalGateId: $this->reasonPresent($byReason, 'index_state_context_missing') ? 'production_readonly_db_context' : null,
-                suppliedInput: $this->reasonPresent($byReason, 'index_state_context_missing') ? null : 'configured read-only DB connection',
-                requiredInput: 'approved read-only DB context for index_states',
-                reason: 'Index-state authority cannot be proven until the audit can read occupations and index_states.',
+                requiresApproval: $indexStateContextPath === null && $this->reasonPresent($byReason, 'index_state_context_missing'),
+                approvalGateId: $indexStateContextPath === null && $this->reasonPresent($byReason, 'index_state_context_missing') ? 'production_readonly_db_context' : null,
+                suppliedInput: $indexStateContextPath ?? ($this->reasonPresent($byReason, 'index_state_context_missing') ? null : 'configured read-only DB connection'),
+                requiredInput: '--index-state-context=/path/to/index_state_context.json',
+                reason: 'Index-state authority can be satisfied by an approved read-only index-state context artifact or by a configured read-only DB context.',
                 evidence: [['row_reason_count' => $byReason['index_state_context_missing'] ?? 0]]
             ),
             $this->contextRequirement(
@@ -295,13 +316,15 @@ final class CareerAuditCanonicalEligibility extends Command
             ],
             entity: [
                 'entity_db_context' => $requirements[1]->status,
-                'local_db_available' => ! $this->reasonPresent($byReason, 'entity_db_context_missing'),
-                'production_readonly_db_needed' => $this->reasonPresent($byReason, 'entity_db_context_missing'),
+                'entity_context_path' => $entityContextPath,
+                'local_db_available' => $entityContextPath === null && ! $this->reasonPresent($byReason, 'entity_db_context_missing'),
+                'production_readonly_db_needed' => $entityContextPath === null && $this->reasonPresent($byReason, 'entity_db_context_missing'),
             ],
             index: [
                 'index_state_context' => $requirements[2]->status,
-                'local_db_available' => ! $this->reasonPresent($byReason, 'index_state_context_missing'),
-                'production_readonly_db_needed' => $this->reasonPresent($byReason, 'index_state_context_missing'),
+                'index_state_context_path' => $indexStateContextPath,
+                'local_db_available' => $indexStateContextPath === null && ! $this->reasonPresent($byReason, 'index_state_context_missing'),
+                'production_readonly_db_needed' => $indexStateContextPath === null && $this->reasonPresent($byReason, 'index_state_context_missing'),
             ],
             runtime: [
                 'ledger_path' => $ledgerPath,
@@ -477,6 +500,60 @@ final class CareerAuditCanonicalEligibility extends Command
     }
 
     /**
+     * @param  array<string, int>  $byReason
+     */
+    private function entityContextSupplied(?string $path, array $byReason): bool
+    {
+        if ($path === null) {
+            return false;
+        }
+
+        foreach ([CareerEntityContextArtifactIssue::FILE_MISSING, CareerEntityContextArtifactIssue::JSON_INVALID, CareerEntityContextArtifactIssue::ROWS_MISSING] as $reason) {
+            if ($this->reasonPresent($byReason, $reason)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, int>  $byReason
+     */
+    private function indexContextSupplied(?string $path, array $byReason): bool
+    {
+        if ($path === null) {
+            return false;
+        }
+
+        foreach ([CareerIndexStateContextArtifactIssue::FILE_MISSING, CareerIndexStateContextArtifactIssue::JSON_INVALID, CareerIndexStateContextArtifactIssue::ROWS_MISSING] as $reason) {
+            if ($this->reasonPresent($byReason, $reason)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function containsString(string $rawValue, array $values, string $needle): bool
+    {
+        if (str_contains($rawValue, $needle)) {
+            return true;
+        }
+
+        foreach ($values as $value) {
+            if (str_contains($value, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param  list<CareerPublicResolutionPlanRow>  $planRows
      * @param  list<string>  $slugs
      * @param  list<string>  $locales
@@ -487,34 +564,9 @@ final class CareerAuditCanonicalEligibility extends Command
         $sidecars = [];
         $plan = $this->planFromRows($planRows);
 
-        $entityResult = (new CareerOccupationEntityInventoryAuditor)->auditSlugs($slugs, $scope);
         $baselineResult = (new CareerBaselineMetadataInventoryAuditor)->auditRows($planRows);
-        $entityByReason = $entityResult->byReason();
-        $entityContextMissing = array_key_exists('occupation_query_failed', $entityByReason);
-        if ($entityContextMissing) {
-            $sidecars[] = $this->contextSidecar(
-                sidecarId: 'entity_db_context_missing',
-                title: 'Occupation entity inventory DB context could not be queried.',
-                scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_INSIDE,
-                mayContinueTrain: false,
-                evidence: [['reason' => 'occupation_query_failed']]
-            );
-        }
-
-        try {
-            $indexResult = (new CareerIndexStateAuthorityAuditor)->auditSlugs($slugs);
-            $indexStatuses = $this->statusMapBySlug($indexResult->rows, 'canonicalSlug', 'indexStatus');
-        } catch (Throwable $exception) {
-            $indexResult = null;
-            $indexStatuses = [];
-            $sidecars[] = $this->contextSidecar(
-                sidecarId: 'index_state_context_missing',
-                title: 'Index-state authority context could not be queried.',
-                scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_INSIDE,
-                mayContinueTrain: false,
-                evidence: [$this->exceptionEvidence($exception)]
-            );
-        }
+        [$entityStatuses, $entitySidecars] = $this->entityStatuses($slugs, $scope);
+        [$indexStatuses, $indexSidecars] = $this->indexStatuses($slugs);
 
         [$runtimeStatuses, $runtimeSidecars] = $this->runtimeStatuses($plan, $planRows, $slugs, $locales);
         [$surfaceStatuses, $surfaceSidecars] = $this->surfaceStatuses($planRows, $slugs, $locales);
@@ -522,17 +574,14 @@ final class CareerAuditCanonicalEligibility extends Command
 
         $sidecars = [
             ...$sidecars,
-            ...($entityContextMissing ? [] : $entityResult->sidecars),
+            ...$entitySidecars,
             ...$baselineResult->sidecars,
-            ...($indexResult?->sidecars ?? []),
+            ...$indexSidecars,
             ...$runtimeSidecars,
             ...$seoGeoResult->sidecars,
             ...$surfaceSidecars,
         ];
 
-        $entityStatuses = $entityContextMissing
-            ? $this->statusMapForSlugs($slugs, CareerCanonicalEligibilityLayer::ENTITY, ['entity_db_context_missing'], [['reason' => 'occupation_query_failed']], 'occupations')
-            : $this->statusMapBySlug($entityResult->rows, 'canonicalSlug', 'entityStatus');
         $baselineStatuses = $this->statusMapBySlug($baselineResult->rows, 'canonicalSlug', 'baselineStatus');
         $seoGeoStatuses = $this->statusMapByKey($seoGeoResult->rows, 'canonicalSlug', 'locale', 'seoGeoStatus');
 
@@ -578,6 +627,255 @@ final class CareerAuditCanonicalEligibility extends Command
             checksum: null,
             rows: $planRows,
         );
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{0: array<string, CareerCanonicalEligibilityLayerStatus>, 1: list<CareerCanonicalEligibilitySidecar>}
+     */
+    private function entityStatuses(array $slugs, string $scope): array
+    {
+        $entityContextPath = $this->stringOption('entity-context');
+        if ($entityContextPath !== null) {
+            $artifact = CareerEntityContextArtifactReader::fromPath($entityContextPath);
+
+            return [
+                $this->entityStatusesFromArtifact($artifact, $slugs),
+                $artifact->issues === [] ? [] : [
+                    $this->contextSidecar(
+                        sidecarId: 'entity_context_artifact_issue',
+                        title: 'Entity context artifact has structured validation issues.',
+                        evidence: [['artifact' => $artifact->toArray()]]
+                    ),
+                ],
+            ];
+        }
+
+        $entityResult = (new CareerOccupationEntityInventoryAuditor)->auditSlugs($slugs, $scope);
+        $entityByReason = $entityResult->byReason();
+        if (array_key_exists('occupation_query_failed', $entityByReason)) {
+            return [
+                $this->statusMapForSlugs($slugs, CareerCanonicalEligibilityLayer::ENTITY, ['entity_db_context_missing'], [['reason' => 'occupation_query_failed']], 'occupations'),
+                [
+                    $this->contextSidecar(
+                        sidecarId: 'entity_db_context_missing',
+                        title: 'Occupation entity inventory DB context could not be queried.',
+                        scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_INSIDE,
+                        mayContinueTrain: false,
+                        evidence: [['reason' => 'occupation_query_failed']]
+                    ),
+                ],
+            ];
+        }
+
+        return [$this->statusMapBySlug($entityResult->rows, 'canonicalSlug', 'entityStatus'), $entityResult->sidecars];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, CareerCanonicalEligibilityLayerStatus>
+     */
+    private function entityStatusesFromArtifact(CareerEntityContextArtifact $artifact, array $slugs): array
+    {
+        $rowsBySlug = $artifact->rowsBySlug();
+        $issuesBySlug = $artifact->issuesBySlug();
+        $globalReasons = array_values(array_unique(array_map(
+            static fn (CareerEntityContextArtifactIssue $issue): string => $issue->reason,
+            $artifact->globalIssues()
+        )));
+        $globalEvidence = array_map(
+            static fn (CareerEntityContextArtifactIssue $issue): array => $issue->toArray(),
+            $artifact->globalIssues()
+        );
+
+        $statuses = [];
+        foreach ($slugs as $slug) {
+            $row = $rowsBySlug[$slug] ?? null;
+            $rowIssues = $issuesBySlug[$slug] ?? [];
+            $reasons = [
+                ...$globalReasons,
+                ...array_map(static fn (CareerEntityContextArtifactIssue $issue): string => $issue->reason, $rowIssues),
+            ];
+            $evidence = [
+                ...$globalEvidence,
+                ...array_map(static fn (CareerEntityContextArtifactIssue $issue): array => $issue->toArray(), $rowIssues),
+            ];
+
+            if ($row === null) {
+                $statuses[$slug] = new CareerCanonicalEligibilityLayerStatus(
+                    layer: CareerCanonicalEligibilityLayer::ENTITY,
+                    status: CareerCanonicalEligibilityStatus::BLOCKED,
+                    reasons: array_values(array_unique([...$reasons, CareerOccupationEntityInventoryIssue::OCCUPATION_MISSING])),
+                    evidence: [...$evidence, ['canonical_slug' => $slug, 'context_row_present' => false]],
+                    source: 'entity_context_artifact'
+                );
+
+                continue;
+            }
+
+            if (! $row->occupationExists) {
+                $reasons[] = CareerOccupationEntityInventoryIssue::OCCUPATION_MISSING;
+            }
+            if ($row->missingEntityFields !== []) {
+                $reasons[] = CareerOccupationEntityInventoryIssue::ENTITY_FIELD_MISSING;
+            }
+
+            $statuses[$slug] = new CareerCanonicalEligibilityLayerStatus(
+                layer: CareerCanonicalEligibilityLayer::ENTITY,
+                status: $reasons === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+                reasons: array_values(array_unique($reasons)),
+                evidence: [
+                    ...$evidence,
+                    [
+                        'canonical_slug' => $slug,
+                        'occupation_exists' => $row->occupationExists,
+                        'occupation_id' => $row->occupationId,
+                        'missing_entity_fields' => $row->missingEntityFields,
+                    ],
+                ],
+                source: 'entity_context_artifact'
+            );
+        }
+
+        return $statuses;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{0: array<string, CareerCanonicalEligibilityLayerStatus>, 1: list<CareerCanonicalEligibilitySidecar>}
+     */
+    private function indexStatuses(array $slugs): array
+    {
+        $indexContextPath = $this->stringOption('index-state-context');
+        if ($indexContextPath !== null) {
+            $artifact = CareerIndexStateContextArtifactReader::fromPath($indexContextPath);
+
+            return [
+                $this->indexStatusesFromArtifact($artifact, $slugs),
+                $artifact->issues === [] ? [] : [
+                    $this->contextSidecar(
+                        sidecarId: 'index_context_artifact_issue',
+                        title: 'Index-state context artifact has structured validation issues.',
+                        evidence: [['artifact' => $artifact->toArray()]]
+                    ),
+                ],
+            ];
+        }
+
+        try {
+            $indexResult = (new CareerIndexStateAuthorityAuditor)->auditSlugs($slugs);
+
+            return [$this->statusMapBySlug($indexResult->rows, 'canonicalSlug', 'indexStatus'), $indexResult->sidecars];
+        } catch (Throwable $exception) {
+            return [
+                [],
+                [
+                    $this->contextSidecar(
+                        sidecarId: 'index_state_context_missing',
+                        title: 'Index-state authority context could not be queried.',
+                        scopeRelation: CareerCanonicalEligibilitySidecar::SCOPE_RELATION_INSIDE,
+                        mayContinueTrain: false,
+                        evidence: [$this->exceptionEvidence($exception)]
+                    ),
+                ],
+            ];
+        }
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, CareerCanonicalEligibilityLayerStatus>
+     */
+    private function indexStatusesFromArtifact(CareerIndexStateContextArtifact $artifact, array $slugs): array
+    {
+        $rowsBySlug = $artifact->rowsBySlug();
+        $issuesBySlug = $artifact->issuesBySlug();
+        $globalReasons = array_values(array_unique(array_map(
+            static fn (CareerIndexStateContextArtifactIssue $issue): string => $issue->reason,
+            $artifact->globalIssues()
+        )));
+        $globalEvidence = array_map(
+            static fn (CareerIndexStateContextArtifactIssue $issue): array => $issue->toArray(),
+            $artifact->globalIssues()
+        );
+
+        $statuses = [];
+        foreach ($slugs as $slug) {
+            $row = $rowsBySlug[$slug] ?? null;
+            $rowIssues = $issuesBySlug[$slug] ?? [];
+            $reasons = [
+                ...$globalReasons,
+                ...array_map(static fn (CareerIndexStateContextArtifactIssue $issue): string => $issue->reason, $rowIssues),
+            ];
+            $evidence = [
+                ...$globalEvidence,
+                ...array_map(static fn (CareerIndexStateContextArtifactIssue $issue): array => $issue->toArray(), $rowIssues),
+            ];
+
+            if ($row === null) {
+                $statuses[$slug] = new CareerCanonicalEligibilityLayerStatus(
+                    layer: CareerCanonicalEligibilityLayer::INDEX,
+                    status: CareerCanonicalEligibilityStatus::BLOCKED,
+                    reasons: array_values(array_unique([...$reasons, CareerIndexStateAuthorityIssue::INDEX_STATE_MISSING])),
+                    evidence: [...$evidence, ['canonical_slug' => $slug, 'context_row_present' => false]],
+                    source: 'index_state_context_artifact'
+                );
+
+                continue;
+            }
+
+            $reasons = [...$reasons, ...$this->indexArtifactRowReasons($row)];
+            $statuses[$slug] = new CareerCanonicalEligibilityLayerStatus(
+                layer: CareerCanonicalEligibilityLayer::INDEX,
+                status: $reasons === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+                reasons: array_values(array_unique($reasons)),
+                evidence: [
+                    ...$evidence,
+                    [
+                        'canonical_slug' => $slug,
+                        'latest_index_state' => $row->latestIndexState,
+                        'public_facing_state' => $row->publicFacingState,
+                        'index_eligible' => $row->indexEligible,
+                        'reason_codes' => $row->reasonCodes,
+                    ],
+                ],
+                source: 'index_state_context_artifact'
+            );
+        }
+
+        return $statuses;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function indexArtifactRowReasons(CareerIndexStateContextArtifactRow $row): array
+    {
+        $state = strtolower((string) ($row->publicFacingState ?? $row->latestIndexState ?? ''));
+        $rawState = strtolower((string) ($row->latestIndexState ?? $row->publicFacingState ?? ''));
+        $reasonCodes = array_map('strtolower', $row->reasonCodes);
+        $reasons = [];
+
+        if ($state === '' && $rawState === '') {
+            $reasons[] = CareerIndexStateAuthorityIssue::INDEX_STATE_MISSING;
+        }
+        if ($row->indexEligible === false) {
+            $reasons[] = CareerIndexStateAuthorityIssue::INDEX_ELIGIBLE_FALSE;
+        }
+        if ($state === 'noindex' || $rawState === 'noindex') {
+            $reasons[] = CareerIndexStateAuthorityIssue::EXPLICIT_NOINDEX_BLOCK;
+        }
+        if ($this->containsString($rawState, $reasonCodes, 'quarantine')) {
+            $reasons[] = CareerIndexStateAuthorityIssue::QUARANTINE_BLOCK;
+        }
+        if ($this->containsString($rawState, $reasonCodes, 'rollback')) {
+            $reasons[] = CareerIndexStateAuthorityIssue::ROLLBACK_BLOCK;
+        }
+        if ($reasons === [] && ! in_array($state, ['indexed', 'indexable'], true)) {
+            $reasons[] = CareerIndexStateAuthorityIssue::INDEX_STATE_NOT_INDEXED_LIKE;
+        }
+
+        return array_values(array_unique($reasons));
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerEntityContextArtifact.php
+++ b/backend/app/Domain/Career/Audit/CareerEntityContextArtifact.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerEntityContextArtifact
+{
+    /**
+     * @param  array<string, mixed>  $source
+     * @param  list<CareerEntityContextArtifactRow>  $rows
+     * @param  list<CareerEntityContextArtifactIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $sourcePath,
+        public readonly ?string $schemaVersion,
+        public readonly array $source,
+        public readonly array $rows,
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->sourcePath, 'source_path');
+        self::assertMap($this->source, 'source');
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+
+        if ($this->schemaVersion !== null) {
+            self::assertNonEmptyString($this->schemaVersion, 'schema_version');
+        }
+    }
+
+    /**
+     * @return array<string, CareerEntityContextArtifactRow>
+     */
+    public function rowsBySlug(): array
+    {
+        $rows = [];
+        foreach ($this->rows as $row) {
+            $rows[$row->canonicalSlug] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, list<CareerEntityContextArtifactIssue>>
+     */
+    public function issuesBySlug(): array
+    {
+        $issues = [];
+        foreach ($this->issues as $issue) {
+            if ($issue->canonicalSlug === null) {
+                continue;
+            }
+
+            $issues[$issue->canonicalSlug] ??= [];
+            $issues[$issue->canonicalSlug][] = $issue;
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<CareerEntityContextArtifactIssue>
+     */
+    public function globalIssues(): array
+    {
+        return array_values(array_filter(
+            $this->issues,
+            static fn (CareerEntityContextArtifactIssue $issue): bool => $issue->canonicalSlug === null
+        ));
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{source_path: string, schema_version: string|null, source: array<string, mixed>, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'source_path' => $this->sourcePath,
+            'schema_version' => $this->schemaVersion,
+            'source' => $this->source,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerEntityContextArtifactRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerEntityContextArtifactIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career entity context artifact requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career entity context artifact [%s] must be an object map.', $key));
+        }
+    }
+
+    /**
+     * @param  list<CareerEntityContextArtifactRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career entity context artifact rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerEntityContextArtifactRow) {
+                throw new InvalidArgumentException('Career entity context artifact rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerEntityContextArtifactIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career entity context artifact issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerEntityContextArtifactIssue) {
+                throw new InvalidArgumentException('Career entity context artifact issues must contain issue DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerEntityContextArtifactIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerEntityContextArtifactIssue.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerEntityContextArtifactIssue
+{
+    public const FILE_MISSING = 'entity_context_file_missing';
+
+    public const JSON_INVALID = 'entity_context_json_invalid';
+
+    public const ROWS_MISSING = 'entity_context_rows_missing';
+
+    public const ROW_MALFORMED = 'entity_context_row_malformed';
+
+    public const SLUG_MISSING = 'entity_context_slug_missing';
+
+    public const SLUG_DUPLICATE = 'entity_context_slug_duplicate';
+
+    public const REQUIRED_FIELD_MISSING = 'entity_context_required_field_missing';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::HIGH,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $field = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->field !== null) {
+            self::assertNonEmptyString($this->field, 'field');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::FILE_MISSING,
+            self::JSON_INVALID,
+            self::ROWS_MISSING,
+            self::ROW_MALFORMED,
+            self::SLUG_MISSING,
+            self::SLUG_DUPLICATE,
+            self::REQUIRED_FIELD_MISSING,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career entity context artifact issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, canonical_slug: string|null, field: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'canonical_slug' => $this->canonicalSlug,
+            'field' => $this->field,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career entity context artifact issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career entity context artifact issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerEntityContextArtifactReader.php
+++ b/backend/app/Domain/Career/Audit/CareerEntityContextArtifactReader.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerEntityContextArtifactReader
+{
+    public static function fromPath(string $path): CareerEntityContextArtifact
+    {
+        if (! is_file($path)) {
+            return new CareerEntityContextArtifact(
+                sourcePath: $path,
+                schemaVersion: null,
+                source: [],
+                rows: [],
+                issues: [
+                    new CareerEntityContextArtifactIssue(
+                        reason: CareerEntityContextArtifactIssue::FILE_MISSING,
+                        message: 'Entity context artifact file was not found.',
+                        evidence: [['path' => $path]]
+                    ),
+                ],
+            );
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            return new CareerEntityContextArtifact(
+                sourcePath: $path,
+                schemaVersion: null,
+                source: [],
+                rows: [],
+                issues: [
+                    new CareerEntityContextArtifactIssue(
+                        reason: CareerEntityContextArtifactIssue::JSON_INVALID,
+                        message: 'Entity context artifact JSON could not be parsed.',
+                        evidence: [['path' => $path, 'json_error' => json_last_error_msg()]]
+                    ),
+                ],
+            );
+        }
+
+        $rowsValue = $payload['rows'] ?? null;
+        if (! is_array($rowsValue) || ! array_is_list($rowsValue)) {
+            return new CareerEntityContextArtifact(
+                sourcePath: $path,
+                schemaVersion: self::optionalString($payload['schema_version'] ?? null),
+                source: self::mapOrEmpty($payload['source'] ?? []),
+                rows: [],
+                issues: [
+                    new CareerEntityContextArtifactIssue(
+                        reason: CareerEntityContextArtifactIssue::ROWS_MISSING,
+                        message: 'Entity context artifact requires a rows list.',
+                        evidence: [['path' => $path]]
+                    ),
+                ],
+            );
+        }
+
+        $rows = [];
+        $issues = [];
+        $seen = [];
+        foreach ($rowsValue as $index => $rowValue) {
+            if (! is_array($rowValue) || array_is_list($rowValue)) {
+                $issues[] = new CareerEntityContextArtifactIssue(
+                    reason: CareerEntityContextArtifactIssue::ROW_MALFORMED,
+                    message: 'Entity context row must be an object.',
+                    evidence: [['row_index' => $index]]
+                );
+
+                continue;
+            }
+
+            $slug = self::normalizedSlug($rowValue['canonical_slug'] ?? $rowValue['slug'] ?? null);
+            if ($slug === null) {
+                $issues[] = new CareerEntityContextArtifactIssue(
+                    reason: CareerEntityContextArtifactIssue::SLUG_MISSING,
+                    message: 'Entity context row requires canonical_slug.',
+                    evidence: [['row_index' => $index]]
+                );
+
+                continue;
+            }
+
+            if (isset($seen[$slug])) {
+                $issues[] = new CareerEntityContextArtifactIssue(
+                    reason: CareerEntityContextArtifactIssue::SLUG_DUPLICATE,
+                    message: 'Entity context canonical_slug appears more than once.',
+                    canonicalSlug: $slug,
+                    evidence: [['row_index' => $index, 'canonical_slug' => $slug]]
+                );
+
+                continue;
+            }
+            $seen[$slug] = true;
+
+            if (! array_key_exists('occupation_exists', $rowValue) || ! is_bool($rowValue['occupation_exists'])) {
+                $issues[] = new CareerEntityContextArtifactIssue(
+                    reason: CareerEntityContextArtifactIssue::REQUIRED_FIELD_MISSING,
+                    message: 'Entity context row requires boolean occupation_exists.',
+                    canonicalSlug: $slug,
+                    field: 'occupation_exists',
+                    evidence: [['row_index' => $index, 'canonical_slug' => $slug]]
+                );
+
+                continue;
+            }
+
+            $rows[] = new CareerEntityContextArtifactRow(
+                canonicalSlug: $slug,
+                occupationExists: $rowValue['occupation_exists'],
+                occupationId: self::optionalString($rowValue['occupation_id'] ?? null),
+                titleEn: self::optionalString($rowValue['title_en'] ?? null),
+                titleZh: self::optionalString($rowValue['title_zh'] ?? null),
+                family: self::optionalString($rowValue['family'] ?? null),
+                crosswalks: self::listOrEmpty($rowValue['crosswalks'] ?? []),
+                missingEntityFields: self::stringListOrEmpty($rowValue['missing_entity_fields'] ?? []),
+                evidence: self::mapOrEmpty($rowValue['evidence'] ?? []),
+                raw: $rowValue,
+            );
+        }
+
+        return new CareerEntityContextArtifact(
+            sourcePath: $path,
+            schemaVersion: self::optionalString($payload['schema_version'] ?? null),
+            source: self::mapOrEmpty($payload['source'] ?? []),
+            rows: $rows,
+            issues: $issues,
+        );
+    }
+
+    private static function normalizedSlug(mixed $value): ?string
+    {
+        $normalized = self::optionalString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private static function optionalString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private static function listOrEmpty(mixed $value): array
+    {
+        return is_array($value) && array_is_list($value) ? $value : [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function stringListOrEmpty(mixed $value): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $item) {
+            $normalized = self::optionalString($item);
+            if ($normalized !== null) {
+                $items[] = $normalized;
+            }
+        }
+
+        return array_values(array_unique($items));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function mapOrEmpty(mixed $value): array
+    {
+        return is_array($value) && (! array_is_list($value) || $value === []) ? $value : [];
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerEntityContextArtifactRow.php
+++ b/backend/app/Domain/Career/Audit/CareerEntityContextArtifactRow.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerEntityContextArtifactRow
+{
+    /**
+     * @param  list<mixed>  $crosswalks
+     * @param  list<string>  $missingEntityFields
+     * @param  array<string, mixed>  $evidence
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly bool $occupationExists,
+        public readonly ?string $occupationId = null,
+        public readonly ?string $titleEn = null,
+        public readonly ?string $titleZh = null,
+        public readonly ?string $family = null,
+        public readonly array $crosswalks = [],
+        public readonly array $missingEntityFields = [],
+        public readonly array $evidence = [],
+        public readonly array $raw = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertList($this->crosswalks, 'crosswalks');
+        self::assertListOfStrings($this->missingEntityFields, 'missing_entity_fields');
+        self::assertMap($this->evidence, 'evidence');
+        self::assertMap($this->raw, 'raw');
+
+        foreach ([
+            'occupation_id' => $this->occupationId,
+            'title_en' => $this->titleEn,
+            'title_zh' => $this->titleZh,
+            'family' => $this->family,
+        ] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, occupation_exists: bool, occupation_id: string|null, title_en: string|null, title_zh: string|null, family: string|null, crosswalks: list<mixed>, missing_entity_fields: list<string>, evidence: array<string, mixed>, raw: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'occupation_exists' => $this->occupationExists,
+            'occupation_id' => $this->occupationId,
+            'title_en' => $this->titleEn,
+            'title_zh' => $this->titleZh,
+            'family' => $this->family,
+            'crosswalks' => $this->crosswalks,
+            'missing_entity_fields' => $this->missingEntityFields,
+            'evidence' => $this->evidence,
+            'raw' => $this->raw,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career entity context artifact row requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career entity context artifact row [%s] must be an object map.', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career entity context artifact row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career entity context artifact row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifact.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifact.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerIndexStateContextArtifact
+{
+    /**
+     * @param  array<string, mixed>  $source
+     * @param  list<CareerIndexStateContextArtifactRow>  $rows
+     * @param  list<CareerIndexStateContextArtifactIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $sourcePath,
+        public readonly ?string $schemaVersion,
+        public readonly array $source,
+        public readonly array $rows,
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->sourcePath, 'source_path');
+        self::assertMap($this->source, 'source');
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+
+        if ($this->schemaVersion !== null) {
+            self::assertNonEmptyString($this->schemaVersion, 'schema_version');
+        }
+    }
+
+    /**
+     * @return array<string, CareerIndexStateContextArtifactRow>
+     */
+    public function rowsBySlug(): array
+    {
+        $rows = [];
+        foreach ($this->rows as $row) {
+            $rows[$row->canonicalSlug] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, list<CareerIndexStateContextArtifactIssue>>
+     */
+    public function issuesBySlug(): array
+    {
+        $issues = [];
+        foreach ($this->issues as $issue) {
+            if ($issue->canonicalSlug === null) {
+                continue;
+            }
+
+            $issues[$issue->canonicalSlug] ??= [];
+            $issues[$issue->canonicalSlug][] = $issue;
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<CareerIndexStateContextArtifactIssue>
+     */
+    public function globalIssues(): array
+    {
+        return array_values(array_filter(
+            $this->issues,
+            static fn (CareerIndexStateContextArtifactIssue $issue): bool => $issue->canonicalSlug === null
+        ));
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{source_path: string, schema_version: string|null, source: array<string, mixed>, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'source_path' => $this->sourcePath,
+            'schema_version' => $this->schemaVersion,
+            'source' => $this->source,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerIndexStateContextArtifactRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'issues' => array_map(
+                static fn (CareerIndexStateContextArtifactIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career index-state context artifact requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career index-state context artifact [%s] must be an object map.', $key));
+        }
+    }
+
+    /**
+     * @param  list<CareerIndexStateContextArtifactRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career index-state context artifact rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerIndexStateContextArtifactRow) {
+                throw new InvalidArgumentException('Career index-state context artifact rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerIndexStateContextArtifactIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career index-state context artifact issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerIndexStateContextArtifactIssue) {
+                throw new InvalidArgumentException('Career index-state context artifact issues must contain issue DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactIssue.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerIndexStateContextArtifactIssue
+{
+    public const FILE_MISSING = 'index_context_file_missing';
+
+    public const JSON_INVALID = 'index_context_json_invalid';
+
+    public const ROWS_MISSING = 'index_context_rows_missing';
+
+    public const ROW_MALFORMED = 'index_context_row_malformed';
+
+    public const SLUG_MISSING = 'index_context_slug_missing';
+
+    public const SLUG_DUPLICATE = 'index_context_slug_duplicate';
+
+    public const REQUIRED_FIELD_MISSING = 'index_context_required_field_missing';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly string $severity = CareerCanonicalEligibilitySeverity::HIGH,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $field = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        CareerCanonicalEligibilitySeverity::assertValid($this->severity);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->field !== null) {
+            self::assertNonEmptyString($this->field, 'field');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::FILE_MISSING,
+            self::JSON_INVALID,
+            self::ROWS_MISSING,
+            self::ROW_MALFORMED,
+            self::SLUG_MISSING,
+            self::SLUG_DUPLICATE,
+            self::REQUIRED_FIELD_MISSING,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career index-state context artifact issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, severity: string, canonical_slug: string|null, field: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'canonical_slug' => $this->canonicalSlug,
+            'field' => $this->field,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career index-state context artifact issue requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career index-state context artifact issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactReader.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactReader.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerIndexStateContextArtifactReader
+{
+    public static function fromPath(string $path): CareerIndexStateContextArtifact
+    {
+        if (! is_file($path)) {
+            return new CareerIndexStateContextArtifact(
+                sourcePath: $path,
+                schemaVersion: null,
+                source: [],
+                rows: [],
+                issues: [
+                    new CareerIndexStateContextArtifactIssue(
+                        reason: CareerIndexStateContextArtifactIssue::FILE_MISSING,
+                        message: 'Index-state context artifact file was not found.',
+                        evidence: [['path' => $path]]
+                    ),
+                ],
+            );
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            return new CareerIndexStateContextArtifact(
+                sourcePath: $path,
+                schemaVersion: null,
+                source: [],
+                rows: [],
+                issues: [
+                    new CareerIndexStateContextArtifactIssue(
+                        reason: CareerIndexStateContextArtifactIssue::JSON_INVALID,
+                        message: 'Index-state context artifact JSON could not be parsed.',
+                        evidence: [['path' => $path, 'json_error' => json_last_error_msg()]]
+                    ),
+                ],
+            );
+        }
+
+        $rowsValue = $payload['rows'] ?? null;
+        if (! is_array($rowsValue) || ! array_is_list($rowsValue)) {
+            return new CareerIndexStateContextArtifact(
+                sourcePath: $path,
+                schemaVersion: self::optionalString($payload['schema_version'] ?? null),
+                source: self::mapOrEmpty($payload['source'] ?? []),
+                rows: [],
+                issues: [
+                    new CareerIndexStateContextArtifactIssue(
+                        reason: CareerIndexStateContextArtifactIssue::ROWS_MISSING,
+                        message: 'Index-state context artifact requires a rows list.',
+                        evidence: [['path' => $path]]
+                    ),
+                ],
+            );
+        }
+
+        $rows = [];
+        $issues = [];
+        $seen = [];
+        foreach ($rowsValue as $index => $rowValue) {
+            if (! is_array($rowValue) || array_is_list($rowValue)) {
+                $issues[] = new CareerIndexStateContextArtifactIssue(
+                    reason: CareerIndexStateContextArtifactIssue::ROW_MALFORMED,
+                    message: 'Index-state context row must be an object.',
+                    evidence: [['row_index' => $index]]
+                );
+
+                continue;
+            }
+
+            $slug = self::normalizedSlug($rowValue['canonical_slug'] ?? $rowValue['slug'] ?? null);
+            if ($slug === null) {
+                $issues[] = new CareerIndexStateContextArtifactIssue(
+                    reason: CareerIndexStateContextArtifactIssue::SLUG_MISSING,
+                    message: 'Index-state context row requires canonical_slug.',
+                    evidence: [['row_index' => $index]]
+                );
+
+                continue;
+            }
+
+            if (isset($seen[$slug])) {
+                $issues[] = new CareerIndexStateContextArtifactIssue(
+                    reason: CareerIndexStateContextArtifactIssue::SLUG_DUPLICATE,
+                    message: 'Index-state context canonical_slug appears more than once.',
+                    canonicalSlug: $slug,
+                    evidence: [['row_index' => $index, 'canonical_slug' => $slug]]
+                );
+
+                continue;
+            }
+            $seen[$slug] = true;
+
+            if (array_key_exists('index_eligible', $rowValue) && ! is_bool($rowValue['index_eligible']) && $rowValue['index_eligible'] !== null) {
+                $issues[] = new CareerIndexStateContextArtifactIssue(
+                    reason: CareerIndexStateContextArtifactIssue::REQUIRED_FIELD_MISSING,
+                    message: 'Index-state context row requires nullable boolean index_eligible.',
+                    canonicalSlug: $slug,
+                    field: 'index_eligible',
+                    evidence: [['row_index' => $index, 'canonical_slug' => $slug]]
+                );
+
+                continue;
+            }
+
+            $rows[] = new CareerIndexStateContextArtifactRow(
+                canonicalSlug: $slug,
+                latestIndexState: self::optionalString($rowValue['latest_index_state'] ?? null),
+                publicFacingState: self::optionalString($rowValue['public_facing_state'] ?? null),
+                indexEligible: $rowValue['index_eligible'] ?? null,
+                changedAt: self::optionalString($rowValue['changed_at'] ?? null),
+                reasonCodes: self::stringListOrEmpty($rowValue['reason_codes'] ?? []),
+                evidence: self::mapOrEmpty($rowValue['evidence'] ?? []),
+                raw: $rowValue,
+            );
+        }
+
+        return new CareerIndexStateContextArtifact(
+            sourcePath: $path,
+            schemaVersion: self::optionalString($payload['schema_version'] ?? null),
+            source: self::mapOrEmpty($payload['source'] ?? []),
+            rows: $rows,
+            issues: $issues,
+        );
+    }
+
+    private static function normalizedSlug(mixed $value): ?string
+    {
+        $normalized = self::optionalString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private static function optionalString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function stringListOrEmpty(mixed $value): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $item) {
+            $normalized = self::optionalString($item);
+            if ($normalized !== null) {
+                $items[] = $normalized;
+            }
+        }
+
+        return array_values(array_unique($items));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function mapOrEmpty(mixed $value): array
+    {
+        return is_array($value) && (! array_is_list($value) || $value === []) ? $value : [];
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactRow.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactRow.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerIndexStateContextArtifactRow
+{
+    /**
+     * @param  list<string>  $reasonCodes
+     * @param  array<string, mixed>  $evidence
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly ?string $latestIndexState = null,
+        public readonly ?string $publicFacingState = null,
+        public readonly ?bool $indexEligible = null,
+        public readonly ?string $changedAt = null,
+        public readonly array $reasonCodes = [],
+        public readonly array $evidence = [],
+        public readonly array $raw = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertListOfStrings($this->reasonCodes, 'reason_codes');
+        self::assertMap($this->evidence, 'evidence');
+        self::assertMap($this->raw, 'raw');
+
+        foreach ([
+            'latest_index_state' => $this->latestIndexState,
+            'public_facing_state' => $this->publicFacingState,
+            'changed_at' => $this->changedAt,
+        ] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, latest_index_state: string|null, public_facing_state: string|null, index_eligible: bool|null, changed_at: string|null, reason_codes: list<string>, evidence: array<string, mixed>, raw: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'latest_index_state' => $this->latestIndexState,
+            'public_facing_state' => $this->publicFacingState,
+            'index_eligible' => $this->indexEligible,
+            'changed_at' => $this->changedAt,
+            'reason_codes' => $this->reasonCodes,
+            'evidence' => $this->evidence,
+            'raw' => $this->raw,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career index-state context artifact row requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career index-state context artifact row [%s] must be an object map.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career index-state context artifact row [%s] must be a list.', $key));
+        }
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career index-state context artifact row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/docs/career/audits/audit_run_context.md
+++ b/backend/docs/career/audits/audit_run_context.md
@@ -93,6 +93,8 @@ Full read-only context rerun, after explicit approvals/artifacts:
 php -d memory_limit=512M artisan career:audit-canonical-eligibility \
   --scope=all \
   --public-resolution-plan=/tmp/career_2786_public_resolution_plan_from_d23b.json \
+  --entity-context=/tmp/career_2786_entity_context.json \
+  --index-state-context=/tmp/career_2786_index_state_context.json \
   --projection=/tmp/career_2786_runtime_projection.json \
   --truth=/tmp/career_2786_runtime_truth.json \
   --ledger=/tmp/career_2786_full_release_ledger.json \
@@ -102,6 +104,8 @@ php -d memory_limit=512M artisan career:audit-canonical-eligibility \
   --output=/tmp/career_2786_canonical_eligibility_audit_with_context.json \
   --context-output=/tmp/career_2786_audit_run_context_requirements.json
 ```
+
+`--entity-context` and `--index-state-context` consume approved read-only JSON artifacts. They do not export production context; that producer workflow remains approval-gated.
 
 ## Non-Goals
 

--- a/backend/docs/career/audits/canonical_eligibility_audit_command.md
+++ b/backend/docs/career/audits/canonical_eligibility_audit_command.md
@@ -14,6 +14,8 @@ The command is an integration shell for the canonical eligibility stack. It does
 - `--slugs=`
 - `--locales=`
 - `--public-resolution-plan=`
+- `--entity-context=`
+- `--index-state-context=`
 - `--projection=`
 - `--truth=`
 - `--ledger=`
@@ -25,6 +27,8 @@ The command is an integration shell for the canonical eligibility stack. It does
 - `--base-url=`
 
 `scope=slugs` can run from explicit slugs. `scope=all` and `scope=batch` require a public-resolution plan path and report a structured `public_resolution_plan_missing` reason when it is absent.
+
+`--entity-context` and `--index-state-context` are consumer-only JSON artifact inputs. They satisfy entity and index context without querying or exporting a DB context. The artifacts must be produced separately by an approved read-only context export workflow.
 
 ## Read-Only Contract
 
@@ -52,6 +56,13 @@ CMD-FIX-1 makes the command call the completed audit layer services instead of e
 - runtime projection/truth uses `CareerRuntimeProjectionTruthEligibilityAuditor` when `--projection` and `--truth` are supplied
 - SEO/GEO readiness uses `CareerSeoGeoReadinessAuditor` from plan/backend artifact fields
 - surface readiness uses `CareerSurfaceReadinessAuditor` when `--include-surfaces` or `--include-live-html` is requested
+
+When supplied, entity and index artifact rows bypass DB-backed entity/index auditors:
+
+- `--entity-context=/path/to/entity_context.json` supplies `career_entity_context.v1`
+- `--index-state-context=/path/to/index_state_context.json` supplies `career_index_state_context.v1`
+
+Missing or malformed artifact paths produce structured reasons such as `entity_context_file_missing`, `entity_context_json_invalid`, `index_context_file_missing`, and `index_context_json_invalid`; the command does not silently fall back to a DB query when an explicit artifact path is invalid.
 
 ## Context Handling
 

--- a/backend/docs/career/audits/entity_index_context_artifacts.md
+++ b/backend/docs/career/audits/entity_index_context_artifacts.md
@@ -1,0 +1,116 @@
+# Career Entity and Index Context Artifacts
+
+CTX-CONSUME-1 adds consumer-only context artifact inputs to `career:audit-canonical-eligibility`.
+
+The command can now consume:
+
+```bash
+--entity-context=/tmp/career_2786_entity_context.json
+--index-state-context=/tmp/career_2786_index_state_context.json
+```
+
+These options are read-only. They do not export production context, query production DB, mutate DB state, apply rollout, backfill data, or publish occupations.
+
+## Entity Context
+
+Expected shape:
+
+```json
+{
+  "schema_version": "career_entity_context.v1",
+  "source": {
+    "type": "read_only_db_export",
+    "generated_at": "2026-05-13T00:00:00Z",
+    "environment": "production"
+  },
+  "rows": [
+    {
+      "canonical_slug": "actuaries",
+      "occupation_exists": true,
+      "occupation_id": 123,
+      "title_en": "Actuaries",
+      "title_zh": "精算师",
+      "family": "math",
+      "crosswalks": [],
+      "missing_entity_fields": [],
+      "evidence": {}
+    }
+  ]
+}
+```
+
+Required fields:
+
+- `canonical_slug`
+- `occupation_exists` as a boolean
+
+Issue reasons:
+
+- `entity_context_file_missing`
+- `entity_context_json_invalid`
+- `entity_context_rows_missing`
+- `entity_context_row_malformed`
+- `entity_context_slug_missing`
+- `entity_context_slug_duplicate`
+- `entity_context_required_field_missing`
+
+## Index-State Context
+
+Expected shape:
+
+```json
+{
+  "schema_version": "career_index_state_context.v1",
+  "source": {
+    "type": "read_only_db_export",
+    "generated_at": "2026-05-13T00:00:00Z",
+    "environment": "production"
+  },
+  "rows": [
+    {
+      "canonical_slug": "actuaries",
+      "latest_index_state": "indexed",
+      "public_facing_state": "indexed",
+      "index_eligible": true,
+      "changed_at": "2026-05-13T00:00:00Z",
+      "reason_codes": [],
+      "evidence": {}
+    }
+  ]
+}
+```
+
+Required fields:
+
+- `canonical_slug`
+
+Issue reasons:
+
+- `index_context_file_missing`
+- `index_context_json_invalid`
+- `index_context_rows_missing`
+- `index_context_row_malformed`
+- `index_context_slug_missing`
+- `index_context_slug_duplicate`
+- `index_context_required_field_missing`
+
+## Runtime Behavior
+
+If valid artifacts are supplied:
+
+- `context_summary.entity_db_context` becomes `supplied`
+- `context_summary.index_state_context` becomes `supplied`
+- row-level `entity_db_context_missing` and `index_state_context_missing` disappear
+
+If an explicit artifact path is missing or malformed, the command reports the artifact issue and does not silently query DB as a fallback.
+
+## Non-Goals
+
+CTX-CONSUME-1 does not:
+
+- produce the entity or index artifacts
+- approve or run production read-only export
+- mutate DB state
+- backfill Occupations
+- apply index-state changes
+- run 80 readiness or rollout

--- a/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
@@ -133,6 +133,150 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertSame('supplied', $payload['context_summary']['runtime_truth_context']);
     }
 
+    public function test_entity_and_index_context_artifacts_mark_contexts_supplied(): void
+    {
+        $planPath = $this->writePlanner([
+            ['row_number' => 2, 'canonical_slug' => 'actuaries', 'status' => 'ready_for_pilot', 'title_en' => 'Actuaries', 'title_zh' => '精算师'],
+        ]);
+        $entityPath = $this->writeEntityContext([
+            ['canonical_slug' => 'actuaries', 'occupation_exists' => true, 'occupation_id' => 123, 'missing_entity_fields' => []],
+        ]);
+        $indexPath = $this->writeIndexContext([
+            ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed', 'public_facing_state' => 'indexed', 'index_eligible' => true],
+        ]);
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'all',
+            '--public-resolution-plan' => $planPath,
+            '--entity-context' => $entityPath,
+            '--index-state-context' => $indexPath,
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('supplied', $payload['context_summary']['entity_db_context']);
+        $this->assertSame('supplied', $payload['context_summary']['index_state_context']);
+        $this->assertSame($entityPath, $payload['run_context']['entity']['entity_context_path']);
+        $this->assertSame($indexPath, $payload['run_context']['index']['index_state_context_path']);
+        $this->assertArrayNotHasKey('entity_db_context_missing', $payload['by_reason']);
+        $this->assertArrayNotHasKey('index_state_context_missing', $payload['by_reason']);
+        $this->assertSame('pass', data_get($payload, 'rows.0.entity_status.status'));
+        $this->assertSame('pass', data_get($payload, 'rows.0.index_status.status'));
+        $this->assertSame('entity_context_artifact', data_get($payload, 'rows.0.entity_status.source'));
+        $this->assertSame('index_state_context_artifact', data_get($payload, 'rows.0.index_status.source'));
+    }
+
+    public function test_missing_entity_context_file_reports_structured_artifact_issue(): void
+    {
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--entity-context' => sys_get_temp_dir().'/missing-entity-context-'.bin2hex(random_bytes(4)).'.json',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('entity_context_file_missing', $payload['by_reason']);
+        $this->assertSame('missing', $payload['context_summary']['entity_db_context']);
+        $this->assertContains('entity_context_artifact_issue', array_column($payload['sidecars'], 'sidecar_id'));
+    }
+
+    public function test_malformed_entity_context_json_reports_structured_artifact_issue(): void
+    {
+        $path = sys_get_temp_dir().'/career-audit-command-bad-entity-'.bin2hex(random_bytes(4)).'.json';
+        file_put_contents($path, '{bad json');
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--entity-context' => $path,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('entity_context_json_invalid', $payload['by_reason']);
+        $this->assertSame('missing', $payload['context_summary']['entity_db_context']);
+    }
+
+    public function test_duplicate_entity_context_slug_reports_structured_artifact_issue(): void
+    {
+        $entityPath = $this->writeEntityContext([
+            ['canonical_slug' => 'actuaries', 'occupation_exists' => true, 'occupation_id' => 123],
+            ['canonical_slug' => 'actuaries', 'occupation_exists' => true, 'occupation_id' => 456],
+        ]);
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--entity-context' => $entityPath,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('entity_context_slug_duplicate', $payload['by_reason']);
+        $this->assertSame('supplied', $payload['context_summary']['entity_db_context']);
+        $this->assertContains('entity_context_slug_duplicate', data_get($payload, 'rows.0.entity_status.reasons'));
+    }
+
+    public function test_missing_index_context_file_reports_structured_artifact_issue(): void
+    {
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--index-state-context' => sys_get_temp_dir().'/missing-index-context-'.bin2hex(random_bytes(4)).'.json',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('index_context_file_missing', $payload['by_reason']);
+        $this->assertSame('missing', $payload['context_summary']['index_state_context']);
+        $this->assertContains('index_context_artifact_issue', array_column($payload['sidecars'], 'sidecar_id'));
+    }
+
+    public function test_malformed_index_context_json_reports_structured_artifact_issue(): void
+    {
+        $path = sys_get_temp_dir().'/career-audit-command-bad-index-'.bin2hex(random_bytes(4)).'.json';
+        file_put_contents($path, '{bad json');
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--index-state-context' => $path,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('index_context_json_invalid', $payload['by_reason']);
+        $this->assertSame('missing', $payload['context_summary']['index_state_context']);
+    }
+
+    public function test_duplicate_index_context_slug_reports_structured_artifact_issue(): void
+    {
+        $indexPath = $this->writeIndexContext([
+            ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed', 'public_facing_state' => 'indexed', 'index_eligible' => true],
+            ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed', 'public_facing_state' => 'indexed', 'index_eligible' => true],
+        ]);
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--index-state-context' => $indexPath,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('index_context_slug_duplicate', $payload['by_reason']);
+        $this->assertSame('supplied', $payload['context_summary']['index_state_context']);
+        $this->assertContains('index_context_slug_duplicate', data_get($payload, 'rows.0.index_status.reasons'));
+    }
+
     public function test_command_writes_output_json_when_requested(): void
     {
         $outputPath = sys_get_temp_dir().'/career-audit-command-output-'.bin2hex(random_bytes(4)).'.json';
@@ -340,6 +484,30 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
     {
         return $this->writeJsonArtifact('plan', [
             'workbook' => ['rows' => count($rows)],
+            'rows' => $rows,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function writeEntityContext(array $rows): string
+    {
+        return $this->writeJsonArtifact('entity-context', [
+            'schema_version' => 'career_entity_context.v1',
+            'source' => ['type' => 'read_only_db_export', 'environment' => 'local'],
+            'rows' => $rows,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function writeIndexContext(array $rows): string
+    {
+        return $this->writeJsonArtifact('index-context', [
+            'schema_version' => 'career_index_state_context.v1',
+            'source' => ['type' => 'read_only_db_export', 'environment' => 'local'],
             'rows' => $rows,
         ]);
     }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerEntityIndexContextArtifactReaderTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerEntityIndexContextArtifactReaderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerEntityContextArtifactReader;
+use App\Domain\Career\Audit\CareerIndexStateContextArtifactReader;
+use PHPUnit\Framework\TestCase;
+
+final class CareerEntityIndexContextArtifactReaderTest extends TestCase
+{
+    public function test_entity_context_reader_parses_stable_artifact(): void
+    {
+        $artifact = CareerEntityContextArtifactReader::fromPath($this->writeJson('entity', [
+            'schema_version' => 'career_entity_context.v1',
+            'source' => ['type' => 'read_only_db_export', 'environment' => 'local'],
+            'rows' => [
+                [
+                    'canonical_slug' => 'actuaries',
+                    'occupation_exists' => true,
+                    'occupation_id' => 123,
+                    'title_en' => 'Actuaries',
+                    'title_zh' => '精算师',
+                    'family' => 'math',
+                    'crosswalks' => [],
+                    'missing_entity_fields' => [],
+                    'evidence' => ['export_id' => 'test'],
+                ],
+            ],
+        ]));
+
+        $this->assertSame([], $artifact->byReason());
+        $this->assertSame('career_entity_context.v1', $artifact->schemaVersion);
+        $this->assertSame(['actuaries'], array_keys($artifact->rowsBySlug()));
+        $this->assertSame([
+            'source_path',
+            'schema_version',
+            'source',
+            'by_reason',
+            'rows',
+            'issues',
+        ], array_keys($artifact->toArray()));
+    }
+
+    public function test_entity_context_reader_reports_duplicate_slug(): void
+    {
+        $artifact = CareerEntityContextArtifactReader::fromPath($this->writeJson('entity-duplicate', [
+            'rows' => [
+                ['canonical_slug' => 'actuaries', 'occupation_exists' => true],
+                ['canonical_slug' => 'actuaries', 'occupation_exists' => true],
+            ],
+        ]));
+
+        $this->assertSame(['entity_context_slug_duplicate' => 1], $artifact->byReason());
+    }
+
+    public function test_index_context_reader_parses_stable_artifact(): void
+    {
+        $artifact = CareerIndexStateContextArtifactReader::fromPath($this->writeJson('index', [
+            'schema_version' => 'career_index_state_context.v1',
+            'source' => ['type' => 'read_only_db_export', 'environment' => 'local'],
+            'rows' => [
+                [
+                    'canonical_slug' => 'actuaries',
+                    'latest_index_state' => 'indexed',
+                    'public_facing_state' => 'indexed',
+                    'index_eligible' => true,
+                    'changed_at' => '2026-05-13T00:00:00Z',
+                    'reason_codes' => [],
+                    'evidence' => ['export_id' => 'test'],
+                ],
+            ],
+        ]));
+
+        $this->assertSame([], $artifact->byReason());
+        $this->assertSame('career_index_state_context.v1', $artifact->schemaVersion);
+        $this->assertSame(['actuaries'], array_keys($artifact->rowsBySlug()));
+        $this->assertSame([
+            'source_path',
+            'schema_version',
+            'source',
+            'by_reason',
+            'rows',
+            'issues',
+        ], array_keys($artifact->toArray()));
+    }
+
+    public function test_index_context_reader_reports_duplicate_slug(): void
+    {
+        $artifact = CareerIndexStateContextArtifactReader::fromPath($this->writeJson('index-duplicate', [
+            'rows' => [
+                ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed', 'index_eligible' => true],
+                ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed', 'index_eligible' => true],
+            ],
+        ]));
+
+        $this->assertSame(['index_context_slug_duplicate' => 1], $artifact->byReason());
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = sys_get_temp_dir().'/career-context-reader-'.$prefix.'-'.bin2hex(random_bytes(4)).'.json';
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -321,6 +321,22 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_entity_index_context_artifact_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerEntityContextArtifact.php',
+            'backend/app/Domain/Career/Audit/CareerEntityContextArtifactIssue.php',
+            'backend/app/Domain/Career/Audit/CareerEntityContextArtifactReader.php',
+            'backend/app/Domain/Career/Audit/CareerEntityContextArtifactRow.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateContextArtifact.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactIssue.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactReader.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_runtime_projection_truth_audit_changes(): void
     {
         $changed = [
@@ -1117,6 +1133,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerEntityIndexContextArtifactFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionTruthAuditFile($file)) {
                 continue;
             }
@@ -1557,6 +1577,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityIssue.php',
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityResult.php',
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityRow.php',
+        ], true);
+    }
+
+    private function isCareerEntityIndexContextArtifactFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerEntityContextArtifact.php',
+            'backend/app/Domain/Career/Audit/CareerEntityContextArtifactIssue.php',
+            'backend/app/Domain/Career/Audit/CareerEntityContextArtifactReader.php',
+            'backend/app/Domain/Career/Audit/CareerEntityContextArtifactRow.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateContextArtifact.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactIssue.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactReader.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2485,6 +2485,59 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "CTX-CONSUME-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-audit-entity-index-context-consumer",
+      "title": "fix(api): add career audit entity index context inputs",
+      "name": "Add entity and index context artifact inputs for 2786 audit",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-RUN-CTX-1"
+      ],
+      "scope_type": "audit_context_consumer_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerAuditCanonicalEligibility.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no production export",
+        "no production DB query",
+        "no DB mutation",
+        "no rollout",
+        "no backfill",
+        "no 80 readiness run",
+        "no producer/export command"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided CTX-CONSUME-1 execution goal and authorized updating PR train manifest/state."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-RUN-CTX-1 is merged as PR #1341 and current main contains 3203e9b7e7f11ec71a37dd9353e4d6e526b23fc4."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to audit command context inputs, audit domain artifact readers, audit tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "CTX-BUNDLE-1A rerun, then either CTX-EXPORT-1 or approved read-only context export",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1277,3 +1277,48 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: CTX-CONSUME-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-RUN-CTX-1
+    branch: fix/career-audit-entity-index-context-consumer
+    title: "fix(api): add career audit entity index context inputs"
+    name: "Add entity and index context artifact inputs for 2786 audit"
+    scope_type: audit_context_consumer_only
+    scope:
+      - Add --entity-context and --index-state-context inputs to career:audit-canonical-eligibility.
+      - Consume read-only entity and index-state JSON artifacts without querying or exporting production context.
+      - Report structured artifact validation issues for missing, malformed, duplicate, or incomplete rows.
+      - Mark entity/index run_context as supplied when valid artifacts are provided.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Export production context.
+      - Query production DB.
+      - Mutate DB or production state.
+      - Apply rollout.
+      - Backfill data.
+      - Run 80 readiness.
+      - Deploy.
+      - Add producer/export commands.
+    validation:
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditRunContext --no-ansi
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "CTX-BUNDLE-1A rerun, then either CTX-EXPORT-1 or approved read-only context export"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds `--entity-context` and `--index-state-context` to `career:audit-canonical-eligibility`.
- Adds read-only entity/index context artifact readers and structured artifact validation reasons.
- Marks entity/index run context as supplied when valid artifacts are provided, without falling back to production DB export/query behavior.
- Updates audit run docs and PR train metadata for CTX-CONSUME-1.

## Safety / Non-goals
- Consumer-only: no production export added.
- No DB mutation.
- No production commands.
- No rollout/backfill/apply.
- No 80 readiness run.
- Producer/export remains approval-gated.
- Next step is CTX preflight or CTX export planning.

## Local Validation
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi` ✅
- `php artisan test --filter=CareerCanonicalEligibilityAuditRunContext --no-ansi` ✅ (no tests found; command completed)
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi` ✅
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi` ✅
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi` ✅
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` ✅
- `php artisan test --filter=CareerEntityIndexContextArtifactReader --no-ansi` ✅
- `vendor/bin/pint --test` ✅
- `git diff --check` ✅
- `php artisan route:list --no-ansi` ✅
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force` ✅
- `bash scripts/ci_verify_mbti.sh` ✅

## Optional Synthetic Run
A tiny `/tmp` synthetic plan plus entity/index context artifacts was used only to verify the new consumer inputs. It confirmed:
- `context_summary.entity_db_context=supplied`
- `context_summary.index_state_context=supplied`
- entity/index layer statuses pass from supplied artifacts

No fake artifacts were used as real RUN-1 inputs.
