### PR TITLE
feat(api): add career audit db context exporters

### DIFF
--- a/backend/app/Console/Commands/CareerExportCanonicalEligibilityDbContext.php
+++ b/backend/app/Console/Commands/CareerExportCanonicalEligibilityDbContext.php
@@ -1,0 +1,548 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerPublicResolutionPlanIssue;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanResolver;
+use App\Domain\Career\IndexStateValue;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\File;
+
+final class CareerExportCanonicalEligibilityDbContext extends Command
+{
+    /**
+     * Entity-level fields required to form future canonical eligibility rows.
+     *
+     * @var list<string>
+     */
+    private const REQUIRED_ENTITY_FIELDS = [
+        'id',
+        'canonical_slug',
+        'family_id',
+        'entity_level',
+        'truth_market',
+        'display_market',
+        'crosswalk_mode',
+        'canonical_title_en',
+        'canonical_title_zh',
+        'search_h1_zh',
+    ];
+
+    protected $signature = 'career:export-canonical-eligibility-db-context
+        {--public-resolution-plan= : Required public-resolution planner JSON artifact}
+        {--entity-output= : Optional output path for career_entity_context.v1 JSON}
+        {--index-state-output= : Optional output path for career_index_state_context.v1 JSON}
+        {--locales=en,zh : Optional locale list for summary context}
+        {--json : Emit JSON summary output}';
+
+    protected $description = 'Export read-only Career entity and index-state context artifacts for canonical eligibility audit reruns.';
+
+    public function handle(): int
+    {
+        $planPath = $this->normalizedOption('public-resolution-plan');
+        $entityOutput = $this->normalizedOption('entity-output');
+        $indexOutput = $this->normalizedOption('index-state-output');
+
+        if ($planPath === null) {
+            return $this->finish([
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'by_reason' => ['public_resolution_plan_missing' => 1],
+                'issues' => [[
+                    'reason' => 'public_resolution_plan_missing',
+                    'message' => 'A --public-resolution-plan JSON artifact is required.',
+                ]],
+            ], self::FAILURE);
+        }
+
+        if ($entityOutput === null && $indexOutput === null) {
+            return $this->finish([
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'by_reason' => ['output_path_missing' => 1],
+                'issues' => [[
+                    'reason' => 'output_path_missing',
+                    'message' => 'At least one of --entity-output or --index-state-output is required.',
+                ]],
+            ], self::FAILURE);
+        }
+
+        $planValidation = CareerPublicResolutionPlanResolver::fromPath($planPath);
+        if ($planValidation->plan === null) {
+            return $this->finish([
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'by_reason' => $planValidation->byReason(),
+                'plan_validation' => $planValidation->toArray(),
+                'issues' => array_map(
+                    static fn (CareerPublicResolutionPlanIssue $issue): array => $issue->toArray(),
+                    $planValidation->issues
+                ),
+            ], self::FAILURE);
+        }
+
+        $slugs = $this->canonicalSlugs($planValidation->rows());
+        $duplicateInputSlugs = $this->duplicateInputSlugs($planValidation->rows());
+        $occupationsBySlug = $this->occupationsBySlug($slugs);
+
+        $source = [
+            'type' => 'read_only_db_export',
+            'generated_at' => now('UTC')->toISOString(),
+            'environment' => app()->environment(),
+            'planner_path' => $planValidation->sourcePath,
+            'planner_checksum' => $planValidation->checksum(),
+            'locales' => $this->locales(),
+        ];
+
+        $summary = [
+            'status' => 'materialized',
+            'read_only' => true,
+            'writes_database' => false,
+            'public_resolution_plan' => $planValidation->sourcePath,
+            'expected_slugs' => count($slugs),
+            'duplicate_input_slugs' => count($duplicateInputSlugs),
+            'duplicate_input_slug_values' => array_keys($duplicateInputSlugs),
+            'artifacts' => [],
+            'entity' => null,
+            'index_state' => null,
+        ];
+
+        if ($entityOutput !== null) {
+            [$artifact, $entitySummary] = $this->entityArtifact($source, $slugs, $duplicateInputSlugs, $occupationsBySlug);
+            $this->writeJson($entityOutput, $artifact);
+            $summary['artifacts']['entity_context'] = $entityOutput;
+            $summary['entity'] = [...$entitySummary, 'output_path' => $entityOutput];
+        }
+
+        if ($indexOutput !== null) {
+            [$artifact, $indexSummary] = $this->indexStateArtifact($source, $slugs, $occupationsBySlug);
+            $this->writeJson($indexOutput, $artifact);
+            $summary['artifacts']['index_state_context'] = $indexOutput;
+            $summary['index_state'] = [...$indexSummary, 'output_path' => $indexOutput];
+        }
+
+        return $this->finish($summary, self::SUCCESS);
+    }
+
+    private function normalizedOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  list<\App\Domain\Career\Audit\CareerPublicResolutionPlanRow>  $rows
+     * @return list<string>
+     */
+    private function canonicalSlugs(array $rows): array
+    {
+        $slugs = [];
+        foreach ($rows as $row) {
+            if ($row->canonicalSlug !== null && ! in_array($row->canonicalSlug, $slugs, true)) {
+                $slugs[] = $row->canonicalSlug;
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<\App\Domain\Career\Audit\CareerPublicResolutionPlanRow>  $rows
+     * @return array<string, true>
+     */
+    private function duplicateInputSlugs(array $rows): array
+    {
+        $seen = [];
+        $duplicates = [];
+        foreach ($rows as $row) {
+            if ($row->canonicalSlug === null) {
+                continue;
+            }
+
+            if (isset($seen[$row->canonicalSlug])) {
+                $duplicates[$row->canonicalSlug] = true;
+
+                continue;
+            }
+
+            $seen[$row->canonicalSlug] = true;
+        }
+
+        return $duplicates;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, list<Occupation>>
+     */
+    private function occupationsBySlug(array $slugs): array
+    {
+        if ($slugs === []) {
+            return [];
+        }
+
+        /** @var EloquentCollection<int, Occupation> $occupations */
+        $occupations = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->with([
+                'family',
+                'crosswalks',
+                'indexStates' => fn ($query) => $query
+                    ->orderByDesc('changed_at')
+                    ->orderByDesc('created_at')
+                    ->orderByDesc('updated_at'),
+            ])
+            ->get();
+
+        $bySlug = [];
+        foreach ($occupations as $occupation) {
+            $slug = $this->normalizeString($occupation->getAttribute('canonical_slug'));
+            if ($slug === null) {
+                continue;
+            }
+
+            $bySlug[$slug] ??= [];
+            $bySlug[$slug][] = $occupation;
+        }
+
+        return $bySlug;
+    }
+
+    /**
+     * @param  array<string, mixed>  $source
+     * @param  list<string>  $slugs
+     * @param  array<string, true>  $duplicateInputSlugs
+     * @param  array<string, list<Occupation>>  $occupationsBySlug
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>}
+     */
+    private function entityArtifact(array $source, array $slugs, array $duplicateInputSlugs, array $occupationsBySlug): array
+    {
+        $rows = [];
+        $occupationsFound = 0;
+        $duplicateEntitySlugs = [];
+
+        foreach ($slugs as $slug) {
+            $occupations = $occupationsBySlug[$slug] ?? [];
+            $occupation = $occupations[0] ?? null;
+            if ($occupation !== null) {
+                $occupationsFound++;
+            }
+            if (count($occupations) > 1) {
+                $duplicateEntitySlugs[] = $slug;
+            }
+
+            $rows[] = $this->entityRow($slug, $occupation, count($occupations), isset($duplicateInputSlugs[$slug]));
+        }
+
+        return [
+            [
+                'schema_version' => 'career_entity_context.v1',
+                'source' => $source,
+                'rows' => $rows,
+            ],
+            [
+                'expected_slugs' => count($slugs),
+                'entity_rows_written' => count($rows),
+                'occupations_found' => $occupationsFound,
+                'occupations_missing' => count($slugs) - $occupationsFound,
+                'duplicate_input_slugs' => count($duplicateInputSlugs),
+                'duplicate_entity_slugs' => count($duplicateEntitySlugs),
+                'duplicate_entity_slug_values' => $duplicateEntitySlugs,
+            ],
+        ];
+    }
+
+    private function entityRow(string $slug, ?Occupation $occupation, int $entityRowCount, bool $duplicateInputSlug): array
+    {
+        if ($occupation === null) {
+            return [
+                'canonical_slug' => $slug,
+                'occupation_exists' => false,
+                'occupation_id' => null,
+                'title_en' => null,
+                'title_zh' => null,
+                'family' => null,
+                'crosswalks' => [],
+                'missing_entity_fields' => [],
+                'evidence' => [
+                    'canonical_slug' => $slug,
+                    'occupation_missing' => true,
+                    'duplicate_input_slug' => $duplicateInputSlug,
+                ],
+            ];
+        }
+
+        $missingFields = $this->missingEntityFields($occupation);
+
+        return [
+            'canonical_slug' => $slug,
+            'occupation_exists' => true,
+            'occupation_id' => $this->normalizeString($occupation->getAttribute('id')),
+            'title_en' => $this->normalizeString($occupation->getAttribute('canonical_title_en')),
+            'title_zh' => $this->normalizeString($occupation->getAttribute('canonical_title_zh')),
+            'family' => $this->familyValue($occupation),
+            'crosswalks' => $this->crosswalkRows($occupation),
+            'missing_entity_fields' => $missingFields,
+            'evidence' => [
+                'occupation_id' => $this->normalizeString($occupation->getAttribute('id')),
+                'entity_row_count' => $entityRowCount,
+                'duplicate_entity_slug' => $entityRowCount > 1,
+                'duplicate_input_slug' => $duplicateInputSlug,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function missingEntityFields(Model $occupation): array
+    {
+        $missing = [];
+        foreach (self::REQUIRED_ENTITY_FIELDS as $field) {
+            if ($this->normalizeString($occupation->getAttribute($field)) === null) {
+                $missing[] = $field;
+            }
+        }
+
+        return $missing;
+    }
+
+    private function familyValue(Occupation $occupation): ?string
+    {
+        $family = $occupation->getRelationValue('family');
+        if ($family instanceof Model) {
+            return $this->normalizeString($family->getAttribute('canonical_slug'))
+                ?? $this->normalizeString($family->getAttribute('title_en'))
+                ?? $this->normalizeString($family->getAttribute('id'));
+        }
+
+        return $this->normalizeString($occupation->getAttribute('family_id'));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function crosswalkRows(Occupation $occupation): array
+    {
+        $crosswalks = $occupation->getRelationValue('crosswalks');
+        if (! $crosswalks instanceof EloquentCollection) {
+            return [];
+        }
+
+        return $crosswalks->map(fn (Model $crosswalk): array => [
+            'source_system' => $this->normalizeString($crosswalk->getAttribute('source_system')),
+            'source_code' => $this->normalizeString($crosswalk->getAttribute('source_code')),
+            'source_title' => $this->normalizeString($crosswalk->getAttribute('source_title')),
+            'mapping_type' => $this->normalizeString($crosswalk->getAttribute('mapping_type')),
+        ])->values()->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $source
+     * @param  list<string>  $slugs
+     * @param  array<string, list<Occupation>>  $occupationsBySlug
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>}
+     */
+    private function indexStateArtifact(array $source, array $slugs, array $occupationsBySlug): array
+    {
+        $rows = [];
+        $latestFound = 0;
+        $observedStates = [];
+
+        foreach ($slugs as $slug) {
+            $occupation = ($occupationsBySlug[$slug] ?? [])[0] ?? null;
+            $row = $this->indexStateRow($slug, $occupation);
+            if ($row['latest_index_state'] !== null) {
+                $latestFound++;
+                $observedStates[$row['latest_index_state']] = ($observedStates[$row['latest_index_state']] ?? 0) + 1;
+            }
+            $rows[] = $row;
+        }
+
+        ksort($observedStates);
+
+        return [
+            [
+                'schema_version' => 'career_index_state_context.v1',
+                'source' => $source,
+                'rows' => $rows,
+            ],
+            [
+                'expected_slugs' => count($slugs),
+                'index_rows_written' => count($rows),
+                'latest_index_state_found' => $latestFound,
+                'latest_index_state_missing' => count($slugs) - $latestFound,
+                'observed_states' => $observedStates,
+            ],
+        ];
+    }
+
+    private function indexStateRow(string $slug, ?Occupation $occupation): array
+    {
+        if ($occupation === null) {
+            return [
+                'canonical_slug' => $slug,
+                'latest_index_state' => null,
+                'public_facing_state' => null,
+                'index_eligible' => null,
+                'changed_at' => null,
+                'reason_codes' => [],
+                'evidence' => [
+                    'canonical_slug' => $slug,
+                    'occupation_missing' => true,
+                ],
+            ];
+        }
+
+        $indexStates = $occupation->getRelationValue('indexStates');
+        $indexState = $indexStates instanceof EloquentCollection ? $indexStates->first() : null;
+        if (! $indexState instanceof IndexState) {
+            return [
+                'canonical_slug' => $slug,
+                'latest_index_state' => null,
+                'public_facing_state' => null,
+                'index_eligible' => null,
+                'changed_at' => null,
+                'reason_codes' => [],
+                'evidence' => [
+                    'canonical_slug' => $slug,
+                    'occupation_id' => $this->normalizeString($occupation->getAttribute('id')),
+                    'index_state_missing' => true,
+                ],
+            ];
+        }
+
+        $rawState = $this->normalizeString($indexState->getAttribute('index_state')) ?? '';
+        $indexEligible = (bool) $indexState->getAttribute('index_eligible');
+
+        return [
+            'canonical_slug' => $slug,
+            'latest_index_state' => $rawState === '' ? null : $rawState,
+            'public_facing_state' => IndexStateValue::publicFacing($rawState, $indexEligible),
+            'index_eligible' => $indexEligible,
+            'changed_at' => $this->dateString($indexState->getAttribute('changed_at')),
+            'reason_codes' => $this->reasonCodes($indexState),
+            'evidence' => [
+                'occupation_id' => $this->normalizeString($occupation->getAttribute('id')),
+                'index_state_id' => $this->normalizeString($indexState->getAttribute('id')),
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function reasonCodes(IndexState $indexState): array
+    {
+        $reasonCodes = $indexState->getAttribute('reason_codes');
+        if (! is_array($reasonCodes) || ! array_is_list($reasonCodes)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($reasonCodes as $reasonCode) {
+            $value = $this->normalizeString($reasonCode);
+            if ($value !== null) {
+                $normalized[] = $value;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function locales(): array
+    {
+        $raw = $this->normalizedOption('locales') ?? 'en,zh';
+        $locales = [];
+        foreach (explode(',', $raw) as $locale) {
+            $normalized = $this->normalizeString($locale);
+            if ($normalized !== null) {
+                $locales[] = $normalized;
+            }
+        }
+
+        return $locales === [] ? ['en', 'zh'] : array_values(array_unique($locales));
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        if ($normalized === '' || strtolower($normalized) === 'null') {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    private function dateString(mixed $value): ?string
+    {
+        if (is_object($value) && method_exists($value, 'toISOString')) {
+            return $value->toISOString();
+        }
+
+        return $this->normalizeString($value);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $path, array $payload): void
+    {
+        $directory = dirname($path);
+        if ($directory !== '' && $directory !== '.') {
+            File::ensureDirectoryExists($directory);
+        }
+
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('Failed to encode career context artifact JSON.');
+        }
+
+        File::put($path, $encoded.PHP_EOL);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+            return $exitCode;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+        $this->line('read_only=true');
+        $this->line('writes_database=false');
+
+        foreach ((array) ($payload['artifacts'] ?? []) as $name => $path) {
+            $this->line($name.'='.(string) $path);
+        }
+
+        return $exitCode;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -18,6 +18,7 @@ use App\Console\Commands\CareerAuditCanonicalEligibility;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCompileRecommendationSubjects;
 use App\Console\Commands\CareerCrosswalkOps;
+use App\Console\Commands\CareerExportCanonicalEligibilityDbContext;
 use App\Console\Commands\CareerExportCanonicalExpansionManifest;
 use App\Console\Commands\CareerExportCanonicalRuntimeTruth;
 use App\Console\Commands\CareerExportCrosswalkBacklogConvergence;
@@ -219,6 +220,7 @@ class Kernel extends ConsoleKernel
         CareerCompileRecommendationSubjects::class,
         CareerCrosswalkOps::class,
         CareerExportCanonicalExpansionManifest::class,
+        CareerExportCanonicalEligibilityDbContext::class,
         CareerExportCanonicalRuntimeTruth::class,
         CareerExportCrosswalkBacklogConvergence::class,
         CareerExportFullReleaseLedger::class,

--- a/backend/docs/career/audits/db_context_export.md
+++ b/backend/docs/career/audits/db_context_export.md
@@ -1,0 +1,105 @@
+# Career Canonical Eligibility DB Context Export
+
+CTX-EXPORT-1 adds a producer command for the read-only entity and index-state context artifacts consumed by `career:audit-canonical-eligibility`.
+
+Command:
+
+```bash
+php artisan career:export-canonical-eligibility-db-context \
+  --public-resolution-plan=/path/to/public-resolution-plan.json \
+  --entity-output=/tmp/career_2786_entity_context.json \
+  --index-state-output=/tmp/career_2786_index_state_context.json \
+  --json
+```
+
+The command is read-only. It loads the planner through the AUDIT-2 resolver, extracts canonical slugs, queries the current configured DB for matching `occupations` and latest `index_states`, and writes JSON artifacts. It does not insert, update, delete, backfill, apply rollout, publish occupations, or deploy.
+
+## Entity Artifact
+
+`--entity-output` writes `career_entity_context.v1`:
+
+```json
+{
+  "schema_version": "career_entity_context.v1",
+  "source": {
+    "type": "read_only_db_export",
+    "generated_at": "2026-05-13T00:00:00.000000Z",
+    "environment": "production",
+    "planner_path": "/tmp/career_2786_public_resolution_plan_from_d23b.json"
+  },
+  "rows": [
+    {
+      "canonical_slug": "actuaries",
+      "occupation_exists": true,
+      "occupation_id": "uuid",
+      "title_en": "Actuaries",
+      "title_zh": "精算师",
+      "family": "math",
+      "crosswalks": [],
+      "missing_entity_fields": [],
+      "evidence": {}
+    }
+  ]
+}
+```
+
+The export includes one row per planner canonical slug. Missing occupations are represented with `occupation_exists=false` and `occupation_id=null`; rows are not omitted.
+
+## Index-State Artifact
+
+`--index-state-output` writes `career_index_state_context.v1`:
+
+```json
+{
+  "schema_version": "career_index_state_context.v1",
+  "source": {
+    "type": "read_only_db_export",
+    "generated_at": "2026-05-13T00:00:00.000000Z",
+    "environment": "production",
+    "planner_path": "/tmp/career_2786_public_resolution_plan_from_d23b.json"
+  },
+  "rows": [
+    {
+      "canonical_slug": "actuaries",
+      "latest_index_state": "indexed",
+      "public_facing_state": "indexable",
+      "index_eligible": true,
+      "changed_at": "2026-05-13T00:00:00.000000Z",
+      "reason_codes": [],
+      "evidence": {}
+    }
+  ]
+}
+```
+
+Latest index-state selection follows the audit layer order: `changed_at desc`, `created_at desc`, `updated_at desc`. The `public_facing_state` value uses `IndexStateValue::publicFacing`.
+
+## Approval Boundary
+
+This PR adds producer support only. Running the command against production requires a later explicit approval gate for read-only production context export. The approved run should write to `/tmp` or another approved artifact location and then rerun:
+
+```bash
+php artisan career:audit-canonical-eligibility \
+  --scope=all \
+  --public-resolution-plan=/tmp/career_2786_public_resolution_plan_from_d23b.json \
+  --entity-context=/tmp/career_2786_entity_context.json \
+  --index-state-context=/tmp/career_2786_index_state_context.json \
+  --projection=/tmp/career_2786_runtime_projection.json \
+  --truth=/tmp/career_2786_runtime_truth.json \
+  --locales=en,zh \
+  --json \
+  --output=/tmp/career_2786_canonical_eligibility_audit_with_context.json \
+  --context-output=/tmp/career_2786_audit_run_context_requirements.json
+```
+
+## Non-Goals
+
+CTX-EXPORT-1 does not:
+
+- run production export
+- mutate DB state
+- backfill Occupations
+- apply index-state changes
+- apply rollout
+- run 80 readiness
+- deploy

--- a/backend/docs/career/audits/entity_index_context_artifacts.md
+++ b/backend/docs/career/audits/entity_index_context_artifacts.md
@@ -1,6 +1,17 @@
 # Career Entity and Index Context Artifacts
 
-CTX-CONSUME-1 adds consumer-only context artifact inputs to `career:audit-canonical-eligibility`.
+CTX-CONSUME-1 adds context artifact inputs to `career:audit-canonical-eligibility`.
+CTX-EXPORT-1 adds the matching read-only producer command:
+
+```bash
+php artisan career:export-canonical-eligibility-db-context \
+  --public-resolution-plan=/path/to/public-resolution-plan.json \
+  --entity-output=/tmp/career_2786_entity_context.json \
+  --index-state-output=/tmp/career_2786_index_state_context.json \
+  --json
+```
+
+The producer command reads the current configured DB only. Production use remains approval-gated.
 
 The command can now consume:
 
@@ -106,9 +117,8 @@ If an explicit artifact path is missing or malformed, the command reports the ar
 
 ## Non-Goals
 
-CTX-CONSUME-1 does not:
+The consumer/producer contract does not:
 
-- produce the entity or index artifacts
 - approve or run production read-only export
 - mutate DB state
 - backfill Occupations

--- a/backend/tests/Feature/Console/CareerExportCanonicalEligibilityDbContextCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportCanonicalEligibilityDbContextCommandTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\Audit\CareerEntityContextArtifactReader;
+use App\Domain\Career\Audit\CareerIndexStateContextArtifactReader;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerExportCanonicalEligibilityDbContextCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:export-canonical-eligibility-db-context', Artisan::all());
+    }
+
+    public function test_command_requires_public_resolution_plan(): void
+    {
+        $exitCode = Artisan::call('career:export-canonical-eligibility-db-context', [
+            '--entity-output' => $this->tempPath('entity'),
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['public_resolution_plan_missing' => 1], $payload['by_reason']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_command_requires_at_least_one_output_path(): void
+    {
+        $exitCode = Artisan::call('career:export-canonical-eligibility-db-context', [
+            '--public-resolution-plan' => $this->writePlanner(['actuaries']),
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['output_path_missing' => 1], $payload['by_reason']);
+    }
+
+    public function test_command_emits_entity_and_index_context_artifacts_for_all_planner_slugs(): void
+    {
+        $actuariesId = $this->insertOccupation('actuaries', 'Actuaries', '精算师');
+        $this->insertIndexState($actuariesId, 'noindex', false, '2026-05-12 00:00:00');
+        $latestIndexStateId = $this->insertIndexState($actuariesId, 'indexed', true, '2026-05-13 00:00:00', ['manual_review_passed']);
+        $planPath = $this->writePlanner(['actuaries', 'missing-career']);
+        $entityOutput = $this->tempPath('entity-context');
+        $indexOutput = $this->tempPath('index-context');
+
+        $occupationCountBefore = DB::table('occupations')->count();
+        $indexStateCountBefore = DB::table('index_states')->count();
+        $exitCode = Artisan::call('career:export-canonical-eligibility-db-context', [
+            '--public-resolution-plan' => $planPath,
+            '--entity-output' => $entityOutput,
+            '--index-state-output' => $indexOutput,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('materialized', $payload['status']);
+        $this->assertSame(2, $payload['expected_slugs']);
+        $this->assertSame(2, $payload['entity']['entity_rows_written']);
+        $this->assertSame(1, $payload['entity']['occupations_found']);
+        $this->assertSame(1, $payload['entity']['occupations_missing']);
+        $this->assertSame(2, $payload['index_state']['index_rows_written']);
+        $this->assertSame(1, $payload['index_state']['latest_index_state_found']);
+        $this->assertSame(['indexed' => 1], $payload['index_state']['observed_states']);
+        $this->assertSame($occupationCountBefore, DB::table('occupations')->count());
+        $this->assertSame($indexStateCountBefore, DB::table('index_states')->count());
+
+        $entityArtifact = CareerEntityContextArtifactReader::fromPath($entityOutput);
+        $indexArtifact = CareerIndexStateContextArtifactReader::fromPath($indexOutput);
+
+        $this->assertSame([], $entityArtifact->byReason());
+        $this->assertSame([], $indexArtifact->byReason());
+        $this->assertSame(['actuaries', 'missing-career'], array_keys($entityArtifact->rowsBySlug()));
+        $this->assertSame(['actuaries', 'missing-career'], array_keys($indexArtifact->rowsBySlug()));
+        $this->assertTrue($entityArtifact->rowsBySlug()['actuaries']->occupationExists);
+        $this->assertFalse($entityArtifact->rowsBySlug()['missing-career']->occupationExists);
+        $this->assertSame('indexed', $indexArtifact->rowsBySlug()['actuaries']->latestIndexState);
+        $this->assertSame('indexable', $indexArtifact->rowsBySlug()['actuaries']->publicFacingState);
+        $this->assertTrue($indexArtifact->rowsBySlug()['actuaries']->indexEligible);
+        $this->assertSame(['manual_review_passed'], $indexArtifact->rowsBySlug()['actuaries']->reasonCodes);
+        $this->assertSame($latestIndexStateId, $indexArtifact->rowsBySlug()['actuaries']->evidence['index_state_id']);
+        $this->assertNull($indexArtifact->rowsBySlug()['missing-career']->latestIndexState);
+    }
+
+    public function test_exported_artifacts_can_be_consumed_by_canonical_eligibility_audit(): void
+    {
+        $occupationId = $this->insertOccupation('actuaries', 'Actuaries', '精算师');
+        $this->insertIndexState($occupationId, 'indexed', true, '2026-05-13 00:00:00');
+        $planPath = $this->writePlanner(['actuaries']);
+        $entityOutput = $this->tempPath('entity-context');
+        $indexOutput = $this->tempPath('index-context');
+
+        Artisan::call('career:export-canonical-eligibility-db-context', [
+            '--public-resolution-plan' => $planPath,
+            '--entity-output' => $entityOutput,
+            '--index-state-output' => $indexOutput,
+            '--json' => true,
+        ]);
+
+        $exitCode = Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'all',
+            '--public-resolution-plan' => $planPath,
+            '--entity-context' => $entityOutput,
+            '--index-state-context' => $indexOutput,
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('supplied', $payload['context_summary']['entity_db_context']);
+        $this->assertSame('supplied', $payload['context_summary']['index_state_context']);
+        $this->assertArrayNotHasKey('entity_db_context_missing', $payload['by_reason']);
+        $this->assertArrayNotHasKey('index_state_context_missing', $payload['by_reason']);
+        $this->assertSame('pass', data_get($payload, 'rows.0.entity_status.status'));
+        $this->assertSame('pass', data_get($payload, 'rows.0.index_status.status'));
+    }
+
+    public function test_malformed_planner_path_reports_structured_failure(): void
+    {
+        $exitCode = Artisan::call('career:export-canonical-eligibility-db-context', [
+            '--public-resolution-plan' => sys_get_temp_dir().'/missing-plan-'.bin2hex(random_bytes(4)).'.json',
+            '--entity-output' => $this->tempPath('entity-context'),
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['plan_file_missing' => 1], $payload['by_reason']);
+        $this->assertSame('blocked', $payload['plan_validation']['status']);
+    }
+
+    public function test_summary_json_shape_is_stable(): void
+    {
+        $planPath = $this->writePlanner(['actuaries']);
+        $entityOutput = $this->tempPath('entity-context');
+
+        Artisan::call('career:export-canonical-eligibility-db-context', [
+            '--public-resolution-plan' => $planPath,
+            '--entity-output' => $entityOutput,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame([
+            'status',
+            'read_only',
+            'writes_database',
+            'public_resolution_plan',
+            'expected_slugs',
+            'duplicate_input_slugs',
+            'duplicate_input_slug_values',
+            'artifacts',
+            'entity',
+            'index_state',
+        ], array_keys($payload));
+        $this->assertSame([
+            'expected_slugs',
+            'entity_rows_written',
+            'occupations_found',
+            'occupations_missing',
+            'duplicate_input_slugs',
+            'duplicate_entity_slugs',
+            'duplicate_entity_slug_values',
+            'output_path',
+        ], array_keys($payload['entity']));
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writePlanner(array $slugs): string
+    {
+        $rows = [];
+        foreach ($slugs as $index => $slug) {
+            $rows[] = [
+                'row_number' => $index + 2,
+                'canonical_slug' => $slug,
+                'status' => 'ready_for_pilot',
+                'title_en' => Str::headline($slug),
+                'title_zh' => '职业'.$index,
+                'locales' => ['en', 'zh'],
+            ];
+        }
+
+        $path = $this->tempPath('planner');
+        file_put_contents($path, json_encode([
+            'schema_version' => 'career_public_resolution_plan.v1',
+            'workbook' => ['rows' => count($rows)],
+            'rows' => $rows,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+
+    private function insertOccupation(string $slug, string $titleEn, string $titleZh): string
+    {
+        $now = now()->toDateTimeString();
+        $familyId = (string) Str::uuid();
+        $occupationId = (string) Str::uuid();
+
+        DB::table('occupation_families')->insert([
+            'id' => $familyId,
+            'canonical_slug' => $slug.'-family',
+            'title_en' => $titleEn.' Family',
+            'title_zh' => $titleZh.'族',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('occupations')->insert([
+            'id' => $occupationId,
+            'family_id' => $familyId,
+            'parent_id' => null,
+            'canonical_slug' => $slug,
+            'entity_level' => 'occupation',
+            'truth_market' => 'global',
+            'display_market' => 'global',
+            'crosswalk_mode' => 'canonical',
+            'canonical_title_en' => $titleEn,
+            'canonical_title_zh' => $titleZh,
+            'search_h1_zh' => $titleZh,
+            'structural_stability' => null,
+            'task_prototype_signature' => null,
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('occupation_crosswalks')->insert([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => $occupationId,
+            'source_system' => 'O_NET',
+            'source_code' => '15-0000.00',
+            'source_title' => $titleEn,
+            'mapping_type' => 'canonical',
+            'confidence_score' => null,
+            'notes' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        return $occupationId;
+    }
+
+    /**
+     * @param  list<string>  $reasonCodes
+     */
+    private function insertIndexState(string $occupationId, string $state, bool $indexEligible, string $changedAt, array $reasonCodes = []): string
+    {
+        $now = now()->toDateTimeString();
+        $id = (string) Str::uuid();
+
+        DB::table('index_states')->insert([
+            'id' => $id,
+            'occupation_id' => $occupationId,
+            'index_state' => $state,
+            'index_eligible' => $indexEligible,
+            'canonical_path' => '/career/'.$occupationId,
+            'canonical_target' => null,
+            'reason_codes' => json_encode($reasonCodes, JSON_THROW_ON_ERROR),
+            'changed_at' => $changedAt,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        return $id;
+    }
+
+    private function tempPath(string $prefix): string
+    {
+        return sys_get_temp_dir().'/career-export-db-context-'.$prefix.'-'.bin2hex(random_bytes(4)).'.json';
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2538,6 +2538,60 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "CTX-EXPORT-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-audit-db-context-export-producers",
+      "title": "feat(api): add career audit db context exporters",
+      "name": "Add read-only entity/index context export producers",
+      "status": "in_progress",
+      "depends_on": [
+        "CTX-CONSUME-1"
+      ],
+      "scope_type": "audit_context_producer_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/*",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no production export",
+        "no production DB query",
+        "no DB mutation",
+        "no rollout",
+        "no backfill",
+        "no 80 readiness run",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided CTX-EXPORT-1 execution goal and authorized updating PR train manifest/state."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "CTX-CONSUME-1 is merged as PR #1342 and current main contains cc72cf6c88a90cb14a190052e6659d258c784e8e."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to read-only audit context producer command, audit domain/docs/tests, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "CTX-BUNDLE-1A rerun, then approval-gated read-only context export if ready",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1322,3 +1322,50 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: CTX-EXPORT-1
+    repo: fap-api
+    depends_on:
+      - CTX-CONSUME-1
+    branch: fix/career-audit-db-context-export-producers
+    title: "feat(api): add career audit db context exporters"
+    name: "Add read-only entity/index context export producers"
+    scope_type: audit_context_producer_only
+    scope:
+      - Add a read-only command that exports entity and index-state context artifacts from the current DB.
+      - Emit career_entity_context.v1 and career_index_state_context.v1 JSON compatible with career:audit-canonical-eligibility inputs.
+      - Load canonical slugs through the public-resolution planner resolver.
+      - Preserve approval gating for any production execution.
+    allowed_paths:
+      - backend/app/Console/Commands/*
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run production export.
+      - Query production DB.
+      - Mutate DB or production state.
+      - Apply rollout.
+      - Backfill data.
+      - Run 80 readiness.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerExportCanonicalEligibilityDbContext --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerEntityContextArtifact --no-ansi
+      - php artisan test --filter=CareerIndexStateContextArtifact --no-ansi
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "CTX-BUNDLE-1A rerun, then approval-gated read-only context export if ready"
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds `career:export-canonical-eligibility-db-context`, a read-only producer command for Career canonical eligibility DB context artifacts.
- Writes `career_entity_context.v1` and `career_index_state_context.v1` JSON compatible with `career:audit-canonical-eligibility --entity-context` and `--index-state-context`.
- Registers CTX-EXPORT-1 in the PR train manifest/state and documents the approval-gated export workflow.

## Scope and safety
- Producer-only support.
- No production export performed.
- No production DB queried.
- No DB mutation.
- No rollout/backfill/apply.
- No 80 readiness run.
- No deploy.

## Validation
- `php artisan test --filter=CareerExportCanonicalEligibilityDbContext --no-ansi` passed: 7 tests / 45 assertions.
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi` passed: 21 tests / 103 assertions.
- `php artisan test --filter=CareerEntityContextArtifact --no-ansi` ran: no tests found for that exact filter; covered by `CareerEntityIndexContextArtifactReader`.
- `php artisan test --filter=CareerIndexStateContextArtifact --no-ansi` ran: no tests found for that exact filter; covered by `CareerEntityIndexContextArtifactReader`.
- `php artisan test --filter=CareerEntityIndexContextArtifactReader --no-ansi` passed: 4 tests / 10 assertions.
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi` passed: 13 tests / 45 assertions.
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi` passed: 12 tests / 28 assertions.
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi` passed: 14 tests / 37 assertions.
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` passed: 14 tests / 28 assertions.
- `vendor/bin/pint --test` passed: 3142 files.
- `git diff --check` passed.
- `php artisan route:list --no-ansi` passed: 197 routes.
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-ctx-export.sqlite php artisan migrate --force --no-ansi` passed.
- `bash backend/scripts/ci_verify_mbti.sh` passed.

## Next step
CTX-BUNDLE-1A rerun, then approval-gated read-only production context export if ready.
