### PR TITLE
RIASEC-PERSONALIZATION-01 — Interpretation Rule Spec v2 contract

### DIFF
--- a/backend/app/Services/Riasec/RiasecInterpretationRuleContract.php
+++ b/backend/app/Services/Riasec/RiasecInterpretationRuleContract.php
@@ -1,0 +1,384 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+final class RiasecInterpretationRuleContract
+{
+    public const VERSION = 'riasec_interpretation_rule_spec_v2';
+
+    public const PROFILE_SHAPE_VERSION = 'riasec_profile_shape_v2_0';
+
+    public const MODULE_VISIBILITY_POLICY_ID = 'riasec_module_visibility_policy_v1';
+
+    /** @var list<string> */
+    private const DIMENSIONS = ['R', 'I', 'A', 'S', 'E', 'C'];
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>|null  $qualitySummary
+     * @return array<string,mixed>
+     */
+    public function build(array $payload, ?array $qualitySummary = null): array
+    {
+        $scores = $this->scores($payload);
+        $ranked = $this->rankScores($scores);
+        $qualityState = $this->qualityState($payload, $qualitySummary);
+        $helpers = $this->helpers($ranked, $scores);
+        $nearTieState = $this->nearTieState($ranked, $helpers, $qualityState);
+        $profileShape = $this->profileShape($helpers, $nearTieState, $qualityState);
+        $alternateCode = $this->alternateCode($ranked, $nearTieState, $qualityState);
+
+        return [
+            'interpretation_rule_version' => self::VERSION,
+            'profile_shape' => $profileShape,
+            'profile_shape_version' => self::PROFILE_SHAPE_VERSION,
+            'clarity_label' => $this->clarityLabel($helpers, $qualityState),
+            'near_tie_state' => $nearTieState,
+            'alternate_code' => $alternateCode,
+            'alternate_code_reason' => $alternateCode['reason'],
+            'top_code_confidence' => $this->topCodeConfidence($profileShape, $helpers, $qualityState),
+            'reading_strength' => $this->readingStrength($profileShape, $qualityState),
+            'result_page_strategy' => $this->resultPageStrategy($profileShape),
+            'module_visibility_policy_id' => self::MODULE_VISIBILITY_POLICY_ID,
+            'validation_status' => 'theory_based_under_validation',
+            'field_authority' => $this->fieldAuthority(),
+            'score_interpretation_helpers' => $helpers,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,float>
+     */
+    private function scores(array $payload): array
+    {
+        $source = is_array($payload['scores_0_100'] ?? null) ? $payload['scores_0_100'] : [];
+        if ($source === []) {
+            foreach (self::DIMENSIONS as $dimension) {
+                $scoreKey = 'score_'.$dimension;
+                if (array_key_exists($scoreKey, $payload)) {
+                    $source[$dimension] = $payload[$scoreKey];
+                }
+            }
+        }
+
+        $scores = [];
+        foreach (self::DIMENSIONS as $dimension) {
+            $scores[$dimension] = $this->roundScore((float) ($source[$dimension] ?? 0.0));
+        }
+
+        return $scores;
+    }
+
+    /**
+     * @param  array<string,float>  $scores
+     * @return list<array{type:string,score:float}>
+     */
+    private function rankScores(array $scores): array
+    {
+        $order = array_flip(self::DIMENSIONS);
+        uksort($scores, static function (string $leftType, string $rightType) use ($scores, $order): int {
+            $leftScore = (float) ($scores[$leftType] ?? 0.0);
+            $rightScore = (float) ($scores[$rightType] ?? 0.0);
+            if (abs($rightScore - $leftScore) > 0.00001) {
+                return $rightScore <=> $leftScore;
+            }
+
+            return ($order[$leftType] ?? 0) <=> ($order[$rightType] ?? 0);
+        });
+
+        $ranked = [];
+        foreach ($scores as $type => $score) {
+            $ranked[] = ['type' => $type, 'score' => $this->roundScore($score)];
+        }
+
+        return $ranked;
+    }
+
+    /**
+     * @param  list<array{type:string,score:float}>  $ranked
+     * @param  array<string,float>  $scores
+     * @return array<string,mixed>
+     */
+    private function helpers(array $ranked, array $scores): array
+    {
+        $scoreOrder = array_map(static fn (array $row): string => $row['type'], $ranked);
+
+        return [
+            'score_order' => $scoreOrder,
+            'measured_holland_code' => implode('', array_slice($scoreOrder, 0, 3)),
+            'score_gap_1_2' => $this->scoreGap($ranked, 0, 1),
+            'score_gap_2_3' => $this->scoreGap($ranked, 1, 2),
+            'score_gap_3_4' => $this->scoreGap($ranked, 2, 3),
+            'top3_spread' => $this->roundScore((float) ($ranked[0]['score'] ?? 0.0) - (float) ($ranked[2]['score'] ?? 0.0)),
+            'high_interest_count' => count(array_filter($scores, static fn (float $score): bool => $score >= 65.0)),
+            'mid_or_high_count' => count(array_filter($scores, static fn (float $score): bool => $score >= 45.0)),
+            'low_interest_count' => count(array_filter($scores, static fn (float $score): bool => $score < 45.0)),
+            'profile_stddev' => $this->roundScore($this->standardDeviation(array_values($scores))),
+        ];
+    }
+
+    /**
+     * @param  list<array{type:string,score:float}>  $ranked
+     */
+    private function scoreGap(array $ranked, int $left, int $right): float
+    {
+        return $this->roundScore((float) ($ranked[$left]['score'] ?? 0.0) - (float) ($ranked[$right]['score'] ?? 0.0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>|null  $qualitySummary
+     */
+    private function qualityState(array $payload, ?array $qualitySummary): string
+    {
+        $candidate = strtolower(trim((string) (
+            $qualitySummary['quality_state']
+            ?? $payload['quality_state']
+            ?? $payload['response_quality']
+            ?? ''
+        )));
+
+        return in_array($candidate, ['normal', 'caution', 'low_quality'], true) ? $candidate : 'normal';
+    }
+
+    /**
+     * @param  list<array{type:string,score:float}>  $ranked
+     * @param  array<string,mixed>  $helpers
+     * @return array{state:string,dimensions:list<string>,threshold_rule:string}
+     */
+    private function nearTieState(array $ranked, array $helpers, string $qualityState): array
+    {
+        $fallback = [
+            'state' => 'none',
+            'dimensions' => [],
+            'threshold_rule' => 'adjacent_gap_lt_5_points_provisional',
+        ];
+        if ($qualityState === 'low_quality') {
+            return $fallback;
+        }
+
+        $gap12 = (float) ($helpers['score_gap_1_2'] ?? 0.0);
+        $gap23 = (float) ($helpers['score_gap_2_3'] ?? 0.0);
+        if ($gap12 < 5.0 && $gap23 < 5.0) {
+            return ['state' => 'multi_near_tie', 'dimensions' => $this->rankedDimensions($ranked, 0, 3), 'threshold_rule' => $fallback['threshold_rule']];
+        }
+        if ($gap12 < 5.0) {
+            return ['state' => 'top1_top2_near_tie', 'dimensions' => $this->rankedDimensions($ranked, 0, 2), 'threshold_rule' => $fallback['threshold_rule']];
+        }
+        if ($gap23 < 5.0) {
+            return ['state' => 'top2_top3_near_tie', 'dimensions' => $this->rankedDimensions($ranked, 1, 2), 'threshold_rule' => $fallback['threshold_rule']];
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * @param  list<array{type:string,score:float}>  $ranked
+     * @return list<string>
+     */
+    private function rankedDimensions(array $ranked, int $offset, int $length): array
+    {
+        return array_values(array_map(
+            static fn (array $row): string => $row['type'],
+            array_slice($ranked, $offset, $length)
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $helpers
+     */
+    private function clarityLabel(array $helpers, string $qualityState): string
+    {
+        if ($qualityState === 'low_quality') {
+            return 'not_readable';
+        }
+
+        $gap12 = (float) ($helpers['score_gap_1_2'] ?? 0.0);
+        $stddev = (float) ($helpers['profile_stddev'] ?? 0.0);
+        if ($gap12 >= 15.0 && $stddev >= 15.0) {
+            return 'high';
+        }
+        if ($gap12 >= 10.0 && $stddev >= 10.0) {
+            return 'medium_high';
+        }
+        if ($gap12 >= 5.0) {
+            return 'medium';
+        }
+
+        return 'low';
+    }
+
+    /**
+     * @param  array<string,mixed>  $helpers
+     * @param  array{state:string,dimensions:list<string>,threshold_rule:string}  $nearTieState
+     */
+    private function profileShape(array $helpers, array $nearTieState, string $qualityState): string
+    {
+        if ($qualityState === 'low_quality') {
+            return 'low_quality';
+        }
+        if (
+            (float) ($helpers['profile_stddev'] ?? 0.0) < 10.0
+            || (int) ($helpers['high_interest_count'] ?? 0) >= 4
+            || (float) ($helpers['top3_spread'] ?? 0.0) < 8.0
+        ) {
+            return 'broad_profile';
+        }
+        if ($nearTieState['state'] !== 'none') {
+            return 'near_tie';
+        }
+        if ((float) ($helpers['score_gap_1_2'] ?? 0.0) >= 10.0 && (float) ($helpers['profile_stddev'] ?? 0.0) >= 10.0) {
+            return 'clear_code';
+        }
+        if ((float) ($helpers['score_gap_1_2'] ?? 0.0) < 10.0 || (float) ($helpers['score_gap_2_3'] ?? 0.0) < 8.0) {
+            return 'blended_code';
+        }
+
+        return 'low_clarity';
+    }
+
+    /**
+     * @param  list<array{type:string,score:float}>  $ranked
+     * @param  array{state:string,dimensions:list<string>,threshold_rule:string}  $nearTieState
+     * @return array{show:bool,codes:list<string>,reason:?string,display_boundary:string}
+     */
+    private function alternateCode(array $ranked, array $nearTieState, string $qualityState): array
+    {
+        $boundary = 'Alternate code is a reading aid, not a second measured result.';
+        if ($qualityState === 'low_quality' || $nearTieState['state'] === 'none') {
+            return ['show' => false, 'codes' => [], 'reason' => null, 'display_boundary' => $boundary];
+        }
+
+        $top = array_values(array_map(static fn (array $row): string => $row['type'], array_slice($ranked, 0, 3)));
+        $codes = match ($nearTieState['state']) {
+            'top1_top2_near_tie' => [$this->code([$top[1] ?? '', $top[0] ?? '', $top[2] ?? ''])],
+            'top2_top3_near_tie' => [$this->code([$top[0] ?? '', $top[2] ?? '', $top[1] ?? ''])],
+            'multi_near_tie' => [
+                $this->code([$top[1] ?? '', $top[0] ?? '', $top[2] ?? '']),
+                $this->code([$top[0] ?? '', $top[2] ?? '', $top[1] ?? '']),
+            ],
+            default => [],
+        };
+        $codes = array_values(array_slice(array_unique(array_filter($codes)), 0, 2));
+
+        return [
+            'show' => $codes !== [],
+            'codes' => $codes,
+            'reason' => 'Adjacent RIASEC dimensions are close in this form. Read the result as a bounded combination, not a fixed identity.',
+            'display_boundary' => $boundary,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $letters
+     */
+    private function code(array $letters): string
+    {
+        $code = implode('', array_slice($letters, 0, 3));
+
+        return strlen($code) === 3 ? $code : '';
+    }
+
+    /**
+     * @param  array<string,mixed>  $helpers
+     * @return array{level:string,user_label:string,meaning:string}
+     */
+    private function topCodeConfidence(string $profileShape, array $helpers, string $qualityState): array
+    {
+        $level = 'low';
+        if ($qualityState === 'low_quality') {
+            $level = 'not_available';
+        } elseif ($qualityState === 'caution' || $profileShape === 'low_clarity') {
+            $level = 'low';
+        } elseif ($profileShape === 'clear_code' && (float) ($helpers['score_gap_1_2'] ?? 0.0) >= 15.0) {
+            $level = 'high';
+        } elseif (in_array($profileShape, ['clear_code', 'blended_code'], true) && (float) ($helpers['score_gap_1_2'] ?? 0.0) >= 10.0) {
+            $level = 'medium_high';
+        } elseif (in_array($profileShape, ['blended_code', 'near_tie'], true)) {
+            $level = 'medium';
+        }
+
+        return [
+            'level' => $level,
+            'user_label' => match ($level) {
+                'high' => '高',
+                'medium_high' => '中高',
+                'medium' => '中等',
+                'low' => '谨慎阅读',
+                default => '暂不显示',
+            },
+            'meaning' => 'readability strength, not probability',
+        ];
+    }
+
+    private function readingStrength(string $profileShape, string $qualityState): string
+    {
+        if ($qualityState === 'low_quality') {
+            return 'retake_recommended';
+        }
+        if ($qualityState === 'caution' || in_array($profileShape, ['low_clarity', 'broad_profile'], true)) {
+            return 'cautious_reading';
+        }
+
+        return 'normal_reading';
+    }
+
+    /**
+     * @return array{primary_reading_mode:string,tone:string}
+     */
+    private function resultPageStrategy(string $profileShape): array
+    {
+        return match ($profileShape) {
+            'clear_code' => ['primary_reading_mode' => 'single_chain', 'tone' => 'stable_not_absolute'],
+            'blended_code' => ['primary_reading_mode' => 'combination_chain', 'tone' => 'blended'],
+            'broad_profile' => ['primary_reading_mode' => 'activity_filter_first', 'tone' => 'exploratory'],
+            'near_tie' => ['primary_reading_mode' => 'candidate_chains', 'tone' => 'blended'],
+            'low_quality' => ['primary_reading_mode' => 'retake_first', 'tone' => 'retake_first'],
+            default => ['primary_reading_mode' => 'cautious_overview', 'tone' => 'cautious'],
+        };
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function fieldAuthority(): array
+    {
+        return [
+            'profile_shape' => 'backend_owned',
+            'profile_shape_version' => 'backend_owned',
+            'clarity_label' => 'backend_owned',
+            'near_tie_state' => 'backend_owned',
+            'alternate_code' => 'backend_owned',
+            'alternate_code_reason' => 'backend_owned',
+            'top_code_confidence' => 'backend_owned',
+            'reading_strength' => 'backend_owned',
+            'interpretation_rule_version' => 'backend_owned',
+        ];
+    }
+
+    /**
+     * @param  list<float>  $values
+     */
+    private function standardDeviation(array $values): float
+    {
+        if ($values === []) {
+            return 0.0;
+        }
+
+        $mean = array_sum($values) / count($values);
+        $variance = 0.0;
+        foreach ($values as $value) {
+            $variance += (($value - $mean) ** 2);
+        }
+
+        return sqrt($variance / count($values));
+    }
+
+    private function roundScore(float $score): float
+    {
+        return round(max(0.0, min(100.0, $score)), 2);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -612,6 +612,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_interpretation_rule_contract_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Riasec/RiasecInterpretationRuleContract.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_riasec_projection_v2_minimal_changes(): void
     {
         $changed = [
@@ -1220,6 +1229,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecInterpretationRuleContractFile($file)) {
+                continue;
+            }
+
             if ($this->isRiasecProjectionV2MinimalFile($file)) {
                 continue;
             }
@@ -1382,6 +1395,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
             'backend/app/Services/V0_3/Me/MeAttemptsService.php',
         ], true);
+    }
+
+    private function isRiasecInterpretationRuleContractFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Riasec/RiasecInterpretationRuleContract.php';
     }
 
     private function isRiasecProjectionV2MinimalFile(string $file): bool

--- a/backend/tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Services\Assessment\Scorers\RiasecScorer;
+use App\Services\Riasec\RiasecInterpretationRuleContract;
+use PHPUnit\Framework\TestCase;
+
+final class RiasecInterpretationRuleContractTest extends TestCase
+{
+    public function test_clear_code_emits_backend_owned_interpretation_state(): void
+    {
+        $state = (new RiasecInterpretationRuleContract)->build([
+            'top_code' => 'RIA',
+            'scores_0_100' => ['R' => 92, 'I' => 62, 'A' => 48, 'S' => 33, 'E' => 25, 'C' => 12],
+        ]);
+
+        $this->assertSame(RiasecInterpretationRuleContract::VERSION, $state['interpretation_rule_version']);
+        $this->assertSame('clear_code', $state['profile_shape']);
+        $this->assertSame(RiasecInterpretationRuleContract::PROFILE_SHAPE_VERSION, $state['profile_shape_version']);
+        $this->assertSame('high', $state['clarity_label']);
+        $this->assertSame('none', $state['near_tie_state']['state']);
+        $this->assertFalse($state['alternate_code']['show']);
+        $this->assertSame('high', $state['top_code_confidence']['level']);
+        $this->assertSame('readability strength, not probability', $state['top_code_confidence']['meaning']);
+        $this->assertSame('normal_reading', $state['reading_strength']);
+        $this->assertSame('single_chain', $state['result_page_strategy']['primary_reading_mode']);
+        $this->assertSame('backend_owned', $state['field_authority']['profile_shape']);
+        $this->assertSame(RiasecInterpretationRuleContract::MODULE_VISIBILITY_POLICY_ID, $state['module_visibility_policy_id']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_near_tie_emits_safe_alternate_code_as_reading_aid(): void
+    {
+        $state = (new RiasecInterpretationRuleContract)->build([
+            'top_code' => 'IAS',
+            'scores_0_100' => ['I' => 80, 'A' => 78, 'S' => 72, 'C' => 40, 'R' => 25, 'E' => 20],
+        ]);
+
+        $this->assertSame('near_tie', $state['profile_shape']);
+        $this->assertSame('top1_top2_near_tie', $state['near_tie_state']['state']);
+        $this->assertSame(['I', 'A'], $state['near_tie_state']['dimensions']);
+        $this->assertTrue($state['alternate_code']['show']);
+        $this->assertSame(['AIS'], $state['alternate_code']['codes']);
+        $this->assertStringContainsString('not a second measured result', $state['alternate_code']['display_boundary']);
+        $this->assertSame('medium', $state['top_code_confidence']['level']);
+        $this->assertSame('candidate_chains', $state['result_page_strategy']['primary_reading_mode']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_broad_profile_routes_to_activity_filter_first_before_near_tie(): void
+    {
+        $state = (new RiasecInterpretationRuleContract)->build([
+            'scores_0_100' => ['R' => 58, 'I' => 57, 'A' => 56, 'S' => 55, 'E' => 54, 'C' => 53],
+        ]);
+
+        $this->assertSame('broad_profile', $state['profile_shape']);
+        $this->assertSame('multi_near_tie', $state['near_tie_state']['state']);
+        $this->assertSame('activity_filter_first', $state['result_page_strategy']['primary_reading_mode']);
+        $this->assertSame('cautious_reading', $state['reading_strength']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_low_quality_suppresses_strong_interpretation_fields(): void
+    {
+        $state = (new RiasecInterpretationRuleContract)->build([
+            'top_code' => 'RIA',
+            'scores_0_100' => ['R' => 90, 'I' => 65, 'A' => 45, 'S' => 30, 'E' => 20, 'C' => 10],
+        ], [
+            'quality_state' => 'low_quality',
+        ]);
+
+        $this->assertSame('low_quality', $state['profile_shape']);
+        $this->assertSame('not_readable', $state['clarity_label']);
+        $this->assertSame('none', $state['near_tie_state']['state']);
+        $this->assertFalse($state['alternate_code']['show']);
+        $this->assertSame('not_available', $state['top_code_confidence']['level']);
+        $this->assertSame('retake_recommended', $state['reading_strength']);
+        $this->assertSame('retake_first', $state['result_page_strategy']['primary_reading_mode']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_contract_does_not_mutate_scorer_payload_or_scoring_math(): void
+    {
+        $answers = [];
+        for ($qid = 1; $qid <= 60; $qid++) {
+            $answers[$qid] = $qid <= 10 ? 5 : 1;
+        }
+
+        $payload = (new RiasecScorer)->score($answers, $this->questionIndex(60), [
+            'form_kind' => 'standard',
+            'scoring_spec_version' => 'riasec_standard_60_v1',
+        ]);
+        $before = $payload;
+        $state = (new RiasecInterpretationRuleContract)->build($payload);
+
+        $this->assertSame($before, $payload);
+        $this->assertSame('RIA', $payload['top_code']);
+        $this->assertSame(100.0, $payload['score_R']);
+        $this->assertSame(0.0, $payload['score_I']);
+        $this->assertSame(100.0, $payload['clarity_index']);
+        $this->assertContains($state['profile_shape'], ['clear_code', 'near_tie']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function questionIndex(int $count): array
+    {
+        $dimensions = ['R', 'I', 'A', 'S', 'E', 'C'];
+        $index = [];
+        $qid = 1;
+        foreach ($dimensions as $dimension) {
+            for ($i = 0; $i < 10; $i++) {
+                $index[$qid] = ['dimension' => $dimension, 'subscale' => 'activity'];
+                $qid++;
+            }
+        }
+
+        for (; $qid <= $count; $qid++) {
+            $index[$qid] = ['dimension' => '', 'subscale' => 'quality'];
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertNoForbiddenClaims(array $payload): void
+    {
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $forbidden = [
+            'Matches',
+            'career match',
+            'occupation match',
+            'job fit',
+            'fit score',
+            'success prediction',
+            'best career',
+            'recommended career',
+            '适合度',
+            '匹配度',
+            '最适合',
+            '职业成功',
+            '岗位匹配',
+            'more accurate',
+            '更准确',
+            'raw delta',
+            'score increased',
+            'score decreased',
+            '140Q more accurate',
+            '60Q wrong',
+            'AI-generated formal report',
+        ];
+
+        foreach ($forbidden as $phrase) {
+            $this->assertStringNotContainsString($phrase, $json);
+        }
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T14:58:00+08:00",
+  "updated_at": "2026-05-13T15:12:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2597,15 +2597,15 @@
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-00-train-registration",
       "title": "docs(codex): register RIASEC personalization train",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [],
       "scope_type": "train_registration_only",
       "allowed_paths": [
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "7207f737cd469883370ccae25c6d175ff75c951d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1344",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -2617,16 +2617,16 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-13T07:06:00Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-01": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-01-interpretation-contract",
       "title": "feat(riasec): add interpretation rule spec v2 contract",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "RIASEC-PERSONALIZATION-00"
       ],
@@ -2634,11 +2634,41 @@
       "allowed_paths": [
         "backend/app/**/Riasec*Interpretation*",
         "backend/tests/**/Riasec*Interpretation*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "focused_interpretation_contract": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Assessment/RiasecScorerTest.php",
+          "evidence": "7 tests passed, 154 assertions."
+        },
+        "riasec_flow": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+          "evidence": "5 tests passed, 193 assertions."
+        },
+        "freeze_classifier": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "evidence": "64 tests passed, 409 assertions; freeze classifier treats the RIASEC interpretation contract as RIASEC-owned and non-MBTI-impacting."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecInterpretationRuleContract.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to RIASEC interpretation contract, its unit tests, freeze classifier allowance, and docs/codex metadata."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1404,6 +1404,7 @@ prs:
     allowed_paths:
       - backend/app/**/Riasec*Interpretation*
       - backend/tests/**/Riasec*Interpretation*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train-state.json
     do_not:
       - Change scorer math.


### PR DESCRIPTION
## What changed
- Added `RiasecInterpretationRuleContract` as a backend-owned contract for profile shape, clarity, near-tie, alternate code, top-code readability, reading strength, and result-page strategy.
- Added focused unit tests for clear, near-tie, broad, and low-quality routing states.
- Reconciled the PR00 state entry as merged and marked PR01 in progress with local validation evidence.

## Why
RIASEC personalization needs backend authority before projection and frontend consumption. This PR defines the interpretation rule contract without changing scorer math, content pack semantics, projection output, or UI rendering.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Assessment/RiasecScorerTest.php`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecInterpretationRuleContract.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'`
- `git diff --check`

## Intentionally deferred
- Projection v2 emission waits for RIASEC-PERSONALIZATION-03.
- Quality Rule Spec v2 waits for RIASEC-PERSONALIZATION-02.
- Module visibility waits for RIASEC-PERSONALIZATION-04.
- Frontend fail-closed rendering waits for RIASEC-PERSONALIZATION-06.

## Repository rule impact
Backend contract authority only. No scoring math, content pack, CMS, public editorial content, career matching, or frontend fallback authority changes.
