### PR TITLE
RIASEC-PERSONALIZATION-02 — Quality Rule Spec v2 contract

### DIFF
--- a/backend/app/Services/Riasec/RiasecQualityRuleContract.php
+++ b/backend/app/Services/Riasec/RiasecQualityRuleContract.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+final class RiasecQualityRuleContract
+{
+    public const VERSION = 'riasec_quality_rule_spec_v2';
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    public function build(array $payload): array
+    {
+        $formCode = $this->formCode($payload);
+        $flags = $this->flags($payload);
+        $missingItems = $this->missingItems($payload, $formCode);
+        $attentionFailCount = count(array_intersect($flags, ['attention_133_failed', 'attention_137_failed']));
+        $attentionFlag = $attentionFailCount > 0;
+        $inconsistencySignal = in_array('low_consistency', $flags, true);
+        $idealizationSignal = in_array('idealization', $flags, true) || in_array('strong_idealization', $flags, true);
+        $broadAgreementSignal = in_array('broad_agreement', $flags, true);
+        $tooFast = $this->boolSignal($payload, 'too_fast');
+        $neutralOveruse = $this->boolSignal($payload, 'neutral_overuse');
+
+        $qualityState = $this->qualityState(
+            formCode: $formCode,
+            flags: $flags,
+            missingItems: $missingItems,
+            attentionFailCount: $attentionFailCount,
+            tooFast: $tooFast,
+            neutralOveruse: $neutralOveruse,
+        );
+        $readingStrength = $this->readingStrength($qualityState);
+
+        return [
+            'quality_rule_version' => self::VERSION,
+            'quality_state' => $qualityState,
+            'response_quality' => $qualityState,
+            'reading_strength' => $readingStrength,
+            'quality_flags' => $flags,
+            'too_fast' => $tooFast,
+            'neutral_overuse' => $neutralOveruse,
+            'missing_items' => $missingItems,
+            'inconsistency_signal' => $inconsistencySignal,
+            'attention_flag' => $attentionFlag,
+            'idealization_signal' => $idealizationSignal,
+            'broad_agreement_signal' => $broadAgreementSignal,
+            'quality_boundary_note' => $this->boundaryNote($formCode, $qualityState),
+            'result_page_behavior' => $this->resultPageBehavior($qualityState),
+            'module_policy' => [
+                'hide_strong_modules' => $qualityState === 'low_quality',
+                'show_activity_chain' => $qualityState !== 'low_quality',
+                'show_occupation_examples' => $qualityState === 'normal',
+                'allow_140q_cta' => $qualityState !== 'low_quality',
+                'cta_strength' => match ($qualityState) {
+                    'normal' => 'standard',
+                    'caution' => 'soft_or_hidden',
+                    default => 'hidden',
+                },
+            ],
+            'score_mutation_allowed' => false,
+            'measured_holland_code_mutation_allowed' => false,
+            'field_authority' => [
+                'quality_state' => 'backend_owned',
+                'response_quality' => 'backend_owned',
+                'reading_strength' => 'backend_owned',
+                'quality_rule_version' => 'backend_owned',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function formCode(array $payload): string
+    {
+        $candidate = strtolower(trim((string) (
+            $payload['form_code']
+            ?? ($payload['measurement_contract_v1']['form']['form_code'] ?? null)
+            ?? ''
+        )));
+        if (in_array($candidate, ['riasec_140', '140', 'enhanced', 'v1-enhanced-140'], true)) {
+            return 'riasec_140';
+        }
+        if (in_array($candidate, ['riasec_60', '60', 'standard', 'v1-standard-60'], true)) {
+            return 'riasec_60';
+        }
+
+        return ((int) ($payload['answer_count'] ?? 0)) >= 140 ? 'riasec_140' : 'riasec_60';
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    private function flags(array $payload): array
+    {
+        $flags = $payload['quality_flags'] ?? ($payload['quality']['flags'] ?? []);
+        if (! is_array($flags)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $flag): string => strtolower(trim((string) $flag)),
+            $flags
+        ))));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function missingItems(array $payload, string $formCode): bool
+    {
+        if ($this->boolSignal($payload, 'missing_items')) {
+            return true;
+        }
+
+        $answerCount = (int) ($payload['answer_count'] ?? 0);
+        if ($answerCount <= 0) {
+            return false;
+        }
+
+        return $answerCount < ($formCode === 'riasec_140' ? 140 : 60);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function boolSignal(array $payload, string $key): bool
+    {
+        return filter_var($payload[$key] ?? false, FILTER_VALIDATE_BOOL);
+    }
+
+    /**
+     * @param  list<string>  $flags
+     */
+    private function qualityState(
+        string $formCode,
+        array $flags,
+        bool $missingItems,
+        int $attentionFailCount,
+        bool $tooFast,
+        bool $neutralOveruse,
+    ): string {
+        if ($missingItems) {
+            return 'low_quality';
+        }
+
+        if ($formCode === 'riasec_140' && $attentionFailCount >= 2) {
+            return 'low_quality';
+        }
+
+        if ($flags !== [] || $tooFast || $neutralOveruse) {
+            return 'caution';
+        }
+
+        return 'normal';
+    }
+
+    private function readingStrength(string $qualityState): string
+    {
+        return match ($qualityState) {
+            'low_quality' => 'retake_recommended',
+            'caution' => 'cautious_reading',
+            default => 'normal_reading',
+        };
+    }
+
+    private function resultPageBehavior(string $qualityState): string
+    {
+        return match ($qualityState) {
+            'low_quality' => 'show_retake_recommended_page',
+            'caution' => 'show_cautious_result_page',
+            default => 'show_standard_result_page',
+        };
+    }
+
+    private function boundaryNote(string $formCode, string $qualityState): string
+    {
+        if ($formCode === 'riasec_60') {
+            return $qualityState === 'low_quality'
+                ? '60Q low_quality is limited to incomplete or missing required response evidence.'
+                : '60Q quality is minimal and must not overclaim strong low_quality without approved signals.';
+        }
+
+        return '140Q quality uses existing attention, consistency and response-pattern flags as contextual readability evidence.';
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -621,6 +621,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_quality_rule_contract_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Riasec/RiasecQualityRuleContract.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_riasec_projection_v2_minimal_changes(): void
     {
         $changed = [
@@ -1233,6 +1242,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecQualityRuleContractFile($file)) {
+                continue;
+            }
+
             if ($this->isRiasecProjectionV2MinimalFile($file)) {
                 continue;
             }
@@ -1400,6 +1413,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isRiasecInterpretationRuleContractFile(string $file): bool
     {
         return $file === 'backend/app/Services/Riasec/RiasecInterpretationRuleContract.php';
+    }
+
+    private function isRiasecQualityRuleContractFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Riasec/RiasecQualityRuleContract.php';
     }
 
     private function isRiasecProjectionV2MinimalFile(string $file): bool

--- a/backend/tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Services\Riasec\RiasecQualityRuleContract;
+use PHPUnit\Framework\TestCase;
+
+final class RiasecQualityRuleContractTest extends TestCase
+{
+    public function test_standard_60_defaults_to_normal_with_minimal_quality_boundary(): void
+    {
+        $state = (new RiasecQualityRuleContract)->build([
+            'form_code' => 'riasec_60',
+            'answer_count' => 60,
+            'quality_flags' => [],
+        ]);
+
+        $this->assertSame(RiasecQualityRuleContract::VERSION, $state['quality_rule_version']);
+        $this->assertSame('normal', $state['quality_state']);
+        $this->assertSame('normal_reading', $state['reading_strength']);
+        $this->assertSame('show_standard_result_page', $state['result_page_behavior']);
+        $this->assertTrue($state['module_policy']['allow_140q_cta']);
+        $this->assertStringContainsString('minimal', $state['quality_boundary_note']);
+        $this->assertFalse($state['score_mutation_allowed']);
+        $this->assertFalse($state['measured_holland_code_mutation_allowed']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_standard_60_supported_weak_signal_routes_to_caution_not_low_quality(): void
+    {
+        $state = (new RiasecQualityRuleContract)->build([
+            'form_code' => 'riasec_60',
+            'answer_count' => 60,
+            'neutral_overuse' => true,
+        ]);
+
+        $this->assertSame('caution', $state['quality_state']);
+        $this->assertSame('cautious_reading', $state['reading_strength']);
+        $this->assertSame('show_cautious_result_page', $state['result_page_behavior']);
+        $this->assertTrue($state['module_policy']['allow_140q_cta']);
+        $this->assertSame('soft_or_hidden', $state['module_policy']['cta_strength']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_standard_60_incomplete_attempt_is_low_quality_boundary_only(): void
+    {
+        $state = (new RiasecQualityRuleContract)->build([
+            'form_code' => 'riasec_60',
+            'answer_count' => 52,
+        ]);
+
+        $this->assertSame('low_quality', $state['quality_state']);
+        $this->assertSame('retake_recommended', $state['reading_strength']);
+        $this->assertSame('show_retake_recommended_page', $state['result_page_behavior']);
+        $this->assertFalse($state['module_policy']['allow_140q_cta']);
+        $this->assertSame('hidden', $state['module_policy']['cta_strength']);
+        $this->assertStringContainsString('incomplete', $state['quality_boundary_note']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_140q_single_attention_flag_routes_to_caution(): void
+    {
+        $state = (new RiasecQualityRuleContract)->build([
+            'form_code' => 'riasec_140',
+            'answer_count' => 140,
+            'quality_flags' => ['attention_133_failed'],
+        ]);
+
+        $this->assertSame('caution', $state['quality_state']);
+        $this->assertTrue($state['attention_flag']);
+        $this->assertSame('cautious_reading', $state['reading_strength']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_140q_two_attention_flags_route_to_low_quality_and_hide_140q_upsell(): void
+    {
+        $state = (new RiasecQualityRuleContract)->build([
+            'form_code' => 'riasec_140',
+            'answer_count' => 140,
+            'quality_flags' => ['attention_133_failed', 'attention_137_failed'],
+        ]);
+
+        $this->assertSame('low_quality', $state['quality_state']);
+        $this->assertTrue($state['attention_flag']);
+        $this->assertSame('retake_recommended', $state['reading_strength']);
+        $this->assertTrue($state['module_policy']['hide_strong_modules']);
+        $this->assertFalse($state['module_policy']['allow_140q_cta']);
+        $this->assertSame('hidden', $state['module_policy']['cta_strength']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    public function test_contract_does_not_mutate_payload(): void
+    {
+        $payload = [
+            'form_code' => 'riasec_140',
+            'answer_count' => 140,
+            'quality_flags' => ['low_consistency', 'broad_agreement'],
+        ];
+        $before = $payload;
+
+        $state = (new RiasecQualityRuleContract)->build($payload);
+
+        $this->assertSame($before, $payload);
+        $this->assertSame('caution', $state['quality_state']);
+        $this->assertTrue($state['inconsistency_signal']);
+        $this->assertTrue($state['broad_agreement_signal']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertNoForbiddenClaims(array $payload): void
+    {
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $forbidden = [
+            'Matches',
+            'career match',
+            'occupation match',
+            'job fit',
+            'fit score',
+            'success prediction',
+            'best career',
+            'recommended career',
+            '适合度',
+            '匹配度',
+            '最适合',
+            '职业成功',
+            '岗位匹配',
+            'more accurate',
+            '更准确',
+            'raw delta',
+            'score increased',
+            'score decreased',
+            '140Q more accurate',
+            '60Q wrong',
+            'AI-generated formal report',
+        ];
+
+        foreach ($forbidden as $phrase) {
+            $this->assertStringNotContainsString($phrase, $json);
+        }
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T15:12:00+08:00",
+  "updated_at": "2026-05-13T15:44:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2626,7 +2626,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-01-interpretation-contract",
       "title": "feat(riasec): add interpretation rule spec v2 contract",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "RIASEC-PERSONALIZATION-00"
       ],
@@ -2638,8 +2638,8 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "d02bd229959da50af6eaa9090ad9b02076b77e85",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1345",
       "checks": {
         "focused_interpretation_contract": {
           "status": "pass",
@@ -2670,16 +2670,16 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-13T07:35:00Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-02": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-02-quality-contract",
       "title": "feat(riasec): add quality rule spec v2 contract",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "RIASEC-PERSONALIZATION-01"
       ],
@@ -2687,11 +2687,37 @@
       "allowed_paths": [
         "backend/app/**/Riasec*Quality*",
         "backend/tests/**/Riasec*Quality*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "focused_quality_contract": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Assessment/RiasecScorerTest.php",
+          "evidence": "13 tests passed, 312 assertions."
+        },
+        "riasec_flow": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+          "evidence": "5 tests passed, 193 assertions."
+        },
+        "freeze_classifier": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "evidence": "65 tests passed, 410 assertions."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecQualityRuleContract.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to RIASEC quality contract, its tests, freeze classifier allowance, and docs/codex metadata."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1431,6 +1431,8 @@ prs:
     allowed_paths:
       - backend/app/**/Riasec*Quality*
       - backend/tests/**/Riasec*Quality*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
       - Change scorer math.


### PR DESCRIPTION
## What changed
- Added `RiasecQualityRuleContract` for backend-owned `quality_state`, `response_quality`, `reading_strength`, quality flags, and result-page behavior.
- Kept 60Q low-quality routing conservative: incomplete/missing response evidence only for strong low_quality; weak signals route to caution.
- Added 140Q attention-flag mapping and explicit no-140Q-upsell behavior for low_quality.
- Added focused tests and a freeze-classifier allowance for the new RIASEC-owned quality contract.
- Reconciled PR01 as merged in the train state.

## Why
Personalization routing needs a backend quality boundary before projection and module visibility can expose stronger states. This keeps quality as readability strength, not accuracy, and prevents low-quality from mutating measured scores or codes.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Assessment/RiasecScorerTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecQualityRuleContract.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `ruby -e 'require "yaml"; require "json"; YAML.load_file("docs/codex/pr-train.yaml"); JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "ok"'`
- `git diff --check`

## Intentionally deferred
- Projection v2 emission waits for RIASEC-PERSONALIZATION-03.
- Module visibility waits for RIASEC-PERSONALIZATION-04.
- Frontend consumption waits for RIASEC-PERSONALIZATION-06.

## Repository rule impact
Backend contract authority only. No scoring math, content pack, CMS, public editorial copy, career matching, or frontend fallback authority changes.
