### PR TITLE
RIASEC-PERSONALIZATION-03 — Projection v2 extension for interpretation state

### DIFF
--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -21,6 +21,8 @@ final class RiasecPublicProjectionService
         private readonly RiasecMeasurementContract $measurementContract,
         private readonly RiasecActivityExplorerService $activityExplorer,
         private readonly RiasecExplorationFeedbackOverlayService $feedbackOverlay,
+        private readonly RiasecInterpretationRuleContract $interpretationRuleContract,
+        private readonly RiasecQualityRuleContract $qualityRuleContract,
     ) {}
 
     public function buildFromResult(Result $result, string $locale = 'zh-CN'): array
@@ -94,6 +96,11 @@ final class RiasecPublicProjectionService
                 : $this->measurementContract->comparePolicyForFormCode((string) data_get($v1, 'form.form_code', '')));
         $scoreSpaceVersion = (string) data_get($measurementContract, 'form.score_space_version', data_get($v1, 'form.score_space_version', ''));
         $formCode = (string) data_get($measurementContract, 'form.form_code', data_get($v1, 'form.form_code', ''));
+        $qualityRule = $this->qualityRuleContract->build(array_merge($payload, [
+            'form_code' => $formCode,
+            'answer_count' => (int) data_get($measurementContract, 'form.question_count', (int) ($payload['answer_count'] ?? 0)),
+        ]));
+        $interpretationRule = $this->interpretationRuleContract->build($payload, $qualityRule);
 
         $projection = [
             'schema_version' => 'riasec.public_projection.v2',
@@ -138,9 +145,10 @@ final class RiasecPublicProjectionService
                 'quality_rule_version' => $this->firstString([
                     data_get($payload, 'version_snapshot.quality_rule_version'),
                     data_get($payload, 'quality_rule_version'),
+                    $qualityRule['quality_rule_version'] ?? null,
                 ]),
                 'quality_rule_status' => (string) data_get($measurementContract, 'quality.quality_rule_status', ''),
-                'interpretation_rule_version' => null,
+                'interpretation_rule_version' => (string) ($interpretationRule['interpretation_rule_version'] ?? ''),
                 'validation_status' => 'runtime_contract_defined_validation_pending',
                 'snapshot_bound' => $snapshotBound,
             ],
@@ -148,7 +156,16 @@ final class RiasecPublicProjectionService
                 'grade' => (string) ($v1['quality_grade'] ?? ''),
                 'flags' => is_array($v1['quality_flags'] ?? null) ? array_values($v1['quality_flags']) : [],
                 'low_quality_strength' => (string) data_get($measurementContract, 'quality.low_quality_strength', ''),
+                'quality_rule_version' => (string) ($qualityRule['quality_rule_version'] ?? ''),
+                'quality_state' => (string) ($qualityRule['quality_state'] ?? ''),
+                'response_quality' => (string) ($qualityRule['response_quality'] ?? ''),
+                'reading_strength' => (string) ($qualityRule['reading_strength'] ?? ''),
+                'result_page_behavior' => (string) ($qualityRule['result_page_behavior'] ?? ''),
+                'module_policy' => is_array($qualityRule['module_policy'] ?? null) ? $qualityRule['module_policy'] : [],
+                'score_mutation_allowed' => false,
+                'measured_holland_code_mutation_allowed' => false,
             ],
+            'interpretation_state' => $this->publicInterpretationState($interpretationRule),
             'indices' => [
                 'clarity_index' => (float) ($v1['clarity_index'] ?? 0),
                 'breadth_index' => (float) ($v1['breadth_index'] ?? 0),
@@ -250,5 +267,28 @@ final class RiasecPublicProjectionService
         }
 
         return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $interpretationRule
+     * @return array<string,mixed>
+     */
+    private function publicInterpretationState(array $interpretationRule): array
+    {
+        return [
+            'interpretation_rule_version' => (string) ($interpretationRule['interpretation_rule_version'] ?? ''),
+            'profile_shape' => (string) ($interpretationRule['profile_shape'] ?? ''),
+            'profile_shape_version' => (string) ($interpretationRule['profile_shape_version'] ?? ''),
+            'clarity_label' => (string) ($interpretationRule['clarity_label'] ?? ''),
+            'near_tie_state' => is_array($interpretationRule['near_tie_state'] ?? null) ? $interpretationRule['near_tie_state'] : [],
+            'alternate_code' => is_array($interpretationRule['alternate_code'] ?? null) ? $interpretationRule['alternate_code'] : [],
+            'alternate_code_reason' => $interpretationRule['alternate_code_reason'] ?? null,
+            'top_code_confidence' => is_array($interpretationRule['top_code_confidence'] ?? null) ? $interpretationRule['top_code_confidence'] : [],
+            'reading_strength' => (string) ($interpretationRule['reading_strength'] ?? ''),
+            'result_page_strategy' => is_array($interpretationRule['result_page_strategy'] ?? null) ? $interpretationRule['result_page_strategy'] : [],
+            'module_visibility_policy_id' => (string) ($interpretationRule['module_visibility_policy_id'] ?? ''),
+            'validation_status' => (string) ($interpretationRule['validation_status'] ?? ''),
+            'field_authority' => is_array($interpretationRule['field_authority'] ?? null) ? $interpretationRule['field_authority'] : [],
+        ];
     }
 }

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -113,7 +113,17 @@ final class RiasecAssessmentFlowTest extends TestCase
         $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.scoring_spec_version', 'riasec_standard_60_v1');
         $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.normalization_method', 'raw_sum_per_dimension_min10_max50_to_0_100');
         $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.quality_rule_status', 'minimal_answer_completion_only');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.quality_rule_version', 'riasec_quality_rule_spec_v2');
+        $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.interpretation_rule_version', 'riasec_interpretation_rule_spec_v2');
         $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.quality.quality_state', 'normal');
+        $readback->assertJsonPath('riasec_public_projection_v2.quality.score_mutation_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.quality.measured_holland_code_mutation_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.interpretation_state.interpretation_rule_version', 'riasec_interpretation_rule_spec_v2');
+        $readback->assertJsonPath('riasec_public_projection_v2.interpretation_state.profile_shape_version', 'riasec_profile_shape_v2_0');
+        $readback->assertJsonPath('riasec_public_projection_v2.interpretation_state.module_visibility_policy_id', 'riasec_module_visibility_policy_v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.interpretation_state.top_code_confidence.meaning', 'readability strength, not probability');
+        $readback->assertJsonPath('riasec_public_projection_v2.interpretation_state.field_authority.profile_shape', 'backend_owned');
         $readback->assertJsonPath('riasec_public_projection_v2.claim_boundary.does_not_measure.3', 'career_success_probability');
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.schema_version', 'riasec.activity_explorer.v0.1');
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.status', 'content_examples_only');
@@ -147,7 +157,9 @@ final class RiasecAssessmentFlowTest extends TestCase
         $report->assertJsonPath('riasec_form_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
         $report->assertJsonPath('report._meta.riasec_public_projection_v2.schema_version', 'riasec.public_projection.v2');
         $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
+        $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.interpretation_rule_version', 'riasec_interpretation_rule_spec_v2');
         $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
+        $report->assertJsonPath('riasec_public_projection_v2.interpretation_state.field_authority.reading_strength', 'backend_owned');
         $report->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.boundary.occupation_examples_policy', 'content_example_not_registry_match_without_reviewed_registry_source');
         $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.snapshot_bound', true);
         $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.surface_policy.formal_report_mutation_allowed', false);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T15:44:00+08:00",
+  "updated_at": "2026-05-13T16:02:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2679,7 +2679,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-02-quality-contract",
       "title": "feat(riasec): add quality rule spec v2 contract",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "RIASEC-PERSONALIZATION-01"
       ],
@@ -2691,8 +2691,8 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "8d851f4503146a63fbfb1f87aa40fe5c8ccfa6a7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1346",
       "checks": {
         "focused_quality_contract": {
           "status": "pass",
@@ -2719,16 +2719,16 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-13T07:53:00Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-03": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-03-projection-extension",
       "title": "feat(riasec): extend projection v2 with interpretation state",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "RIASEC-PERSONALIZATION-01",
         "RIASEC-PERSONALIZATION-02"
@@ -2737,11 +2737,32 @@
       "allowed_paths": [
         "backend/app/**/RiasecPublicProjectionService*",
         "backend/tests/**/Riasec*Projection*",
+        "backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+        "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "riasec_flow_projection": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+          "evidence": "5 tests passed, 205 assertions."
+        },
+        "contract_regression": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php tests/Unit/Assessment/RiasecScorerTest.php",
+          "evidence": "13 tests passed, 312 assertions."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecPublicProjectionService.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to RIASEC projection service, RIASEC flow assertions, and docs/codex metadata."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1460,6 +1460,8 @@ prs:
     allowed_paths:
       - backend/app/**/RiasecPublicProjectionService*
       - backend/tests/**/Riasec*Projection*
+      - backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+      - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
       - Change scorer math.


### PR DESCRIPTION
## What changed
- Extended RIASEC projection v2 with backend-provided `interpretation_state` and quality-state fields.
- Populated measurement evidence with `riasec_interpretation_rule_spec_v2` and `riasec_quality_rule_spec_v2`.
- Preserved v1 and existing v2 structure by adding fields only.
- Added flow assertions proving result/report projection paths expose backend-owned state.
- Reconciled PR02 as merged in the train state.

## Why
Frontend and report module routing must consume backend authority. This PR makes interpretation and quality state available in projection v2 without changing scoring math or adding UI/copy behavior.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php tests/Unit/Assessment/RiasecScorerTest.php`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecPublicProjectionService.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `ruby -e 'require "yaml"; require "json"; YAML.load_file("docs/codex/pr-train.yaml"); JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "ok"'`
- `git diff --check`

## Intentionally deferred
- Report module selector waits for RIASEC-PERSONALIZATION-04.
- Content registry readiness waits for RIASEC-PERSONALIZATION-05.
- Frontend fail-closed consumption waits for RIASEC-PERSONALIZATION-06.

## Repository rule impact
Backend projection contract only. No scoring math, content pack, CMS, public copy, career matching, or frontend fallback authority changes.
