### PR TITLE
RIASEC-PERSONALIZATION-04 — Report module selector contract

### DIFF
--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -23,6 +23,7 @@ final class RiasecPublicProjectionService
         private readonly RiasecExplorationFeedbackOverlayService $feedbackOverlay,
         private readonly RiasecInterpretationRuleContract $interpretationRuleContract,
         private readonly RiasecQualityRuleContract $qualityRuleContract,
+        private readonly RiasecReportModuleSelector $moduleSelector,
     ) {}
 
     public function buildFromResult(Result $result, string $locale = 'zh-CN'): array
@@ -181,6 +182,7 @@ final class RiasecPublicProjectionService
             ],
             'activity_explorer_v0_1' => $this->activityExplorer->build((string) ($v1['top_code'] ?? ''), $locale),
         ];
+        $projection['module_visibility_policy'] = $this->moduleSelector->build($projection);
         $projection['exploration_feedback_overlay_v0_1'] = $this->feedbackOverlay->build($result, $projection, $snapshotBound);
 
         return $projection;

--- a/backend/app/Services/Riasec/RiasecReportModuleSelector.php
+++ b/backend/app/Services/Riasec/RiasecReportModuleSelector.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+final class RiasecReportModuleSelector
+{
+    public const POLICY_ID = 'riasec_module_visibility_policy_v1';
+
+    /**
+     * @param  array<string,mixed>  $projectionV2
+     * @return array<string,mixed>
+     */
+    public function build(array $projectionV2): array
+    {
+        $qualityState = (string) ($projectionV2['quality']['quality_state'] ?? 'normal');
+        $profileShape = (string) ($projectionV2['interpretation_state']['profile_shape'] ?? 'low_clarity');
+        $formCode = (string) ($projectionV2['form']['form_code'] ?? 'riasec_60');
+
+        $modules = $this->standardModules($formCode);
+        if ($qualityState === 'low_quality') {
+            $modules = $this->applyLowQuality($modules);
+        } elseif ($qualityState === 'caution') {
+            $modules = $this->applyCaution($modules);
+        }
+
+        $modules = match ($profileShape) {
+            'broad_profile' => $this->applyBroadProfile($modules),
+            'near_tie' => $this->applyNearTie($modules),
+            'low_clarity' => $this->applyLowClarity($modules),
+            default => $modules,
+        };
+
+        if ($formCode !== 'riasec_140') {
+            $modules['140q_context_cards'] = $this->module('140q_context_cards', 'hidden', 'requires_riasec_140_contextual_form');
+        }
+
+        return [
+            'schema_version' => 'riasec.module_visibility_policy.v1',
+            'policy_id' => self::POLICY_ID,
+            'quality_state' => $qualityState,
+            'profile_shape' => $profileShape,
+            'form_code' => $formCode,
+            'modules' => array_values($modules),
+            'fallback_policy' => [
+                'unknown_module' => 'hidden',
+                'missing_backend_state' => 'hidden',
+                'frontend_inference_allowed' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,array<string,string>>
+     */
+    private function standardModules(string $formCode): array
+    {
+        return [
+            'hero_activity_chain' => $this->module('hero_activity_chain', 'visible', 'standard_reading_available'),
+            'six_dimension_map' => $this->module('six_dimension_map', 'visible', 'dimension_overview_available'),
+            'pair_blend' => $this->module('pair_blend', 'visible', 'combination_reading_available'),
+            'activity_explorer' => $this->module('activity_explorer', 'visible', 'examples_only_activity_explorer_available'),
+            'occupation_examples' => $this->module('occupation_examples', 'collapsed', 'examples_only_not_registry_match'),
+            '140q_cta' => $this->module('140q_cta', $formCode === 'riasec_140' ? 'hidden' : 'visible', 'contextual_form_optional_not_more_accurate'),
+            '140q_context_cards' => $this->module('140q_context_cards', $formCode === 'riasec_140' ? 'visible' : 'hidden', 'contextual_layer_available_for_140q_only'),
+            'share_card' => $this->module('share_card', 'visible', 'safe_share_available'),
+            'pdf' => $this->module('pdf', 'visible', 'snapshot_bound_pdf_available'),
+            'history' => $this->module('history', 'visible', 'snapshot_bound_history_available'),
+            'feedback_overlay' => $this->module('feedback_overlay', 'visible', 'feedback_does_not_mutate_measured_result'),
+        ];
+    }
+
+    /**
+     * @param  array<string,array<string,string>>  $modules
+     * @return array<string,array<string,string>>
+     */
+    private function applyLowQuality(array $modules): array
+    {
+        foreach (['hero_activity_chain', 'pair_blend', 'activity_explorer', 'occupation_examples', '140q_cta', '140q_context_cards'] as $key) {
+            $modules[$key] = $this->module($key, 'hidden', 'low_quality_hides_strong_modules');
+        }
+        $modules['six_dimension_map'] = $this->module('six_dimension_map', 'visible', 'low_quality_overview_only');
+        $modules['share_card'] = $this->module('share_card', 'collapsed', 'low_quality_no_strong_public_share');
+        $modules['pdf'] = $this->module('pdf', 'collapsed', 'low_quality_cautious_pdf_only');
+
+        return $modules;
+    }
+
+    /**
+     * @param  array<string,array<string,string>>  $modules
+     * @return array<string,array<string,string>>
+     */
+    private function applyCaution(array $modules): array
+    {
+        foreach (['pair_blend', 'occupation_examples', '140q_cta'] as $key) {
+            $modules[$key] = $this->module($key, 'collapsed', 'caution_softens_interpretation');
+        }
+
+        return $modules;
+    }
+
+    /**
+     * @param  array<string,array<string,string>>  $modules
+     * @return array<string,array<string,string>>
+     */
+    private function applyBroadProfile(array $modules): array
+    {
+        $modules['hero_activity_chain'] = $this->module('hero_activity_chain', 'hidden', 'broad_profile_activity_filter_first');
+        $modules['occupation_examples'] = $this->module('occupation_examples', 'hidden', 'broad_profile_no_single_chain_examples');
+
+        return $modules;
+    }
+
+    /**
+     * @param  array<string,array<string,string>>  $modules
+     * @return array<string,array<string,string>>
+     */
+    private function applyNearTie(array $modules): array
+    {
+        $modules['hero_activity_chain'] = $this->module('hero_activity_chain', 'collapsed', 'near_tie_candidate_chains_first');
+        $modules['pair_blend'] = $this->module('pair_blend', 'visible', 'near_tie_pair_blend_required');
+
+        return $modules;
+    }
+
+    /**
+     * @param  array<string,array<string,string>>  $modules
+     * @return array<string,array<string,string>>
+     */
+    private function applyLowClarity(array $modules): array
+    {
+        $modules['hero_activity_chain'] = $this->module('hero_activity_chain', 'collapsed', 'low_clarity_cautious_overview');
+        $modules['occupation_examples'] = $this->module('occupation_examples', 'hidden', 'low_clarity_hides_strong_examples');
+
+        return $modules;
+    }
+
+    /**
+     * @return array{key:string,visibility:string,reason:string}
+     */
+    private function module(string $key, string $visibility, string $reason): array
+    {
+        return [
+            'key' => $key,
+            'visibility' => $visibility,
+            'reason' => $reason,
+        ];
+    }
+}

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -124,6 +124,9 @@ final class RiasecAssessmentFlowTest extends TestCase
         $readback->assertJsonPath('riasec_public_projection_v2.interpretation_state.module_visibility_policy_id', 'riasec_module_visibility_policy_v1');
         $readback->assertJsonPath('riasec_public_projection_v2.interpretation_state.top_code_confidence.meaning', 'readability strength, not probability');
         $readback->assertJsonPath('riasec_public_projection_v2.interpretation_state.field_authority.profile_shape', 'backend_owned');
+        $readback->assertJsonPath('riasec_public_projection_v2.module_visibility_policy.schema_version', 'riasec.module_visibility_policy.v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.module_visibility_policy.policy_id', 'riasec_module_visibility_policy_v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.module_visibility_policy.fallback_policy.frontend_inference_allowed', false);
         $readback->assertJsonPath('riasec_public_projection_v2.claim_boundary.does_not_measure.3', 'career_success_probability');
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.schema_version', 'riasec.activity_explorer.v0.1');
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.status', 'content_examples_only');
@@ -160,6 +163,7 @@ final class RiasecAssessmentFlowTest extends TestCase
         $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.interpretation_rule_version', 'riasec_interpretation_rule_spec_v2');
         $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
         $report->assertJsonPath('riasec_public_projection_v2.interpretation_state.field_authority.reading_strength', 'backend_owned');
+        $report->assertJsonPath('riasec_public_projection_v2.module_visibility_policy.policy_id', 'riasec_module_visibility_policy_v1');
         $report->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.boundary.occupation_examples_policy', 'content_example_not_registry_match_without_reviewed_registry_source');
         $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.snapshot_bound', true);
         $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.surface_policy.formal_report_mutation_allowed', false);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -630,6 +630,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_module_selector_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Riasec/RiasecReportModuleSelector.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_riasec_projection_v2_minimal_changes(): void
     {
         $changed = [
@@ -1246,6 +1256,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecModuleSelectorFile($file)) {
+                continue;
+            }
+
             if ($this->isRiasecProjectionV2MinimalFile($file)) {
                 continue;
             }
@@ -1418,6 +1432,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isRiasecQualityRuleContractFile(string $file): bool
     {
         return $file === 'backend/app/Services/Riasec/RiasecQualityRuleContract.php';
+    }
+
+    private function isRiasecModuleSelectorFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Riasec/RiasecReportModuleSelector.php',
+            'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
+        ], true);
     }
 
     private function isRiasecProjectionV2MinimalFile(string $file): bool

--- a/backend/tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Services\Riasec\RiasecReportModuleSelector;
+use PHPUnit\Framework\TestCase;
+
+final class RiasecReportModuleSelectorTest extends TestCase
+{
+    public function test_normal_clear_60q_exposes_standard_modules_without_context_cards(): void
+    {
+        $policy = (new RiasecReportModuleSelector)->build($this->projection(
+            qualityState: 'normal',
+            profileShape: 'clear_code',
+            formCode: 'riasec_60',
+        ));
+
+        $this->assertSame('riasec.module_visibility_policy.v1', $policy['schema_version']);
+        $this->assertSame(RiasecReportModuleSelector::POLICY_ID, $policy['policy_id']);
+        $this->assertSame('visible', $this->moduleVisibility($policy, 'hero_activity_chain'));
+        $this->assertSame('visible', $this->moduleVisibility($policy, 'activity_explorer'));
+        $this->assertSame('collapsed', $this->moduleVisibility($policy, 'occupation_examples'));
+        $this->assertSame('visible', $this->moduleVisibility($policy, '140q_cta'));
+        $this->assertSame('hidden', $this->moduleVisibility($policy, '140q_context_cards'));
+        $this->assertFalse($policy['fallback_policy']['frontend_inference_allowed']);
+        $this->assertNoForbiddenClaims($policy);
+    }
+
+    public function test_low_quality_hides_strong_modules_and_140q_cta(): void
+    {
+        $policy = (new RiasecReportModuleSelector)->build($this->projection(
+            qualityState: 'low_quality',
+            profileShape: 'low_quality',
+            formCode: 'riasec_140',
+        ));
+
+        foreach (['hero_activity_chain', 'pair_blend', 'activity_explorer', 'occupation_examples', '140q_cta', '140q_context_cards'] as $module) {
+            $this->assertSame('hidden', $this->moduleVisibility($policy, $module));
+        }
+        $this->assertSame('visible', $this->moduleVisibility($policy, 'six_dimension_map'));
+        $this->assertSame('collapsed', $this->moduleVisibility($policy, 'share_card'));
+        $this->assertNoForbiddenClaims($policy);
+    }
+
+    public function test_near_tie_routes_to_candidate_chain_without_fixed_identity(): void
+    {
+        $policy = (new RiasecReportModuleSelector)->build($this->projection(
+            qualityState: 'normal',
+            profileShape: 'near_tie',
+            formCode: 'riasec_60',
+        ));
+
+        $this->assertSame('collapsed', $this->moduleVisibility($policy, 'hero_activity_chain'));
+        $this->assertSame('visible', $this->moduleVisibility($policy, 'pair_blend'));
+        $this->assertSame('near_tie_candidate_chains_first', $this->moduleReason($policy, 'hero_activity_chain'));
+        $this->assertNoForbiddenClaims($policy);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function projection(string $qualityState, string $profileShape, string $formCode): array
+    {
+        return [
+            'quality' => ['quality_state' => $qualityState],
+            'interpretation_state' => ['profile_shape' => $profileShape],
+            'form' => ['form_code' => $formCode],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     */
+    private function moduleVisibility(array $policy, string $key): string
+    {
+        return (string) ($this->module($policy, $key)['visibility'] ?? '');
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     */
+    private function moduleReason(array $policy, string $key): string
+    {
+        return (string) ($this->module($policy, $key)['reason'] ?? '');
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     * @return array<string,string>
+     */
+    private function module(array $policy, string $key): array
+    {
+        foreach ((array) ($policy['modules'] ?? []) as $module) {
+            if (is_array($module) && ($module['key'] ?? null) === $key) {
+                return $module;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertNoForbiddenClaims(array $payload): void
+    {
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        foreach (['Matches', 'career match', 'occupation match', 'job fit', 'fit score', 'success prediction', 'more accurate', '更准确', 'raw delta'] as $phrase) {
+            $this->assertStringNotContainsString($phrase, $json);
+        }
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T16:02:00+08:00",
+  "updated_at": "2026-05-13T16:25:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2728,7 +2728,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-03-projection-extension",
       "title": "feat(riasec): extend projection v2 with interpretation state",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "RIASEC-PERSONALIZATION-01",
         "RIASEC-PERSONALIZATION-02"
@@ -2741,8 +2741,8 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "569dd5e4f17f97f95fc052712485d2c25ab5009f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1347",
       "checks": {
         "riasec_flow_projection": {
           "status": "pass",
@@ -2764,29 +2764,52 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-13T08:16:00Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-04": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-04-module-selector",
       "title": "feat(riasec): add report module selector contract",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "RIASEC-PERSONALIZATION-03"
       ],
       "scope_type": "backend_module_selector_only",
       "allowed_paths": [
         "backend/app/**/Riasec*Module*",
+        "backend/app/**/RiasecPublicProjectionService*",
         "backend/app/**/RiasecReportComposer*",
         "backend/tests/**/Riasec*Module*",
+        "backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "module_selector": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+          "evidence": "8 tests passed, 255 assertions."
+        },
+        "freeze_classifier": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "evidence": "66 tests passed, 411 assertions."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecReportModuleSelector.php app/Services/Riasec/RiasecPublicProjectionService.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to RIASEC module selector, projection emission, RIASEC flow assertions, freeze classifier allowance, and docs/codex metadata."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1487,8 +1487,12 @@ prs:
       - Ensure low_quality hides strong modules and 140Q tension remains bounded.
     allowed_paths:
       - backend/app/**/Riasec*Module*
+      - backend/app/**/RiasecPublicProjectionService*
       - backend/app/**/RiasecReportComposer*
       - backend/tests/**/Riasec*Module*
+      - backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
       - Change frontend UI.


### PR DESCRIPTION
## What changed
- Added `RiasecReportModuleSelector` for deterministic `visible | collapsed | hidden` module policy.
- Added projection v2 `module_visibility_policy` emission for backend-authoritative frontend consumption.
- Covered normal 60Q, low_quality, and near_tie routing behavior in unit tests.
- Added RIASEC flow assertions and freeze-classifier allowance for the new selector.
- Reconciled PR03 as merged in the train state.

## Why
RIASEC personalization needs backend-owned module routing before frontend fail-closed rendering. This PR defines visibility metadata without adding final copy, changing scores, or creating career matching behavior.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecReportModuleSelector.php app/Services/Riasec/RiasecPublicProjectionService.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `ruby -e 'require "yaml"; require "json"; YAML.load_file("docs/codex/pr-train.yaml"); JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "ok"'`
- `git diff --check`

## Intentionally deferred
- Content registry readiness waits for RIASEC-PERSONALIZATION-05.
- Frontend fail-closed rendering waits for RIASEC-PERSONALIZATION-06.

## Repository rule impact
Backend projection/report module metadata only. No scoring math, content pack, public copy, career matching, or frontend fallback authority changes.
