### PR TITLE
RIASEC-PERSONALIZATION-05 — Content registry readiness contract

### DIFF
--- a/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
+++ b/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+final class RiasecContentRegistrySlotContract
+{
+    public const SCHEMA_VERSION = 'riasec.content_registry_slot_contract.v1';
+
+    /** @var list<string> */
+    private const SLOTS = [
+        'dimension_copy',
+        'pair_blend_copy',
+        'triad_blend_copy',
+        'shadow_cost_copy',
+        '140q_task_card_copy',
+        '140q_environment_card_copy',
+        '140q_role_card_copy',
+        'low_quality_copy',
+        'structural_difference_copy',
+        'aspiration_calibration_copy',
+        'feedback_response_copy',
+        'module_boundary_copy',
+    ];
+
+    /** @var list<string> */
+    private const FORBIDDEN_FIELDS = [
+        'career_match',
+        'occupation_match',
+        'job_fit',
+        'fit_score',
+        'success_prediction',
+        'ranking',
+        'recommended_career',
+        'source_url',
+        'soc_code',
+        'onet_code',
+    ];
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function schema(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'slot_status' => 'readiness_contract_only',
+            'runtime_public_copy_included' => false,
+            'missing_content_policy' => 'omit_module_fail_closed',
+            'unknown_slot_policy' => 'reject',
+            'frontend_fallback_allowed' => false,
+            'required_fields' => ['slot', 'version', 'locale', 'owner', 'evidence_level', 'status'],
+            'allowed_statuses' => ['draft', 'reviewed', 'approved', 'deprecated'],
+            'allowed_evidence_levels' => ['content_example', 'theory_based', 'expert_reviewed', 'validated'],
+            'slots' => array_map(
+                fn (string $slot): array => $this->slotDefinition($slot),
+                self::SLOTS
+            ),
+            'forbidden_fields' => self::FORBIDDEN_FIELDS,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $slot
+     * @return array{ok:bool,errors:list<string>}
+     */
+    public function validate(array $slot): array
+    {
+        $errors = [];
+        $slotName = trim((string) ($slot['slot'] ?? ''));
+        if (! in_array($slotName, self::SLOTS, true)) {
+            $errors[] = 'unsupported_slot';
+        }
+
+        foreach (['version', 'locale', 'owner', 'evidence_level', 'status'] as $required) {
+            if (trim((string) ($slot[$required] ?? '')) === '') {
+                $errors[] = 'missing_'.$required;
+            }
+        }
+
+        if (! in_array((string) ($slot['status'] ?? ''), ['draft', 'reviewed', 'approved', 'deprecated'], true)) {
+            $errors[] = 'unsupported_status';
+        }
+        if (! in_array((string) ($slot['evidence_level'] ?? ''), ['content_example', 'theory_based', 'expert_reviewed', 'validated'], true)) {
+            $errors[] = 'unsupported_evidence_level';
+        }
+
+        foreach (self::FORBIDDEN_FIELDS as $field) {
+            if (array_key_exists($field, $slot)) {
+                $errors[] = 'forbidden_field_'.$field;
+            }
+        }
+
+        return [
+            'ok' => $errors === [],
+            'errors' => array_values(array_unique($errors)),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function slotDefinition(string $slot): array
+    {
+        return [
+            'slot' => $slot,
+            'version_required' => true,
+            'locale_required' => true,
+            'owner_required' => true,
+            'evidence_level_required' => true,
+            'status_required' => true,
+            'missing_behavior' => 'omit_module',
+            'public_runtime_authority' => 'backend_or_cms_registry_only',
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -640,6 +640,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_content_registry_slot_contract_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_riasec_projection_v2_minimal_changes(): void
     {
         $changed = [
@@ -1260,6 +1269,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecContentRegistrySlotContractFile($file)) {
+                continue;
+            }
+
             if ($this->isRiasecProjectionV2MinimalFile($file)) {
                 continue;
             }
@@ -1440,6 +1453,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Riasec/RiasecReportModuleSelector.php',
             'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
         ], true);
+    }
+
+    private function isRiasecContentRegistrySlotContractFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php';
     }
 
     private function isRiasecProjectionV2MinimalFile(string $file): bool

--- a/backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Services\Riasec\RiasecContentRegistrySlotContract;
+use PHPUnit\Framework\TestCase;
+
+final class RiasecContentRegistrySlotContractTest extends TestCase
+{
+    public function test_schema_defines_readiness_slots_without_public_copy_runtime(): void
+    {
+        $schema = (new RiasecContentRegistrySlotContract)->schema();
+
+        $this->assertSame(RiasecContentRegistrySlotContract::SCHEMA_VERSION, $schema['schema_version']);
+        $this->assertSame('readiness_contract_only', $schema['slot_status']);
+        $this->assertFalse($schema['runtime_public_copy_included']);
+        $this->assertFalse($schema['frontend_fallback_allowed']);
+        $this->assertSame('omit_module_fail_closed', $schema['missing_content_policy']);
+        $this->assertContains('pair_blend_copy', array_column($schema['slots'], 'slot'));
+        $this->assertContains('low_quality_copy', array_column($schema['slots'], 'slot'));
+        $this->assertContains('140q_task_card_copy', array_column($schema['slots'], 'slot'));
+        $this->assertNoForbiddenClaims($schema);
+    }
+
+    public function test_validator_accepts_supported_slot_metadata(): void
+    {
+        $result = (new RiasecContentRegistrySlotContract)->validate([
+            'slot' => 'pair_blend_copy',
+            'version' => 'v0.1-draft',
+            'locale' => 'zh-CN',
+            'owner' => 'content',
+            'evidence_level' => 'theory_based',
+            'status' => 'draft',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['errors']);
+    }
+
+    public function test_validator_rejects_unknown_slots_and_forbidden_claim_fields(): void
+    {
+        $result = (new RiasecContentRegistrySlotContract)->validate([
+            'slot' => 'career_recommendation_copy',
+            'version' => 'v0.1-draft',
+            'locale' => 'zh-CN',
+            'owner' => 'content',
+            'evidence_level' => 'content_example',
+            'status' => 'draft',
+            'career_match' => true,
+            'source_url' => 'https://example.test/fake-source',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertContains('unsupported_slot', $result['errors']);
+        $this->assertContains('forbidden_field_career_match', $result['errors']);
+        $this->assertContains('forbidden_field_source_url', $result['errors']);
+    }
+
+    public function test_validator_fails_closed_when_required_metadata_is_missing(): void
+    {
+        $result = (new RiasecContentRegistrySlotContract)->validate([
+            'slot' => 'low_quality_copy',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertContains('missing_version', $result['errors']);
+        $this->assertContains('missing_locale', $result['errors']);
+        $this->assertContains('missing_owner', $result['errors']);
+        $this->assertContains('missing_evidence_level', $result['errors']);
+        $this->assertContains('missing_status', $result['errors']);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertNoForbiddenClaims(array $payload): void
+    {
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        foreach (['Matches', 'job fit', 'fit score', 'success prediction', 'more accurate', '更准确', 'raw delta'] as $phrase) {
+            $this->assertStringNotContainsString($phrase, $json);
+        }
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T16:25:00+08:00",
+  "updated_at": "2026-05-13T16:43:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2773,7 +2773,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-04-module-selector",
       "title": "feat(riasec): add report module selector contract",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "RIASEC-PERSONALIZATION-03"
       ],
@@ -2788,8 +2788,8 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "337da6de12610b90948390ddfb6a3ea67c11130b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1348",
       "checks": {
         "module_selector": {
           "status": "pass",
@@ -2811,16 +2811,16 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-13T08:33:00Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-05": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-05-content-registry-readiness",
       "title": "feat(riasec): add content registry readiness contract",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "RIASEC-PERSONALIZATION-04"
       ],
@@ -2828,12 +2828,33 @@
       "allowed_paths": [
         "backend/app/**/Riasec*Content*",
         "backend/tests/**/Riasec*Content*",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
         "backend/docs/riasec/**",
+        "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "content_registry_contract": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php",
+          "evidence": "4 tests passed, 27 assertions."
+        },
+        "freeze_classifier": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "evidence": "67 tests passed, 412 assertions."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to RIASEC content registry slot contract, its tests, freeze classifier allowance, and docs/codex metadata."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1519,7 +1519,9 @@ prs:
     allowed_paths:
       - backend/app/**/Riasec*Content*
       - backend/tests/**/Riasec*Content*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
       - Add frontend local fallback copy.


### PR DESCRIPTION
## What changed
- Added `RiasecContentRegistrySlotContract` defining readiness slots for future RIASEC deep-copy content.
- Added validation for required metadata, allowed statuses/evidence levels, unsupported slots, and forbidden career/source fields.
- Kept runtime public copy out of scope and encoded missing-content fail-closed behavior.
- Added freeze-classifier allowance for the new RIASEC-owned contract.
- Reconciled PR04 as merged in the train state.

## Why
The frontend must not invent pair blend, low-quality, 140Q, aspiration, or feedback copy. This PR defines backend/CMS registry slots and validation boundaries before any final copy is imported or rendered.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `ruby -e 'require "yaml"; require "json"; YAML.load_file("docs/codex/pr-train.yaml"); JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "ok"'`
- `git diff --check`

## Intentionally deferred
- No final public editorial copy.
- No CMS migration or import.
- Frontend fail-closed consumption waits for RIASEC-PERSONALIZATION-06.

## Repository rule impact
Backend content-readiness contract only. No runtime page-rendering authority moved to frontend, no CMS migration, no scoring math, and no career matching/source claims.
