### PR TITLE
fix(api): republish article baseline and complete public projection

### DIFF
--- a/backend/app/Console/Commands/ArticleImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ArticleImportLocalBaseline.php
@@ -83,6 +83,21 @@ final class ArticleImportLocalBaseline extends Command
             $this->line('will_skip='.(string) $summary['will_skip']);
             $this->line('errors_count='.(string) $summary['errors_count']);
 
+            if ((bool) $this->option('dry-run')) {
+                foreach (($summary['planned_actions'] ?? []) as $plannedAction) {
+                    if (! is_array($plannedAction)) {
+                        continue;
+                    }
+
+                    $this->line(sprintf(
+                        'article_action=%s:%s:%s',
+                        (string) ($plannedAction['locale'] ?? ''),
+                        (string) ($plannedAction['slug'] ?? ''),
+                        (string) ($plannedAction['action'] ?? 'unknown'),
+                    ));
+                }
+            }
+
             $this->info((bool) $this->option('dry-run') ? 'dry-run complete' : 'import complete');
 
             return self::SUCCESS;
@@ -333,7 +348,7 @@ final class ArticleImportLocalBaseline extends Command
     /**
      * @param  array<int, array<string, mixed>>  $rows
      * @param  array{dry_run: bool, upsert: bool, status: string}  $options
-     * @return array<string, int>
+     * @return array<string, mixed>
      */
     private function importRows(
         array $rows,
@@ -353,6 +368,7 @@ final class ArticleImportLocalBaseline extends Command
             'will_update' => 0,
             'will_skip' => 0,
             'errors_count' => 0,
+            'planned_actions' => [],
         ];
 
         $planned = [];
@@ -386,6 +402,15 @@ final class ArticleImportLocalBaseline extends Command
         }
 
         if ($dryRun) {
+            $summary['planned_actions'] = collect($planned)
+                ->map(static fn (array $operation): array => [
+                    'locale' => (string) (($operation['row']['locale'] ?? '') ?: ''),
+                    'slug' => (string) (($operation['row']['slug'] ?? '') ?: ''),
+                    'action' => (string) ($operation['action'] ?? 'unknown'),
+                ])
+                ->values()
+                ->all();
+
             return $summary;
         }
 
@@ -444,7 +469,10 @@ final class ArticleImportLocalBaseline extends Command
             );
 
             if ((string) $desired['status'] === 'published') {
-                if ((string) $article->status !== 'published' || ! (bool) $article->is_public) {
+                $mustRepublishRevision = in_array((string) $operation['action'], ['create', 'update'], true)
+                    || (int) ($article->published_revision_id ?? 0) !== (int) ($article->working_revision_id ?? 0);
+
+                if ($mustRepublishRevision || (string) $article->status !== 'published' || ! (bool) $article->is_public) {
                     $article = $articlePublishService->publishArticle((int) $article->id);
                 }
 
@@ -569,11 +597,55 @@ final class ArticleImportLocalBaseline extends Command
         if ((bool) $article->is_public !== (bool) $desired['is_public']) {
             return false;
         }
+        if ((string) $desired['status'] === 'published' && ! $this->publishedRevisionMatchesDesired($article, $desired)) {
+            return false;
+        }
 
         $desiredPublishedAt = is_string($desired['published_at']) ? $desired['published_at'] : null;
         $currentPublishedAt = $article->published_at?->copy()->utc()->toISOString();
 
         return $desiredPublishedAt === $currentPublishedAt;
+    }
+
+    /**
+     * @param  array<string, mixed>  $desired
+     */
+    private function publishedRevisionMatchesDesired(Article $article, array $desired): bool
+    {
+        $article->loadMissing('publishedRevision');
+
+        if (! $article->publishedRevision instanceof ArticleTranslationRevision) {
+            return false;
+        }
+
+        $revision = $article->publishedRevision;
+        if ((int) $revision->article_id !== (int) $article->id) {
+            return false;
+        }
+        if ((int) $revision->org_id !== (int) $article->org_id) {
+            return false;
+        }
+        if ((string) $revision->locale !== (string) $desired['locale']) {
+            return false;
+        }
+        if ((string) $revision->revision_status !== ArticleTranslationRevision::STATUS_PUBLISHED) {
+            return false;
+        }
+        if ((string) $revision->title !== (string) $desired['title']) {
+            return false;
+        }
+        if ((string) ($revision->excerpt ?? '') !== (string) $desired['excerpt']) {
+            return false;
+        }
+        if ((string) $revision->content_md !== (string) $desired['content_md']) {
+            return false;
+        }
+        if ($this->normalizeNullableString($revision->seo_title) !== $this->normalizeNullableString($desired['seo_title'] ?? null)) {
+            return false;
+        }
+
+        return $this->normalizeNullableString($revision->seo_description)
+            === $this->normalizeNullableString($desired['seo_description'] ?? null);
     }
 
     private function findExistingArticle(string $slug, string $locale): ?Article
@@ -620,7 +692,16 @@ final class ArticleImportLocalBaseline extends Command
                 ],
             );
 
-        $article = $article->fresh(['seoMeta']) ?? $article;
+        $article = $article->fresh(['seoMeta', 'publishedRevision', 'workingRevision']) ?? $article;
+        if (
+            $article->published_revision_id !== null
+            && $article->working_revision_id !== null
+            && (int) $article->published_revision_id === (int) $article->working_revision_id
+        ) {
+            $article->forceFill(['working_revision_id' => null])->save();
+            $article->unsetRelation('workingRevision');
+        }
+
         $revision = $translationRevisionWorkspace->resolveWorkingRevision($article);
         $revisionHash = $translationRevisionWorkspace->hashForRevision($article, [
             'title' => (string) $desired['title'],

--- a/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
@@ -6,8 +6,14 @@ namespace App\Http\Controllers\API\V0_5\Cms;
 
 use App\Http\Controllers\Controller;
 use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
 use App\Models\LandingSurface;
 use App\Models\PageBlock;
+use App\Services\Cms\ArticleSeoService;
+use App\Support\CanonicalFrontendUrl;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -17,6 +23,10 @@ use Illuminate\Validation\Rule;
 
 final class LandingSurfaceController extends Controller
 {
+    public function __construct(
+        private readonly ArticleSeoService $articleSeoService,
+    ) {}
+
     public function show(Request $request, string $surfaceKey): JsonResponse
     {
         $validated = $this->validateReadQuery($request);
@@ -208,7 +218,7 @@ final class LandingSurfaceController extends Controller
     }
 
     /**
-     * @return array<string, array{published_revision_id: int, published_revision: array{id: int}}>
+     * @return array<string, array<string, mixed>>
      */
     private function recommendedArticlePayloadMap(PageBlock $block, string $locale, int $orgId): array
     {
@@ -236,22 +246,130 @@ final class LandingSurfaceController extends Controller
         /** @var Collection<int, Article> $articles */
         $articles = Article::query()
             ->withoutGlobalScopes()
+            ->with([
+                'category' => fn ($query) => $query->withoutGlobalScopes(),
+                'tags' => fn ($query) => $query->withoutGlobalScopes(),
+                'seoMeta',
+                'publishedRevision',
+            ])
             ->where('org_id', $orgId)
             ->where('locale', $locale)
             ->whereIn('slug', $slugs)
+            ->where('is_indexable', true)
             ->publiclyReadable()
-            ->get(['slug', 'published_revision_id']);
+            ->get();
 
         return $articles
-            ->filter(fn (Article $article): bool => $article->published_revision_id !== null)
+            ->filter(fn (Article $article): bool => $article->publishedRevision instanceof ArticleTranslationRevision)
             ->mapWithKeys(fn (Article $article): array => [
-                (string) $article->slug => [
-                    'published_revision_id' => (int) $article->published_revision_id,
-                    'published_revision' => [
-                        'id' => (int) $article->published_revision_id,
-                    ],
-                ],
+                (string) $article->slug => $this->recommendedArticleProjection($article),
             ])
+            ->all();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendedArticleProjection(Article $article): array
+    {
+        $revision = $article->publishedRevision;
+        if (! $revision instanceof ArticleTranslationRevision) {
+            return [];
+        }
+
+        $seoMeta = PublicMediaUrlGuard::sanitizeArrayFields(
+            $article->seoMeta?->toArray(),
+            ['og_image_url', 'twitter_image_url']
+        );
+        if (is_array($seoMeta)) {
+            $seoMeta['seo_title'] = $revision->seo_title;
+            $seoMeta['seo_description'] = $revision->seo_description;
+            $seoMeta['canonical_url'] = CanonicalFrontendUrl::normalizeAbsoluteUrl(
+                $seoMeta['canonical_url'] ?? null
+            );
+            if (array_key_exists('schema_json', $seoMeta)) {
+                $seoMeta['schema_json'] = CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json']);
+            }
+        }
+
+        return [
+            'id' => (int) $article->id,
+            'org_id' => (int) $article->org_id,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'title' => (string) $revision->title,
+            'excerpt' => $revision->excerpt,
+            'cover_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($article->cover_image_url),
+            'cover_image_alt' => $article->cover_image_alt,
+            'cover_image_width' => $article->cover_image_width !== null ? (int) $article->cover_image_width : null,
+            'cover_image_height' => $article->cover_image_height !== null ? (int) $article->cover_image_height : null,
+            'cover_image_variants' => PublicMediaUrlGuard::sanitizeArrayFields(
+                $article->cover_image_variants,
+                ['url']
+            ),
+            'category' => $this->recommendedArticleCategory($article),
+            'tags' => $this->recommendedArticleTags($article),
+            'author_name' => $article->author_name,
+            'reading_minutes' => $article->reading_minutes !== null ? (int) $article->reading_minutes : null,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'published_at' => $article->published_at?->toISOString(),
+            'created_at' => $article->created_at?->toISOString(),
+            'updated_at' => $revision->updated_at?->toISOString() ?? $article->updated_at?->toISOString(),
+            'published_revision_id' => (int) $revision->id,
+            'published_revision' => [
+                'id' => (int) $revision->id,
+            ],
+            'canonical_url' => $this->articleSeoService->buildCanonicalUrl(
+                (string) $article->slug,
+                (string) $article->locale
+            ),
+            'seo_title' => $revision->seo_title,
+            'meta_description' => $revision->seo_description,
+            'seo_meta' => $seoMeta,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function recommendedArticleCategory(Article $article): ?array
+    {
+        if (! $article->relationLoaded('category')) {
+            return null;
+        }
+
+        $category = $article->category;
+        if (! $category instanceof ArticleCategory || (int) $category->org_id !== (int) $article->org_id) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $category->id,
+            'slug' => (string) $category->slug,
+            'name' => (string) $category->name,
+            'title' => (string) $category->name,
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function recommendedArticleTags(Article $article): array
+    {
+        if (! $article->relationLoaded('tags')) {
+            return [];
+        }
+
+        return $article->tags
+            ->filter(static fn (ArticleTag $tag): bool => (int) $tag->org_id === (int) $article->org_id)
+            ->map(static fn (ArticleTag $tag): array => [
+                'id' => (int) $tag->id,
+                'slug' => (string) $tag->slug,
+                'name' => (string) $tag->name,
+            ])
+            ->values()
             ->all();
     }
 
@@ -283,24 +401,24 @@ final class LandingSurfaceController extends Controller
 
     /**
      * @param  array<string, mixed>  $payload
-     * @param  array<string, array{published_revision_id: int, published_revision: array{id: int}}>  $articleMap
+     * @param  array<string, array<string, mixed>>  $articleMap
      * @return array<string, mixed>
      */
     private function enrichRecommendedArticlesPayload(array $payload, array $articleMap): array
     {
         $items = $payload['items'] ?? null;
-        if (! is_array($items) || $items === [] || $articleMap === []) {
+        if (! is_array($items) || $items === []) {
             return $payload;
         }
 
-        $payload['items'] = array_map(function (mixed $item) use ($articleMap): mixed {
+        $payload['items'] = array_values(array_filter(array_map(function (mixed $item) use ($articleMap): mixed {
             if (! is_array($item)) {
-                return $item;
+                return null;
             }
 
             $slug = $this->recommendedArticleSlug($item);
             if ($slug === null || ! array_key_exists($slug, $articleMap)) {
-                return $item;
+                return null;
             }
 
             $articlePatch = $articleMap[$slug];
@@ -308,7 +426,7 @@ final class LandingSurfaceController extends Controller
             $item['article'] = array_merge($article, $articlePatch);
 
             return $item;
-        }, $items);
+        }, $items), static fn (mixed $item): bool => $item !== null));
 
         return $payload;
     }

--- a/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+++ b/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Tests\Feature\CareerCms;
 
 use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
 use App\Services\Cms\ArticleSeoService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 final class ArticleBaselineImportTest extends TestCase
@@ -123,6 +126,147 @@ final class ArticleBaselineImportTest extends TestCase
         $this->assertSame(45, Article::query()->withoutGlobalScopes()->count());
     }
 
+    public function test_upsert_republishes_existing_published_article_revision_from_baseline(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $slug = 'which-love-script-fits-you-best';
+        $baseline = $this->baselineArticle($slug);
+        $oldPublishedAt = Carbon::create(2026, 4, 18, 0, 0, 0, 'UTC');
+
+        /** @var Article $article */
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_name' => 'Fermat Institute',
+            'reviewer_name' => null,
+            'reading_minutes' => 10,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => (string) $baseline['title'],
+            'excerpt' => '很多人以为自己在找“合适的人”，其实更常见的情况是：你还没搞清楚，自己到底在寻求哪一种关系结构。',
+            'content_md' => "# 旧稿标题\n\n## 读完这篇文章，你会带走什么\n\n旧 published revision 正文。",
+            'content_html' => null,
+            'cover_image_url' => null,
+            'cover_image_alt' => null,
+            'cover_image_width' => null,
+            'cover_image_height' => null,
+            'cover_image_variants' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => $oldPublishedAt,
+        ]);
+
+        /** @var ArticleTranslationRevision $oldRevision */
+        $oldRevision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => '旧 SEO 标题',
+            'seo_description' => '旧 SEO 描述。',
+            'published_at' => $oldPublishedAt,
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $oldRevision->id,
+            'published_revision_id' => (int) $oldRevision->id,
+        ])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => '旧 SEO 标题',
+            'seo_description' => '旧 SEO 描述。',
+            'canonical_url' => 'https://fermatmind.com/zh/articles/'.$slug,
+            'og_title' => '旧 SEO 标题',
+            'og_description' => '旧 SEO 描述。',
+            'og_image_url' => null,
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        $this->artisan('articles:import-local-baseline', [
+            '--dry-run' => true,
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+            '--locale' => 'zh-CN',
+            '--article' => [$slug],
+        ])
+            ->expectsOutputToContain('articles_found=1')
+            ->expectsOutputToContain('will_update=1')
+            ->expectsOutputToContain('article_action=zh-CN:'.$slug.':update')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            (int) $oldRevision->id,
+            (int) Article::query()->withoutGlobalScopes()->whereKey($article->id)->value('published_revision_id')
+        );
+
+        $this->artisan('articles:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+            '--locale' => 'zh-CN',
+            '--article' => [$slug],
+        ])
+            ->expectsOutputToContain('articles_found=1')
+            ->expectsOutputToContain('will_update=1')
+            ->assertExitCode(0);
+
+        $updated = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['publishedRevision', 'seoMeta', 'category', 'tags'])
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', $slug)
+            ->firstOrFail();
+
+        $this->assertNotSame((int) $oldRevision->id, (int) $updated->published_revision_id);
+        $this->assertSame((string) $baseline['content_md'], (string) $updated->publishedRevision?->content_md);
+        $this->assertSame((string) $baseline['excerpt'], (string) $updated->publishedRevision?->excerpt);
+        $this->assertSame((string) $baseline['seo_title'], (string) $updated->publishedRevision?->seo_title);
+        $this->assertSame((string) $baseline['seo_description'], (string) $updated->publishedRevision?->seo_description);
+        $this->assertSame((string) $baseline['cover_image_url'], (string) $updated->cover_image_url);
+        $this->assertSame((string) $baseline['cover_image_alt'], (string) $updated->cover_image_alt);
+        $this->assertSame((string) $baseline['category'], (string) $updated->category?->name);
+        $expectedTags = $baseline['tags'];
+        $actualTags = $updated->tags->pluck('name')->values()->all();
+        sort($expectedTags);
+        sort($actualTags);
+        $this->assertSame($expectedTags, $actualTags);
+        $this->assertSame((string) $baseline['seo_title'], (string) $updated->seoMeta?->seo_title);
+        $this->assertSame((string) $baseline['cover_image_url'], (string) $updated->seoMeta?->og_image_url);
+
+        $this->getJson('/api/v0.5/articles/'.$slug.'?locale=zh-CN&org_id=0')
+            ->assertOk()
+            ->assertJsonPath('article.content_md', (string) $baseline['content_md'])
+            ->assertJsonPath('article.excerpt', (string) $baseline['excerpt'])
+            ->assertJsonPath('article.cover_image_url', (string) $baseline['cover_image_url'])
+            ->assertJsonPath('article.cover_image_alt', (string) $baseline['cover_image_alt'])
+            ->assertJsonPath('article.category.name', (string) $baseline['category'])
+            ->assertJsonPath('article.seo_meta.seo_title', (string) $baseline['seo_title']);
+
+        $this->getJson('/api/v0.5/articles/'.$slug.'/seo?locale=zh-CN&org_id=0')
+            ->assertOk()
+            ->assertJsonPath('meta.title', (string) $baseline['seo_title'])
+            ->assertJsonPath('meta.description', (string) $baseline['seo_description'])
+            ->assertJsonPath('jsonld.image', (string) $baseline['cover_image_url'])
+            ->assertJsonPath('jsonld.url', 'https://fermatmind.com/zh/articles/'.$slug);
+    }
+
     private function assertSixEditorialArticlesConvergeThroughSeoAuthority(): void
     {
         config(['app.frontend_url' => 'https://fermatmind.com']);
@@ -209,5 +353,23 @@ final class ArticleBaselineImportTest extends TestCase
             $this->assertSame($contract['seo_description'], data_get($jsonLd, 'description'));
             $this->assertSame($cover, data_get($jsonLd, 'image'));
         }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function baselineArticle(string $slug): array
+    {
+        $path = base_path('../content_baselines/articles/articles.zh-CN.json');
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        foreach ((array) ($payload['articles'] ?? []) as $article) {
+            if (is_array($article) && (string) ($article['slug'] ?? '') === $slug) {
+                return $article;
+            }
+        }
+
+        $this->fail('Baseline article not found: '.$slug);
     }
 }

--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -6,6 +6,9 @@ namespace Tests\Feature\LandingSurfaces;
 
 use App\Models\AdminUser;
 use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTag;
 use App\Models\ArticleTranslationRevision;
 use App\Models\LandingSurface;
 use App\Models\PageBlock;
@@ -351,6 +354,8 @@ final class LandingSurfacePublicApiTest extends TestCase
 
     public function test_public_api_enriches_recommended_articles_with_published_revision_pointer(): void
     {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
         $surface = LandingSurface::query()->withoutGlobalScopes()->create([
             'org_id' => 0,
             'surface_key' => 'home',
@@ -406,7 +411,15 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath(
                 'surface.page_blocks.0.payload_json.items.0.article.published_revision.id',
                 (int) $article->published_revision_id
-            );
+            )
+            ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.title', '推荐文章 published')
+            ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.cover_image_url', 'https://api.fermatmind.com/static/articles/covers/recommended-article.svg')
+            ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.cover_image_alt', '推荐文章封面')
+            ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.category.name', '推荐分类')
+            ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.tags.0.name', '推荐标签')
+            ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.status', 'published')
+            ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.is_indexable', true)
+            ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.canonical_url', 'https://fermatmind.com/zh/articles/recommended-article');
     }
 
     public function test_public_api_skips_malformed_recommended_article_slugs_without_crashing(): void
@@ -454,12 +467,100 @@ final class LandingSurfacePublicApiTest extends TestCase
         $response->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath(
-                'surface.page_blocks.0.payload_json.items.2.article.published_revision_id',
+                'surface.page_blocks.0.payload_json.items.0.article.published_revision_id',
                 (int) $article->published_revision_id
             );
 
-        $this->assertNull($response->json('surface.page_blocks.0.payload_json.items.0.article.published_revision_id'));
-        $this->assertNull($response->json('surface.page_blocks.0.payload_json.items.1.article.published_revision_id'));
+        $this->assertCount(1, $response->json('surface.page_blocks.0.payload_json.items'));
+    }
+
+    public function test_home_recommended_articles_are_enriched_from_article_authority_baseline(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $this->artisan('articles:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+            '--locale' => 'zh-CN',
+            '--article' => [
+                'how-personality-shapes-attitude-toward-ai',
+                'which-love-script-fits-you-best',
+                'are-infj-men-rare-or-socially-silenced',
+                'best-valentines-date-by-personality-and-relationship-science',
+                'how-16-personality-types-talk-to-an-ai-coach',
+                'childhood-dream-job-still-shapes-career-choice',
+            ],
+        ])->assertExitCode(0);
+
+        $this->artisan('landing-surfaces:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/landing_surfaces',
+        ])->assertExitCode(0);
+
+        $response = $this->getJson('/api/v0.5/landing-surfaces/home?locale=zh-CN&org_id=0');
+        $response->assertOk()
+            ->assertJsonPath('ok', true);
+
+        $recommendedBlock = collect($response->json('surface.page_blocks') ?? [])
+            ->firstWhere('block_key', 'recommended_articles');
+        $this->assertIsArray($recommendedBlock);
+
+        $items = data_get($recommendedBlock, 'payload_json.items');
+        $this->assertIsArray($items);
+        $this->assertCount(6, $items);
+
+        $slugs = array_map(static fn (array $item): string => (string) data_get($item, 'article.slug'), $items);
+        $this->assertSame(
+            [
+                'which-love-script-fits-you-best',
+                'how-personality-shapes-attitude-toward-ai',
+                'how-16-personality-types-talk-to-an-ai-coach',
+                'childhood-dream-job-still-shapes-career-choice',
+                'best-valentines-date-by-personality-and-relationship-science',
+                'are-infj-men-rare-or-socially-silenced',
+            ],
+            $slugs
+        );
+
+        foreach ($items as $item) {
+            $article = data_get($item, 'article');
+            $this->assertIsArray($article);
+            $this->assertSame('published', (string) data_get($article, 'status'));
+            $this->assertTrue((bool) data_get($article, 'is_public'));
+            $this->assertTrue((bool) data_get($article, 'is_indexable'));
+            $this->assertNotEmpty(data_get($article, 'published_revision_id'));
+            $this->assertNotEmpty(data_get($article, 'title'));
+            $this->assertNotEmpty(data_get($article, 'excerpt'));
+            $this->assertNotEmpty(data_get($article, 'cover_image_url'));
+            $this->assertNotEmpty(data_get($article, 'cover_image_alt'));
+            $this->assertNotEmpty(data_get($article, 'cover_image_width'));
+            $this->assertNotEmpty(data_get($article, 'cover_image_height'));
+            $this->assertNotEmpty(data_get($article, 'cover_image_variants.hero'));
+            $this->assertNotEmpty(data_get($article, 'category.name'));
+            $this->assertNotEmpty(data_get($article, 'tags.0.name'));
+            $this->assertStringStartsWith('https://fermatmind.com/zh/articles/', (string) data_get($article, 'canonical_url'));
+        }
+
+        $noindex = Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', 'which-love-script-fits-you-best')
+            ->firstOrFail();
+        $noindex->forceFill(['is_indexable' => false])->save();
+
+        $afterNoindex = $this->getJson('/api/v0.5/landing-surfaces/home?locale=zh-CN&org_id=0');
+        $afterNoindex->assertOk();
+        $afterNoindexRecommendedBlock = collect($afterNoindex->json('surface.page_blocks') ?? [])
+            ->firstWhere('block_key', 'recommended_articles');
+        $this->assertIsArray($afterNoindexRecommendedBlock);
+        $filteredSlugs = array_map(
+            static fn (array $item): string => (string) data_get($item, 'article.slug'),
+            data_get($afterNoindexRecommendedBlock, 'payload_json.items') ?? []
+        );
+        $this->assertNotContains('which-love-script-fits-you-best', $filteredSlugs);
     }
 
     /**
@@ -472,17 +573,36 @@ final class LandingSurfacePublicApiTest extends TestCase
         bool $withPublishedRevision = true
     ): Article {
         /** @var Article $article */
+        $category = ArticleCategory::query()->firstOrCreate([
+            'org_id' => 0,
+            'slug' => 'recommended-category',
+        ], [
+            'name' => '推荐分类',
+            'description' => null,
+            'sort_order' => 0,
+            'is_active' => true,
+        ]);
+
         $article = Article::query()->create(array_merge([
             'org_id' => 0,
-            'category_id' => null,
+            'category_id' => (int) $category->id,
             'author_admin_user_id' => null,
+            'author_name' => 'Fermat Institute',
             'slug' => 'article-slug',
             'locale' => 'en',
             'title' => 'Article Title',
             'excerpt' => 'Article excerpt.',
             'content_md' => '# Article body',
             'content_html' => null,
-            'cover_image_url' => null,
+            'cover_image_url' => 'https://api.fermatmind.com/static/articles/covers/recommended-article.svg',
+            'cover_image_alt' => '推荐文章封面',
+            'cover_image_width' => 1200,
+            'cover_image_height' => 675,
+            'cover_image_variants' => [
+                'hero' => ['url' => 'https://api.fermatmind.com/static/articles/covers/recommended-article.svg', 'width' => 1200, 'height' => 675],
+                'card' => ['url' => 'https://api.fermatmind.com/static/articles/covers/recommended-article.svg', 'width' => 1200, 'height' => 675],
+                'og' => ['url' => 'https://api.fermatmind.com/static/articles/covers/recommended-article.svg', 'width' => 1200, 'height' => 675],
+            ],
             'status' => 'published',
             'is_public' => true,
             'is_indexable' => true,
@@ -497,7 +617,33 @@ final class LandingSurfacePublicApiTest extends TestCase
             $article->forceFill(['published_revision_id' => $revision->id])->save();
         }
 
-        return $article->fresh(['publishedRevision']) ?? $article;
+        $tag = ArticleTag::query()->firstOrCreate([
+            'org_id' => 0,
+            'slug' => 'recommended-tag',
+        ], [
+            'name' => '推荐标签',
+            'is_active' => true,
+        ]);
+        $article->tags()->syncWithoutDetaching([
+            (int) $tag->id => ['org_id' => 0],
+        ]);
+
+        ArticleSeoMeta::query()->updateOrCreate([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+        ], [
+            'seo_title' => (string) ($revisionOverrides['seo_title'] ?? $article->title),
+            'seo_description' => (string) ($revisionOverrides['seo_description'] ?? $article->excerpt),
+            'canonical_url' => 'https://fermatmind.com/'.((string) $article->locale === 'zh-CN' ? 'zh' : (string) $article->locale).'/articles/'.(string) $article->slug,
+            'og_title' => (string) ($revisionOverrides['seo_title'] ?? $article->title),
+            'og_description' => (string) ($revisionOverrides['seo_description'] ?? $article->excerpt),
+            'og_image_url' => (string) $article->cover_image_url,
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh(['category', 'tags', 'seoMeta', 'publishedRevision']) ?? $article;
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -469,6 +469,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_baseline_projection_convergence_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleImportLocalBaseline.php',
+            'backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_privacy_logs_dsar_key_rotation_changes(): void
     {
         $changed = [
@@ -1390,6 +1400,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ArticleImportLocalBaseline.php',
+            'backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php',
             'backend/app/Services/Career/StructuredData/CareerArticleStructuredDataBuilder.php',
             'backend/app/Services/Cms/ArticleSeoService.php',
         ], true);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2942,7 +2942,7 @@
         },
         "scope_validation": {
           "status": "pass",
-          "evidence": "Changed files are confined to Article baseline importer, landing surface recommended article projection, focused backend tests, and PR train metadata."
+          "evidence": "Changed files are confined to Article baseline importer, landing surface recommended article projection, focused backend tests, test-only Big Five freeze classifier governance, and PR train metadata."
         },
         "article_baseline_import": {
           "status": "pass",
@@ -2971,8 +2971,13 @@
         },
         "pint_scoped": {
           "status": "pass",
-          "command": "vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php",
-          "evidence": "Scoped Pint check passed for 4 files."
+          "command": "vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "evidence": "Scoped Pint check passed for 5 files."
+        },
+        "bigfive_freeze_classifier": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|article_baseline_projection_convergence' --no-ansi",
+          "evidence": "2 tests passed, 4 assertions. Added test-only classifier allowance for PR-RT-04 LandingSurfaceController article projection convergence scope."
         },
         "diff_check": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T17:32:00+08:00",
+  "updated_at": "2026-05-13T17:37:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2924,13 +2924,13 @@
       "branch": "codex/pr-rt-04-article-baseline-republish",
       "title": "fix(api): republish article baseline and complete public projection",
       "name": "Article Baseline Republish and Public Projection Convergence",
-      "status": "in_progress",
+      "status": "open",
       "depends_on": [
         "PR-RT-03"
       ],
       "scope_type": "article_baseline_republish_projection_convergence_only",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "deaa13aaec5114ba84486602db2378fd4de8a0a2",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1350",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -2982,6 +2982,10 @@
           "status": "pass",
           "command": "pnpm test:contract -- article-publishing-runtime-truth.contract.test.ts homepage-recommended-articles-block.contract.test.ts; pnpm typecheck; NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build; pnpm seo:check-sitemap",
           "evidence": "Contract suite passed across 340 files / 1912 tests, typecheck passed, production build passed, and sitemap indexability check passed for 206 URLs. Generated sitemap artifact was restored; fap-web worktree clean."
+        },
+        "github_pr": {
+          "status": "open",
+          "evidence": "Opened PR #1350 for PR-RT-04 on branch codex/pr-rt-04-article-baseline-republish."
         }
       },
       "failure_reason": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T16:43:00+08:00",
+  "updated_at": "2026-05-13T17:32:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2256,12 +2256,12 @@
       "branch": "codex/pr-rt-03-article-graph-authority",
       "title": "feat(api): close six-article graph recommendation authority",
       "name": "6 Articles Site Graph and Recommendation Authority Closure",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "PR-RT-02"
       ],
       "scope_type": "article_graph_authority_closure_only",
-      "commit_sha": "119c97ec2ed13f8a22186ab6adecdc6e0ed1f9c8",
+      "commit_sha": "f276bcfe68da52bd804e912cf049bf581c0a4de0",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1338",
       "checks": {
         "authorization": {
@@ -2314,18 +2314,23 @@
         "diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "reconciliation": {
+          "status": "pass",
+          "evidence": "GitHub PR #1338 is MERGED with merge commit 44621613e5255a76631138d641da218e2993e343; origin/main contains the merge commit; local and remote task branches are absent."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-13T03:02:49Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "deferred_decisions": [
         "Article detail related articles remain deferred because the current fap-web Article detail related arrays are empty and no backend Article-to-Article authority exists in this PR scope.",
         "Personality type related articles remain deferred because no stable Personality related article authority was identified for INFJ-A/INFJ-T pages.",
         "Test detail related articles remain deferred because the existing related_test_slug contract is a fixed three-article test page slot and changing it would widen PR-RT-03 scope."
       ],
-      "sidecar_issues": []
+      "sidecar_issues": [],
+      "merge_sha": "44621613e5255a76631138d641da218e2993e343"
     },
     "CMD-FIX-1": {
       "repo": "fap-api",
@@ -2913,6 +2918,78 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "PR-RT-04": {
+      "repo": "fap-api",
+      "branch": "codex/pr-rt-04-article-baseline-republish",
+      "title": "fix(api): republish article baseline and complete public projection",
+      "name": "Article Baseline Republish and Public Projection Convergence",
+      "status": "in_progress",
+      "depends_on": [
+        "PR-RT-03"
+      ],
+      "scope_type": "article_baseline_republish_projection_convergence_only",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided explicit PR-RT-04 execute instruction and scope, authorizing manifest/state registration before implementation."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR-RT-03 is merged as PR #1338 with merge commit 44621613e5255a76631138d641da218e2993e343 and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Article baseline importer, landing surface recommended article projection, focused backend tests, and PR train metadata."
+        },
+        "article_baseline_import": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi",
+          "evidence": "3 tests passed, 225 assertions; covers dry-run, fresh import, and old production published revision republish."
+        },
+        "article_runtime_truth": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/V0_5/ArticlePublishingRuntimeTruthTest.php --no-ansi",
+          "evidence": "2 tests passed, 250 assertions."
+        },
+        "landing_surface_projection": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php --no-ansi",
+          "evidence": "6 tests passed, 223 assertions; includes complete recommended article projection and noindex filtering."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Command completed successfully; no route changes were introduced."
+        },
+        "sqlite_migrate_pretend": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+          "evidence": "Command completed successfully; PR-RT-04 adds no migrations."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php",
+          "evidence": "Scoped Pint check passed for 4 files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "fap_web_companion_validation": {
+          "status": "pass",
+          "command": "pnpm test:contract -- article-publishing-runtime-truth.contract.test.ts homepage-recommended-articles-block.contract.test.ts; pnpm typecheck; NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build; pnpm seo:check-sitemap",
+          "evidence": "Contract suite passed across 340 files / 1912 tests, typecheck passed, production build passed, and sitemap indexability check passed for 206 URLs. Generated sitemap artifact was restored; fap-web worktree clean."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "post_merge_runbook_required": true
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1081,6 +1081,7 @@ prs:
       - backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
       - backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
       - backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
@@ -1096,6 +1097,7 @@ prs:
       - php artisan route:list --no-ansi
       - "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
       - vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+      - php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|article_baseline_projection_convergence' --no-ansi
       - git diff --check
     companion_validation:
       repo: fap-web

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1062,6 +1062,52 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: PR-RT-04
+    repo: fap-api
+    depends_on:
+      - PR-RT-03
+    branch: codex/pr-rt-04-article-baseline-republish
+    title: "fix(api): republish article baseline and complete public projection"
+    name: "Article Baseline Republish and Public Projection Convergence"
+    scope_type: article_baseline_republish_projection_convergence_only
+    scope:
+      - Make article baseline import upsert republish changed existing published articles so public APIs read the new published revision.
+      - Preserve create-missing-only behavior when --upsert is not provided and add dry-run per-article action reporting.
+      - Complete Article list/detail and homepage recommended article public projection from Article authority, including cover, alt, category, tags, SEO, and published revision.
+      - Add backend tests for old production revision republish, complete public projections, landing surface recommendation enrichment, and noindex exclusion.
+      - Provide a post-merge six-article production dry-run and upsert runbook.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleImportLocalBaseline.php
+      - backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
+      - backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+      - backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Rewrite article body, title, SEO title, meta description, excerpt, references, or cover assets.
+      - Add article body content or recommendation fallbacks to fap-web.
+      - Change fap-web homepage filtering to hide backend projection gaps.
+      - Implement Topic graph, Article detail related articles, Personality related articles, Career expansion, or test page recommendation changes.
+      - Touch MBTI, Big Five, RIASEC, IQ, Personality, Career expansion, payment, report, invite, order, scoring, Ads, or launch smoke runtime.
+    validation:
+      - php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi
+      - php artisan test tests/Feature/V0_5/ArticlePublishingRuntimeTruthTest.php --no-ansi
+      - php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php --filter='recommended_articles|home_recommended_articles_are_enriched' --no-ansi
+      - php artisan route:list --no-ansi
+      - "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
+      - vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+      - git diff --check
+    companion_validation:
+      repo: fap-web
+      branch: main
+      checks:
+        - pnpm test:contract -- article-publishing-runtime-truth.contract.test.ts homepage-recommended-articles-block.contract.test.ts
+        - pnpm typecheck
+        - NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build
+        - pnpm seo:check-sitemap
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: AUDIT-12
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed

- Registered `PR-RT-04` in the fap-api PR train manifest/state and reconciled merged `PR-RT-03` ledger state.
- Updated `articles:import-local-baseline --upsert --status=published` so changed existing published Articles get a fresh working translation revision and publish it as the new `published_revision_id`.
- Added dry-run per-article action output (`article_action=locale:slug:create|update|skip`) so production dry-run can verify the six expected updates before writing.
- Completed landing surface `recommended_articles` enrichment from Article authority: title, excerpt, cover URL/alt/variants, category, tags, status/indexability, canonical, SEO fields, and published revision.
- Added backend tests covering old production published revision republish, Article public projection convergence, homepage recommended article enrichment, and noindex exclusion.

## Why

PR-RT-02 imported the new six-article baseline, but production already had published rows for these slugs. The importer updated the working Article data but did not republish a new translation revision, while public APIs read `publishedRevision`. Separately, homepage recommended articles only received `published_revision_id`, leaving cover/category/tags incomplete and causing fap-web to filter them out.

## Validation commands

Backend:

```bash
cd backend
php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi
php artisan test tests/Feature/V0_5/ArticlePublishingRuntimeTruthTest.php --no-ansi
php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php --no-ansi
php artisan route:list --no-ansi
APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
git diff --check && git diff --cached --check
```

Frontend companion validation, no fap-web code changes:

```bash
pnpm test:contract -- article-publishing-runtime-truth.contract.test.ts homepage-recommended-articles-block.contract.test.ts
pnpm typecheck
NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build
pnpm seo:check-sitemap
```

## Post-merge production runbook

Codex did not run production upsert. After merge, run dry-run first:

```bash
php artisan articles:import-local-baseline \
  --locale=zh-CN \
  --article=how-personality-shapes-attitude-toward-ai \
  --article=which-love-script-fits-you-best \
  --article=are-infj-men-rare-or-socially-silenced \
  --article=best-valentines-date-by-personality-and-relationship-science \
  --article=how-16-personality-types-talk-to-an-ai-coach \
  --article=childhood-dream-job-still-shapes-career-choice \
  --upsert \
  --status=published \
  --dry-run
```

Dry-run acceptance:

- `articles_found=6`
- `will_update=6`
- `will_create=0`
- no unexpected `skip`

Then run the write:

```bash
php artisan articles:import-local-baseline \
  --locale=zh-CN \
  --article=how-personality-shapes-attitude-toward-ai \
  --article=which-love-script-fits-you-best \
  --article=are-infj-men-rare-or-socially-silenced \
  --article=best-valentines-date-by-personality-and-relationship-science \
  --article=how-16-personality-types-talk-to-an-ai-coach \
  --article=childhood-dream-job-still-shapes-career-choice \
  --upsert \
  --status=published
```

Manual verify after production upsert:

- Six article detail APIs return baseline body, not old April draft body.
- Each detail/list payload has `cover_image_url`, `cover_image_alt`, `cover_image_width`, `cover_image_height`, `cover_image_variants`, `category`, `tags`, and SEO fields.
- `/api/v0.5/landing-surfaces/home?locale=zh-CN&org_id=0` recommended_articles items have complete article projection and are published/indexable.
- `/zh/articles` no longer shows striped cover placeholders.
- Homepage recommended reading renders cards.
- Article JSON-LD image/description/canonical align with the public payload.
- Sitemap / llms / canonical / robots remain governed by published/indexable state.

## Intentionally deferred

- No fap-web filtering changes.
- No article body/title/SEO copy edits.
- No SVG cover regeneration.
- No Topic graph, Article detail related articles, Personality related articles, Career expansion, or test-page recommendation work.
