### PR TITLE
fix(api): add career surface context artifact support

### DIFF
--- a/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+++ b/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
@@ -33,6 +33,9 @@ use App\Domain\Career\Audit\CareerPublicResolutionPlanResolver;
 use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
 use App\Domain\Career\Audit\CareerRuntimeProjectionTruthEligibilityAuditor;
 use App\Domain\Career\Audit\CareerSeoGeoReadinessAuditor;
+use App\Domain\Career\Audit\CareerSurfaceContextArtifact;
+use App\Domain\Career\Audit\CareerSurfaceContextArtifactIssue;
+use App\Domain\Career\Audit\CareerSurfaceContextArtifactReader;
 use App\Domain\Career\Audit\CareerSurfaceReadinessAuditor;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -47,6 +50,7 @@ final class CareerAuditCanonicalEligibility extends Command
         {--public-resolution-plan= : Optional public-resolution planner JSON artifact}
         {--entity-context= : Optional read-only entity context JSON artifact}
         {--index-state-context= : Optional read-only index-state context JSON artifact}
+        {--surface-context= : Optional read-only surface context JSON artifact}
         {--projection= : Optional runtime publish projection JSON artifact}
         {--truth= : Optional canonical runtime truth JSON artifact}
         {--ledger= : Optional full release ledger JSON artifact}
@@ -177,10 +181,11 @@ final class CareerAuditCanonicalEligibility extends Command
         $planPath = $this->stringOption('public-resolution-plan');
         $entityContextPath = $this->stringOption('entity-context');
         $indexStateContextPath = $this->stringOption('index-state-context');
+        $surfaceContextPath = $this->stringOption('surface-context');
         $projectionPath = $this->stringOption('projection');
         $truthPath = $this->stringOption('truth');
         $ledgerPath = $this->stringOption('ledger');
-        $includeSurfaces = (bool) $this->option('include-surfaces') || (bool) $this->option('include-live-html');
+        $includeSurfaces = $surfaceContextPath !== null || (bool) $this->option('include-surfaces') || (bool) $this->option('include-live-html');
         $includeLiveHtml = (bool) $this->option('include-live-html');
         $baseUrl = $this->stringOption('base-url');
 
@@ -273,17 +278,24 @@ final class CareerAuditCanonicalEligibility extends Command
             $this->contextRequirement(
                 contextId: 'surface_context',
                 label: 'Surface readiness artifact mode',
-                status: $includeSurfaces
-                    ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
-                    : CareerCanonicalEligibilityAuditRunContextStatus::MISSING,
+                status: $surfaceContextPath !== null
+                    ? ($this->surfaceContextSupplied($surfaceContextPath, $byReason)
+                        ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                        : CareerCanonicalEligibilityAuditRunContextStatus::MISSING)
+                    : ($includeSurfaces
+                        ? CareerCanonicalEligibilityAuditRunContextStatus::SUPPLIED
+                        : CareerCanonicalEligibilityAuditRunContextStatus::MISSING),
                 requiredForMeaningfulRerun: true,
                 blocks80Readiness: true,
                 requiresApproval: false,
                 approvalGateId: null,
-                suppliedInput: $includeSurfaces ? '--include-surfaces' : null,
-                requiredInput: '--include-surfaces',
-                reason: 'Surface readiness is grouped as one context-level requirement; missing surface context is not 5572 independent data defects.',
-                evidence: [['row_reason_count' => $byReason['surface_context_missing'] ?? 0]]
+                suppliedInput: $surfaceContextPath ?? ($includeSurfaces ? '--include-surfaces' : null),
+                requiredInput: '--surface-context=/path/to/surface_context.json or --include-surfaces',
+                reason: 'Surface readiness is supplied by a read-only surface context artifact or explicitly requested safe artifact mode; missing surface context is not 5572 independent data defects.',
+                evidence: [[
+                    'row_reason_count' => $byReason['surface_context_missing'] ?? 0,
+                    'artifact_issue_count' => array_sum(array_intersect_key($byReason, array_flip(CareerSurfaceContextArtifactIssue::reasons()))),
+                ]]
             ),
             $this->contextRequirement(
                 contextId: 'live_html_context',
@@ -337,6 +349,7 @@ final class CareerAuditCanonicalEligibility extends Command
                 'include_surfaces' => $includeSurfaces,
                 'include_live_html' => $includeLiveHtml,
                 'base_url' => $baseUrl,
+                'surface_context_path' => $surfaceContextPath,
                 'surface_context' => $requirements[5]->status,
                 'live_html_context' => $requirements[6]->status,
             ],
@@ -527,6 +540,24 @@ final class CareerAuditCanonicalEligibility extends Command
         }
 
         foreach ([CareerIndexStateContextArtifactIssue::FILE_MISSING, CareerIndexStateContextArtifactIssue::JSON_INVALID, CareerIndexStateContextArtifactIssue::ROWS_MISSING] as $reason) {
+            if ($this->reasonPresent($byReason, $reason)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, int>  $byReason
+     */
+    private function surfaceContextSupplied(?string $path, array $byReason): bool
+    {
+        if ($path === null) {
+            return false;
+        }
+
+        foreach ([CareerSurfaceContextArtifactIssue::FILE_MISSING, CareerSurfaceContextArtifactIssue::JSON_INVALID, CareerSurfaceContextArtifactIssue::ROWS_MISSING] as $reason) {
             if ($this->reasonPresent($byReason, $reason)) {
                 return false;
             }
@@ -944,6 +975,29 @@ final class CareerAuditCanonicalEligibility extends Command
      */
     private function surfaceStatuses(array $planRows, array $slugs, array $locales): array
     {
+        $surfaceContextPath = $this->stringOption('surface-context');
+        if ($surfaceContextPath !== null) {
+            $artifact = CareerSurfaceContextArtifactReader::fromPath($surfaceContextPath);
+
+            return [
+                $this->surfaceStatusesFromArtifact(
+                    artifact: $artifact,
+                    planRows: $planRows,
+                    slugs: $slugs,
+                    locales: $locales,
+                    includeLiveHtml: (bool) $this->option('include-live-html'),
+                    baseUrl: $this->stringOption('base-url'),
+                ),
+                $artifact->issues === [] ? [] : [
+                    $this->contextSidecar(
+                        sidecarId: 'surface_context_artifact_issue',
+                        title: 'Surface context artifact has structured validation issues.',
+                        evidence: [['artifact' => $artifact->toArray()]]
+                    ),
+                ],
+            ];
+        }
+
         $includeSurfaces = (bool) $this->option('include-surfaces') || (bool) $this->option('include-live-html');
         if (! $includeSurfaces) {
             return [
@@ -979,6 +1033,114 @@ final class CareerAuditCanonicalEligibility extends Command
         );
 
         return [$this->statusMapByKey($surfaceResult->rows, 'canonicalSlug', 'locale', 'surfaceStatus'), [...$sidecars, ...$surfaceResult->sidecars]];
+    }
+
+    /**
+     * @param  list<CareerPublicResolutionPlanRow>  $planRows
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return array<string, CareerCanonicalEligibilityLayerStatus>
+     */
+    private function surfaceStatusesFromArtifact(CareerSurfaceContextArtifact $artifact, array $planRows, array $slugs, array $locales, bool $includeLiveHtml, ?string $baseUrl): array
+    {
+        $globalIssues = $artifact->globalIssues();
+        $globalReasons = array_values(array_unique(array_map(
+            static fn (CareerSurfaceContextArtifactIssue $issue): string => $issue->reason,
+            $globalIssues
+        )));
+        $globalEvidence = array_map(
+            static fn (CareerSurfaceContextArtifactIssue $issue): array => $issue->toArray(),
+            $globalIssues
+        );
+
+        if ($this->hasBlockingSurfaceArtifactIssue($globalReasons)) {
+            return $this->statusMapForSlugLocales(
+                slugs: $slugs,
+                locales: $locales,
+                layer: CareerCanonicalEligibilityLayer::SURFACE,
+                reasons: $globalReasons,
+                evidence: $globalEvidence,
+                source: 'surface_context_artifact'
+            );
+        }
+
+        $surfaceResult = (new CareerSurfaceReadinessAuditor)->audit(
+            planRows: $planRows,
+            locales: $locales,
+            apiArtifact: ['items' => $artifact->surfaceApiRows()],
+            includeLiveHtml: $includeLiveHtml,
+            baseUrl: $baseUrl,
+            liveHtmlByKey: [],
+        );
+        $auditedStatuses = $this->statusMapByKey($surfaceResult->rows, 'canonicalSlug', 'locale', 'surfaceStatus');
+        $rowsByKey = $artifact->rowsByKey();
+        $issuesByKey = $artifact->issuesByKey();
+        $statuses = [];
+
+        foreach (array_values(array_unique($slugs)) as $slug) {
+            foreach ($locales as $locale) {
+                $key = $this->rowKey($slug, $locale);
+                if (! isset($rowsByKey[$key])) {
+                    $statuses[$key] = new CareerCanonicalEligibilityLayerStatus(
+                        layer: CareerCanonicalEligibilityLayer::SURFACE,
+                        status: CareerCanonicalEligibilityStatus::UNVERIFIED,
+                        reasons: array_values(array_unique([...$globalReasons, CareerSurfaceContextArtifactIssue::ROW_MISSING])),
+                        evidence: [
+                            ...$globalEvidence,
+                            ['canonical_slug' => $slug, 'locale' => $locale, 'context_row_present' => false],
+                        ],
+                        source: 'surface_context_artifact',
+                    );
+
+                    continue;
+                }
+
+                $artifactIssues = [
+                    ...$globalIssues,
+                    ...($issuesByKey[$key] ?? []),
+                ];
+                $artifactReasons = array_map(
+                    static fn (CareerSurfaceContextArtifactIssue $issue): string => $issue->reason,
+                    $artifactIssues
+                );
+                $artifactEvidence = array_map(
+                    static fn (CareerSurfaceContextArtifactIssue $issue): array => $issue->toArray(),
+                    $artifactIssues
+                );
+                $auditedStatus = $auditedStatuses[$key] ?? $this->unverifiedLayer(
+                    CareerCanonicalEligibilityLayer::SURFACE,
+                    [CareerSurfaceContextArtifactIssue::ROW_MISSING],
+                    [['canonical_slug' => $slug, 'locale' => $locale, 'context_row_present' => false]],
+                    'surface_context_artifact'
+                );
+
+                $statuses[$key] = new CareerCanonicalEligibilityLayerStatus(
+                    layer: CareerCanonicalEligibilityLayer::SURFACE,
+                    status: $artifactReasons === []
+                        ? $auditedStatus->status
+                        : ($auditedStatus->status === CareerCanonicalEligibilityStatus::PASS ? CareerCanonicalEligibilityStatus::BLOCKED : $auditedStatus->status),
+                    reasons: array_values(array_unique([...$auditedStatus->reasons, ...$artifactReasons])),
+                    evidence: [...$auditedStatus->evidence, ...$artifactEvidence],
+                    source: 'surface_context_artifact',
+                );
+            }
+        }
+
+        return $statuses;
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     */
+    private function hasBlockingSurfaceArtifactIssue(array $reasons): bool
+    {
+        foreach ([CareerSurfaceContextArtifactIssue::FILE_MISSING, CareerSurfaceContextArtifactIssue::JSON_INVALID, CareerSurfaceContextArtifactIssue::ROWS_MISSING] as $reason) {
+            if (in_array($reason, $reasons, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function auditRow(

--- a/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifact.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifact.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSurfaceContextArtifact
+{
+    /**
+     * @param  array<string, mixed>  $source
+     * @param  list<CareerSurfaceContextArtifactRow>  $rows
+     * @param  list<CareerSurfaceContextArtifactIssue>  $issues
+     */
+    public function __construct(
+        public readonly string $sourcePath,
+        public readonly ?string $schemaVersion,
+        public readonly array $source,
+        public readonly array $rows,
+        public readonly array $issues = [],
+    ) {
+        self::assertNonEmptyString($this->sourcePath, 'source_path');
+        self::assertMap($this->source, 'source');
+        self::assertRows($this->rows);
+        self::assertIssues($this->issues);
+
+        if ($this->schemaVersion !== null) {
+            self::assertNonEmptyString($this->schemaVersion, 'schema_version');
+        }
+    }
+
+    /**
+     * @return array<string, CareerSurfaceContextArtifactRow>
+     */
+    public function rowsByKey(): array
+    {
+        $rows = [];
+        foreach ($this->rows as $row) {
+            $rows[$this->rowKey($row->canonicalSlug, $row->locale)] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function surfaceApiRows(): array
+    {
+        return array_map(
+            static fn (CareerSurfaceContextArtifactRow $row): array => $row->toSurfaceApiRow(),
+            $this->rows,
+        );
+    }
+
+    /**
+     * @return array<string, list<CareerSurfaceContextArtifactIssue>>
+     */
+    public function issuesByKey(): array
+    {
+        $issues = [];
+        foreach ($this->issues as $issue) {
+            if ($issue->canonicalSlug === null || $issue->locale === null) {
+                continue;
+            }
+
+            $key = $this->rowKey($issue->canonicalSlug, $issue->locale);
+            $issues[$key] ??= [];
+            $issues[$key][] = $issue;
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<CareerSurfaceContextArtifactIssue>
+     */
+    public function globalIssues(): array
+    {
+        return array_values(array_filter(
+            $this->issues,
+            static fn (CareerSurfaceContextArtifactIssue $issue): bool => $issue->canonicalSlug === null || $issue->locale === null
+        ));
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byReason(): array
+    {
+        $counts = [];
+        foreach ($this->issues as $issue) {
+            $counts[$issue->reason] = ($counts[$issue->reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{source_path: string, schema_version: string|null, source: array<string, mixed>, by_reason: array<string, int>, rows: list<array<string, mixed>>, issues: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'source_path' => $this->sourcePath,
+            'schema_version' => $this->schemaVersion,
+            'source' => $this->source,
+            'by_reason' => $this->byReason(),
+            'rows' => array_map(
+                static fn (CareerSurfaceContextArtifactRow $row): array => $row->toArray(),
+                $this->rows,
+            ),
+            'issues' => array_map(
+                static fn (CareerSurfaceContextArtifactIssue $issue): array => $issue->toArray(),
+                $this->issues,
+            ),
+        ];
+    }
+
+    private function rowKey(string $slug, string $locale): string
+    {
+        return strtolower($slug).'|'.strtolower($locale);
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career surface context artifact requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career surface context artifact [%s] must be an object map.', $key));
+        }
+    }
+
+    /**
+     * @param  list<CareerSurfaceContextArtifactRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career surface context artifact rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerSurfaceContextArtifactRow) {
+                throw new InvalidArgumentException('Career surface context artifact rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerSurfaceContextArtifactIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        if (! array_is_list($issues)) {
+            throw new InvalidArgumentException('Career surface context artifact issues must be a list.');
+        }
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof CareerSurfaceContextArtifactIssue) {
+                throw new InvalidArgumentException('Career surface context artifact issues must contain issue DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactIssue.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSurfaceContextArtifactIssue
+{
+    public const FILE_MISSING = 'surface_context_file_missing';
+
+    public const JSON_INVALID = 'surface_context_json_invalid';
+
+    public const ROWS_MISSING = 'surface_context_rows_missing';
+
+    public const ROW_MALFORMED = 'surface_context_row_malformed';
+
+    public const ROW_MISSING = 'surface_context_row_missing';
+
+    public const SLUG_MISSING = 'surface_context_slug_missing';
+
+    public const LOCALE_MISSING = 'surface_context_locale_missing';
+
+    public const SLUG_LOCALE_DUPLICATE = 'surface_context_slug_locale_duplicate';
+
+    public const REQUIRED_FIELD_MISSING = 'surface_context_required_field_missing';
+
+    /**
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $message,
+        public readonly ?string $canonicalSlug = null,
+        public readonly ?string $locale = null,
+        public readonly ?string $field = null,
+        public readonly array $evidence = [],
+    ) {
+        self::assertValidReason($this->reason);
+        self::assertNonEmptyString($this->message, 'message');
+        self::assertList($this->evidence, 'evidence');
+
+        if ($this->canonicalSlug !== null) {
+            self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        }
+
+        if ($this->locale !== null) {
+            self::assertNonEmptyString($this->locale, 'locale');
+        }
+
+        if ($this->field !== null) {
+            self::assertNonEmptyString($this->field, 'field');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reasons(): array
+    {
+        return [
+            self::FILE_MISSING,
+            self::JSON_INVALID,
+            self::ROWS_MISSING,
+            self::ROW_MALFORMED,
+            self::ROW_MISSING,
+            self::SLUG_MISSING,
+            self::LOCALE_MISSING,
+            self::SLUG_LOCALE_DUPLICATE,
+            self::REQUIRED_FIELD_MISSING,
+        ];
+    }
+
+    public static function assertValidReason(string $value): string
+    {
+        if (! in_array($value, self::reasons(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career surface context artifact issue reason [%s].', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{reason: string, message: string, canonical_slug: string|null, locale: string|null, field: string|null, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'message' => $this->message,
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'field' => $this->field,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career surface context artifact issue requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career surface context artifact issue [%s] must be a list.', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactReader.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactReader.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerSurfaceContextArtifactReader
+{
+    public static function fromPath(string $path): CareerSurfaceContextArtifact
+    {
+        if (! is_file($path)) {
+            return new CareerSurfaceContextArtifact(
+                sourcePath: $path,
+                schemaVersion: null,
+                source: [],
+                rows: [],
+                issues: [
+                    new CareerSurfaceContextArtifactIssue(
+                        reason: CareerSurfaceContextArtifactIssue::FILE_MISSING,
+                        message: 'Surface context artifact file was not found.',
+                        evidence: [['path' => $path]],
+                    ),
+                ],
+            );
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            return new CareerSurfaceContextArtifact(
+                sourcePath: $path,
+                schemaVersion: null,
+                source: [],
+                rows: [],
+                issues: [
+                    new CareerSurfaceContextArtifactIssue(
+                        reason: CareerSurfaceContextArtifactIssue::JSON_INVALID,
+                        message: 'Surface context artifact JSON could not be parsed.',
+                        evidence: [['path' => $path, 'json_error' => json_last_error_msg()]],
+                    ),
+                ],
+            );
+        }
+
+        $rowsValue = $payload['rows'] ?? null;
+        if (! is_array($rowsValue) || ! array_is_list($rowsValue)) {
+            return new CareerSurfaceContextArtifact(
+                sourcePath: $path,
+                schemaVersion: self::optionalString($payload['schema_version'] ?? null),
+                source: self::mapOrEmpty($payload['source'] ?? []),
+                rows: [],
+                issues: [
+                    new CareerSurfaceContextArtifactIssue(
+                        reason: CareerSurfaceContextArtifactIssue::ROWS_MISSING,
+                        message: 'Surface context artifact requires a rows list.',
+                        evidence: [['path' => $path]],
+                    ),
+                ],
+            );
+        }
+
+        $rows = [];
+        $issues = [];
+        $seen = [];
+        foreach ($rowsValue as $index => $rowValue) {
+            if (! is_array($rowValue) || array_is_list($rowValue)) {
+                $issues[] = new CareerSurfaceContextArtifactIssue(
+                    reason: CareerSurfaceContextArtifactIssue::ROW_MALFORMED,
+                    message: 'Surface context row must be an object.',
+                    evidence: [['row_index' => $index]],
+                );
+
+                continue;
+            }
+
+            $slug = self::normalizedSlug($rowValue['canonical_slug'] ?? $rowValue['slug'] ?? null);
+            if ($slug === null) {
+                $issues[] = new CareerSurfaceContextArtifactIssue(
+                    reason: CareerSurfaceContextArtifactIssue::SLUG_MISSING,
+                    message: 'Surface context row requires canonical_slug.',
+                    evidence: [['row_index' => $index]],
+                );
+
+                continue;
+            }
+
+            $locale = self::normalizedLocale($rowValue['locale'] ?? null);
+            if ($locale === null) {
+                $issues[] = new CareerSurfaceContextArtifactIssue(
+                    reason: CareerSurfaceContextArtifactIssue::LOCALE_MISSING,
+                    message: 'Surface context row requires locale.',
+                    canonicalSlug: $slug,
+                    evidence: [['row_index' => $index, 'canonical_slug' => $slug]],
+                );
+
+                continue;
+            }
+
+            $key = $slug.'|'.$locale;
+            if (isset($seen[$key])) {
+                $issues[] = new CareerSurfaceContextArtifactIssue(
+                    reason: CareerSurfaceContextArtifactIssue::SLUG_LOCALE_DUPLICATE,
+                    message: 'Surface context canonical_slug and locale appears more than once.',
+                    canonicalSlug: $slug,
+                    locale: $locale,
+                    evidence: [['row_index' => $index, 'canonical_slug' => $slug, 'locale' => $locale]],
+                );
+
+                continue;
+            }
+            $seen[$key] = true;
+
+            if (! array_key_exists('api_indexable', $rowValue) || ! is_bool($rowValue['api_indexable'])) {
+                $issues[] = new CareerSurfaceContextArtifactIssue(
+                    reason: CareerSurfaceContextArtifactIssue::REQUIRED_FIELD_MISSING,
+                    message: 'Surface context row requires boolean api_indexable.',
+                    canonicalSlug: $slug,
+                    locale: $locale,
+                    field: 'api_indexable',
+                    evidence: [['row_index' => $index, 'canonical_slug' => $slug, 'locale' => $locale]],
+                );
+
+                continue;
+            }
+
+            $rows[] = new CareerSurfaceContextArtifactRow(
+                canonicalSlug: $slug,
+                locale: $locale,
+                apiCanonicalPath: self::optionalString($rowValue['api_canonical_path'] ?? $rowValue['canonical_path'] ?? null),
+                apiIndexable: $rowValue['api_indexable'],
+                liveCanonicalPath: self::optionalString($rowValue['live_canonical_path'] ?? null),
+                liveRobotsPolicy: self::optionalString($rowValue['live_robots_policy'] ?? null),
+                ctaPresent: array_key_exists('cta_present', $rowValue) && is_bool($rowValue['cta_present']) ? $rowValue['cta_present'] : null,
+                evidence: self::mapOrEmpty($rowValue['evidence'] ?? []),
+                raw: $rowValue,
+            );
+        }
+
+        return new CareerSurfaceContextArtifact(
+            sourcePath: $path,
+            schemaVersion: self::optionalString($payload['schema_version'] ?? null),
+            source: self::mapOrEmpty($payload['source'] ?? []),
+            rows: $rows,
+            issues: $issues,
+        );
+    }
+
+    private static function normalizedSlug(mixed $value): ?string
+    {
+        $normalized = self::optionalString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private static function normalizedLocale(mixed $value): ?string
+    {
+        $normalized = self::optionalString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private static function optionalString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function mapOrEmpty(mixed $value): array
+    {
+        return is_array($value) && (! array_is_list($value) || $value === []) ? $value : [];
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactRow.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactRow.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerSurfaceContextArtifactRow
+{
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $locale,
+        public readonly ?string $apiCanonicalPath,
+        public readonly bool $apiIndexable,
+        public readonly ?string $liveCanonicalPath = null,
+        public readonly ?string $liveRobotsPolicy = null,
+        public readonly ?bool $ctaPresent = null,
+        public readonly array $evidence = [],
+        public readonly array $raw = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertNonEmptyString($this->locale, 'locale');
+        self::assertMap($this->evidence, 'evidence');
+        self::assertMap($this->raw, 'raw');
+
+        foreach ([
+            'api_canonical_path' => $this->apiCanonicalPath,
+            'live_canonical_path' => $this->liveCanonicalPath,
+            'live_robots_policy' => $this->liveRobotsPolicy,
+        ] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSurfaceApiRow(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'api_canonical_path' => $this->apiCanonicalPath,
+            'api_indexable' => $this->apiIndexable,
+            'live_canonical_path' => $this->liveCanonicalPath,
+            'live_robots_policy' => $this->liveRobotsPolicy,
+            'cta_present' => $this->ctaPresent,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    /**
+     * @return array{canonical_slug: string, locale: string, api_canonical_path: string|null, api_indexable: bool, live_canonical_path: string|null, live_robots_policy: string|null, cta_present: bool|null, evidence: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'locale' => $this->locale,
+            'api_canonical_path' => $this->apiCanonicalPath,
+            'api_indexable' => $this->apiIndexable,
+            'live_canonical_path' => $this->liveCanonicalPath,
+            'live_robots_policy' => $this->liveRobotsPolicy,
+            'cta_present' => $this->ctaPresent,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career surface context row requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career surface context row [%s] must be an object map.', $key));
+        }
+    }
+}

--- a/backend/docs/career/audits/audit_run_context.md
+++ b/backend/docs/career/audits/audit_run_context.md
@@ -43,7 +43,7 @@ Use `--context-output=/tmp/career_2786_audit_run_context_requirements.json` to w
 - `planner_only`: validates planner rows and static artifact-derived layers only.
 - `planner_plus_local_db`: adds local/read-only DB context for Occupation and index-state layers.
 - `planner_plus_runtime_artifacts`: adds `--projection`, `--truth`, and optionally `--ledger`.
-- `planner_plus_surface_base_url`: adds surface verification context; live HTML requires `--include-live-html` and `--base-url`.
+- `planner_plus_surface_base_url`: adds surface verification context from `--surface-context` or explicit surface mode; live HTML requires `--include-live-html` and `--base-url`.
 - `full_readonly_context`: planner, read-only DB context, runtime artifacts, and surface context are all supplied.
 
 ## Context Interpretation
@@ -54,7 +54,9 @@ Context-level reasons are aggregated:
 - `index_state_context_missing`: index-state authority could not be interpreted from the current DB context.
 - `runtime_projection_context_missing`: `--projection` artifact is absent.
 - `runtime_truth_context_missing`: `--truth` artifact is absent.
-- `surface_context_missing`: surface artifact mode was not requested.
+- `surface_context_missing`: surface artifact mode or `--surface-context` was not requested.
+- `surface_context_file_missing`: an explicit surface artifact path was invalid.
+- `surface_context_row_missing`: the surface artifact was supplied but did not contain an expected slug/locale row.
 - `surface_live_html_context_missing`: live HTML verification was requested without a base URL.
 
 These blockers prevent 80-readiness planning from being meaningful. They do not authorize DB mutation, rollout apply, publication, or deployment.
@@ -95,17 +97,17 @@ php -d memory_limit=512M artisan career:audit-canonical-eligibility \
   --public-resolution-plan=/tmp/career_2786_public_resolution_plan_from_d23b.json \
   --entity-context=/tmp/career_2786_entity_context.json \
   --index-state-context=/tmp/career_2786_index_state_context.json \
+  --surface-context=/tmp/career_2786_surface_context.json \
   --projection=/tmp/career_2786_runtime_projection.json \
   --truth=/tmp/career_2786_runtime_truth.json \
   --ledger=/tmp/career_2786_full_release_ledger.json \
   --locales=en,zh \
-  --include-surfaces \
   --json \
   --output=/tmp/career_2786_canonical_eligibility_audit_with_context.json \
   --context-output=/tmp/career_2786_audit_run_context_requirements.json
 ```
 
-`--entity-context` and `--index-state-context` consume approved read-only JSON artifacts. They do not export production context; that producer workflow remains approval-gated.
+`--entity-context`, `--index-state-context`, and `--surface-context` consume approved read-only JSON artifacts. They do not export production context or crawl live HTML; producer workflows remain approval-gated.
 
 ## Non-Goals
 

--- a/backend/docs/career/audits/canonical_eligibility_audit_command.md
+++ b/backend/docs/career/audits/canonical_eligibility_audit_command.md
@@ -16,6 +16,7 @@ The command is an integration shell for the canonical eligibility stack. It does
 - `--public-resolution-plan=`
 - `--entity-context=`
 - `--index-state-context=`
+- `--surface-context=`
 - `--projection=`
 - `--truth=`
 - `--ledger=`
@@ -28,7 +29,7 @@ The command is an integration shell for the canonical eligibility stack. It does
 
 `scope=slugs` can run from explicit slugs. `scope=all` and `scope=batch` require a public-resolution plan path and report a structured `public_resolution_plan_missing` reason when it is absent.
 
-`--entity-context` and `--index-state-context` are consumer-only JSON artifact inputs. They satisfy entity and index context without querying or exporting a DB context. The artifacts must be produced separately by an approved read-only context export workflow.
+`--entity-context`, `--index-state-context`, and `--surface-context` are consumer-only JSON artifact inputs. They satisfy entity, index, and surface context without querying/exporting production DB context or crawling live HTML. The artifacts must be produced separately by approved read-only workflows.
 
 ## Read-Only Contract
 
@@ -55,14 +56,15 @@ CMD-FIX-1 makes the command call the completed audit layer services instead of e
 - index-state authority uses `CareerIndexStateAuthorityAuditor`
 - runtime projection/truth uses `CareerRuntimeProjectionTruthEligibilityAuditor` when `--projection` and `--truth` are supplied
 - SEO/GEO readiness uses `CareerSeoGeoReadinessAuditor` from plan/backend artifact fields
-- surface readiness uses `CareerSurfaceReadinessAuditor` when `--include-surfaces` or `--include-live-html` is requested
+- surface readiness uses `CareerSurfaceReadinessAuditor` when `--surface-context`, `--include-surfaces`, or `--include-live-html` is requested
 
 When supplied, entity and index artifact rows bypass DB-backed entity/index auditors:
 
 - `--entity-context=/path/to/entity_context.json` supplies `career_entity_context.v1`
 - `--index-state-context=/path/to/index_state_context.json` supplies `career_index_state_context.v1`
+- `--surface-context=/path/to/surface_context.json` supplies `career_surface_context.v1`
 
-Missing or malformed artifact paths produce structured reasons such as `entity_context_file_missing`, `entity_context_json_invalid`, `index_context_file_missing`, and `index_context_json_invalid`; the command does not silently fall back to a DB query when an explicit artifact path is invalid.
+Missing or malformed artifact paths produce structured reasons such as `entity_context_file_missing`, `entity_context_json_invalid`, `index_context_file_missing`, `index_context_json_invalid`, `surface_context_file_missing`, and `surface_context_json_invalid`; the command does not silently fall back to another context source when an explicit artifact path is invalid.
 
 ## Context Handling
 
@@ -73,9 +75,11 @@ The command separates real blockers from missing verifier context. Missing requi
 - `runtime_projection_context_missing`
 - `runtime_truth_context_missing`
 - `surface_context_missing`
+- `surface_context_file_missing`
+- `surface_context_row_missing`
 - `surface_live_html_context_missing`
 
-Missing runtime projection/truth artifacts mark the runtime layer as `unverified`; they do not fabricate runtime pass/fail results. Optional live HTML validation requires `--include-live-html` and `--base-url`; if live verification context is absent, the surface layer is unverified and the report includes a sidecar. The command remains read-only and does not fetch live HTML by itself.
+Missing runtime projection/truth artifacts mark the runtime layer as `unverified`; they do not fabricate runtime pass/fail results. Missing surface artifacts or missing surface rows mark the surface layer as unverified instead of reporting one blanket `surface_context_missing` blocker when `--surface-context` is supplied. Real surface mismatches from artifact evidence, such as API canonical mismatch or noindex state, remain blocked. Optional live HTML validation requires `--include-live-html` and `--base-url`; if live verification context is absent, the surface layer is unverified and the report includes a sidecar. The command remains read-only and does not fetch live HTML by itself.
 
 ## Run Context Contract
 

--- a/backend/docs/career/audits/surface_context_artifacts.md
+++ b/backend/docs/career/audits/surface_context_artifacts.md
@@ -1,0 +1,62 @@
+# Career Surface Context Artifacts
+
+REPAIR-SURFACE-CONTEXT-1 adds read-only surface context artifact support to `career:audit-canonical-eligibility`.
+
+The artifact lets the audit consume previously generated or locally verified surface evidence without running a production live crawl and without touching `fap-web`.
+
+## Command Usage
+
+```bash
+php artisan career:audit-canonical-eligibility \
+  --scope=all \
+  --public-resolution-plan=/tmp/career_2786_public_resolution_plan_from_d23b.json \
+  --surface-context=/tmp/career_2786_surface_context.json \
+  --json
+```
+
+## Shape
+
+```json
+{
+  "schema_version": "career_surface_context.v1",
+  "source": {
+    "type": "read_only_surface_export",
+    "generated_at": "2026-05-13T00:00:00Z",
+    "environment": "local|production|unknown"
+  },
+  "rows": [
+    {
+      "canonical_slug": "actuaries",
+      "locale": "en",
+      "api_canonical_path": "/en/career/jobs/actuaries",
+      "api_indexable": true,
+      "live_canonical_path": null,
+      "live_robots_policy": null,
+      "cta_present": null,
+      "evidence": {}
+    }
+  ]
+}
+```
+
+Rows are keyed by `canonical_slug` and `locale`. `api_indexable` is required and must be boolean. `api_canonical_path` is optional but a missing or mismatched value remains a real surface readiness blocker.
+
+## Read-Only Behavior
+
+`--surface-context` only reads JSON from the supplied path. It does not:
+
+- crawl live production HTML
+- deploy or modify `fap-web`
+- mutate DB state
+- apply rollout, backfill, rollback, or quarantine
+
+## Reason Semantics
+
+- `surface_context_missing`: no surface context mode or artifact was supplied.
+- `surface_context_file_missing`: an explicit artifact path was invalid.
+- `surface_context_json_invalid`: an explicit artifact file was not valid JSON.
+- `surface_context_rows_missing`: the artifact did not contain a `rows` list.
+- `surface_context_row_missing`: a slug/locale expected by the planner had no artifact row.
+- `api_canonical_not_self`, `api_noindex_present`, and live HTML reasons remain real surface blockers when supported by artifact evidence.
+
+This separates missing/unverified surface context from real surface mismatch evidence.

--- a/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
@@ -277,6 +277,64 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertContains('index_context_slug_duplicate', data_get($payload, 'rows.0.index_status.reasons'));
     }
 
+    public function test_surface_context_artifact_marks_context_supplied(): void
+    {
+        $surfacePath = $this->writeSurfaceContext([
+            ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actuaries', 'api_indexable' => true],
+        ]);
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--surface-context' => $surfacePath,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('supplied', $payload['context_summary']['surface_context']);
+        $this->assertSame($surfacePath, $payload['run_context']['surface']['surface_context_path']);
+        $this->assertArrayNotHasKey('surface_context_missing', $payload['by_reason']);
+        $this->assertSame('pass', data_get($payload, 'rows.0.surface_status.status'));
+        $this->assertSame('surface_context_artifact', data_get($payload, 'rows.0.surface_status.source'));
+    }
+
+    public function test_missing_surface_context_file_reports_structured_artifact_issue(): void
+    {
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--surface-context' => sys_get_temp_dir().'/missing-surface-context-'.bin2hex(random_bytes(4)).'.json',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('surface_context_file_missing', $payload['by_reason']);
+        $this->assertSame('missing', $payload['context_summary']['surface_context']);
+        $this->assertContains('surface_context_artifact_issue', array_column($payload['sidecars'], 'sidecar_id'));
+    }
+
+    public function test_surface_context_artifact_canonical_mismatch_remains_blocked(): void
+    {
+        $surfacePath = $this->writeSurfaceContext([
+            ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actors', 'api_indexable' => true],
+        ]);
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--surface-context' => $surfacePath,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('supplied', $payload['context_summary']['surface_context']);
+        $this->assertArrayHasKey('api_canonical_not_self', $payload['by_reason']);
+        $this->assertSame('blocked', data_get($payload, 'rows.0.surface_status.status'));
+    }
+
     public function test_command_writes_output_json_when_requested(): void
     {
         $outputPath = sys_get_temp_dir().'/career-audit-command-output-'.bin2hex(random_bytes(4)).'.json';
@@ -508,6 +566,18 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         return $this->writeJsonArtifact('index-context', [
             'schema_version' => 'career_index_state_context.v1',
             'source' => ['type' => 'read_only_db_export', 'environment' => 'local'],
+            'rows' => $rows,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function writeSurfaceContext(array $rows): string
+    {
+        return $this->writeJsonArtifact('surface-context', [
+            'schema_version' => 'career_surface_context.v1',
+            'source' => ['type' => 'read_only_surface_export', 'environment' => 'local'],
             'rows' => $rows,
         ]);
     }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerSurfaceContextArtifactReaderTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerSurfaceContextArtifactReaderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerSurfaceContextArtifactReader;
+use PHPUnit\Framework\TestCase;
+
+final class CareerSurfaceContextArtifactReaderTest extends TestCase
+{
+    public function test_surface_context_reader_parses_stable_artifact(): void
+    {
+        $artifact = CareerSurfaceContextArtifactReader::fromPath($this->writeJson('surface', [
+            'schema_version' => 'career_surface_context.v1',
+            'source' => ['type' => 'read_only_surface_export', 'environment' => 'local'],
+            'rows' => [
+                [
+                    'canonical_slug' => 'actuaries',
+                    'locale' => 'en',
+                    'api_canonical_path' => '/en/career/jobs/actuaries',
+                    'api_indexable' => true,
+                    'evidence' => ['export_id' => 'test'],
+                ],
+            ],
+        ]));
+
+        $this->assertSame([], $artifact->byReason());
+        $this->assertSame('career_surface_context.v1', $artifact->schemaVersion);
+        $this->assertSame(['actuaries|en'], array_keys($artifact->rowsByKey()));
+        $this->assertSame([
+            'source_path',
+            'schema_version',
+            'source',
+            'by_reason',
+            'rows',
+            'issues',
+        ], array_keys($artifact->toArray()));
+    }
+
+    public function test_surface_context_reader_reports_duplicate_slug_locale(): void
+    {
+        $artifact = CareerSurfaceContextArtifactReader::fromPath($this->writeJson('surface-duplicate', [
+            'rows' => [
+                ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actuaries', 'api_indexable' => true],
+                ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actuaries', 'api_indexable' => true],
+            ],
+        ]));
+
+        $this->assertSame(['surface_context_slug_locale_duplicate' => 1], $artifact->byReason());
+    }
+
+    public function test_surface_context_reader_reports_missing_required_api_indexable(): void
+    {
+        $artifact = CareerSurfaceContextArtifactReader::fromPath($this->writeJson('surface-missing-field', [
+            'rows' => [
+                ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actuaries'],
+            ],
+        ]));
+
+        $this->assertSame(['surface_context_required_field_missing' => 1], $artifact->byReason());
+        $this->assertSame([], $artifact->rows);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = sys_get_temp_dir().'/career-surface-context-reader-'.$prefix.'-'.bin2hex(random_bytes(4)).'.json';
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -373,6 +373,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_surface_context_artifact_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerSurfaceContextArtifact.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactIssue.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactReader.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_80_cohort_readiness_plan_changes(): void
     {
         $changed = [
@@ -1186,6 +1198,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerSurfaceContextArtifactFile($file)) {
+                continue;
+            }
+
             if ($this->isCareer80CohortReadinessPlanFile($file)) {
                 continue;
             }
@@ -1697,6 +1713,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerSurfaceReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerSurfaceReadinessResult.php',
             'backend/app/Domain/Career/Audit/CareerSurfaceReadinessRow.php',
+        ], true);
+    }
+
+    private function isCareerSurfaceContextArtifactFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerSurfaceContextArtifact.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactIssue.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactReader.php',
+            'backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2593,6 +2593,61 @@
       "local_cleanup_executed": false,
       "sidecar_issues": []
     },
+    "REPAIR-SURFACE-CONTEXT-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-surface-context-repair-1",
+      "title": "fix(api): add career surface context artifact support",
+      "name": "Add read-only career surface context artifact support",
+      "status": "in_progress",
+      "depends_on": [
+        "CTX-BUNDLE-1B",
+        "SCAN-3"
+      ],
+      "scope_type": "audit_surface_context_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerAuditCanonicalEligibility.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no production live crawl",
+        "no fap-web changes",
+        "no production DB query",
+        "no DB mutation",
+        "no rollout",
+        "no backfill",
+        "no 80 readiness run",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided remediation train execution goal and authorized registering the current remediation PR item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SCAN-3 artifacts are present locally and identify REPAIR-SURFACE-CONTEXT-1 as the first remediation PR."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to surface context artifact support, audit command consumer wiring, audit tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-SEO-GEO-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
     "RIASEC-PERSONALIZATION-00": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-00-train-registration",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1369,6 +1369,50 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-SURFACE-CONTEXT-1
+    repo: fap-api
+    depends_on:
+      - CTX-BUNDLE-1B
+      - SCAN-3
+    branch: fix/career-surface-context-repair-1
+    title: "fix(api): add career surface context artifact support"
+    name: "Add read-only career surface context artifact support"
+    scope_type: audit_surface_context_only
+    scope:
+      - Add read-only surface context artifact DTOs and reader.
+      - Add --surface-context input to career:audit-canonical-eligibility.
+      - Distinguish missing surface artifact, unverified surface rows, and real surface mismatch evidence.
+      - Preserve no-live-crawl and no-production-mutation behavior.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run production live crawl.
+      - Touch fap-web.
+      - Query production DB.
+      - Mutate DB or production state.
+      - Apply rollout.
+      - Backfill data.
+      - Run 80 readiness.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerSurfaceContextArtifact --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "REPAIR-SEO-GEO-1"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: RIASEC-PERSONALIZATION-00
     repo: fap-api
     branch: codex/riasec-personalization-00-train-registration


### PR DESCRIPTION
## Summary
- Adds read-only `career_surface_context.v1` artifact DTOs and reader.
- Adds `--surface-context` to `career:audit-canonical-eligibility`.
- Distinguishes missing surface artifact, missing/unverified slug-locale rows, and real surface mismatch evidence.
- Registers REPAIR-SURFACE-CONTEXT-1 in the PR train manifest/state.

## Non-goals
- No production live crawl.
- No fap-web changes.
- No production DB query.
- No DB mutation.
- No rollout/backfill/apply/rollback/quarantine.
- No 80 readiness run.
- No deploy.

## Tests
- php artisan test --filter=CareerSurfaceContextArtifact --no-ansi
- php artisan test --filter=CareerEntityIndexContextArtifactReader --no-ansi
- php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
- php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi
- php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
- php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
- php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
- php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi
- php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE='':memory:'' php artisan migrate --pretend --no-ansi --force
- vendor/bin/pint --test
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh

## Scope validation
Changed files are limited to audit command/context artifacts, audit tests/docs, and PR train metadata.

## Next
REPAIR-SEO-GEO-1.