### PR TITLE
fix(api): normalize career seo geo readiness sources

### DIFF
--- a/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+++ b/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
@@ -1334,9 +1334,11 @@ final class CareerAuditCanonicalEligibility extends Command
                     'locale' => $locale,
                     'canonical_path' => '/'.$locale.'/career/jobs/'.$row->canonicalSlug,
                     'robots_indexable' => true,
-                    'sitemap_eligible' => $this->boolField($row->raw, ['ready_for_sitemap', 'Ready_For_Sitemap']),
-                    'llms_eligible' => $this->boolField($row->raw, ['ready_for_llms', 'Ready_For_LLMS']),
-                    'llms_full_eligible' => $this->boolField($row->raw, ['ready_for_llms_full', 'Ready_For_LLMS_Full']),
+                    'sitemap_eligible' => $this->boolFieldForPlanRow($row, ['ready_for_sitemap', 'Ready_For_Sitemap']),
+                    'llms_eligible' => $this->boolFieldForPlanRow($row, ['ready_for_llms', 'Ready_For_LLMS'])
+                        ?? ($this->hasLlmsMetadata($row, $locale) ? false : null),
+                    'llms_full_eligible' => $this->boolFieldForPlanRow($row, ['ready_for_llms_full', 'Ready_For_LLMS_Full', 'ready_for_llms', 'Ready_For_LLMS'])
+                        ?? ($this->hasLlmsMetadata($row, $locale) ? false : null),
                     'structured_data_ready' => $this->hasStructuredData($row, $locale),
                     'dataset_eligible' => true,
                     'search_eligible' => true,
@@ -1346,6 +1348,15 @@ final class CareerAuditCanonicalEligibility extends Command
         }
 
         return ['items' => $items];
+    }
+
+    /**
+     * @param  list<string>  $keys
+     */
+    private function boolFieldForPlanRow(CareerPublicResolutionPlanRow $row, array $keys): ?bool
+    {
+        return $this->boolField($row->raw, $keys)
+            ?? (is_array($row->raw['raw'] ?? null) ? $this->boolField($row->raw['raw'], $keys) : null);
     }
 
     /**
@@ -1382,20 +1393,55 @@ final class CareerAuditCanonicalEligibility extends Command
 
     private function hasStructuredData(CareerPublicResolutionPlanRow $row, string $locale): bool
     {
-        $key = $locale === 'zh' ? 'CN_Occupation_Schema_JSON' : 'EN_Occupation_Schema_JSON';
+        $schemaKeys = $locale === 'zh'
+            ? ['CN_Occupation_Schema_JSON', 'zh_occupation_schema_json', 'structured_data_json_zh', 'structured_data_zh']
+            : ['EN_Occupation_Schema_JSON', 'en_occupation_schema_json', 'structured_data_json_en', 'structured_data_en'];
 
-        return $this->nonEmptyString($row->raw[$key] ?? null);
+        if ($this->hasAnyPlanString($row, $schemaKeys)) {
+            return true;
+        }
+
+        return $row->canonicalSlug !== null
+            && $this->nonEmptyString($locale === 'zh' ? $row->titleZh : $row->titleEn)
+            && $this->nonEmptyString($row->sourceCode)
+            && $this->hasSeoMetadata($row, $locale);
     }
 
     private function hasSeoMetadata(CareerPublicResolutionPlanRow $row, string $locale): bool
     {
         if ($locale === 'zh') {
-            return $this->nonEmptyString($row->raw['CN_SEO_Title'] ?? null)
-                && $this->nonEmptyString($row->raw['CN_SEO_Description'] ?? null);
+            return $this->hasAnyPlanString($row, ['CN_SEO_Title', 'zh_seo_title'])
+                && $this->hasAnyPlanString($row, ['CN_SEO_Description', 'zh_seo_description']);
         }
 
-        return $this->nonEmptyString($row->raw['EN_SEO_Title'] ?? null)
-            && $this->nonEmptyString($row->raw['EN_SEO_Description'] ?? null);
+        return $this->hasAnyPlanString($row, ['EN_SEO_Title', 'en_seo_title'])
+            && $this->hasAnyPlanString($row, ['EN_SEO_Description', 'en_seo_description']);
+    }
+
+    private function hasLlmsMetadata(CareerPublicResolutionPlanRow $row, string $locale): bool
+    {
+        $queryKeys = $locale === 'zh'
+            ? ['CN_Target_Queries', 'zh_target_queries']
+            : ['EN_Target_Queries', 'en_target_queries'];
+
+        return $this->hasAnyPlanString($row, $queryKeys)
+            && $this->hasAnyPlanString($row, ['Search_Intent_Type', 'search_intent_type']);
+    }
+
+    /**
+     * @param  list<string>  $keys
+     */
+    private function hasAnyPlanString(CareerPublicResolutionPlanRow $row, array $keys): bool
+    {
+        foreach ([$row->raw, is_array($row->raw['raw'] ?? null) ? $row->raw['raw'] : [], is_array($row->raw['seo'] ?? null) ? $row->raw['seo'] : []] as $source) {
+            foreach ($keys as $key) {
+                if ($this->nonEmptyString($source[$key] ?? null)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private function nonEmptyString(mixed $value): bool

--- a/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessAuditor.php
@@ -58,11 +58,11 @@ final class CareerSeoGeoReadinessAuditor
         $llmsEligible = $this->boolValue($row, ['llms_eligible', 'llms_live', 'llms']);
         $llmsFullEligible = $this->boolValue($row, ['llms_full_eligible', 'llms_full_live', 'llms_full']);
         $structuredDataReady = $this->boolValue($row, ['structured_data_ready', 'structured_metadata_ready'])
-            ?? $this->nonEmptyArrayValue($row, ['structured_data', 'structured_data_json', 'jsonld']);
+            ?? $this->nonEmptyValue($row, ['structured_data', 'structured_data_json', 'jsonld']);
         $datasetEligible = $this->boolValue($row, ['dataset_eligible', 'dataset_visible', 'dataset']);
         $searchEligible = $this->boolValue($row, ['search_eligible', 'search_visible', 'search']);
         $citationMetadataReady = $this->boolValue($row, ['citation_metadata_ready', 'ai_citation_metadata_ready'])
-            ?? $this->nonEmptyArrayValue($row, ['citation_metadata', 'ai_citation_metadata']);
+            ?? $this->nonEmptyValue($row, ['citation_metadata', 'ai_citation_metadata']);
 
         $issues = $this->issuesFor(
             slug: $slug,
@@ -140,14 +140,41 @@ final class CareerSeoGeoReadinessAuditor
         if (! $robotsIndexable) {
             $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::ROBOTS_NOINDEX, 'Robots policy or indexability indicates noindex.', ['robots_policy' => $robotsPolicy, 'robots_indexable' => $robotsIndexable]);
         }
-        if ($sitemapEligible !== true) {
+        if ($sitemapEligible === null) {
             $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::SITEMAP_MISSING, 'Sitemap eligibility is missing or false.', ['sitemap_eligible' => $sitemapEligible]);
+        } elseif (! $sitemapEligible) {
+            $issues[] = $this->issue(
+                $slug,
+                $locale,
+                CareerSeoGeoReadinessIssue::SITEMAP_EXPECTED_NOT_READY,
+                'Sitemap eligibility is explicitly not ready by source policy.',
+                ['sitemap_eligible' => $sitemapEligible],
+                CareerCanonicalEligibilitySeverity::MEDIUM
+            );
         }
-        if ($llmsEligible !== true) {
+        if ($llmsEligible === null) {
             $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::LLMS_MISSING, 'LLMS eligibility is missing or false.', ['llms_eligible' => $llmsEligible]);
+        } elseif (! $llmsEligible) {
+            $issues[] = $this->issue(
+                $slug,
+                $locale,
+                CareerSeoGeoReadinessIssue::LLMS_EXPECTED_NOT_READY,
+                'LLMS eligibility is explicitly not ready by source policy.',
+                ['llms_eligible' => $llmsEligible],
+                CareerCanonicalEligibilitySeverity::MEDIUM
+            );
         }
-        if ($llmsFullEligible !== true) {
+        if ($llmsFullEligible === null) {
             $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::LLMS_FULL_MISSING, 'LLMS-full eligibility is missing or false.', ['llms_full_eligible' => $llmsFullEligible]);
+        } elseif (! $llmsFullEligible) {
+            $issues[] = $this->issue(
+                $slug,
+                $locale,
+                CareerSeoGeoReadinessIssue::LLMS_FULL_EXPECTED_NOT_READY,
+                'LLMS-full eligibility is explicitly not ready by source policy.',
+                ['llms_full_eligible' => $llmsFullEligible],
+                CareerCanonicalEligibilitySeverity::MEDIUM
+            );
         }
         if ($structuredDataReady !== true) {
             $issues[] = $this->issue($slug, $locale, CareerSeoGeoReadinessIssue::STRUCTURED_DATA_MISSING, 'Structured metadata readiness is missing or false.', ['structured_data_ready' => $structuredDataReady]);
@@ -168,12 +195,18 @@ final class CareerSeoGeoReadinessAuditor
     /**
      * @param  array<string, mixed>  $evidence
      */
-    private function issue(string $slug, string $locale, string $reason, string $message, array $evidence): CareerSeoGeoReadinessIssue
-    {
+    private function issue(
+        string $slug,
+        string $locale,
+        string $reason,
+        string $message,
+        array $evidence,
+        string $severity = CareerCanonicalEligibilitySeverity::HIGH,
+    ): CareerSeoGeoReadinessIssue {
         return new CareerSeoGeoReadinessIssue(
             reason: $reason,
             message: $message,
-            severity: CareerCanonicalEligibilitySeverity::HIGH,
+            severity: $severity,
             canonicalSlug: $slug,
             locale: $locale,
             evidence: [$evidence],
@@ -376,11 +409,16 @@ final class CareerSeoGeoReadinessAuditor
      * @param  array<string, mixed>  $row
      * @param  list<string>  $keys
      */
-    private function nonEmptyArrayValue(array $row, array $keys): ?bool
+    private function nonEmptyValue(array $row, array $keys): ?bool
     {
         foreach ($keys as $key) {
             if (array_key_exists($key, $row)) {
-                return is_array($row[$key]) && $row[$key] !== [];
+                $value = $row[$key];
+                if (is_array($value)) {
+                    return $value !== [];
+                }
+
+                return is_scalar($value) && trim((string) $value) !== '';
             }
         }
 

--- a/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerSeoGeoReadinessIssue.php
@@ -14,9 +14,15 @@ final class CareerSeoGeoReadinessIssue
 
     public const SITEMAP_MISSING = 'sitemap_missing';
 
+    public const SITEMAP_EXPECTED_NOT_READY = 'sitemap_expected_not_ready';
+
     public const LLMS_MISSING = 'llms_missing';
 
+    public const LLMS_EXPECTED_NOT_READY = 'llms_expected_not_ready';
+
     public const LLMS_FULL_MISSING = 'llms_full_missing';
+
+    public const LLMS_FULL_EXPECTED_NOT_READY = 'llms_full_expected_not_ready';
 
     public const STRUCTURED_DATA_MISSING = 'structured_data_missing';
 
@@ -60,8 +66,11 @@ final class CareerSeoGeoReadinessIssue
             self::CANONICAL_NOT_SELF,
             self::ROBOTS_NOINDEX,
             self::SITEMAP_MISSING,
+            self::SITEMAP_EXPECTED_NOT_READY,
             self::LLMS_MISSING,
+            self::LLMS_EXPECTED_NOT_READY,
             self::LLMS_FULL_MISSING,
+            self::LLMS_FULL_EXPECTED_NOT_READY,
             self::STRUCTURED_DATA_MISSING,
             self::DATASET_MISSING,
             self::SEARCH_MISSING,

--- a/backend/docs/career/audits/canonical_eligibility_audit_command.md
+++ b/backend/docs/career/audits/canonical_eligibility_audit_command.md
@@ -58,6 +58,12 @@ CMD-FIX-1 makes the command call the completed audit layer services instead of e
 - SEO/GEO readiness uses `CareerSeoGeoReadinessAuditor` from plan/backend artifact fields
 - surface readiness uses `CareerSurfaceReadinessAuditor` when `--surface-context`, `--include-surfaces`, or `--include-live-html` is requested
 
+SEO/GEO readiness distinguishes absent source evidence from explicit not-ready release policy. For example, a planner row with
+`Ready_For_Sitemap=false` now reports `sitemap_expected_not_ready` instead of `sitemap_missing`, while absent sitemap evidence
+still reports `sitemap_missing`. The planner mapper also reads nested workbook/export fields under `raw` and `seo` so existing
+SEO titles, descriptions, target queries, and structured source fields can satisfy source availability without implying that
+sitemap, LLMS, or LLMS-full publication has happened.
+
 When supplied, entity and index artifact rows bypass DB-backed entity/index auditors:
 
 - `--entity-context=/path/to/entity_context.json` supplies `career_entity_context.v1`

--- a/backend/docs/career/audits/seo_geo_readiness_sources.md
+++ b/backend/docs/career/audits/seo_geo_readiness_sources.md
@@ -1,0 +1,34 @@
+# Career SEO/GEO Readiness Sources
+
+REPAIR-SEO-GEO-1 normalizes planner-derived SEO/GEO readiness for the canonical eligibility audit.
+
+The audit remains read-only. It does not deploy sitemap or LLMS files, crawl live HTML, mutate DB rows, publish occupations, or claim 2786 readiness.
+
+## Source Mapping
+
+`career:audit-canonical-eligibility` builds the SEO/GEO audit input from public-resolution planner rows. The mapper reads both top-level planner fields and nested workbook/export fields under `raw` and `seo`.
+
+Accepted planner source evidence includes:
+
+- sitemap policy: `ready_for_sitemap` or `Ready_For_Sitemap`
+- LLMS policy: `ready_for_llms`, `Ready_For_LLMS`, `ready_for_llms_full`, or `Ready_For_LLMS_Full`
+- citation metadata: EN/CN SEO title and description fields, including nested `seo.en_title`, `seo.en_description`, `seo.zh_title`, and `seo.zh_description`
+- LLMS metadata source: EN/CN target queries plus `Search_Intent_Type` or `seo.search_intent_type`
+- structured data source: explicit occupation schema JSON fields, or canonical slug, locale title, source code, and SEO metadata sufficient for the static structured-data source layer
+
+## Missing vs Expected Not Ready
+
+The auditor now separates absent evidence from explicit source policy:
+
+- `sitemap_missing`: no sitemap readiness source was supplied
+- `sitemap_expected_not_ready`: the source explicitly says sitemap is not ready
+- `llms_missing`: no LLMS readiness source or metadata source was supplied
+- `llms_expected_not_ready`: LLMS metadata exists but the source policy is not ready
+- `llms_full_missing`: no LLMS-full readiness source or metadata source was supplied
+- `llms_full_expected_not_ready`: LLMS-full metadata exists but the source policy is not ready
+
+Expected-not-ready reasons still block eligibility. They are not publication defects and do not authorize rollout, DB mutation, sitemap deployment, LLMS deployment, or live crawling.
+
+## Deferred Baseline Display Fields
+
+`required_display_field_missing` is emitted by the baseline layer. SCAN-3 grouped it with broad SEO/GEO symptoms because the same workbook-derived display source is involved, but the code remediation for baseline display mapping belongs to `REPAIR-BASELINE-1`.

--- a/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
@@ -103,6 +103,59 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertSame(2, $payload['run_context']['planner']['found_rows']);
     }
 
+    public function test_planner_nested_seo_fields_are_mapped_and_policy_not_ready_is_distinguished(): void
+    {
+        $planPath = $this->writePlanner([
+            [
+                'row_number' => 2,
+                'canonical_slug' => 'actuaries',
+                'status' => 'ready_for_pilot',
+                'source_code' => '15-2011.00',
+                'title_en' => 'Actuaries',
+                'title_zh' => '精算师',
+                'ready_for_sitemap' => false,
+                'seo' => [
+                    'en_title' => 'Actuaries Career Guide',
+                    'en_description' => 'Explore actuaries with source-backed career evidence.',
+                    'zh_title' => '精算师职业指南',
+                    'zh_description' => '了解精算师职业证据。',
+                    'en_target_queries' => '["actuaries career"]',
+                    'zh_target_queries' => '["精算师职业"]',
+                    'search_intent_type' => '["career_exploration"]',
+                ],
+                'raw' => [
+                    'Ready_For_Sitemap' => false,
+                    'EN_SEO_Title' => 'Actuaries Career Guide',
+                    'EN_SEO_Description' => 'Explore actuaries with source-backed career evidence.',
+                    'CN_SEO_Title' => '精算师职业指南',
+                    'CN_SEO_Description' => '了解精算师职业证据。',
+                    'EN_Target_Queries' => '["actuaries career"]',
+                    'CN_Target_Queries' => '["精算师职业"]',
+                    'Search_Intent_Type' => '["career_exploration"]',
+                ],
+            ],
+        ]);
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'all',
+            '--public-resolution-plan' => $planPath,
+            '--locales' => 'en,zh',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayNotHasKey('structured_data_missing', $payload['by_reason']);
+        $this->assertArrayNotHasKey('citation_metadata_missing', $payload['by_reason']);
+        $this->assertArrayNotHasKey('sitemap_missing', $payload['by_reason']);
+        $this->assertArrayNotHasKey('llms_missing', $payload['by_reason']);
+        $this->assertArrayNotHasKey('llms_full_missing', $payload['by_reason']);
+        $this->assertSame(2, $payload['by_reason']['sitemap_expected_not_ready']);
+        $this->assertSame(2, $payload['by_reason']['llms_expected_not_ready']);
+        $this->assertSame(2, $payload['by_reason']['llms_full_expected_not_ready']);
+        $this->assertSame('blocked', data_get($payload, 'rows.0.seo_geo_status.status'));
+        $this->assertContains('sitemap_expected_not_ready', data_get($payload, 'rows.0.seo_geo_status.reasons'));
+    }
+
     public function test_projection_truth_artifacts_drive_runtime_layer_status(): void
     {
         $projectionPath = $this->writeJsonArtifact('projection', [

--- a/backend/tests/Unit/Domain/Career/Audit/CareerSeoGeoReadinessAuditorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerSeoGeoReadinessAuditorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Domain\Career\Audit;
 
 use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
 use App\Domain\Career\Audit\CareerPublicResolutionPlan;
 use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
@@ -45,13 +46,34 @@ final class CareerSeoGeoReadinessAuditorTest extends TestCase
         $this->assertSame(CareerSeoGeoReadinessIssue::ROBOTS_NOINDEX, $result->issues[0]->reason);
     }
 
-    public function test_sitemap_llms_and_llms_full_missing_are_reported(): void
+    public function test_sitemap_llms_and_llms_full_expected_not_ready_policy_is_distinguished_from_missing_sources(): void
     {
         $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([
             $this->row('actuaries', 'en', [
                 'sitemap_eligible' => false,
                 'llms_eligible' => false,
                 'llms_full_eligible' => false,
+            ]),
+        ]));
+
+        $this->assertSame([
+            CareerSeoGeoReadinessIssue::LLMS_EXPECTED_NOT_READY => 1,
+            CareerSeoGeoReadinessIssue::LLMS_FULL_EXPECTED_NOT_READY => 1,
+            CareerSeoGeoReadinessIssue::SITEMAP_EXPECTED_NOT_READY => 1,
+        ], $result->byReason());
+        $this->assertSame(0, $result->sitemapMissingRows);
+        $this->assertSame(0, $result->llmsMissingRows);
+        $this->assertSame(0, $result->llmsFullMissingRows);
+        $this->assertSame(CareerCanonicalEligibilitySeverity::MEDIUM, $result->issues[0]->severity);
+    }
+
+    public function test_sitemap_llms_and_llms_full_missing_are_reported_when_sources_are_absent(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([
+            $this->row('actuaries', 'en', [
+                'sitemap_eligible' => null,
+                'llms_eligible' => null,
+                'llms_full_eligible' => null,
             ]),
         ]));
 
@@ -82,6 +104,22 @@ final class CareerSeoGeoReadinessAuditorTest extends TestCase
             CareerSeoGeoReadinessIssue::SEARCH_MISSING => 1,
             CareerSeoGeoReadinessIssue::STRUCTURED_DATA_MISSING => 1,
         ], $result->byReason());
+    }
+
+    public function test_structured_data_and_citation_artifact_strings_are_accepted_as_sources(): void
+    {
+        $result = $this->auditor()->audit(['actuaries'], ['en'], $this->artifact([
+            $this->row('actuaries', 'en', [
+                'structured_data_ready' => null,
+                'structured_data_json' => '{"@type":"Occupation"}',
+                'citation_metadata_ready' => null,
+                'citation_metadata' => 'career source citations available',
+            ]),
+        ]));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertArrayNotHasKey(CareerSeoGeoReadinessIssue::STRUCTURED_DATA_MISSING, $result->byReason());
+        $this->assertArrayNotHasKey(CareerSeoGeoReadinessIssue::CITATION_METADATA_MISSING, $result->byReason());
     }
 
     public function test_missing_artifact_row_reports_all_static_readiness_issues(): void

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2648,6 +2648,124 @@
       "local_cleanup_executed": false,
       "sidecar_issues": []
     },
+    "REPAIR-SEO-GEO-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-seo-geo-readiness-repair-1",
+      "title": "fix(api): normalize career seo geo readiness sources",
+      "name": "Normalize career SEO/GEO readiness sources",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-SURFACE-CONTEXT-1",
+        "SCAN-3"
+      ],
+      "scope_type": "audit_seo_geo_mapping_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerAuditCanonicalEligibility.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no sitemap deployment",
+        "no LLMS deployment",
+        "no fap-web changes",
+        "no production DB query",
+        "no DB mutation",
+        "no rollout",
+        "no backfill",
+        "no 80 readiness run",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided remediation train execution goal and authorized registering the current remediation PR item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-SURFACE-CONTEXT-1 is merged and local train worktree is based on origin/main after that merge."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to SEO/GEO audit mapping, audit tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        },
+        "career_seo_geo_readiness_auditor": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi",
+          "evidence": "13 tests passed, 28 assertions."
+        },
+        "career_audit_canonical_eligibility": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi",
+          "evidence": "25 tests passed, 124 assertions."
+        },
+        "career_canonical_eligibility_audit_schema": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "impacted_audit_layers": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi && php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi && php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi && php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi && php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi && php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi && php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi",
+          "evidence": "All impacted audit-layer regressions passed locally."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi"
+        },
+        "migrate_pretend": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "3155 files passed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full CI master chain exited 0; generated BigFive compiled artifacts were restored before staging."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-BASELINE-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "repair-seo-geo-1-baseline-display-field-deferred",
+          "title": "required_display_field_missing belongs to baseline layer repair",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [
+            "en",
+            "zh"
+          ],
+          "evidence": [
+            "SCAN-3 counts_by_reason_layer maps required_display_field_missing to baseline, not seo_geo.",
+            "REPAIR-BASELINE-1 is the next train item and explicitly owns baseline/display metadata mapping."
+          ],
+          "severity": "blocker_for_full_2786_claim",
+          "next_goal": "REPAIR-BASELINE-1",
+          "may_continue_train": true
+        }
+      ]
+    },
     "RIASEC-PERSONALIZATION-00": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-00-train-registration",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1413,6 +1413,49 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-SEO-GEO-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-SURFACE-CONTEXT-1
+      - SCAN-3
+    branch: fix/career-seo-geo-readiness-repair-1
+    title: "fix(api): normalize career seo geo readiness sources"
+    name: "Normalize career SEO/GEO readiness sources"
+    scope_type: audit_seo_geo_mapping_only
+    scope:
+      - Distinguish absent SEO/GEO source evidence from explicit not-ready source policy.
+      - Map nested planner/workbook SEO fields into the audit input for static source availability.
+      - Preserve sitemap, LLMS, and LLMS-full not-ready policy blockers without treating them as missing artifacts.
+      - Defer baseline display-field repair to REPAIR-BASELINE-1.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Deploy sitemap or LLMS artifacts.
+      - Touch fap-web.
+      - Query production DB.
+      - Mutate DB or production state.
+      - Apply rollout.
+      - Backfill data.
+      - Run 80 readiness.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "REPAIR-BASELINE-1"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: RIASEC-PERSONALIZATION-00
     repo: fap-api
     branch: codex/riasec-personalization-00-train-registration


### PR DESCRIPTION
## Summary
- Normalizes Career canonical eligibility SEO/GEO readiness mapping from planner/workbook artifacts.
- Reads nested planner `raw` and `seo` fields for SEO titles, descriptions, target queries, search intent, and structured-data source availability.
- Distinguishes explicit not-ready policy from missing source evidence with `sitemap_expected_not_ready`, `llms_expected_not_ready`, and `llms_full_expected_not_ready`.
- Registers REPAIR-SEO-GEO-1 in the PR train metadata.

## Non-goals / Safety
- No deploy.
- No production DB query.
- No DB mutation.
- No sitemap or LLMS publication.
- No rollout/backfill/apply/rollback/quarantine.
- No 80 readiness run.
- No fap-web changes.

## Sidecar
- `required_display_field_missing` is baseline-layer evidence in SCAN-3 and is deferred to REPAIR-BASELINE-1.

## Tests
- `php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi` PASS
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi` PASS
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` PASS
- `php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi` PASS
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi` PASS
- `php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi` PASS
- `php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi` PASS
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi` PASS
- `php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi` PASS
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi` PASS
- `php artisan route:list --no-ansi` PASS
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force` PASS
- `vendor/bin/pint --test` PASS
- `git diff --check` PASS
- `bash backend/scripts/ci_verify_mbti.sh` PASS
