### PR TITLE
fix(api): use workbook english titles in career audit

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditor.php
@@ -53,7 +53,8 @@ final class CareerBaselineMetadataInventoryAuditor
                 sourceScope: $planRow->batchId ?? 'plan',
                 zhRow: $sources['zh_rows'][$canonicalSlug] ?? $this->plannerZhDisplayRow($planRow),
                 enRow: $sources['en_rows'][$canonicalSlug] ?? null,
-                manifestRow: $sources['manifest_rows'][$canonicalSlug] ?? null
+                manifestRow: $sources['manifest_rows'][$canonicalSlug] ?? null,
+                plannerTitleEn: $this->normalizeString($planRow->titleEn)
             );
         }
 
@@ -194,11 +195,12 @@ final class CareerBaselineMetadataInventoryAuditor
         ?array $zhRow,
         ?array $enRow,
         ?array $manifestRow,
+        ?string $plannerTitleEn,
     ): CareerBaselineMetadataInventoryRow {
         $issues = [];
         $missingDisplayFields = $this->missingDisplayFields($zhRow);
         $titleZh = $this->titleForLocale($zhRow, 'zh');
-        [$titleEn, $titleEnSource] = $this->resolveTitleEn($canonicalSlug, $enRow, $manifestRow);
+        [$titleEn, $titleEnSource] = $this->resolveTitleEn($canonicalSlug, $enRow, $manifestRow, $plannerTitleEn);
 
         if ($zhRow === null) {
             $issues[] = new CareerBaselineMetadataInventoryIssue(
@@ -331,7 +333,7 @@ final class CareerBaselineMetadataInventoryAuditor
      * @param  array<string, mixed>|null  $manifestRow
      * @return array{0: string|null, 1: string}
      */
-    private function resolveTitleEn(string $canonicalSlug, ?array $enRow, ?array $manifestRow): array
+    private function resolveTitleEn(string $canonicalSlug, ?array $enRow, ?array $manifestRow, ?string $plannerTitleEn): array
     {
         $title = $this->titleForLocale($enRow, 'en');
         if ($title !== null) {
@@ -341,6 +343,10 @@ final class CareerBaselineMetadataInventoryAuditor
         $title = $this->titleForLocale($manifestRow, 'en');
         if ($title !== null) {
             return [$title, CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_BATCH_MANIFEST];
+        }
+
+        if ($plannerTitleEn !== null) {
+            return [$plannerTitleEn, CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_PLANNER_WORKBOOK];
         }
 
         $derived = $this->deriveTitleEn($canonicalSlug);

--- a/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryRow.php
+++ b/backend/app/Domain/Career/Audit/CareerBaselineMetadataInventoryRow.php
@@ -12,6 +12,8 @@ final class CareerBaselineMetadataInventoryRow
 
     public const TITLE_EN_SOURCE_BATCH_MANIFEST = 'batch_manifest';
 
+    public const TITLE_EN_SOURCE_PLANNER_WORKBOOK = 'planner_workbook';
+
     public const TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED = 'canonical_slug_derived';
 
     public const TITLE_EN_SOURCE_MISSING = 'missing';
@@ -69,6 +71,7 @@ final class CareerBaselineMetadataInventoryRow
         return [
             self::TITLE_EN_SOURCE_EN_BASELINE,
             self::TITLE_EN_SOURCE_BATCH_MANIFEST,
+            self::TITLE_EN_SOURCE_PLANNER_WORKBOOK,
             self::TITLE_EN_SOURCE_CANONICAL_SLUG_DERIVED,
             self::TITLE_EN_SOURCE_MISSING,
         ];

--- a/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanRow.php
+++ b/backend/app/Domain/Career/Audit/CareerPublicResolutionPlanRow.php
@@ -126,7 +126,8 @@ final class CareerPublicResolutionPlanRow
     private static function titleValue(array $raw, string $locale): ?string
     {
         if ($locale === 'en') {
-            $direct = self::normalizeString($raw['title_en'] ?? null);
+            $direct = self::normalizeString($raw['title_en'] ?? null)
+                ?? self::normalizeString($raw['EN_Title'] ?? null);
             if ($direct !== null) {
                 return $direct;
             }

--- a/backend/docs/career/audits/baseline_metadata_inventory_audit.md
+++ b/backend/docs/career/audits/baseline_metadata_inventory_audit.md
@@ -38,6 +38,8 @@ The baseline auditor loads JSON sources from explicit paths supplied by the call
 
 REPAIR-BASELINE-1 adds a read-only fallback for planner/workbook display metadata. If a zh baseline JSON row is absent but the plan row carries `title_zh` plus zh SEO title and description fields under the top-level row, `raw`, or `seo`, the auditor can satisfy the baseline display metadata source from that planner row. This removes false `zh_baseline_missing` and `required_display_field_missing` blockers for workbook-derived rows without generating new content or mutating DB state.
 
+REPAIR-TITLE-1 adds a read-only English title source for planner/workbook rows. If no English baseline row or batch manifest title exists, the auditor accepts an authorized plan-row `title_en` / workbook `EN_Title` value before falling back to canonical-slug title derivation. This removes false `en_title_derivation_required` warnings where workbook English titles are already present.
+
 The default required display metadata fields are:
 
 - `title`
@@ -76,6 +78,7 @@ Each `CareerBaselineMetadataInventoryRow` serializes as:
 
 - `en_baseline`
 - `batch_manifest`
+- `planner_workbook`
 - `canonical_slug_derived`
 - `missing`
 

--- a/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
@@ -187,8 +187,10 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
 
         $this->assertArrayNotHasKey('zh_baseline_missing', $payload['by_reason']);
         $this->assertArrayNotHasKey('required_display_field_missing', $payload['by_reason']);
-        $this->assertSame('warning', data_get($payload, 'rows.0.baseline_status.status'));
+        $this->assertSame('pass', data_get($payload, 'rows.0.baseline_status.status'));
         $this->assertSame('planner_workbook', data_get($payload, 'rows.0.baseline_status.evidence.0.zh_baseline_source'));
+        $this->assertSame('planner_workbook', data_get($payload, 'rows.0.baseline_status.evidence.0.title_en_source'));
+        $this->assertArrayNotHasKey('en_title_derivation_required', $payload['by_reason']);
     }
 
     public function test_projection_truth_artifacts_drive_runtime_layer_status(): void

--- a/backend/tests/Unit/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerBaselineMetadataInventoryAuditorTest.php
@@ -137,6 +137,29 @@ final class CareerBaselineMetadataInventoryAuditorTest extends TestCase
         $this->assertSame(CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_BATCH_MANIFEST, $result->rows[0]->titleEnSource);
     }
 
+    public function test_en_title_from_planner_workbook_when_authorized_source_exists(): void
+    {
+        $result = $this->auditor(
+            zhRows: [$this->baselineRow('actuaries', '精算师')],
+            enRows: [],
+            manifestRows: [],
+        )->auditPlan(new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-audit-4-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw([
+                    'canonical_slug' => 'actuaries',
+                    'EN_Title' => 'Actuaries',
+                ]),
+            ],
+        ));
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame('Actuaries', $result->rows[0]->titleEn);
+        $this->assertSame(CareerBaselineMetadataInventoryRow::TITLE_EN_SOURCE_PLANNER_WORKBOOK, $result->rows[0]->titleEnSource);
+        $this->assertArrayNotHasKey(CareerBaselineMetadataInventoryIssue::EN_TITLE_DERIVATION_REQUIRED, $result->byReason());
+    }
+
     public function test_en_title_can_be_derived_from_canonical_slug(): void
     {
         $result = $this->auditor(

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2776,7 +2776,7 @@
       "branch": "fix/career-baseline-metadata-repair-1",
       "title": "fix(api): map career workbook baseline metadata for audit",
       "name": "Map career workbook baseline metadata for audit",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "REPAIR-SEO-GEO-1",
         "SCAN-3"
@@ -2802,8 +2802,8 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "49714abc8749e0d3ddda5332768c66968fe3473b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1353",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -2867,6 +2867,112 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-TITLE-1",
+      "merged_at": "2026-05-13T10:31:09Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": []
+    },
+    "REPAIR-TITLE-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-title-source-repair-1",
+      "title": "fix(api): use workbook english titles in career audit",
+      "name": "Use workbook English titles in career audit",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-BASELINE-1",
+        "SCAN-3"
+      ],
+      "scope_type": "audit_title_source_mapping_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no generated fake English titles",
+        "no production DB query",
+        "no DB mutation",
+        "no content generation",
+        "no fap-web changes",
+        "no rollout",
+        "no 80 readiness run",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided remediation train execution goal and authorized registering the current remediation PR item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-BASELINE-1 merged as PR #1353 and local train worktree is based on origin/main after that merge."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to title source mapping in the audit domain, audit tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        },
+        "career_baseline_metadata_inventory": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi",
+          "evidence": "13 tests passed, 39 assertions."
+        },
+        "career_audit_canonical_eligibility": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi",
+          "evidence": "26 tests passed, 130 assertions."
+        },
+        "career_public_resolution_plan_resolver": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "14 tests passed, 37 assertions."
+        },
+        "career_canonical_eligibility_audit_schema": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "title_only_real_planner_projection": {
+          "status": "pass",
+          "command": "Local PHP domain-only read of /tmp/career_2786_public_resolution_plan_from_d23b.json through CareerPublicResolutionPlanResolver and CareerBaselineMetadataInventoryAuditor.",
+          "evidence": "2786 expected, en_title_found=2786, en_title_derived=0, by_reason empty."
+        },
+        "impacted_audit_layers": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi && php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi && php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi && php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi && php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi && php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi",
+          "evidence": "All impacted audit-layer regressions passed locally."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi"
+        },
+        "migrate_pretend": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "3155 files passed."
+        },
+        "mbti_master_chain": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "CI master chain exited 0 locally; generated BigFive compiled verification artifacts were restored before staging."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-RUNTIME-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1546,6 +1546,47 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-TITLE-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-BASELINE-1
+      - SCAN-3
+    branch: fix/career-title-source-repair-1
+    title: "fix(api): use workbook english titles in career audit"
+    name: "Use workbook English titles in career audit"
+    scope_type: audit_title_source_mapping_only
+    scope:
+      - Accept authorized planner/workbook English titles as a baseline audit source.
+      - Resolve false en_title_derivation_required warnings when title_en or EN_Title is present.
+      - Keep canonical slug derivation only as a fallback when no approved English title source exists.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Generate fake English titles.
+      - Mutate DB or production state.
+      - Generate content.
+      - Touch fap-web.
+      - Apply rollout.
+      - Run 80 readiness.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "REPAIR-RUNTIME-1"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: RIASEC-PERSONALIZATION-00
     repo: fap-api
     branch: codex/riasec-personalization-00-train-registration


### PR DESCRIPTION
## Summary
- accepts authorized planner/workbook English titles as `planner_workbook` baseline audit source
- parses workbook `EN_Title` into public-resolution plan rows
- removes false `en_title_derivation_required` warnings when `title_en` / `EN_Title` is already present
- registers REPAIR-TITLE-1 and marks REPAIR-BASELINE-1 merged in the train ledger

## Evidence
- Local real planner title-only check on `/tmp/career_2786_public_resolution_plan_from_d23b.json`: `expected=2786`, `en_title_found=2786`, `en_title_derived=0`, `by_reason=[]`

## Validation
- `php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi`
- `php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi`
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi`
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Scope and non-goals
- no generated/fake English titles
- no DB mutation
- no content generation
- no import/apply/backfill
- no deploy
- no fap-web changes
- runtime/index/entity remediation remains deferred to later train items
