### PR TITLE
fix(api): classify career runtime authority gaps for audit

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditor.php
@@ -10,6 +10,12 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
 
     private const PUBLIC_CANONICAL_JOB = 'public_canonical_job';
 
+    private const EXPECTED_PUBLISHED = 'expected_published';
+
+    private const GOVERNED_NON_PUBLIC = 'governed_non_public';
+
+    private const NOT_YET_PROMOTED = 'not_yet_promoted';
+
     /**
      * @param  list<mixed>  $planRows
      * @param  list<string>  $locales
@@ -30,6 +36,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
         $truthRows = $this->rowsBySlugLocale($this->artifactRows($truth));
         $ledgerSlugs = $ledger === null ? null : $this->ledgerSlugs($ledger);
         $planTypes = $this->publicTypesBySlug($planRows);
+        $planExpectations = $this->runtimeExpectationsBySlug($planRows);
 
         $rows = [];
         foreach ($expectedSlugs as $slug) {
@@ -41,6 +48,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
                     truthRow: $truthRows[$this->rowKey($slug, $locale)] ?? null,
                     ledgerMemberExists: $ledgerSlugs === null ? null : in_array($slug, $ledgerSlugs, true),
                     planPublicType: $planTypes[$slug] ?? null,
+                    planRuntimeExpectation: $planExpectations[$slug] ?? self::EXPECTED_PUBLISHED,
                 );
             }
         }
@@ -129,6 +137,51 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
     }
 
     /**
+     * @return array<string, string>
+     */
+    private function runtimeExpectationsBySlug(array $planRows): array
+    {
+        $expectations = [];
+        foreach ($planRows as $row) {
+            $slug = $this->slugForPlanRow($row);
+            if ($slug !== null) {
+                $expectations[$slug] = $this->runtimeExpectationForPlanRow($row);
+            }
+        }
+
+        return $expectations;
+    }
+
+    private function runtimeExpectationForPlanRow(mixed $row): string
+    {
+        $publicType = $this->publicTypeForRow($row);
+        if ($publicType === self::PUBLIC_CANONICAL_JOB) {
+            return self::EXPECTED_PUBLISHED;
+        }
+
+        if ($publicType !== null) {
+            return $this->isGovernedNonPublicType($publicType)
+                ? self::GOVERNED_NON_PUBLIC
+                : self::EXPECTED_PUBLISHED;
+        }
+
+        $states = $this->planStates($row);
+        foreach ($states as $state) {
+            if (in_array($state, ['published', 'live'], true)) {
+                return self::EXPECTED_PUBLISHED;
+            }
+        }
+
+        foreach ($states as $state) {
+            if (in_array($state, ['ready_for_pilot', 'planned', 'candidate', 'published_candidate', 'approved', 'draft', 'review_needed'], true)) {
+                return self::NOT_YET_PROMOTED;
+            }
+        }
+
+        return self::EXPECTED_PUBLISHED;
+    }
+
+    /**
      * @param  array<string, mixed>|null  $projectionRow
      * @param  array<string, mixed>|null  $truthRow
      */
@@ -139,6 +192,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
         ?array $truthRow,
         ?bool $ledgerMemberExists,
         ?string $planPublicType,
+        ?string $planRuntimeExpectation,
     ): CareerRuntimeProjectionTruthEligibilityRow {
         $projectionState = $this->normalizeString($projectionRow['projection_state'] ?? null);
         $runtimePublishState = $this->normalizeString($projectionRow['runtime_publish_state'] ?? null);
@@ -158,10 +212,18 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
             $truthRow['public_type'] ?? null,
             $planPublicType,
         ]);
+        $runtimeExpectation = $this->runtimeExpectation(
+            projectionState: $projectionState,
+            runtimePublishState: $runtimePublishState,
+            truthState: $truthState,
+            canonicalPublicType: $canonicalPublicType,
+            planRuntimeExpectation: $planRuntimeExpectation,
+        );
 
         $issues = $this->issuesFor(
             slug: $slug,
             locale: $locale,
+            runtimeExpectation: $runtimeExpectation,
             projectionRow: $projectionRow,
             truthRow: $truthRow,
             projectionState: $projectionState,
@@ -177,6 +239,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
             runtimePublishState: $runtimePublishState,
             truthState: $truthState,
             canonicalPublicType: $canonicalPublicType,
+            runtimeExpectation: $runtimeExpectation,
             ledgerMemberExists: $ledgerMemberExists,
         );
 
@@ -204,6 +267,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
     private function issuesFor(
         string $slug,
         string $locale,
+        string $runtimeExpectation,
         ?array $projectionRow,
         ?array $truthRow,
         ?string $projectionState,
@@ -214,8 +278,9 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
     ): array {
         $issues = [];
         $rowEvidence = [['slug' => $slug, 'locale' => $locale]];
+        $strictPublishedExpected = $runtimeExpectation === self::EXPECTED_PUBLISHED;
 
-        if ($ledgerMemberExists === false) {
+        if ($strictPublishedExpected && $ledgerMemberExists === false) {
             $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
                 reason: CareerRuntimeProjectionTruthEligibilityIssue::LEDGER_MEMBER_MISSING,
                 message: 'Ledger input was provided but did not include the expected canonical slug.',
@@ -226,7 +291,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
             );
         }
 
-        if ($projectionRow === null && $truthRow === null) {
+        if ($strictPublishedExpected && $projectionRow === null && $truthRow === null) {
             $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
                 reason: CareerRuntimeProjectionTruthEligibilityIssue::LOCALE_ROW_MISSING,
                 message: 'No runtime projection or truth row was found for the expected slug and locale.',
@@ -237,7 +302,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
             );
         }
 
-        if ($projectionRow === null) {
+        if ($strictPublishedExpected && $projectionRow === null) {
             $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
                 reason: CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_ROW_MISSING,
                 message: 'Runtime publish projection row was not found for the expected slug and locale.',
@@ -246,7 +311,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
                 locale: $locale,
                 evidence: $rowEvidence,
             );
-        } elseif ($runtimePublishState !== null && $runtimePublishState !== self::PUBLISHED) {
+        } elseif ($strictPublishedExpected && $runtimePublishState !== null && $runtimePublishState !== self::PUBLISHED) {
             $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
                 reason: CareerRuntimeProjectionTruthEligibilityIssue::RUNTIME_PUBLISH_STATE_NOT_PUBLISHED,
                 message: 'Runtime publish projection row is not published.',
@@ -255,7 +320,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
                 locale: $locale,
                 evidence: [['runtime_publish_state' => $runtimePublishState]],
             );
-        } elseif ($runtimePublishState === null && $projectionState !== null && $projectionState !== self::PUBLISHED) {
+        } elseif ($strictPublishedExpected && $runtimePublishState === null && $projectionState !== null && $projectionState !== self::PUBLISHED) {
             $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
                 reason: CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_STATE_NOT_PUBLISHED,
                 message: 'Projection row state is not published.',
@@ -266,7 +331,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
             );
         }
 
-        if ($truthRow === null) {
+        if ($strictPublishedExpected && $truthRow === null) {
             $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
                 reason: CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_ROW_MISSING,
                 message: 'Canonical runtime truth row was not found for the expected slug and locale.',
@@ -275,7 +340,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
                 locale: $locale,
                 evidence: $rowEvidence,
             );
-        } elseif ($truthState !== null && $truthState !== self::PUBLISHED) {
+        } elseif ($strictPublishedExpected && $truthState !== null && $truthState !== self::PUBLISHED) {
             $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
                 reason: CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_STATE_NOT_PUBLISHED,
                 message: 'Canonical runtime truth row state is not published.',
@@ -286,7 +351,7 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
             );
         }
 
-        if ($canonicalPublicType !== null && $canonicalPublicType !== self::PUBLIC_CANONICAL_JOB) {
+        if ($strictPublishedExpected && $canonicalPublicType !== null && $canonicalPublicType !== self::PUBLIC_CANONICAL_JOB) {
             $issues[] = new CareerRuntimeProjectionTruthEligibilityIssue(
                 reason: CareerRuntimeProjectionTruthEligibilityIssue::CANONICAL_PUBLIC_TYPE_INVALID,
                 message: 'Runtime projection/truth row exposes a non-canonical public type.',
@@ -328,9 +393,10 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
         ?string $runtimePublishState,
         ?string $truthState,
         ?string $canonicalPublicType,
+        string $runtimeExpectation,
         ?bool $ledgerMemberExists,
     ): array {
-        $evidence = [['slug' => $slug, 'locale' => $locale]];
+        $evidence = [['slug' => $slug, 'locale' => $locale, 'runtime_expectation' => $runtimeExpectation]];
 
         if ($ledgerMemberExists !== null) {
             $evidence[] = ['ledger_member_exists' => $ledgerMemberExists];
@@ -349,6 +415,28 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
         }
 
         return $evidence;
+    }
+
+    private function runtimeExpectation(
+        ?string $projectionState,
+        ?string $runtimePublishState,
+        ?string $truthState,
+        ?string $canonicalPublicType,
+        ?string $planRuntimeExpectation,
+    ): string {
+        if ($runtimePublishState === self::PUBLISHED || $projectionState === self::PUBLISHED || $truthState === self::PUBLISHED) {
+            return self::EXPECTED_PUBLISHED;
+        }
+
+        if ($canonicalPublicType === self::PUBLIC_CANONICAL_JOB) {
+            return self::EXPECTED_PUBLISHED;
+        }
+
+        if ($canonicalPublicType !== null && $this->isGovernedNonPublicType($canonicalPublicType)) {
+            return self::GOVERNED_NON_PUBLIC;
+        }
+
+        return $planRuntimeExpectation ?? self::EXPECTED_PUBLISHED;
     }
 
     /**
@@ -477,6 +565,59 @@ final class CareerRuntimeProjectionTruthEligibilityAuditor
         }
 
         return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function planStates(mixed $row): array
+    {
+        $values = [];
+
+        if ($row instanceof CareerPublicResolutionPlanRow) {
+            $values = [
+                $row->publicResolutionState,
+                $row->rolloutState,
+                $row->projectionState,
+            ];
+        } elseif (is_array($row)) {
+            $values = [
+                $row['public_resolution_state'] ?? null,
+                $row['status'] ?? null,
+                $row['current_status'] ?? null,
+                $row['rollout_state'] ?? null,
+                $row['projection_state'] ?? null,
+            ];
+        } elseif (is_object($row)) {
+            $values = [
+                property_exists($row, 'publicResolutionState') ? $row->publicResolutionState : null,
+                property_exists($row, 'rolloutState') ? $row->rolloutState : null,
+                property_exists($row, 'projectionState') ? $row->projectionState : null,
+            ];
+        }
+
+        $states = [];
+        foreach ($values as $value) {
+            $state = $this->normalizeString($value);
+            if ($state !== null) {
+                $states[] = strtolower($state);
+            }
+        }
+
+        return array_values(array_unique($states));
+    }
+
+    private function isGovernedNonPublicType(string $publicType): bool
+    {
+        return in_array($publicType, [
+            'blocked',
+            'blocked_until_governance_approval',
+            'explorer_only',
+            'family_handoff',
+            'governed_non_public',
+            'not_public',
+            'review_needed',
+        ], true);
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityResult.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityResult.php
@@ -70,7 +70,10 @@ final class CareerRuntimeProjectionTruthEligibilityResult
             expectedRows: count($rows),
             foundProjectionRows: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => $row->projectionExists)),
             foundTruthRows: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => $row->truthExists)),
-            foundPublished: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => $row->issues === [])),
+            foundPublished: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => $row->issues === []
+                && $row->runtimePublishState === 'published'
+                && $row->truthState === 'published'
+                && $row->canonicalPublicType === 'public_canonical_job')),
             missingProjectionRows: self::countRowsWithReason($rows, CareerRuntimeProjectionTruthEligibilityIssue::PROJECTION_ROW_MISSING),
             missingTruthRows: self::countRowsWithReason($rows, CareerRuntimeProjectionTruthEligibilityIssue::TRUTH_ROW_MISSING),
             notPublishedRows: count(array_filter($rows, static fn (CareerRuntimeProjectionTruthEligibilityRow $row): bool => self::rowHasAnyReason($row, [

--- a/backend/docs/career/audits/runtime_projection_truth_eligibility_audit.md
+++ b/backend/docs/career/audits/runtime_projection_truth_eligibility_audit.md
@@ -32,9 +32,15 @@ Truth rows may expose:
 - `state`
 - `status`
 
-For AUDIT-6 eligibility, exposed runtime/truth state must be `published`. If a ledger artifact is provided, the slug must also exist in that ledger. If no ledger artifact is provided, ledger membership is not audited.
+For AUDIT-6 eligibility, rows with `runtime_expectation=expected_published` are strict: exposed runtime/truth state must be `published`, and if a ledger artifact is provided, the slug must also exist in that ledger. If no ledger artifact is provided, ledger membership is not audited.
 
-The canonical public type is accepted only when it is absent or `public_canonical_job`. Any exposed non-canonical type is reported as an audit issue.
+REPAIR-RUNTIME-1 adds explicit runtime expectation classification:
+
+- `expected_published`: the row is expected to be live/public and remains subject to strict projection, truth, ledger, state, and public-type checks.
+- `governed_non_public`: the row is explicitly blocked by governance/non-public runtime authority and is not misclassified as a publication defect.
+- `not_yet_promoted`: the planner row is ready for pilot or otherwise staged, but no runtime publication is expected yet.
+
+The canonical public type is accepted only when it is absent or `public_canonical_job` for `expected_published` rows. Governed non-public runtime types such as `blocked_until_governance_approval` are preserved as readiness evidence instead of being reported as invalid public type defects.
 
 ## Result Shape
 
@@ -66,6 +72,7 @@ Each row includes an AUDIT-1-compatible runtime layer status:
     {
       "slug": "actuaries",
       "locale": "en",
+      "runtime_expectation": "expected_published",
       "runtime_publish_state": "published",
       "truth_state": "published"
     }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeProjectionTruthEligibilityAuditorTest.php
@@ -162,6 +162,47 @@ final class CareerRuntimeProjectionTruthEligibilityAuditorTest extends TestCase
         $this->assertNull($result->rows[0]->ledgerMemberExists);
     }
 
+    public function test_governed_non_public_projection_is_not_misclassified_as_publication_defect(): void
+    {
+        $result = $this->auditor()->audit(
+            planRows: [CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'actors', 'status' => 'ready_for_pilot'])],
+            locales: ['en'],
+            projection: $this->projection([
+                $this->projectionRow('actors', 'en', [
+                    'public_resolution_type' => 'blocked_until_governance_approval',
+                    'runtime_publish_state' => 'blocked',
+                ]),
+            ]),
+            truth: $this->truth([]),
+            ledger: ['members' => [['canonical_slug' => 'actors']]],
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(0, $result->foundPublished);
+        $this->assertSame([], $result->byReason());
+        $this->assertSame('governed_non_public', $result->rows[0]->runtimeStatus->evidence[0]['runtime_expectation']);
+    }
+
+    public function test_not_yet_promoted_plan_row_does_not_require_runtime_artifacts(): void
+    {
+        $result = $this->auditor()->auditPlan(
+            plan: new CareerPublicResolutionPlan(
+                sourcePath: '__fixture__',
+                checksum: null,
+                rows: [CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'actors', 'status' => 'ready_for_pilot'])],
+            ),
+            locales: ['en'],
+            projection: $this->projection([]),
+            truth: $this->truth([]),
+            ledger: ['members' => []],
+        );
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $result->status);
+        $this->assertSame(0, $result->foundPublished);
+        $this->assertSame([], $result->byReason());
+        $this->assertSame('not_yet_promoted', $result->rows[0]->runtimeStatus->evidence[0]['runtime_expectation']);
+    }
+
     public function test_result_by_reason_counts_issues(): void
     {
         $result = $this->auditor()->audit(
@@ -208,7 +249,8 @@ final class CareerRuntimeProjectionTruthEligibilityAuditorTest extends TestCase
         "evidence": [
             {
                 "slug": "actuaries",
-                "locale": "en"
+                "locale": "en",
+                "runtime_expectation": "expected_published"
             },
             {
                 "ledger_member_exists": true
@@ -228,7 +270,8 @@ final class CareerRuntimeProjectionTruthEligibilityAuditorTest extends TestCase
     "evidence": [
         {
             "slug": "actuaries",
-            "locale": "en"
+            "locale": "en",
+            "runtime_expectation": "expected_published"
         },
         {
             "ledger_member_exists": true
@@ -291,7 +334,8 @@ JSON,
                 "evidence": [
                     {
                         "slug": "actuaries",
-                        "locale": "en"
+                        "locale": "en",
+                        "runtime_expectation": "expected_published"
                     },
                     {
                         "runtime_publish_state": "published"
@@ -308,7 +352,8 @@ JSON,
             "evidence": [
                 {
                     "slug": "actuaries",
-                    "locale": "en"
+                    "locale": "en",
+                    "runtime_expectation": "expected_published"
                 },
                 {
                     "runtime_publish_state": "published"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1078,7 +1078,7 @@
       "branch": "fix/career-public-resolution-source-resolver-audit2",
       "title": "feat(api): add career public resolution plan resolver",
       "name": "Career 2786 Public Resolution Source Resolver",
-      "status": "in_progress",
+      "status": "merged",
       "scope_type": "source_resolver_only",
       "allowed_paths": [
         "backend/app/Domain/Career/Audit/*",
@@ -2342,8 +2342,8 @@
         "AUDIT-13"
       ],
       "scope_type": "audit_command_orchestration_only",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "e594cecac5e24a68d652c0225da232f97759354a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1354",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -2877,7 +2877,7 @@
       "branch": "fix/career-title-source-repair-1",
       "title": "fix(api): use workbook english titles in career audit",
       "name": "Use workbook English titles in career audit",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "REPAIR-BASELINE-1",
         "SCAN-3"
@@ -2903,8 +2903,8 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "e594cecac5e24a68d652c0225da232f97759354a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1354",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -2973,6 +2973,111 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-RUNTIME-1",
+      "merged_at": "2026-05-13T10:49:47Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": []
+    },
+    "REPAIR-RUNTIME-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-runtime-authority-gap-repair-1",
+      "title": "fix(api): classify career runtime authority gaps for audit",
+      "name": "Classify career runtime authority gaps for audit",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-TITLE-1",
+        "SCAN-3"
+      ],
+      "scope_type": "audit_runtime_authority_classification_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no runtime promotion",
+        "no production DB query",
+        "no DB mutation",
+        "no apply/rollout/backfill",
+        "no fap-web changes",
+        "no 80 readiness run",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided remediation train execution goal and authorized registering the current remediation PR item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-TITLE-1 merged as PR #1354 and local train worktree is based on origin/main after that merge."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to runtime authority audit classification, audit tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        },
+        "career_runtime_projection_truth_eligibility": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi",
+          "evidence": "18 tests passed, 43 assertions."
+        },
+        "career_audit_canonical_eligibility": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi",
+          "evidence": "26 tests passed, 130 assertions."
+        },
+        "career_2786_full_audit_artifact_builder": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi",
+          "evidence": "3 tests passed, 10 assertions."
+        },
+        "career_canonical_eligibility_audit_schema": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "real_runtime_context_projection": {
+          "status": "pass",
+          "command": "Local PHP domain-only read of /tmp/career_2786_public_resolution_plan_from_d23b.json, /tmp/career_2786_runtime_projection.json, /tmp/career_2786_runtime_truth.json, and /tmp/career_2786_full_release_ledger.json through CareerRuntimeProjectionTruthEligibilityAuditor.",
+          "evidence": "5572 expected rows, found_projection_rows=682, found_truth_rows=68, found_published=68, by_reason empty after classifying governed non-public and not-yet-promoted rows."
+        },
+        "impacted_audit_layers": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi && php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi && php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi && php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi && php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi",
+          "evidence": "All impacted audit-layer regressions passed locally."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi"
+        },
+        "migrate_pretend": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "3155 files passed."
+        },
+        "mbti_master_chain": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "CI master chain exited 0 locally; generated BigFive compiled verification artifacts were restored before staging."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-INDEX-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1587,6 +1587,47 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-RUNTIME-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-TITLE-1
+      - SCAN-3
+    branch: fix/career-runtime-authority-gap-repair-1
+    title: "fix(api): classify career runtime authority gaps for audit"
+    name: "Classify career runtime authority gaps for audit"
+    scope_type: audit_runtime_authority_classification_only
+    scope:
+      - Distinguish expected published rows from governed non-public rows and not-yet-promoted planner rows.
+      - Preserve strict runtime projection/truth/ledger checks for rows expected to be published.
+      - Avoid misclassifying non-public or not-yet-promoted rows as publication defects.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Promote runtime rows.
+      - Mutate DB or production state.
+      - Apply rollout.
+      - Backfill data.
+      - Touch fap-web.
+      - Run 80 readiness.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "REPAIR-INDEX-1"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: RIASEC-PERSONALIZATION-00
     repo: fap-api
     branch: codex/riasec-personalization-00-train-registration


### PR DESCRIPTION
## Summary
- classifies runtime rows as `expected_published`, `governed_non_public`, or `not_yet_promoted`
- preserves strict projection/truth/ledger/public-type checks for rows expected to be published
- stops misclassifying governed non-public and not-yet-promoted rows as runtime publication defects
- documents REPAIR-RUNTIME-1 behavior and registers the train item

## Evidence
- Local real runtime context check using restored `/tmp` artifacts: `expected_rows=5572`, `found_projection_rows=682`, `found_truth_rows=68`, `found_published=68`, `by_reason=[]`

## Validation
- `php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi`
- `php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi`
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Scope and non-goals
- no runtime promotion
- no DB mutation
- no apply/rollout/backfill
- no deploy
- no fap-web changes
- index/entity remediation remains deferred to later train items
