### PR TITLE
RIASEC-DEEP-COPY-01: Deep copy slot schema contract hardening

### DIFF
--- a/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
+++ b/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
@@ -6,22 +6,137 @@ namespace App\Services\Riasec;
 
 final class RiasecContentRegistrySlotContract
 {
-    public const SCHEMA_VERSION = 'riasec.content_registry_slot_contract.v1';
+    public const SCHEMA_VERSION = 'riasec.deep_copy_slot_schema.v1';
 
     /** @var list<string> */
-    private const SLOTS = [
-        'dimension_copy',
+    private const SLOT_GROUPS = [
+        'method_assets',
+        'dimension_deep_copy',
         'pair_blend_copy',
-        'triad_blend_copy',
-        'shadow_cost_copy',
-        '140q_task_card_copy',
-        '140q_environment_card_copy',
-        '140q_role_card_copy',
-        'low_quality_copy',
+        'quality_copy',
+        'module_visibility_copy',
+        '140q_layer_copy',
         'structural_difference_copy',
-        'aspiration_calibration_copy',
+        'aspirations_copy',
         'feedback_response_copy',
-        'module_boundary_copy',
+    ];
+
+    /** @var array<string,array<string,mixed>> */
+    private const SLOT_DEFINITIONS = [
+        'interpretation_rule_spec_v2' => [
+            'slot_group' => 'method_assets',
+            'required_versions' => ['interpretation_rule_version'],
+            'content_fields' => ['title', 'summary', 'body'],
+            'fallback_behavior' => 'reject_payload',
+        ],
+        'quality_rule_spec_v2' => [
+            'slot_group' => 'method_assets',
+            'required_versions' => ['quality_rule_version'],
+            'content_fields' => ['title', 'summary', 'body'],
+            'fallback_behavior' => 'reject_payload',
+        ],
+        'module_visibility_policy' => [
+            'slot_group' => 'module_visibility_copy',
+            'required_versions' => ['module_visibility_policy_id'],
+            'content_fields' => ['title', 'summary', 'body'],
+            'fallback_behavior' => 'omit_module',
+        ],
+        'dimension_deep_copy' => [
+            'slot_group' => 'dimension_deep_copy',
+            'required_versions' => ['interpretation_rule_version'],
+            'content_fields' => ['title', 'summary', 'body', 'core_drive', 'cost', 'shadow'],
+            'fallback_behavior' => 'omit_module',
+        ],
+        'core_drive_cost_shadow_copy' => [
+            'slot_group' => 'dimension_deep_copy',
+            'required_versions' => ['interpretation_rule_version'],
+            'content_fields' => ['title', 'summary', 'body', 'core_drive', 'cost', 'shadow'],
+            'fallback_behavior' => 'omit_module',
+        ],
+        'pair_blend_copy' => [
+            'slot_group' => 'pair_blend_copy',
+            'required_versions' => ['interpretation_rule_version'],
+            'content_fields' => ['title', 'summary', 'body'],
+            'fallback_behavior' => 'omit_module',
+        ],
+        'triad_blend_copy' => [
+            'slot_group' => 'pair_blend_copy',
+            'required_versions' => ['interpretation_rule_version'],
+            'content_fields' => ['title', 'summary', 'body'],
+            'fallback_behavior' => 'omit_module',
+        ],
+        '140q_task_card_copy' => [
+            'slot_group' => '140q_layer_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        '140q_environment_card_copy' => [
+            'slot_group' => '140q_layer_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        '140q_role_card_copy' => [
+            'slot_group' => '140q_layer_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        '140q_tension_copy' => [
+            'slot_group' => '140q_layer_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        'low_quality_copy' => [
+            'slot_group' => 'quality_copy',
+            'required_versions' => ['quality_rule_version'],
+        ],
+        'cautious_reading_copy' => [
+            'slot_group' => 'quality_copy',
+            'required_versions' => ['quality_rule_version'],
+        ],
+        'structural_difference_copy' => [
+            'slot_group' => 'structural_difference_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        'aspirations_calibration_copy' => [
+            'slot_group' => 'aspirations_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        'disagree_path_copy' => [
+            'slot_group' => 'feedback_response_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        'feedback_response_copy' => [
+            'slot_group' => 'feedback_response_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+    ];
+
+    /** @var list<string> */
+    private const REQUIRED_FIELDS = [
+        'slot_key',
+        'slot_group',
+        'scale_code',
+        'locale',
+        'content_version',
+        'applicable_form_codes',
+        'applicable_profile_shapes',
+        'applicable_quality_states',
+        'forbidden_claims',
+        'required_boundaries',
+        'evidence_level',
+        'source_status',
+        'review_status',
+        'fallback_behavior',
+    ];
+
+    /** @var list<string> */
+    private const REQUIRED_BOUNDARIES = [
+        'interest_evidence_only',
+        'not_career_recommendation',
+        'not_job_fit',
+        'not_success_prediction',
+        'not_ability_or_skill_measure',
+        'no_60q_140q_raw_delta',
+        '140q_contextual_not_more_accurate',
+        'feedback_does_not_mutate_measured_result',
+        'missing_content_fails_closed',
+        'frontend_fallback_forbidden',
     ];
 
     /** @var list<string> */
@@ -36,6 +151,50 @@ final class RiasecContentRegistrySlotContract
         'source_url',
         'soc_code',
         'onet_code',
+        'raw_delta',
+        'percentile',
+        'percentiles',
+        'norm',
+        'z_score',
+        't_score',
+        'ability_inference',
+        'skill_inference',
+        'frontend_fallback_copy',
+        'ai_generated_report',
+    ];
+
+    /** @var list<string> */
+    private const FORBIDDEN_PHRASES = [
+        'Matches',
+        'career recommendation',
+        'recommended career',
+        'best career',
+        'career match',
+        'occupation match',
+        'job fit',
+        'fit score',
+        'occupation ranking',
+        'success probability',
+        'career success',
+        'hiring suitability',
+        '140Q more accurate',
+        'more accurate',
+        '更准确',
+        '60Q wrong',
+        'raw delta',
+        'score increased',
+        'score decreased',
+        'percentile',
+        'normative percentile',
+        'z-score',
+        't-score',
+        'ability inference',
+        'skill inference',
+        '职业推荐',
+        '岗位匹配',
+        '匹配度',
+        '适合度',
+        '职业成功',
     ];
 
     /**
@@ -45,19 +204,25 @@ final class RiasecContentRegistrySlotContract
     {
         return [
             'schema_version' => self::SCHEMA_VERSION,
-            'slot_status' => 'readiness_contract_only',
+            'scale_code' => 'RIASEC',
+            'slot_status' => 'schema_contract_only',
             'runtime_public_copy_included' => false,
             'missing_content_policy' => 'omit_module_fail_closed',
             'unknown_slot_policy' => 'reject',
             'frontend_fallback_allowed' => false,
-            'required_fields' => ['slot', 'version', 'locale', 'owner', 'evidence_level', 'status'],
-            'allowed_statuses' => ['draft', 'reviewed', 'approved', 'deprecated'],
-            'allowed_evidence_levels' => ['content_example', 'theory_based', 'expert_reviewed', 'validated'],
-            'slots' => array_map(
-                fn (string $slot): array => $this->slotDefinition($slot),
-                self::SLOTS
-            ),
+            'allowed_slot_groups' => self::SLOT_GROUPS,
+            'required_fields' => self::REQUIRED_FIELDS,
+            'required_boundaries' => self::REQUIRED_BOUNDARIES,
+            'allowed_review_statuses' => $this->allowedReviewStatuses(),
+            'allowed_evidence_levels' => $this->allowedEvidenceLevels(),
+            'allowed_source_statuses' => $this->allowedSourceStatuses(),
+            'allowed_fallback_behaviors' => $this->allowedFallbackBehaviors(),
+            'slots' => array_values(array_map(
+                fn (string $slotKey): array => $this->slotDefinition($slotKey),
+                $this->slotKeys()
+            )),
             'forbidden_fields' => self::FORBIDDEN_FIELDS,
+            'forbidden_phrases' => self::FORBIDDEN_PHRASES,
         ];
     }
 
@@ -68,22 +233,67 @@ final class RiasecContentRegistrySlotContract
     public function validate(array $slot): array
     {
         $errors = [];
-        $slotName = trim((string) ($slot['slot'] ?? ''));
-        if (! in_array($slotName, self::SLOTS, true)) {
-            $errors[] = 'unsupported_slot';
-        }
+        $slotKey = trim((string) ($slot['slot_key'] ?? ''));
+        $slotDefinition = $this->slotDefinition($slotKey);
 
-        foreach (['version', 'locale', 'owner', 'evidence_level', 'status'] as $required) {
-            if (trim((string) ($slot[$required] ?? '')) === '') {
+        foreach (self::REQUIRED_FIELDS as $required) {
+            if (! array_key_exists($required, $slot) || $this->isBlank($slot[$required])) {
                 $errors[] = 'missing_'.$required;
             }
         }
 
-        if (! in_array((string) ($slot['status'] ?? ''), ['draft', 'reviewed', 'approved', 'deprecated'], true)) {
-            $errors[] = 'unsupported_status';
+        if ($slotDefinition === null) {
+            $errors[] = 'unsupported_slot_key';
+        } elseif ((string) ($slot['slot_group'] ?? '') !== $slotDefinition['slot_group']) {
+            $errors[] = 'slot_group_mismatch';
         }
-        if (! in_array((string) ($slot['evidence_level'] ?? ''), ['content_example', 'theory_based', 'expert_reviewed', 'validated'], true)) {
+
+        if ((string) ($slot['scale_code'] ?? '') !== 'RIASEC') {
+            $errors[] = 'unsupported_scale_code';
+        }
+        if (! in_array((string) ($slot['slot_group'] ?? ''), self::SLOT_GROUPS, true)) {
+            $errors[] = 'unsupported_slot_group';
+        }
+        if (! in_array((string) ($slot['review_status'] ?? ''), $this->allowedReviewStatuses(), true)) {
+            $errors[] = 'unsupported_review_status';
+        }
+        if (! in_array((string) ($slot['evidence_level'] ?? ''), $this->allowedEvidenceLevels(), true)) {
             $errors[] = 'unsupported_evidence_level';
+        }
+        if (! in_array((string) ($slot['source_status'] ?? ''), $this->allowedSourceStatuses(), true)) {
+            $errors[] = 'unsupported_source_status';
+        }
+        if (! in_array((string) ($slot['fallback_behavior'] ?? ''), $this->allowedFallbackBehaviors(), true)) {
+            $errors[] = 'unsupported_fallback_behavior';
+        }
+        if (in_array((string) ($slot['fallback_behavior'] ?? ''), ['frontend_fallback', 'frontend_generated_copy'], true)) {
+            $errors[] = 'frontend_fallback_forbidden';
+        }
+
+        foreach (['applicable_form_codes', 'applicable_profile_shapes', 'applicable_quality_states', 'forbidden_claims', 'required_boundaries'] as $field) {
+            if (! is_array($slot[$field] ?? null) || $slot[$field] === []) {
+                $errors[] = $field.'_must_be_non_empty_array';
+            }
+        }
+        if (! is_array($slot['applicable_codes'] ?? null) && ! is_array($slot['applicable_dimensions'] ?? null)) {
+            $errors[] = 'missing_applicable_codes_or_dimensions';
+        }
+        if ($slotDefinition !== null) {
+            foreach ((array) ($slotDefinition['required_versions'] ?? []) as $requiredVersion) {
+                if (! array_key_exists($requiredVersion, $slot) || $this->isBlank($slot[$requiredVersion])) {
+                    $errors[] = 'missing_'.$requiredVersion;
+                }
+            }
+            if ((string) ($slot['fallback_behavior'] ?? '') !== (string) ($slotDefinition['fallback_behavior'] ?? 'omit_module')) {
+                $errors[] = 'fallback_behavior_mismatch';
+            }
+        }
+
+        $boundaries = array_values(array_map('strval', (array) ($slot['required_boundaries'] ?? [])));
+        foreach (self::REQUIRED_BOUNDARIES as $boundary) {
+            if (! in_array($boundary, $boundaries, true)) {
+                $errors[] = 'missing_boundary_'.$boundary;
+            }
         }
 
         foreach (self::FORBIDDEN_FIELDS as $field) {
@@ -91,6 +301,7 @@ final class RiasecContentRegistrySlotContract
                 $errors[] = 'forbidden_field_'.$field;
             }
         }
+        $errors = array_merge($errors, $this->forbiddenPhraseErrors($slot));
 
         return [
             'ok' => $errors === [],
@@ -99,19 +310,149 @@ final class RiasecContentRegistrySlotContract
     }
 
     /**
-     * @return array<string,mixed>
+     * @return array{slot_key:string,exists:bool,behavior:string,module_state:string,frontend_fallback_allowed:bool,reason:string}
      */
-    private function slotDefinition(string $slot): array
+    public function missingContentBehavior(string $slotKey): array
     {
+        $definition = $this->slotDefinition($slotKey);
+
         return [
-            'slot' => $slot,
-            'version_required' => true,
-            'locale_required' => true,
-            'owner_required' => true,
-            'evidence_level_required' => true,
-            'status_required' => true,
+            'slot_key' => $slotKey,
+            'exists' => $definition !== null,
+            'behavior' => $definition === null ? 'reject_payload' : (string) $definition['fallback_behavior'],
+            'module_state' => $definition === null ? 'hidden' : 'omitted',
+            'frontend_fallback_allowed' => false,
+            'reason' => $definition === null ? 'unknown_slot_rejected' : 'missing_backend_content_fails_closed',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slotKeys(): array
+    {
+        return array_keys($this->slotDefinitionMap());
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function slotDefinitionMap(): array
+    {
+        $default = [
+            'required_versions' => ['interpretation_rule_version'],
+            'content_fields' => ['title', 'summary', 'body'],
+            'fallback_behavior' => 'omit_module',
+        ];
+
+        $definitions = [];
+        foreach (self::SLOT_DEFINITIONS as $slotKey => $definition) {
+            $definitions[$slotKey] = array_merge($default, $definition, ['slot_key' => $slotKey]);
+        }
+
+        return $definitions;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function slotDefinition(string $slotKey): ?array
+    {
+        if ($slotKey === '') {
+            return null;
+        }
+
+        $definitions = $this->slotDefinitionMap();
+        if (! array_key_exists($slotKey, $definitions)) {
+            return null;
+        }
+
+        $definition = $definitions[$slotKey];
+
+        return [
+            'slot_key' => $slotKey,
+            'slot_group' => $definition['slot_group'],
+            'scale_code' => 'RIASEC',
+            'required_versions' => $definition['required_versions'],
+            'content_fields' => $definition['content_fields'],
+            'required_fields' => self::REQUIRED_FIELDS,
+            'fallback_behavior' => $definition['fallback_behavior'],
             'missing_behavior' => 'omit_module',
             'public_runtime_authority' => 'backend_or_cms_registry_only',
+            'frontend_fallback_allowed' => false,
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedReviewStatuses(): array
+    {
+        return ['fixture_only', 'draft', 'content_review', 'psychometric_review', 'approved_for_staging', 'deprecated'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedEvidenceLevels(): array
+    {
+        return ['contract_only', 'content_example', 'theory_based', 'expert_review_required', 'expert_reviewed', 'validated'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedSourceStatuses(): array
+    {
+        return ['schema_only', 'docs_only_candidate', 'placeholder_fixture', 'reviewed_content_copy', 'content_example_not_registry_match'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedFallbackBehaviors(): array
+    {
+        return ['omit_module', 'minimal_backend_empty_state', 'reject_payload'];
+    }
+
+    private function isBlank(mixed $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+        if (is_string($value)) {
+            return trim($value) === '';
+        }
+        if (is_array($value)) {
+            return $value === [];
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    private function forbiddenPhraseErrors(array $payload): array
+    {
+        $errors = [];
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        foreach (self::FORBIDDEN_PHRASES as $phrase) {
+            if (str_contains($json, $phrase)) {
+                $errors[] = 'forbidden_claim_phrase_'.$this->errorToken($phrase);
+            }
+        }
+
+        return $errors;
+    }
+
+    private function errorToken(string $phrase): string
+    {
+        $token = strtolower($phrase);
+        $token = preg_replace('/[^a-z0-9]+/', '_', $token) ?: 'non_ascii';
+        $token = trim($token, '_');
+
+        return $token !== '' ? $token : 'non_ascii';
     }
 }

--- a/backend/docs/riasec/deep-copy-slot-schema-contract.md
+++ b/backend/docs/riasec/deep-copy-slot-schema-contract.md
@@ -1,0 +1,79 @@
+# RIASEC Deep Copy Slot Schema Contract
+
+Status: schema contract only
+Schema: `riasec.deep_copy_slot_schema.v1`
+
+This contract defines the backend-authoritative shape for future RIASEC V11 deep content slots. It does not import final editorial copy, does not render UI, and does not change scoring.
+
+## Authority Rules
+
+- `scale_code` must be `RIASEC`.
+- Runtime copy must come from backend/CMS registry slots after validation.
+- Missing content must fail closed with `omit_module` or `reject_payload`.
+- Frontend fallback copy is forbidden.
+- Slots are allowed to carry schema fixture text only in tests.
+
+## Slot Groups
+
+- `method_assets`
+- `dimension_deep_copy`
+- `pair_blend_copy`
+- `quality_copy`
+- `module_visibility_copy`
+- `140q_layer_copy`
+- `structural_difference_copy`
+- `aspirations_copy`
+- `feedback_response_copy`
+
+## Required Metadata
+
+Every slot payload must include:
+
+- `slot_key`
+- `slot_group`
+- `scale_code`
+- `locale`
+- `content_version`
+- `applicable_form_codes`
+- `applicable_profile_shapes`
+- `applicable_quality_states`
+- `applicable_codes` or `applicable_dimensions`
+- `forbidden_claims`
+- `required_boundaries`
+- `evidence_level`
+- `source_status`
+- `review_status`
+- `fallback_behavior`
+
+Slots tied to interpretation routing must include `interpretation_rule_version`. Slots tied to quality routing must include `quality_rule_version`. Module-visibility boundary slots must include `module_visibility_policy_id`.
+
+## Required Boundaries
+
+- `interest_evidence_only`
+- `not_career_recommendation`
+- `not_job_fit`
+- `not_success_prediction`
+- `not_ability_or_skill_measure`
+- `no_60q_140q_raw_delta`
+- `140q_contextual_not_more_accurate`
+- `feedback_does_not_mutate_measured_result`
+- `missing_content_fails_closed`
+- `frontend_fallback_forbidden`
+
+## Forbidden Claims
+
+Validators must reject content or fields that introduce:
+
+- career matching or occupation matching
+- job fit, fit scores, rankings, or hiring suitability
+- career success or success probability
+- ability or skill inference
+- 140Q as a more accurate result
+- 60Q / 140Q raw score delta
+- unsupported norm, percentile, z-score, or t-score claims
+- invented source URL, O*NET, or SOC source rows
+- AI-generated formal report runtime
+
+## Future PR Usage
+
+`RIASEC-DEEP-COPY-02` should add the deterministic registry loader/resolver on top of this schema. Later PRs can wire approved slots into projection/composer output only after the resolver validates slot metadata and fails closed for missing content.

--- a/backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
@@ -9,77 +9,155 @@ use PHPUnit\Framework\TestCase;
 
 final class RiasecContentRegistrySlotContractTest extends TestCase
 {
-    public function test_schema_defines_readiness_slots_without_public_copy_runtime(): void
+    public function test_schema_defines_deep_copy_slots_without_public_copy_runtime(): void
     {
         $schema = (new RiasecContentRegistrySlotContract)->schema();
 
         $this->assertSame(RiasecContentRegistrySlotContract::SCHEMA_VERSION, $schema['schema_version']);
-        $this->assertSame('readiness_contract_only', $schema['slot_status']);
+        $this->assertSame('RIASEC', $schema['scale_code']);
+        $this->assertSame('schema_contract_only', $schema['slot_status']);
         $this->assertFalse($schema['runtime_public_copy_included']);
         $this->assertFalse($schema['frontend_fallback_allowed']);
         $this->assertSame('omit_module_fail_closed', $schema['missing_content_policy']);
-        $this->assertContains('pair_blend_copy', array_column($schema['slots'], 'slot'));
-        $this->assertContains('low_quality_copy', array_column($schema['slots'], 'slot'));
-        $this->assertContains('140q_task_card_copy', array_column($schema['slots'], 'slot'));
-        $this->assertNoForbiddenClaims($schema);
+
+        $slotKeys = array_column($schema['slots'], 'slot_key');
+        $this->assertContains('interpretation_rule_spec_v2', $slotKeys);
+        $this->assertContains('quality_rule_spec_v2', $slotKeys);
+        $this->assertContains('module_visibility_policy', $slotKeys);
+        $this->assertContains('dimension_deep_copy', $slotKeys);
+        $this->assertContains('core_drive_cost_shadow_copy', $slotKeys);
+        $this->assertContains('pair_blend_copy', $slotKeys);
+        $this->assertContains('140q_task_card_copy', $slotKeys);
+        $this->assertContains('140q_environment_card_copy', $slotKeys);
+        $this->assertContains('140q_role_card_copy', $slotKeys);
+        $this->assertContains('140q_tension_copy', $slotKeys);
+        $this->assertContains('low_quality_copy', $slotKeys);
+        $this->assertContains('cautious_reading_copy', $slotKeys);
+        $this->assertContains('structural_difference_copy', $slotKeys);
+        $this->assertContains('aspirations_calibration_copy', $slotKeys);
+        $this->assertContains('disagree_path_copy', $slotKeys);
+        $this->assertContains('feedback_response_copy', $slotKeys);
     }
 
-    public function test_validator_accepts_supported_slot_metadata(): void
+    public function test_validator_accepts_backend_governed_schema_fixture(): void
     {
-        $result = (new RiasecContentRegistrySlotContract)->validate([
-            'slot' => 'pair_blend_copy',
-            'version' => 'v0.1-draft',
-            'locale' => 'zh-CN',
-            'owner' => 'content',
-            'evidence_level' => 'theory_based',
-            'status' => 'draft',
-        ]);
+        $result = (new RiasecContentRegistrySlotContract)->validate($this->validSlot([
+            'slot_key' => 'dimension_deep_copy',
+            'slot_group' => 'dimension_deep_copy',
+            'applicable_dimensions' => ['I'],
+        ]));
 
         $this->assertTrue($result['ok']);
         $this->assertSame([], $result['errors']);
     }
 
-    public function test_validator_rejects_unknown_slots_and_forbidden_claim_fields(): void
+    public function test_validator_requires_metadata_and_applicability_fields(): void
     {
         $result = (new RiasecContentRegistrySlotContract)->validate([
-            'slot' => 'career_recommendation_copy',
-            'version' => 'v0.1-draft',
-            'locale' => 'zh-CN',
-            'owner' => 'content',
-            'evidence_level' => 'content_example',
-            'status' => 'draft',
-            'career_match' => true,
-            'source_url' => 'https://example.test/fake-source',
+            'slot_key' => 'low_quality_copy',
+            'slot_group' => 'quality_copy',
+            'scale_code' => 'RIASEC',
         ]);
 
         $this->assertFalse($result['ok']);
-        $this->assertContains('unsupported_slot', $result['errors']);
-        $this->assertContains('forbidden_field_career_match', $result['errors']);
-        $this->assertContains('forbidden_field_source_url', $result['errors']);
+        $this->assertContains('missing_content_version', $result['errors']);
+        $this->assertContains('missing_locale', $result['errors']);
+        $this->assertContains('missing_applicable_form_codes', $result['errors']);
+        $this->assertContains('missing_applicable_profile_shapes', $result['errors']);
+        $this->assertContains('missing_applicable_quality_states', $result['errors']);
+        $this->assertContains('missing_applicable_codes_or_dimensions', $result['errors']);
+        $this->assertContains('missing_quality_rule_version', $result['errors']);
     }
 
-    public function test_validator_fails_closed_when_required_metadata_is_missing(): void
+    public function test_validator_rejects_unknown_slot_group_and_frontend_fallback(): void
     {
-        $result = (new RiasecContentRegistrySlotContract)->validate([
-            'slot' => 'low_quality_copy',
-        ]);
+        $result = (new RiasecContentRegistrySlotContract)->validate($this->validSlot([
+            'slot_key' => 'career_recommendation_copy',
+            'slot_group' => 'career_matching_copy',
+            'fallback_behavior' => 'frontend_fallback',
+            'applicable_codes' => ['IAS'],
+        ]));
 
         $this->assertFalse($result['ok']);
-        $this->assertContains('missing_version', $result['errors']);
-        $this->assertContains('missing_locale', $result['errors']);
-        $this->assertContains('missing_owner', $result['errors']);
-        $this->assertContains('missing_evidence_level', $result['errors']);
-        $this->assertContains('missing_status', $result['errors']);
+        $this->assertContains('unsupported_slot_key', $result['errors']);
+        $this->assertContains('unsupported_slot_group', $result['errors']);
+        $this->assertContains('unsupported_fallback_behavior', $result['errors']);
+        $this->assertContains('frontend_fallback_forbidden', $result['errors']);
+    }
+
+    public function test_validator_rejects_forbidden_claim_fields_and_language(): void
+    {
+        $result = (new RiasecContentRegistrySlotContract)->validate($this->validSlot([
+            'slot_key' => 'pair_blend_copy',
+            'slot_group' => 'pair_blend_copy',
+            'applicable_codes' => ['IA'],
+            'career_match' => true,
+            'source_url' => 'https://example.test/unreviewed-source',
+            'body' => 'This fixture intentionally contains job fit, success probability, and 140Q more accurate claims.',
+        ]));
+
+        $this->assertFalse($result['ok']);
+        $this->assertContains('forbidden_field_career_match', $result['errors']);
+        $this->assertContains('forbidden_field_source_url', $result['errors']);
+        $this->assertContains('forbidden_claim_phrase_job_fit', $result['errors']);
+        $this->assertContains('forbidden_claim_phrase_success_probability', $result['errors']);
+        $this->assertContains('forbidden_claim_phrase_140q_more_accurate', $result['errors']);
+    }
+
+    public function test_missing_content_behavior_fails_closed_without_frontend_copy(): void
+    {
+        $contract = new RiasecContentRegistrySlotContract;
+
+        $known = $contract->missingContentBehavior('pair_blend_copy');
+        $this->assertTrue($known['exists']);
+        $this->assertSame('omit_module', $known['behavior']);
+        $this->assertSame('omitted', $known['module_state']);
+        $this->assertFalse($known['frontend_fallback_allowed']);
+
+        $unknown = $contract->missingContentBehavior('unknown_deep_copy_slot');
+        $this->assertFalse($unknown['exists']);
+        $this->assertSame('reject_payload', $unknown['behavior']);
+        $this->assertSame('hidden', $unknown['module_state']);
+        $this->assertFalse($unknown['frontend_fallback_allowed']);
     }
 
     /**
-     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $overrides
+     * @return array<string,mixed>
      */
-    private function assertNoForbiddenClaims(array $payload): void
+    private function validSlot(array $overrides = []): array
     {
-        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
-        foreach (['Matches', 'job fit', 'fit score', 'success prediction', 'more accurate', '更准确', 'raw delta'] as $phrase) {
-            $this->assertStringNotContainsString($phrase, $json);
-        }
+        return array_merge([
+            'slot_key' => 'dimension_deep_copy',
+            'slot_group' => 'dimension_deep_copy',
+            'scale_code' => 'RIASEC',
+            'locale' => 'zh-CN',
+            'content_version' => 'v0.1-schema-fixture',
+            'interpretation_rule_version' => 'riasec_interpretation_rule_spec_v2',
+            'applicable_form_codes' => ['riasec_60', 'riasec_140'],
+            'applicable_profile_shapes' => ['clear_code', 'blended_code', 'broad_profile', 'near_tie'],
+            'applicable_quality_states' => ['normal', 'caution'],
+            'applicable_dimensions' => ['I'],
+            'title' => 'Schema fixture title',
+            'summary' => 'Schema fixture summary',
+            'body' => 'Schema fixture body for validator coverage only.',
+            'forbidden_claims' => ['career_outcome_claims_forbidden'],
+            'required_boundaries' => [
+                'interest_evidence_only',
+                'not_career_recommendation',
+                'not_job_fit',
+                'not_success_prediction',
+                'not_ability_or_skill_measure',
+                'no_60q_140q_raw_delta',
+                '140q_contextual_not_more_accurate',
+                'feedback_does_not_mutate_measured_result',
+                'missing_content_fails_closed',
+                'frontend_fallback_forbidden',
+            ],
+            'evidence_level' => 'theory_based',
+            'source_status' => 'placeholder_fixture',
+            'review_status' => 'fixture_only',
+            'fallback_behavior' => 'omit_module',
+        ], $overrides);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T17:37:00+08:00",
+  "updated_at": "2026-05-13T19:16:46+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -3484,6 +3484,73 @@
       "local_cleanup_executed": false,
       "sidecar_issues": [],
       "post_merge_runbook_required": true
+    },
+    "RIASEC-DEEP-COPY-01": {
+      "repo": "fap-api",
+      "branch": "codex/riasec-deep-copy-01-slot-schema",
+      "title": "feat(riasec): harden deep copy slot schema contract",
+      "status": "in_progress",
+      "depends_on": [
+        "RIASEC-DEEP-COPY-00"
+      ],
+      "scope_type": "backend_deep_copy_slot_schema_contract_only",
+      "allowed_paths": [
+        "backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php",
+        "backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "backend/docs/riasec/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "RIASEC-DEEP-COPY-00 is merged in fap-web as PR #786 with merge commit c17b55c3b8942eb72ac9845d3414876b14c4fe5c; ledger cleanup PR #787 confirmed state."
+        },
+        "content_registry_contract": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php --no-ansi",
+          "evidence": "6 tests passed, 51 assertions."
+        },
+        "freeze_classifier": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_content_registry' --no-ansi",
+          "evidence": "2 tests passed, 4 assertions."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php"
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --no-ansi",
+          "evidence": "Command completed successfully; PR introduces no route changes."
+        },
+        "sqlite_migrate_pretend": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+          "evidence": "Command completed successfully; PR introduces no migrations."
+        },
+        "json_yaml_validity": {
+          "status": "pass",
+          "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")' && jq empty docs/codex/pr-train-state.json"
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to RIASEC content slot contract, its unit test, backend RIASEC schema docs, and docs/codex train metadata."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -721,8 +721,8 @@
       "depends_on": [
         "frontend-result-email-gate"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "f8d8ff9433a97acfd0ce5a7d161fac20e0283f6d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1356",
       "checks": {},
       "sidecar_issues": [],
       "failure_reason": null,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1853,3 +1853,35 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: RIASEC-DEEP-COPY-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-DEEP-COPY-00
+    branch: codex/riasec-deep-copy-01-slot-schema
+    title: "feat(riasec): harden deep copy slot schema contract"
+    scope:
+      - Extend backend-authoritative RIASEC deep copy slot schema and validator.
+      - Cover method, dimension, pair blend, quality, module visibility, 140Q, structural difference, aspirations, disagree path, and feedback response slots.
+      - Keep runtime copy absent and missing content fail-closed.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
+      - backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change scorer math.
+      - Change RIASEC content pack question semantics.
+      - Import final public copy.
+      - Add frontend fallback copy.
+      - Add career matching, job fit, ranking, success, source URL, O*NET, or SOC claims.
+    validation:
+      - targeted PHPUnit for RIASEC content slot contract
+      - scoped Big Five freeze classifier test if touched
+      - scoped Pint for touched PHP
+      - JSON/YAML validity
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## What changed
- Hardened `RiasecContentRegistrySlotContract` into explicit `riasec.deep_copy_slot_schema.v1` backend schema authority.
- Added slot groups and slot keys for method assets, dimension deep copy, core drive/cost/shadow, pair/triad blend, 140Q narratives, low-quality/cautious copy, structural difference, aspirations, disagree path, and feedback response.
- Added required metadata, required boundaries, allowed review/evidence/source/fallback statuses, forbidden fields, forbidden phrase validation, and missing-content fail-closed behavior.
- Updated unit coverage for valid slot metadata, missing required fields, unknown slot group, forbidden claims, and missing content behavior.
- Added backend docs for future DEEP-COPY PRs and registered the fap-api companion train entry/state.

## Why
RIASEC deep content needs a backend-authoritative content slot schema before any registry loader, final copy import, projection wiring, or frontend rendering can safely land. This PR keeps runtime public copy absent and forces missing content to omit/reject rather than fallback to frontend copy.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_content_registry' --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")' && jq empty docs/codex/pr-train-state.json`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No final RIASEC V11 copy import.
- No registry loader/resolver implementation.
- No projection/composer module emission.
- No frontend UI/rendering or local fallback copy.
- No scoring math, RIASEC question content pack changes, share/PDF/history changes, analytics changes, feedback runtime changes, or career registry changes.

## Repository rule impact
Adds a backend-authoritative schema contract for a future RIASEC content surface. Runtime authority remains backend/CMS registry only; frontend fallback copy is explicitly forbidden. No public editorial content becomes runtime authority in this PR.
