### PR TITLE
fix(api): add career index-state remediation planning

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateAuthorityAuditor.php
@@ -25,6 +25,45 @@ final class CareerIndexStateAuthorityAuditor
         ));
     }
 
+    public function planRemediation(CareerPublicResolutionPlan $plan): CareerIndexStateRemediationPlan
+    {
+        $result = $this->auditPlan($plan);
+        $planRows = $this->planRowsBySlug($plan);
+
+        $rows = [];
+        foreach ($result->rows as $row) {
+            $planRow = $planRows[$row->canonicalSlug] ?? null;
+            $expectation = $this->indexExpectation($planRow);
+            [$action, $approvalRequired] = $this->remediationAction($row, $expectation);
+
+            $rows[] = new CareerIndexStateRemediationPlanRow(
+                canonicalSlug: $row->canonicalSlug,
+                expectation: $expectation,
+                action: $action,
+                approvalRequired: $approvalRequired,
+                occupationId: $row->occupationId,
+                indexStateId: $row->indexStateId,
+                rawIndexState: $row->rawIndexState,
+                publicIndexState: $row->publicIndexState,
+                indexEligible: $row->indexEligible,
+                reasons: $row->indexStatus->reasons,
+                evidence: [
+                    ...$row->evidence,
+                    [
+                        'index_expectation' => $expectation,
+                        'plan_state' => $planRow?->publicResolutionState,
+                        'plan_public_type' => $planRow?->canonicalPublicType,
+                        'plan_rollout_state' => $planRow?->rolloutState,
+                        'plan_projection_state' => $planRow?->projectionState,
+                        'plan_index_state_hint' => $planRow?->indexStateHint,
+                    ],
+                ],
+            );
+        }
+
+        return CareerIndexStateRemediationPlan::build($rows, $result->sidecars);
+    }
+
     public function auditEntityInventory(CareerOccupationEntityInventoryResult $result): CareerIndexStateAuthorityResult
     {
         return $this->auditSlugs(array_map(
@@ -105,6 +144,125 @@ final class CareerIndexStateAuthorityAuditor
             evidence: $evidence,
             issues: $issues
         );
+    }
+
+    /**
+     * @return array<string, CareerPublicResolutionPlanRow>
+     */
+    private function planRowsBySlug(CareerPublicResolutionPlan $plan): array
+    {
+        $rows = [];
+        foreach ($plan->rows as $row) {
+            $slug = $this->normalizeSlug($row->canonicalSlug);
+            if ($slug !== null) {
+                $rows[$slug] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array{0: string, 1: bool}
+     */
+    private function remediationAction(CareerIndexStateAuthorityRow $row, string $expectation): array
+    {
+        if ($row->issues === []) {
+            return [CareerIndexStateRemediationPlanRow::ACTION_NONE, false];
+        }
+
+        if ($row->indexStateId !== null) {
+            return [CareerIndexStateRemediationPlanRow::ACTION_REVIEW_EXISTING_INDEX_STATE, true];
+        }
+
+        return match ($expectation) {
+            CareerIndexStateRemediationPlanRow::EXPECTATION_GOVERNED_NON_PUBLIC => [CareerIndexStateRemediationPlanRow::ACTION_DEFER_GOVERNED_NON_PUBLIC, false],
+            CareerIndexStateRemediationPlanRow::EXPECTATION_NOT_YET_PROMOTED => [CareerIndexStateRemediationPlanRow::ACTION_DEFER_UNTIL_RUNTIME_PROMOTION, false],
+            default => [CareerIndexStateRemediationPlanRow::ACTION_CREATE_INDEX_STATE, true],
+        };
+    }
+
+    private function indexExpectation(?CareerPublicResolutionPlanRow $row): string
+    {
+        if ($row === null) {
+            return CareerIndexStateRemediationPlanRow::EXPECTATION_EXPECTED_INDEXED;
+        }
+
+        $indexStateHint = strtolower((string) ($row->indexStateHint ?? ''));
+        if (in_array($indexStateHint, [IndexStateValue::INDEXED, IndexStateValue::INDEXABLE], true)) {
+            return CareerIndexStateRemediationPlanRow::EXPECTATION_EXPECTED_INDEXED;
+        }
+
+        $publicType = strtolower((string) ($row->canonicalPublicType ?? ''));
+        if (in_array($publicType, ['public_canonical_job', 'public'], true)) {
+            return CareerIndexStateRemediationPlanRow::EXPECTATION_EXPECTED_INDEXED;
+        }
+
+        if ($this->containsAny($publicType, ['non_public', 'non-public', 'private', 'governed'])) {
+            return CareerIndexStateRemediationPlanRow::EXPECTATION_GOVERNED_NON_PUBLIC;
+        }
+
+        $states = $this->planStates($row);
+        foreach ($states as $state) {
+            if ($this->containsAny($state, ['governance', 'blocked', 'hold', 'non_public', 'non-public', 'private'])) {
+                return CareerIndexStateRemediationPlanRow::EXPECTATION_GOVERNED_NON_PUBLIC;
+            }
+        }
+
+        foreach ($states as $state) {
+            if (in_array($state, ['published', 'indexed', 'indexable', 'live'], true)) {
+                return CareerIndexStateRemediationPlanRow::EXPECTATION_EXPECTED_INDEXED;
+            }
+        }
+
+        foreach ($states as $state) {
+            if (in_array($state, ['ready_for_pilot', 'planned', 'candidate', 'published_candidate', 'approved', 'draft', 'review_needed'], true)) {
+                return CareerIndexStateRemediationPlanRow::EXPECTATION_NOT_YET_PROMOTED;
+            }
+        }
+
+        return CareerIndexStateRemediationPlanRow::EXPECTATION_EXPECTED_INDEXED;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function planStates(CareerPublicResolutionPlanRow $row): array
+    {
+        $states = [];
+        foreach ([
+            $row->publicResolutionState,
+            $row->rolloutState,
+            $row->projectionState,
+            $row->raw['status'] ?? null,
+            $row->raw['release_status'] ?? null,
+            $row->raw['Release_Status'] ?? null,
+            $row->raw['content_status'] ?? null,
+            $row->raw['Content_Status'] ?? null,
+            $row->raw['review_state'] ?? null,
+            $row->raw['Review_State'] ?? null,
+        ] as $value) {
+            $state = $this->normalizeString($value);
+            if ($state !== null) {
+                $states[] = strtolower($state);
+            }
+        }
+
+        return array_values(array_unique($states));
+    }
+
+    /**
+     * @param  list<string>  $needles
+     */
+    private function containsAny(string $value, array $needles): bool
+    {
+        foreach ($needles as $needle) {
+            if (str_contains($value, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerIndexStateRemediationPlan.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateRemediationPlan.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerIndexStateRemediationPlan
+{
+    public const SCHEMA_VERSION = 'career_index_state_remediation_plan.v1';
+
+    /**
+     * @param  list<CareerIndexStateRemediationPlanRow>  $rows
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     * @param  list<CareerCanonicalEligibilityAuditRunContextApprovalGate>  $approvalGates
+     */
+    public function __construct(
+        public readonly string $schemaVersion,
+        public readonly array $rows,
+        public readonly array $sidecars = [],
+        public readonly array $approvalGates = [],
+    ) {
+        self::assertNonEmptyString($this->schemaVersion, 'schema_version');
+        self::assertRows($this->rows);
+        self::assertSidecars($this->sidecars);
+        self::assertApprovalGates($this->approvalGates);
+    }
+
+    /**
+     * @param  list<CareerIndexStateRemediationPlanRow>  $rows
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public static function build(array $rows, array $sidecars = []): self
+    {
+        return new self(
+            schemaVersion: self::SCHEMA_VERSION,
+            rows: $rows,
+            sidecars: $sidecars,
+            approvalGates: self::approvalGatesFor($rows),
+        );
+    }
+
+    public function createIndexStateCount(): int
+    {
+        return count(array_filter(
+            $this->rows,
+            static fn (CareerIndexStateRemediationPlanRow $row): bool => $row->action === CareerIndexStateRemediationPlanRow::ACTION_CREATE_INDEX_STATE
+        ));
+    }
+
+    public function reviewExistingIndexStateCount(): int
+    {
+        return count(array_filter(
+            $this->rows,
+            static fn (CareerIndexStateRemediationPlanRow $row): bool => $row->action === CareerIndexStateRemediationPlanRow::ACTION_REVIEW_EXISTING_INDEX_STATE
+        ));
+    }
+
+    public function deferredCount(): int
+    {
+        return count(array_filter(
+            $this->rows,
+            static fn (CareerIndexStateRemediationPlanRow $row): bool => in_array($row->action, [
+                CareerIndexStateRemediationPlanRow::ACTION_DEFER_GOVERNED_NON_PUBLIC,
+                CareerIndexStateRemediationPlanRow::ACTION_DEFER_UNTIL_RUNTIME_PROMOTION,
+            ], true)
+        ));
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byAction(): array
+    {
+        $counts = [];
+        foreach ($this->rows as $row) {
+            $counts[$row->action] = ($counts[$row->action] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byExpectation(): array
+    {
+        $counts = [];
+        foreach ($this->rows as $row) {
+            $counts[$row->expectation] = ($counts[$row->expectation] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{schema_version: string, summary: array<string, mixed>, rows: list<array<string, mixed>>, sidecars: list<array<string, mixed>>, approval_gates: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'schema_version' => $this->schemaVersion,
+            'summary' => [
+                'expected_count' => count($this->rows),
+                'create_index_state_count' => $this->createIndexStateCount(),
+                'review_existing_index_state_count' => $this->reviewExistingIndexStateCount(),
+                'deferred_count' => $this->deferredCount(),
+                'approval_required_count' => count(array_filter(
+                    $this->rows,
+                    static fn (CareerIndexStateRemediationPlanRow $row): bool => $row->approvalRequired
+                )),
+                'by_action' => $this->byAction(),
+                'by_expectation' => $this->byExpectation(),
+            ],
+            'rows' => array_map(
+                static fn (CareerIndexStateRemediationPlanRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+            'approval_gates' => array_map(
+                static fn (CareerCanonicalEligibilityAuditRunContextApprovalGate $gate): array => $gate->toArray(),
+                $this->approvalGates
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerIndexStateRemediationPlanRow>  $rows
+     * @return list<CareerCanonicalEligibilityAuditRunContextApprovalGate>
+     */
+    private static function approvalGatesFor(array $rows): array
+    {
+        foreach ($rows as $row) {
+            if ($row->approvalRequired) {
+                return [
+                    new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                        gateId: 'production_index_state_remediation_apply',
+                        title: 'Production index_state remediation apply requires explicit approval.',
+                        required: true,
+                        reason: 'The remediation plan identifies index_state rows that may require production DB writes; this PR only plans the work.',
+                        approvalPhraseTemplate: 'I explicitly approve production index_state remediation apply for Career 2786 using reviewed plan <PLAN_PATH>.',
+                        allowedAction: 'Apply reviewed index_state remediation plan only.',
+                        forbiddenActions: [
+                            'deploy',
+                            'rollout',
+                            'backfill outside reviewed plan',
+                            'quarantine',
+                            'rollback',
+                            'publish occupations',
+                        ],
+                        preconditions: [
+                            'Reviewed remediation plan artifact exists.',
+                            'Plan was generated from approved read-only Career 2786 context.',
+                            'Production DB mutation approval is explicit and current.',
+                        ]
+                    ),
+                ];
+            }
+        }
+
+        return [];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career index-state remediation plan requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<CareerIndexStateRemediationPlanRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career index-state remediation rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerIndexStateRemediationPlanRow) {
+                throw new InvalidArgumentException('Career index-state remediation rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career index-state remediation sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career index-state remediation sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRunContextApprovalGate>  $approvalGates
+     */
+    private static function assertApprovalGates(array $approvalGates): void
+    {
+        if (! array_is_list($approvalGates)) {
+            throw new InvalidArgumentException('Career index-state remediation approval gates must be a list.');
+        }
+
+        foreach ($approvalGates as $approvalGate) {
+            if (! $approvalGate instanceof CareerCanonicalEligibilityAuditRunContextApprovalGate) {
+                throw new InvalidArgumentException('Career index-state remediation approval gates must contain gate DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerIndexStateRemediationPlanRow.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateRemediationPlanRow.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerIndexStateRemediationPlanRow
+{
+    public const EXPECTATION_EXPECTED_INDEXED = 'expected_indexed';
+
+    public const EXPECTATION_GOVERNED_NON_PUBLIC = 'governed_non_public';
+
+    public const EXPECTATION_NOT_YET_PROMOTED = 'not_yet_promoted';
+
+    public const ACTION_NONE = 'none';
+
+    public const ACTION_CREATE_INDEX_STATE = 'create_index_state';
+
+    public const ACTION_REVIEW_EXISTING_INDEX_STATE = 'review_existing_index_state';
+
+    public const ACTION_DEFER_GOVERNED_NON_PUBLIC = 'defer_governed_non_public';
+
+    public const ACTION_DEFER_UNTIL_RUNTIME_PROMOTION = 'defer_until_runtime_promotion';
+
+    /**
+     * @param  list<string>  $reasons
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $expectation,
+        public readonly string $action,
+        public readonly bool $approvalRequired,
+        public readonly ?string $occupationId,
+        public readonly ?string $indexStateId,
+        public readonly ?string $rawIndexState,
+        public readonly ?string $publicIndexState,
+        public readonly bool $indexEligible,
+        public readonly array $reasons = [],
+        public readonly array $evidence = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertValidExpectation($this->expectation);
+        self::assertValidAction($this->action);
+        self::assertListOfStrings($this->reasons, 'reasons');
+        self::assertList($this->evidence, 'evidence');
+
+        foreach ([
+            'occupation_id' => $this->occupationId,
+            'index_state_id' => $this->indexStateId,
+            'raw_index_state' => $this->rawIndexState,
+            'public_index_state' => $this->publicIndexState,
+        ] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, expectation: string, action: string, approval_required: bool, occupation_id: string|null, index_state_id: string|null, raw_index_state: string|null, public_index_state: string|null, index_eligible: bool, reasons: list<string>, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'expectation' => $this->expectation,
+            'action' => $this->action,
+            'approval_required' => $this->approvalRequired,
+            'occupation_id' => $this->occupationId,
+            'index_state_id' => $this->indexStateId,
+            'raw_index_state' => $this->rawIndexState,
+            'public_index_state' => $this->publicIndexState,
+            'index_eligible' => $this->indexEligible,
+            'reasons' => $this->reasons,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function expectations(): array
+    {
+        return [
+            self::EXPECTATION_EXPECTED_INDEXED,
+            self::EXPECTATION_GOVERNED_NON_PUBLIC,
+            self::EXPECTATION_NOT_YET_PROMOTED,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function actions(): array
+    {
+        return [
+            self::ACTION_NONE,
+            self::ACTION_CREATE_INDEX_STATE,
+            self::ACTION_REVIEW_EXISTING_INDEX_STATE,
+            self::ACTION_DEFER_GOVERNED_NON_PUBLIC,
+            self::ACTION_DEFER_UNTIL_RUNTIME_PROMOTION,
+        ];
+    }
+
+    private static function assertValidExpectation(string $value): void
+    {
+        if (! in_array($value, self::expectations(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career index-state remediation expectation [%s].', $value));
+        }
+    }
+
+    private static function assertValidAction(string $value): void
+    {
+        if (! in_array($value, self::actions(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career index-state remediation action [%s].', $value));
+        }
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career index-state remediation row requires non-empty [%s].', $key));
+        }
+    }
+
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career index-state remediation row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career index-state remediation row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/docs/career/audits/index_state_authority_audit.md
+++ b/backend/docs/career/audits/index_state_authority_audit.md
@@ -67,3 +67,27 @@ AUDIT-6 should consume this result only as the index layer authority. Runtime pu
 ## Readiness Warning
 
 AUDIT-5 does not claim 2786 readiness. It proves only reusable index-state authority inventory behavior for future command integration.
+
+## REPAIR-INDEX-1 Remediation Planning
+
+REPAIR-INDEX-1 adds a read-only remediation plan shape on top of the existing authority audit. `CareerIndexStateAuthorityAuditor::planRemediation()` consumes a `CareerPublicResolutionPlan`, runs the same latest-index-state inspection, and returns `career_index_state_remediation_plan.v1`.
+
+The remediation plan does not apply, seed, backfill, or mutate `index_states`. It classifies each slug into one of:
+
+- `expected_indexed`
+- `governed_non_public`
+- `not_yet_promoted`
+
+The plan then assigns a non-mutating action:
+
+- `none` for indexed/indexable rows with no issues
+- `create_index_state` for expected-public rows missing an index-state authority row
+- `review_existing_index_state` for existing rows with noindex, ineligible, quarantine, rollback, or non-indexed-like state
+- `defer_governed_non_public` for governed non-public rows that should not be treated as publish-blocking index defects yet
+- `defer_until_runtime_promotion` for planner rows that are present but not promoted into the public runtime authority
+
+Rows requiring production DB writes set `approval_required=true` and emit the approval gate:
+
+`I explicitly approve production index_state remediation apply for Career 2786 using reviewed plan <PLAN_PATH>.`
+
+This approval gate is informational in this PR. No apply command is added, and no production mutation is performed.

--- a/backend/tests/Feature/Domain/Career/Audit/CareerIndexStateAuthorityAuditorTest.php
+++ b/backend/tests/Feature/Domain/Career/Audit/CareerIndexStateAuthorityAuditorTest.php
@@ -8,6 +8,8 @@ use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
 use App\Domain\Career\Audit\CareerIndexStateAuthorityAuditor;
 use App\Domain\Career\Audit\CareerIndexStateAuthorityIssue;
+use App\Domain\Career\Audit\CareerIndexStateRemediationPlan;
+use App\Domain\Career\Audit\CareerIndexStateRemediationPlanRow;
 use App\Domain\Career\Audit\CareerPublicResolutionPlan;
 use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
 use App\Domain\Career\IndexStateValue;
@@ -224,6 +226,102 @@ JSON,
         $this->assertSame($before, IndexState::query()->count());
     }
 
+    public function test_missing_expected_public_index_state_produces_remediation_plan(): void
+    {
+        $this->createOccupation('actuaries');
+        $plan = $this->plan([
+            ['canonical_slug' => 'actuaries', 'canonical_public_type' => 'public_canonical_job'],
+        ]);
+
+        $remediation = (new CareerIndexStateAuthorityAuditor)->planRemediation($plan);
+
+        $this->assertSame(CareerIndexStateRemediationPlan::SCHEMA_VERSION, $remediation->schemaVersion);
+        $this->assertSame(1, $remediation->createIndexStateCount());
+        $this->assertSame(1, $remediation->toArray()['summary']['approval_required_count']);
+        $this->assertSame('production_index_state_remediation_apply', $remediation->approvalGates[0]->gateId);
+        $this->assertSame(CareerIndexStateRemediationPlanRow::EXPECTATION_EXPECTED_INDEXED, $remediation->rows[0]->expectation);
+        $this->assertSame(CareerIndexStateRemediationPlanRow::ACTION_CREATE_INDEX_STATE, $remediation->rows[0]->action);
+        $this->assertTrue($remediation->rows[0]->approvalRequired);
+    }
+
+    public function test_indexed_indexable_rows_do_not_need_remediation(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::INDEXABLE, true);
+        $plan = $this->plan([
+            ['canonical_slug' => 'actuaries', 'canonical_public_type' => 'public_canonical_job'],
+        ]);
+
+        $remediation = (new CareerIndexStateAuthorityAuditor)->planRemediation($plan);
+
+        $this->assertSame(0, $remediation->createIndexStateCount());
+        $this->assertSame([], $remediation->approvalGates);
+        $this->assertSame(CareerIndexStateRemediationPlanRow::ACTION_NONE, $remediation->rows[0]->action);
+        $this->assertFalse($remediation->rows[0]->approvalRequired);
+    }
+
+    public function test_non_public_missing_index_state_is_deferred_not_publish_blocking(): void
+    {
+        $this->createOccupation('restricted-career');
+        $plan = $this->plan([
+            [
+                'canonical_slug' => 'restricted-career',
+                'public_resolution_state' => 'blocked_until_governance_approval',
+                'canonical_public_type' => 'governed_non_public',
+            ],
+        ]);
+
+        $remediation = (new CareerIndexStateAuthorityAuditor)->planRemediation($plan);
+
+        $this->assertSame(1, $remediation->deferredCount());
+        $this->assertSame([], $remediation->approvalGates);
+        $this->assertSame(CareerIndexStateRemediationPlanRow::EXPECTATION_GOVERNED_NON_PUBLIC, $remediation->rows[0]->expectation);
+        $this->assertSame(CareerIndexStateRemediationPlanRow::ACTION_DEFER_GOVERNED_NON_PUBLIC, $remediation->rows[0]->action);
+        $this->assertFalse($remediation->rows[0]->approvalRequired);
+    }
+
+    public function test_ready_for_pilot_without_public_type_is_deferred_until_promotion(): void
+    {
+        $this->createOccupation('pilot-career');
+        $plan = $this->plan([
+            ['canonical_slug' => 'pilot-career', 'public_resolution_state' => 'ready_for_pilot'],
+        ]);
+
+        $remediation = (new CareerIndexStateAuthorityAuditor)->planRemediation($plan);
+
+        $this->assertSame(CareerIndexStateRemediationPlanRow::EXPECTATION_NOT_YET_PROMOTED, $remediation->rows[0]->expectation);
+        $this->assertSame(CareerIndexStateRemediationPlanRow::ACTION_DEFER_UNTIL_RUNTIME_PROMOTION, $remediation->rows[0]->action);
+        $this->assertFalse($remediation->rows[0]->approvalRequired);
+    }
+
+    public function test_existing_bad_index_state_produces_review_plan(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::NOINDEX, false);
+        $plan = $this->plan([
+            ['canonical_slug' => 'actuaries', 'canonical_public_type' => 'public_canonical_job'],
+        ]);
+
+        $remediation = (new CareerIndexStateAuthorityAuditor)->planRemediation($plan);
+
+        $this->assertSame(1, $remediation->reviewExistingIndexStateCount());
+        $this->assertSame(CareerIndexStateRemediationPlanRow::ACTION_REVIEW_EXISTING_INDEX_STATE, $remediation->rows[0]->action);
+        $this->assertTrue($remediation->rows[0]->approvalRequired);
+    }
+
+    public function test_remediation_planning_does_not_mutate_database(): void
+    {
+        $this->createOccupation('actuaries');
+        $plan = $this->plan([
+            ['canonical_slug' => 'actuaries', 'canonical_public_type' => 'public_canonical_job'],
+        ]);
+        $before = IndexState::query()->count();
+
+        (new CareerIndexStateAuthorityAuditor)->planRemediation($plan);
+
+        $this->assertSame($before, IndexState::query()->count());
+    }
+
     public function test_no_baseline_projection_or_surface_logic_is_invoked(): void
     {
         $occupation = $this->createOccupation('actuaries');
@@ -265,6 +363,21 @@ JSON,
         $occupation = Occupation::query()->create($payload);
 
         return $occupation;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function plan(array $rows): CareerPublicResolutionPlan
+    {
+        return new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-index-remediation-plan.json',
+            checksum: null,
+            rows: array_map(
+                static fn (array $row): CareerPublicResolutionPlanRow => CareerPublicResolutionPlanRow::fromRaw($row),
+                $rows
+            )
+        );
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -316,6 +316,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityIssue.php',
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityResult.php',
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityRow.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateRemediationPlan.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateRemediationPlanRow.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -1680,6 +1682,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityIssue.php',
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityResult.php',
             'backend/app/Domain/Career/Audit/CareerIndexStateAuthorityRow.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateRemediationPlan.php',
+            'backend/app/Domain/Career/Audit/CareerIndexStateRemediationPlanRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2983,7 +2983,7 @@
       "branch": "fix/career-runtime-authority-gap-repair-1",
       "title": "fix(api): classify career runtime authority gaps for audit",
       "name": "Classify career runtime authority gaps for audit",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "REPAIR-TITLE-1",
         "SCAN-3"
@@ -3008,8 +3008,8 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "b8c7376161f46b9445af5981b9e070b97dcc5956",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1355",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -3078,6 +3078,106 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-INDEX-1",
+      "merged_at": "2026-05-13T11:08:33Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": []
+    },
+    "REPAIR-INDEX-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-index-remediation-plan-1",
+      "title": "fix(api): add career index-state remediation planning",
+      "name": "Add career index-state remediation planning",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-RUNTIME-1",
+        "SCAN-3"
+      ],
+      "scope_type": "audit_index_state_remediation_planning_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no index_state apply",
+        "no production DB query",
+        "no DB mutation",
+        "no rollout/backfill",
+        "no fap-web changes",
+        "no 80 readiness run",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided remediation train execution goal and authorized registering the current remediation PR item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-RUNTIME-1 merged as PR #1355 and local train worktree is based on origin/main after that merge."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to index-state remediation planning, audit tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        },
+        "career_index_state_authority": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi",
+          "evidence": "18 tests passed, 51 assertions."
+        },
+        "career_audit_canonical_eligibility": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi",
+          "evidence": "26 tests passed, 130 assertions."
+        },
+        "career_canonical_eligibility_audit_schema": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi",
+          "evidence": "14 tests passed, 28 assertions."
+        },
+        "career_2786_full_audit_artifact_builder": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi",
+          "evidence": "3 tests passed, 10 assertions."
+        },
+        "impacted_audit_layers": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi && php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi && php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi && php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi && php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi && php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi",
+          "evidence": "All impacted audit-layer regressions passed locally."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi"
+        },
+        "migrate_pretend": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "3157 files passed."
+        },
+        "mbti_master_chain": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "CI master chain exited 0 locally; generated BigFive compiled verification artifacts were restored before staging."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-ENTITY-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1628,6 +1628,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-INDEX-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-RUNTIME-1
+      - SCAN-3
+    branch: fix/career-index-remediation-plan-1
+    title: "fix(api): add career index-state remediation planning"
+    name: "Add career index-state remediation planning"
+    scope_type: audit_index_state_remediation_planning_only
+    scope:
+      - Add non-mutating index_state remediation planning from Career public-resolution plan rows and latest index authority rows.
+      - Distinguish expected indexed rows from governed non-public rows and not-yet-promoted planner rows.
+      - Emit a stable remediation plan artifact shape and explicit approval gate for any future production DB apply.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Apply index_state changes.
+      - Mutate DB or production state.
+      - Run rollout or backfill.
+      - Touch fap-web.
+      - Run 80 readiness.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "REPAIR-ENTITY-1"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: RIASEC-PERSONALIZATION-00
     repo: fap-api
     branch: codex/riasec-personalization-00-train-registration


### PR DESCRIPTION
## Summary
- adds read-only `career_index_state_remediation_plan.v1` planning for Career index-state authority gaps
- classifies expected indexed, governed non-public, and not-yet-promoted planner rows
- emits explicit approval gate for any future production index_state apply while performing no mutation in this PR
- updates index-state audit docs and PR train state for REPAIR-INDEX-1

## Non-goals
- no index_state apply
- no DB mutation
- no production DB query
- no rollout/backfill/apply
- no 80 readiness run
- no deploy
- no fap-web changes

## Tests
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi` (18 passed, 51 assertions)
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi` (26 passed, 130 assertions)
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi` (14 passed, 28 assertions)
- `php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi` (3 passed, 10 assertions)
- `php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi`
- `php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi`
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi`
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `vendor/bin/pint --test`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
