### PR TITLE
docs(api): tighten production deploy target SOP

### DIFF
--- a/.agents/skills/fap-api-deploy-sre/SKILL.md
+++ b/.agents/skills/fap-api-deploy-sre/SKILL.md
@@ -6,6 +6,8 @@ description: Use for fap-api deploy-readiness and SRE review when Codex must ass
 ## Purpose
 Assess fap-api deploy and runtime readiness while keeping release execution under explicit human control.
 
+Use `backend/docs/ops/production-deploy-targeting-sop.md` as the repository-backed deploy target authority.
+
 ## When to use
 - Use when a PR affects migrations, routes, queues, cache, scheduler, environment assumptions, or runtime operations.
 - Use before advising whether a deploy-impacting PR is ready for human release review.
@@ -26,13 +28,59 @@ Assess fap-api deploy and runtime readiness while keeping release execution unde
 - Required checks for fap-api are hygiene, verify-mbti-v2, and verify-mbti-legacy.
 - Deploy Application must remain green for deploy or runtime-impacting PRs.
 - Do not run production deploy commands unless the user explicitly confirms the exact operation.
+- Do not reinterpret a PR number, branch name, or short SHA as permission to deploy the latest `origin/main`.
+- Do not deploy an older target SHA after newer commits have reached `origin/main` unless the user explicitly approves a bounded exact-SHA deploy and the deploy command path is verified to pin that exact SHA.
+- Do not run post-deploy production mutation commands, including content import/upsert commands, until the active production release is verified to contain the required target SHA.
+
+## Production deploy targeting protocol
+Before asking for or acting on any production deploy approval, resolve and report:
+
+- requested target PR number, if any
+- requested target commit as a full 40-character SHA
+- current `origin/main` SHA
+- latest merged PRs between the current production SHA and `origin/main`
+- current production release SHA, using read-only SSH or another read-only production signal
+- whether the deploy would include newer merged PRs beyond the requested target
+- the exact deploy command shape and whether it deploys `origin/main` or an exact pinned revision
+
+Classify the deploy decision as one of:
+
+- `no_deploy_needed`: production already contains the requested full target SHA.
+- `deploy_latest_main`: the requested target SHA equals current `origin/main`; deploying main is allowed after explicit confirmation.
+- `bounded_exact_sha_required`: the requested target SHA is behind `origin/main`; stop unless the user explicitly confirms a bounded exact-SHA deploy and the deployment path can pin that SHA.
+- `blocked_ambiguous_target`: the user references a PR number, branch, short SHA, or release name that does not uniquely resolve to one full target SHA.
+- `blocked_tooling_gap`: the user requests a bounded exact-SHA deploy but the available deploy command can only deploy `origin/main`.
+
+If `origin/main` contains newer merged PRs after the requested target SHA, the readiness output must name those newer PRs/commits as included or excluded. Never hide this behind "latest main".
+
+Required confirmation phrases:
+
+```text
+I explicitly approve backend production deploy for exact SHA <40-character-sha> release <release-name>.
+```
+
+For a target behind `origin/main`, require this stronger phrase instead:
+
+```text
+I explicitly approve bounded backend production deploy for exact SHA <40-character-sha>, excluding newer main commits <short-sha/pr-list>, release <release-name>.
+```
+
+Use a separate confirmation for any production data mutation after deploy, for example:
+
+```text
+I explicitly approve production article baseline upsert for slugs <slug-list> after verifying production contains SHA <40-character-sha>.
+```
+
+The approval phrase must match the resolved target SHA. If the user changes the target after readiness, rerun readiness and request a new phrase.
 
 ## Standard workflow
 1. Classify runtime impact: migration, route, queue, cache, scheduler, external provider, or config.
 2. Run route, migration, MBTI, and diff checks.
 3. Confirm Deploy Application status for runtime-impacting work before merge recommendation.
 4. Prepare rollout and rollback notes for a human operator.
-5. Stop before any live deploy command unless explicitly confirmed.
+5. Resolve the exact production deploy target using the production deploy targeting protocol.
+6. Stop before any live deploy command unless explicitly confirmed with the matching target-SHA phrase.
+7. After deploy, verify production contains the approved SHA before running any post-deploy content import, upsert, queue, or cache mutation.
 
 ## Acceptance commands
 ```bash
@@ -45,7 +93,8 @@ cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check
 ## Output contract
 - Always report changed files, acceptance commands run, PR URL if a PR was created, CI status, Deploy Application or deploy/runtime status when relevant, merge commit if merged, branch cleanup status when cleanup is requested, revalidation status for security-related work, stop reason when blocked, and confirmation that no unrelated files were touched.
 - Report runtime impact, migration result, route result, MBTI verification, Deploy Application status, rollback notes, and release blockers.
+- For deploy readiness, report target SHA, origin/main SHA, production SHA, latest merged PRs considered, deploy decision classification, included/excluded commits, exact confirmation phrase required, and whether post-deploy mutation is allowed or still blocked.
 
 ## Stop conditions
 - Stop if active Critical/High/Medium appears during Low/Informational work, required checks fail, Deploy Application or deploy/runtime status regresses where relevant, the worktree is dirty in a way that cannot be isolated, scope drift appears, product/runtime behavior is ambiguous, closure would lack source/test evidence, or production deploy/rollback is requested without explicit manual confirmation.
-- Stop on failed migration, failed route check, failed MBTI verification, dirty scope, missing Deploy Application status, or absent manual confirmation for live deployment.
+- Stop on failed migration, failed route check, failed MBTI verification, dirty scope, missing Deploy Application status, absent manual confirmation for live deployment, ambiguous deploy target, target-SHA mismatch, deploy tooling that cannot honor a requested bounded SHA, or any request to run production mutation before production is verified on the required SHA.

--- a/backend/docs/ops/production-deploy-targeting-sop.md
+++ b/backend/docs/ops/production-deploy-targeting-sop.md
@@ -1,0 +1,64 @@
+# Production Deploy Targeting SOP
+
+This SOP defines the fap-api production deploy targeting rule. It exists to prevent a requested PR or SHA deploy from accidentally becoming a "latest main" deploy.
+
+## Required Target Resolution
+
+Before any production deploy approval is requested or accepted, the operator must resolve:
+
+- requested PR number, if any
+- requested target commit as a full 40-character SHA
+- current `origin/main` SHA
+- current production release SHA
+- latest merged PRs between production and `origin/main`
+- whether deploying the requested target would include newer merged PRs
+- whether the deploy command path deploys `origin/main` or an exact pinned revision
+
+Do not treat a PR number, branch name, release name, or short SHA as sufficient deploy authority.
+
+## Deploy Decision Classes
+
+- `no_deploy_needed`: production already contains the full target SHA.
+- `deploy_latest_main`: target SHA equals `origin/main`; deploy may proceed after exact confirmation.
+- `bounded_exact_sha_required`: target SHA is behind `origin/main`; stop unless the user explicitly approves excluding newer commits and the deploy command can pin the exact SHA.
+- `blocked_ambiguous_target`: the request does not uniquely resolve to one full target SHA.
+- `blocked_tooling_gap`: the requested bounded deploy cannot be honored by the available deploy command.
+
+If newer commits exist after the target SHA, list them as included or excluded before deploy approval. Never hide that distinction behind "latest main".
+
+## Confirmation Phrases
+
+For a normal latest-main production deploy:
+
+```text
+I explicitly approve backend production deploy for exact SHA <40-character-sha> release <release-name>.
+```
+
+For a bounded deploy where the target SHA is behind `origin/main`:
+
+```text
+I explicitly approve bounded backend production deploy for exact SHA <40-character-sha>, excluding newer main commits <short-sha/pr-list>, release <release-name>.
+```
+
+For post-deploy production data mutation:
+
+```text
+I explicitly approve production article baseline upsert for slugs <slug-list> after verifying production contains SHA <40-character-sha>.
+```
+
+Post-deploy mutation must use a separate confirmation from code deployment.
+
+## Stop Rules
+
+Stop before deploy if:
+
+- the target SHA is ambiguous
+- the approval phrase does not match the resolved SHA
+- `origin/main` has newer commits and the user has not explicitly approved whether they are included or excluded
+- the user requests a bounded deploy but the deploy command cannot pin the exact SHA
+- production does not yet contain the required SHA and a post-deploy mutation is requested
+- read-only production verification cannot determine the active deployed SHA
+
+## Repository Rule Impact
+
+This SOP changes only deploy governance. It does not change runtime code, database schema, content authority, public API behavior, sitemap/llms behavior, or production deploy scripts.


### PR DESCRIPTION
## Summary
- add repository-backed production deploy targeting SOP
- require full target SHA resolution before backend production deploy approval
- require bounded exact-SHA confirmation when target is behind origin/main
- block post-deploy production mutation until production is verified on the required SHA

## Validation
- git diff --check

## Repository rule impact
Docs/SOP only. No runtime code, schema, content authority, public API, sitemap/llms, or deploy script behavior changed.