### PR TITLE
RIASEC-DEEP-COPY-01: reconcile slot schema ledger

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3489,7 +3489,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-deep-copy-01-slot-schema",
       "title": "feat(riasec): harden deep copy slot schema contract",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "RIASEC-DEEP-COPY-00"
       ],
@@ -3502,8 +3502,8 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "565ef580525a6feda00bdfba2abb98ae6dfded18",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1356",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -3547,9 +3547,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-13T11:31:25Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": []
     }
   }


### PR DESCRIPTION
## What changed
- Reconciles the RIASEC-DEEP-COPY-01 train ledger after PR #1356 merged.
- Marks the merged commit, PR URL, remote branch deletion, and local cleanup state.

## Why
- The primary fap-api checkout was externally switched to an unrelated dirty branch during post-merge cleanup, so ledger reconciliation is isolated in a clean worktree.

## Validation
- `jq empty docs/codex/pr-train-state.json`
- `git diff --check`

## Intentionally deferred
- No runtime changes.
- No scorer, content pack, frontend UI, share/PDF/history, career registry, feedback, or analytics changes.