### PR TITLE
fix(api): add career occupation entity remediation planning

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryAuditor.php
@@ -46,6 +46,46 @@ final class CareerOccupationEntityInventoryAuditor
         );
     }
 
+    public function planRemediation(CareerPublicResolutionPlan $plan): CareerOccupationEntityRemediationPlan
+    {
+        $result = $this->auditPlan($plan);
+        $planRows = $this->planRowsBySlug($plan);
+
+        $rows = [];
+        foreach ($result->rows as $row) {
+            $planRow = $planRows[$row->canonicalSlug] ?? null;
+            [$action, $approvalRequired] = $this->remediationAction($row, $planRow);
+
+            $rows[] = new CareerOccupationEntityRemediationPlanRow(
+                canonicalSlug: $row->canonicalSlug,
+                sourceStatus: $this->sourceStatus($planRow),
+                action: $action,
+                approvalRequired: $approvalRequired,
+                occupationExists: $row->occupationExists,
+                occupationId: $row->occupationId,
+                missingEntityFields: $row->missingEntityFields,
+                plannerTitleEn: $planRow?->titleEn,
+                plannerTitleZh: $planRow?->titleZh,
+                plannerFamily: $planRow?->family,
+                plannerSourceCode: $planRow?->sourceCode,
+                reasons: $row->entityStatus->reasons,
+                evidence: [
+                    ...$row->evidence,
+                    [
+                        'planner_source_available' => $this->hasPlannerSource($planRow),
+                        'planner_row_number' => $planRow?->rowNumber,
+                        'planner_title_en' => $planRow?->titleEn,
+                        'planner_title_zh' => $planRow?->titleZh,
+                        'planner_family' => $planRow?->family,
+                        'planner_source_code' => $planRow?->sourceCode,
+                    ],
+                ],
+            );
+        }
+
+        return CareerOccupationEntityRemediationPlan::build($rows, $result->sidecars);
+    }
+
     /**
      * @param  list<string|null>  $slugs
      */
@@ -335,6 +375,73 @@ final class CareerOccupationEntityInventoryAuditor
         }
 
         return $missing;
+    }
+
+    /**
+     * @return array<string, CareerPublicResolutionPlanRow>
+     */
+    private function planRowsBySlug(CareerPublicResolutionPlan $plan): array
+    {
+        $rows = [];
+        foreach ($plan->rows as $row) {
+            $slug = $this->normalizeSlug($row->canonicalSlug);
+            if ($slug !== null) {
+                $rows[$slug] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array{0: string, 1: bool}
+     */
+    private function remediationAction(
+        CareerOccupationEntityInventoryRow $row,
+        ?CareerPublicResolutionPlanRow $planRow,
+    ): array {
+        if ($row->issues === []) {
+            return [CareerOccupationEntityRemediationPlanRow::ACTION_NONE, false];
+        }
+
+        if ($row->duplicateEntitySlug) {
+            return [CareerOccupationEntityRemediationPlanRow::ACTION_REVIEW_DUPLICATE_ENTITY, true];
+        }
+
+        if (! $row->occupationExists) {
+            return $this->hasPlannerSource($planRow)
+                ? [CareerOccupationEntityRemediationPlanRow::ACTION_CREATE_OCCUPATION, true]
+                : [CareerOccupationEntityRemediationPlanRow::ACTION_REVIEW_MISSING_SOURCE, false];
+        }
+
+        if ($row->missingEntityFields !== []) {
+            return [CareerOccupationEntityRemediationPlanRow::ACTION_REPAIR_ENTITY_FIELDS, true];
+        }
+
+        if ($row->duplicateInputSlug) {
+            return [CareerOccupationEntityRemediationPlanRow::ACTION_REVIEW_DUPLICATE_INPUT, false];
+        }
+
+        return [CareerOccupationEntityRemediationPlanRow::ACTION_NONE, false];
+    }
+
+    private function sourceStatus(?CareerPublicResolutionPlanRow $row): string
+    {
+        return $this->hasPlannerSource($row)
+            ? CareerOccupationEntityRemediationPlanRow::SOURCE_AVAILABLE
+            : CareerOccupationEntityRemediationPlanRow::SOURCE_MISSING;
+    }
+
+    private function hasPlannerSource(?CareerPublicResolutionPlanRow $row): bool
+    {
+        if ($row === null) {
+            return false;
+        }
+
+        return $row->titleEn !== null
+            || $row->titleZh !== null
+            || $row->family !== null
+            || $row->sourceCode !== null;
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerOccupationEntityRemediationPlan.php
+++ b/backend/app/Domain/Career/Audit/CareerOccupationEntityRemediationPlan.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerOccupationEntityRemediationPlan
+{
+    public const SCHEMA_VERSION = 'career_occupation_entity_remediation_plan.v1';
+
+    /**
+     * @param  list<CareerOccupationEntityRemediationPlanRow>  $rows
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     * @param  list<CareerCanonicalEligibilityAuditRunContextApprovalGate>  $approvalGates
+     */
+    public function __construct(
+        public readonly string $schemaVersion,
+        public readonly array $rows,
+        public readonly array $sidecars = [],
+        public readonly array $approvalGates = [],
+    ) {
+        self::assertNonEmptyString($this->schemaVersion, 'schema_version');
+        self::assertRows($this->rows);
+        self::assertSidecars($this->sidecars);
+        self::assertApprovalGates($this->approvalGates);
+    }
+
+    /**
+     * @param  list<CareerOccupationEntityRemediationPlanRow>  $rows
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    public static function build(array $rows, array $sidecars = []): self
+    {
+        return new self(
+            schemaVersion: self::SCHEMA_VERSION,
+            rows: $rows,
+            sidecars: $sidecars,
+            approvalGates: self::approvalGatesFor($rows),
+        );
+    }
+
+    public function createOccupationCount(): int
+    {
+        return count(array_filter(
+            $this->rows,
+            static fn (CareerOccupationEntityRemediationPlanRow $row): bool => $row->action === CareerOccupationEntityRemediationPlanRow::ACTION_CREATE_OCCUPATION
+        ));
+    }
+
+    public function repairEntityFieldsCount(): int
+    {
+        return count(array_filter(
+            $this->rows,
+            static fn (CareerOccupationEntityRemediationPlanRow $row): bool => $row->action === CareerOccupationEntityRemediationPlanRow::ACTION_REPAIR_ENTITY_FIELDS
+        ));
+    }
+
+    public function reviewCount(): int
+    {
+        return count(array_filter(
+            $this->rows,
+            static fn (CareerOccupationEntityRemediationPlanRow $row): bool => in_array($row->action, [
+                CareerOccupationEntityRemediationPlanRow::ACTION_REVIEW_DUPLICATE_ENTITY,
+                CareerOccupationEntityRemediationPlanRow::ACTION_REVIEW_DUPLICATE_INPUT,
+                CareerOccupationEntityRemediationPlanRow::ACTION_REVIEW_MISSING_SOURCE,
+            ], true)
+        ));
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function byAction(): array
+    {
+        $counts = [];
+        foreach ($this->rows as $row) {
+            $counts[$row->action] = ($counts[$row->action] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function bySourceStatus(): array
+    {
+        $counts = [];
+        foreach ($this->rows as $row) {
+            $counts[$row->sourceStatus] = ($counts[$row->sourceStatus] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array{schema_version: string, summary: array<string, mixed>, rows: list<array<string, mixed>>, sidecars: list<array<string, mixed>>, approval_gates: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'schema_version' => $this->schemaVersion,
+            'summary' => [
+                'expected_count' => count($this->rows),
+                'create_occupation_count' => $this->createOccupationCount(),
+                'repair_entity_fields_count' => $this->repairEntityFieldsCount(),
+                'review_count' => $this->reviewCount(),
+                'approval_required_count' => count(array_filter(
+                    $this->rows,
+                    static fn (CareerOccupationEntityRemediationPlanRow $row): bool => $row->approvalRequired
+                )),
+                'by_action' => $this->byAction(),
+                'by_source_status' => $this->bySourceStatus(),
+            ],
+            'rows' => array_map(
+                static fn (CareerOccupationEntityRemediationPlanRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+            'sidecars' => array_map(
+                static fn (CareerCanonicalEligibilitySidecar $sidecar): array => $sidecar->toArray(),
+                $this->sidecars
+            ),
+            'approval_gates' => array_map(
+                static fn (CareerCanonicalEligibilityAuditRunContextApprovalGate $gate): array => $gate->toArray(),
+                $this->approvalGates
+            ),
+        ];
+    }
+
+    /**
+     * @param  list<CareerOccupationEntityRemediationPlanRow>  $rows
+     * @return list<CareerCanonicalEligibilityAuditRunContextApprovalGate>
+     */
+    private static function approvalGatesFor(array $rows): array
+    {
+        foreach ($rows as $row) {
+            if ($row->approvalRequired) {
+                return [
+                    new CareerCanonicalEligibilityAuditRunContextApprovalGate(
+                        gateId: 'production_occupation_entity_remediation_apply',
+                        title: 'Production occupation entity remediation apply requires explicit approval.',
+                        required: true,
+                        reason: 'The remediation plan identifies occupation entities or entity fields that may require production DB writes; this PR only plans the work.',
+                        approvalPhraseTemplate: 'I explicitly approve production occupation entity remediation apply for Career 2786 using reviewed plan <PLAN_PATH>.',
+                        allowedAction: 'Apply reviewed occupation entity remediation plan only.',
+                        forbiddenActions: [
+                            'deploy',
+                            'rollout',
+                            'backfill outside reviewed plan',
+                            'quarantine',
+                            'rollback',
+                            'publish occupations',
+                        ],
+                        preconditions: [
+                            'Reviewed remediation plan artifact exists.',
+                            'Plan was generated from approved read-only Career 2786 context.',
+                            'Production DB mutation approval is explicit and current.',
+                        ]
+                    ),
+                ];
+            }
+        }
+
+        return [];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career occupation entity remediation plan requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<CareerOccupationEntityRemediationPlanRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career occupation entity remediation rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerOccupationEntityRemediationPlanRow) {
+                throw new InvalidArgumentException('Career occupation entity remediation rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilitySidecar>  $sidecars
+     */
+    private static function assertSidecars(array $sidecars): void
+    {
+        if (! array_is_list($sidecars)) {
+            throw new InvalidArgumentException('Career occupation entity remediation sidecars must be a list.');
+        }
+
+        foreach ($sidecars as $sidecar) {
+            if (! $sidecar instanceof CareerCanonicalEligibilitySidecar) {
+                throw new InvalidArgumentException('Career occupation entity remediation sidecars must contain sidecar DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRunContextApprovalGate>  $approvalGates
+     */
+    private static function assertApprovalGates(array $approvalGates): void
+    {
+        if (! array_is_list($approvalGates)) {
+            throw new InvalidArgumentException('Career occupation entity remediation approval gates must be a list.');
+        }
+
+        foreach ($approvalGates as $approvalGate) {
+            if (! $approvalGate instanceof CareerCanonicalEligibilityAuditRunContextApprovalGate) {
+                throw new InvalidArgumentException('Career occupation entity remediation approval gates must contain gate DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerOccupationEntityRemediationPlanRow.php
+++ b/backend/app/Domain/Career/Audit/CareerOccupationEntityRemediationPlanRow.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerOccupationEntityRemediationPlanRow
+{
+    public const SOURCE_AVAILABLE = 'planner_source_available';
+
+    public const SOURCE_MISSING = 'planner_source_missing';
+
+    public const ACTION_NONE = 'none';
+
+    public const ACTION_CREATE_OCCUPATION = 'create_occupation';
+
+    public const ACTION_REPAIR_ENTITY_FIELDS = 'repair_entity_fields';
+
+    public const ACTION_REVIEW_DUPLICATE_ENTITY = 'review_duplicate_entity';
+
+    public const ACTION_REVIEW_DUPLICATE_INPUT = 'review_duplicate_input';
+
+    public const ACTION_REVIEW_MISSING_SOURCE = 'review_missing_source';
+
+    /**
+     * @param  list<string>  $missingEntityFields
+     * @param  list<string>  $reasons
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $sourceStatus,
+        public readonly string $action,
+        public readonly bool $approvalRequired,
+        public readonly bool $occupationExists,
+        public readonly ?string $occupationId,
+        public readonly array $missingEntityFields = [],
+        public readonly ?string $plannerTitleEn = null,
+        public readonly ?string $plannerTitleZh = null,
+        public readonly ?string $plannerFamily = null,
+        public readonly ?string $plannerSourceCode = null,
+        public readonly array $reasons = [],
+        public readonly array $evidence = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        self::assertValidSourceStatus($this->sourceStatus);
+        self::assertValidAction($this->action);
+        self::assertListOfStrings($this->missingEntityFields, 'missing_entity_fields');
+        self::assertListOfStrings($this->reasons, 'reasons');
+        self::assertList($this->evidence, 'evidence');
+
+        foreach ([
+            'occupation_id' => $this->occupationId,
+            'planner_title_en' => $this->plannerTitleEn,
+            'planner_title_zh' => $this->plannerTitleZh,
+            'planner_family' => $this->plannerFamily,
+            'planner_source_code' => $this->plannerSourceCode,
+        ] as $key => $value) {
+            if ($value !== null) {
+                self::assertNonEmptyString($value, $key);
+            }
+        }
+    }
+
+    /**
+     * @return array{canonical_slug: string, source_status: string, action: string, approval_required: bool, occupation_exists: bool, occupation_id: string|null, missing_entity_fields: list<string>, planner_title_en: string|null, planner_title_zh: string|null, planner_family: string|null, planner_source_code: string|null, reasons: list<string>, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'source_status' => $this->sourceStatus,
+            'action' => $this->action,
+            'approval_required' => $this->approvalRequired,
+            'occupation_exists' => $this->occupationExists,
+            'occupation_id' => $this->occupationId,
+            'missing_entity_fields' => $this->missingEntityFields,
+            'planner_title_en' => $this->plannerTitleEn,
+            'planner_title_zh' => $this->plannerTitleZh,
+            'planner_family' => $this->plannerFamily,
+            'planner_source_code' => $this->plannerSourceCode,
+            'reasons' => $this->reasons,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function sourceStatuses(): array
+    {
+        return [
+            self::SOURCE_AVAILABLE,
+            self::SOURCE_MISSING,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function actions(): array
+    {
+        return [
+            self::ACTION_NONE,
+            self::ACTION_CREATE_OCCUPATION,
+            self::ACTION_REPAIR_ENTITY_FIELDS,
+            self::ACTION_REVIEW_DUPLICATE_ENTITY,
+            self::ACTION_REVIEW_DUPLICATE_INPUT,
+            self::ACTION_REVIEW_MISSING_SOURCE,
+        ];
+    }
+
+    private static function assertValidSourceStatus(string $value): void
+    {
+        if (! in_array($value, self::sourceStatuses(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career occupation entity remediation source status [%s].', $value));
+        }
+    }
+
+    private static function assertValidAction(string $value): void
+    {
+        if (! in_array($value, self::actions(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid career occupation entity remediation action [%s].', $value));
+        }
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career occupation entity remediation row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career occupation entity remediation row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career occupation entity remediation row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/docs/career/audits/occupation_entity_inventory_audit.md
+++ b/backend/docs/career/audits/occupation_entity_inventory_audit.md
@@ -142,3 +142,35 @@ AUDIT-4+ should consume AUDIT-3 output as the entity layer authority:
 - preserve `issues` and `by_reason` in later aggregate reports
 
 AUDIT-3 does not claim 2786 readiness. It only proves the read-only entity inventory contract for future canonical eligibility audits.
+
+## Remediation Planning
+
+REPAIR-ENTITY-1 adds a non-mutating remediation plan on top of the same inventory result:
+
+```php
+(new CareerOccupationEntityInventoryAuditor())->planRemediation($plan);
+```
+
+The plan schema is `career_occupation_entity_remediation_plan.v1`. It is planning-only and does not create, update, backfill, or publish occupations.
+
+Plan rows distinguish whether the public-resolution planner has enough source evidence to support future review:
+
+- `planner_source_available`
+- `planner_source_missing`
+
+Plan actions are:
+
+- `none`
+- `create_occupation`
+- `repair_entity_fields`
+- `review_duplicate_entity`
+- `review_duplicate_input`
+- `review_missing_source`
+
+Rows that would require future production writes carry `approval_required=true`. The plan emits one approval gate when any row requires an apply step:
+
+```text
+I explicitly approve production occupation entity remediation apply for Career 2786 using reviewed plan <PLAN_PATH>.
+```
+
+That approval gate is for a future task only. REPAIR-ENTITY-1 does not add an apply command, does not mutate DB state, and does not run a production export.

--- a/backend/tests/Feature/Domain/Career/Audit/CareerOccupationEntityInventoryAuditorTest.php
+++ b/backend/tests/Feature/Domain/Career/Audit/CareerOccupationEntityInventoryAuditorTest.php
@@ -8,6 +8,8 @@ use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
 use App\Domain\Career\Audit\CareerOccupationEntityInventoryAuditor;
 use App\Domain\Career\Audit\CareerOccupationEntityInventoryIssue;
+use App\Domain\Career\Audit\CareerOccupationEntityRemediationPlan;
+use App\Domain\Career\Audit\CareerOccupationEntityRemediationPlanRow;
 use App\Domain\Career\Audit\CareerPublicResolutionPlan;
 use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
 use App\Models\Occupation;
@@ -165,6 +167,160 @@ final class CareerOccupationEntityInventoryAuditorTest extends TestCase
         $this->assertStringNotContainsString('index_states', $queries);
         $this->assertStringNotContainsString('career_job_display_assets', $queries);
         $this->assertStringNotContainsString('occupation_truth_metrics', $queries);
+    }
+
+    public function test_missing_occupation_with_planner_source_produces_remediation_plan(): void
+    {
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-entity-remediation-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw([
+                    'canonical_slug' => 'actuaries',
+                    'title_en' => 'Actuaries',
+                    'title_zh' => '精算师',
+                    'family' => 'Business',
+                    'source_code' => '15-2011.00',
+                ]),
+            ]
+        );
+
+        $remediation = (new CareerOccupationEntityInventoryAuditor)->planRemediation($plan);
+
+        $this->assertSame(CareerOccupationEntityRemediationPlan::SCHEMA_VERSION, $remediation->schemaVersion);
+        $this->assertSame(1, $remediation->createOccupationCount());
+        $this->assertCount(1, $remediation->approvalGates);
+        $this->assertSame(
+            CareerOccupationEntityRemediationPlanRow::ACTION_CREATE_OCCUPATION,
+            $remediation->rows[0]->action
+        );
+        $this->assertSame(CareerOccupationEntityRemediationPlanRow::SOURCE_AVAILABLE, $remediation->rows[0]->sourceStatus);
+        $this->assertTrue($remediation->rows[0]->approvalRequired);
+        $this->assertSame('Actuaries', $remediation->rows[0]->plannerTitleEn);
+        $this->assertSame(['occupation_missing'], $remediation->rows[0]->reasons);
+    }
+
+    public function test_missing_occupation_without_planner_source_requires_source_review_not_apply(): void
+    {
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-entity-remediation-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'missing-career']),
+            ]
+        );
+
+        $remediation = (new CareerOccupationEntityInventoryAuditor)->planRemediation($plan);
+
+        $this->assertSame(
+            CareerOccupationEntityRemediationPlanRow::ACTION_REVIEW_MISSING_SOURCE,
+            $remediation->rows[0]->action
+        );
+        $this->assertSame(CareerOccupationEntityRemediationPlanRow::SOURCE_MISSING, $remediation->rows[0]->sourceStatus);
+        $this->assertFalse($remediation->rows[0]->approvalRequired);
+        $this->assertSame([], $remediation->approvalGates);
+    }
+
+    public function test_missing_entity_fields_produce_repair_plan(): void
+    {
+        $occupation = $this->createOccupation('actuaries', ['canonical_title_zh' => '']);
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-entity-remediation-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw([
+                    'canonical_slug' => 'actuaries',
+                    'title_en' => 'Actuaries',
+                    'title_zh' => '精算师',
+                ]),
+            ]
+        );
+
+        $remediation = (new CareerOccupationEntityInventoryAuditor)->planRemediation($plan);
+
+        $this->assertSame(
+            CareerOccupationEntityRemediationPlanRow::ACTION_REPAIR_ENTITY_FIELDS,
+            $remediation->rows[0]->action
+        );
+        $this->assertTrue($remediation->rows[0]->approvalRequired);
+        $this->assertSame($occupation->id, $remediation->rows[0]->occupationId);
+        $this->assertSame(['canonical_title_zh'], $remediation->rows[0]->missingEntityFields);
+        $this->assertSame(1, $remediation->repairEntityFieldsCount());
+    }
+
+    public function test_entity_present_has_no_remediation_action(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-entity-remediation-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw([
+                    'canonical_slug' => 'actuaries',
+                    'title_en' => 'Actuaries',
+                ]),
+            ]
+        );
+
+        $remediation = (new CareerOccupationEntityInventoryAuditor)->planRemediation($plan);
+
+        $this->assertSame(CareerOccupationEntityRemediationPlanRow::ACTION_NONE, $remediation->rows[0]->action);
+        $this->assertFalse($remediation->rows[0]->approvalRequired);
+        $this->assertTrue($remediation->rows[0]->occupationExists);
+        $this->assertSame($occupation->id, $remediation->rows[0]->occupationId);
+        $this->assertSame([], $remediation->approvalGates);
+    }
+
+    public function test_remediation_plan_to_array_is_stable(): void
+    {
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-entity-remediation-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw([
+                    'row_number' => 12,
+                    'canonical_slug' => 'actuaries',
+                    'title_en' => 'Actuaries',
+                    'title_zh' => '精算师',
+                    'family' => 'Business',
+                    'source_code' => '15-2011.00',
+                ]),
+            ]
+        );
+
+        $payload = (new CareerOccupationEntityInventoryAuditor)->planRemediation($plan)->toArray();
+
+        $this->assertSame('career_occupation_entity_remediation_plan.v1', $payload['schema_version']);
+        $this->assertSame([
+            'expected_count' => 1,
+            'create_occupation_count' => 1,
+            'repair_entity_fields_count' => 0,
+            'review_count' => 0,
+            'approval_required_count' => 1,
+            'by_action' => ['create_occupation' => 1],
+            'by_source_status' => ['planner_source_available' => 1],
+        ], $payload['summary']);
+        $this->assertSame('actuaries', $payload['rows'][0]['canonical_slug']);
+        $this->assertSame('create_occupation', $payload['rows'][0]['action']);
+        $this->assertSame('I explicitly approve production occupation entity remediation apply for Career 2786 using reviewed plan <PLAN_PATH>.', $payload['approval_gates'][0]['approval_phrase_template']);
+    }
+
+    public function test_remediation_planning_does_not_mutate_database(): void
+    {
+        $this->createOccupation('actuaries', ['canonical_title_zh' => '']);
+        $before = Occupation::query()->count();
+        $plan = new CareerPublicResolutionPlan(
+            sourcePath: 'synthetic-entity-remediation-plan.json',
+            checksum: null,
+            rows: [
+                CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'actuaries', 'title_en' => 'Actuaries']),
+                CareerPublicResolutionPlanRow::fromRaw(['canonical_slug' => 'missing-career', 'title_en' => 'Missing Career']),
+            ]
+        );
+
+        (new CareerOccupationEntityInventoryAuditor)->planRemediation($plan);
+
+        $this->assertSame($before, Occupation::query()->count());
     }
 
     public function test_result_to_array_is_stable(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -292,6 +292,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryIssue.php',
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryResult.php',
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryRow.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityRemediationPlan.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityRemediationPlanRow.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -1662,6 +1664,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryIssue.php',
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryResult.php',
             'backend/app/Domain/Career/Audit/CareerOccupationEntityInventoryRow.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityRemediationPlan.php',
+            'backend/app/Domain/Career/Audit/CareerOccupationEntityRemediationPlanRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1119,7 +1119,7 @@
       "branch": "fix/career-occupation-entity-inventory-audit3",
       "title": "feat(api): add career occupation entity inventory audit",
       "name": "Career Occupation Entity Inventory Audit",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "AUDIT-2"
       ],
@@ -2453,8 +2453,8 @@
       ],
       "failure_reason": null,
       "next_pr": "RIASEC-AH-05 end-to-end smoke acceptance",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "0244e8fee1784452744c598ae6060c9292431c4c",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1357",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
@@ -3178,6 +3178,59 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-ENTITY-1",
+      "merged_at": "2026-05-13T11:37:01Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": []
+    },
+    "REPAIR-ENTITY-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-entity-remediation-plan-1",
+      "title": "fix(api): add career occupation entity remediation planning",
+      "name": "Add career occupation entity remediation planning",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-INDEX-1",
+        "SCAN-3"
+      ],
+      "scope_type": "audit_occupation_entity_remediation_planning_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no Occupation/entity apply",
+        "no production DB query",
+        "no DB mutation",
+        "no rollout/backfill",
+        "no fap-web changes",
+        "no 80 readiness run",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided remediation train execution goal and authorized registering the current remediation PR item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-INDEX-1 merged as PR #1357 and local train worktree is based on origin/main after that merge."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to occupation entity remediation planning, audit tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-80-CANDIDATE-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1667,6 +1667,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-ENTITY-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-INDEX-1
+      - SCAN-3
+    branch: fix/career-entity-remediation-plan-1
+    title: "fix(api): add career occupation entity remediation planning"
+    name: "Add career occupation entity remediation planning"
+    scope_type: audit_occupation_entity_remediation_planning_only
+    scope:
+      - Add non-mutating Occupation/entity remediation planning from Career public-resolution plan rows and entity inventory results.
+      - Distinguish planner source available from missing planner source for Occupation remediation.
+      - Emit a stable remediation plan artifact shape and explicit approval gate for any future production DB apply.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Apply Occupation/entity changes.
+      - Mutate DB or production state.
+      - Run rollout or backfill.
+      - Touch fap-web.
+      - Run 80 readiness.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "REPAIR-80-CANDIDATE-1"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: RIASEC-PERSONALIZATION-00
     repo: fap-api
     branch: codex/riasec-personalization-00-train-registration


### PR DESCRIPTION
## Summary
- adds a read-only Occupation/entity remediation plan on top of the existing Career entity inventory auditor
- distinguishes planner source available vs missing planner source for missing Occupation rows
- emits an approval gate template for any future reviewed production entity apply
- registers REPAIR-ENTITY-1 in the PR train state after REPAIR-INDEX-1

## Non-goals
- no DB mutation
- no Occupation backfill/apply
- no rollout/backfill/quarantine/rollback
- no deploy
- no fap-web changes
- no 80 readiness run

## Tests
- php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
- php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|career_occupation_entity' --no-ansi
- php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi
- php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
- php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
- php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
- php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
- php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
- vendor/bin/pint --test
- ruby -e "require \"yaml\"; require \"json\"; YAML.load_file(\"docs/codex/pr-train.yaml\"); JSON.parse(File.read(\"docs/codex/pr-train-state.json\")); puts \"metadata ok\""
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh

## Scope
Changed files are limited to Career audit domain, audit docs/tests, PR train metadata, and the scoped BigFive runtime-freeze classifier allowlist for the new audit DTO files.