### PR TITLE
RIASEC-DEEP-COPY-02: Dimension deep copy runtime slots

### DIFF
--- a/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+++ b/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+final class RiasecDeepCopySlotRegistry
+{
+    private const CONTENT_VERSION = 'riasec_dimension_deep_copy_v1';
+
+    /** @var list<string> */
+    public const DIMENSIONS = ['R', 'I', 'A', 'S', 'E', 'C'];
+
+    public function __construct(
+        private readonly RiasecContentRegistrySlotContract $contract = new RiasecContentRegistrySlotContract,
+    ) {}
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    public function dimensionSlots(): array
+    {
+        return $this->dimensionContent();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function resolveDimensionSlot(string $dimensionCode): array
+    {
+        $dimensionCode = strtoupper(trim($dimensionCode));
+        $slot = $this->dimensionSlots()[$dimensionCode] ?? null;
+
+        if ($slot === null) {
+            return [
+                'slot_key' => 'dimension_deep_copy',
+                'dimension_code' => $dimensionCode,
+                'content_status' => 'unavailable',
+                'module_state' => 'omitted',
+                'fallback_behavior' => 'omit_module',
+                'frontend_fallback_allowed' => false,
+                'reason' => 'missing_dimension_deep_copy_slot',
+            ];
+        }
+
+        return $slot;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function validateSlot(array $slot): array
+    {
+        $contractResult = $this->contract->validate($slot);
+        $errors = $contractResult['errors'];
+
+        if (($slot['slot_key'] ?? null) === 'dimension_deep_copy') {
+            foreach ($this->dimensionRequiredFields() as $field) {
+                if (! array_key_exists($field, $slot) || $this->isBlank($slot[$field])) {
+                    $errors[] = 'missing_'.$field;
+                }
+            }
+            if (! in_array((string) ($slot['dimension_code'] ?? ''), self::DIMENSIONS, true)) {
+                $errors[] = 'unsupported_dimension_code';
+            }
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function dimensionRequiredFields(): array
+    {
+        return [
+            'dimension_code',
+            'title',
+            'core_drive',
+            'positive_value',
+            'real_world_cost',
+            'high_score_reading',
+            'low_score_safe_reading',
+            'work_activity_examples',
+            'possible_drains',
+            'common_misread',
+            'action_advice',
+            'forbidden_claims',
+            'user_visible_boundary',
+            'content_version',
+            'evidence_level',
+        ];
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function dimensionContent(): array
+    {
+        return [
+            'R' => $this->dimensionSlot('R', '实作型', [
+                'core_drive' => '你的燃料来自把想法落到真实物体、真实空间、真实系统或可操作成果上。',
+                'positive_value' => 'R 让人愿意接触现实材料、工具、设备、现场和可见成果。它能把抽象想法拉回可执行、可验证、可修正的现实。',
+                'real_world_cost' => '当 R 很高时，纯讨论、长时间抽象会议和没有落地对象的方案容易显得空转；当 R 较低时，现场操作、工具维护、重复实操未必自然提供能量。',
+                'high_score_reading' => '你可能更愿意动手试、调试、搭建、修理、实施，或者在真实系统里解决问题。',
+                'low_score_safe_reading' => '低 R 不是不能动手，也不是不能做技术或工程；它只表示实物、现场、工具和机械操作不是当前最自然的兴趣入口。',
+                'work_activity_examples' => ['搭建或修理', '现场调试', '操作工具或设备', '把方案做成样品', '处理真实系统问题'],
+                'possible_drains' => ['长时间纯理论讨论', '没有可见成果的空转', '必须大量实物操作但缺少理解空间'],
+                'common_misread' => '不要把低 R 读成手笨、不能学技术或不能做实操；RIASEC 不测能力。',
+                'action_advice' => '如果你对 R 类方向有现实机会，先做一个短任务验证：修一个小物件、完成一次工具操作、把一个想法做成原型。',
+                'forbidden_expression' => '不得写成实操能力、工程胜任力、体力水平、职业资格或安全操作能力判断。',
+            ]),
+            'I' => $this->dimensionSlot('I', '研究型', [
+                'core_drive' => '你的燃料是把问题看清楚：原因、证据、模型、假设和底层机制。',
+                'positive_value' => 'I 让人不满足于表面答案。它能提供求证、判断、拆解复杂问题和建立可靠解释的动力。',
+                'real_world_cost' => '当 I 很高时，拍脑袋推进、粗糙结论和只要速度不要证据的环境会消耗你；也可能出现过度研究、迟迟不交付的风险。',
+                'high_score_reading' => '你可能喜欢阅读资料、比较解释、分析数据、提出假设、找出事情为什么会这样。',
+                'low_score_safe_reading' => '低 I 不代表不聪明，也不代表不能做分析；它只说明深度研究和证据推理不是当前最自然的兴趣入口。',
+                'work_activity_examples' => ['分析复杂问题', '阅读研究资料', '提出假设', '比较证据', '建立模型或判断'],
+                'possible_drains' => ['只有结论没有依据', '不允许深入理解', '长期没有现实反馈的孤立研究'],
+                'common_misread' => '高 I 是兴趣线索，不是智力证明；低 I 也不是认知能力否定。',
+                'action_advice' => '选一个真实问题，写下 3 个可能原因、证据来源和你目前最相信的判断。',
+                'forbidden_expression' => '不得写成智商、研究能力、专业资格、学术潜力或长期结果预测。',
+            ]),
+            'A' => $this->dimensionSlot('A', '艺术型', [
+                'core_drive' => '你的燃料是表达空间：把想法、感受、信息或体验变成有质感、有个人判断的形式。',
+                'positive_value' => 'A 让人愿意创造、改写、设计、叙事和打破模板。它能让复杂内容有温度、有形状、有记忆点。',
+                'real_world_cost' => '当 A 很高时，过度模板化、千篇一律、只许按流程交差的环境会让你失去生命力；也可能因为追求质感而被反复打磨消耗。',
+                'high_score_reading' => '你可能喜欢写作、设计、表达、构思、视觉/文字/概念创造，或把普通内容做出独特风格。',
+                'low_score_safe_reading' => '低 A 不代表没有审美或不能创作；它只说明开放式表达与创意探索不是当前最自然的兴趣入口。',
+                'work_activity_examples' => ['创造表达', '内容构思', '视觉或文字设计', '把抽象想法变成作品', '用新方式呈现信息'],
+                'possible_drains' => ['高度标准化', '只能按模板执行', '质量被不断压缩', '表达被过度审查且没有空间'],
+                'common_misread' => 'A 不是艺术天赋证明，也不等于适合所有创意职业。',
+                'action_advice' => '把一个复杂主题改写成一页图文或 5 句话，观察你更享受构思、表达还是受众反馈。',
+                'forbidden_expression' => '不得写成艺术天赋、创作能力、职业结论或作品质量保证。',
+            ]),
+            'S' => $this->dimensionSlot('S', '社会型', [
+                'core_drive' => '你的燃料来自真实的人：理解、支持、解释、陪伴、协调，让别人更清楚或更能行动。',
+                'positive_value' => 'S 让成果不只停留在自己手里，而是面向真实对象。它能把知识、判断和表达转化为支持他人的力量。',
+                'real_world_cost' => '当 S 很高时，真实人的复杂反馈、情绪负担和长期陪伴会带来消耗；当 S 较低时，高互动助人场景未必自然给能量。',
+                'high_score_reading' => '你可能喜欢倾听、辅导、解释、培训、协调、服务、理解需求，或看到别人因你的支持而更清楚。',
+                'low_score_safe_reading' => '低 S 不代表冷漠，也不代表不能合作；它只说明高互动、持续助人或情绪密度较高的活动不是当前最自然的兴趣入口。',
+                'work_activity_examples' => ['倾听真实需求', '解释和辅导', '协调协作', '支持别人做判断', '设计帮助别人理解的材料'],
+                'possible_drains' => ['情绪边界模糊', '持续被索取', '大量低质量沟通', '真实反馈太复杂但缺少结构'],
+                'common_misread' => 'S 不是善良程度，也不是咨询、教育或医疗资格证明。',
+                'action_advice' => '找一个真实对象试讲、访谈或收集反馈，记录反馈让你有能量还是更消耗。',
+                'forbidden_expression' => '不得写成同理心能力、心理咨询能力、教育资格、医疗/法律/职业指导资格或筛选能力。',
+            ]),
+            'E' => $this->dimensionSlot('E', '企业型', [
+                'core_drive' => '你的燃料来自推动：影响他人、争取资源、设定目标、承担结果、把机会变成行动。',
+                'positive_value' => 'E 让人愿意站出来推动事情、争取资源、面对竞争和把模糊机会变成可见结果。',
+                'real_world_cost' => '当 E 很高时，缺少决策权、长期无影响力或目标含混的环境会消耗你；当 E 较低时，高曝光、高竞争、持续谈判和强商务压力可能消耗更快。',
+                'high_score_reading' => '你可能喜欢主导推进、说服影响、商务拓展、目标达成、组织资源、承担结果。',
+                'low_score_safe_reading' => '低 E 不代表不能创业、销售、管理或影响别人；它只说明强推动和高竞争不是当前最自然的兴趣入口。',
+                'work_activity_examples' => ['推动目标', '争取资源', '公开表达', '商务拓展', '组织人和节奏'],
+                'possible_drains' => ['持续竞争', '高压谈判', '强曝光', '只看短期指标', '每天都要争资源'],
+                'common_misread' => 'E 不是领导能力或商业能力证明；低 E 也不是不能做管理。',
+                'action_advice' => '读 3 条商务/增长/管理岗位描述，只圈出让你有兴趣的任务动词，区分你喜欢影响结果，还是只喜欢想法被看见。',
+                'forbidden_expression' => '不得写成领导力、销售能力、创业成功率、岗位胜任力或雇佣风险。',
+            ]),
+            'C' => $this->dimensionSlot('C', '常规型', [
+                'core_drive' => '你的燃料来自秩序：分类、流程、记录、标准、质量校验和稳定交付。',
+                'positive_value' => 'C 让事情不只被想出来，也能被保存、复用、交接和持续维护。它是复杂系统里的稳定支架。',
+                'real_world_cost' => '当 C 很高时，混乱、随意变更和责任不清会消耗你；当 C 较低时，长期流程维护、重复记录和高度标准化可能让你感到生命力被压住。',
+                'high_score_reading' => '你可能喜欢规划、整理、维护清单、做流程、校验质量、把杂乱信息排成稳定结构。',
+                'low_score_safe_reading' => '低 C 不代表没有责任感或不能守规则；它只说明流程、重复维护和标准作业不是当前最自然的兴趣入口。',
+                'work_activity_examples' => ['整理分类', '流程管理', '进度跟踪', '质量校验', '文档化和清单维护'],
+                'possible_drains' => ['长期重复维护', '高度模板化', '只守流程不允许优化', '细节责任过多但缺少意义'],
+                'common_misread' => 'C 不是尽责性人格分数，也不是责任心能力判断。',
+                'action_advice' => '尝试把一个混乱任务整理成 5 步流程，观察结构化本身是给你能量，还是只是必要工具。',
+                'forbidden_expression' => '不得写成责任感、执行力、纪律性、会计/行政能力或职业资格。',
+            ]),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $content
+     * @return array<string,mixed>
+     */
+    private function dimensionSlot(string $dimensionCode, string $title, array $content): array
+    {
+        return array_merge([
+            'slot_key' => 'dimension_deep_copy',
+            'slot_group' => 'dimension_deep_copy',
+            'scale_code' => 'RIASEC',
+            'locale' => 'zh-CN',
+            'content_version' => self::CONTENT_VERSION,
+            'interpretation_rule_version' => 'riasec_interpretation_rule_spec_v2',
+            'applicable_form_codes' => ['riasec_60', 'riasec_140'],
+            'applicable_profile_shapes' => ['clear_code', 'blended_code', 'broad_profile', 'near_tie', 'low_clarity'],
+            'applicable_quality_states' => ['normal', 'caution'],
+            'applicable_dimensions' => [$dimensionCode],
+            'dimension_code' => $dimensionCode,
+            'title' => $title,
+            'forbidden_claims' => [
+                'ability_or_skill_inference',
+                'personality_identity',
+                'job_fit',
+                'career_success_prediction',
+                'hiring_or_screening_use',
+                'occupation_matching',
+            ],
+            'required_boundaries' => $this->requiredBoundaries(),
+            'user_visible_boundary' => '这是职业兴趣线索，不是能力、人格身份、雇佣判断或岗位结论。',
+            'evidence_level' => 'expert_reviewed',
+            'source_status' => 'reviewed_content_copy',
+            'review_status' => 'approved_for_staging',
+            'fallback_behavior' => 'omit_module',
+            'content_status' => 'authored',
+            'frontend_fallback_allowed' => false,
+        ], $content);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredBoundaries(): array
+    {
+        return [
+            'interest_evidence_only',
+            'not_career_recommendation',
+            'not_job_fit',
+            'not_success_prediction',
+            'not_ability_or_skill_measure',
+            'no_60q_140q_raw_delta',
+            '140q_contextual_not_more_accurate',
+            'feedback_does_not_mutate_measured_result',
+            'missing_content_fails_closed',
+            'frontend_fallback_forbidden',
+        ];
+    }
+
+    private function isBlank(mixed $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+        if (is_string($value)) {
+            return trim($value) === '';
+        }
+        if (is_array($value)) {
+            return $value === [];
+        }
+
+        return false;
+    }
+}

--- a/backend/docs/riasec/deep-copy-slot-schema-contract.md
+++ b/backend/docs/riasec/deep-copy-slot-schema-contract.md
@@ -76,4 +76,26 @@ Validators must reject content or fields that introduce:
 
 ## Future PR Usage
 
-`RIASEC-DEEP-COPY-02` should add the deterministic registry loader/resolver on top of this schema. Later PRs can wire approved slots into projection/composer output only after the resolver validates slot metadata and fails closed for missing content.
+`RIASEC-DEEP-COPY-02` adds the first deterministic backend registry resolver for six dimension deep copy slots. Later PRs can extend the same resolver with pair blend, 140Q layer, low-quality, structural difference, aspirations, and feedback response slots. Projection/composer output must only consume slots after validator pass and must fail closed for missing content.
+
+## Dimension Deep Copy Runtime Slots
+
+`RiasecDeepCopySlotRegistry` owns the first approved dimension deep copy atoms for `R`, `I`, `A`, `S`, `E`, and `C`. Each slot must include:
+
+- `dimension_code`
+- `title`
+- `core_drive`
+- `positive_value`
+- `real_world_cost`
+- `high_score_reading`
+- `low_score_safe_reading`
+- `work_activity_examples`
+- `possible_drains`
+- `common_misread`
+- `action_advice`
+- `forbidden_claims`
+- `user_visible_boundary`
+- `content_version`
+- `evidence_level`
+
+Dimension copy remains backend-authoritative content. The frontend may render a validated payload in a later PR, but must not hardcode these explanations or synthesize missing copy. If a requested dimension slot is missing, the registry returns `content_status=unavailable`, `module_state=omitted`, and `frontend_fallback_allowed=false`.

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -664,10 +664,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
-    public function test_runtime_freeze_classifier_ignores_riasec_content_registry_slot_contract_changes(): void
+    public function test_runtime_freeze_classifier_ignores_riasec_content_registry_contract_changes(): void
     {
         $changed = [
             'backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php',
+            'backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -1297,7 +1298,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
-            if ($this->isRiasecContentRegistrySlotContractFile($file)) {
+            if ($this->isRiasecContentRegistryContractFile($file)) {
                 continue;
             }
 
@@ -1484,9 +1485,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
-    private function isRiasecContentRegistrySlotContractFile(string $file): bool
+    private function isRiasecContentRegistryContractFile(string $file): bool
     {
-        return $file === 'backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php';
+        return in_array($file, [
+            'backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php',
+            'backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php',
+        ], true);
     }
 
     private function isRiasecProjectionV2MinimalFile(string $file): bool

--- a/backend/tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Services\Riasec\RiasecDeepCopySlotRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class RiasecDeepCopySlotRegistryTest extends TestCase
+{
+    public function test_dimension_deep_copy_slots_cover_all_six_dimensions(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slots = $registry->dimensionSlots();
+
+        $this->assertSame(['R', 'I', 'A', 'S', 'E', 'C'], array_keys($slots));
+
+        foreach ($slots as $dimension => $slot) {
+            $this->assertSame('dimension_deep_copy', $slot['slot_key']);
+            $this->assertSame([$dimension], $slot['applicable_dimensions']);
+            $this->assertSame($dimension, $slot['dimension_code']);
+            $this->assertSame('reviewed_content_copy', $slot['source_status']);
+            $this->assertSame('approved_for_staging', $slot['review_status']);
+            $this->assertSame('expert_reviewed', $slot['evidence_level']);
+            $this->assertFalse($slot['frontend_fallback_allowed']);
+
+            foreach ($registry->dimensionRequiredFields() as $requiredField) {
+                $this->assertArrayHasKey($requiredField, $slot);
+                $this->assertNotEmpty($slot[$requiredField]);
+            }
+
+            $this->assertSame([], $registry->validateSlot($slot), 'Dimension '.$dimension.' slot should be contract-clean.');
+        }
+    }
+
+    public function test_dimension_slot_contract_rejects_forbidden_claims(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slot = $registry->resolveDimensionSlot('I');
+        $slot['body'] = 'This invalid slot says job fit, success probability, and career recommendation.';
+        $slot['job_fit'] = true;
+
+        $errors = $registry->validateSlot($slot);
+
+        $this->assertContains('forbidden_field_job_fit', $errors);
+        $this->assertContains('forbidden_claim_phrase_job_fit', $errors);
+        $this->assertContains('forbidden_claim_phrase_success_probability', $errors);
+        $this->assertContains('forbidden_claim_phrase_career_recommendation', $errors);
+    }
+
+    public function test_missing_dimension_content_fails_closed_without_frontend_fallback(): void
+    {
+        $slot = (new RiasecDeepCopySlotRegistry)->resolveDimensionSlot('X');
+
+        $this->assertSame('dimension_deep_copy', $slot['slot_key']);
+        $this->assertSame('X', $slot['dimension_code']);
+        $this->assertSame('unavailable', $slot['content_status']);
+        $this->assertSame('omitted', $slot['module_state']);
+        $this->assertSame('omit_module', $slot['fallback_behavior']);
+        $this->assertFalse($slot['frontend_fallback_allowed']);
+    }
+
+    public function test_dimension_slot_requires_deep_copy_fields(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slot = $registry->resolveDimensionSlot('A');
+        unset($slot['core_drive'], $slot['work_activity_examples']);
+
+        $errors = $registry->validateSlot($slot);
+
+        $this->assertContains('missing_core_drive', $errors);
+        $this->assertContains('missing_work_activity_examples', $errors);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3651,6 +3651,70 @@
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
       "sidecar_issues": []
+    },
+    "RIASEC-DEEP-COPY-02": {
+      "repo": "fap-api",
+      "branch": "codex/riasec-deep-copy-02-dimension-slots",
+      "title": "feat(riasec): add dimension deep copy runtime slots",
+      "status": "in_progress",
+      "depends_on": [
+        "RIASEC-DEEP-COPY-01"
+      ],
+      "scope_type": "backend_dimension_deep_copy_slots_only",
+      "allowed_paths": [
+        "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
+        "backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php",
+        "backend/tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php",
+        "backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "backend/docs/riasec/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "commit_sha": "c6f959dca6987dcbbf7c9785a1408043fb2100e8",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1361",
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "RIASEC-DEEP-COPY-01 is merged as PR #1356 with merge commit 565ef580525a6feda00bdfba2abb98ae6dfded18; ledger cleanup PR #1359 reconciled state."
+        },
+        "dimension_registry_contract": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php --no-ansi",
+          "evidence": "10 tests passed, 292 assertions."
+        },
+        "riasec_personalization_contracts": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php --no-ansi",
+          "evidence": "8 tests passed, 188 assertions."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        },
+        "freeze_classifier": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_content_registry' --no-ansi",
+          "evidence": "2 tests passed after adding the RIASEC deep copy registry to the scoped content-registry allowance."
+        },
+        "json_yaml_validity": {
+          "status": "pass",
+          "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")' && jq empty docs/codex/pr-train-state.json"
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to backend RIASEC deep copy slot registry, its unit tests, backend RIASEC docs, and docs/codex train metadata. No scorer, content pack, frontend UI, share/PDF/history, feedback, analytics, or career runtime files changed."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1924,3 +1924,37 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: RIASEC-DEEP-COPY-02
+    repo: fap-api
+    depends_on:
+      - RIASEC-DEEP-COPY-01
+    branch: codex/riasec-deep-copy-02-dimension-slots
+    title: "feat(riasec): add dimension deep copy runtime slots"
+    scope:
+      - Add backend-authoritative RIASEC dimension deep copy slots for R, I, A, S, E, and C.
+      - Validate core drive, positive value, cost/shadow, high and low safe readings, activity examples, drains, misread clarification, action advice, and boundaries.
+      - Keep frontend rendering and scoring unchanged.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
+      - backend/tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change scorer math.
+      - Change RIASEC content pack question semantics.
+      - Add frontend local copy or rendering.
+      - Add career matching, job fit, ranking, success, hiring, O*NET, SOC, or source URL claims.
+      - Change 140Q scoring or compare policy.
+    validation:
+      - targeted PHPUnit for RIASEC deep copy registry and content slot contract
+      - relevant RIASEC flow tests when touched
+      - scoped Pint for touched PHP
+      - JSON/YAML validity
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## What changed
- Adds backend-authoritative RIASEC dimension deep copy slots for R/I/A/S/E/C.
- Adds a fail-closed slot resolver and validator coverage for required dimension fields and forbidden claims.
- Registers RIASEC-DEEP-COPY-02 in the train manifest/state ledger.

## Why
- Establishes the first runtime-ready deep copy content authority layer after the DEEP-COPY-01 schema contract.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=' :memory:' php artisan test tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php --no-ansi`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php --no-ansi`\n- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php`\n- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")' && jq empty docs/codex/pr-train-state.json`\n- `git diff --check`\n\n## Intentionally deferred\n- No frontend rendering.\n- No scoring or question content changes.\n- No 140Q, pair blend, low-quality, structural difference, aspirations, feedback, career registry, share/PDF/history, or analytics runtime changes.