### PR TITLE
fix(api): add career 80 candidate readiness selector

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonical80CandidateSelectionReport
+{
+    public const SCHEMA_VERSION = 'career_80_candidate_selection.v1';
+
+    /**
+     * @param  list<CareerCanonical80CandidateSelectionRow>  $rows
+     * @param  list<string>  $selectedSlugs
+     * @param  list<string>  $nearEligibleSlugs
+     * @param  list<string>  $excludedSlugs
+     */
+    public function __construct(
+        public readonly string $schemaVersion,
+        public readonly string $status,
+        public readonly int $targetCount,
+        public readonly int $candidateCount,
+        public readonly int $selectedCount,
+        public readonly int $nearEligibleCount,
+        public readonly int $excludedCount,
+        public readonly bool $readinessCanRun,
+        public readonly array $rows,
+        public readonly array $selectedSlugs,
+        public readonly array $nearEligibleSlugs,
+        public readonly array $excludedSlugs,
+    ) {
+        self::assertNonEmptyString($this->schemaVersion, 'schema_version');
+        CareerCanonicalEligibilityStatus::assertValid($this->status);
+        foreach ([
+            'target_count' => $this->targetCount,
+            'candidate_count' => $this->candidateCount,
+            'selected_count' => $this->selectedCount,
+            'near_eligible_count' => $this->nearEligibleCount,
+            'excluded_count' => $this->excludedCount,
+        ] as $key => $value) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(sprintf('Career 80 candidate selection [%s] must be non-negative.', $key));
+            }
+        }
+        self::assertRows($this->rows);
+        self::assertListOfStrings($this->selectedSlugs, 'selected_slugs');
+        self::assertListOfStrings($this->nearEligibleSlugs, 'near_eligible_slugs');
+        self::assertListOfStrings($this->excludedSlugs, 'excluded_slugs');
+    }
+
+    /**
+     * @param  list<CareerCanonical80CandidateSelectionRow>  $rows
+     */
+    public static function build(int $targetCount, array $rows): self
+    {
+        self::assertRows($rows);
+
+        $selectedSlugs = array_values(array_map(
+            static fn (CareerCanonical80CandidateSelectionRow $row): string => $row->canonicalSlug,
+            array_filter($rows, static fn (CareerCanonical80CandidateSelectionRow $row): bool => $row->selected)
+        ));
+        $nearEligibleSlugs = array_values(array_map(
+            static fn (CareerCanonical80CandidateSelectionRow $row): string => $row->canonicalSlug,
+            array_filter($rows, static fn (CareerCanonical80CandidateSelectionRow $row): bool => $row->candidateStatus === CareerCanonical80CandidateSelectionRow::STATUS_NEAR_ELIGIBLE)
+        ));
+        $excludedSlugs = array_values(array_map(
+            static fn (CareerCanonical80CandidateSelectionRow $row): string => $row->canonicalSlug,
+            array_filter($rows, static fn (CareerCanonical80CandidateSelectionRow $row): bool => $row->candidateStatus === CareerCanonical80CandidateSelectionRow::STATUS_EXCLUDED_HARD_BLOCKER)
+        ));
+        $readinessCanRun = count($selectedSlugs) >= $targetCount;
+
+        return new self(
+            schemaVersion: self::SCHEMA_VERSION,
+            status: $readinessCanRun ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            targetCount: $targetCount,
+            candidateCount: count($rows),
+            selectedCount: count($selectedSlugs),
+            nearEligibleCount: count($nearEligibleSlugs),
+            excludedCount: count($excludedSlugs),
+            readinessCanRun: $readinessCanRun,
+            rows: $rows,
+            selectedSlugs: array_slice($selectedSlugs, 0, $targetCount),
+            nearEligibleSlugs: $nearEligibleSlugs,
+            excludedSlugs: $excludedSlugs,
+        );
+    }
+
+    /**
+     * @return array{schema_version: string, status: string, target_count: int, candidate_count: int, selected_count: int, near_eligible_count: int, excluded_count: int, readiness_can_run: bool, selected_slugs: list<string>, near_eligible_slugs: list<string>, excluded_slugs: list<string>, rows: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'schema_version' => $this->schemaVersion,
+            'status' => $this->status,
+            'target_count' => $this->targetCount,
+            'candidate_count' => $this->candidateCount,
+            'selected_count' => $this->selectedCount,
+            'near_eligible_count' => $this->nearEligibleCount,
+            'excluded_count' => $this->excludedCount,
+            'readiness_can_run' => $this->readinessCanRun,
+            'selected_slugs' => $this->selectedSlugs,
+            'near_eligible_slugs' => $this->nearEligibleSlugs,
+            'excluded_slugs' => $this->excludedSlugs,
+            'rows' => array_map(
+                static fn (CareerCanonical80CandidateSelectionRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career 80 candidate selection requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<CareerCanonical80CandidateSelectionRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career 80 candidate selection rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof CareerCanonical80CandidateSelectionRow) {
+                throw new InvalidArgumentException('Career 80 candidate selection rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career 80 candidate selection [%s] must be a list.', $key));
+        }
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career 80 candidate selection [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonical80CandidateSelectionRow
+{
+    public const STATUS_READY = 'ready';
+
+    public const STATUS_NEAR_ELIGIBLE = 'near_eligible';
+
+    public const STATUS_EXCLUDED_HARD_BLOCKER = 'excluded_hard_blocker';
+
+    /**
+     * @param  list<string>  $locales
+     * @param  list<string>  $reasons
+     * @param  list<string>  $hardBlockers
+     * @param  array<string, string>  $layerStatuses
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly int $rank,
+        public readonly int $score,
+        public readonly string $candidateStatus,
+        public readonly bool $selected,
+        public readonly bool $hardBlocked,
+        public readonly int $passedLocaleCount,
+        public readonly int $blockedLocaleCount,
+        public readonly array $locales = [],
+        public readonly array $reasons = [],
+        public readonly array $hardBlockers = [],
+        public readonly array $layerStatuses = [],
+        public readonly array $evidence = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        if ($this->rank < 0 || $this->score < 0 || $this->passedLocaleCount < 0 || $this->blockedLocaleCount < 0) {
+            throw new InvalidArgumentException('Career 80 candidate selection numeric fields must be non-negative.');
+        }
+        self::assertValidStatus($this->candidateStatus);
+        self::assertListOfStrings($this->locales, 'locales');
+        self::assertListOfStrings($this->reasons, 'reasons');
+        self::assertListOfStrings($this->hardBlockers, 'hard_blockers');
+        self::assertLayerStatuses($this->layerStatuses);
+        self::assertList($this->evidence, 'evidence');
+    }
+
+    /**
+     * @return array{canonical_slug: string, rank: int, score: int, candidate_status: string, selected: bool, hard_blocked: bool, passed_locale_count: int, blocked_locale_count: int, locales: list<string>, reasons: list<string>, hard_blockers: list<string>, layer_statuses: array<string, string>, evidence: list<mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'rank' => $this->rank,
+            'score' => $this->score,
+            'candidate_status' => $this->candidateStatus,
+            'selected' => $this->selected,
+            'hard_blocked' => $this->hardBlocked,
+            'passed_locale_count' => $this->passedLocaleCount,
+            'blocked_locale_count' => $this->blockedLocaleCount,
+            'locales' => $this->locales,
+            'reasons' => $this->reasons,
+            'hard_blockers' => $this->hardBlockers,
+            'layer_statuses' => $this->layerStatuses,
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function statuses(): array
+    {
+        return [
+            self::STATUS_READY,
+            self::STATUS_NEAR_ELIGIBLE,
+            self::STATUS_EXCLUDED_HARD_BLOCKER,
+        ];
+    }
+
+    private static function assertValidStatus(string $value): void
+    {
+        if (! in_array($value, self::statuses(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid Career 80 candidate selection status [%s].', $value));
+        }
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career 80 candidate selection row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career 80 candidate selection row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career 80 candidate selection row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $value
+     */
+    private static function assertLayerStatuses(array $value): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException('Career 80 candidate selection layer_statuses must be an object map.');
+        }
+
+        foreach ($value as $layer => $status) {
+            if (! is_string($layer) || trim($layer) === '' || ! is_string($status) || trim($status) === '') {
+                throw new InvalidArgumentException('Career 80 candidate selection layer_statuses must map non-empty strings.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class CareerCanonical80CandidateSelector
+{
+    /**
+     * These reasons require remediation or approval-gated data/runtime work before a slug can enter an 80-readiness run.
+     *
+     * @var list<string>
+     */
+    private const DEFAULT_HARD_BLOCKERS = [
+        'occupation_missing',
+        'entity_field_missing',
+        'index_state_missing',
+        'projection_row_missing',
+        'truth_row_missing',
+        'locale_row_missing',
+        'ledger_member_missing',
+        'runtime_publish_state_not_published',
+        'canonical_public_type_invalid',
+        'zh_baseline_missing',
+        'en_title_derivation_required',
+        'surface_context_missing',
+        'structured_data_missing',
+        'sitemap_missing',
+        'required_display_field_missing',
+        'llms_missing',
+        'llms_full_missing',
+        'citation_metadata_missing',
+    ];
+
+    /**
+     * @param  list<string>  $hardBlockers
+     */
+    public function select(
+        CareerCanonicalEligibilityReport $report,
+        int $targetCount = CareerCanonical80CohortReadinessPlanner::DEFAULT_TARGET_COUNT,
+        array $hardBlockers = self::DEFAULT_HARD_BLOCKERS,
+    ): CareerCanonical80CandidateSelectionReport {
+        if ($targetCount <= 0) {
+            throw new InvalidArgumentException('Career 80 candidate selection target_count must be positive.');
+        }
+
+        $hardBlockers = $this->normalizeReasons($hardBlockers);
+        $ranked = $this->rankedRows($report, $hardBlockers);
+        $selectedCount = 0;
+        $rows = [];
+
+        foreach ($ranked as $index => $row) {
+            $selected = $row['candidate_status'] === CareerCanonical80CandidateSelectionRow::STATUS_READY
+                && $selectedCount < $targetCount;
+            if ($selected) {
+                $selectedCount++;
+            }
+
+            $rows[] = new CareerCanonical80CandidateSelectionRow(
+                canonicalSlug: $row['canonical_slug'],
+                rank: $index + 1,
+                score: $row['score'],
+                candidateStatus: $row['candidate_status'],
+                selected: $selected,
+                hardBlocked: $row['hard_blockers'] !== [],
+                passedLocaleCount: $row['passed_locale_count'],
+                blockedLocaleCount: $row['blocked_locale_count'],
+                locales: $row['locales'],
+                reasons: $row['reasons'],
+                hardBlockers: $row['hard_blockers'],
+                layerStatuses: $row['layer_statuses'],
+                evidence: $row['evidence'],
+            );
+        }
+
+        return CareerCanonical80CandidateSelectionReport::build($targetCount, $rows);
+    }
+
+    /**
+     * @param  list<string>  $hardBlockers
+     * @return list<array{canonical_slug: string, score: int, candidate_status: string, passed_locale_count: int, blocked_locale_count: int, locales: list<string>, reasons: list<string>, hard_blockers: list<string>, layer_statuses: array<string, string>, evidence: list<mixed>}>
+     */
+    private function rankedRows(CareerCanonicalEligibilityReport $report, array $hardBlockers): array
+    {
+        $rows = [];
+        foreach ($this->rowsBySlug($report->rows) as $slug => $auditRows) {
+            $locales = [];
+            $reasons = [];
+            $layerStatuses = [];
+            $passedLocaleCount = 0;
+            $blockedLocaleCount = 0;
+
+            foreach ($auditRows as $auditRow) {
+                $locales[] = $auditRow->locale;
+                $reasons = [...$reasons, ...$auditRow->reasons];
+                $passedLocaleCount += $auditRow->overallStatus === CareerCanonicalEligibilityStatus::PASS ? 1 : 0;
+                $blockedLocaleCount += $auditRow->overallStatus === CareerCanonicalEligibilityStatus::PASS ? 0 : 1;
+                foreach ($this->layerStatuses($auditRow) as $layer => $status) {
+                    $layerStatuses[$layer] = $this->leastReadyStatus($layerStatuses[$layer] ?? null, $status);
+                }
+            }
+
+            $reasons = $this->normalizeReasons($reasons);
+            $rowHardBlockers = array_values(array_intersect($reasons, $hardBlockers));
+            $score = $this->score($passedLocaleCount, $blockedLocaleCount, count($reasons), count($rowHardBlockers));
+
+            $rows[] = [
+                'canonical_slug' => $slug,
+                'score' => $score,
+                'candidate_status' => $this->candidateStatus($rowHardBlockers, $blockedLocaleCount),
+                'passed_locale_count' => $passedLocaleCount,
+                'blocked_locale_count' => $blockedLocaleCount,
+                'locales' => array_values(array_unique($locales)),
+                'reasons' => $reasons,
+                'hard_blockers' => $rowHardBlockers,
+                'layer_statuses' => $layerStatuses,
+                'evidence' => [[
+                    'report_status' => $report->status,
+                    'report_scope' => $report->scope,
+                    'row_count' => count($auditRows),
+                    'reason_count' => count($reasons),
+                    'hard_blocker_count' => count($rowHardBlockers),
+                ]],
+            ];
+        }
+
+        usort($rows, static function (array $left, array $right): int {
+            if ($left['score'] !== $right['score']) {
+                return $right['score'] <=> $left['score'];
+            }
+
+            return $left['canonical_slug'] <=> $right['canonical_slug'];
+        });
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     * @return array<string, list<CareerCanonicalEligibilityAuditRow>>
+     */
+    private function rowsBySlug(array $rows): array
+    {
+        $bySlug = [];
+        foreach ($rows as $row) {
+            $bySlug[$row->slug] ??= [];
+            $bySlug[$row->slug][] = $row;
+        }
+
+        return $bySlug;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function layerStatuses(CareerCanonicalEligibilityAuditRow $row): array
+    {
+        return [
+            CareerCanonicalEligibilityLayer::ENTITY => $row->entityStatus->status,
+            CareerCanonicalEligibilityLayer::BASELINE => $row->baselineStatus->status,
+            CareerCanonicalEligibilityLayer::INDEX => $row->indexStatus->status,
+            CareerCanonicalEligibilityLayer::RUNTIME => $row->runtimeStatus->status,
+            CareerCanonicalEligibilityLayer::SEO_GEO => $row->seoGeoStatus->status,
+            CareerCanonicalEligibilityLayer::SURFACE => $row->surfaceStatus->status,
+            CareerCanonicalEligibilityLayer::SAFETY => $row->safetyStatus->status,
+        ];
+    }
+
+    private function leastReadyStatus(?string $current, string $next): string
+    {
+        if ($current === null) {
+            return $next;
+        }
+
+        $rank = [
+            CareerCanonicalEligibilityStatus::PASS => 0,
+            CareerCanonicalEligibilityStatus::WARNING => 1,
+            CareerCanonicalEligibilityStatus::BLOCKED => 2,
+            CareerCanonicalEligibilityStatus::FAIL => 3,
+        ];
+
+        return ($rank[$next] ?? 3) > ($rank[$current] ?? -1) ? $next : $current;
+    }
+
+    private function candidateStatus(array $hardBlockers, int $blockedLocaleCount): string
+    {
+        if ($hardBlockers !== []) {
+            return CareerCanonical80CandidateSelectionRow::STATUS_EXCLUDED_HARD_BLOCKER;
+        }
+
+        return $blockedLocaleCount === 0
+            ? CareerCanonical80CandidateSelectionRow::STATUS_READY
+            : CareerCanonical80CandidateSelectionRow::STATUS_NEAR_ELIGIBLE;
+    }
+
+    private function score(int $passedLocaleCount, int $blockedLocaleCount, int $reasonCount, int $hardBlockerCount): int
+    {
+        return max(0, 1000 + ($passedLocaleCount * 100) - ($blockedLocaleCount * 25) - ($reasonCount * 5) - ($hardBlockerCount * 100));
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     * @return list<string>
+     */
+    private function normalizeReasons(array $reasons): array
+    {
+        if (! array_is_list($reasons)) {
+            throw new InvalidArgumentException('Career 80 candidate selection reasons must be a list.');
+        }
+
+        $normalized = [];
+        foreach ($reasons as $reason) {
+            if (! is_string($reason)) {
+                throw new InvalidArgumentException('Career 80 candidate selection reasons must contain strings.');
+            }
+
+            $value = trim($reason);
+            if ($value !== '') {
+                $normalized[] = $value;
+            }
+        }
+
+        sort($normalized);
+
+        return array_values(array_unique($normalized));
+    }
+}

--- a/backend/docs/career/audits/80_cohort_readiness_plan.md
+++ b/backend/docs/career/audits/80_cohort_readiness_plan.md
@@ -64,3 +64,30 @@ The result serializes as:
 ## AUDIT-11 Consumption
 
 AUDIT-11 should consume `ready_slugs` and `rollout_allowed`. It must not generate expansion manifests unless `status=pass`, `rollout_allowed=true`, and the expected cohort size is met.
+
+## Candidate Selection Report
+
+REPAIR-80-CANDIDATE-1 adds a planning-only selector before the readiness planner:
+
+```php
+(new CareerCanonical80CandidateSelector())->select($report);
+```
+
+The selector consumes a canonical eligibility report and emits `career_80_candidate_selection.v1`. It does not run 80 readiness, generate manifests, apply rollout, or mutate DB state.
+
+The selector ranks slugs by:
+
+- passing locale count
+- blocked locale count
+- reason count
+- hard blocker count
+
+Rows are classified as:
+
+- `ready`: all audit rows pass and the slug can be selected for a future readiness run
+- `near_eligible`: no configured hard blockers, but one or more locale rows still block
+- `excluded_hard_blocker`: at least one hard blocker remains
+
+Default hard blockers include entity gaps, baseline/title gaps, index gaps, runtime authority gaps, surface context gaps, and SEO/GEO metadata gaps. A future scan can override the hard blocker list for a narrower policy review, but the default stays conservative for Career 2786.
+
+`readiness_can_run=true` only when at least 80 ready slugs are selected. If fewer than 80 qualify, the report remains `blocked` and explains the selected, near-eligible, and excluded slug sets.

--- a/backend/tests/Unit/Domain/Career/Audit/CareerCanonical80CandidateSelectorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerCanonical80CandidateSelectorTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerCanonical80CandidateSelectionRow;
+use App\Domain\Career\Audit\CareerCanonical80CandidateSelector;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayerStatus;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityScope;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use PHPUnit\Framework\TestCase;
+
+final class CareerCanonical80CandidateSelectorTest extends TestCase
+{
+    public function test_selects_ready_candidates_without_running_readiness(): void
+    {
+        $report = $this->report([
+            $this->row('actuaries', 'en'),
+            $this->row('actors', 'en'),
+        ]);
+
+        $selection = (new CareerCanonical80CandidateSelector)->select($report, targetCount: 2);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $selection->status);
+        $this->assertTrue($selection->readinessCanRun);
+        $this->assertSame(['actors', 'actuaries'], $selection->selectedSlugs);
+        $this->assertSame(CareerCanonical80CandidateSelectionRow::STATUS_READY, $selection->rows[0]->candidateStatus);
+        $this->assertSame(0, $selection->nearEligibleCount);
+    }
+
+    public function test_excludes_hard_blockers_and_reports_fewer_than_80_condition(): void
+    {
+        $report = $this->report([
+            $this->row('surface-blocked', 'en', reasons: ['surface_context_missing']),
+            $this->row('runtime-blocked', 'en', reasons: ['truth_row_missing']),
+            $this->row('ready-one', 'en'),
+        ]);
+
+        $selection = (new CareerCanonical80CandidateSelector)->select($report, targetCount: 2);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $selection->status);
+        $this->assertFalse($selection->readinessCanRun);
+        $this->assertSame(['ready-one'], $selection->selectedSlugs);
+        $this->assertSame(2, $selection->excludedCount);
+        $this->assertContains('surface-blocked', $selection->excludedSlugs);
+        $runtimeBlocked = array_values(array_filter(
+            $selection->rows,
+            static fn (CareerCanonical80CandidateSelectionRow $row): bool => $row->canonicalSlug === 'runtime-blocked'
+        ))[0];
+        $this->assertContains('truth_row_missing', $runtimeBlocked->hardBlockers);
+    }
+
+    public function test_near_eligible_rows_are_ranked_after_ready_rows(): void
+    {
+        $report = $this->report([
+            $this->row('near-one', 'en', reasons: ['manual_review_needed']),
+            $this->row('ready-one', 'en'),
+            $this->row('near-one', 'zh'),
+        ]);
+
+        $selection = (new CareerCanonical80CandidateSelector)->select($report, targetCount: 2);
+
+        $this->assertSame(['ready-one'], $selection->selectedSlugs);
+        $this->assertSame(['near-one'], $selection->nearEligibleSlugs);
+        $this->assertSame(CareerCanonical80CandidateSelectionRow::STATUS_READY, $selection->rows[0]->candidateStatus);
+        $this->assertSame(CareerCanonical80CandidateSelectionRow::STATUS_NEAR_ELIGIBLE, $selection->rows[1]->candidateStatus);
+        $this->assertGreaterThan($selection->rows[1]->score, $selection->rows[0]->score);
+    }
+
+    public function test_result_to_array_is_stable(): void
+    {
+        $report = $this->report([
+            $this->row('actuaries', 'en'),
+            $this->row('blocked', 'en', reasons: ['index_state_missing']),
+        ]);
+
+        $payload = (new CareerCanonical80CandidateSelector)->select($report, targetCount: 1)->toArray();
+
+        $this->assertSame('career_80_candidate_selection.v1', $payload['schema_version']);
+        $this->assertSame(CareerCanonicalEligibilityStatus::PASS, $payload['status']);
+        $this->assertSame(1, $payload['target_count']);
+        $this->assertSame(2, $payload['candidate_count']);
+        $this->assertSame(1, $payload['selected_count']);
+        $this->assertSame(1, $payload['excluded_count']);
+        $this->assertSame(['actuaries'], $payload['selected_slugs']);
+        $this->assertSame('excluded_hard_blocker', $payload['rows'][1]['candidate_status']);
+    }
+
+    public function test_custom_hard_blockers_can_exclude_policy_reasons(): void
+    {
+        $report = $this->report([
+            $this->row('policy-wait', 'en', reasons: ['policy_wait']),
+        ]);
+
+        $selection = (new CareerCanonical80CandidateSelector)->select($report, targetCount: 1, hardBlockers: ['policy_wait']);
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $selection->status);
+        $this->assertSame(['policy-wait'], $selection->excludedSlugs);
+        $this->assertSame(['policy_wait'], $selection->rows[0]->hardBlockers);
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     */
+    private function report(array $rows): CareerCanonicalEligibilityReport
+    {
+        return new CareerCanonicalEligibilityReport(
+            status: CareerCanonicalEligibilityStatus::BLOCKED,
+            scope: CareerCanonicalEligibilityScope::ALL,
+            expectedOccupations: count(array_unique(array_map(static fn (CareerCanonicalEligibilityAuditRow $row): string => $row->slug, $rows))),
+            auditedOccupations: count(array_unique(array_map(static fn (CareerCanonicalEligibilityAuditRow $row): string => $row->slug, $rows))),
+            eligibleCount: count(array_filter($rows, static fn (CareerCanonicalEligibilityAuditRow $row): bool => $row->overallStatus === CareerCanonicalEligibilityStatus::PASS)),
+            blockedCount: count(array_filter($rows, static fn (CareerCanonicalEligibilityAuditRow $row): bool => $row->overallStatus !== CareerCanonicalEligibilityStatus::PASS)),
+            byReason: CareerCanonicalEligibilityReport::byReasonFromRows($rows),
+            rows: $rows,
+        );
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     */
+    private function row(string $slug, string $locale, array $reasons = []): CareerCanonicalEligibilityAuditRow
+    {
+        $status = $reasons === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED;
+        $severity = $reasons === [] ? CareerCanonicalEligibilitySeverity::INFO : CareerCanonicalEligibilitySeverity::HIGH;
+
+        return new CareerCanonicalEligibilityAuditRow(
+            slug: $slug,
+            locale: $locale,
+            sourceScope: CareerCanonicalEligibilityScope::ALL,
+            entityStatus: $this->layer(CareerCanonicalEligibilityLayer::ENTITY, $this->layerStatus($reasons, 'occupation_missing')),
+            baselineStatus: $this->layer(CareerCanonicalEligibilityLayer::BASELINE, $this->layerStatus($reasons, 'zh_baseline_missing')),
+            indexStatus: $this->layer(CareerCanonicalEligibilityLayer::INDEX, $this->layerStatus($reasons, 'index_state_missing')),
+            runtimeStatus: $this->layer(CareerCanonicalEligibilityLayer::RUNTIME, $this->layerStatus($reasons, 'truth_row_missing')),
+            seoGeoStatus: $this->layer(CareerCanonicalEligibilityLayer::SEO_GEO, $this->layerStatus($reasons, 'structured_data_missing')),
+            surfaceStatus: $this->layer(CareerCanonicalEligibilityLayer::SURFACE, $this->layerStatus($reasons, 'surface_context_missing')),
+            safetyStatus: $this->layer(CareerCanonicalEligibilityLayer::SAFETY, CareerCanonicalEligibilityStatus::PASS),
+            overallStatus: $status,
+            severity: $severity,
+            reasons: $reasons,
+            evidence: [['slug' => $slug]],
+            sidecars: [],
+        );
+    }
+
+    private function layerStatus(array $reasons, string $reason): string
+    {
+        return in_array($reason, $reasons, true)
+            ? CareerCanonicalEligibilityStatus::BLOCKED
+            : CareerCanonicalEligibilityStatus::PASS;
+    }
+
+    private function layer(string $layer, string $status): CareerCanonicalEligibilityLayerStatus
+    {
+        return new CareerCanonicalEligibilityLayerStatus(
+            layer: $layer,
+            status: $status,
+            reasons: $status === CareerCanonicalEligibilityStatus::PASS ? [] : ['unit_blocker'],
+            evidence: [['layer' => $layer]],
+            source: 'unit_test',
+        );
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -396,6 +396,9 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessRow.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -1752,6 +1755,9 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessRow.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php',
+            'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1211,7 +1211,7 @@
       "branch": "fix/career-baseline-metadata-inventory-audit4",
       "title": "feat(api): add career baseline metadata inventory audit",
       "name": "Career Baseline/display Metadata Inventory Audit",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "AUDIT-3"
       ],
@@ -2469,8 +2469,8 @@
         "CMD-FIX-1"
       ],
       "scope_type": "audit_run_context_only",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "48834b4adcb4e63f998daef556e483cd492f128d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1360",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -3231,6 +3231,59 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-80-CANDIDATE-1",
+      "merged_at": "2026-05-13T11:53:44Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": []
+    },
+    "REPAIR-80-CANDIDATE-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-80-candidate-readiness-selector-1",
+      "title": "fix(api): add career 80 candidate readiness selector",
+      "name": "Add career 80 candidate readiness selector",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-ENTITY-1",
+        "SCAN-3"
+      ],
+      "scope_type": "audit_80_candidate_selector_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no 80 readiness run",
+        "no manifest generation",
+        "no production DB query",
+        "no DB mutation",
+        "no rollout/backfill",
+        "no fap-web changes",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided remediation train execution goal and authorized registering the current remediation PR item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-ENTITY-1 merged as PR #1360 and local train worktree is based on origin/main after that merge."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to 80 candidate selector/report, audit tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "RUN-1D full-context audit rerun and SCAN-4",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1706,6 +1706,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-80-CANDIDATE-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-ENTITY-1
+      - SCAN-3
+    branch: fix/career-80-candidate-readiness-selector-1
+    title: "fix(api): add career 80 candidate readiness selector"
+    name: "Add career 80 candidate readiness selector"
+    scope_type: audit_80_candidate_selector_only
+    scope:
+      - Add a planning-only selector/report for Career 80-readiness candidates from full-context canonical eligibility audit rows.
+      - Rank near-eligible slugs, exclude configured hard blockers, and explain when fewer than 80 candidates qualify.
+      - Preserve AUDIT-10 readiness planner semantics without running readiness or generating expansion manifests.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run 80 readiness.
+      - Generate expansion manifests.
+      - Mutate DB or production state.
+      - Run rollout or backfill.
+      - Touch fap-web.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi
+      - php artisan test --filter=CareerCanonical80CohortReadinessPlanner --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "RUN-1D full-context audit rerun and SCAN-4"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: RIASEC-PERSONALIZATION-00
     repo: fap-api
     branch: codex/riasec-personalization-00-train-registration


### PR DESCRIPTION
## Summary
- adds a planning-only Career 80 candidate selector/report for full-context audit rows
- ranks ready and near-eligible slugs, excludes configured hard blockers, and reports when fewer than 80 qualify
- preserves existing AUDIT-10 readiness planner semantics without running readiness or generating manifests
- registers REPAIR-80-CANDIDATE-1 after REPAIR-ENTITY-1

## Non-goals
- no 80 readiness execution
- no manifest generation
- no DB mutation
- no rollout/backfill/quarantine/rollback
- no deploy
- no fap-web changes

## Tests
- php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi
- php artisan test --filter=CareerCanonical80CohortReadinessPlanner --no-ansi
- php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|career_80_cohort' --no-ansi
- php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi
- php artisan test --filter=CareerCanonicalExpansionManifestTrainGenerator --no-ansi
- php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
- php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi
- php artisan test --filter=CareerRuntimeProjectionTruthEligibilityAuditor --no-ansi
- php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
- php artisan test --filter=CareerBaselineMetadataInventoryAuditor --no-ansi
- php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi
- php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
- vendor/bin/pint --test
- ruby -e "require \"yaml\"; require \"json\"; YAML.load_file(\"docs/codex/pr-train.yaml\"); JSON.parse(File.read(\"docs/codex/pr-train-state.json\")); puts \"metadata ok\""
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh

## Scope
Changed files are limited to Career audit domain, audit docs/tests, PR train metadata, and scoped BigFive runtime-freeze classifier allowlist for the new audit selector DTO files.