### PR TITLE
RIASEC-DEEP-COPY-04: 140Q three-card narrative runtime slots

### DIFF
--- a/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
+++ b/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
@@ -81,6 +81,22 @@ final class RiasecContentRegistrySlotContract
             'slot_group' => '140q_layer_copy',
             'required_versions' => ['interpretation_rule_version'],
         ],
+        '140q_layer_agreement_copy' => [
+            'slot_group' => '140q_layer_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        '140q_layer_unavailable_copy' => [
+            'slot_group' => '140q_layer_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        '140q_cta_copy' => [
+            'slot_group' => '140q_layer_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        '140q_not_recommended_copy' => [
+            'slot_group' => '140q_layer_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
         'low_quality_copy' => [
             'slot_group' => 'quality_copy',
             'required_versions' => ['quality_rule_version'],
@@ -180,8 +196,13 @@ final class RiasecContentRegistrySlotContract
         '140Q more accurate',
         'more accurate',
         '更准确',
+        '更准',
+        '推翻',
+        '最终答案',
         '60Q wrong',
         'raw delta',
+        '分数上升',
+        '分数下降',
         'score increased',
         'score decreased',
         'percentile',

--- a/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+++ b/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
@@ -20,6 +20,15 @@ final class RiasecDeepCopySlotRegistry
         'E_C',
     ];
 
+    /** @var list<string> */
+    public const LAYER_140Q_STATES = [
+        'agreement',
+        'tension',
+        'unavailable',
+        'insufficient_quality',
+        'not_applicable_60q_only',
+    ];
+
     public function __construct(
         private readonly RiasecContentRegistrySlotContract $contract = new RiasecContentRegistrySlotContract,
     ) {}
@@ -97,6 +106,85 @@ final class RiasecDeepCopySlotRegistry
     }
 
     /**
+     * @return array<string,array<string,mixed>>
+     */
+    public function layer140qSlots(): array
+    {
+        return [
+            'task_activity_card' => $this->layer140qSlot('140q_task_card_copy', 'task_activity_card', [
+                'title' => '任务活动卡',
+                'question' => '你真正喜欢做的，是哪类工作活动？',
+                'summary' => '这张卡把兴趣拆成更具体的任务活动，帮助区分你喜欢的是问题本身，还是某个职业名带来的想象。',
+                'what_user_sees' => ['更容易激活你的任务活动', '可能消耗你的任务活动', '值得先验证的一个小任务'],
+                'layer_state' => 'agreement',
+            ]),
+            'environment_card' => $this->layer140qSlot('140q_environment_card_copy', 'environment_card', [
+                'title' => '工作环境卡',
+                'question' => '这些活动出现在哪种环境里，你仍然有兴趣？',
+                'summary' => '同一个任务在不同环境里感受会不同。环境卡帮助把任务兴趣和工作日常拆开。',
+                'what_user_sees' => ['安静深研 vs 真实反馈', '合作支持 vs 结果导向', '开放表达 vs 流程约束'],
+                'layer_state' => 'agreement',
+            ]),
+            'role_responsibility_card' => $this->layer140qSlot('140q_role_card_copy', 'role_responsibility_card', [
+                'title' => '角色责任卡',
+                'question' => '你愿意在工作里承担哪种责任？',
+                'summary' => '喜欢一个任务，不等于喜欢它所在岗位的责任。角色卡帮助看见你想定义问题、表达答案、支持理解、推动落地，还是守住流程。',
+                'what_user_sees' => ['定义问题', '表达答案', '支持理解', '推动落地', '守住流程'],
+                'layer_state' => 'agreement',
+            ]),
+            'layer_agreement' => $this->layer140qSlot('140q_layer_agreement_copy', 'layer_agreement', [
+                'title' => '任务、环境和角色线索大体一致',
+                'summary' => '你的任务活动、工作环境和角色责任线索大体一致。下一步可以选择一个低风险任务进行验证，而不是急着锁定职业名称。',
+                'layer_state' => 'agreement',
+            ]),
+            'layer_tension' => $this->layer140qSlot('140q_tension_copy', 'layer_tension', [
+                'title' => '任务兴趣和工作日常线索有张力',
+                'summary' => '你的任务兴趣和工作日常线索强调了不同层面。更稳妥的读法是：喜欢的任务、能长期投入的环境、愿意承担的角色责任，需要分开验证。',
+                'layer_state' => 'tension',
+            ]),
+            'layer_unavailable' => $this->layer140qSlot('140q_layer_unavailable_copy', 'layer_unavailable', [
+                'title' => '工作日常三张卡暂不可用',
+                'summary' => '当前结果可以看基础兴趣方向。任务、环境和角色责任三张卡需要完成 140Q 后才会显示；它们只会让工作日常线索更具体。',
+                'layer_state' => 'not_applicable_60q_only',
+            ]),
+            '140q_cta' => $this->layer140qSlot('140q_cta_copy', '140q_cta', [
+                'title' => '你喜欢的是任务本身，还是这份工作的真实日常？',
+                'summary' => '60Q 看兴趣方向；140Q 看工作日常。140Q 提供更具体的情境线索，不代表正确性更高，也不会覆盖 60Q。',
+                'button_label' => '查看 140Q 工作日常三张卡',
+                'layer_state' => 'unavailable',
+            ]),
+            '140q_not_recommended' => $this->layer140qSlot('140q_not_recommended_copy', '140q_not_recommended', [
+                'title' => '暂不建议继续深入版',
+                'summary' => '由于本次作答需要谨慎阅读，暂不展示 140Q 三张卡。建议稍后重测，而不是继续做强解释。',
+                'layer_state' => 'insufficient_quality',
+            ]),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function resolve140qLayerSlot(string $slotName): array
+    {
+        $slotName = trim($slotName);
+        $slot = $this->layer140qSlots()[$slotName] ?? null;
+
+        if ($slot === null) {
+            return [
+                'slot_key' => '140q_layer_unknown',
+                'slot_name' => $slotName,
+                'content_status' => 'unavailable',
+                'module_state' => 'omitted',
+                'fallback_behavior' => 'omit_module',
+                'frontend_fallback_allowed' => false,
+                'reason' => 'unsupported_140q_layer_slot',
+            ];
+        }
+
+        return $slot;
+    }
+
+    /**
      * @return list<string>
      */
     public function validateSlot(array $slot): array
@@ -130,6 +218,17 @@ final class RiasecDeepCopySlotRegistry
                         $errors[] = 'missing_'.$field;
                     }
                 }
+            }
+        }
+
+        if (($slot['slot_group'] ?? null) === '140q_layer_copy') {
+            foreach ($this->layer140qRequiredFields() as $field) {
+                if (! array_key_exists($field, $slot) || $this->isBlank($slot[$field])) {
+                    $errors[] = 'missing_'.$field;
+                }
+            }
+            if (! in_array((string) ($slot['layer_state'] ?? ''), self::LAYER_140Q_STATES, true)) {
+                $errors[] = 'unsupported_140q_layer_state';
             }
         }
 
@@ -187,6 +286,24 @@ final class RiasecDeepCopySlotRegistry
             'real_world_cost',
             'common_misread',
             'activities_to_validate',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function layer140qRequiredFields(): array
+    {
+        return [
+            'slot_name',
+            'title',
+            'summary',
+            'layer_state',
+            'forbidden_claims',
+            'user_visible_boundary',
+            'content_version',
+            'evidence_level',
+            'content_status',
         ];
     }
 
@@ -408,6 +525,42 @@ final class RiasecDeepCopySlotRegistry
             'fallback_behavior' => 'omit_module',
             'frontend_fallback_allowed' => false,
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $content
+     * @return array<string,mixed>
+     */
+    private function layer140qSlot(string $slotKey, string $slotName, array $content): array
+    {
+        return array_merge([
+            'slot_key' => $slotKey,
+            'slot_group' => '140q_layer_copy',
+            'scale_code' => 'RIASEC',
+            'locale' => 'zh-CN',
+            'content_version' => 'riasec_140q_layer_state_copy_v1',
+            'interpretation_rule_version' => 'riasec_interpretation_rule_spec_v2',
+            'applicable_form_codes' => ['riasec_140'],
+            'applicable_profile_shapes' => ['clear_code', 'blended_code', 'broad_profile', 'near_tie', 'low_clarity'],
+            'applicable_quality_states' => ['normal', 'caution'],
+            'applicable_codes' => ['any'],
+            'slot_name' => $slotName,
+            'forbidden_claims' => [
+                '140q_accuracy_claim',
+                '60q_override',
+                'raw_score_delta',
+                'job_fit',
+                'ability_or_skill_inference',
+            ],
+            'required_boundaries' => $this->requiredBoundaries(),
+            'user_visible_boundary' => '140Q 是工作日常情境线索，不改写 60Q，不比较 raw score，也不输出岗位结论。',
+            'evidence_level' => 'expert_reviewed',
+            'source_status' => 'reviewed_content_copy',
+            'review_status' => 'approved_for_staging',
+            'fallback_behavior' => 'omit_module',
+            'content_status' => 'authored',
+            'frontend_fallback_allowed' => false,
+        ], $content);
     }
 
     /**

--- a/backend/docs/riasec/deep-copy-slot-schema-contract.md
+++ b/backend/docs/riasec/deep-copy-slot-schema-contract.md
@@ -111,3 +111,18 @@ Dimension copy remains backend-authoritative content. The frontend may render a 
 - `E_C`
 
 The first runtime-authored pair slots are `I_A`, `I_S`, and `A_S`, sourced from the expert pair blend asset. Other pairs are explicit `content_status=pending` slots and fail closed with `module_state=omitted` until reviewed content is approved. Pair blend copy is an interest-combination reading aid; it is not a subtype, personality identity, ability proof, career conclusion, ranking, or hiring signal.
+
+## 140Q Layer Runtime Slots
+
+`RIASEC-DEEP-COPY-04` adds backend-authored 140Q narrative slots for:
+
+- `task_activity_card`
+- `environment_card`
+- `role_responsibility_card`
+- `layer_agreement`
+- `layer_tension`
+- `layer_unavailable`
+- `140q_cta`
+- `140q_not_recommended`
+
+The layer state enum is backend-owned: `agreement`, `tension`, `unavailable`, `insufficient_quality`, and `not_applicable_60q_only`. 140Q slots describe work-daily task, environment, and role-responsibility context. They do not overwrite 60Q, do not compare raw scores, and do not make accuracy, ability, job, or occupational conclusions. Low-quality states resolve to `140q_not_recommended` and must not upsell the longer form.

--- a/backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php
+++ b/backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Services\Riasec\RiasecDeepCopySlotRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class Riasec140qLayerSlotRegistryTest extends TestCase
+{
+    public function test_140q_three_card_and_state_slots_are_backend_authored(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slots = $registry->layer140qSlots();
+
+        foreach ([
+            'task_activity_card',
+            'environment_card',
+            'role_responsibility_card',
+            'layer_agreement',
+            'layer_tension',
+            'layer_unavailable',
+            '140q_cta',
+            '140q_not_recommended',
+        ] as $slotName) {
+            $slot = $slots[$slotName] ?? null;
+            $this->assertIsArray($slot, $slotName.' slot should exist.');
+            $this->assertSame('140q_layer_copy', $slot['slot_group']);
+            $this->assertSame('authored', $slot['content_status']);
+            $this->assertSame('reviewed_content_copy', $slot['source_status']);
+            $this->assertFalse($slot['frontend_fallback_allowed']);
+
+            foreach ($registry->layer140qRequiredFields() as $field) {
+                $this->assertArrayHasKey($field, $slot);
+                $this->assertNotEmpty($slot[$field]);
+            }
+
+            $this->assertSame([], $registry->validateSlot($slot), $slotName.' should be contract-clean.');
+        }
+    }
+
+    public function test_140q_layer_states_are_backend_authoritative(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+
+        $this->assertSame('agreement', $registry->resolve140qLayerSlot('layer_agreement')['layer_state']);
+        $this->assertSame('tension', $registry->resolve140qLayerSlot('layer_tension')['layer_state']);
+        $this->assertSame('not_applicable_60q_only', $registry->resolve140qLayerSlot('layer_unavailable')['layer_state']);
+        $this->assertSame('insufficient_quality', $registry->resolve140qLayerSlot('140q_not_recommended')['layer_state']);
+    }
+
+    public function test_140q_copy_rejects_accuracy_override_job_and_raw_delta_claims(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slot = $registry->resolve140qLayerSlot('140q_cta');
+        $slot['summary'] = '140Q 更准确，会推翻 60Q，是最终答案，还会显示 raw delta 和岗位胜任。';
+
+        $errors = $registry->validateSlot($slot);
+
+        $this->assertContains('forbidden_claim_phrase_non_ascii', $errors);
+        $this->assertContains('forbidden_claim_phrase_raw_delta', $errors);
+    }
+
+    public function test_low_quality_state_uses_not_recommended_slot_without_upsell(): void
+    {
+        $slot = (new RiasecDeepCopySlotRegistry)->resolve140qLayerSlot('140q_not_recommended');
+
+        $this->assertSame('insufficient_quality', $slot['layer_state']);
+        $this->assertStringContainsString('暂不展示 140Q 三张卡', $slot['summary']);
+        $this->assertStringContainsString('建议稍后重测', $slot['summary']);
+        $this->assertStringNotContainsString('购买', $slot['summary']);
+    }
+
+    public function test_unknown_140q_layer_slot_fails_closed(): void
+    {
+        $slot = (new RiasecDeepCopySlotRegistry)->resolve140qLayerSlot('unknown_layer');
+
+        $this->assertSame('unavailable', $slot['content_status']);
+        $this->assertSame('omitted', $slot['module_state']);
+        $this->assertSame('omit_module', $slot['fallback_behavior']);
+        $this->assertFalse($slot['frontend_fallback_allowed']);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3826,7 +3826,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-deep-copy-03-pair-blend-slots",
       "title": "feat(riasec): add pair blend copy runtime slots",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "RIASEC-DEEP-COPY-02"
       ],
@@ -3842,7 +3842,7 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": "77f42cf70fb8d742ad365d6a8aabb4aa82920506",
+      "commit_sha": "160bc108aed2a1527d89ec04e79096fbd0209175",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1363",
       "checks": {
         "dependency": {
@@ -3877,9 +3877,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-13T12:18:04Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "Non-IAS pair assets deferred pending validator-safe review",
@@ -3892,6 +3892,67 @@
           ]
         }
       ]
+    },
+    "RIASEC-DEEP-COPY-04": {
+      "repo": "fap-api",
+      "branch": "codex/riasec-deep-copy-04-140q-narrative-slots",
+      "title": "feat(riasec): add 140q narrative runtime slots",
+      "status": "in_progress",
+      "depends_on": [
+        "RIASEC-DEEP-COPY-03"
+      ],
+      "scope_type": "backend_140q_narrative_slots_only",
+      "allowed_paths": [
+        "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
+        "backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php",
+        "backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php",
+        "backend/tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php",
+        "backend/tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php",
+        "backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "backend/docs/riasec/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "commit_sha": "ee2c4f0c1a953a69acdfa951bf8ac6d543f06e96",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1365",
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "RIASEC-DEEP-COPY-03 is merged as PR #1363 with merge commit 160bc108aed2a1527d89ec04e79096fbd0209175."
+        },
+        "140q_layer_registry_contract": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php --no-ansi",
+          "evidence": "21 tests passed, 827 assertions."
+        },
+        "freeze_classifier": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_content_registry' --no-ansi",
+          "evidence": "2 tests passed, 4 assertions."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        },
+        "json_yaml_validity": {
+          "status": "pass",
+          "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")' && jq empty docs/codex/pr-train-state.json"
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to backend RIASEC slot registry/validator, 140Q layer registry tests, backend RIASEC docs, and docs/codex train metadata. No 60Q/140Q scoring, question pack, frontend UI, sales/paywall, share/PDF/history, feedback, analytics, or career runtime files changed."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2069,3 +2069,37 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: RIASEC-DEEP-COPY-04
+    repo: fap-api
+    depends_on:
+      - RIASEC-DEEP-COPY-03
+    branch: codex/riasec-deep-copy-04-140q-narrative-slots
+    title: "feat(riasec): add 140q narrative runtime slots"
+    scope:
+      - Add backend-authoritative 140Q task, environment, role, CTA, agreement, tension, unavailable, and not-recommended slots.
+      - Define safe 140Q layer state contract without changing 140Q scoring.
+      - Keep frontend rendering, paywall, share/PDF/history, and analytics unchanged.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
+      - backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change 60Q or 140Q scoring.
+      - Add frontend 140Q copy/rendering, sales copy, paywall, or local fallback.
+      - Add accuracy, override, raw delta, job fit, ranking, success, hiring, or matching claims.
+    validation:
+      - targeted PHPUnit for RIASEC 140Q layer and deep copy registry contracts
+      - scoped freeze classifier test if runtime path allowance changes
+      - scoped Pint for touched PHP
+      - JSON/YAML validity
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## What changed
- Adds backend-authoritative 140Q task, environment, role, agreement, tension, unavailable, CTA, and not-recommended narrative slots.
- Extends the content slot contract for additional 140Q layer slot keys.
- Adds contract tests for safe layer states, low-quality not-recommended behavior, fail-closed unknown slots, and forbidden 140Q claims.

## Why
- Allows future frontend consumers to render 140Q work-daily narrative only from backend content slots, without local fallback or accuracy/override language.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php --no-ansi`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|riasec_content_registry' --no-ansi`\n- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`\n- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")' && jq empty docs/codex/pr-train-state.json`\n- `git diff --check`\n\n## Intentionally deferred\n- No frontend rendering, sales copy, paywall, scoring, question content, share/PDF/history, feedback, analytics, or career runtime changes.