### PR TITLE
fix(api): add career surface context export producer

### DIFF
--- a/backend/app/Console/Commands/CareerExportCanonicalEligibilitySurfaceContext.php
+++ b/backend/app/Console/Commands/CareerExportCanonicalEligibilitySurfaceContext.php
@@ -1,0 +1,430 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerPublicResolutionPlanIssue;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanResolver;
+use App\Domain\Career\Audit\CareerSurfaceContextArtifactIssue;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerExportCanonicalEligibilitySurfaceContext extends Command
+{
+    protected $signature = 'career:export-canonical-eligibility-surface-context
+        {--public-resolution-plan= : Required public-resolution planner JSON artifact}
+        {--output= : Required output path for career_surface_context.v1 JSON}
+        {--locales=en,zh : Optional locale list}
+        {--mode=artifact : Surface context mode; planner-only artifact mode is the default}
+        {--api-artifact= : Optional backend/API surface artifact JSON}
+        {--projection= : Optional runtime projection artifact for route/indexable hints}
+        {--truth= : Optional runtime truth artifact for route/indexable hints}
+        {--json : Emit JSON summary output}';
+
+    protected $description = 'Export read-only Career surface context artifacts for canonical eligibility audit reruns.';
+
+    public function handle(): int
+    {
+        $planPath = $this->normalizedOption('public-resolution-plan');
+        $output = $this->normalizedOption('output');
+
+        if ($planPath === null) {
+            return $this->finish([
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'live_crawl_performed' => false,
+                'by_reason' => ['public_resolution_plan_missing' => 1],
+                'issues' => [[
+                    'reason' => 'public_resolution_plan_missing',
+                    'message' => 'A --public-resolution-plan JSON artifact is required.',
+                ]],
+            ], self::FAILURE);
+        }
+
+        if ($output === null) {
+            return $this->finish([
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'live_crawl_performed' => false,
+                'by_reason' => ['output_path_missing' => 1],
+                'issues' => [[
+                    'reason' => 'output_path_missing',
+                    'message' => 'An --output path is required.',
+                ]],
+            ], self::FAILURE);
+        }
+
+        $planValidation = CareerPublicResolutionPlanResolver::fromPath($planPath);
+        if ($planValidation->plan === null) {
+            return $this->finish([
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'live_crawl_performed' => false,
+                'by_reason' => $planValidation->byReason(),
+                'plan_validation' => $planValidation->toArray(),
+                'issues' => array_map(
+                    static fn (CareerPublicResolutionPlanIssue $issue): array => $issue->toArray(),
+                    $planValidation->issues
+                ),
+            ], self::FAILURE);
+        }
+
+        $slugs = $this->canonicalSlugs($planValidation->rows());
+        $locales = $this->locales();
+        $apiRows = $this->surfaceRowsByKey($this->readArtifactRows($this->normalizedOption('api-artifact')));
+        $projectionRows = $this->surfaceRowsByKey($this->readArtifactRows($this->normalizedOption('projection')));
+        $truthRows = $this->surfaceRowsByKey($this->readArtifactRows($this->normalizedOption('truth')));
+        $duplicateInputSlugs = $this->duplicateInputSlugs($planValidation->rows());
+        $duplicateArtifactRows = $this->duplicateArtifactKeys();
+
+        $source = [
+            'type' => 'read_only_surface_artifact',
+            'generated_at' => now('UTC')->toISOString(),
+            'environment' => app()->environment(),
+            'mode' => $this->mode(),
+            'base_url' => null,
+            'planner_path' => $planValidation->sourcePath,
+            'planner_checksum' => $planValidation->checksum(),
+            'api_artifact_path' => $this->normalizedOption('api-artifact'),
+            'projection_path' => $this->normalizedOption('projection'),
+            'truth_path' => $this->normalizedOption('truth'),
+            'locales' => $locales,
+        ];
+
+        $rows = [];
+        $issueCounts = [];
+        foreach ($slugs as $slug) {
+            foreach ($locales as $locale) {
+                $row = $this->surfaceRow(
+                    slug: $slug,
+                    locale: $locale,
+                    apiRow: $apiRows[$this->rowKey($slug, $locale)] ?? null,
+                    projectionRow: $projectionRows[$this->rowKey($slug, $locale)] ?? $projectionRows[$slug] ?? null,
+                    truthRow: $truthRows[$this->rowKey($slug, $locale)] ?? $truthRows[$slug] ?? null,
+                );
+                foreach ($row['issues'] as $issue) {
+                    $issueCounts[$issue] = ($issueCounts[$issue] ?? 0) + 1;
+                }
+                $rows[] = $row;
+            }
+        }
+        ksort($issueCounts);
+
+        $artifact = [
+            'schema_version' => 'career_surface_context.v1',
+            'source' => $source,
+            'rows' => $rows,
+        ];
+        $this->writeJson($output, $artifact);
+
+        $verifiedRows = count(array_filter($rows, static fn (array $row): bool => ($row['surface_verified'] ?? false) === true));
+        $summary = [
+            'status' => 'materialized',
+            'read_only' => true,
+            'writes_database' => false,
+            'live_crawl_performed' => false,
+            'public_resolution_plan' => $planValidation->sourcePath,
+            'output_path' => $output,
+            'expected_slugs' => count($slugs),
+            'expected_rows' => count($slugs) * count($locales),
+            'written_rows' => count($rows),
+            'verified_rows' => $verifiedRows,
+            'unverified_rows' => count($rows) - $verifiedRows,
+            'duplicate_input_slugs' => count($duplicateInputSlugs),
+            'duplicate_input_slug_values' => array_keys($duplicateInputSlugs),
+            'duplicate_artifact_rows' => count($duplicateArtifactRows),
+            'duplicate_artifact_row_keys' => $duplicateArtifactRows,
+            'by_reason' => $issueCounts,
+            'artifacts' => [
+                'surface_context' => $output,
+            ],
+        ];
+
+        return $this->finish($summary, self::SUCCESS);
+    }
+
+    private function normalizedOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function mode(): string
+    {
+        return $this->normalizedOption('mode') ?? 'artifact';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function locales(): array
+    {
+        $raw = $this->normalizedOption('locales') ?? 'en,zh';
+        $locales = [];
+        foreach (explode(',', $raw) as $locale) {
+            $normalized = strtolower(trim($locale));
+            if ($normalized !== '' && ! in_array($normalized, $locales, true)) {
+                $locales[] = $normalized;
+            }
+        }
+
+        return $locales === [] ? ['en', 'zh'] : $locales;
+    }
+
+    /**
+     * @param  list<\App\Domain\Career\Audit\CareerPublicResolutionPlanRow>  $rows
+     * @return list<string>
+     */
+    private function canonicalSlugs(array $rows): array
+    {
+        $slugs = [];
+        foreach ($rows as $row) {
+            if ($row->canonicalSlug !== null && ! in_array($row->canonicalSlug, $slugs, true)) {
+                $slugs[] = $row->canonicalSlug;
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<\App\Domain\Career\Audit\CareerPublicResolutionPlanRow>  $rows
+     * @return array<string, true>
+     */
+    private function duplicateInputSlugs(array $rows): array
+    {
+        $seen = [];
+        $duplicates = [];
+        foreach ($rows as $row) {
+            if ($row->canonicalSlug === null) {
+                continue;
+            }
+            if (isset($seen[$row->canonicalSlug])) {
+                $duplicates[$row->canonicalSlug] = true;
+
+                continue;
+            }
+
+            $seen[$row->canonicalSlug] = true;
+        }
+
+        return $duplicates;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function readArtifactRows(?string $path): array
+    {
+        if ($path === null || ! is_file($path)) {
+            return [];
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            return [];
+        }
+
+        foreach ([$payload, $payload['rows'] ?? null, $payload['items'] ?? null, $payload['api']['rows'] ?? null, $payload['api']['items'] ?? null] as $candidate) {
+            if (is_array($candidate) && array_is_list($candidate)) {
+                return array_values(array_filter($candidate, static fn (mixed $row): bool => is_array($row) && ! array_is_list($row)));
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, array<string, mixed>>
+     */
+    private function surfaceRowsByKey(array $rows): array
+    {
+        $indexed = [];
+        foreach ($rows as $row) {
+            $slug = $this->normalizedSlug($row['canonical_slug'] ?? $row['slug'] ?? null);
+            if ($slug === null) {
+                continue;
+            }
+            $locale = $this->normalizedLocale($row['locale'] ?? null);
+            $key = $locale === null ? $slug : $this->rowKey($slug, $locale);
+            if (isset($indexed[$key])) {
+                continue;
+            }
+            $indexed[$key] = $row;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function duplicateArtifactKeys(): array
+    {
+        $duplicates = [];
+        foreach (['api-artifact', 'projection', 'truth'] as $option) {
+            $seen = [];
+            foreach ($this->readArtifactRows($this->normalizedOption($option)) as $row) {
+                $slug = $this->normalizedSlug($row['canonical_slug'] ?? $row['slug'] ?? null);
+                if ($slug === null) {
+                    continue;
+                }
+                $locale = $this->normalizedLocale($row['locale'] ?? null);
+                $key = $option.':'.($locale === null ? $slug : $this->rowKey($slug, $locale));
+                if (isset($seen[$key]) && ! in_array($key, $duplicates, true)) {
+                    $duplicates[] = $key;
+                }
+                $seen[$key] = true;
+            }
+        }
+        sort($duplicates);
+
+        return $duplicates;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $apiRow
+     * @param  array<string, mixed>|null  $projectionRow
+     * @param  array<string, mixed>|null  $truthRow
+     * @return array<string, mixed>
+     */
+    private function surfaceRow(string $slug, string $locale, ?array $apiRow, ?array $projectionRow, ?array $truthRow): array
+    {
+        $sourceRow = $apiRow ?? $truthRow ?? $projectionRow;
+        $hasConcreteEvidence = $sourceRow !== null;
+        $canonicalPath = $this->canonicalPath($sourceRow, $slug, $locale);
+        $apiIndexable = $this->indexable($sourceRow);
+        $issues = $hasConcreteEvidence ? [] : [
+            CareerSurfaceContextArtifactIssue::SURFACE_ARTIFACT_MISSING,
+            CareerSurfaceContextArtifactIssue::SURFACE_UNVERIFIED,
+        ];
+
+        return [
+            'canonical_slug' => $slug,
+            'locale' => $locale,
+            'api_canonical_path' => $canonicalPath,
+            'api_indexable' => $apiIndexable,
+            'live_canonical_path' => $this->optionalString($sourceRow['live_canonical_path'] ?? null),
+            'live_robots_policy' => $this->optionalString($sourceRow['live_robots_policy'] ?? $sourceRow['robots_policy'] ?? null),
+            'cta_present' => array_key_exists('cta_present', $sourceRow ?? []) && is_bool($sourceRow['cta_present']) ? $sourceRow['cta_present'] : null,
+            'surface_verified' => $hasConcreteEvidence,
+            'surface_mode' => $hasConcreteEvidence ? 'artifact' : 'planner_only',
+            'issues' => $issues,
+            'evidence' => [
+                'source' => $hasConcreteEvidence ? 'artifact' : 'planner_only',
+                'planner_only_unverified' => ! $hasConcreteEvidence,
+                'live_crawl_performed' => false,
+                'api_artifact_present' => $apiRow !== null,
+                'projection_artifact_present' => $projectionRow !== null,
+                'truth_artifact_present' => $truthRow !== null,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $row
+     */
+    private function canonicalPath(?array $row, string $slug, string $locale): string
+    {
+        $path = $this->optionalString($row['api_canonical_path'] ?? $row['canonical_path'] ?? $row['route'] ?? null);
+        if ($path !== null) {
+            return $path;
+        }
+
+        $url = $this->optionalString($row['api_canonical_url'] ?? $row['canonical_url'] ?? null);
+        if ($url !== null) {
+            $parsed = parse_url($url, PHP_URL_PATH);
+            if (is_string($parsed) && trim($parsed) !== '') {
+                return $parsed;
+            }
+        }
+
+        return '/'.$locale.'/career/jobs/'.$slug;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $row
+     */
+    private function indexable(?array $row): bool
+    {
+        $indexable = $row['api_indexable'] ?? $row['indexable'] ?? $row['robots_indexable'] ?? null;
+        if (is_bool($indexable)) {
+            return $indexable;
+        }
+
+        $robots = $this->optionalString($row['api_robots_policy'] ?? $row['robots_policy'] ?? $row['robots'] ?? null);
+        if ($robots !== null) {
+            return ! str_contains(strtolower($robots), 'noindex');
+        }
+
+        return true;
+    }
+
+    private function normalizedSlug(mixed $value): ?string
+    {
+        $normalized = $this->optionalString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private function normalizedLocale(mixed $value): ?string
+    {
+        $normalized = $this->optionalString($value);
+
+        return $normalized === null ? null : strtolower($normalized);
+    }
+
+    private function optionalString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function rowKey(string $slug, string $locale): string
+    {
+        return strtolower($slug).'|'.strtolower($locale);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $path, array $payload): void
+    {
+        File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR).PHP_EOL);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            if (isset($payload['output_path'])) {
+                $this->line('output_path='.(string) $payload['output_path']);
+            }
+        }
+
+        return $exitCode;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -19,6 +19,7 @@ use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCompileRecommendationSubjects;
 use App\Console\Commands\CareerCrosswalkOps;
 use App\Console\Commands\CareerExportCanonicalEligibilityDbContext;
+use App\Console\Commands\CareerExportCanonicalEligibilitySurfaceContext;
 use App\Console\Commands\CareerExportCanonicalExpansionManifest;
 use App\Console\Commands\CareerExportCanonicalRuntimeTruth;
 use App\Console\Commands\CareerExportCrosswalkBacklogConvergence;
@@ -221,6 +222,7 @@ class Kernel extends ConsoleKernel
         CareerCrosswalkOps::class,
         CareerExportCanonicalExpansionManifest::class,
         CareerExportCanonicalEligibilityDbContext::class,
+        CareerExportCanonicalEligibilitySurfaceContext::class,
         CareerExportCanonicalRuntimeTruth::class,
         CareerExportCrosswalkBacklogConvergence::class,
         CareerExportFullReleaseLedger::class,

--- a/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactIssue.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactIssue.php
@@ -26,6 +26,10 @@ final class CareerSurfaceContextArtifactIssue
 
     public const REQUIRED_FIELD_MISSING = 'surface_context_required_field_missing';
 
+    public const SURFACE_UNVERIFIED = 'surface_unverified';
+
+    public const SURFACE_ARTIFACT_MISSING = 'surface_artifact_missing';
+
     /**
      * @param  list<mixed>  $evidence
      */
@@ -69,6 +73,8 @@ final class CareerSurfaceContextArtifactIssue
             self::LOCALE_MISSING,
             self::SLUG_LOCALE_DUPLICATE,
             self::REQUIRED_FIELD_MISSING,
+            self::SURFACE_UNVERIFIED,
+            self::SURFACE_ARTIFACT_MISSING,
         ];
     }
 

--- a/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactReader.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactReader.php
@@ -130,9 +130,33 @@ final class CareerSurfaceContextArtifactReader
                 liveCanonicalPath: self::optionalString($rowValue['live_canonical_path'] ?? null),
                 liveRobotsPolicy: self::optionalString($rowValue['live_robots_policy'] ?? null),
                 ctaPresent: array_key_exists('cta_present', $rowValue) && is_bool($rowValue['cta_present']) ? $rowValue['cta_present'] : null,
+                surfaceVerified: array_key_exists('surface_verified', $rowValue) && is_bool($rowValue['surface_verified']) ? $rowValue['surface_verified'] : null,
+                surfaceMode: self::optionalString($rowValue['surface_mode'] ?? null),
+                issues: self::issueReasons($rowValue['issues'] ?? []),
                 evidence: self::mapOrEmpty($rowValue['evidence'] ?? []),
                 raw: $rowValue,
             );
+
+            $rowIssues = self::issueReasons($rowValue['issues'] ?? []);
+            if (array_key_exists('surface_verified', $rowValue) && $rowValue['surface_verified'] === false && $rowIssues === []) {
+                $rowIssues[] = CareerSurfaceContextArtifactIssue::SURFACE_UNVERIFIED;
+            }
+
+            foreach ($rowIssues as $reason) {
+                $issues[] = new CareerSurfaceContextArtifactIssue(
+                    reason: $reason,
+                    message: self::messageForIssueReason($reason),
+                    canonicalSlug: $slug,
+                    locale: $locale,
+                    evidence: [[
+                        'row_index' => $index,
+                        'canonical_slug' => $slug,
+                        'locale' => $locale,
+                        'surface_verified' => $rowValue['surface_verified'] ?? null,
+                        'surface_mode' => $rowValue['surface_mode'] ?? null,
+                    ]],
+                );
+            }
         }
 
         return new CareerSurfaceContextArtifact(
@@ -167,6 +191,39 @@ final class CareerSurfaceContextArtifactReader
         $normalized = trim((string) $value);
 
         return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function issueReasons(mixed $value): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            return [];
+        }
+
+        $reasons = [];
+        foreach ($value as $reason) {
+            $normalized = self::optionalString($reason);
+            if ($normalized === null || ! in_array($normalized, CareerSurfaceContextArtifactIssue::reasons(), true)) {
+                continue;
+            }
+
+            if (! in_array($normalized, $reasons, true)) {
+                $reasons[] = $normalized;
+            }
+        }
+
+        return $reasons;
+    }
+
+    private static function messageForIssueReason(string $reason): string
+    {
+        return match ($reason) {
+            CareerSurfaceContextArtifactIssue::SURFACE_ARTIFACT_MISSING => 'Surface row was produced without concrete surface artifact evidence.',
+            CareerSurfaceContextArtifactIssue::SURFACE_UNVERIFIED => 'Surface row is present but explicitly unverified.',
+            default => 'Surface context row reports an artifact issue.',
+        };
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactRow.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceContextArtifactRow.php
@@ -10,6 +10,7 @@ final class CareerSurfaceContextArtifactRow
 {
     /**
      * @param  array<string, mixed>  $evidence
+     * @param  list<string>  $issues
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
@@ -20,11 +21,15 @@ final class CareerSurfaceContextArtifactRow
         public readonly ?string $liveCanonicalPath = null,
         public readonly ?string $liveRobotsPolicy = null,
         public readonly ?bool $ctaPresent = null,
+        public readonly ?bool $surfaceVerified = null,
+        public readonly ?string $surfaceMode = null,
+        public readonly array $issues = [],
         public readonly array $evidence = [],
         public readonly array $raw = [],
     ) {
         self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
         self::assertNonEmptyString($this->locale, 'locale');
+        self::assertList($this->issues, 'issues');
         self::assertMap($this->evidence, 'evidence');
         self::assertMap($this->raw, 'raw');
 
@@ -32,10 +37,15 @@ final class CareerSurfaceContextArtifactRow
             'api_canonical_path' => $this->apiCanonicalPath,
             'live_canonical_path' => $this->liveCanonicalPath,
             'live_robots_policy' => $this->liveRobotsPolicy,
+            'surface_mode' => $this->surfaceMode,
         ] as $key => $value) {
             if ($value !== null) {
                 self::assertNonEmptyString($value, $key);
             }
+        }
+
+        foreach ($this->issues as $issue) {
+            CareerSurfaceContextArtifactIssue::assertValidReason($issue);
         }
     }
 
@@ -52,12 +62,15 @@ final class CareerSurfaceContextArtifactRow
             'live_canonical_path' => $this->liveCanonicalPath,
             'live_robots_policy' => $this->liveRobotsPolicy,
             'cta_present' => $this->ctaPresent,
+            'surface_verified' => $this->surfaceVerified,
+            'surface_mode' => $this->surfaceMode,
+            'issues' => $this->issues,
             'evidence' => $this->evidence,
         ];
     }
 
     /**
-     * @return array{canonical_slug: string, locale: string, api_canonical_path: string|null, api_indexable: bool, live_canonical_path: string|null, live_robots_policy: string|null, cta_present: bool|null, evidence: array<string, mixed>}
+     * @return array{canonical_slug: string, locale: string, api_canonical_path: string|null, api_indexable: bool, live_canonical_path: string|null, live_robots_policy: string|null, cta_present: bool|null, surface_verified: bool|null, surface_mode: string|null, issues: list<string>, evidence: array<string, mixed>}
      */
     public function toArray(): array
     {
@@ -69,6 +82,9 @@ final class CareerSurfaceContextArtifactRow
             'live_canonical_path' => $this->liveCanonicalPath,
             'live_robots_policy' => $this->liveRobotsPolicy,
             'cta_present' => $this->ctaPresent,
+            'surface_verified' => $this->surfaceVerified,
+            'surface_mode' => $this->surfaceMode,
+            'issues' => $this->issues,
             'evidence' => $this->evidence,
         ];
     }
@@ -84,6 +100,13 @@ final class CareerSurfaceContextArtifactRow
     {
         if (array_is_list($value) && $value !== []) {
             throw new InvalidArgumentException(sprintf('Career surface context row [%s] must be an object map.', $key));
+        }
+    }
+
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career surface context row [%s] must be a list.', $key));
         }
     }
 }

--- a/backend/docs/career/audits/canonical_eligibility_audit_command.md
+++ b/backend/docs/career/audits/canonical_eligibility_audit_command.md
@@ -29,7 +29,19 @@ The command is an integration shell for the canonical eligibility stack. It does
 
 `scope=slugs` can run from explicit slugs. `scope=all` and `scope=batch` require a public-resolution plan path and report a structured `public_resolution_plan_missing` reason when it is absent.
 
-`--entity-context`, `--index-state-context`, and `--surface-context` are consumer-only JSON artifact inputs. They satisfy entity, index, and surface context without querying/exporting production DB context or crawling live HTML. The artifacts must be produced separately by approved read-only workflows.
+`--entity-context`, `--index-state-context`, and `--surface-context` are JSON artifact inputs. They satisfy entity, index,
+and surface context without querying/exporting production DB context or crawling live HTML. Surface context can be produced by:
+
+```bash
+php artisan career:export-canonical-eligibility-surface-context \
+  --public-resolution-plan=/tmp/career_2786_public_resolution_plan_from_d23b.json \
+  --output=/tmp/career_2786_surface_context.json \
+  --locales=en,zh \
+  --json
+```
+
+Planner-only surface export writes unverified rows. It removes generic `surface_context_missing` but preserves explicit
+`surface_artifact_missing` / `surface_unverified` blockers until real API/static/live surface evidence is supplied.
 
 ## Read-Only Contract
 

--- a/backend/docs/career/audits/surface_context_artifacts.md
+++ b/backend/docs/career/audits/surface_context_artifacts.md
@@ -1,10 +1,27 @@
 # Career Surface Context Artifacts
 
 REPAIR-SURFACE-CONTEXT-1 adds read-only surface context artifact support to `career:audit-canonical-eligibility`.
+CTX-SURFACE-EXPORT-1 adds the matching read-only producer command.
 
 The artifact lets the audit consume previously generated or locally verified surface evidence without running a production live crawl and without touching `fap-web`.
 
 ## Command Usage
+
+Generate a surface context artifact without crawling live production HTML:
+
+```bash
+php artisan career:export-canonical-eligibility-surface-context \
+  --public-resolution-plan=/tmp/career_2786_public_resolution_plan_from_d23b.json \
+  --output=/tmp/career_2786_surface_context.json \
+  --locales=en,zh \
+  --json
+```
+
+Planner-only mode is intentionally conservative. It writes one row per planner slug and locale, but sets
+`surface_verified=false` with `surface_artifact_missing` and `surface_unverified` issues. That removes the generic
+`surface_context_missing` blocker when the audit consumes the artifact, but it does not prove live or API surface readiness.
+
+Consume the artifact:
 
 ```bash
 php artisan career:audit-canonical-eligibility \
@@ -33,6 +50,12 @@ php artisan career:audit-canonical-eligibility \
       "live_canonical_path": null,
       "live_robots_policy": null,
       "cta_present": null,
+      "surface_verified": false,
+      "surface_mode": "planner_only",
+      "issues": [
+        "surface_artifact_missing",
+        "surface_unverified"
+      ],
       "evidence": {}
     }
   ]
@@ -40,6 +63,7 @@ php artisan career:audit-canonical-eligibility \
 ```
 
 Rows are keyed by `canonical_slug` and `locale`. `api_indexable` is required and must be boolean. `api_canonical_path` is optional but a missing or mismatched value remains a real surface readiness blocker.
+`surface_verified=false` is explicit unverified evidence. It is not a pass condition.
 
 ## Read-Only Behavior
 
@@ -57,6 +81,21 @@ Rows are keyed by `canonical_slug` and `locale`. `api_indexable` is required and
 - `surface_context_json_invalid`: an explicit artifact file was not valid JSON.
 - `surface_context_rows_missing`: the artifact did not contain a `rows` list.
 - `surface_context_row_missing`: a slug/locale expected by the planner had no artifact row.
+- `surface_artifact_missing`: the producer had no concrete API/static/live surface artifact for the row.
+- `surface_unverified`: the row is present but explicitly unverified.
 - `api_canonical_not_self`, `api_noindex_present`, and live HTML reasons remain real surface blockers when supported by artifact evidence.
 
 This separates missing/unverified surface context from real surface mismatch evidence.
+
+## Non-Goals
+
+This producer does not:
+
+- run production live crawl
+- touch `fap-web`
+- mutate DB state
+- deploy
+- run rollout, backfill, rollback, quarantine, or 80 readiness
+
+Future live HTML verification must be separately approved with a base URL, rate limit, and output path. That approval is not
+implied by this read-only artifact producer.

--- a/backend/tests/Feature/Console/CareerExportCanonicalEligibilitySurfaceContextCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportCanonicalEligibilitySurfaceContextCommandTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\Audit\CareerSurfaceContextArtifactIssue;
+use App\Domain\Career\Audit\CareerSurfaceContextArtifactReader;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerExportCanonicalEligibilitySurfaceContextCommandTest extends TestCase
+{
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:export-canonical-eligibility-surface-context', Artisan::all());
+    }
+
+    public function test_command_requires_public_resolution_plan(): void
+    {
+        $exitCode = Artisan::call('career:export-canonical-eligibility-surface-context', [
+            '--output' => $this->tempPath('surface-context'),
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['public_resolution_plan_missing' => 1], $payload['by_reason']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['live_crawl_performed']);
+    }
+
+    public function test_command_requires_output_path(): void
+    {
+        $exitCode = Artisan::call('career:export-canonical-eligibility-surface-context', [
+            '--public-resolution-plan' => $this->writePlanner(['actuaries']),
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['output_path_missing' => 1], $payload['by_reason']);
+    }
+
+    public function test_planner_only_mode_emits_unverified_slug_locale_rows(): void
+    {
+        $planPath = $this->writePlanner(['actuaries', 'software-developers']);
+        $output = $this->tempPath('surface-context');
+
+        $exitCode = Artisan::call('career:export-canonical-eligibility-surface-context', [
+            '--public-resolution-plan' => $planPath,
+            '--output' => $output,
+            '--locales' => 'en,zh',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('materialized', $payload['status']);
+        $this->assertSame(2, $payload['expected_slugs']);
+        $this->assertSame(4, $payload['expected_rows']);
+        $this->assertSame(4, $payload['written_rows']);
+        $this->assertSame(0, $payload['verified_rows']);
+        $this->assertSame(4, $payload['unverified_rows']);
+        $this->assertSame([
+            CareerSurfaceContextArtifactIssue::SURFACE_ARTIFACT_MISSING => 4,
+            CareerSurfaceContextArtifactIssue::SURFACE_UNVERIFIED => 4,
+        ], $payload['by_reason']);
+
+        $artifact = CareerSurfaceContextArtifactReader::fromPath($output);
+        $this->assertSame([
+            CareerSurfaceContextArtifactIssue::SURFACE_ARTIFACT_MISSING => 4,
+            CareerSurfaceContextArtifactIssue::SURFACE_UNVERIFIED => 4,
+        ], $artifact->byReason());
+        $this->assertSame(['actuaries|en', 'actuaries|zh', 'software-developers|en', 'software-developers|zh'], array_keys($artifact->rowsByKey()));
+        $this->assertFalse($artifact->rowsByKey()['actuaries|en']->surfaceVerified);
+        $this->assertSame('planner_only', $artifact->rowsByKey()['actuaries|en']->surfaceMode);
+        $this->assertSame('/en/career/jobs/actuaries', $artifact->rowsByKey()['actuaries|en']->apiCanonicalPath);
+    }
+
+    public function test_api_artifact_mode_marks_rows_verified_when_evidence_exists(): void
+    {
+        $planPath = $this->writePlanner(['actuaries']);
+        $apiArtifact = $this->writeJson('api-surface', [
+            'items' => [
+                [
+                    'canonical_slug' => 'actuaries',
+                    'locale' => 'en',
+                    'api_canonical_path' => '/en/career/jobs/actuaries',
+                    'api_indexable' => true,
+                ],
+            ],
+        ]);
+        $output = $this->tempPath('surface-context');
+
+        Artisan::call('career:export-canonical-eligibility-surface-context', [
+            '--public-resolution-plan' => $planPath,
+            '--output' => $output,
+            '--locales' => 'en',
+            '--api-artifact' => $apiArtifact,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+        $artifact = CareerSurfaceContextArtifactReader::fromPath($output);
+
+        $this->assertSame(1, $payload['verified_rows']);
+        $this->assertSame(0, $payload['unverified_rows']);
+        $this->assertSame([], $artifact->byReason());
+        $this->assertTrue($artifact->rowsByKey()['actuaries|en']->surfaceVerified);
+    }
+
+    public function test_exported_artifact_can_be_consumed_by_canonical_eligibility_audit_without_fake_pass(): void
+    {
+        $planPath = $this->writePlanner(['actuaries']);
+        $output = $this->tempPath('surface-context');
+
+        Artisan::call('career:export-canonical-eligibility-surface-context', [
+            '--public-resolution-plan' => $planPath,
+            '--output' => $output,
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+
+        $exitCode = Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'all',
+            '--public-resolution-plan' => $planPath,
+            '--surface-context' => $output,
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('supplied', $payload['context_summary']['surface_context']);
+        $this->assertArrayNotHasKey('surface_context_missing', $payload['by_reason']);
+        $this->assertSame('blocked', data_get($payload, 'rows.0.surface_status.status'));
+        $this->assertContains(CareerSurfaceContextArtifactIssue::SURFACE_UNVERIFIED, data_get($payload, 'rows.0.surface_status.reasons'));
+        $this->assertContains(CareerSurfaceContextArtifactIssue::SURFACE_ARTIFACT_MISSING, data_get($payload, 'rows.0.surface_status.reasons'));
+    }
+
+    public function test_duplicate_slug_locale_detection_is_preserved_by_reader(): void
+    {
+        $artifact = CareerSurfaceContextArtifactReader::fromPath($this->writeJson('surface-duplicate', [
+            'schema_version' => 'career_surface_context.v1',
+            'rows' => [
+                ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actuaries', 'api_indexable' => true],
+                ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actuaries', 'api_indexable' => true],
+            ],
+        ]));
+
+        $this->assertSame(['surface_context_slug_locale_duplicate' => 1], $artifact->byReason());
+    }
+
+    public function test_malformed_planner_path_reports_structured_failure(): void
+    {
+        $exitCode = Artisan::call('career:export-canonical-eligibility-surface-context', [
+            '--public-resolution-plan' => sys_get_temp_dir().'/missing-surface-plan-'.bin2hex(random_bytes(4)).'.json',
+            '--output' => $this->tempPath('surface-context'),
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['plan_file_missing' => 1], $payload['by_reason']);
+        $this->assertSame('blocked', $payload['plan_validation']['status']);
+    }
+
+    public function test_summary_json_shape_is_stable(): void
+    {
+        Artisan::call('career:export-canonical-eligibility-surface-context', [
+            '--public-resolution-plan' => $this->writePlanner(['actuaries']),
+            '--output' => $this->tempPath('surface-context'),
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame([
+            'status',
+            'read_only',
+            'writes_database',
+            'live_crawl_performed',
+            'public_resolution_plan',
+            'output_path',
+            'expected_slugs',
+            'expected_rows',
+            'written_rows',
+            'verified_rows',
+            'unverified_rows',
+            'duplicate_input_slugs',
+            'duplicate_input_slug_values',
+            'duplicate_artifact_rows',
+            'duplicate_artifact_row_keys',
+            'by_reason',
+            'artifacts',
+        ], array_keys($payload));
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writePlanner(array $slugs): string
+    {
+        $rows = [];
+        foreach ($slugs as $index => $slug) {
+            $rows[] = [
+                'row_number' => $index + 2,
+                'canonical_slug' => $slug,
+                'status' => 'ready_for_pilot',
+                'title_en' => Str::headline($slug),
+                'title_zh' => '职业'.$index,
+                'locales' => ['en', 'zh'],
+            ];
+        }
+
+        return $this->writeJson('planner', [
+            'schema_version' => 'career_public_resolution_plan.v1',
+            'workbook' => ['rows' => count($rows)],
+            'rows' => $rows,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = $this->tempPath($prefix);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+
+    private function tempPath(string $prefix): string
+    {
+        return sys_get_temp_dir().'/career-surface-context-export-'.$prefix.'-'.bin2hex(random_bytes(4)).'.json';
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-13T19:16:46+08:00",
+  "updated_at": "2026-05-13T13:23:39Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -708,8 +708,11 @@
       ],
       "commit_sha": "32f35c17a0f29758f0f700010ac1b0c7492ffb6c",
       "pr_url": null,
-      "checks": {},
-      "sidecar_issues": [],
+      "checks": {
+      },
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -723,8 +726,11 @@
       ],
       "commit_sha": "f8d8ff9433a97acfd0ce5a7d161fac20e0283f6d",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1356",
-      "checks": {},
-      "sidecar_issues": [],
+      "checks": {
+      },
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -941,7 +947,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -979,7 +987,8 @@
       "depends_on": [
         "iq-report-builder-three-dimension-result-schema"
       ],
-      "checks": {},
+      "checks": {
+      },
       "sidecar_issues": [
         {
           "sidecar_id": "IQ-SIDECAR-COMMERCE-DEFERRED-001",
@@ -1066,7 +1075,9 @@
           "evidence": "User explicitly authorized registering AUDIT-1 in docs/codex/pr-train.yaml and docs/codex/pr-train-state.json only."
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-2 2786 public-resolution source resolver",
       "merged_at": null,
@@ -1107,7 +1118,9 @@
           "evidence": "AUDIT-1 merged as 0c6dc52e9806242dc73cec405c7f09c05161d19b and origin/main contains the merge commit."
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-3 Occupation entity inventory audit",
       "merged_at": null,
@@ -1199,7 +1212,9 @@
           "evidence": "Full MBTI CI chain exited 0 after the test-only allowlist fix; generated compiled artifacts were restored because they are outside AUDIT-3 scope."
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-4 Baseline/display metadata inventory audit",
       "merged_at": null,
@@ -1298,8 +1313,12 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [],
-          "affected_locales": [],
+          "affected_slugs": [
+
+          ],
+          "affected_locales": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed after AUDIT-4 allowlist fix in unrelated BigFive norm/content tests with SQLSTATE[HY000]: General error: 5 database is locked against /tmp/fap-ci.sqlite.",
             "Scoped AUDIT-4 tests, AUDIT-1/2/3 regressions, pint, git diff --check, and BigFive runtime freeze path gate passed."
@@ -1399,7 +1418,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-6 Runtime projection/truth eligibility audit",
       "merged_at": null,
@@ -1490,7 +1511,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-7 SEO/GEO readiness audit",
       "merged_at": null,
@@ -1585,7 +1608,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-8 Surface readiness audit",
       "merged_at": null,
@@ -1675,7 +1700,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-9 career:audit-canonical-eligibility command integration",
       "merged_at": null,
@@ -1771,7 +1798,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-10 80-cohort readiness plan",
       "merged_at": null,
@@ -1864,7 +1893,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-11 Manifest train generator",
       "merged_at": null,
@@ -1951,7 +1982,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-12 Batch live acceptance v2",
       "merged_at": null,
@@ -2101,7 +2134,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "AUDIT-13 2786 full audit artifact/report",
       "merged_at": null,
@@ -2184,7 +2219,9 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "failure_reason": null,
       "next_pr": "End of 2786 eligibility audit PR train",
       "merged_at": null,
@@ -2249,7 +2286,9 @@
       "merged_at": "2026-05-12T16:55:20Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "PR-RT-03": {
       "repo": "fap-api",
@@ -2329,7 +2368,9 @@
         "Personality type related articles remain deferred because no stable Personality related article authority was identified for INFJ-A/INFJ-T pages.",
         "Test detail related articles remain deferred because the existing related_test_slug contract is a fixed three-article test page slot and changing it would widen PR-RT-03 scope."
       ],
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "merge_sha": "44621613e5255a76631138d641da218e2993e343"
     },
     "CMD-FIX-1": {
@@ -2358,7 +2399,9 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-AH-04": {
       "repo": "fap-api",
@@ -2489,7 +2532,9 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "CTX-CONSUME-1": {
       "repo": "fap-api",
@@ -2542,7 +2587,9 @@
       "merged_at": "2026-05-13T12:11:29Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "CTX-EXPORT-1": {
       "repo": "fap-api",
@@ -2596,7 +2643,9 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "REPAIR-SURFACE-CONTEXT-1": {
       "repo": "fap-api",
@@ -2651,7 +2700,9 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "REPAIR-SEO-GEO-1": {
       "repo": "fap-api",
@@ -2756,7 +2807,9 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [],
+          "affected_slugs": [
+
+          ],
           "affected_locales": [
             "en",
             "zh"
@@ -2870,7 +2923,9 @@
       "merged_at": "2026-05-13T10:31:09Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "REPAIR-TITLE-1": {
       "repo": "fap-api",
@@ -2976,7 +3031,9 @@
       "merged_at": "2026-05-13T10:49:47Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "REPAIR-RUNTIME-1": {
       "repo": "fap-api",
@@ -3081,7 +3138,9 @@
       "merged_at": "2026-05-13T11:08:33Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "REPAIR-INDEX-1": {
       "repo": "fap-api",
@@ -3181,7 +3240,9 @@
       "merged_at": "2026-05-13T11:37:01Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "REPAIR-ENTITY-1": {
       "repo": "fap-api",
@@ -3234,7 +3295,9 @@
       "merged_at": "2026-05-13T11:53:44Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "REPAIR-80-CANDIDATE-1": {
       "repo": "fap-api",
@@ -3287,14 +3350,18 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-PERSONALIZATION-00": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-00-train-registration",
       "title": "docs(codex): register RIASEC personalization train",
       "status": "merged",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "scope_type": "train_registration_only",
       "allowed_paths": [
         "docs/codex/pr-train.yaml",
@@ -3316,7 +3383,9 @@
       "merged_at": "2026-05-13T07:06:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-PERSONALIZATION-01": {
       "repo": "fap-api",
@@ -3369,7 +3438,9 @@
       "merged_at": "2026-05-13T07:35:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-PERSONALIZATION-02": {
       "repo": "fap-api",
@@ -3418,7 +3489,9 @@
       "merged_at": "2026-05-13T07:53:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-PERSONALIZATION-03": {
       "repo": "fap-api",
@@ -3463,7 +3536,9 @@
       "merged_at": "2026-05-13T08:16:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-PERSONALIZATION-04": {
       "repo": "fap-api",
@@ -3510,7 +3585,9 @@
       "merged_at": "2026-05-13T08:33:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-PERSONALIZATION-05": {
       "repo": "fap-api",
@@ -3555,7 +3632,9 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-PERSONALIZATION-06": {
       "repo": "fap-web",
@@ -3575,12 +3654,15 @@
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-PERSONALIZATION-07": {
       "repo": "fap-web",
@@ -3603,12 +3685,15 @@
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "PR-RT-04": {
       "repo": "fap-api",
@@ -3688,7 +3773,9 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "post_merge_runbook_required": true
     },
     "RIASEC-DEEP-COPY-01": {
@@ -3756,7 +3843,9 @@
       "merged_at": "2026-05-13T11:31:25Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-DEEP-COPY-02": {
       "repo": "fap-api",
@@ -3820,7 +3909,9 @@
       "merged_at": "2026-05-13T12:05:30Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
     },
     "RIASEC-DEEP-COPY-03": {
       "repo": "fap-api",
@@ -4025,7 +4116,67 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": []
+      "sidecar_issues": [
+
+      ]
+    },
+    "CTX-SURFACE-EXPORT-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-surface-context-export-producer",
+      "title": "fix(api): add career surface context export producer",
+      "name": "Add read-only Career 2786 surface context artifact producer",
+      "status": "in_progress",
+      "depends_on": [
+        "RUN-1D",
+        "REPAIR-80-CANDIDATE-1"
+      ],
+      "scope_type": "surface_context_producer_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerExportCanonicalEligibilitySurfaceContext.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no production crawl",
+        "no fap-web change",
+        "no production DB query",
+        "no DB mutation",
+        "no rollout",
+        "no backfill",
+        "no 80 readiness run",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided CTX-SURFACE-EXPORT-1 execution goal and authorized updating PR train manifest/state for the current item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "RUN-1D completed with CONTEXT_ARTIFACT_MISSING because surface context is missing; remediation train PRs are merged."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to read-only surface context producer command, surface artifact reader/DTO compatibility, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "RUN-1E rerun full-context audit with --surface-context",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+
+      ]
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1461,6 +1461,53 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: CTX-SURFACE-EXPORT-1
+    repo: fap-api
+    depends_on:
+      - RUN-1D
+      - REPAIR-80-CANDIDATE-1
+    branch: fix/career-surface-context-export-producer
+    title: "fix(api): add career surface context export producer"
+    name: "Add read-only Career 2786 surface context artifact producer"
+    scope_type: surface_context_producer_only
+    scope:
+      - Add read-only surface context artifact producer command.
+      - Generate planner-only unverified rows without claiming surface pass.
+      - Preserve compatibility with --surface-context audit consumer.
+      - Document no-live-crawl and no-production-mutation behavior.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerExportCanonicalEligibilitySurfaceContext.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/*
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run production crawl.
+      - Touch fap-web.
+      - Query production DB.
+      - Mutate DB or production state.
+      - Apply rollout.
+      - Backfill data.
+      - Run 80 readiness.
+      - Deploy.
+    validation:
+      - php artisan test --filter=CareerExportCanonicalEligibilitySurfaceContext --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi
+      - php artisan test --filter=CareerSurfaceContext --no-ansi
+      - php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "RUN-1E rerun full-context audit with --surface-context"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-SEO-GEO-1
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- Adds read-only `career:export-canonical-eligibility-surface-context` producer for `career_surface_context.v1` artifacts.
- Registers the command and documents `--surface-context` usage for canonical eligibility audit reruns.
- Planner-only mode emits explicit unverified rows (`surface_artifact_missing`, `surface_unverified`) and does not fake a surface pass.

## Safety
- No production crawl performed.
- No fap-web change.
- No DB mutation.
- No rollout/backfill/apply.
- No deploy.

## Tests
- `php artisan test --filter=CareerExportCanonicalEligibilitySurfaceContext --no-ansi`
- `php artisan test --filter=CareerSurfaceContext --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Next
- RUN-1E rerun full-context 2786 audit with `--surface-context`.
