### PR TITLE
fix(api): classify career readiness policy blockers

### DIFF
--- a/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+++ b/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Domain\Career\Audit\Career2786ReadinessPolicyClassifier;
 use App\Domain\Career\Audit\CareerBaselineMetadataInventoryAuditor;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRunContext;
@@ -112,6 +113,8 @@ final class CareerAuditCanonicalEligibility extends Command
             rows: $rows,
             sidecars: $sidecars,
         );
+        $policyResult = (new Career2786ReadinessPolicyClassifier)->classify($report);
+        $policySummary = $policyResult->summary();
         $runContext = $this->runContext(
             scope: $scope,
             planRows: $planRows,
@@ -129,6 +132,7 @@ final class CareerAuditCanonicalEligibility extends Command
         $payload = [
             ...$report->toArray(),
             'context_summary' => $contextPayload['context_summary'],
+            'policy_summary' => $policySummary,
             'run_context' => $contextPayload['run_context'],
             'read_only' => true,
             'writes_database' => false,

--- a/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyClassifier.php
+++ b/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyClassifier.php
@@ -1,0 +1,420 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class Career2786ReadinessPolicyClassifier
+{
+    public const DEFAULT_TARGET_COUNT = 80;
+
+    private const REMEDIATION_REQUIRED_REASONS = [
+        'occupation_missing',
+        'entity_field_missing',
+        'index_state_missing',
+    ];
+
+    private const APPROVAL_GATED_REASONS = [
+        'index_state_missing',
+        'occupation_missing',
+        'entity_field_missing',
+    ];
+
+    private const EXPECTED_NOT_READY_REASONS = [
+        'sitemap_expected_not_ready',
+        'llms_expected_not_ready',
+        'llms_full_expected_not_ready',
+    ];
+
+    private const DEFERRED_SURFACE_REASONS = [
+        'surface_artifact_missing',
+        'surface_unverified',
+    ];
+
+    private const CONTEXT_HARD_BLOCKERS = [
+        'surface_context_missing',
+        'entity_db_context_missing',
+        'index_state_context_missing',
+        'runtime_projection_context_missing',
+        'runtime_truth_context_missing',
+        'public_resolution_plan_missing',
+    ];
+
+    /**
+     * @param  list<string>  $selectedCandidateSlugs
+     */
+    public function classify(
+        CareerCanonicalEligibilityReport $report,
+        int $targetCount = self::DEFAULT_TARGET_COUNT,
+        array $selectedCandidateSlugs = [],
+    ): Career2786ReadinessPolicyResult {
+        if ($targetCount <= 0) {
+            throw new InvalidArgumentException('Career 2786 readiness policy target_count must be positive.');
+        }
+
+        $selectedCandidateSlugs = $this->normalizeReasons($selectedCandidateSlugs);
+        $rows = [];
+        foreach ($this->rowsBySlug($report->rows) as $slug => $auditRows) {
+            $rows[] = $this->classifySlug($slug, $auditRows, in_array($slug, $selectedCandidateSlugs, true));
+        }
+
+        usort(
+            $rows,
+            static fn (Career2786ReadinessPolicyRow $left, Career2786ReadinessPolicyRow $right): int => $left->canonicalSlug <=> $right->canonicalSlug
+        );
+
+        $byClassification = [];
+        $byReason = [];
+        $nearEligibleSlugs = [];
+        $eligibleCandidateSlugs = [];
+        $candidateBlockingSlugs = [];
+        $approvalGatedSlugs = [];
+
+        foreach ($rows as $row) {
+            $byClassification[$row->classification] = ($byClassification[$row->classification] ?? 0) + 1;
+            foreach ($row->issues as $issue) {
+                $byReason[$issue->reason] = ($byReason[$issue->reason] ?? 0) + 1;
+            }
+            if ($row->nearEligible) {
+                $nearEligibleSlugs[] = $row->canonicalSlug;
+            }
+            if ($row->eligibleCandidate) {
+                $eligibleCandidateSlugs[] = $row->canonicalSlug;
+            }
+            if ($row->blocks80Readiness) {
+                $candidateBlockingSlugs[] = $row->canonicalSlug;
+            }
+            if ($row->requiresApproval) {
+                $approvalGatedSlugs[] = $row->canonicalSlug;
+            }
+        }
+
+        ksort($byClassification);
+        ksort($byReason);
+
+        return new Career2786ReadinessPolicyResult(
+            schemaVersion: Career2786ReadinessPolicyResult::SCHEMA_VERSION,
+            targetCount: $targetCount,
+            readinessCanRun: count($eligibleCandidateSlugs) >= $targetCount,
+            rows: $rows,
+            byClassification: $byClassification,
+            byReason: $byReason,
+            nearEligibleSlugs: $nearEligibleSlugs,
+            eligibleCandidateSlugs: $eligibleCandidateSlugs,
+            candidateBlockingSlugs: $candidateBlockingSlugs,
+            approvalGatedSlugs: $approvalGatedSlugs,
+            candidateCohortPrerequisites: $this->candidateCohortPrerequisites($rows, $targetCount),
+            recommendedOrder: $this->recommendedOrder($rows),
+        );
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     */
+    private function classifySlug(string $slug, array $auditRows, bool $selectedCandidate): Career2786ReadinessPolicyRow
+    {
+        $locales = [];
+        $reasons = [];
+        $layerByReason = [];
+        foreach ($auditRows as $auditRow) {
+            $locales[] = $auditRow->locale;
+            foreach ($this->layerStatuses($auditRow) as $layerStatus) {
+                foreach ($layerStatus->reasons as $reason) {
+                    $layerByReason[$reason] = $layerStatus->layer;
+                }
+            }
+            $reasons = [...$reasons, ...$auditRow->reasons];
+        }
+
+        $locales = $this->normalizeReasons($locales);
+        $reasons = $this->normalizeReasons($reasons);
+        $remediation = array_values(array_intersect($reasons, self::REMEDIATION_REQUIRED_REASONS));
+        $expectedNotReady = array_values(array_intersect($reasons, self::EXPECTED_NOT_READY_REASONS));
+        $surface = array_values(array_intersect($reasons, self::DEFERRED_SURFACE_REASONS));
+        $contextHardBlockers = array_values(array_intersect($reasons, self::CONTEXT_HARD_BLOCKERS));
+        $approvalGated = array_values(array_intersect($reasons, self::APPROVAL_GATED_REASONS));
+        if ($selectedCandidate) {
+            $approvalGated = array_values(array_unique([...$approvalGated, ...$expectedNotReady, ...$surface]));
+            sort($approvalGated);
+        }
+
+        $knownReasons = array_values(array_unique([
+            ...self::REMEDIATION_REQUIRED_REASONS,
+            ...self::EXPECTED_NOT_READY_REASONS,
+            ...self::DEFERRED_SURFACE_REASONS,
+            ...self::CONTEXT_HARD_BLOCKERS,
+        ]));
+        $unknownHardBlockers = array_values(array_diff($reasons, $knownReasons));
+        $hardBlockers = $this->normalizeReasons([...$contextHardBlockers, ...$unknownHardBlockers]);
+        $candidateReady = $hardBlockers === [] && $remediation === [];
+        $eligibleCandidate = $candidateReady && $expectedNotReady === [] && $surface === [];
+        $nearEligible = $candidateReady && ! $eligibleCandidate;
+        $requiresApproval = $approvalGated !== [];
+        $blocks80Readiness = $hardBlockers !== [] || $remediation !== [];
+        $classification = $this->rowClassification(
+            hardBlockers: $hardBlockers,
+            remediation: $remediation,
+            selectedCandidate: $selectedCandidate,
+            expectedNotReady: $expectedNotReady,
+            surface: $surface,
+            eligibleCandidate: $eligibleCandidate,
+            nearEligible: $nearEligible,
+        );
+
+        $issues = [];
+        foreach ($hardBlockers as $reason) {
+            $issues[] = $this->issue($reason, Career2786ReadinessPolicyIssue::HARD_BLOCKER, $layerByReason[$reason] ?? 'context', true);
+        }
+        foreach ($remediation as $reason) {
+            $issues[] = $this->issue($reason, Career2786ReadinessPolicyIssue::REMEDIATION_REQUIRED, $layerByReason[$reason] ?? $this->layerForReason($reason), true);
+        }
+        foreach ($expectedNotReady as $reason) {
+            $issues[] = $this->issue($reason, $selectedCandidate ? Career2786ReadinessPolicyIssue::APPROVAL_GATED : Career2786ReadinessPolicyIssue::EXPECTED_NOT_READY, $layerByReason[$reason] ?? CareerCanonicalEligibilityLayer::SEO_GEO, $selectedCandidate);
+        }
+        foreach ($surface as $reason) {
+            $issues[] = $this->issue($reason, $selectedCandidate ? Career2786ReadinessPolicyIssue::APPROVAL_GATED : Career2786ReadinessPolicyIssue::DEFERRED_UNTIL_CANDIDATE, $layerByReason[$reason] ?? CareerCanonicalEligibilityLayer::SURFACE, $selectedCandidate);
+        }
+        if ($eligibleCandidate) {
+            $issues[] = $this->issue('eligible_candidate', Career2786ReadinessPolicyIssue::ELIGIBLE_CANDIDATE, 'policy', false);
+        } elseif ($nearEligible) {
+            $issues[] = $this->issue('near_eligible', Career2786ReadinessPolicyIssue::NEAR_ELIGIBLE, 'policy', false);
+        }
+
+        return new Career2786ReadinessPolicyRow(
+            canonicalSlug: $slug,
+            classification: $classification,
+            candidateReady: $candidateReady,
+            nearEligible: $nearEligible,
+            eligibleCandidate: $eligibleCandidate,
+            requiresApproval: $requiresApproval,
+            blocks80Readiness: $blocks80Readiness,
+            locales: $locales,
+            reasons: $reasons,
+            hardBlockerReasons: $hardBlockers,
+            remediationRequiredReasons: $remediation,
+            expectedNotReadyReasons: $expectedNotReady,
+            deferredUntilCandidateReasons: $surface,
+            approvalGatedReasons: $approvalGated,
+            issues: $issues,
+            evidence: [[
+                'selected_candidate' => $selectedCandidate,
+                'candidate_ready_excludes_entity_index_blockers' => true,
+                'surface_verification_deferred_until_candidate' => $surface !== [] && ! $selectedCandidate,
+                'expected_not_ready_policy_deferred_until_candidate' => $expectedNotReady !== [] && ! $selectedCandidate,
+                'locale_count' => count($locales),
+            ]],
+        );
+    }
+
+    /**
+     * @param  list<string>  $hardBlockers
+     * @param  list<string>  $remediation
+     * @param  list<string>  $expectedNotReady
+     * @param  list<string>  $surface
+     */
+    private function rowClassification(array $hardBlockers, array $remediation, bool $selectedCandidate, array $expectedNotReady, array $surface, bool $eligibleCandidate, bool $nearEligible): string
+    {
+        if ($hardBlockers !== []) {
+            return Career2786ReadinessPolicyIssue::HARD_BLOCKER;
+        }
+
+        if ($remediation !== []) {
+            return Career2786ReadinessPolicyIssue::REMEDIATION_REQUIRED;
+        }
+
+        if ($selectedCandidate && ($expectedNotReady !== [] || $surface !== [])) {
+            return Career2786ReadinessPolicyIssue::APPROVAL_GATED;
+        }
+
+        if ($surface !== []) {
+            return Career2786ReadinessPolicyIssue::DEFERRED_UNTIL_CANDIDATE;
+        }
+
+        if ($expectedNotReady !== []) {
+            return Career2786ReadinessPolicyIssue::EXPECTED_NOT_READY;
+        }
+
+        if ($eligibleCandidate) {
+            return Career2786ReadinessPolicyIssue::ELIGIBLE_CANDIDATE;
+        }
+
+        return $nearEligible
+            ? Career2786ReadinessPolicyIssue::NEAR_ELIGIBLE
+            : Career2786ReadinessPolicyIssue::HARD_BLOCKER;
+    }
+
+    private function issue(string $reason, string $classification, string $layer, bool $requiresApproval): Career2786ReadinessPolicyIssue
+    {
+        return new Career2786ReadinessPolicyIssue(
+            reason: $reason,
+            classification: $classification,
+            layer: $layer,
+            requiresApproval: $requiresApproval,
+            blocks80Readiness: in_array($classification, [Career2786ReadinessPolicyIssue::HARD_BLOCKER, Career2786ReadinessPolicyIssue::REMEDIATION_REQUIRED], true),
+            message: $this->messageFor($reason, $classification),
+        );
+    }
+
+    private function messageFor(string $reason, string $classification): string
+    {
+        return match ($classification) {
+            Career2786ReadinessPolicyIssue::REMEDIATION_REQUIRED => sprintf('[%s] requires reviewed remediation before a slug can enter an 80-candidate run.', $reason),
+            Career2786ReadinessPolicyIssue::EXPECTED_NOT_READY => sprintf('[%s] is an expected-not-ready policy state until the slug is selected for publication.', $reason),
+            Career2786ReadinessPolicyIssue::DEFERRED_UNTIL_CANDIDATE => sprintf('[%s] is deferred until a candidate cohort exists; it is not a 2786-wide live crawl trigger.', $reason),
+            Career2786ReadinessPolicyIssue::APPROVAL_GATED => sprintf('[%s] requires explicit approval or concrete evidence for selected publication candidates.', $reason),
+            Career2786ReadinessPolicyIssue::NEAR_ELIGIBLE => 'Slug has no entity/index hard blockers but still has deferred policy or surface prerequisites.',
+            Career2786ReadinessPolicyIssue::ELIGIBLE_CANDIDATE => 'Slug has no remaining policy classifier blockers for candidate selection.',
+            default => sprintf('[%s] is a hard blocker for 80 readiness until classified or repaired.', $reason),
+        };
+    }
+
+    private function layerForReason(string $reason): string
+    {
+        return match ($reason) {
+            'occupation_missing', 'entity_field_missing' => CareerCanonicalEligibilityLayer::ENTITY,
+            'index_state_missing' => CareerCanonicalEligibilityLayer::INDEX,
+            default => 'policy',
+        };
+    }
+
+    /**
+     * @param  list<Career2786ReadinessPolicyRow>  $rows
+     * @return list<string>
+     */
+    private function candidateCohortPrerequisites(array $rows, int $targetCount): array
+    {
+        $nearEligible = count(array_filter($rows, static fn (Career2786ReadinessPolicyRow $row): bool => $row->nearEligible || $row->eligibleCandidate));
+        $items = [];
+        if ($nearEligible < $targetCount) {
+            $items[] = sprintf('increase_near_eligible_candidates_to_%d', $targetCount);
+        }
+        if ($this->anyClassification($rows, Career2786ReadinessPolicyIssue::REMEDIATION_REQUIRED)) {
+            $items[] = 'resolve_index_entity_remediation_required';
+        }
+        if ($this->anyReason($rows, self::EXPECTED_NOT_READY_REASONS)) {
+            $items[] = 'resolve_or_scope_sitemap_llms_expected_not_ready_policy';
+        }
+        if ($this->anyReason($rows, self::DEFERRED_SURFACE_REASONS)) {
+            $items[] = 'defer_surface_verification_until_candidate_cohort';
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param  list<Career2786ReadinessPolicyRow>  $rows
+     * @return list<string>
+     */
+    private function recommendedOrder(array $rows): array
+    {
+        $order = [];
+        if ($this->anyReason($rows, ['index_state_missing'])) {
+            $order[] = 'index_state_remediation_plan_then_approval_gate';
+        }
+        if ($this->anyReason($rows, ['occupation_missing', 'entity_field_missing'])) {
+            $order[] = 'occupation_entity_remediation_plan_then_approval_gate';
+        }
+        if ($this->anyReason($rows, self::EXPECTED_NOT_READY_REASONS)) {
+            $order[] = 'sitemap_llms_expected_not_ready_policy_pr';
+        }
+        if ($this->anyReason($rows, self::DEFERRED_SURFACE_REASONS)) {
+            $order[] = 'candidate_only_surface_verification_after_80_candidates_exist';
+        }
+        if ($order === []) {
+            $order[] = 'run_80_readiness_read_only';
+        }
+
+        return $order;
+    }
+
+    /**
+     * @param  list<Career2786ReadinessPolicyRow>  $rows
+     */
+    private function anyClassification(array $rows, string $classification): bool
+    {
+        foreach ($rows as $row) {
+            if ($row->classification === $classification) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<Career2786ReadinessPolicyRow>  $rows
+     * @param  list<string>  $reasons
+     */
+    private function anyReason(array $rows, array $reasons): bool
+    {
+        foreach ($rows as $row) {
+            if (array_intersect($row->reasons, $reasons) !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     * @return array<string, list<CareerCanonicalEligibilityAuditRow>>
+     */
+    private function rowsBySlug(array $rows): array
+    {
+        $bySlug = [];
+        foreach ($rows as $row) {
+            $bySlug[$row->slug] ??= [];
+            $bySlug[$row->slug][] = $row;
+        }
+
+        ksort($bySlug);
+
+        return $bySlug;
+    }
+
+    /**
+     * @return list<CareerCanonicalEligibilityLayerStatus>
+     */
+    private function layerStatuses(CareerCanonicalEligibilityAuditRow $row): array
+    {
+        return [
+            $row->entityStatus,
+            $row->baselineStatus,
+            $row->indexStatus,
+            $row->runtimeStatus,
+            $row->seoGeoStatus,
+            $row->surfaceStatus,
+            $row->safetyStatus,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     * @return list<string>
+     */
+    private function normalizeReasons(array $reasons): array
+    {
+        if (! array_is_list($reasons)) {
+            throw new InvalidArgumentException('Career 2786 readiness policy values must be a list.');
+        }
+
+        $normalized = [];
+        foreach ($reasons as $reason) {
+            if (! is_string($reason)) {
+                throw new InvalidArgumentException('Career 2786 readiness policy values must contain strings.');
+            }
+
+            $value = trim($reason);
+            if ($value !== '') {
+                $normalized[] = $value;
+            }
+        }
+
+        sort($normalized);
+
+        return array_values(array_unique($normalized));
+    }
+}

--- a/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyIssue.php
+++ b/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyIssue.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class Career2786ReadinessPolicyIssue
+{
+    public const HARD_BLOCKER = 'hard_blocker';
+
+    public const REMEDIATION_REQUIRED = 'remediation_required';
+
+    public const EXPECTED_NOT_READY = 'expected_not_ready';
+
+    public const DEFERRED_UNTIL_CANDIDATE = 'deferred_until_candidate';
+
+    public const APPROVAL_GATED = 'approval_gated';
+
+    public const NEAR_ELIGIBLE = 'near_eligible';
+
+    public const ELIGIBLE_CANDIDATE = 'eligible_candidate';
+
+    public function __construct(
+        public readonly string $reason,
+        public readonly string $classification,
+        public readonly string $layer,
+        public readonly bool $requiresApproval,
+        public readonly bool $blocks80Readiness,
+        public readonly string $message,
+    ) {
+        self::assertNonEmptyString($this->reason, 'reason');
+        self::assertValidClassification($this->classification);
+        self::assertNonEmptyString($this->layer, 'layer');
+        self::assertNonEmptyString($this->message, 'message');
+    }
+
+    /**
+     * @return array{reason: string, classification: string, layer: string, requires_approval: bool, blocks_80_readiness: bool, message: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason,
+            'classification' => $this->classification,
+            'layer' => $this->layer,
+            'requires_approval' => $this->requiresApproval,
+            'blocks_80_readiness' => $this->blocks80Readiness,
+            'message' => $this->message,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function classifications(): array
+    {
+        return [
+            self::HARD_BLOCKER,
+            self::REMEDIATION_REQUIRED,
+            self::EXPECTED_NOT_READY,
+            self::DEFERRED_UNTIL_CANDIDATE,
+            self::APPROVAL_GATED,
+            self::NEAR_ELIGIBLE,
+            self::ELIGIBLE_CANDIDATE,
+        ];
+    }
+
+    public static function assertValidClassification(string $value): void
+    {
+        if (! in_array($value, self::classifications(), true)) {
+            throw new InvalidArgumentException(sprintf('Invalid Career 2786 readiness policy classification [%s].', $value));
+        }
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career 2786 readiness policy issue requires non-empty [%s].', $key));
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyResult.php
+++ b/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyResult.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class Career2786ReadinessPolicyResult
+{
+    public const SCHEMA_VERSION = 'career_2786_readiness_policy.v1';
+
+    /**
+     * @param  list<Career2786ReadinessPolicyRow>  $rows
+     * @param  array<string, int>  $byClassification
+     * @param  array<string, int>  $byReason
+     * @param  list<string>  $nearEligibleSlugs
+     * @param  list<string>  $eligibleCandidateSlugs
+     * @param  list<string>  $candidateBlockingSlugs
+     * @param  list<string>  $approvalGatedSlugs
+     * @param  list<string>  $candidateCohortPrerequisites
+     * @param  list<string>  $recommendedOrder
+     */
+    public function __construct(
+        public readonly string $schemaVersion,
+        public readonly int $targetCount,
+        public readonly bool $readinessCanRun,
+        public readonly array $rows,
+        public readonly array $byClassification,
+        public readonly array $byReason,
+        public readonly array $nearEligibleSlugs,
+        public readonly array $eligibleCandidateSlugs,
+        public readonly array $candidateBlockingSlugs,
+        public readonly array $approvalGatedSlugs,
+        public readonly array $candidateCohortPrerequisites,
+        public readonly array $recommendedOrder,
+    ) {
+        if ($this->schemaVersion !== self::SCHEMA_VERSION) {
+            throw new InvalidArgumentException('Career 2786 readiness policy schema version is invalid.');
+        }
+        if ($this->targetCount <= 0) {
+            throw new InvalidArgumentException('Career 2786 readiness policy target_count must be positive.');
+        }
+        self::assertRows($this->rows);
+        self::assertIntMap($this->byClassification, 'by_classification');
+        self::assertIntMap($this->byReason, 'by_reason');
+        self::assertListOfStrings($this->nearEligibleSlugs, 'near_eligible_slugs');
+        self::assertListOfStrings($this->eligibleCandidateSlugs, 'eligible_candidate_slugs');
+        self::assertListOfStrings($this->candidateBlockingSlugs, 'candidate_blocking_slugs');
+        self::assertListOfStrings($this->approvalGatedSlugs, 'approval_gated_slugs');
+        self::assertListOfStrings($this->candidateCohortPrerequisites, 'candidate_cohort_prerequisites');
+        self::assertListOfStrings($this->recommendedOrder, 'recommended_order');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'schema_version' => $this->schemaVersion,
+            'target_count' => $this->targetCount,
+            'readiness_can_run' => $this->readinessCanRun,
+            'by_classification' => $this->byClassification,
+            'by_reason' => $this->byReason,
+            'near_eligible_count' => count($this->nearEligibleSlugs),
+            'eligible_candidate_count' => count($this->eligibleCandidateSlugs),
+            'candidate_blocking_count' => count($this->candidateBlockingSlugs),
+            'approval_gated_count' => count($this->approvalGatedSlugs),
+            'near_eligible_slugs' => $this->nearEligibleSlugs,
+            'eligible_candidate_slugs' => $this->eligibleCandidateSlugs,
+            'candidate_blocking_slugs' => $this->candidateBlockingSlugs,
+            'approval_gated_slugs' => $this->approvalGatedSlugs,
+            'candidate_cohort_prerequisites' => $this->candidateCohortPrerequisites,
+            'recommended_order' => $this->recommendedOrder,
+            'rows' => array_map(
+                static fn (Career2786ReadinessPolicyRow $row): array => $row->toArray(),
+                $this->rows
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function summary(): array
+    {
+        return [
+            'schema_version' => $this->schemaVersion,
+            'target_count' => $this->targetCount,
+            'readiness_can_run' => $this->readinessCanRun,
+            'hard_blocker_count' => $this->byClassification[Career2786ReadinessPolicyIssue::HARD_BLOCKER] ?? 0,
+            'remediation_required_count' => $this->byClassification[Career2786ReadinessPolicyIssue::REMEDIATION_REQUIRED] ?? 0,
+            'expected_not_ready_count' => $this->byClassification[Career2786ReadinessPolicyIssue::EXPECTED_NOT_READY] ?? 0,
+            'deferred_until_candidate_count' => $this->byClassification[Career2786ReadinessPolicyIssue::DEFERRED_UNTIL_CANDIDATE] ?? 0,
+            'approval_gated_count' => $this->byClassification[Career2786ReadinessPolicyIssue::APPROVAL_GATED] ?? 0,
+            'near_eligible_count' => count($this->nearEligibleSlugs),
+            'eligible_candidate_count' => count($this->eligibleCandidateSlugs),
+            'candidate_blocking_count' => count($this->candidateBlockingSlugs),
+            'candidate_cohort_prerequisites' => $this->candidateCohortPrerequisites,
+            'recommended_order' => $this->recommendedOrder,
+        ];
+    }
+
+    /**
+     * @param  list<Career2786ReadinessPolicyRow>  $rows
+     */
+    private static function assertRows(array $rows): void
+    {
+        if (! array_is_list($rows)) {
+            throw new InvalidArgumentException('Career 2786 readiness policy rows must be a list.');
+        }
+
+        foreach ($rows as $row) {
+            if (! $row instanceof Career2786ReadinessPolicyRow) {
+                throw new InvalidArgumentException('Career 2786 readiness policy rows must contain row DTOs.');
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, int>  $value
+     */
+    private static function assertIntMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career 2786 readiness policy [%s] must be an object map.', $key));
+        }
+
+        foreach ($value as $mapKey => $count) {
+            if (! is_string($mapKey) || trim($mapKey) === '' || ! is_int($count) || $count < 0) {
+                throw new InvalidArgumentException(sprintf('Career 2786 readiness policy [%s] must map non-empty strings to non-negative integers.', $key));
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career 2786 readiness policy [%s] must be a list.', $key));
+        }
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career 2786 readiness policy [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyRow.php
+++ b/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyRow.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use InvalidArgumentException;
+
+final class Career2786ReadinessPolicyRow
+{
+    /**
+     * @param  list<string>  $locales
+     * @param  list<string>  $reasons
+     * @param  list<string>  $hardBlockerReasons
+     * @param  list<string>  $remediationRequiredReasons
+     * @param  list<string>  $expectedNotReadyReasons
+     * @param  list<string>  $deferredUntilCandidateReasons
+     * @param  list<string>  $approvalGatedReasons
+     * @param  list<Career2786ReadinessPolicyIssue>  $issues
+     * @param  list<mixed>  $evidence
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $classification,
+        public readonly bool $candidateReady,
+        public readonly bool $nearEligible,
+        public readonly bool $eligibleCandidate,
+        public readonly bool $requiresApproval,
+        public readonly bool $blocks80Readiness,
+        public readonly array $locales,
+        public readonly array $reasons = [],
+        public readonly array $hardBlockerReasons = [],
+        public readonly array $remediationRequiredReasons = [],
+        public readonly array $expectedNotReadyReasons = [],
+        public readonly array $deferredUntilCandidateReasons = [],
+        public readonly array $approvalGatedReasons = [],
+        public readonly array $issues = [],
+        public readonly array $evidence = [],
+    ) {
+        self::assertNonEmptyString($this->canonicalSlug, 'canonical_slug');
+        Career2786ReadinessPolicyIssue::assertValidClassification($this->classification);
+        self::assertListOfStrings($this->locales, 'locales');
+        self::assertListOfStrings($this->reasons, 'reasons');
+        self::assertListOfStrings($this->hardBlockerReasons, 'hard_blocker_reasons');
+        self::assertListOfStrings($this->remediationRequiredReasons, 'remediation_required_reasons');
+        self::assertListOfStrings($this->expectedNotReadyReasons, 'expected_not_ready_reasons');
+        self::assertListOfStrings($this->deferredUntilCandidateReasons, 'deferred_until_candidate_reasons');
+        self::assertListOfStrings($this->approvalGatedReasons, 'approval_gated_reasons');
+        self::assertIssues($this->issues);
+        self::assertList($this->evidence, 'evidence');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'classification' => $this->classification,
+            'candidate_ready' => $this->candidateReady,
+            'near_eligible' => $this->nearEligible,
+            'eligible_candidate' => $this->eligibleCandidate,
+            'requires_approval' => $this->requiresApproval,
+            'blocks_80_readiness' => $this->blocks80Readiness,
+            'locales' => $this->locales,
+            'reasons' => $this->reasons,
+            'hard_blocker_reasons' => $this->hardBlockerReasons,
+            'remediation_required_reasons' => $this->remediationRequiredReasons,
+            'expected_not_ready_reasons' => $this->expectedNotReadyReasons,
+            'deferred_until_candidate_reasons' => $this->deferredUntilCandidateReasons,
+            'approval_gated_reasons' => $this->approvalGatedReasons,
+            'issues' => array_map(
+                static fn (Career2786ReadinessPolicyIssue $issue): array => $issue->toArray(),
+                $this->issues
+            ),
+            'evidence' => $this->evidence,
+        ];
+    }
+
+    private static function assertNonEmptyString(string $value, string $key): void
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(sprintf('Career 2786 readiness policy row requires non-empty [%s].', $key));
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $value
+     */
+    private static function assertList(array $value, string $key): void
+    {
+        if (! array_is_list($value)) {
+            throw new InvalidArgumentException(sprintf('Career 2786 readiness policy row [%s] must be a list.', $key));
+        }
+    }
+
+    /**
+     * @param  list<string>  $value
+     */
+    private static function assertListOfStrings(array $value, string $key): void
+    {
+        self::assertList($value, $key);
+
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                throw new InvalidArgumentException(sprintf('Career 2786 readiness policy row [%s] must contain non-empty strings.', $key));
+            }
+        }
+    }
+
+    /**
+     * @param  list<Career2786ReadinessPolicyIssue>  $issues
+     */
+    private static function assertIssues(array $issues): void
+    {
+        self::assertList($issues, 'issues');
+
+        foreach ($issues as $issue) {
+            if (! $issue instanceof Career2786ReadinessPolicyIssue) {
+                throw new InvalidArgumentException('Career 2786 readiness policy row issues must contain issue DTOs.');
+            }
+        }
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php
@@ -12,6 +12,7 @@ final class CareerCanonical80CandidateSelectionReport
 
     /**
      * @param  list<CareerCanonical80CandidateSelectionRow>  $rows
+     * @param  array<string, mixed>  $policySummary
      * @param  list<string>  $selectedSlugs
      * @param  list<string>  $nearEligibleSlugs
      * @param  list<string>  $excludedSlugs
@@ -29,6 +30,7 @@ final class CareerCanonical80CandidateSelectionReport
         public readonly array $selectedSlugs,
         public readonly array $nearEligibleSlugs,
         public readonly array $excludedSlugs,
+        public readonly array $policySummary = [],
     ) {
         self::assertNonEmptyString($this->schemaVersion, 'schema_version');
         CareerCanonicalEligibilityStatus::assertValid($this->status);
@@ -44,6 +46,7 @@ final class CareerCanonical80CandidateSelectionReport
             }
         }
         self::assertRows($this->rows);
+        self::assertMap($this->policySummary, 'policy_summary');
         self::assertListOfStrings($this->selectedSlugs, 'selected_slugs');
         self::assertListOfStrings($this->nearEligibleSlugs, 'near_eligible_slugs');
         self::assertListOfStrings($this->excludedSlugs, 'excluded_slugs');
@@ -51,10 +54,12 @@ final class CareerCanonical80CandidateSelectionReport
 
     /**
      * @param  list<CareerCanonical80CandidateSelectionRow>  $rows
+     * @param  array<string, mixed>  $policySummary
      */
-    public static function build(int $targetCount, array $rows): self
+    public static function build(int $targetCount, array $rows, array $policySummary = []): self
     {
         self::assertRows($rows);
+        self::assertMap($policySummary, 'policy_summary');
 
         $selectedSlugs = array_values(array_map(
             static fn (CareerCanonical80CandidateSelectionRow $row): string => $row->canonicalSlug,
@@ -83,11 +88,12 @@ final class CareerCanonical80CandidateSelectionReport
             selectedSlugs: array_slice($selectedSlugs, 0, $targetCount),
             nearEligibleSlugs: $nearEligibleSlugs,
             excludedSlugs: $excludedSlugs,
+            policySummary: $policySummary,
         );
     }
 
     /**
-     * @return array{schema_version: string, status: string, target_count: int, candidate_count: int, selected_count: int, near_eligible_count: int, excluded_count: int, readiness_can_run: bool, selected_slugs: list<string>, near_eligible_slugs: list<string>, excluded_slugs: list<string>, rows: list<array<string, mixed>>}
+     * @return array{schema_version: string, status: string, target_count: int, candidate_count: int, selected_count: int, near_eligible_count: int, excluded_count: int, readiness_can_run: bool, policy_summary: array<string, mixed>, selected_slugs: list<string>, near_eligible_slugs: list<string>, excluded_slugs: list<string>, rows: list<array<string, mixed>>}
      */
     public function toArray(): array
     {
@@ -100,6 +106,7 @@ final class CareerCanonical80CandidateSelectionReport
             'near_eligible_count' => $this->nearEligibleCount,
             'excluded_count' => $this->excludedCount,
             'readiness_can_run' => $this->readinessCanRun,
+            'policy_summary' => $this->policySummary,
             'selected_slugs' => $this->selectedSlugs,
             'near_eligible_slugs' => $this->nearEligibleSlugs,
             'excluded_slugs' => $this->excludedSlugs,
@@ -108,6 +115,16 @@ final class CareerCanonical80CandidateSelectionReport
                 $this->rows
             ),
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    private static function assertMap(array $value, string $key): void
+    {
+        if (array_is_list($value) && $value !== []) {
+            throw new InvalidArgumentException(sprintf('Career 80 candidate selection [%s] must be an object map.', $key));
+        }
     }
 
     private static function assertNonEmptyString(string $value, string $key): void

--- a/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php
@@ -46,6 +46,10 @@ final class CareerCanonical80CandidateSelector
             throw new InvalidArgumentException('Career 80 candidate selection target_count must be positive.');
         }
 
+        $policy = (new Career2786ReadinessPolicyClassifier)->classify(
+            report: $report,
+            targetCount: $targetCount,
+        );
         $hardBlockers = $this->normalizeReasons($hardBlockers);
         $ranked = $this->rankedRows($report, $hardBlockers);
         $selectedCount = 0;
@@ -75,7 +79,7 @@ final class CareerCanonical80CandidateSelector
             );
         }
 
-        return CareerCanonical80CandidateSelectionReport::build($targetCount, $rows);
+        return CareerCanonical80CandidateSelectionReport::build($targetCount, $rows, $policy->summary());
     }
 
     /**

--- a/backend/docs/career/audits/canonical_eligibility_audit_command.md
+++ b/backend/docs/career/audits/canonical_eligibility_audit_command.md
@@ -105,6 +105,14 @@ REPAIR-RUN-CTX-1 adds top-level `context_summary` and `run_context` sections. Th
 
 The context layer intentionally groups row-wide context blockers. For example, `runtime_projection_context_missing` across 5,572 slug/locale rows is one missing `--projection` artifact requirement, not 5,572 separate data defects.
 
+REPAIR-INDEX-ENTITY-POLICY-2 adds top-level `policy_summary`. It classifies broad surface and SEO/GEO policy states separately from entity/index remediation gaps:
+
+- planner-only `surface_unverified` and `surface_artifact_missing` rows are `deferred_until_candidate` until a candidate cohort is selected
+- `sitemap_expected_not_ready`, `llms_expected_not_ready`, and `llms_full_expected_not_ready` are `expected_not_ready` for non-candidate rows
+- `index_state_missing`, `occupation_missing`, and `entity_field_missing` remain remediation-required blockers and approval-gated data tasks
+
+The command still preserves `by_reason`; policy classification adds planning clarity without hiding blockers or claiming surface/live acceptance.
+
 See `backend/docs/career/audits/audit_run_context.md` for rerun modes and approval gate templates.
 
 ## Non-Goals

--- a/backend/docs/career/audits/readiness_policy_classification.md
+++ b/backend/docs/career/audits/readiness_policy_classification.md
@@ -1,0 +1,77 @@
+# Career 2786 Readiness Policy Classification
+
+`REPAIR-INDEX-ENTITY-POLICY-2` adds a read-only policy layer on top of the
+canonical eligibility audit. It does not remove audit reasons and does not turn
+blocked rows into passing rows. Its purpose is to explain which blockers must be
+fixed now, which are expected pre-publication states, and which checks should be
+deferred until a real candidate cohort exists.
+
+## Classifications
+
+- `hard_blocker`: context or unknown blockers that prevent meaningful candidate
+  planning until repaired or classified.
+- `remediation_required`: entity/index authority gaps that require reviewed
+  remediation before a slug can enter an 80-candidate run.
+- `expected_not_ready`: SEO/GEO publication policy states that are expected for
+  non-candidate rows.
+- `deferred_until_candidate`: surface verification states that should not
+  trigger a 2786-wide live crawl before a candidate cohort exists.
+- `approval_gated`: checks that become required for selected publication
+  candidates and need explicit approval or concrete evidence.
+- `near_eligible`: slugs with no entity/index hard blockers but remaining
+  deferred policy or surface prerequisites.
+- `eligible_candidate`: slugs with no classifier blockers for candidate
+  selection.
+
+## Surface Verification
+
+Planner-only surface rows are allowed as context evidence, but they are not live
+surface acceptance. `surface_unverified` and `surface_artifact_missing` stay in
+`by_reason`. For rows that are not selected publication candidates, the policy
+classifier marks those reasons as `deferred_until_candidate`.
+
+For selected candidates, surface evidence becomes required before live
+acceptance. A future live crawl must be explicit, scoped, read-only, and normally
+candidate-limited rather than all 2786 rows.
+
+## SEO/GEO Expected-Not-Ready
+
+`sitemap_expected_not_ready`, `llms_expected_not_ready`, and
+`llms_full_expected_not_ready` are expected-not-ready states for rows that are
+not yet intended for publication. For selected rollout candidates, those states
+become required publication prerequisites.
+
+## Entity And Index Gaps
+
+`occupation_missing`, `entity_field_missing`, and `index_state_missing` remain
+`remediation_required`. They are not deferred surface policy and they are not
+treated as expected-not-ready. Any production apply/backfill/index-state write
+requires a reviewed plan and explicit approval.
+
+## Output
+
+`career:audit-canonical-eligibility` includes a `policy_summary` object with
+counts for:
+
+- `hard_blocker_count`
+- `remediation_required_count`
+- `expected_not_ready_count`
+- `deferred_until_candidate_count`
+- `approval_gated_count`
+- `near_eligible_count`
+- `eligible_candidate_count`
+- `candidate_blocking_count`
+
+The 80-candidate selector also embeds the same summary so readiness reports can
+explain why fewer than 80 candidates are available without running 80 readiness
+or generating a rollout manifest.
+
+## Non-Goals
+
+- No live crawl.
+- No DB mutation.
+- No index-state apply.
+- No occupation backfill apply.
+- No 80 readiness run.
+- No rollout manifest generation.
+- No rollout or deploy.

--- a/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
@@ -425,6 +425,108 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertSame('blocked', data_get($payload, 'rows.0.surface_status.status'));
     }
 
+    public function test_command_output_includes_policy_summary_for_deferred_surface_and_remediation(): void
+    {
+        $planPath = $this->writePlanner([
+            [
+                'row_number' => 2,
+                'canonical_slug' => 'actuaries',
+                'status' => 'ready_for_pilot',
+                'source_code' => '15-2011.00',
+                'title_en' => 'Actuaries',
+                'title_zh' => '精算师',
+                'ready_for_sitemap' => false,
+                'seo' => [
+                    'en_title' => 'Actuaries Career Guide',
+                    'en_description' => 'Explore actuaries with source-backed career evidence.',
+                    'en_target_queries' => '["actuaries career"]',
+                    'search_intent_type' => '["career_exploration"]',
+                ],
+                'raw' => [
+                    'Ready_For_Sitemap' => false,
+                    'Ready_For_LLMS' => false,
+                    'EN_SEO_Title' => 'Actuaries Career Guide',
+                    'EN_SEO_Description' => 'Explore actuaries with source-backed career evidence.',
+                    'CN_SEO_Title' => '精算师职业指南',
+                    'CN_SEO_Description' => '了解精算师职业证据。',
+                    'EN_Target_Queries' => '["actuaries career"]',
+                    'Search_Intent_Type' => '["career_exploration"]',
+                ],
+            ],
+            [
+                'row_number' => 3,
+                'canonical_slug' => 'missing-index',
+                'status' => 'ready_for_pilot',
+                'source_code' => '00-0000.00',
+                'title_en' => 'Missing Index',
+                'title_zh' => '缺少索引',
+                'ready_for_sitemap' => false,
+                'seo' => [
+                    'en_title' => 'Missing Index Career Guide',
+                    'en_description' => 'Explore missing index with source-backed career evidence.',
+                    'en_target_queries' => '["missing index career"]',
+                    'search_intent_type' => '["career_exploration"]',
+                ],
+                'raw' => [
+                    'Ready_For_Sitemap' => false,
+                    'Ready_For_LLMS' => false,
+                    'EN_SEO_Title' => 'Missing Index Career Guide',
+                    'EN_SEO_Description' => 'Explore missing index with source-backed career evidence.',
+                    'CN_SEO_Title' => '缺少索引职业指南',
+                    'CN_SEO_Description' => '了解缺少索引职业证据。',
+                    'EN_Target_Queries' => '["missing index career"]',
+                    'Search_Intent_Type' => '["career_exploration"]',
+                ],
+            ],
+        ]);
+        $projectionPath = $this->writeJsonArtifact('projection', [
+            'items' => [
+                ['slug' => 'actuaries', 'locale' => 'en', 'runtime_publish_state' => 'published', 'canonical_public_type' => 'public_canonical_job'],
+                ['slug' => 'missing-index', 'locale' => 'en', 'runtime_publish_state' => 'published', 'canonical_public_type' => 'public_canonical_job'],
+            ],
+        ]);
+        $truthPath = $this->writeJsonArtifact('truth', [
+            'items' => [
+                ['slug' => 'actuaries', 'locale' => 'en', 'state' => 'published', 'canonical_public_type' => 'public_canonical_job'],
+                ['slug' => 'missing-index', 'locale' => 'en', 'state' => 'published', 'canonical_public_type' => 'public_canonical_job'],
+            ],
+        ]);
+        $entityPath = $this->writeEntityContext([
+            ['canonical_slug' => 'actuaries', 'occupation_exists' => true, 'occupation_id' => 123, 'missing_entity_fields' => []],
+            ['canonical_slug' => 'missing-index', 'occupation_exists' => true, 'occupation_id' => 456, 'missing_entity_fields' => []],
+        ]);
+        $indexPath = $this->writeIndexContext([
+            ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed', 'public_facing_state' => 'indexed', 'index_eligible' => true],
+            ['canonical_slug' => 'missing-index', 'latest_index_state' => null, 'public_facing_state' => null, 'index_eligible' => null, 'evidence' => ['occupation_missing' => false]],
+        ]);
+        $surfacePath = $this->writeSurfaceContext([
+            ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actuaries', 'api_indexable' => true, 'surface_verified' => false, 'issues' => ['surface_unverified']],
+            ['canonical_slug' => 'missing-index', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/missing-index', 'api_indexable' => true, 'surface_verified' => false, 'issues' => ['surface_unverified']],
+        ]);
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'all',
+            '--public-resolution-plan' => $planPath,
+            '--entity-context' => $entityPath,
+            '--index-state-context' => $indexPath,
+            '--surface-context' => $surfacePath,
+            '--projection' => $projectionPath,
+            '--truth' => $truthPath,
+            '--locales' => 'en',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('policy_summary', $payload);
+        $this->assertSame('career_2786_readiness_policy.v1', $payload['policy_summary']['schema_version']);
+        $this->assertSame(1, $payload['policy_summary']['deferred_until_candidate_count']);
+        $this->assertSame(1, $payload['policy_summary']['remediation_required_count']);
+        $this->assertSame(1, $payload['policy_summary']['near_eligible_count']);
+        $this->assertSame(0, $payload['policy_summary']['eligible_candidate_count']);
+        $this->assertContains('resolve_index_entity_remediation_required', $payload['policy_summary']['candidate_cohort_prerequisites']);
+        $this->assertContains('candidate_only_surface_verification_after_80_candidates_exist', $payload['policy_summary']['recommended_order']);
+    }
+
     public function test_command_writes_output_json_when_requested(): void
     {
         $outputPath = sys_get_temp_dir().'/career-audit-command-output-'.bin2hex(random_bytes(4)).'.json';
@@ -601,6 +703,7 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
             'rows',
             'sidecars',
             'context_summary',
+            'policy_summary',
             'run_context',
             'read_only',
             'writes_database',

--- a/backend/tests/Unit/Domain/Career/Audit/Career2786ReadinessPolicyClassifierTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career2786ReadinessPolicyClassifierTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\Career2786ReadinessPolicyClassifier;
+use App\Domain\Career\Audit\Career2786ReadinessPolicyIssue;
+use App\Domain\Career\Audit\Career2786ReadinessPolicyResult;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayer;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityLayerStatus;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityScope;
+use App\Domain\Career\Audit\CareerCanonicalEligibilitySeverity;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use PHPUnit\Framework\TestCase;
+
+final class Career2786ReadinessPolicyClassifierTest extends TestCase
+{
+    public function test_surface_unverified_is_deferred_for_non_candidate_rows(): void
+    {
+        $result = $this->classify([
+            $this->row('actuaries', 'en', ['surface_unverified', 'surface_artifact_missing']),
+        ]);
+
+        $this->assertSame(1, $result->byClassification[Career2786ReadinessPolicyIssue::DEFERRED_UNTIL_CANDIDATE]);
+        $this->assertSame(['actuaries'], $result->nearEligibleSlugs);
+        $this->assertSame(['surface_artifact_missing', 'surface_unverified'], $result->rows[0]->deferredUntilCandidateReasons);
+        $this->assertFalse($result->rows[0]->requiresApproval);
+        $this->assertFalse($result->rows[0]->blocks80Readiness);
+    }
+
+    public function test_surface_unverified_remains_required_for_selected_candidate_rows(): void
+    {
+        $report = $this->report([
+            $this->row('actuaries', 'en', ['surface_unverified']),
+        ]);
+
+        $result = (new Career2786ReadinessPolicyClassifier)->classify($report, selectedCandidateSlugs: ['actuaries']);
+
+        $this->assertSame(Career2786ReadinessPolicyIssue::APPROVAL_GATED, $result->rows[0]->classification);
+        $this->assertSame(['surface_unverified'], $result->rows[0]->approvalGatedReasons);
+        $this->assertTrue($result->rows[0]->requiresApproval);
+        $this->assertFalse($result->rows[0]->blocks80Readiness);
+    }
+
+    public function test_sitemap_and_llms_expected_not_ready_are_policy_states_until_candidate_stage(): void
+    {
+        $result = $this->classify([
+            $this->row('policy-wait', 'en', ['sitemap_expected_not_ready', 'llms_expected_not_ready', 'llms_full_expected_not_ready']),
+        ]);
+
+        $this->assertSame(Career2786ReadinessPolicyIssue::EXPECTED_NOT_READY, $result->rows[0]->classification);
+        $this->assertSame([
+            'llms_expected_not_ready',
+            'llms_full_expected_not_ready',
+            'sitemap_expected_not_ready',
+        ], $result->rows[0]->expectedNotReadyReasons);
+        $this->assertContains('policy-wait', $result->nearEligibleSlugs);
+    }
+
+    public function test_sitemap_expected_not_ready_blocks_selected_publication_candidate(): void
+    {
+        $report = $this->report([
+            $this->row('policy-wait', 'en', ['sitemap_expected_not_ready']),
+        ]);
+
+        $result = (new Career2786ReadinessPolicyClassifier)->classify($report, selectedCandidateSlugs: ['policy-wait']);
+
+        $this->assertSame(Career2786ReadinessPolicyIssue::APPROVAL_GATED, $result->rows[0]->classification);
+        $this->assertSame(['sitemap_expected_not_ready'], $result->rows[0]->approvalGatedReasons);
+        $this->assertTrue($result->rows[0]->requiresApproval);
+    }
+
+    public function test_index_and_entity_gaps_remain_remediation_required(): void
+    {
+        $result = $this->classify([
+            $this->row('index-gap', 'en', ['index_state_missing']),
+            $this->row('missing-occupation', 'en', ['occupation_missing']),
+            $this->row('field-gap', 'en', ['entity_field_missing']),
+        ]);
+
+        $this->assertSame(3, $result->byClassification[Career2786ReadinessPolicyIssue::REMEDIATION_REQUIRED]);
+        $this->assertSame(['field-gap', 'index-gap', 'missing-occupation'], $result->candidateBlockingSlugs);
+        $this->assertContains('resolve_index_entity_remediation_required', $result->candidateCohortPrerequisites);
+        $this->assertSame(['index_state_missing'], $result->rows[1]->approvalGatedReasons);
+    }
+
+    public function test_near_eligible_classification_excludes_entity_and_index_blockers(): void
+    {
+        $result = $this->classify([
+            $this->row('near-one', 'en', ['surface_unverified', 'sitemap_expected_not_ready']),
+            $this->row('index-gap', 'en', ['index_state_missing']),
+        ], targetCount: 2);
+
+        $this->assertSame(['near-one'], $result->nearEligibleSlugs);
+        $this->assertSame(['index-gap'], $result->candidateBlockingSlugs);
+        $this->assertFalse($result->readinessCanRun);
+        $this->assertContains('increase_near_eligible_candidates_to_2', $result->candidateCohortPrerequisites);
+    }
+
+    public function test_policy_summary_is_stable(): void
+    {
+        $summary = $this->classify([
+            $this->row('near-one', 'en', ['surface_unverified']),
+            $this->row('ready-one', 'en'),
+            $this->row('index-gap', 'en', ['index_state_missing']),
+        ], targetCount: 2)->summary();
+
+        $this->assertSame('career_2786_readiness_policy.v1', $summary['schema_version']);
+        $this->assertFalse($summary['readiness_can_run']);
+        $this->assertSame(1, $summary['remediation_required_count']);
+        $this->assertSame(1, $summary['deferred_until_candidate_count']);
+        $this->assertSame(1, $summary['near_eligible_count']);
+        $this->assertSame(1, $summary['eligible_candidate_count']);
+        $this->assertContains('candidate_only_surface_verification_after_80_candidates_exist', $summary['recommended_order']);
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     */
+    private function classify(array $rows, int $targetCount = 80): Career2786ReadinessPolicyResult
+    {
+        return (new Career2786ReadinessPolicyClassifier)->classify($this->report($rows), targetCount: $targetCount);
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $rows
+     */
+    private function report(array $rows): CareerCanonicalEligibilityReport
+    {
+        $blocked = count(array_filter($rows, static fn (CareerCanonicalEligibilityAuditRow $row): bool => $row->overallStatus !== CareerCanonicalEligibilityStatus::PASS));
+
+        return new CareerCanonicalEligibilityReport(
+            status: $blocked === 0 ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED,
+            scope: CareerCanonicalEligibilityScope::ALL,
+            expectedOccupations: count(array_unique(array_map(static fn (CareerCanonicalEligibilityAuditRow $row): string => $row->slug, $rows))),
+            auditedOccupations: count(array_unique(array_map(static fn (CareerCanonicalEligibilityAuditRow $row): string => $row->slug, $rows))),
+            eligibleCount: count($rows) - $blocked,
+            blockedCount: $blocked,
+            byReason: CareerCanonicalEligibilityReport::byReasonFromRows($rows),
+            rows: $rows,
+        );
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     */
+    private function row(string $slug, string $locale, array $reasons = []): CareerCanonicalEligibilityAuditRow
+    {
+        $status = $reasons === [] ? CareerCanonicalEligibilityStatus::PASS : CareerCanonicalEligibilityStatus::BLOCKED;
+
+        return new CareerCanonicalEligibilityAuditRow(
+            slug: $slug,
+            locale: $locale,
+            sourceScope: CareerCanonicalEligibilityScope::ALL,
+            entityStatus: $this->layer(CareerCanonicalEligibilityLayer::ENTITY, $this->layerStatus($reasons, ['occupation_missing', 'entity_field_missing']), array_values(array_intersect($reasons, ['occupation_missing', 'entity_field_missing']))),
+            baselineStatus: $this->layer(CareerCanonicalEligibilityLayer::BASELINE, CareerCanonicalEligibilityStatus::PASS),
+            indexStatus: $this->layer(CareerCanonicalEligibilityLayer::INDEX, $this->layerStatus($reasons, ['index_state_missing']), array_values(array_intersect($reasons, ['index_state_missing']))),
+            runtimeStatus: $this->layer(CareerCanonicalEligibilityLayer::RUNTIME, CareerCanonicalEligibilityStatus::PASS),
+            seoGeoStatus: $this->layer(CareerCanonicalEligibilityLayer::SEO_GEO, $this->layerStatus($reasons, ['sitemap_expected_not_ready', 'llms_expected_not_ready', 'llms_full_expected_not_ready']), array_values(array_intersect($reasons, ['sitemap_expected_not_ready', 'llms_expected_not_ready', 'llms_full_expected_not_ready']))),
+            surfaceStatus: $this->layer(CareerCanonicalEligibilityLayer::SURFACE, $this->layerStatus($reasons, ['surface_unverified', 'surface_artifact_missing']), array_values(array_intersect($reasons, ['surface_unverified', 'surface_artifact_missing']))),
+            safetyStatus: $this->layer(CareerCanonicalEligibilityLayer::SAFETY, CareerCanonicalEligibilityStatus::PASS),
+            overallStatus: $status,
+            severity: $status === CareerCanonicalEligibilityStatus::PASS ? CareerCanonicalEligibilitySeverity::INFO : CareerCanonicalEligibilitySeverity::HIGH,
+            reasons: $reasons,
+            evidence: [['slug' => $slug]],
+        );
+    }
+
+    /**
+     * @param  list<string>  $matches
+     */
+    private function layerStatus(array $reasons, array $matches): string
+    {
+        return array_intersect($reasons, $matches) === []
+            ? CareerCanonicalEligibilityStatus::PASS
+            : CareerCanonicalEligibilityStatus::BLOCKED;
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     */
+    private function layer(string $layer, string $status, array $reasons = []): CareerCanonicalEligibilityLayerStatus
+    {
+        return new CareerCanonicalEligibilityLayerStatus(
+            layer: $layer,
+            status: $status,
+            reasons: $reasons,
+            evidence: [['layer' => $layer]],
+            source: 'unit_test',
+        );
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/CareerCanonical80CandidateSelectorTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerCanonical80CandidateSelectorTest.php
@@ -87,8 +87,25 @@ final class CareerCanonical80CandidateSelectorTest extends TestCase
         $this->assertSame(2, $payload['candidate_count']);
         $this->assertSame(1, $payload['selected_count']);
         $this->assertSame(1, $payload['excluded_count']);
+        $this->assertSame('career_2786_readiness_policy.v1', $payload['policy_summary']['schema_version']);
         $this->assertSame(['actuaries'], $payload['selected_slugs']);
         $this->assertSame('excluded_hard_blocker', $payload['rows'][1]['candidate_status']);
+    }
+
+    public function test_policy_summary_defers_surface_and_preserves_index_remediation(): void
+    {
+        $report = $this->report([
+            $this->row('surface-wait', 'en', reasons: ['surface_unverified']),
+            $this->row('index-gap', 'en', reasons: ['index_state_missing']),
+        ]);
+
+        $payload = (new CareerCanonical80CandidateSelector)->select($report, targetCount: 2)->toArray();
+
+        $this->assertSame(1, $payload['policy_summary']['deferred_until_candidate_count']);
+        $this->assertSame(1, $payload['policy_summary']['remediation_required_count']);
+        $this->assertSame(1, $payload['policy_summary']['near_eligible_count']);
+        $this->assertContains('resolve_index_entity_remediation_required', $payload['policy_summary']['candidate_cohort_prerequisites']);
+        $this->assertContains('candidate_only_surface_verification_after_80_candidates_exist', $payload['policy_summary']['recommended_order']);
     }
 
     public function test_custom_hard_blockers_can_exclude_policy_reasons(): void
@@ -138,7 +155,7 @@ final class CareerCanonical80CandidateSelectorTest extends TestCase
             indexStatus: $this->layer(CareerCanonicalEligibilityLayer::INDEX, $this->layerStatus($reasons, 'index_state_missing')),
             runtimeStatus: $this->layer(CareerCanonicalEligibilityLayer::RUNTIME, $this->layerStatus($reasons, 'truth_row_missing')),
             seoGeoStatus: $this->layer(CareerCanonicalEligibilityLayer::SEO_GEO, $this->layerStatus($reasons, 'structured_data_missing')),
-            surfaceStatus: $this->layer(CareerCanonicalEligibilityLayer::SURFACE, $this->layerStatus($reasons, 'surface_context_missing')),
+            surfaceStatus: $this->layer(CareerCanonicalEligibilityLayer::SURFACE, $this->surfaceLayerStatus($reasons)),
             safetyStatus: $this->layer(CareerCanonicalEligibilityLayer::SAFETY, CareerCanonicalEligibilityStatus::PASS),
             overallStatus: $status,
             severity: $severity,
@@ -153,6 +170,13 @@ final class CareerCanonical80CandidateSelectorTest extends TestCase
         return in_array($reason, $reasons, true)
             ? CareerCanonicalEligibilityStatus::BLOCKED
             : CareerCanonicalEligibilityStatus::PASS;
+    }
+
+    private function surfaceLayerStatus(array $reasons): string
+    {
+        return array_intersect($reasons, ['surface_context_missing', 'surface_unverified', 'surface_artifact_missing']) === []
+            ? CareerCanonicalEligibilityStatus::PASS
+            : CareerCanonicalEligibilityStatus::BLOCKED;
     }
 
     private function layer(string $layer, string $status): CareerCanonicalEligibilityLayerStatus

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -404,6 +404,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_2786_readiness_policy_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/Career2786ReadinessPolicyClassifier.php',
+            'backend/app/Domain/Career/Audit/Career2786ReadinessPolicyIssue.php',
+            'backend/app/Domain/Career/Audit/Career2786ReadinessPolicyResult.php',
+            'backend/app/Domain/Career/Audit/Career2786ReadinessPolicyRow.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_expansion_manifest_train_changes(): void
     {
         $changed = [
@@ -1224,6 +1236,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareer2786ReadinessPolicyFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerExpansionManifestTrainFile($file)) {
                 continue;
             }
@@ -1762,6 +1778,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php',
+        ], true);
+    }
+
+    private function isCareer2786ReadinessPolicyFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/Career2786ReadinessPolicyClassifier.php',
+            'backend/app/Domain/Career/Audit/Career2786ReadinessPolicyIssue.php',
+            'backend/app/Domain/Career/Audit/Career2786ReadinessPolicyResult.php',
+            'backend/app/Domain/Career/Audit/Career2786ReadinessPolicyRow.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4311,6 +4311,65 @@
       "sidecar_issues": [
 
       ]
+    },
+    "REPAIR-INDEX-ENTITY-POLICY-2": {
+      "repo": "fap-api",
+      "branch": "fix/career-index-entity-policy-readiness-2",
+      "title": "fix(api): classify career readiness policy blockers",
+      "name": "Defer broad surface verification and classify index/entity/policy readiness",
+      "status": "in_progress",
+      "depends_on": [
+        "RUN-1E",
+        "CTX-SURFACE-EXPORT-1"
+      ],
+      "scope_type": "readiness_policy_classification_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/*",
+        "backend/app/Console/Commands/CareerAuditCanonicalEligibility.php",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no live crawl",
+        "no production DB query",
+        "no DB mutation",
+        "no index_state apply",
+        "no occupation backfill apply",
+        "no 80 readiness run",
+        "no manifest generation",
+        "no rollout",
+        "no fap-web change",
+        "no deploy"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided REPAIR-INDEX-ENTITY-POLICY-2 execution goal and authorized docs/codex train metadata updates for this item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "RUN-1E completed with surface context supplied; surface_context_missing removed, but broad surface/SEO policy states and index/entity gaps remain."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to audit policy classification/reporting, synthetic tests, career audit docs, train metadata, and optional freeze allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "RUN-1F rerun audit and SCAN-6 policy-aware decision",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+
+      ]
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1792,6 +1792,51 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-INDEX-ENTITY-POLICY-2
+    repo: fap-api
+    depends_on:
+      - RUN-1E
+      - CTX-SURFACE-EXPORT-1
+    branch: fix/career-index-entity-policy-readiness-2
+    title: "fix(api): classify career readiness policy blockers"
+    name: "Defer broad surface verification and classify index/entity/policy readiness"
+    scope_type: readiness_policy_classification_only
+    scope:
+      - Add policy classification for broad surface verification, SEO/GEO expected-not-ready states, and entity/index remediation gaps.
+      - Defer all-2786 surface verification until candidate cohort readiness without fabricating surface pass results.
+      - Preserve index/entity gaps as remediation-required and approval-gated planning blockers.
+      - Add policy summary output for audit and 80-candidate reports.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/*
+      - backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+      - backend/tests/Unit/Domain/Career/Audit/*
+      - backend/tests/Feature/Console/*
+      - backend/tests/Feature/Domain/Career/Audit/*
+      - backend/docs/career/audits/*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run production live crawl.
+      - Query production DB.
+      - Mutate DB or production state.
+      - Apply index_state remediation.
+      - Backfill occupations.
+      - Run 80 readiness.
+      - Generate expansion manifests.
+      - Run rollout.
+      - Touch fap-web.
+      - Deploy.
+    validation:
+      - php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi
+      - php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    next_pr: "RUN-1F rerun audit and SCAN-6 policy-aware decision"
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: RIASEC-PERSONALIZATION-00
     repo: fap-api
     branch: codex/riasec-personalization-00-train-registration


### PR DESCRIPTION
## Summary
- Adds Career 2786 readiness policy classification for broad surface verification, SEO/GEO expected-not-ready states, and index/entity remediation gaps.
- Defers broad surface verification until candidate stage; planner-only/unverified surface context is not treated as fake pass.
- Distinguishes `expected_not_ready` from hard blockers while preserving existing `by_reason` output.
- Keeps `index_state_missing`, `occupation_missing`, and `entity_field_missing` as remediation-required / approval-gated planning blockers.

## Non-goals / safety
- No live crawl.
- No production DB query.
- No DB mutation.
- No 80 readiness run.
- No manifest generation.
- No rollout/backfill/apply.
- No deploy.
- No fap-web changes.

## Tests
- `php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi`
- `php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=Career2786FullAuditArtifactBuilder --no-ansi`
- `php artisan test --filter=CareerSurfaceReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerSeoGeoReadinessAuditor --no-ansi`
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi`
- `php artisan test --filter=CareerOccupationEntityInventoryAuditor --no-ansi`
- `php artisan test --filter=CareerPublicResolutionPlanResolver --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh`

## Next step
RUN-1F rerun audit and SCAN-6 policy-aware decision.
