### PR TITLE
RIASEC-DEEP-COPY-08A — Expose RIASEC deep content slots through snapshot-bound projection

### DIFF
--- a/backend/app/Services/Report/RiasecReportComposer.php
+++ b/backend/app/Services/Report/RiasecReportComposer.php
@@ -89,6 +89,7 @@ final class RiasecReportComposer
             'score_space_version' => data_get($projectionV2, 'measurement_evidence.score_space_version'),
             'form_code' => data_get($projectionV2, 'form.form_code'),
             'validation_status' => data_get($projectionV2, 'measurement_evidence.validation_status'),
+            'deep_content_slots_schema_version' => data_get($projectionV2, 'deep_content_slots_v1.schema_version'),
         ];
     }
 

--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -24,6 +24,7 @@ final class RiasecPublicProjectionService
         private readonly RiasecInterpretationRuleContract $interpretationRuleContract,
         private readonly RiasecQualityRuleContract $qualityRuleContract,
         private readonly RiasecReportModuleSelector $moduleSelector,
+        private readonly RiasecDeepCopySlotRegistry $deepCopySlots,
     ) {}
 
     public function buildFromResult(Result $result, string $locale = 'zh-CN'): array
@@ -183,9 +184,286 @@ final class RiasecPublicProjectionService
             'activity_explorer_v0_1' => $this->activityExplorer->build((string) ($v1['top_code'] ?? ''), $locale),
         ];
         $projection['module_visibility_policy'] = $this->moduleSelector->build($projection);
+        $projection['deep_content_slots_v1'] = $this->deepContentSlotsEnvelope($projection, $locale);
         $projection['exploration_feedback_overlay_v0_1'] = $this->feedbackOverlay->build($result, $projection, $snapshotBound);
 
         return $projection;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @return array<string,mixed>
+     */
+    private function deepContentSlotsEnvelope(array $projection, string $locale): array
+    {
+        $qualityState = (string) data_get($projection, 'quality.quality_state', 'normal');
+        $formCode = (string) data_get($projection, 'form.form_code', 'riasec_60');
+        $topCode = (string) data_get($projection, 'holland_code.code', '');
+        $modulePolicy = is_array($projection['module_visibility_policy'] ?? null) ? $projection['module_visibility_policy'] : [];
+
+        $slots = [];
+        foreach ($this->deepCopySlots->dimensionSlots() as $slot) {
+            $this->appendRenderableSlot($slots, $slot, 'six_dimension_map', $modulePolicy, $locale);
+        }
+
+        foreach ($this->selectedPairKeys($topCode) as $pairKey) {
+            $this->appendRenderableSlot(
+                $slots,
+                $this->deepCopySlots->resolvePairBlendSlot($pairKey),
+                'pair_blend',
+                $modulePolicy,
+                $locale
+            );
+        }
+
+        foreach ($this->selected140qSlots($formCode, $qualityState) as $slotName) {
+            $moduleKey = str_starts_with($slotName, '140q_') ? '140q_cta' : '140q_context_cards';
+            $this->appendRenderableSlot(
+                $slots,
+                $this->deepCopySlots->resolve140qLayerSlot($slotName),
+                $moduleKey,
+                $modulePolicy,
+                $locale
+            );
+        }
+
+        foreach ($this->selectedQualitySlots($qualityState, $formCode) as $slotName) {
+            $slot = $this->deepCopySlots->lowQualitySlots()[$slotName] ?? null;
+            if (is_array($slot)) {
+                $this->appendRenderableSlot($slots, $slot, 'quality_copy', $modulePolicy, $locale, 'visible');
+            }
+        }
+
+        if ($formCode === 'riasec_140' && ! in_array($qualityState, ['low_quality', 'retake_recommended'], true)) {
+            foreach ($this->deepCopySlots->structuralDifferenceSlots() as $slot) {
+                $this->appendRenderableSlot($slots, $slot, 'structural_difference', $modulePolicy, $locale, 'collapsed');
+            }
+        }
+
+        if (! in_array($qualityState, ['low_quality', 'retake_recommended'], true)) {
+            foreach (['intro', 'input_boundary', 'no_score_mutation_boundary'] as $slotName) {
+                $this->appendRenderableSlot(
+                    $slots,
+                    $this->deepCopySlots->resolveAspirationsSlot($slotName),
+                    'aspirations_calibration',
+                    $modulePolicy,
+                    $locale,
+                    'collapsed'
+                );
+            }
+            foreach (['user_not_wrong_message', 'feedback_no_mutation_boundary', 'next_step'] as $slotName) {
+                $this->appendRenderableSlot(
+                    $slots,
+                    $this->deepCopySlots->resolveDisagreePathSlot($slotName),
+                    'disagree_path',
+                    $modulePolicy,
+                    $locale,
+                    'collapsed'
+                );
+            }
+        }
+
+        return [
+            'schema_version' => 'riasec.deep_content_slots.v1',
+            'scale_code' => 'RIASEC',
+            'locale' => str_starts_with(strtolower($locale), 'zh') ? 'zh-CN' : 'en',
+            'content_authority' => 'backend_riasec_deep_copy_slot_registry',
+            'snapshot_bound' => (bool) data_get($projection, 'measurement_evidence.snapshot_bound', false),
+            'source_policy' => [
+                'frontend_fallback_allowed' => false,
+                'missing_content_behavior' => 'omit_module_fail_closed',
+                'pending_content_behavior' => 'omit_module_fail_closed',
+                'unknown_slot_behavior' => 'hidden',
+                'formal_report_generation' => 'deterministic_backend_snapshot',
+            ],
+            'slot_visibility_policy' => [
+                'module_visibility_policy_id' => (string) data_get($projection, 'module_visibility_policy.policy_id', RiasecReportModuleSelector::POLICY_ID),
+                'hidden_slots_omitted' => true,
+                'pending_or_unavailable_slots_omitted' => true,
+                'frontend_inference_allowed' => false,
+            ],
+            'slots' => array_values($slots),
+        ];
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $slots
+     * @param  array<string,mixed>  $slot
+     * @param  array<string,mixed>  $modulePolicy
+     */
+    private function appendRenderableSlot(
+        array &$slots,
+        array $slot,
+        string $moduleKey,
+        array $modulePolicy,
+        string $locale,
+        ?string $forcedVisibility = null
+    ): void {
+        if (($slot['content_status'] ?? null) !== 'authored') {
+            return;
+        }
+        if (($slot['frontend_fallback_allowed'] ?? true) !== false) {
+            return;
+        }
+        if ($this->deepCopySlots->validateSlot($slot) !== []) {
+            return;
+        }
+
+        $visibility = $forcedVisibility ?? $this->moduleVisibility($modulePolicy, $moduleKey);
+        if ($visibility === 'hidden') {
+            return;
+        }
+
+        $slots[] = $this->publicDeepContentSlot($slot, $moduleKey, $visibility, $locale);
+    }
+
+    /**
+     * @param  array<string,mixed>  $modulePolicy
+     */
+    private function moduleVisibility(array $modulePolicy, string $moduleKey): string
+    {
+        foreach ((array) ($modulePolicy['modules'] ?? []) as $module) {
+            if (is_array($module) && ($module['key'] ?? null) === $moduleKey) {
+                $visibility = (string) ($module['visibility'] ?? 'hidden');
+
+                return in_array($visibility, ['visible', 'collapsed'], true) ? $visibility : 'hidden';
+            }
+        }
+
+        return 'hidden';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectedPairKeys(string $topCode): array
+    {
+        $letters = array_values(array_filter(str_split(strtoupper($topCode)), static fn (string $letter): bool => in_array($letter, RiasecDeepCopySlotRegistry::DIMENSIONS, true)));
+        $pairs = [];
+        for ($i = 0; $i < count($letters); $i++) {
+            for ($j = $i + 1; $j < count($letters); $j++) {
+                $pairs[] = $letters[$i].'_'.$letters[$j];
+            }
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selected140qSlots(string $formCode, string $qualityState): array
+    {
+        if (in_array($qualityState, ['low_quality', 'retake_recommended'], true)) {
+            return [];
+        }
+        if ($formCode === 'riasec_140') {
+            return ['task_activity_card', 'environment_card', 'role_responsibility_card', 'layer_agreement'];
+        }
+
+        return ['layer_unavailable', '140q_cta'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectedQualitySlots(string $qualityState, string $formCode): array
+    {
+        return match ($qualityState) {
+            'low_quality' => ['top_notice', 'user_not_blamed_message', 'what_happened_explanation', 'hidden_modules_explanation', 'retake_guidance', 'share_pdf_boundary', 'next_step'],
+            'retake_recommended' => ['top_notice', 'retake_guidance', 'share_pdf_boundary', 'next_step'],
+            'caution' => ['cautious_reading_notice'],
+            default => $formCode === 'riasec_60' ? ['minimal_quality_boundary_60q'] : [],
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $slot
+     * @return array<string,mixed>
+     */
+    private function publicDeepContentSlot(array $slot, string $moduleKey, string $visibility, string $locale): array
+    {
+        $contentKeys = [
+            'title',
+            'summary',
+            'body',
+            'core_drive',
+            'positive_value',
+            'real_world_cost',
+            'high_score_reading',
+            'low_score_safe_reading',
+            'work_activity_examples',
+            'possible_drains',
+            'common_misread',
+            'action_advice',
+            'pair_label',
+            'short_label',
+            'chemistry',
+            'activities_to_validate',
+            'question',
+            'what_user_sees',
+            'button_label',
+        ];
+        $content = [];
+        foreach ($contentKeys as $key) {
+            if (array_key_exists($key, $slot) && $slot[$key] !== null && $slot[$key] !== '' && $slot[$key] !== []) {
+                $content[$key] = $slot[$key];
+            }
+        }
+
+        return [
+            'slot_key' => (string) ($slot['slot_key'] ?? ''),
+            'slot_group' => (string) ($slot['slot_group'] ?? ''),
+            'slot_id' => $this->slotId($slot),
+            'module_key' => $moduleKey,
+            'slot_visibility' => $visibility,
+            'status' => (string) ($slot['content_status'] ?? 'unavailable'),
+            'content_status' => (string) ($slot['content_status'] ?? 'unavailable'),
+            'content_version' => (string) ($slot['content_version'] ?? ''),
+            'review_status' => (string) ($slot['review_status'] ?? ''),
+            'source_status' => (string) ($slot['source_status'] ?? ''),
+            'evidence_level' => (string) ($slot['evidence_level'] ?? ''),
+            'locale' => (string) ($slot['locale'] ?? (str_starts_with(strtolower($locale), 'zh') ? 'zh-CN' : 'en')),
+            'frontend_fallback_allowed' => false,
+            'fallback_behavior' => (string) ($slot['fallback_behavior'] ?? 'omit_module'),
+            'applicability' => [
+                'form_codes' => array_values((array) ($slot['applicable_form_codes'] ?? [])),
+                'profile_shapes' => array_values((array) ($slot['applicable_profile_shapes'] ?? [])),
+                'quality_states' => array_values((array) ($slot['applicable_quality_states'] ?? [])),
+                'codes' => array_values((array) ($slot['applicable_codes'] ?? [])),
+                'dimensions' => array_values((array) ($slot['applicable_dimensions'] ?? [])),
+            ],
+            'state' => array_filter([
+                'dimension_code' => $slot['dimension_code'] ?? null,
+                'pair_key' => $slot['pair_key'] ?? null,
+                'slot_name' => $slot['slot_name'] ?? null,
+                'layer_state' => $slot['layer_state'] ?? null,
+                'quality_state' => $slot['quality_state'] ?? null,
+                'structural_difference_state' => $slot['structural_difference_state'] ?? null,
+                'aspirations_state' => $slot['aspirations_state'] ?? null,
+                'disagree_state' => $slot['disagree_state'] ?? null,
+            ], static fn (mixed $value): bool => $value !== null && $value !== ''),
+            'content' => $content,
+            'boundaries' => [
+                'user_visible_boundary' => (string) ($slot['user_visible_boundary'] ?? ''),
+                'required_boundaries' => array_values((array) ($slot['required_boundaries'] ?? [])),
+                'forbidden_claims' => array_values((array) ($slot['forbidden_claims'] ?? [])),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $slot
+     */
+    private function slotId(array $slot): string
+    {
+        foreach (['dimension_code', 'pair_key', 'slot_name'] as $field) {
+            if (trim((string) ($slot[$field] ?? '')) !== '') {
+                return (string) ($slot['slot_key'] ?? '').':'.(string) $slot[$field];
+            }
+        }
+
+        return (string) ($slot['slot_key'] ?? '');
     }
 
     /**

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -127,6 +127,11 @@ final class RiasecAssessmentFlowTest extends TestCase
         $readback->assertJsonPath('riasec_public_projection_v2.module_visibility_policy.schema_version', 'riasec.module_visibility_policy.v1');
         $readback->assertJsonPath('riasec_public_projection_v2.module_visibility_policy.policy_id', 'riasec_module_visibility_policy_v1');
         $readback->assertJsonPath('riasec_public_projection_v2.module_visibility_policy.fallback_policy.frontend_inference_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.deep_content_slots_v1.schema_version', 'riasec.deep_content_slots.v1');
+        $readback->assertJsonPath('riasec_public_projection_v2.deep_content_slots_v1.source_policy.frontend_fallback_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.deep_content_slots_v1.slot_visibility_policy.frontend_inference_allowed', false);
+        $readback->assertJsonPath('riasec_public_projection_v2.deep_content_slots_v1.snapshot_bound', false);
+        $this->assertRiasecDeepContentSlots($readback->json('riasec_public_projection_v2.deep_content_slots_v1'), false);
         $readback->assertJsonPath('riasec_public_projection_v2.claim_boundary.does_not_measure.3', 'career_success_probability');
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.schema_version', 'riasec.activity_explorer.v0.1');
         $readback->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.status', 'content_examples_only');
@@ -164,6 +169,13 @@ final class RiasecAssessmentFlowTest extends TestCase
         $report->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
         $report->assertJsonPath('riasec_public_projection_v2.interpretation_state.field_authority.reading_strength', 'backend_owned');
         $report->assertJsonPath('riasec_public_projection_v2.module_visibility_policy.policy_id', 'riasec_module_visibility_policy_v1');
+        $report->assertJsonPath('riasec_public_projection_v2.deep_content_slots_v1.schema_version', 'riasec.deep_content_slots.v1');
+        $report->assertJsonPath('riasec_public_projection_v2.deep_content_slots_v1.snapshot_bound', true);
+        $report->assertJsonPath('report._meta.snapshot_binding_v1.deep_content_slots_schema_version', 'riasec.deep_content_slots.v1');
+        $this->assertSame(
+            $report->json('riasec_public_projection_v2.deep_content_slots_v1'),
+            $report->json('report._meta.riasec_public_projection_v2.deep_content_slots_v1')
+        );
         $report->assertJsonPath('riasec_public_projection_v2.activity_explorer_v0_1.boundary.occupation_examples_policy', 'content_example_not_registry_match_without_reviewed_registry_source');
         $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.snapshot_bound', true);
         $report->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.surface_policy.formal_report_mutation_allowed', false);
@@ -260,6 +272,9 @@ final class RiasecAssessmentFlowTest extends TestCase
         $this->assertIsArray($reportFull);
         $this->assertSame('RIA', (string) data_get($reportFull, 'top_code'));
         $this->assertTrue((bool) data_get($reportFull, '_meta.riasec_public_projection_v2.measurement_evidence.snapshot_bound'));
+        $this->assertSame('riasec.deep_content_slots.v1', (string) data_get($reportFull, '_meta.riasec_public_projection_v2.deep_content_slots_v1.schema_version'));
+        $this->assertTrue((bool) data_get($reportFull, '_meta.riasec_public_projection_v2.deep_content_slots_v1.snapshot_bound'));
+        $this->assertSame('riasec.deep_content_slots.v1', (string) data_get($reportFull, '_meta.snapshot_binding_v1.deep_content_slots_schema_version'));
 
         /** @var Result $stored */
         $stored = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
@@ -291,6 +306,8 @@ final class RiasecAssessmentFlowTest extends TestCase
         $share->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
         $share->assertJsonPath('riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
         $share->assertJsonPath('riasec_snapshot_binding_v1.snapshot_bound', true);
+        $share->assertJsonPath('riasec_public_projection_v2.deep_content_slots_v1.snapshot_bound', true);
+        $share->assertJsonPath('riasec_public_projection_v2.deep_content_slots_v1.source_policy.frontend_fallback_allowed', false);
         $share->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.read_model.raw_feedback_included', false);
         $share->assertJsonPath('riasec_public_projection_v2.exploration_feedback_overlay_v0_1.surface_policy.share_pdf_exposure_allowed', false);
 
@@ -303,6 +320,8 @@ final class RiasecAssessmentFlowTest extends TestCase
         $history->assertJsonPath('items.0.riasec_public_projection_v1.top_code', 'RIA');
         $history->assertJsonPath('items.0.riasec_public_projection_v2.measurement_evidence.snapshot_bound', true);
         $history->assertJsonPath('items.0.riasec_snapshot_binding_v1.snapshot_bound', true);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.deep_content_slots_v1.snapshot_bound', true);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.deep_content_slots_v1.slot_visibility_policy.frontend_inference_allowed', false);
         $history->assertJsonPath('items.0.riasec_public_projection_v2.exploration_feedback_overlay_v0_1.measured_result_guard.scores_mutation_allowed', false);
         $history->assertJsonPath('items.0.riasec_public_projection_v2.exploration_feedback_overlay_v0_1.claim_boundary.feedback_is_career_match', false);
         $history->assertJsonPath('history_compare.current_top_code', 'RIA');
@@ -370,6 +389,15 @@ final class RiasecAssessmentFlowTest extends TestCase
         $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.normalization_method', 'activity_environment_role_weighted_0_100');
         $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.quality_rule_version', 'riasec_quality_v1');
         $readback->assertJsonPath('riasec_public_projection_v2.measurement_evidence.quality_rule_status', 'quality_flags_available');
+        $this->assertRiasecDeepContentSlots($readback->json('riasec_public_projection_v2.deep_content_slots_v1'), false);
+        $slotIds = array_map(
+            static fn (array $slot): string => (string) data_get($slot, 'slot_id'),
+            (array) $readback->json('riasec_public_projection_v2.deep_content_slots_v1.slots')
+        );
+        $this->assertContains('140q_task_card_copy:task_activity_card', $slotIds);
+        $this->assertContains('140q_environment_card_copy:environment_card', $slotIds);
+        $this->assertContains('140q_role_card_copy:role_responsibility_card', $slotIds);
+        $this->assertContains('structural_difference_copy:summary', $slotIds);
     }
 
     public function test_riasec_history_compare_guard_blocks_60_and_140_raw_delta(): void
@@ -438,6 +466,58 @@ final class RiasecAssessmentFlowTest extends TestCase
     private function seedScales(): void
     {
         (new ScaleRegistrySeeder)->run();
+    }
+
+    private function assertRiasecDeepContentSlots(mixed $envelope, bool $snapshotBound): void
+    {
+        $this->assertIsArray($envelope);
+        $this->assertSame('riasec.deep_content_slots.v1', (string) data_get($envelope, 'schema_version'));
+        $this->assertSame($snapshotBound, (bool) data_get($envelope, 'snapshot_bound'));
+        $this->assertFalse((bool) data_get($envelope, 'source_policy.frontend_fallback_allowed', true));
+        $this->assertFalse((bool) data_get($envelope, 'slot_visibility_policy.frontend_inference_allowed', true));
+
+        $slots = data_get($envelope, 'slots');
+        $this->assertIsArray($slots);
+        $this->assertNotEmpty($slots);
+
+        $slotIds = [];
+        foreach ($slots as $slot) {
+            $this->assertIsArray($slot);
+            $this->assertSame('authored', (string) data_get($slot, 'status'));
+            $this->assertSame('authored', (string) data_get($slot, 'content_status'));
+            $this->assertFalse((bool) data_get($slot, 'frontend_fallback_allowed', true));
+            $this->assertContains((string) data_get($slot, 'slot_visibility'), ['visible', 'collapsed']);
+            $this->assertNotSame('', (string) data_get($slot, 'content_version'));
+            $this->assertNotSame('', (string) data_get($slot, 'review_status'));
+            $this->assertNotSame('', (string) data_get($slot, 'source_status'));
+            $this->assertNotSame([], data_get($slot, 'content'));
+            $slotIds[] = (string) data_get($slot, 'slot_id');
+        }
+
+        $this->assertContains('dimension_deep_copy:R', $slotIds);
+        $this->assertContains('dimension_deep_copy:I', $slotIds);
+        $this->assertContains('pair_blend_copy:I_A', $slotIds);
+        $this->assertNotContains('pair_blend_copy:R_I', $slotIds, 'Pending pair slots must fail closed instead of becoming frontend-renderable copy.');
+
+        $serialized = json_encode($envelope, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        foreach ([
+            'Matches',
+            'career recommendation',
+            'job fit',
+            'success prediction',
+            'success probability',
+            'hiring suitability',
+            '140Q more accurate',
+            'raw score delta',
+            '60Q wrong',
+            '更准确',
+            '更准',
+            '岗位匹配',
+            '职业推荐',
+            '职业成功',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $serialized);
+        }
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4263,7 +4263,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-deep-copy-08a-projection-slots",
       "title": "feat(riasec): expose deep content slots in projection",
-      "status": "in_progress",
+      "status": "open",
       "depends_on": [
         "RIASEC-DEEP-COPY-07"
       ],
@@ -4275,8 +4275,8 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": "pending_before_push",
-      "pr_url": "",
+      "commit_sha": "5f8a4579",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1371",
       "checks": {
         "dependency": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4198,7 +4198,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-deep-copy-07-aspirations-disagree-slots",
       "title": "feat(riasec): add aspirations disagree copy slots",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "RIASEC-DEEP-COPY-06"
       ],
@@ -4212,7 +4212,7 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": "ea9701ec",
+      "commit_sha": "058181300f6221f5bfbb5a4455e0b4c86564fb9e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1368",
       "checks": {
         "dependency": {
@@ -4247,11 +4247,90 @@
         }
       },
       "failure_reason": null,
+      "merged_at": "2026-05-13T13:37:47Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "RIASEC-DEEP-COPY-07 local cleanup was not executed in this 08A worktree",
+          "severity": "low",
+          "evidence": "GitHub PR #1368 is merged with commit 058181300f6221f5bfbb5a4455e0b4c86564fb9e and the remote branch is absent. The current task runs in an isolated 08A worktree, so prior local cleanup is recorded as not executed here.",
+          "suggested_owner": "repo-maintenance"
+        }
+      ]
+    },
+    "RIASEC-DEEP-COPY-08A": {
+      "repo": "fap-api",
+      "branch": "codex/riasec-deep-copy-08a-projection-slots",
+      "title": "feat(riasec): expose deep content slots in projection",
+      "status": "in_progress",
+      "depends_on": [
+        "RIASEC-DEEP-COPY-07"
+      ],
+      "scope_type": "backend_projection_report_deep_content_slots_only",
+      "allowed_paths": [
+        "backend/app/Services/Riasec/RiasecPublicProjectionService.php",
+        "backend/app/Services/Report/RiasecReportComposer.php",
+        "backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "commit_sha": "pending_before_push",
+      "pr_url": "",
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "RIASEC-DEEP-COPY-07 is merged as PR #1368 with merge commit 058181300f6221f5bfbb5a4455e0b4c86564fb9e; origin/main contains the merge commit."
+        },
+        "riasec_assessment_flow": {
+          "status": "pass_with_existing_warnings",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi",
+          "evidence": "5 tests passed with pre-existing file_get_contents warnings; 629 assertions. Added coverage for projection/report/share/history deep_content_slots_v1 snapshot binding."
+        },
+        "riasec_deep_copy_registry_contracts": {
+          "status": "pass",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php --no-ansi",
+          "evidence": "39 tests passed, 1622 assertions."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecPublicProjectionService.php app/Services/Report/RiasecReportComposer.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+          "evidence": "PASS, 3 files."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi | rg \"attempts|RIASEC|report\" | head -n 40",
+          "evidence": "Attempt result/report/report-access/report.pdf/share routes remain registered."
+        },
+        "json_yaml_validity": {
+          "status": "pass",
+          "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")' && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        },
+        "forbidden_runtime_claim_grep": {
+          "status": "pass",
+          "command": "rg -n \"Matches|career recommendation|job fit|success prediction|success probability|hiring suitability|140Q more accurate|raw score delta|更准确|更准|岗位匹配|职业推荐|职业成功\" backend/app/Services/Riasec/RiasecPublicProjectionService.php backend/app/Services/Report/RiasecReportComposer.php || true",
+          "evidence": "No runtime service hits."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to fap-api train metadata, RiasecPublicProjectionService, RiasecReportComposer, and RiasecAssessmentFlowTest. No scorer math, question content packs, fap-web UI, career registry, feedback stream, analytics runtime, or AI report generation files changed."
+        }
+      },
+      "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": [
-
+        {
+          "title": "Primary fap-api worktree contains unrelated PR-CMS train metadata edits",
+          "severity": "medium",
+          "evidence": "/Users/rainie/Desktop/GitHub/fap-api has uncommitted backend/docs/codex/pr-train.yaml and backend/docs/codex/pr-train-state.json edits on codex/pr-cms-01-article-editorial-package-draft-gate. 08A is isolated in /private/tmp/fap-api-riasec-deep-copy-08a.",
+          "suggested_owner": "repo-maintenance"
+        }
       ]
     },
     "CTX-SURFACE-EXPORT-1": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2244,3 +2244,32 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: RIASEC-DEEP-COPY-08A
+    repo: fap-api
+    depends_on:
+      - RIASEC-DEEP-COPY-07
+    branch: codex/riasec-deep-copy-08a-projection-slots
+    title: "feat(riasec): expose deep content slots in projection"
+    scope:
+      - Expose backend-authoritative RIASEC deep copy slots through riasec_public_projection_v2.
+      - Keep the deep slot envelope deterministic, snapshot-bound through the existing report meta path, and fail-closed for missing or pending content.
+      - Register the PR train item and cover result/report/share/history snapshot consistency.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecPublicProjectionService.php
+      - backend/app/Services/Report/RiasecReportComposer.php
+      - backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change RIASEC scorer math or question content pack semantics.
+      - Add frontend rendering or local interpretation fallback.
+      - Add career matching, recommendation, job fit, ranking, success, hiring, raw delta, or 140Q accuracy claims.
+      - Change career registry, feedback stream, analytics, share/PDF/history runtime behavior, or AI-generated report logic.
+    validation:
+      - targeted PHPUnit for RIASEC assessment flow and deep copy registry contracts
+      - scoped Pint for touched PHP
+      - JSON/YAML validity
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## What changed
- Registered `RIASEC-DEEP-COPY-08A` in the fap-api PR train manifest/state.
- Added `riasec_public_projection_v2.deep_content_slots_v1` as a backend-authoritative, additive RIASEC projection envelope.
- Exposed only validated/authored slots from `RiasecDeepCopySlotRegistry`; pending, unavailable, hidden, or invalid slots fail closed and are omitted.
- Added the deep slot schema version to the RIASEC snapshot binding so report/share/history/PDF paths can verify the same snapshot-bound projection payload.
- Extended RIASEC flow tests for result/report/snapshot/share/history deep slot consistency and forbidden claim boundaries.

## Why
Frontend DEEP-COPY-08B needs backend-provided content slots before it can render V11 deep copy safely. This keeps interpretation authority in fap-api and prevents frontend inference or local editorial fallback.

## Validation commands
- `php -l backend/app/Services/Riasec/RiasecPublicProjectionService.php && php -l backend/app/Services/Report/RiasecReportComposer.php && php -l backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")' && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecPublicProjectionService.php app/Services/Report/RiasecReportComposer.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `cd backend && php artisan route:list --no-ansi | rg "attempts|RIASEC|report" | head -n 40`
- `rg -n "Matches|career recommendation|job fit|success prediction|success probability|hiring suitability|140Q more accurate|raw score delta|更准确|更准|岗位匹配|职业推荐|职业成功" backend/app/Services/Riasec/RiasecPublicProjectionService.php backend/app/Services/Report/RiasecReportComposer.php || true`

## Intentionally deferred
- No fap-web renderer changes; DEEP-COPY-08B consumes this payload later.
- No scoring math, RIASEC question content pack, career registry, feedback stream, analytics runtime, or AI report generation changes.
- No frontend fallback copy.

## Repository rule impact
RIASEC deep copy remains backend-authoritative. Frontend must consume `deep_content_slots_v1` and fail closed for missing, pending, unavailable, or unknown slots.

## Sidecar issues
- Primary `/Users/rainie/Desktop/GitHub/fap-api` worktree contains unrelated PR-CMS train metadata edits, so this PR was isolated in `/private/tmp/fap-api-riasec-deep-copy-08a`.
- `RiasecAssessmentFlowTest` passes with existing file_get_contents warnings in this isolated worktree.
