### PR TITLE
fix(api): add guarded career index state remediation command

### DIFF
--- a/backend/app/Console/Commands/CareerRemediateCanonicalIndexState.php
+++ b/backend/app/Console/Commands/CareerRemediateCanonicalIndexState.php
@@ -1,0 +1,610 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\IndexStateValue;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+final class CareerRemediateCanonicalIndexState extends Command
+{
+    private const SOURCE = 'career_2786_minimum_index_state_remediation';
+
+    private const DEFAULT_MAX_SLUGS = 100;
+
+    protected $signature = 'career:remediate-canonical-index-state
+        {--slug-artifact= : Reviewed explicit slug artifact JSON path}
+        {--target-state=indexed : Target index_state value}
+        {--batch-id= : Reviewed remediation batch id}
+        {--reason= : Explicit remediation reason}
+        {--dry-run : Plan without writing}
+        {--apply : Execute guarded index_state writes}
+        {--max-slugs=100 : Maximum allowed explicit slugs}
+        {--expect-slug-count= : Expected slug count for confirmation}
+        {--confirm-artifact-sha256= : Required for --apply; must match slug artifact sha256}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for JSON payload}';
+
+    protected $description = 'Guarded explicit-slug Career index_state remediation dry-run/apply gate.';
+
+    public function handle(): int
+    {
+        try {
+            $mode = $this->mode();
+            $artifactPath = $this->requiredOption('slug-artifact');
+            $targetState = $this->targetState();
+            $batchId = $this->requiredOption('batch-id');
+            $reason = $this->reason($mode);
+            $maxSlugs = $this->positiveIntOption('max-slugs', self::DEFAULT_MAX_SLUGS);
+            $expectedSlugCount = $this->nullablePositiveIntOption('expect-slug-count');
+
+            [$artifact, $artifactSha] = $this->readSlugArtifact($artifactPath);
+            $slugs = $artifact['slugs'];
+            $slugCount = count($slugs);
+
+            $blockers = [
+                ...$this->confirmationBlockers($mode, $artifactSha, $slugCount, $expectedSlugCount),
+                ...$this->artifactSafetyBlockers($slugCount, $maxSlugs),
+            ];
+
+            $plan = $this->plan($slugs, $targetState, $batchId, $reason, $artifactPath, $artifactSha);
+            $blockers = [
+                ...$blockers,
+                ...$plan['blockers'],
+            ];
+
+            if ($mode === 'dry-run' || $blockers !== []) {
+                return $this->finish($this->dryRunPayload(
+                    $plan,
+                    $artifact,
+                    $artifactPath,
+                    $artifactSha,
+                    $targetState,
+                    $batchId,
+                    $reason,
+                    $maxSlugs,
+                    $expectedSlugCount,
+                    $blockers
+                ), $blockers === [] ? self::SUCCESS : self::FAILURE);
+            }
+
+            $payload = $this->apply($plan, $artifact, $artifactPath, $artifactSha, $targetState, $batchId, $reason, $maxSlugs, $expectedSlugCount);
+
+            return $this->finish($payload, ($payload['status'] ?? null) === 'applied' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'status' => 'blocked',
+                'writes_database' => false,
+                'write_verified' => false,
+                'by_reason' => [$this->reasonKey($exception->getMessage()) => 1],
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                ]],
+            ], self::FAILURE);
+        }
+    }
+
+    private function mode(): string
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $apply = (bool) $this->option('apply');
+
+        if ($dryRun === $apply) {
+            throw new RuntimeException('exactly_one_of_dry_run_or_apply_required');
+        }
+
+        return $apply ? 'apply' : 'dry-run';
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function reason(string $mode): string
+    {
+        $value = trim((string) ($this->option('reason') ?? ''));
+
+        if ($value === '' && $mode === 'apply') {
+            throw new RuntimeException('reason_missing');
+        }
+
+        return $value !== '' ? $value : 'minimum_80_candidate_unlock';
+    }
+
+    private function targetState(): string
+    {
+        $targetState = strtolower(trim((string) ($this->option('target-state') ?? '')));
+        if (! IndexStateValue::isIndexedLike($targetState, true)) {
+            throw new RuntimeException('target_state_not_indexed_like');
+        }
+
+        return $targetState;
+    }
+
+    private function positiveIntOption(string $name, int $default): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return $default;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    private function nullablePositiveIntOption(string $name): ?int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return null;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    private function readSlugArtifact(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('slug_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException('slug_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException('slug_artifact_json_invalid');
+        }
+
+        $slugs = is_array($decoded) && array_is_list($decoded)
+            ? $decoded
+            : (is_array($decoded) ? ($decoded['slugs'] ?? null) : null);
+
+        if (! is_array($slugs) || ! array_is_list($slugs)) {
+            throw new RuntimeException('slug_list_missing');
+        }
+
+        $normalized = [];
+        $seen = [];
+        foreach ($slugs as $index => $slug) {
+            if (! is_string($slug)) {
+                throw new RuntimeException('slug_invalid_at_'.$index);
+            }
+
+            $value = strtolower(trim($slug));
+            if ($value === '' || str_contains($value, '*')) {
+                throw new RuntimeException('slug_invalid_at_'.$index);
+            }
+
+            if (isset($seen[$value])) {
+                throw new RuntimeException('duplicate_slug_'.$value);
+            }
+
+            $seen[$value] = true;
+            $normalized[] = $value;
+        }
+
+        if ($normalized === []) {
+            throw new RuntimeException('slug_list_empty');
+        }
+
+        $declaredCount = null;
+        if (is_array($decoded) && ! array_is_list($decoded)) {
+            $declaredCount = $decoded['count']
+                ?? $decoded['slug_count']
+                ?? data_get($decoded, 'target.slug_count')
+                ?? data_get($decoded, 'target.needed_additional_count');
+        }
+
+        if ($declaredCount !== null && (int) $declaredCount !== count($normalized)) {
+            throw new RuntimeException('slug_count_declared_mismatch');
+        }
+
+        return [[
+            'schema_version' => is_array($decoded) && ! array_is_list($decoded) ? ($decoded['schema_version'] ?? null) : 'slug_list.v1',
+            'declared_count' => $declaredCount === null ? count($normalized) : (int) $declaredCount,
+            'slugs' => $normalized,
+            'raw_summary' => is_array($decoded) && ! array_is_list($decoded) ? [
+                'source' => $decoded['source'] ?? null,
+                'target' => $decoded['target'] ?? null,
+                'count' => $decoded['count'] ?? null,
+            ] : null,
+        ], hash('sha256', $contents)];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function confirmationBlockers(string $mode, string $artifactSha, int $slugCount, ?int $expectedSlugCount): array
+    {
+        $blockers = [];
+
+        if ($mode === 'apply') {
+            $confirmedSha = trim((string) ($this->option('confirm-artifact-sha256') ?? ''));
+            if ($confirmedSha === '') {
+                $blockers[] = $this->blocker('confirm_artifact_sha256_missing', 'Apply requires --confirm-artifact-sha256.');
+            } elseif (! hash_equals($artifactSha, $confirmedSha)) {
+                $blockers[] = $this->blocker('artifact_sha256_mismatch', 'Artifact sha256 confirmation does not match.');
+            }
+
+            if ($expectedSlugCount === null) {
+                $blockers[] = $this->blocker('expect_slug_count_missing', 'Apply requires --expect-slug-count.');
+            }
+        }
+
+        if ($expectedSlugCount !== null && $expectedSlugCount !== $slugCount) {
+            $blockers[] = $this->blocker('expect_slug_count_mismatch', 'Expected slug count does not match artifact slug count.');
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function artifactSafetyBlockers(int $slugCount, int $maxSlugs): array
+    {
+        if ($slugCount > $maxSlugs) {
+            return [$this->blocker('slug_count_exceeds_max_slugs', 'Artifact slug count exceeds --max-slugs guard.')];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{slugs: list<string>, missing_occupations: list<string>, existing_latest_index_states: list<array<string, mixed>>, planned_writes: list<array<string, mixed>>, blockers: list<array<string, mixed>>}
+     */
+    private function plan(array $slugs, string $targetState, string $batchId, string $reason, string $artifactPath, string $artifactSha): array
+    {
+        $occupations = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->with(['indexStates' => fn ($query) => $query
+                ->orderByDesc('changed_at')
+                ->orderByDesc('created_at')
+                ->orderByDesc('updated_at')])
+            ->get()
+            ->keyBy(fn (Occupation $occupation): string => strtolower((string) $occupation->getAttribute('canonical_slug')));
+
+        $missing = [];
+        $existing = [];
+        $writes = [];
+        $blockers = [];
+
+        foreach ($slugs as $slug) {
+            /** @var Occupation|null $occupation */
+            $occupation = $occupations->get($slug);
+            if ($occupation === null) {
+                $missing[] = $slug;
+                $blockers[] = $this->blocker('occupation_missing', 'Occupation is required before index_state remediation apply.', ['canonical_slug' => $slug]);
+
+                continue;
+            }
+
+            /** @var IndexState|null $latest */
+            $latest = $occupation->indexStates->first();
+            $existing[] = $this->latestIndexStatePayload($slug, $latest);
+
+            if ($latest !== null && IndexStateValue::isIndexedLike((string) $latest->getAttribute('index_state'), (bool) $latest->getAttribute('index_eligible'))) {
+                continue;
+            }
+
+            $writes[] = [
+                'canonical_slug' => $slug,
+                'occupation_id' => (string) $occupation->getAttribute('id'),
+                'target_state' => $targetState,
+                'index_eligible' => true,
+                'canonical_path' => '/career/jobs/'.$slug,
+                'canonical_target' => null,
+                'reason_codes' => $this->reasonCodes($batchId, $reason, $artifactPath, $artifactSha, $targetState),
+                'row_fingerprint' => $this->rowFingerprint($slug, $targetState, $batchId, $artifactSha),
+            ];
+        }
+
+        return [
+            'slugs' => $slugs,
+            'missing_occupations' => $missing,
+            'existing_latest_index_states' => $existing,
+            'planned_writes' => $writes,
+            'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function reasonCodes(string $batchId, string $reason, string $artifactPath, string $artifactSha, string $targetState): array
+    {
+        return [
+            self::SOURCE,
+            'minimum_80_candidate_unlock',
+            'batch_id:'.$batchId,
+            'reason:'.Str::slug($reason, '_'),
+            'artifact_sha256:'.$artifactSha,
+            'artifact_basename:'.basename($artifactPath),
+            'target_state:'.$targetState,
+        ];
+    }
+
+    private function rowFingerprint(string $slug, string $targetState, string $batchId, string $artifactSha): string
+    {
+        return hash('sha256', json_encode([
+            'source' => self::SOURCE,
+            'canonical_slug' => $slug,
+            'target_state' => $targetState,
+            'batch_id' => $batchId,
+            'artifact_sha256' => $artifactSha,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    private function latestIndexStatePayload(string $slug, ?IndexState $latest): array
+    {
+        if ($latest === null) {
+            return [
+                'canonical_slug' => $slug,
+                'index_state_id' => null,
+                'index_state' => null,
+                'index_eligible' => false,
+                'public_facing_state' => null,
+                'changed_at' => null,
+                'reason_codes' => [],
+            ];
+        }
+
+        $state = (string) $latest->getAttribute('index_state');
+        $eligible = (bool) $latest->getAttribute('index_eligible');
+
+        return [
+            'canonical_slug' => $slug,
+            'index_state_id' => (string) $latest->getAttribute('id'),
+            'index_state' => $state,
+            'index_eligible' => $eligible,
+            'public_facing_state' => IndexStateValue::publicFacing($state, $eligible),
+            'changed_at' => $latest->getAttribute('changed_at')?->toISOString(),
+            'reason_codes' => $latest->getAttribute('reason_codes') ?? [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @param  array<string, mixed>  $artifact
+     * @param  list<array<string, mixed>>  $blockers
+     * @return array<string, mixed>
+     */
+    private function dryRunPayload(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $targetState, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount, array $blockers): array
+    {
+        return [
+            'status' => $blockers === [] ? 'planned' : 'blocked',
+            'mode' => 'dry_run',
+            'writes_database' => false,
+            'write_verified' => false,
+            'target_state' => $targetState,
+            'batch_id' => $batchId,
+            'reason' => $reason,
+            'slug_artifact' => $artifactPath,
+            'artifact_schema_version' => $artifact['schema_version'],
+            'artifact_sha256' => $artifactSha,
+            'slug_count' => count($plan['slugs']),
+            'max_slugs' => $maxSlugs,
+            'expect_slug_count' => $expectedSlugCount,
+            'slugs' => $plan['slugs'],
+            'missing_occupations' => $plan['missing_occupations'],
+            'existing_latest_index_states' => $plan['existing_latest_index_states'],
+            'planned_writes' => $plan['planned_writes'],
+            'planned_write_count' => count($plan['planned_writes']),
+            'blockers' => $blockers,
+            'by_reason' => $this->byReason($blockers),
+            'approval_phrase_template' => 'I explicitly approve Career 2786 minimum index_state remediation apply for reviewed slug artifact <SLUG_ARTIFACT> with sha256 <SHA256> and <COUNT> slugs on <ENVIRONMENT>; no deploy, rollout, backfill, rollback, quarantine, or publication expansion is approved.',
+            'read_only' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, mixed>
+     */
+    private function apply(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $targetState, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount): array
+    {
+        $created = [];
+        $failures = [];
+
+        DB::transaction(function () use ($plan, &$created, &$failures): void {
+            foreach ($plan['planned_writes'] as $write) {
+                try {
+                    /** @var IndexState $indexState */
+                    $indexState = IndexState::query()->create([
+                        'occupation_id' => $write['occupation_id'],
+                        'index_state' => $write['target_state'],
+                        'index_eligible' => $write['index_eligible'],
+                        'canonical_path' => $write['canonical_path'],
+                        'canonical_target' => $write['canonical_target'],
+                        'reason_codes' => $write['reason_codes'],
+                        'changed_at' => now(),
+                        'row_fingerprint' => $write['row_fingerprint'],
+                    ]);
+
+                    $created[] = [
+                        'canonical_slug' => $write['canonical_slug'],
+                        'index_state_id' => (string) $indexState->getAttribute('id'),
+                    ];
+                } catch (Throwable $exception) {
+                    $failures[] = [
+                        'canonical_slug' => $write['canonical_slug'],
+                        'reason' => 'index_state_write_failed',
+                        'message' => $exception->getMessage(),
+                    ];
+                }
+            }
+
+            if ($failures !== []) {
+                throw new RuntimeException('index_state_write_failed');
+            }
+        });
+
+        $verification = $this->verifyWrites($plan['slugs'], $targetState, $artifactSha);
+        $blockers = $verification['blockers'];
+
+        return [
+            'status' => $blockers === [] ? 'applied' : 'blocked',
+            'mode' => 'apply',
+            'writes_database' => $blockers === [],
+            'write_verified' => $blockers === [],
+            'target_state' => $targetState,
+            'batch_id' => $batchId,
+            'reason' => $reason,
+            'slug_artifact' => $artifactPath,
+            'artifact_schema_version' => $artifact['schema_version'],
+            'artifact_sha256' => $artifactSha,
+            'slug_count' => count($plan['slugs']),
+            'max_slugs' => $maxSlugs,
+            'expect_slug_count' => $expectedSlugCount,
+            'created_count' => count($created),
+            'verified_count' => $verification['verified_count'],
+            'created' => $created,
+            'failures' => $failures,
+            'blockers' => $blockers,
+            'by_reason' => $this->byReason($blockers),
+            'read_only' => false,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{verified_count: int, blockers: list<array<string, mixed>>}
+     */
+    private function verifyWrites(array $slugs, string $targetState, string $artifactSha): array
+    {
+        $occupations = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->with(['indexStates' => fn ($query) => $query
+                ->orderByDesc('changed_at')
+                ->orderByDesc('created_at')
+                ->orderByDesc('updated_at')])
+            ->get()
+            ->keyBy(fn (Occupation $occupation): string => strtolower((string) $occupation->getAttribute('canonical_slug')));
+
+        $verified = 0;
+        $blockers = [];
+
+        foreach ($slugs as $slug) {
+            /** @var Occupation|null $occupation */
+            $occupation = $occupations->get($slug);
+            /** @var IndexState|null $latest */
+            $latest = $occupation?->indexStates->first();
+            $state = (string) ($latest?->getAttribute('index_state') ?? '');
+            $eligible = (bool) ($latest?->getAttribute('index_eligible') ?? false);
+            $reasonCodes = $latest?->getAttribute('reason_codes') ?? [];
+
+            if ($latest === null || ! IndexStateValue::isIndexedLike($state, $eligible)) {
+                $blockers[] = $this->blocker('write_verification_failed', 'Latest index_state is not indexed-like after apply.', ['canonical_slug' => $slug]);
+
+                continue;
+            }
+
+            if ($state !== $targetState || ! in_array('artifact_sha256:'.$artifactSha, $reasonCodes, true)) {
+                $blockers[] = $this->blocker('write_metadata_verification_failed', 'Latest index_state is missing expected target state or artifact metadata.', ['canonical_slug' => $slug]);
+
+                continue;
+            }
+
+            $verified++;
+        }
+
+        return ['verified_count' => $verified, 'blockers' => $blockers];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $blockers
+     * @return array<string, int>
+     */
+    private function byReason(array $blockers): array
+    {
+        $counts = [];
+        foreach ($blockers as $blocker) {
+            $reason = (string) ($blocker['reason'] ?? 'unknown');
+            $counts[$reason] = ($counts[$reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, string $message, array $evidence = []): array
+    {
+        return [
+            'reason' => $reason,
+            'message' => $message,
+            'evidence' => $evidence,
+        ];
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $value = strtolower(trim($message));
+        $value = preg_replace('/[^a-z0-9_]+/', '_', $value) ?: 'command_failed';
+
+        return trim($value, '_') ?: 'command_failed';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            file_put_contents($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('writes_database='.(($payload['writes_database'] ?? false) ? 'true' : 'false'));
+        }
+
+        return $exitCode;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -42,6 +42,7 @@ use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerNormalizeLegacyDisplayAssets;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
+use App\Console\Commands\CareerRemediateCanonicalIndexState;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
@@ -202,6 +203,7 @@ class Kernel extends ConsoleKernel
         CareerNormalizeLegacyDisplayAssets::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
         CareerReleaseGateNoindexCleanup::class,
+        CareerRemediateCanonicalIndexState::class,
         CareerValidateAssetImport::class,
         CareerValidateBroadGroupFamilyMap::class,
         CareerValidateCanonicalRuntimeTruth::class,

--- a/backend/docs/career/audits/index_state_authority_audit.md
+++ b/backend/docs/career/audits/index_state_authority_audit.md
@@ -91,3 +91,16 @@ Rows requiring production DB writes set `approval_required=true` and emit the ap
 `I explicitly approve production index_state remediation apply for Career 2786 using reviewed plan <PLAN_PATH>.`
 
 This approval gate is informational in this PR. No apply command is added, and no production mutation is performed.
+
+## Minimum Explicit-Slug Apply Gate
+
+`REPAIR-INDEX-STATE-MINIMUM-APPLY-PLAN-2` adds the guarded command
+`career:remediate-canonical-index-state` for reviewed explicit slug artifacts.
+It supports non-mutating dry-run and a future approval-gated apply path. Apply
+requires artifact sha256 confirmation, expected slug count confirmation, a
+batch id, a reason, and the default `--max-slugs=100` safety guard.
+
+The command does not perform rollout, occupation backfill, sitemap/LLMS changes,
+runtime promotion, or publication expansion. See
+`index_state_minimum_remediation.md` for the command contract and future
+approval phrase.

--- a/backend/docs/career/audits/index_state_minimum_remediation.md
+++ b/backend/docs/career/audits/index_state_minimum_remediation.md
@@ -1,0 +1,126 @@
+# Career Index-State Minimum Remediation Gate
+
+`REPAIR-INDEX-STATE-MINIMUM-APPLY-PLAN-2` adds a guarded command for the
+minimum index-state remediation path identified after RUN-1F.
+
+The command is:
+
+```bash
+php artisan career:remediate-canonical-index-state \
+  --slug-artifact=/tmp/career_2786_minimum_index_state_slugs_for_80.json \
+  --batch-id=career_2786_minimum_80_index_state \
+  --reason=minimum_80_candidate_unlock \
+  --expect-slug-count=51 \
+  --dry-run \
+  --json
+```
+
+## Purpose
+
+The command accepts a reviewed explicit slug artifact and plans the exact
+`index_states` rows that would be created for those slugs. It refuses broad or
+implicit remediation. It does not infer all missing index states from the DB or
+from the audit.
+
+The command supports a guarded `--apply` path for a future approval-gated task,
+but this PR does not run production apply.
+
+## Slug Artifact
+
+The reviewed artifact should contain a finite slug list:
+
+```json
+{
+  "schema_version": "career_minimum_index_state_remediation.v1",
+  "source": {
+    "audit_artifact": "/tmp/career_2786_canonical_eligibility_audit_run1f.json",
+    "purpose": "minimum_80_candidate_unlock"
+  },
+  "target": {
+    "current_near_eligible_count": 29,
+    "needed_additional_count": 51,
+    "expected_near_eligible_after_plan": 80
+  },
+  "count": 51,
+  "slugs": ["actors"]
+}
+```
+
+Validation rules:
+
+- artifact file is required
+- JSON must parse
+- slug list must be present and non-empty
+- duplicate slugs are rejected
+- wildcard and empty slugs are rejected
+- declared slug count must match the actual list if present
+- slug count must be at or below `--max-slugs`, default `100`
+- there is no implicit all-2786 mode
+
+## Dry-Run
+
+`--dry-run` is non-mutating. It emits:
+
+- `status=planned` or `status=blocked`
+- `writes_database=false`
+- artifact sha256
+- explicit slug count and slug list
+- missing occupations
+- existing latest index states
+- planned writes
+- blockers
+- future approval phrase template
+
+Dry-run can be used against a reviewed artifact before requesting production DB
+mutation approval.
+
+## Apply Gate
+
+`--apply` is intentionally strict. It requires:
+
+- `--confirm-artifact-sha256` matching the artifact content
+- `--expect-slug-count` matching the artifact slug count
+- `--batch-id`
+- `--reason`
+- slug count at or below `--max-slugs`
+- all target slugs have an existing `Occupation`
+
+The apply path writes only new `index_states` rows for explicit slugs in the
+artifact. It does not create occupations, backfill entities, promote runtime
+truth, update sitemap/LLMS state, run rollout, or publish occupations.
+
+Each written row includes reason code metadata:
+
+- `career_2786_minimum_index_state_remediation`
+- `minimum_80_candidate_unlock`
+- `batch_id:<batch-id>`
+- `reason:<reason>`
+- `artifact_sha256:<sha>`
+- `artifact_basename:<basename>`
+- `target_state:<state>`
+
+## Verification
+
+After apply, the command verifies that the latest `index_states` row for each
+target slug is indexed-like according to `IndexStateValue::isIndexedLike()` and
+that the artifact hash metadata is present in `reason_codes`.
+
+If verification fails, the command reports `blocked` and does not claim success.
+Rollback or quarantine is not automatic and requires a separate approval.
+
+## Future Approval Phrase
+
+```text
+I explicitly approve Career 2786 minimum index_state remediation apply for reviewed slug artifact <SLUG_ARTIFACT> with sha256 <SHA256> and <COUNT> slugs on <ENVIRONMENT>; no deploy, rollout, backfill, rollback, quarantine, or publication expansion is approved.
+```
+
+## Non-Goals
+
+- no production apply in this PR
+- no occupation backfill
+- no entity field repair
+- no rollout or publication expansion
+- no 80 readiness run
+- no manifest generation
+- no deploy
+- no fap-web change

--- a/backend/tests/Feature/Console/CareerRemediateCanonicalIndexStateCommandTest.php
+++ b/backend/tests/Feature/Console/CareerRemediateCanonicalIndexStateCommandTest.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\IndexStateValue;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerRemediateCanonicalIndexStateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:remediate-canonical-index-state', Artisan::all());
+    }
+
+    public function test_missing_slug_artifact_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => sys_get_temp_dir().'/missing-index-state-slugs.json',
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['slug_artifact_missing' => 1], $payload['by_reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_invalid_json_blocks(): void
+    {
+        $path = $this->tempPath('invalid');
+        file_put_contents($path, '{not json');
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $path,
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['slug_artifact_json_invalid' => 1], $payload['by_reason']);
+    }
+
+    public function test_empty_slug_list_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $this->writeSlugArtifact([]),
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['slug_list_empty' => 1], $payload['by_reason']);
+    }
+
+    public function test_duplicate_slugs_block(): void
+    {
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $this->writeSlugArtifact(['actuaries', 'actuaries'], countOverride: 2),
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['duplicate_slug_actuaries' => 1], $payload['by_reason']);
+    }
+
+    public function test_dry_run_does_not_write_and_emits_artifact_sha_and_approval_phrase(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createIndexState($occupation, IndexStateValue::NOINDEX, false);
+        $artifact = $this->writeSlugArtifact(['actuaries']);
+        $before = IndexState::query()->count();
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--dry-run' => true,
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $payload['status']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertSame($before, IndexState::query()->count());
+        $this->assertSame(hash_file('sha256', $artifact), $payload['artifact_sha256']);
+        $this->assertSame(1, $payload['planned_write_count']);
+        $this->assertStringContainsString('I explicitly approve Career 2786 minimum index_state remediation apply', $payload['approval_phrase_template']);
+    }
+
+    public function test_apply_requires_artifact_sha_and_expected_slug_count(): void
+    {
+        $this->createOccupation('actuaries');
+        $artifact = $this->writeSlugArtifact(['actuaries']);
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--apply' => true,
+            '--reason' => 'reviewed minimum index remediation',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(1, $payload['by_reason']['confirm_artifact_sha256_missing']);
+        $this->assertSame(1, $payload['by_reason']['expect_slug_count_missing']);
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    public function test_apply_rejects_sha_mismatch_count_mismatch_and_slug_count_above_max(): void
+    {
+        $this->createOccupation('actuaries');
+        $this->createOccupation('actors');
+        $artifact = $this->writeSlugArtifact(['actuaries', 'actors']);
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--apply' => true,
+            '--reason' => 'reviewed minimum index remediation',
+            '--confirm-artifact-sha256' => str_repeat('0', 64),
+            '--expect-slug-count' => 1,
+            '--max-slugs' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(1, $payload['by_reason']['artifact_sha256_mismatch']);
+        $this->assertSame(1, $payload['by_reason']['expect_slug_count_mismatch']);
+        $this->assertSame(1, $payload['by_reason']['slug_count_exceeds_max_slugs']);
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    public function test_apply_writes_only_explicit_slugs_and_verifies_latest_index_state(): void
+    {
+        $actuaries = $this->createOccupation('actuaries');
+        $actors = $this->createOccupation('actors');
+        $unlisted = $this->createOccupation('unlisted-career');
+        $this->createIndexState($actuaries, IndexStateValue::NOINDEX, false, ['legacy_noindex'], now()->subDay());
+        $this->createIndexState($unlisted, IndexStateValue::NOINDEX, false, ['legacy_noindex'], now()->subDay());
+        $artifact = $this->writeSlugArtifact(['actuaries', 'actors']);
+        $sha = hash_file('sha256', $artifact);
+        $occupationCountBefore = Occupation::query()->count();
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--apply' => true,
+            '--reason' => 'reviewed minimum index remediation',
+            '--confirm-artifact-sha256' => $sha,
+            '--expect-slug-count' => 2,
+            '--max-slugs' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('applied', $payload['status']);
+        $this->assertTrue($payload['writes_database']);
+        $this->assertTrue($payload['write_verified']);
+        $this->assertSame(2, $payload['created_count']);
+        $this->assertSame(2, $payload['verified_count']);
+        $this->assertSame($occupationCountBefore, Occupation::query()->count());
+
+        $this->assertLatestIndexed('actuaries', $sha);
+        $this->assertLatestIndexed('actors', $sha);
+        $this->assertSame(IndexStateValue::NOINDEX, $unlisted->indexStates()->latest('changed_at')->firstOrFail()->index_state);
+    }
+
+    public function test_missing_occupation_blocks_apply_before_any_write(): void
+    {
+        $this->createOccupation('actuaries');
+        $artifact = $this->writeSlugArtifact(['actuaries', 'missing-career']);
+        $before = IndexState::query()->count();
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--apply' => true,
+            '--reason' => 'reviewed minimum index remediation',
+            '--confirm-artifact-sha256' => hash_file('sha256', $artifact),
+            '--expect-slug-count' => 2,
+            '--max-slugs' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['occupation_missing' => 1], $payload['by_reason']);
+        $this->assertSame($before, IndexState::query()->count());
+        $this->assertSame(['missing-career'], $payload['missing_occupations']);
+    }
+
+    public function test_json_output_is_stable_and_target_state_can_be_indexable(): void
+    {
+        $this->createOccupation('actuaries');
+        $artifact = $this->writeSlugArtifact(['actuaries']);
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--target-state' => IndexStateValue::INDEXABLE,
+            '--dry-run' => true,
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame([
+            'status',
+            'mode',
+            'writes_database',
+            'write_verified',
+            'target_state',
+            'batch_id',
+            'reason',
+            'slug_artifact',
+            'artifact_schema_version',
+            'artifact_sha256',
+            'slug_count',
+            'max_slugs',
+            'expect_slug_count',
+            'slugs',
+            'missing_occupations',
+            'existing_latest_index_states',
+            'planned_writes',
+            'planned_write_count',
+            'blockers',
+            'by_reason',
+            'approval_phrase_template',
+            'read_only',
+        ], array_keys($payload));
+        $this->assertSame(IndexStateValue::INDEXABLE, $payload['target_state']);
+    }
+
+    public function test_rejects_non_indexed_like_target_state(): void
+    {
+        $artifact = $this->writeSlugArtifact(['actuaries']);
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--target-state' => IndexStateValue::NOINDEX,
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['target_state_not_indexed_like' => 1], $payload['by_reason']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:remediate-canonical-index-state', array_merge([
+            '--batch-id' => 'career_2786_minimum_80_index_state',
+            '--json' => true,
+        ], $options));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeSlugArtifact(array $slugs, ?int $countOverride = null): string
+    {
+        $path = $this->tempPath('index-state-slugs');
+        file_put_contents($path, json_encode([
+            'schema_version' => 'career_minimum_index_state_remediation.v1',
+            'source' => [
+                'audit_artifact' => '/tmp/career_2786_canonical_eligibility_audit_run1f.json',
+                'purpose' => 'minimum_80_candidate_unlock',
+            ],
+            'target' => [
+                'current_near_eligible_count' => 29,
+                'needed_additional_count' => count($slugs),
+                'expected_near_eligible_after_plan' => 29 + count($slugs),
+            ],
+            'count' => $countOverride ?? count($slugs),
+            'slugs' => $slugs,
+        ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-remediate-index-state-'.Str::uuid().'-'.$name.'.json';
+    }
+
+    private function createOccupation(string $slug): Occupation
+    {
+        /** @var Occupation $occupation */
+        $occupation = Occupation::query()->create([
+            'family_id' => $this->occupationFamily()->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'canonical_rollout_batch',
+            'canonical_title_en' => Str::title(str_replace('-', ' ', $slug)),
+            'canonical_title_zh' => '职业',
+            'search_h1_zh' => '职业',
+        ]);
+
+        return $occupation;
+    }
+
+    /**
+     * @param  list<string>  $reasonCodes
+     */
+    private function createIndexState(Occupation $occupation, string $state, bool $eligible, array $reasonCodes = [], mixed $changedAt = null): IndexState
+    {
+        /** @var IndexState $indexState */
+        $indexState = IndexState::query()->create([
+            'occupation_id' => $occupation->id,
+            'index_state' => $state,
+            'index_eligible' => $eligible,
+            'canonical_path' => '/career/jobs/'.$occupation->canonical_slug,
+            'canonical_target' => null,
+            'reason_codes' => $reasonCodes,
+            'changed_at' => $changedAt ?? now(),
+        ]);
+
+        return $indexState;
+    }
+
+    private function assertLatestIndexed(string $slug, string $sha): void
+    {
+        /** @var Occupation $occupation */
+        $occupation = Occupation::query()->where('canonical_slug', $slug)->firstOrFail();
+        /** @var IndexState $latest */
+        $latest = $occupation->indexStates()
+            ->orderByDesc('changed_at')
+            ->orderByDesc('created_at')
+            ->firstOrFail();
+
+        $this->assertSame(IndexStateValue::INDEXED, $latest->index_state);
+        $this->assertTrue($latest->index_eligible);
+        $this->assertContains('career_2786_minimum_index_state_remediation', $latest->reason_codes);
+        $this->assertContains('batch_id:career_2786_minimum_80_index_state', $latest->reason_codes);
+        $this->assertContains('reason:reviewed_minimum_index_remediation', $latest->reason_codes);
+        $this->assertContains('artifact_sha256:'.$sha, $latest->reason_codes);
+    }
+
+    private function occupationFamily(): OccupationFamily
+    {
+        /** @var OccupationFamily $family */
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'index-remediation-family'],
+            [
+                'title_en' => 'Index Remediation Family',
+                'title_zh' => 'Index Remediation Family',
+            ]
+        );
+
+        return $family;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4449,6 +4449,64 @@
       "sidecar_issues": [
 
       ]
+    },
+    "REPAIR-INDEX-STATE-MINIMUM-APPLY-PLAN-2": {
+      "repo": "fap-api",
+      "branch": "fix/career-index-state-minimum-remediation-gate",
+      "title": "fix(api): add guarded career index state remediation command",
+      "name": "Add guarded explicit-slug index_state remediation dry-run/apply planning",
+      "status": "in_progress",
+      "depends_on": [
+        "RUN-1F",
+        "REPAIR-INDEX-ENTITY-POLICY-2"
+      ],
+      "scope_type": "index_state_remediation_gate_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerRemediateCanonicalIndexState.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no production apply",
+        "no production DB query",
+        "no DB mutation outside tests",
+        "no rollout",
+        "no backfill",
+        "no 80 readiness run",
+        "no manifest generation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided REPAIR-INDEX-STATE-MINIMUM-APPLY-PLAN-2 execution goal and authorized docs/codex train metadata updates for this item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "RUN-1F and the index/entity approval review determined a minimum explicit-slug index_state remediation dry-run/apply gate is needed before approval can be used."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to an explicit-slug index_state remediation command, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "INDEX-STATE-MINIMUM-DRY-RUN-1 using reviewed slug artifact",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+
+      ]
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2318,3 +2318,40 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-INDEX-STATE-MINIMUM-APPLY-PLAN-2
+    repo: fap-api
+    depends_on:
+      - RUN-1F
+      - REPAIR-INDEX-ENTITY-POLICY-2
+    branch: fix/career-index-state-minimum-remediation-gate
+    title: "fix(api): add guarded career index state remediation command"
+    scope:
+      - Add explicit reviewed slug artifact support for Career index_state remediation.
+      - Add guarded dry-run/apply command with artifact sha and slug count confirmation.
+      - Keep the command scoped to index_states rows for explicit slugs only.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerRemediateCanonicalIndexState.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run production apply.
+      - Run rollout, backfill, rollback, quarantine, 80 readiness, or manifest generation.
+      - Touch fap-web or deploy.
+      - Expand beyond explicit reviewed slug artifacts.
+    validation:
+      - php artisan test --filter=CareerRemediateCanonicalIndexState --no-ansi
+      - php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi
+      - php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi
+      - php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds `career:remediate-canonical-index-state`, a guarded explicit-slug index_state remediation dry-run/apply gate.
- Reads reviewed slug artifacts, normalizes strict slug lists, emits stable JSON evidence, and refuses broad/global remediation by default.
- Adds future apply support guarded by artifact SHA-256 confirmation, expected slug count confirmation, max-slug limit, batch id, reason, and post-write verification.

## Safety
- No production apply run.
- No DB mutation outside Laravel/PHPUnit tests.
- No rollout, backfill, rollback, quarantine, or publication expansion.
- No deploy and no fap-web changes.
- Apply writes only explicit slugs from the reviewed artifact and verifies latest index_state rows after write.

## Next step
- `INDEX-STATE-MINIMUM-DRY-RUN-1` using `/tmp/career_2786_minimum_index_state_slugs_for_80.json`.

## Tests
- `php artisan test --filter=CareerRemediateCanonicalIndexState --no-ansi`
- `php artisan test --filter=CareerIndexStateAuthorityAuditor --no-ansi`
- `php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi`
- `php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan route:list --no-ansi`
- `php artisan list | grep "career:remediate-canonical-index-state"`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`
