### PR TITLE
feat(api): add career 80 cohort readiness command

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonical80CohortReadiness.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical80CohortReadiness.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\Career2786ReadinessPolicyClassifier;
+use App\Domain\Career\Audit\Career2786ReadinessPolicyRow;
+use App\Domain\Career\Audit\CareerCanonical80CandidateSelectionRow;
+use App\Domain\Career\Audit\CareerCanonical80CandidateSelector;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+final class CareerPlanCanonical80CohortReadiness extends Command
+{
+    private const SCHEMA_VERSION = 'career_80_cohort_readiness.v1';
+
+    protected $signature = 'career:plan-canonical-80-cohort-readiness
+        {--audit= : Required Career canonical eligibility audit JSON artifact}
+        {--target=80 : Target cohort size}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for readiness JSON}
+        {--include-sidecars : Include audit sidecars in output}
+        {--strict : Fail on malformed or ambiguous audit rows}';
+
+    protected $description = 'Plan the read-only Career 80 canonical cohort readiness from a full eligibility audit artifact.';
+
+    public function handle(): int
+    {
+        try {
+            $auditPath = $this->requiredOption('audit');
+            $target = $this->positiveIntOption('target', 80);
+            [$audit, $report] = $this->readAudit($auditPath);
+
+            $payload = $this->buildPlan($auditPath, $audit, $report, $target);
+
+            return $this->finish($payload, $payload['readiness_pass'] === true ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish($this->blockedPayload($this->reasonKey($exception->getMessage()), $exception->getMessage()), self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function positiveIntOption(string $name, int $default): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return $default;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: CareerCanonicalEligibilityReport}
+     */
+    private function readAudit(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('audit_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException('audit_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException('audit_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException('audit_artifact_shape_invalid');
+        }
+
+        try {
+            $report = CareerCanonicalEligibilityReport::fromArray($decoded);
+        } catch (InvalidArgumentException $exception) {
+            if ((bool) $this->option('strict')) {
+                throw new RuntimeException('audit_artifact_shape_invalid');
+            }
+
+            throw new RuntimeException($exception->getMessage());
+        }
+
+        return [$decoded, $report];
+    }
+
+    /**
+     * @param  array<string, mixed>  $audit
+     * @return array<string, mixed>
+     */
+    private function buildPlan(string $auditPath, array $audit, CareerCanonicalEligibilityReport $report, int $target): array
+    {
+        $policy = (new Career2786ReadinessPolicyClassifier)->classify($report, $target);
+        $policyRowsBySlug = [];
+        foreach ($policy->rows as $row) {
+            $policyRowsBySlug[$row->canonicalSlug] = $row;
+        }
+
+        $selection = (new CareerCanonical80CandidateSelector)->select($report, $target);
+        $selectable = [];
+        foreach ($selection->rows as $row) {
+            $policyRow = $policyRowsBySlug[$row->canonicalSlug] ?? null;
+            if (! $policyRow instanceof Career2786ReadinessPolicyRow) {
+                continue;
+            }
+
+            if (! $this->isSelectable($row, $policyRow)) {
+                continue;
+            }
+
+            $selectable[] = [$row, $policyRow];
+        }
+
+        $selected = array_slice($selectable, 0, $target);
+        $blockers = $this->blockers($report, $target, count($selectable), count($selected));
+        $readinessPass = $blockers === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $readinessPass ? 'pass' : 'blocked',
+            'readiness_pass' => $readinessPass,
+            'target' => $target,
+            'candidate_count' => count($selectable),
+            'selected_count' => count($selected),
+            'read_only' => true,
+            'writes_database' => false,
+            'source_audit' => [
+                'path' => $auditPath,
+                'status' => $report->status,
+                'scope' => $report->scope,
+                'expected_occupations' => $report->expectedOccupations,
+                'audited_occupations' => $report->auditedOccupations,
+                'eligible_count' => $report->eligibleCount,
+                'blocked_count' => $report->blockedCount,
+            ],
+            'policy_summary' => $policy->summary(),
+            'selection' => [
+                'strategy' => 'policy_near_eligible_ranked',
+                'slugs' => array_map(
+                    static fn (array $pair): string => $pair[0]->canonicalSlug,
+                    $selected
+                ),
+                'rows' => array_map(
+                    fn (array $pair): array => $this->selectionRow($pair[0], $pair[1]),
+                    $selected
+                ),
+            ],
+            'blockers' => $blockers,
+            'sidecars' => (bool) $this->option('include-sidecars') && isset($audit['sidecars']) && is_array($audit['sidecars'])
+                ? $audit['sidecars']
+                : [],
+            'rollout' => [
+                'manifest_generation_allowed' => $readinessPass,
+                'apply_allowed' => false,
+                'reason' => 'readiness only; apply requires separate approval',
+            ],
+            'next_required_action' => $readinessPass ? '80_MANIFEST_TRAIN_READ_ONLY' : 'FIX_BLOCKERS',
+        ];
+    }
+
+    private function isSelectable(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow): bool
+    {
+        if (! in_array($row->candidateStatus, [
+            CareerCanonical80CandidateSelectionRow::STATUS_READY,
+            CareerCanonical80CandidateSelectionRow::STATUS_NEAR_ELIGIBLE,
+        ], true)) {
+            return false;
+        }
+
+        return $row->hardBlockers === []
+            && $policyRow->hardBlockerReasons === []
+            && $policyRow->remediationRequiredReasons === []
+            && ($policyRow->nearEligible || $policyRow->eligibleCandidate);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function blockers(CareerCanonicalEligibilityReport $report, int $target, int $candidateCount, int $selectedCount): array
+    {
+        $blockers = [];
+        if ($report->expectedOccupations !== 2786) {
+            $blockers[] = $this->blocker('expected_occupations_mismatch', 'Audit artifact must cover the 2786 Career canonical program.', [
+                'expected_occupations' => $report->expectedOccupations,
+            ]);
+        }
+        if ($report->auditedOccupations !== 2786) {
+            $blockers[] = $this->blocker('audited_occupations_mismatch', 'Audit artifact must include 2786 audited occupations.', [
+                'audited_occupations' => $report->auditedOccupations,
+            ]);
+        }
+        if ($candidateCount < $target || $selectedCount < $target) {
+            $blockers[] = $this->blocker('insufficient_near_eligible_candidates', 'Fewer than the target near-eligible slugs can be evaluated.', [
+                'target' => $target,
+                'candidate_count' => $candidateCount,
+                'selected_count' => $selectedCount,
+            ]);
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function selectionRow(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow): array
+    {
+        return [
+            'slug' => $row->canonicalSlug,
+            'locales' => $policyRow->locales,
+            'score' => $row->score,
+            'rank' => $row->rank,
+            'reasons' => $policyRow->reasons,
+            'deferred_until_candidate' => $policyRow->deferredUntilCandidateReasons,
+            'expected_not_ready' => $policyRow->expectedNotReadyReasons,
+            'remediation_required' => $policyRow->remediationRequiredReasons,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, string $message, array $evidence = []): array
+    {
+        return [
+            'reason' => $reason,
+            'message' => $message,
+            'evidence' => $evidence,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blockedPayload(string $reason, string $message): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'blocked',
+            'readiness_pass' => false,
+            'target' => 80,
+            'candidate_count' => 0,
+            'selected_count' => 0,
+            'read_only' => true,
+            'writes_database' => false,
+            'source_audit' => null,
+            'policy_summary' => [],
+            'selection' => [
+                'strategy' => 'policy_near_eligible_ranked',
+                'slugs' => [],
+                'rows' => [],
+            ],
+            'blockers' => [$this->blocker($reason, $message)],
+            'sidecars' => [],
+            'rollout' => [
+                'manifest_generation_allowed' => false,
+                'apply_allowed' => false,
+                'reason' => 'readiness only; apply requires separate approval',
+            ],
+            'next_required_action' => 'FIX_BLOCKERS',
+        ];
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $value = strtolower(trim($message));
+        $value = preg_replace('/[^a-z0-9_]+/', '_', $value) ?: 'command_failed';
+
+        return trim($value, '_') ?: 'command_failed';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            File::put($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('readiness_pass='.(($payload['readiness_pass'] ?? false) ? 'true' : 'false'));
+        }
+
+        return $exitCode;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -40,6 +40,7 @@ use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerNormalizeLegacyDisplayAssets;
+use App\Console\Commands\CareerPlanCanonical80CohortReadiness;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRemediateCanonicalIndexState;
@@ -201,6 +202,7 @@ class Kernel extends ConsoleKernel
         CareerImportOccupationDirectoryDryRun::class,
         CareerImportSelectedDisplayAssets::class,
         CareerNormalizeLegacyDisplayAssets::class,
+        CareerPlanCanonical80CohortReadiness::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
         CareerReleaseGateNoindexCleanup::class,
         CareerRemediateCanonicalIndexState::class,

--- a/backend/docs/career/audits/80_cohort_readiness.md
+++ b/backend/docs/career/audits/80_cohort_readiness.md
@@ -1,0 +1,62 @@
+# Career 80 Cohort Readiness
+
+`career:plan-canonical-80-cohort-readiness` is a read-only planning command for the first Career canonical expansion cohort.
+
+It consumes a full canonical eligibility audit artifact, selects deterministic near-eligible candidates, and writes a readiness artifact. It does not query production, mutate the database, generate rollout manifests, run rollout dry-runs, or approve rollout apply.
+
+## Usage
+
+```bash
+php artisan career:plan-canonical-80-cohort-readiness \
+  --audit=/tmp/career_2786_canonical_eligibility_audit_after_minimum_index_apply_v2.json \
+  --target=80 \
+  --json \
+  --output=/tmp/career_2786_80_readiness_plan.json
+```
+
+Options:
+
+- `--audit=`: required full Career canonical eligibility audit JSON artifact.
+- `--target=`: cohort size, default `80`.
+- `--output=`: optional JSON artifact path.
+- `--json`: emits the readiness artifact to stdout.
+- `--include-sidecars`: includes audit sidecars in the readiness output.
+- `--strict`: fails on malformed or ambiguous audit rows.
+
+## Output Schema
+
+The artifact schema is `career_80_cohort_readiness.v1`.
+
+Important fields:
+
+- `status`: `pass` or `blocked`.
+- `readiness_pass`: true only when enough near-eligible candidates can be selected.
+- `candidate_count`: selectable near-eligible candidate slugs.
+- `selected_count`: selected cohort size.
+- `selection.strategy`: `policy_near_eligible_ranked`.
+- `selection.slugs`: deterministic selected slug list.
+- `policy_summary`: policy classifier summary from the audit rows.
+- `rollout.manifest_generation_allowed`: true only after readiness passes.
+- `rollout.apply_allowed`: always false.
+
+`readiness_pass=true` means a read-only manifest train can be prepared next. It does not approve publication expansion or rollout apply.
+
+## Candidate Policy
+
+The command selects from slugs classified as near-eligible or eligible candidates, excluding slugs with hard blockers or remediation-required reasons such as:
+
+- `index_state_missing`
+- `occupation_missing`
+- `entity_field_missing`
+
+Deferred surface states and expected-not-ready SEO/GEO policy states remain visible on selected rows. They are candidate-stage requirements, not hidden passes.
+
+## Non-goals
+
+- No DB mutation.
+- No apply.
+- No rollout.
+- No manifest generation.
+- No live crawl.
+- No fap-web change.
+- No production deployment.

--- a/backend/tests/Feature/Console/CareerPlanCanonical80CohortReadinessCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical80CohortReadinessCommandTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
+{
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:plan-canonical-80-cohort-readiness', Artisan::all());
+    }
+
+    public function test_missing_audit_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--audit' => sys_get_temp_dir().'/missing-career-audit.json',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertFalse($payload['readiness_pass']);
+        $this->assertSame('audit_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_malformed_audit_blocks(): void
+    {
+        $path = $this->tempPath('invalid-audit');
+        file_put_contents($path, '{not json');
+
+        $exitCode = $this->callCommand([
+            '--audit' => $path,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('audit_artifact_json_invalid', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_target_defaults_to_80_and_blocks_when_near_eligible_is_insufficient(): void
+    {
+        $path = $this->writeAudit(['actuaries']);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $path,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(80, $payload['target']);
+        $this->assertSame(1, $payload['candidate_count']);
+        $this->assertSame('insufficient_near_eligible_candidates', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['rollout']['manifest_generation_allowed']);
+        $this->assertFalse($payload['rollout']['apply_allowed']);
+    }
+
+    public function test_passes_when_near_eligible_reaches_target_and_writes_output(): void
+    {
+        $audit = $this->writeAudit(['zeta-career', 'alpha-career', 'beta-career']);
+        $output = $this->tempPath('readiness-output');
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--target' => 2,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['readiness_pass']);
+        $this->assertSame(3, $payload['candidate_count']);
+        $this->assertSame(2, $payload['selected_count']);
+        $this->assertSame(['alpha-career', 'beta-career'], $payload['selection']['slugs']);
+        $this->assertTrue($payload['rollout']['manifest_generation_allowed']);
+        $this->assertFalse($payload['rollout']['apply_allowed']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_selected_slugs_are_unique_and_exclude_remediation_required_rows(): void
+    {
+        $audit = $this->writeAudit(
+            nearEligibleSlugs: ['actuaries', 'actuaries', 'actors', 'artists'],
+            remediationSlugs: ['blocked-index']
+        );
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--target' => 3,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(['actors', 'actuaries', 'artists'], $payload['selection']['slugs']);
+        $this->assertNotContains('blocked-index', $payload['selection']['slugs']);
+        $this->assertCount(3, array_unique($payload['selection']['slugs']));
+    }
+
+    public function test_blocks_when_expected_or_audited_occupation_counts_do_not_match_2786(): void
+    {
+        $audit = $this->writeAudit(['actuaries', 'actors'], expectedOccupations: 2, auditedOccupations: 2);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('expected_occupations_mismatch', array_column($payload['blockers'], 'reason'));
+        $this->assertContains('audited_occupations_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
+    public function test_output_schema_is_stable_and_preserves_sidecars_when_requested(): void
+    {
+        $audit = $this->writeAudit(['actuaries'], sidecars: [[
+            'sidecar_id' => 'surface-evidence',
+            'title' => 'Surface evidence remains candidate-stage work',
+            'owner_repo' => 'fap-api',
+            'scope_relation' => 'external_to_current_pr',
+            'introduced_by_current_pr' => false,
+            'affected_slugs' => ['actuaries'],
+            'affected_locales' => ['en', 'zh'],
+            'evidence' => [],
+            'severity' => 'info',
+            'next_goal' => 'candidate surface verification',
+            'may_continue_train' => true,
+        ]]);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--target' => 1,
+            '--include-sidecars' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame([
+            'schema_version',
+            'status',
+            'readiness_pass',
+            'target',
+            'candidate_count',
+            'selected_count',
+            'read_only',
+            'writes_database',
+            'source_audit',
+            'policy_summary',
+            'selection',
+            'blockers',
+            'sidecars',
+            'rollout',
+            'next_required_action',
+        ], array_keys($payload));
+        $this->assertSame('career_80_cohort_readiness.v1', $payload['schema_version']);
+        $this->assertSame('surface-evidence', $payload['sidecars'][0]['sidecar_id']);
+        $this->assertSame('80_MANIFEST_TRAIN_READ_ONLY', $payload['next_required_action']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:plan-canonical-80-cohort-readiness', array_merge([
+            '--json' => true,
+        ], $options));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  list<string>  $nearEligibleSlugs
+     * @param  list<string>  $remediationSlugs
+     * @param  list<array<string, mixed>>  $sidecars
+     */
+    private function writeAudit(
+        array $nearEligibleSlugs,
+        array $remediationSlugs = [],
+        int $expectedOccupations = 2786,
+        int $auditedOccupations = 2786,
+        array $sidecars = [],
+    ): string {
+        $rows = [];
+        foreach (array_values(array_unique($nearEligibleSlugs)) as $slug) {
+            $rows[] = $this->row($slug, 'en', [
+                'sitemap_expected_not_ready',
+                'llms_expected_not_ready',
+                'surface_unverified',
+            ]);
+            $rows[] = $this->row($slug, 'zh', [
+                'llms_full_expected_not_ready',
+                'surface_artifact_missing',
+            ]);
+        }
+
+        foreach ($remediationSlugs as $slug) {
+            $rows[] = $this->row($slug, 'en', ['index_state_missing']);
+            $rows[] = $this->row($slug, 'zh', ['index_state_missing']);
+        }
+
+        $path = $this->tempPath('audit');
+        file_put_contents($path, json_encode([
+            'status' => 'blocked',
+            'scope' => 'all',
+            'expected_occupations' => $expectedOccupations,
+            'audited_occupations' => $auditedOccupations,
+            'eligible_count' => 0,
+            'blocked_count' => count($rows),
+            'by_reason' => $this->byReason($rows),
+            'context_summary' => ['surface_context' => 'supplied'],
+            'policy_summary' => [
+                'near_eligible_count' => count(array_unique($nearEligibleSlugs)),
+            ],
+            'rows' => $rows,
+            'sidecars' => $sidecars,
+        ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     * @return array<string, mixed>
+     */
+    private function row(string $slug, string $locale, array $reasons): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'source_scope' => 'all',
+            'entity_status' => $this->layer('entity', $this->layerReadiness($reasons, ['occupation_missing', 'entity_field_missing'])),
+            'baseline_status' => $this->layer('baseline', 'pass'),
+            'index_status' => $this->layer('index', $this->layerReadiness($reasons, ['index_state_missing'])),
+            'runtime_status' => $this->layer('runtime', 'pass'),
+            'seo_geo_status' => $this->layer('seo_geo', $this->layerReadiness($reasons, [
+                'sitemap_expected_not_ready',
+                'llms_expected_not_ready',
+                'llms_full_expected_not_ready',
+            ])),
+            'surface_status' => $this->layer('surface', $this->layerReadiness($reasons, [
+                'surface_unverified',
+                'surface_artifact_missing',
+            ])),
+            'safety_status' => $this->layer('safety', 'pass'),
+            'overall_status' => $reasons === [] ? 'pass' : 'blocked',
+            'severity' => $reasons === [] ? 'info' : 'high',
+            'reasons' => $reasons,
+            'evidence' => [['slug' => $slug]],
+            'sidecars' => [],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $reasons
+     * @param  list<string>  $blockedReasons
+     */
+    private function layerReadiness(array $reasons, array $blockedReasons): string
+    {
+        return array_intersect($reasons, $blockedReasons) === [] ? 'pass' : 'blocked';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function layer(string $layer, string $status): array
+    {
+        return [
+            'layer' => $layer,
+            'status' => $status,
+            'reasons' => [],
+            'evidence' => [],
+            'source' => 'synthetic_test_fixture',
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, int>
+     */
+    private function byReason(array $rows): array
+    {
+        $counts = [];
+        foreach ($rows as $row) {
+            foreach ($row['reasons'] as $reason) {
+                $counts[$reason] = ($counts[$reason] ?? 0) + 1;
+            }
+        }
+        ksort($counts);
+
+        return $counts;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-80-readiness-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4507,6 +4507,61 @@
       "sidecar_issues": [
 
       ]
+    },
+    "REPAIR-80-READINESS-COMMAND-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-80-cohort-readiness-command",
+      "title": "feat(api): add career 80 cohort readiness command",
+      "name": "Add read-only Career 80 cohort readiness command",
+      "status": "in_progress",
+      "depends_on": [
+        "INDEX-STATE-MINIMUM-APPLY-1"
+      ],
+      "scope_type": "80_readiness_command_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonical80CohortReadiness.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout",
+        "no manifest generation",
+        "no DB mutation",
+        "no apply",
+        "no backfill",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided REPAIR-80-READINESS-COMMAND-1 execution goal and authorized docs/codex train metadata updates for this item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "Post-minimum-index-apply audit reached EIGHTY_READINESS_READY with near_eligible_count=80, but the dedicated read-only 80 readiness command is missing."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to a read-only readiness command, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "80-READINESS-2 run read-only 80 readiness",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+
+      ]
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2355,3 +2355,40 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-80-READINESS-COMMAND-1
+    repo: fap-api
+    depends_on:
+      - INDEX-STATE-MINIMUM-APPLY-1
+    branch: fix/career-80-cohort-readiness-command
+    title: "feat(api): add career 80 cohort readiness command"
+    scope:
+      - Add a read-only Career 80 cohort readiness command.
+      - Consume a full canonical eligibility audit artifact and select deterministic near-eligible candidates.
+      - Emit a stable readiness plan while keeping manifest generation and rollout apply out of scope.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonical80CohortReadiness.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout, apply, backfill, rollback, quarantine, or 80 rollout.
+      - Generate rollout manifests.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi
+      - php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi
+      - php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds `career:plan-canonical-80-cohort-readiness` as a read-only Career 80 readiness command.
- Consumes a canonical eligibility audit artifact and deterministically selects/evaluates 80 policy near-eligible candidates.
- Writes a stable readiness artifact with `apply_allowed=false` and manifest generation only marked as a next read-only stage when readiness passes.

## Safety / Non-goals
- Does not generate a rollout manifest.
- Does not run rollout or apply.
- Does not mutate DB.
- Does not query production DB.
- Rollout apply remains separately approval-gated.

## Next step
- Deploy readiness if this command must be run on the API host.
- Then run `80-READINESS-2` read-only using the post-minimum-index-apply audit artifact.

## Tests
- `php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi`
- `php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi`
- `php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`

Optional local smoke was skipped because `/tmp/career_2786_canonical_eligibility_audit_after_minimum_index_apply_v2.json` is not present locally.
