### PR TITLE
feat(api): add career 80 manifest train command

### DIFF
--- a/backend/app/Console/Commands/CareerGenerateCanonicalExpansionManifestTrain.php
+++ b/backend/app/Console/Commands/CareerGenerateCanonicalExpansionManifestTrain.php
@@ -1,0 +1,436 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerGenerateCanonicalExpansionManifestTrain extends Command
+{
+    private const SCHEMA_VERSION = 'career_canonical_expansion_manifest_train.v1';
+
+    protected $signature = 'career:generate-canonical-expansion-manifest-train
+        {--readiness= : Required Career cohort readiness JSON artifact}
+        {--target=80 : Target cohort size}
+        {--batch-id= : Optional batch id; defaults to career_80_canonical_001 for target 80}
+        {--locales=en,zh : Comma-separated locale list}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for manifest train JSON}
+        {--strict : Fail on ambiguous selected rows}';
+
+    protected $description = 'Generate a read-only Career canonical expansion manifest train from a readiness artifact.';
+
+    public function handle(): int
+    {
+        try {
+            $readinessPath = $this->requiredOption('readiness');
+            $target = $this->positiveIntOption('target', 80);
+            $locales = $this->locales();
+            $batchId = $this->batchId($target);
+            $readiness = $this->readiness($readinessPath);
+            $payload = $this->manifestTrain($readinessPath, $readiness, $target, $batchId, $locales);
+
+            return $this->finish($payload, $payload['status'] === 'pass' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish($this->blockedPayload($this->reasonKey($exception->getMessage()), $exception->getMessage()), self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function positiveIntOption(string $name, int $default): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return $default;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function locales(): array
+    {
+        $raw = trim((string) ($this->option('locales') ?? 'en,zh'));
+        $locales = [];
+        foreach (explode(',', $raw) as $locale) {
+            $normalized = strtolower(trim($locale));
+            if ($normalized !== '' && ! in_array($normalized, $locales, true)) {
+                $locales[] = $normalized;
+            }
+        }
+
+        if ($locales === []) {
+            throw new RuntimeException('locales_empty');
+        }
+
+        return $locales;
+    }
+
+    private function batchId(int $target): string
+    {
+        $batchId = trim((string) ($this->option('batch-id') ?? ''));
+        if ($batchId !== '') {
+            return $batchId;
+        }
+
+        return $target === 80 ? 'career_80_canonical_001' : 'career_'.$target.'_canonical_001';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readiness(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('readiness_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException('readiness_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException('readiness_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException('readiness_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @param  list<string>  $locales
+     * @return array<string, mixed>
+     */
+    private function manifestTrain(string $readinessPath, array $readiness, int $target, string $batchId, array $locales): array
+    {
+        $blockers = $this->readinessBlockers($readiness, $target);
+        if ($blockers !== []) {
+            return $this->blockedManifest($readinessPath, $readiness, $target, $blockers);
+        }
+
+        $slugs = $this->selectedSlugs($readiness, $target);
+        $duplicate = $this->firstDuplicate($slugs);
+        if ($duplicate !== null) {
+            return $this->blockedManifest($readinessPath, $readiness, $target, [
+                $this->blocker('selected_slugs_duplicate', 'Readiness artifact selected the same slug more than once.', [
+                    'slug' => $duplicate,
+                ]),
+            ]);
+        }
+
+        if (count($slugs) < $target) {
+            return $this->blockedManifest($readinessPath, $readiness, $target, [
+                $this->blocker('selected_slug_count_below_target', 'Readiness artifact does not contain enough selected slugs.', [
+                    'target' => $target,
+                    'selected_slug_count' => count($slugs),
+                ]),
+            ]);
+        }
+
+        $selectedSlugs = array_slice($slugs, 0, $target);
+        $members = $this->members($readiness, $selectedSlugs, $locales);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'pass',
+            'target' => $target,
+            'source_readiness' => $this->sourceReadiness($readinessPath, $readiness),
+            'manifest_count' => 1,
+            'selected_count' => count($selectedSlugs),
+            'batch_id' => $batchId,
+            'rollback_group' => $selectedSlugs,
+            'rollout_allowed' => false,
+            'dry_run_allowed' => true,
+            'apply_allowed' => false,
+            'read_only' => true,
+            'writes_database' => false,
+            'rollout_dry_run_executed' => false,
+            'rollout_apply_executed' => false,
+            'batches' => [[
+                'batch_id' => $batchId,
+                'target' => $target,
+                'slugs' => $selectedSlugs,
+                'locales' => $locales,
+                'expected_locale_rows' => count($selectedSlugs) * count($locales),
+                'rollback_group' => $selectedSlugs,
+                'rollout_allowed' => false,
+                'dry_run_allowed' => true,
+                'apply_allowed' => false,
+                'members' => $members,
+            ]],
+            'blockers' => [],
+            'sidecars' => isset($readiness['sidecars']) && is_array($readiness['sidecars']) ? $readiness['sidecars'] : [],
+            'next_required_action' => '80_ROLLOUT_DRY_RUN_READ_ONLY',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @return list<array<string, mixed>>
+     */
+    private function readinessBlockers(array $readiness, int $target): array
+    {
+        $blockers = [];
+        if (($readiness['status'] ?? null) !== 'pass' || ($readiness['readiness_pass'] ?? null) !== true) {
+            $blockers[] = $this->blocker('readiness_not_passed', 'Readiness artifact must have status=pass and readiness_pass=true.');
+        }
+
+        $manifestAllowed = data_get($readiness, 'rollout.manifest_generation_allowed');
+        if ($manifestAllowed !== true) {
+            $blockers[] = $this->blocker('manifest_generation_not_allowed', 'Readiness artifact must explicitly allow read-only manifest generation.');
+        }
+
+        $selectedCount = $readiness['selected_count'] ?? null;
+        if (! is_int($selectedCount) || $selectedCount < $target) {
+            $blockers[] = $this->blocker('selected_count_below_target', 'Readiness artifact selected_count is below target.', [
+                'target' => $target,
+                'selected_count' => $selectedCount,
+            ]);
+        }
+
+        if (! is_array(data_get($readiness, 'selection.slugs'))) {
+            $blockers[] = $this->blocker('selected_slugs_missing', 'Readiness artifact must include selection.slugs.');
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @return list<string>
+     */
+    private function selectedSlugs(array $readiness, int $target): array
+    {
+        $rawSlugs = data_get($readiness, 'selection.slugs');
+        if (! is_array($rawSlugs)) {
+            return [];
+        }
+
+        $slugs = [];
+        foreach ($rawSlugs as $slug) {
+            if (! is_string($slug) || trim($slug) === '') {
+                if ((bool) $this->option('strict')) {
+                    throw new RuntimeException('selected_slug_invalid');
+                }
+
+                continue;
+            }
+
+            $slugs[] = trim($slug);
+        }
+
+        return array_slice($slugs, 0, max($target, count($slugs)));
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function firstDuplicate(array $slugs): ?string
+    {
+        $seen = [];
+        foreach ($slugs as $slug) {
+            if (isset($seen[$slug])) {
+                return $slug;
+            }
+
+            $seen[$slug] = true;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @param  list<string>  $selectedSlugs
+     * @param  list<string>  $locales
+     * @return list<array<string, mixed>>
+     */
+    private function members(array $readiness, array $selectedSlugs, array $locales): array
+    {
+        $rowsBySlug = [];
+        $rows = data_get($readiness, 'selection.rows');
+        if (is_array($rows)) {
+            foreach ($rows as $row) {
+                if (is_array($row) && isset($row['slug']) && is_string($row['slug'])) {
+                    $rowsBySlug[$row['slug']] = $row;
+                }
+            }
+        }
+
+        $members = [];
+        foreach ($selectedSlugs as $slug) {
+            $row = $rowsBySlug[$slug] ?? [];
+            $rowLocales = isset($row['locales']) && is_array($row['locales'])
+                ? array_values(array_filter($row['locales'], static fn (mixed $locale): bool => is_string($locale) && trim($locale) !== ''))
+                : $locales;
+
+            $members[] = [
+                'slug' => $slug,
+                'locales' => $rowLocales === [] ? $locales : array_values(array_unique($rowLocales)),
+                'source' => '80_readiness',
+                'reasons' => isset($row['reasons']) && is_array($row['reasons']) ? array_values($row['reasons']) : [],
+                'sidecars' => isset($row['sidecars']) && is_array($row['sidecars']) ? array_values($row['sidecars']) : [],
+            ];
+        }
+
+        return $members;
+    }
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @return array<string, mixed>
+     */
+    private function sourceReadiness(string $readinessPath, array $readiness): array
+    {
+        return [
+            'path' => $readinessPath,
+            'status' => $readiness['status'] ?? null,
+            'readiness_pass' => $readiness['readiness_pass'] ?? null,
+            'selected_count' => $readiness['selected_count'] ?? null,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $blockers
+     * @return array<string, mixed>
+     */
+    private function blockedManifest(string $readinessPath, array $readiness, int $target, array $blockers): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'blocked',
+            'target' => $target,
+            'source_readiness' => $this->sourceReadiness($readinessPath, $readiness),
+            'manifest_count' => 0,
+            'selected_count' => 0,
+            'batch_id' => null,
+            'rollback_group' => [],
+            'rollout_allowed' => false,
+            'dry_run_allowed' => false,
+            'apply_allowed' => false,
+            'read_only' => true,
+            'writes_database' => false,
+            'rollout_dry_run_executed' => false,
+            'rollout_apply_executed' => false,
+            'batches' => [],
+            'blockers' => $blockers,
+            'sidecars' => isset($readiness['sidecars']) && is_array($readiness['sidecars']) ? $readiness['sidecars'] : [],
+            'next_required_action' => 'FIX_BLOCKERS',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blockedPayload(string $reason, string $message): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'blocked',
+            'target' => 80,
+            'source_readiness' => null,
+            'manifest_count' => 0,
+            'selected_count' => 0,
+            'batch_id' => null,
+            'rollback_group' => [],
+            'rollout_allowed' => false,
+            'dry_run_allowed' => false,
+            'apply_allowed' => false,
+            'read_only' => true,
+            'writes_database' => false,
+            'rollout_dry_run_executed' => false,
+            'rollout_apply_executed' => false,
+            'batches' => [],
+            'blockers' => [$this->blocker($reason, $message)],
+            'sidecars' => [],
+            'next_required_action' => 'FIX_BLOCKERS',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, string $message, array $evidence = []): array
+    {
+        return [
+            'reason' => $reason,
+            'message' => $message,
+            'evidence' => $evidence,
+        ];
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $value = strtolower(trim($message));
+        $value = preg_replace('/[^a-z0-9_]+/', '_', $value) ?: 'command_failed';
+
+        return trim($value, '_') ?: 'command_failed';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            $directory = dirname($outputPath);
+            if (! is_dir($directory) || ! is_writable($directory)) {
+                $payload = $this->blockedPayload('output_path_unwritable', 'Output path directory is not writable.');
+                $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+                if (! is_string($encoded)) {
+                    $this->error('failed_to_encode_json_payload');
+
+                    return self::FAILURE;
+                }
+                $exitCode = self::FAILURE;
+            } else {
+                File::put($outputPath, $encoded.PHP_EOL);
+            }
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('selected_count='.(string) ($payload['selected_count'] ?? 0));
+        }
+
+        return $exitCode;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -34,6 +34,7 @@ use App\Console\Commands\CareerExportRuntimePublishProjection;
 use App\Console\Commands\CareerExportStrongIndexEligibility;
 use App\Console\Commands\CareerFinalizeCanonicalRuntimeTruth;
 use App\Console\Commands\CareerFullDisplayWorkbookValidator;
+use App\Console\Commands\CareerGenerateCanonicalExpansionManifestTrain;
 use App\Console\Commands\CareerImportActorsDisplayAsset;
 use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
@@ -225,6 +226,7 @@ class Kernel extends ConsoleKernel
         CareerCompileAuthorityWave::class,
         CareerCompileRecommendationSubjects::class,
         CareerCrosswalkOps::class,
+        CareerGenerateCanonicalExpansionManifestTrain::class,
         CareerExportCanonicalExpansionManifest::class,
         CareerExportCanonicalEligibilityDbContext::class,
         CareerExportCanonicalEligibilitySurfaceContext::class,

--- a/backend/docs/career/audits/80_manifest_train.md
+++ b/backend/docs/career/audits/80_manifest_train.md
@@ -1,0 +1,78 @@
+# Career 80 Manifest Train
+
+`career:generate-canonical-expansion-manifest-train` is a read-only planning command for turning a passed Career 80 cohort readiness artifact into a manifest train artifact.
+
+It consumes `/tmp/career_2786_80_readiness_plan.json` and emits `/tmp/career_2786_80_manifest_train.json`. It does not query the database, mutate state, run rollout dry-runs, run rollout apply, publish occupations, deploy, or touch `fap-web`.
+
+## Usage
+
+```bash
+php artisan career:generate-canonical-expansion-manifest-train \
+  --readiness=/tmp/career_2786_80_readiness_plan.json \
+  --target=80 \
+  --json \
+  --output=/tmp/career_2786_80_manifest_train.json
+```
+
+Options:
+
+- `--readiness=`: required Career cohort readiness JSON artifact.
+- `--target=`: cohort size, default `80`.
+- `--batch-id=`: optional batch id. The default for target 80 is `career_80_canonical_001`.
+- `--locales=`: comma-separated locale list, default `en,zh`.
+- `--json`: emits the manifest train artifact to stdout.
+- `--output=`: optional JSON artifact path.
+- `--strict`: fails on ambiguous selected rows.
+
+## Output Schema
+
+The artifact schema is `career_canonical_expansion_manifest_train.v1`.
+
+Important fields:
+
+- `status`: `pass` or `blocked`.
+- `target`: selected cohort size.
+- `source_readiness`: readiness artifact path and readiness pass evidence.
+- `manifest_count`: number of generated manifest batches.
+- `selected_count`: selected slug count.
+- `batch_id`: stable batch id for the first 80 cohort.
+- `rollback_group`: explicit selected slug list.
+- `batches[].slugs`: explicit selected slug list for the batch.
+- `batches[].rollback_group`: explicit slug-list rollback group, never only a batch id.
+- `batches[].expected_locale_rows`: selected slug count multiplied by locale count.
+- `dry_run_allowed`: true only when the manifest train is valid for the next read-only rollout dry-run step.
+- `apply_allowed`: always false.
+
+`status=pass` means the next step can be a separately controlled read-only rollout dry-run. It does not approve rollout apply or publication expansion.
+
+## Safety Rules
+
+The command blocks when:
+
+- the readiness artifact is missing or malformed;
+- `readiness_pass` is not true;
+- `rollout.manifest_generation_allowed` is not true;
+- `selected_count` is below the requested target;
+- selected slugs are missing or duplicated;
+- locales are empty;
+- the output path is not writable.
+
+The command always reports:
+
+- `read_only=true`;
+- `writes_database=false`;
+- `rollout_allowed=false`;
+- `rollout_dry_run_executed=false`;
+- `rollout_apply_executed=false`;
+- `apply_allowed=false`.
+
+## Non-goals
+
+- No DB mutation.
+- No rollout dry-run execution.
+- No rollout apply.
+- No backfill, rollback, or quarantine.
+- No deploy.
+- No live crawl.
+- No fap-web change.
+- No 300/800/2786 expansion execution.

--- a/backend/tests/Feature/Console/CareerGenerateCanonicalExpansionManifestTrainCommandTest.php
+++ b/backend/tests/Feature/Console/CareerGenerateCanonicalExpansionManifestTrainCommandTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerGenerateCanonicalExpansionManifestTrainCommandTest extends TestCase
+{
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:generate-canonical-expansion-manifest-train', Artisan::all());
+    }
+
+    public function test_missing_readiness_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--readiness' => sys_get_temp_dir().'/missing-career-readiness.json',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('readiness_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+    }
+
+    public function test_invalid_json_blocks(): void
+    {
+        $path = $this->tempPath('invalid-readiness');
+        file_put_contents($path, '{not json');
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('readiness_artifact_json_invalid', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_readiness_pass_false_blocks(): void
+    {
+        $path = $this->writeReadiness(['alpha-career'], readinessPass: false);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('readiness_not_passed', array_column($payload['blockers'], 'reason'));
+        $this->assertFalse($payload['dry_run_allowed']);
+        $this->assertFalse($payload['apply_allowed']);
+    }
+
+    public function test_manifest_generation_not_allowed_blocks(): void
+    {
+        $path = $this->writeReadiness(['alpha-career'], manifestGenerationAllowed: false);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('manifest_generation_not_allowed', array_column($payload['blockers'], 'reason'));
+        $this->assertFalse($payload['dry_run_allowed']);
+    }
+
+    public function test_selected_count_below_target_blocks(): void
+    {
+        $path = $this->writeReadiness(['alpha-career']);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('selected_count_below_target', array_column($payload['blockers'], 'reason'));
+    }
+
+    public function test_duplicate_slugs_block(): void
+    {
+        $path = $this->writeReadiness(['alpha-career', 'alpha-career']);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('selected_slugs_duplicate', $payload['blockers'][0]['reason']);
+        $this->assertSame('alpha-career', $payload['blockers'][0]['evidence']['slug']);
+    }
+
+    public function test_target_defaults_to_80(): void
+    {
+        $path = $this->writeReadiness(['alpha-career']);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(80, $payload['target']);
+        $this->assertContains('selected_count_below_target', array_column($payload['blockers'], 'reason'));
+    }
+
+    public function test_command_accepts_target_override_and_writes_manifest_train(): void
+    {
+        $path = $this->writeReadiness(['beta-career', 'alpha-career', 'gamma-career']);
+        $output = $this->tempPath('manifest-train');
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 2,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame('career_canonical_expansion_manifest_train.v1', $payload['schema_version']);
+        $this->assertSame(2, $payload['target']);
+        $this->assertSame(1, $payload['manifest_count']);
+        $this->assertSame(2, $payload['selected_count']);
+        $this->assertSame(['beta-career', 'alpha-career'], $payload['batches'][0]['slugs']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_rollback_group_is_explicit_slug_list(): void
+    {
+        $path = $this->writeReadiness(['alpha-career', 'beta-career']);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(['alpha-career', 'beta-career'], $payload['rollback_group']);
+        $this->assertSame(['alpha-career', 'beta-career'], $payload['batches'][0]['rollback_group']);
+    }
+
+    public function test_expected_locale_rows_equals_selected_count_times_locales(): void
+    {
+        $path = $this->writeReadiness(['alpha-career', 'beta-career']);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 2,
+            '--locales' => 'en,zh,es',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(['en', 'zh', 'es'], $payload['batches'][0]['locales']);
+        $this->assertSame(6, $payload['batches'][0]['expected_locale_rows']);
+    }
+
+    public function test_apply_allowed_is_always_false_and_dry_run_allowed_only_when_valid(): void
+    {
+        $passing = $this->writeReadiness(['alpha-career']);
+        $blocked = $this->writeReadiness(['alpha-career'], readinessPass: false);
+
+        $this->assertSame(0, $this->callCommand([
+            '--readiness' => $passing,
+            '--target' => 1,
+        ]));
+        $passPayload = $this->payload();
+
+        $this->assertFalse($passPayload['apply_allowed']);
+        $this->assertFalse($passPayload['batches'][0]['apply_allowed']);
+        $this->assertTrue($passPayload['dry_run_allowed']);
+        $this->assertTrue($passPayload['batches'][0]['dry_run_allowed']);
+        $this->assertFalse($passPayload['rollout_dry_run_executed']);
+        $this->assertFalse($passPayload['rollout_apply_executed']);
+
+        $this->assertSame(1, $this->callCommand([
+            '--readiness' => $blocked,
+            '--target' => 1,
+        ]));
+        $blockedPayload = $this->payload();
+
+        $this->assertFalse($blockedPayload['apply_allowed']);
+        $this->assertFalse($blockedPayload['dry_run_allowed']);
+        $this->assertFalse($blockedPayload['writes_database']);
+    }
+
+    public function test_json_output_schema_is_stable(): void
+    {
+        $path = $this->writeReadiness(['alpha-career']);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame([
+            'schema_version',
+            'status',
+            'target',
+            'source_readiness',
+            'manifest_count',
+            'selected_count',
+            'batch_id',
+            'rollback_group',
+            'rollout_allowed',
+            'dry_run_allowed',
+            'apply_allowed',
+            'read_only',
+            'writes_database',
+            'rollout_dry_run_executed',
+            'rollout_apply_executed',
+            'batches',
+            'blockers',
+            'sidecars',
+            'next_required_action',
+        ], array_keys($payload));
+        $this->assertSame('80_ROLLOUT_DRY_RUN_READ_ONLY', $payload['next_required_action']);
+    }
+
+    public function test_command_does_not_mutate_db_or_invoke_rollout(): void
+    {
+        $path = $this->writeReadiness(['alpha-career']);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['rollout_allowed']);
+        $this->assertFalse($payload['rollout_dry_run_executed']);
+        $this->assertFalse($payload['rollout_apply_executed']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:generate-canonical-expansion-manifest-train', array_merge([
+            '--json' => true,
+        ], $options));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeReadiness(
+        array $slugs,
+        bool $readinessPass = true,
+        bool $manifestGenerationAllowed = true,
+    ): string {
+        $rows = [];
+        foreach ($slugs as $index => $slug) {
+            $rows[] = [
+                'slug' => $slug,
+                'locales' => ['en', 'zh'],
+                'score' => $index + 1,
+                'reasons' => [],
+                'deferred_until_candidate' => ['surface_unverified'],
+                'expected_not_ready' => [],
+                'remediation_required' => [],
+            ];
+        }
+
+        $payload = [
+            'schema_version' => 'career_80_cohort_readiness.v1',
+            'status' => $readinessPass ? 'pass' : 'blocked',
+            'readiness_pass' => $readinessPass,
+            'target' => 80,
+            'candidate_count' => count($slugs),
+            'selected_count' => count($slugs),
+            'read_only' => true,
+            'writes_database' => false,
+            'source_audit' => [
+                'path' => '/tmp/synthetic-career-audit.json',
+                'status' => 'blocked',
+                'expected_occupations' => 2786,
+                'audited_occupations' => 2786,
+            ],
+            'policy_summary' => [
+                'near_eligible_count' => count($slugs),
+            ],
+            'selection' => [
+                'strategy' => 'policy_near_eligible_ranked',
+                'slugs' => $slugs,
+                'rows' => $rows,
+            ],
+            'blockers' => [],
+            'sidecars' => [],
+            'rollout' => [
+                'manifest_generation_allowed' => $manifestGenerationAllowed,
+                'apply_allowed' => false,
+                'reason' => 'readiness only; apply requires separate approval',
+            ],
+            'next_required_action' => $readinessPass ? '80_MANIFEST_TRAIN_READ_ONLY' : 'FIX_BLOCKERS',
+        ];
+
+        $path = $this->tempPath('readiness');
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-80-manifest-train-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4562,6 +4562,61 @@
       "sidecar_issues": [
 
       ]
+    },
+    "REPAIR-80-MANIFEST-TRAIN-COMMAND-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-80-manifest-train-command",
+      "title": "feat(api): add career 80 manifest train command",
+      "name": "Add read-only Career 80 manifest train command",
+      "status": "in_progress",
+      "depends_on": [
+        "80-READINESS-2"
+      ],
+      "scope_type": "80_manifest_train_command_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerGenerateCanonicalExpansionManifestTrain.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout",
+        "no rollout dry-run",
+        "no apply",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change",
+        "no 300/800/2786 expansion execution"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided REPAIR-80-MANIFEST-TRAIN-COMMAND-1 execution goal and authorized docs/codex train metadata updates for this item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "80-READINESS-2 passed with selected_count=80 and manifest_generation_allowed=true, but a read-only manifest train command is missing."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to a read-only manifest train command, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "80-MANIFEST-TRAIN-2 run read-only manifest train",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+
+      ]
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2392,3 +2392,42 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-80-MANIFEST-TRAIN-COMMAND-1
+    repo: fap-api
+    depends_on:
+      - 80-READINESS-2
+    branch: fix/career-80-manifest-train-command
+    title: "feat(api): add career 80 manifest train command"
+    scope:
+      - Add a read-only Career canonical expansion manifest train command.
+      - Consume the passed 80 readiness artifact and emit a stable manifest train artifact.
+      - Keep rollback_group as an explicit slug list and keep apply_allowed=false.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerGenerateCanonicalExpansionManifestTrain.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout or rollout dry-run.
+      - Run apply, backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Implement 300/800/2786 expansion beyond generic schema support.
+    validation:
+      - php artisan test --filter=CareerGenerateCanonicalExpansionManifestTrain --no-ansi
+      - php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi
+      - php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi
+      - php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds a read-only `career:generate-canonical-expansion-manifest-train` command that consumes the 80 readiness artifact and emits a stable manifest train artifact.
- Preserves an explicit slug-list `rollback_group` and keeps `apply_allowed=false` in both top-level and batch output.
- Registers REPAIR-80-MANIFEST-TRAIN-COMMAND-1 in the PR train metadata and documents the command contract.

## Safety / non-goals
- No rollout dry-run was run or implemented.
- No rollout apply was run or implemented.
- No DB mutation, apply, backfill, rollback, quarantine, deploy, or fap-web change.
- 300/800/2786 execution remains out of scope beyond generic schema support.

## Validation
- `php artisan test --filter=CareerGenerateCanonicalExpansionManifestTrain --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi`
- `php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi`
- `php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- JSON/YAML metadata validation

## Optional smoke
- Ran local read-only smoke with `/tmp/career_2786_80_readiness_plan.json`.
- Output: `/tmp/career_2786_80_manifest_train_local_smoke.json`
- Result: `status=pass`, `selected_count=80`, `dry_run_allowed=true`, `apply_allowed=false`.

## Next step
- `80-MANIFEST-TRAIN-2` read-only manifest train run after deploy readiness if the command must run on the API host.