### PR TITLE
fix(api): tighten career 80 readiness candidate selection

### DIFF
--- a/backend/app/Console/Commands/CareerGenerateCanonicalExpansionManifestTrain.php
+++ b/backend/app/Console/Commands/CareerGenerateCanonicalExpansionManifestTrain.php
@@ -219,6 +219,26 @@ final class CareerGenerateCanonicalExpansionManifestTrain extends Command
             $blockers[] = $this->blocker('selected_slugs_missing', 'Readiness artifact must include selection.slugs.');
         }
 
+        $rolloutGate = data_get($readiness, 'rollout_candidate_gate');
+        if (is_array($rolloutGate) && ($rolloutGate['required'] ?? null) === true) {
+            $eligibleCount = $rolloutGate['eligible_count'] ?? null;
+            if (! is_int($eligibleCount) || $eligibleCount < $target) {
+                $blockers[] = $this->blocker('rollout_candidate_gate_below_target', 'Readiness artifact does not contain enough rollout-candidate eligible slugs.', [
+                    'target' => $target,
+                    'eligible_count' => $eligibleCount,
+                ]);
+            }
+        }
+
+        foreach ($this->selectedRows($readiness, $target) as $row) {
+            if (($row['rollout_candidate_eligible'] ?? true) !== true) {
+                $blockers[] = $this->blocker('selected_slug_not_rollout_candidate_eligible', 'Readiness artifact selected a slug excluded by the rollout candidate gate.', [
+                    'slug' => $row['slug'] ?? null,
+                    'exclusion_reasons' => $row['rollout_candidate_exclusions'] ?? [],
+                ]);
+            }
+        }
+
         return $blockers;
     }
 
@@ -247,6 +267,33 @@ final class CareerGenerateCanonicalExpansionManifestTrain extends Command
         }
 
         return array_slice($slugs, 0, max($target, count($slugs)));
+    }
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @return list<array<string, mixed>>
+     */
+    private function selectedRows(array $readiness, int $target): array
+    {
+        $selected = $this->selectedSlugs($readiness, $target);
+        $selectedSet = array_fill_keys(array_slice($selected, 0, $target), true);
+        $rows = data_get($readiness, 'selection.rows');
+        if (! is_array($rows)) {
+            return [];
+        }
+
+        $selectedRows = [];
+        foreach ($rows as $row) {
+            if (! is_array($row) || ! isset($row['slug']) || ! is_string($row['slug'])) {
+                continue;
+            }
+
+            if (isset($selectedSet[$row['slug']])) {
+                $selectedRows[] = $row;
+            }
+        }
+
+        return $selectedRows;
     }
 
     /**

--- a/backend/app/Console/Commands/CareerPlanCanonical80CohortReadiness.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical80CohortReadiness.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Domain\Career\Audit\Career2786ReadinessPolicyClassifier;
 use App\Domain\Career\Audit\Career2786ReadinessPolicyRow;
+use App\Domain\Career\Audit\Career80RolloutCandidateGate;
 use App\Domain\Career\Audit\CareerCanonical80CandidateSelectionRow;
 use App\Domain\Career\Audit\CareerCanonical80CandidateSelector;
 use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
@@ -118,8 +119,12 @@ final class CareerPlanCanonical80CohortReadiness extends Command
             $policyRowsBySlug[$row->canonicalSlug] = $row;
         }
 
+        $auditRowsBySlug = $this->auditRowsBySlug($report);
+        $rolloutGate = new Career80RolloutCandidateGate;
         $selection = (new CareerCanonical80CandidateSelector)->select($report, $target);
         $selectable = [];
+        $excluded = [];
+        $exclusionsByReason = [];
         foreach ($selection->rows as $row) {
             $policyRow = $policyRowsBySlug[$row->canonicalSlug] ?? null;
             if (! $policyRow instanceof Career2786ReadinessPolicyRow) {
@@ -130,7 +135,18 @@ final class CareerPlanCanonical80CohortReadiness extends Command
                 continue;
             }
 
-            $selectable[] = [$row, $policyRow];
+            $gate = $rolloutGate->evaluate($auditRowsBySlug[$row->canonicalSlug] ?? []);
+            if ($gate['eligible'] === true) {
+                $selectable[] = [$row, $policyRow, $gate];
+
+                continue;
+            }
+
+            foreach ($gate['reasons'] as $reason) {
+                $exclusionsByReason[$reason] = ($exclusionsByReason[$reason] ?? 0) + 1;
+            }
+            ksort($exclusionsByReason);
+            $excluded[] = $this->excludedRow($row, $policyRow, $gate);
         }
 
         $selected = array_slice($selectable, 0, $target);
@@ -146,6 +162,18 @@ final class CareerPlanCanonical80CohortReadiness extends Command
             'selected_count' => count($selected),
             'read_only' => true,
             'writes_database' => false,
+            'rollout_candidate_gate' => [
+                'required' => true,
+                'expected_runtime_state' => Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE,
+                'eligible_count' => count($selectable),
+                'excluded_count' => count($excluded),
+                'exclusions_by_reason' => $exclusionsByReason,
+                'eligible_slugs' => array_map(
+                    static fn (array $pair): string => $pair[0]->canonicalSlug,
+                    $selectable
+                ),
+                'excluded_rows' => $excluded,
+            ],
             'source_audit' => [
                 'path' => $auditPath,
                 'status' => $report->status,
@@ -163,7 +191,7 @@ final class CareerPlanCanonical80CohortReadiness extends Command
                     $selected
                 ),
                 'rows' => array_map(
-                    fn (array $pair): array => $this->selectionRow($pair[0], $pair[1]),
+                    fn (array $pair): array => $this->selectionRow($pair[0], $pair[1], $pair[2]),
                     $selected
                 ),
             ],
@@ -212,7 +240,7 @@ final class CareerPlanCanonical80CohortReadiness extends Command
             ]);
         }
         if ($candidateCount < $target || $selectedCount < $target) {
-            $blockers[] = $this->blocker('insufficient_near_eligible_candidates', 'Fewer than the target near-eligible slugs can be evaluated.', [
+            $blockers[] = $this->blocker('insufficient_rollout_candidate_eligible_slugs', 'Fewer than the target rollout-candidate eligible slugs can be evaluated.', [
                 'target' => $target,
                 'candidate_count' => $candidateCount,
                 'selected_count' => $selectedCount,
@@ -223,9 +251,10 @@ final class CareerPlanCanonical80CohortReadiness extends Command
     }
 
     /**
+     * @param  array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $gate
      * @return array<string, mixed>
      */
-    private function selectionRow(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow): array
+    private function selectionRow(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow, array $gate): array
     {
         return [
             'slug' => $row->canonicalSlug,
@@ -233,9 +262,44 @@ final class CareerPlanCanonical80CohortReadiness extends Command
             'score' => $row->score,
             'rank' => $row->rank,
             'reasons' => $policyRow->reasons,
+            'rollout_candidate_eligible' => true,
+            'runtime_state_evidence' => $gate['evidence'],
             'deferred_until_candidate' => $policyRow->deferredUntilCandidateReasons,
             'expected_not_ready' => $policyRow->expectedNotReadyReasons,
             'remediation_required' => $policyRow->remediationRequiredReasons,
+            'rollout_candidate_exclusions' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, list<\App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow>>
+     */
+    private function auditRowsBySlug(CareerCanonicalEligibilityReport $report): array
+    {
+        $rowsBySlug = [];
+        foreach ($report->rows as $row) {
+            $rowsBySlug[$row->slug] ??= [];
+            $rowsBySlug[$row->slug][] = $row;
+        }
+
+        return $rowsBySlug;
+    }
+
+    /**
+     * @param  array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $gate
+     * @return array<string, mixed>
+     */
+    private function excludedRow(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow, array $gate): array
+    {
+        return [
+            'slug' => $row->canonicalSlug,
+            'locales' => $policyRow->locales,
+            'candidate_status' => $row->candidateStatus,
+            'score' => $row->score,
+            'rank' => $row->rank,
+            'reasons' => $policyRow->reasons,
+            'exclusion_reasons' => $gate['reasons'],
+            'runtime_state_evidence' => $gate['evidence'],
         ];
     }
 
@@ -266,6 +330,15 @@ final class CareerPlanCanonical80CohortReadiness extends Command
             'selected_count' => 0,
             'read_only' => true,
             'writes_database' => false,
+            'rollout_candidate_gate' => [
+                'required' => true,
+                'expected_runtime_state' => Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE,
+                'eligible_count' => 0,
+                'excluded_count' => 0,
+                'exclusions_by_reason' => [],
+                'eligible_slugs' => [],
+                'excluded_rows' => [],
+            ],
             'source_audit' => null,
             'policy_summary' => [],
             'selection' => [

--- a/backend/app/Domain/Career/Audit/Career80RolloutCandidateGate.php
+++ b/backend/app/Domain/Career/Audit/Career80RolloutCandidateGate.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class Career80RolloutCandidateGate
+{
+    public const EXPECTED_RUNTIME_STATE = 'published_candidate';
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}
+     */
+    public function evaluate(array $auditRows): array
+    {
+        $reasons = [];
+        $runtimeStates = $this->runtimeStates($auditRows);
+        $truthStates = $this->truthStates($auditRows);
+        $projectionStates = $this->projectionStates($auditRows, $runtimeStates);
+        $canonicalPublicTypes = $this->canonicalPublicTypes($auditRows);
+        $candidatePreRouteExpected = $this->candidatePreRouteExpected($auditRows);
+        $candidateUnexpectedExposures = $this->candidateUnexpectedExposures($auditRows);
+        $auditReasons = $this->auditReasons($auditRows);
+
+        foreach ($this->reasonExclusions($auditReasons) as $reason) {
+            $reasons[] = $reason;
+        }
+
+        if (in_array('published', $runtimeStates, true) || in_array('published', $truthStates, true) || in_array('published', $projectionStates, true)) {
+            $reasons[] = 'already_published';
+        }
+
+        if (in_array('blocked', $runtimeStates, true) || in_array('blocked', $truthStates, true) || in_array('blocked', $projectionStates, true)) {
+            $reasons[] = 'runtime_state_blocked';
+        }
+
+        if ($projectionStates === []) {
+            $reasons[] = 'projection_row_missing';
+        } elseif ($this->containsUnexpectedCandidateState($projectionStates)) {
+            $reasons[] = 'projection_state_mismatch';
+        }
+
+        if ($runtimeStates === []) {
+            $reasons[] = 'projection_row_missing';
+        } elseif ($this->containsUnexpectedCandidateState($runtimeStates)) {
+            $reasons[] = 'projection_state_mismatch';
+        }
+
+        if ($truthStates === []) {
+            $reasons[] = 'truth_row_missing';
+        } elseif ($this->containsUnexpectedCandidateState($truthStates)) {
+            $reasons[] = 'truth_state_mismatch';
+        }
+
+        foreach ($canonicalPublicTypes as $type) {
+            if ($type !== 'public_canonical_job') {
+                $reasons[] = 'projection_state_mismatch';
+                break;
+            }
+        }
+
+        if (in_array(false, $candidatePreRouteExpected, true)) {
+            $reasons[] = 'pre_route_not_expected';
+        }
+
+        if ($candidateUnexpectedExposures !== []) {
+            if (in_array('api', $candidateUnexpectedExposures, true)) {
+                $reasons[] = 'unexpected_api_exposure';
+            }
+            if (in_array('route', $candidateUnexpectedExposures, true)) {
+                $reasons[] = 'unexpected_route_exposure';
+            }
+        }
+
+        $reasons = $this->normalizeStrings($reasons);
+
+        return [
+            'eligible' => $reasons === [],
+            'reasons' => $reasons,
+            'evidence' => [
+                'runtime_publish_states' => $runtimeStates,
+                'truth_states' => $truthStates,
+                'projection_states' => $projectionStates,
+                'canonical_public_types' => $canonicalPublicTypes,
+                'candidate_pre_route_expected' => $candidatePreRouteExpected,
+                'candidate_unexpected_exposures' => $candidateUnexpectedExposures,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<string>
+     */
+    private function auditReasons(array $auditRows): array
+    {
+        $reasons = [];
+        foreach ($auditRows as $row) {
+            $reasons = [...$reasons, ...$row->reasons, ...$row->runtimeStatus->reasons, ...$row->surfaceStatus->reasons];
+        }
+
+        return $this->normalizeStrings($reasons);
+    }
+
+    /**
+     * @param  list<string>  $auditReasons
+     * @return list<string>
+     */
+    private function reasonExclusions(array $auditReasons): array
+    {
+        $map = [
+            'candidate_unexpected_api_exposure' => 'unexpected_api_exposure',
+            'candidate_unexpected_route_exposure' => 'unexpected_route_exposure',
+            'candidate_truth_row_missing' => 'truth_row_missing',
+            'truth_row_missing' => 'truth_row_missing',
+            'candidate_projection_row_missing' => 'projection_row_missing',
+            'projection_row_missing' => 'projection_row_missing',
+            'candidate_projection_state_mismatch' => 'projection_state_mismatch',
+            'candidate_projection_must_be_public_canonical_job' => 'projection_state_mismatch',
+            'candidate_truth_state_mismatch' => 'truth_state_mismatch',
+            'candidate_pre_route_not_expected' => 'pre_route_not_expected',
+        ];
+
+        $reasons = [];
+        foreach ($auditReasons as $reason) {
+            if (isset($map[$reason])) {
+                $reasons[] = $map[$reason];
+            }
+        }
+
+        return $this->normalizeStrings($reasons);
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<string>
+     */
+    private function runtimeStates(array $auditRows): array
+    {
+        return $this->stringEvidenceValues($auditRows, 'runtime_publish_state');
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<string>
+     */
+    private function truthStates(array $auditRows): array
+    {
+        return $this->stringEvidenceValues($auditRows, 'truth_state');
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @param  list<string>  $runtimeStates
+     * @return list<string>
+     */
+    private function projectionStates(array $auditRows, array $runtimeStates): array
+    {
+        $states = $this->stringEvidenceValues($auditRows, 'projection_state');
+
+        return $states === [] ? $runtimeStates : $states;
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<string>
+     */
+    private function canonicalPublicTypes(array $auditRows): array
+    {
+        return $this->stringEvidenceValues($auditRows, 'canonical_public_type');
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<bool>
+     */
+    private function candidatePreRouteExpected(array $auditRows): array
+    {
+        $values = [];
+        foreach ($this->evidence($auditRows) as $item) {
+            if (array_key_exists('candidate_pre_route_expected', $item) && is_bool($item['candidate_pre_route_expected'])) {
+                $values[] = $item['candidate_pre_route_expected'];
+            }
+        }
+
+        return array_values(array_unique($values, SORT_REGULAR));
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<string>
+     */
+    private function candidateUnexpectedExposures(array $auditRows): array
+    {
+        $exposures = [];
+        foreach ($this->evidence($auditRows) as $item) {
+            $raw = $item['candidate_unexpected_exposures'] ?? null;
+            if (! is_array($raw)) {
+                continue;
+            }
+
+            foreach ($raw as $exposure) {
+                if (is_string($exposure) && trim($exposure) !== '') {
+                    $exposures[] = trim($exposure);
+                }
+            }
+        }
+
+        return $this->normalizeStrings($exposures);
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<string>
+     */
+    private function stringEvidenceValues(array $auditRows, string $key): array
+    {
+        $values = [];
+        foreach ($this->evidence($auditRows) as $item) {
+            if (array_key_exists($key, $item) && is_string($item[$key]) && trim($item[$key]) !== '') {
+                $values[] = trim($item[$key]);
+            }
+        }
+
+        return $this->normalizeStrings($values);
+    }
+
+    /**
+     * @param  list<CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<array<string, mixed>>
+     */
+    private function evidence(array $auditRows): array
+    {
+        $items = [];
+        foreach ($auditRows as $row) {
+            foreach ([
+                $row->evidence,
+                $row->runtimeStatus->evidence,
+                $row->surfaceStatus->evidence,
+                $row->seoGeoStatus->evidence,
+            ] as $evidence) {
+                foreach ($this->flattenEvidence($evidence) as $item) {
+                    $items[] = $item;
+                }
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param  list<mixed>  $items
+     * @return list<array<string, mixed>>
+     */
+    private function flattenEvidence(array $items): array
+    {
+        $flattened = [];
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            if (! array_is_list($item)) {
+                /** @var array<string, mixed> $item */
+                $flattened[] = $item;
+            }
+
+            foreach ($item as $nested) {
+                if (is_array($nested)) {
+                    $flattened = [...$flattened, ...$this->flattenEvidence(array_is_list($nested) ? $nested : [$nested])];
+                }
+            }
+        }
+
+        return $flattened;
+    }
+
+    /**
+     * @param  list<string>  $states
+     */
+    private function containsUnexpectedCandidateState(array $states): bool
+    {
+        foreach ($states as $state) {
+            if (! in_array($state, [self::EXPECTED_RUNTIME_STATE, 'published'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function normalizeStrings(array $values): array
+    {
+        $normalized = [];
+        foreach ($values as $value) {
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                $normalized[] = $trimmed;
+            }
+        }
+
+        sort($normalized);
+
+        return array_values(array_unique($normalized));
+    }
+}

--- a/backend/docs/career/audits/80_cohort_readiness.md
+++ b/backend/docs/career/audits/80_cohort_readiness.md
@@ -2,7 +2,7 @@
 
 `career:plan-canonical-80-cohort-readiness` is a read-only planning command for the first Career canonical expansion cohort.
 
-It consumes a full canonical eligibility audit artifact, selects deterministic near-eligible candidates, and writes a readiness artifact. It does not query production, mutate the database, generate rollout manifests, run rollout dry-runs, or approve rollout apply.
+It consumes a full canonical eligibility audit artifact, selects deterministic candidates, and writes a readiness artifact. It does not query production, mutate the database, generate rollout manifests, run rollout dry-runs, or approve rollout apply.
 
 ## Usage
 
@@ -30,11 +30,16 @@ The artifact schema is `career_80_cohort_readiness.v1`.
 Important fields:
 
 - `status`: `pass` or `blocked`.
-- `readiness_pass`: true only when enough near-eligible candidates can be selected.
-- `candidate_count`: selectable near-eligible candidate slugs.
+- `readiness_pass`: true only when enough rollout-candidate eligible slugs can be selected.
+- `candidate_count`: selectable rollout-candidate eligible slugs.
 - `selected_count`: selected cohort size.
 - `selection.strategy`: `policy_near_eligible_ranked`.
 - `selection.slugs`: deterministic selected slug list.
+- `rollout_candidate_gate.required`: true.
+- `rollout_candidate_gate.expected_runtime_state`: `published_candidate`.
+- `rollout_candidate_gate.eligible_count`: slugs that can enter the rollout dry-run candidate gate.
+- `rollout_candidate_gate.excluded_count`: otherwise near-eligible slugs rejected before manifest generation.
+- `rollout_candidate_gate.exclusions_by_reason`: stable counts for rejected runtime/public-exposure states.
 - `policy_summary`: policy classifier summary from the audit rows.
 - `rollout.manifest_generation_allowed`: true only after readiness passes.
 - `rollout.apply_allowed`: always false.
@@ -43,13 +48,30 @@ Important fields:
 
 ## Candidate Policy
 
-The command selects from slugs classified as near-eligible or eligible candidates, excluding slugs with hard blockers or remediation-required reasons such as:
+The audit policy can classify a slug as near-eligible for remediation sequencing before it is safe for rollout dry-run promotion. The readiness command now separates:
+
+- `near_eligible_for_remediation`: index/entity/SEO/surface policy is close enough to continue planning.
+- `eligible_for_readiness`: no hard blockers or remediation-required index/entity gaps.
+- `eligible_for_rollout_dry_run_candidate`: the slug also has clean pre-promotion runtime evidence.
+
+The command selects only rollout-candidate eligible slugs. It excludes slugs with hard blockers or remediation-required reasons such as:
 
 - `index_state_missing`
 - `occupation_missing`
 - `entity_field_missing`
 
+It also excludes slugs with runtime or public-exposure evidence that the rollout dry-run would reject:
+
+- already published or already public slugs;
+- unexpected API or route exposure;
+- missing projection rows;
+- missing truth rows;
+- projection or truth state mismatches;
+- blocked runtime state instead of `published_candidate`.
+
 Deferred surface states and expected-not-ready SEO/GEO policy states remain visible on selected rows. They are candidate-stage requirements, not hidden passes.
+
+If fewer than the requested target pass the rollout candidate gate, the artifact blocks with `insufficient_rollout_candidate_eligible_slugs`. That block is expected until runtime candidate state, projection/truth freshness, or readiness selection is repaired.
 
 ## Non-goals
 

--- a/backend/docs/career/audits/80_manifest_train.md
+++ b/backend/docs/career/audits/80_manifest_train.md
@@ -52,10 +52,14 @@ The command blocks when:
 - the readiness artifact is missing or malformed;
 - `readiness_pass` is not true;
 - `rollout.manifest_generation_allowed` is not true;
+- `rollout_candidate_gate.required=true` and `rollout_candidate_gate.eligible_count` is below the target;
+- any selected row is marked `rollout_candidate_eligible=false`;
 - `selected_count` is below the requested target;
 - selected slugs are missing or duplicated;
 - locales are empty;
 - the output path is not writable.
+
+The manifest train trusts only selected rows that passed the readiness command's rollout-candidate gate. A slug that is already published, already publicly exposed, missing projection/truth evidence, blocked in runtime projection, or otherwise not in `published_candidate` pre-promotion state must be excluded before manifest generation.
 
 The command always reports:
 

--- a/backend/tests/Feature/Console/CareerGenerateCanonicalExpansionManifestTrainCommandTest.php
+++ b/backend/tests/Feature/Console/CareerGenerateCanonicalExpansionManifestTrainCommandTest.php
@@ -88,6 +88,22 @@ final class CareerGenerateCanonicalExpansionManifestTrainCommandTest extends Tes
         $this->assertContains('selected_count_below_target', array_column($payload['blockers'], 'reason'));
     }
 
+    public function test_rollout_candidate_gate_below_target_blocks(): void
+    {
+        $path = $this->writeReadiness(['alpha-career', 'beta-career'], rolloutCandidateEligibleCount: 1);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('rollout_candidate_gate_below_target', array_column($payload['blockers'], 'reason'));
+        $this->assertFalse($payload['dry_run_allowed']);
+        $this->assertFalse($payload['apply_allowed']);
+    }
+
     public function test_duplicate_slugs_block(): void
     {
         $path = $this->writeReadiness(['alpha-career', 'alpha-career']);
@@ -101,6 +117,21 @@ final class CareerGenerateCanonicalExpansionManifestTrainCommandTest extends Tes
         $this->assertSame(1, $exitCode);
         $this->assertSame('selected_slugs_duplicate', $payload['blockers'][0]['reason']);
         $this->assertSame('alpha-career', $payload['blockers'][0]['evidence']['slug']);
+    }
+
+    public function test_selected_rollout_candidate_ineligible_row_blocks(): void
+    {
+        $path = $this->writeReadiness(['alpha-career'], ineligibleSelectedSlugs: ['alpha-career']);
+
+        $exitCode = $this->callCommand([
+            '--readiness' => $path,
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('selected_slug_not_rollout_candidate_eligible', array_column($payload['blockers'], 'reason'));
+        $this->assertFalse($payload['dry_run_allowed']);
     }
 
     public function test_target_defaults_to_80(): void
@@ -277,17 +308,30 @@ final class CareerGenerateCanonicalExpansionManifestTrainCommandTest extends Tes
         array $slugs,
         bool $readinessPass = true,
         bool $manifestGenerationAllowed = true,
+        ?int $rolloutCandidateEligibleCount = null,
+        array $ineligibleSelectedSlugs = [],
     ): string {
         $rows = [];
         foreach ($slugs as $index => $slug) {
+            $rolloutEligible = ! in_array($slug, $ineligibleSelectedSlugs, true);
             $rows[] = [
                 'slug' => $slug,
                 'locales' => ['en', 'zh'],
                 'score' => $index + 1,
                 'reasons' => [],
+                'rollout_candidate_eligible' => $rolloutEligible,
+                'runtime_state_evidence' => [
+                    'runtime_publish_states' => ['published_candidate'],
+                    'truth_states' => ['published_candidate'],
+                    'projection_states' => ['published_candidate'],
+                    'canonical_public_types' => ['public_canonical_job'],
+                    'candidate_pre_route_expected' => [true],
+                    'candidate_unexpected_exposures' => [],
+                ],
                 'deferred_until_candidate' => ['surface_unverified'],
                 'expected_not_ready' => [],
                 'remediation_required' => [],
+                'rollout_candidate_exclusions' => $rolloutEligible ? [] : ['already_published'],
             ];
         }
 
@@ -300,6 +344,15 @@ final class CareerGenerateCanonicalExpansionManifestTrainCommandTest extends Tes
             'selected_count' => count($slugs),
             'read_only' => true,
             'writes_database' => false,
+            'rollout_candidate_gate' => [
+                'required' => true,
+                'expected_runtime_state' => 'published_candidate',
+                'eligible_count' => $rolloutCandidateEligibleCount ?? count($slugs),
+                'excluded_count' => count($ineligibleSelectedSlugs),
+                'exclusions_by_reason' => $ineligibleSelectedSlugs === [] ? [] : ['already_published' => count($ineligibleSelectedSlugs)],
+                'eligible_slugs' => array_values(array_diff($slugs, $ineligibleSelectedSlugs)),
+                'excluded_rows' => [],
+            ],
             'source_audit' => [
                 'path' => '/tmp/synthetic-career-audit.json',
                 'status' => 'blocked',

--- a/backend/tests/Feature/Console/CareerPlanCanonical80CohortReadinessCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical80CohortReadinessCommandTest.php
@@ -55,7 +55,7 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
         $this->assertSame(1, $exitCode);
         $this->assertSame(80, $payload['target']);
         $this->assertSame(1, $payload['candidate_count']);
-        $this->assertSame('insufficient_near_eligible_candidates', $payload['blockers'][0]['reason']);
+        $this->assertSame('insufficient_rollout_candidate_eligible_slugs', $payload['blockers'][0]['reason']);
         $this->assertFalse($payload['rollout']['manifest_generation_allowed']);
         $this->assertFalse($payload['rollout']['apply_allowed']);
     }
@@ -80,7 +80,90 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
         $this->assertSame(['alpha-career', 'beta-career'], $payload['selection']['slugs']);
         $this->assertTrue($payload['rollout']['manifest_generation_allowed']);
         $this->assertFalse($payload['rollout']['apply_allowed']);
+        $this->assertSame(3, $payload['rollout_candidate_gate']['eligible_count']);
+        $this->assertSame(0, $payload['rollout_candidate_gate']['excluded_count']);
+        $this->assertTrue($payload['selection']['rows'][0]['rollout_candidate_eligible']);
         $this->assertFileExists($output);
+    }
+
+    public function test_rollout_candidate_gate_excludes_runtime_invalid_candidates(): void
+    {
+        $path = $this->writeRows([
+            $this->row('valid-candidate', 'en', []),
+            $this->row('valid-candidate', 'zh', []),
+            $this->row('already-published', 'en', [], runtimeEvidence: [
+                ['runtime_publish_state' => 'published'],
+                ['truth_state' => 'published'],
+                ['canonical_public_type' => 'public_canonical_job'],
+            ]),
+            $this->row('api-exposed', 'en', [], runtimeEvidence: [
+                ['runtime_publish_state' => 'published_candidate'],
+                ['truth_state' => 'published_candidate'],
+                ['canonical_public_type' => 'public_canonical_job'],
+                ['candidate_unexpected_exposures' => ['api']],
+            ]),
+            $this->row('route-exposed', 'en', [], runtimeEvidence: [
+                ['runtime_publish_state' => 'published_candidate'],
+                ['truth_state' => 'published_candidate'],
+                ['canonical_public_type' => 'public_canonical_job'],
+                ['candidate_unexpected_exposures' => ['route']],
+            ]),
+            $this->row('missing-truth', 'en', [], runtimeEvidence: [
+                ['runtime_publish_state' => 'published_candidate'],
+                ['canonical_public_type' => 'public_canonical_job'],
+            ]),
+            $this->row('missing-projection', 'en', [], runtimeEvidence: [
+                ['truth_state' => 'published_candidate'],
+                ['canonical_public_type' => 'public_canonical_job'],
+            ]),
+            $this->row('state-mismatch', 'en', [], runtimeEvidence: [
+                ['runtime_publish_state' => 'blocked'],
+                ['truth_state' => 'blocked'],
+                ['canonical_public_type' => 'blocked_until_governance_approval'],
+            ]),
+        ]);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $path,
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(['valid-candidate'], $payload['selection']['slugs']);
+        $this->assertSame(1, $payload['rollout_candidate_gate']['eligible_count']);
+        $this->assertSame(6, $payload['rollout_candidate_gate']['excluded_count']);
+        $this->assertSame(1, $payload['rollout_candidate_gate']['exclusions_by_reason']['already_published']);
+        $this->assertSame(1, $payload['rollout_candidate_gate']['exclusions_by_reason']['unexpected_api_exposure']);
+        $this->assertSame(1, $payload['rollout_candidate_gate']['exclusions_by_reason']['unexpected_route_exposure']);
+        $this->assertSame(1, $payload['rollout_candidate_gate']['exclusions_by_reason']['truth_row_missing']);
+        $this->assertSame(1, $payload['rollout_candidate_gate']['exclusions_by_reason']['projection_row_missing']);
+        $this->assertSame(1, $payload['rollout_candidate_gate']['exclusions_by_reason']['runtime_state_blocked']);
+        $this->assertSame(1, $payload['rollout_candidate_gate']['exclusions_by_reason']['projection_state_mismatch']);
+    }
+
+    public function test_blocks_when_fewer_than_target_valid_rollout_candidates_exist(): void
+    {
+        $path = $this->writeRows([
+            $this->row('valid-candidate', 'en', []),
+            $this->row('published-candidate', 'en', [], runtimeEvidence: [
+                ['runtime_publish_state' => 'published'],
+                ['truth_state' => 'published'],
+                ['canonical_public_type' => 'public_canonical_job'],
+            ]),
+        ]);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $path,
+            '--target' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['readiness_pass']);
+        $this->assertSame(1, $payload['selected_count']);
+        $this->assertSame('insufficient_rollout_candidate_eligible_slugs', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['rollout']['manifest_generation_allowed']);
     }
 
     public function test_selected_slugs_are_unique_and_exclude_remediation_required_rows(): void
@@ -150,6 +233,7 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
             'selected_count',
             'read_only',
             'writes_database',
+            'rollout_candidate_gate',
             'source_audit',
             'policy_summary',
             'selection',
@@ -159,6 +243,15 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
             'next_required_action',
         ], array_keys($payload));
         $this->assertSame('career_80_cohort_readiness.v1', $payload['schema_version']);
+        $this->assertSame([
+            'required',
+            'expected_runtime_state',
+            'eligible_count',
+            'excluded_count',
+            'exclusions_by_reason',
+            'eligible_slugs',
+            'excluded_rows',
+        ], array_keys($payload['rollout_candidate_gate']));
         $this->assertSame('surface-evidence', $payload['sidecars'][0]['sidecar_id']);
         $this->assertSame('80_MANIFEST_TRAIN_READ_ONLY', $payload['next_required_action']);
     }
@@ -211,6 +304,19 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
             $rows[] = $this->row($slug, 'zh', ['index_state_missing']);
         }
 
+        return $this->writeRows($rows, $expectedOccupations, $auditedOccupations, $sidecars);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @param  list<array<string, mixed>>  $sidecars
+     */
+    private function writeRows(
+        array $rows,
+        int $expectedOccupations = 2786,
+        int $auditedOccupations = 2786,
+        array $sidecars = [],
+    ): string {
         $path = $this->tempPath('audit');
         file_put_contents($path, json_encode([
             'status' => 'blocked',
@@ -222,7 +328,10 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
             'by_reason' => $this->byReason($rows),
             'context_summary' => ['surface_context' => 'supplied'],
             'policy_summary' => [
-                'near_eligible_count' => count(array_unique($nearEligibleSlugs)),
+                'near_eligible_count' => count(array_unique(array_map(
+                    static fn (array $row): string => (string) $row['slug'],
+                    $rows
+                ))),
             ],
             'rows' => $rows,
             'sidecars' => $sidecars,
@@ -235,8 +344,15 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
      * @param  list<string>  $reasons
      * @return array<string, mixed>
      */
-    private function row(string $slug, string $locale, array $reasons): array
+    private function row(string $slug, string $locale, array $reasons, ?array $runtimeEvidence = null): array
     {
+        $runtimeEvidence ??= [
+            ['runtime_publish_state' => 'published_candidate'],
+            ['truth_state' => 'published_candidate'],
+            ['canonical_public_type' => 'public_canonical_job'],
+            ['candidate_pre_route_expected' => true],
+        ];
+
         return [
             'slug' => $slug,
             'locale' => $locale,
@@ -244,7 +360,15 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
             'entity_status' => $this->layer('entity', $this->layerReadiness($reasons, ['occupation_missing', 'entity_field_missing'])),
             'baseline_status' => $this->layer('baseline', 'pass'),
             'index_status' => $this->layer('index', $this->layerReadiness($reasons, ['index_state_missing'])),
-            'runtime_status' => $this->layer('runtime', 'pass'),
+            'runtime_status' => $this->layer('runtime', $this->layerReadiness($reasons, [
+                'truth_row_missing',
+                'projection_row_missing',
+                'candidate_truth_row_missing',
+                'candidate_projection_row_missing',
+                'candidate_projection_state_mismatch',
+                'candidate_truth_state_mismatch',
+                'candidate_pre_route_not_expected',
+            ]), $runtimeEvidence),
             'seo_geo_status' => $this->layer('seo_geo', $this->layerReadiness($reasons, [
                 'sitemap_expected_not_ready',
                 'llms_expected_not_ready',
@@ -275,13 +399,13 @@ final class CareerPlanCanonical80CohortReadinessCommandTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function layer(string $layer, string $status): array
+    private function layer(string $layer, string $status, array $evidence = []): array
     {
         return [
             'layer' => $layer,
             'status' => $status,
             'reasons' => [],
-            'evidence' => [],
+            'evidence' => $evidence,
             'source' => 'synthetic_test_fixture',
         ];
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -409,6 +409,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php',
+            'backend/app/Domain/Career/Audit/Career80RolloutCandidateGate.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -1828,6 +1829,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionReport.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php',
+            'backend/app/Domain/Career/Audit/Career80RolloutCandidateGate.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4617,6 +4617,61 @@
       "sidecar_issues": [
 
       ]
+    },
+    "REPAIR-80-READINESS-SELECTION-2": {
+      "repo": "fap-api",
+      "branch": "fix/career-80-readiness-selection-runtime-gate",
+      "title": "fix(api): tighten career 80 readiness candidate selection",
+      "name": "Exclude already-published and runtime-missing slugs from Career 80 readiness selection",
+      "status": "in_progress",
+      "depends_on": [
+        "80-ROLLOUT-DRY-RUN-1"
+      ],
+      "scope_type": "80_readiness_selection_gate_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonical80CohortReadiness.php",
+        "backend/app/Console/Commands/CareerGenerateCanonicalExpansionManifestTrain.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout",
+        "no rollout dry-run",
+        "no apply",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change",
+        "no 300/800/2786 expansion execution"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided REPAIR-80-READINESS-SELECTION-2 execution goal and authorized docs/codex train metadata updates for this item."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SCAN-11 showed the 80 rollout dry-run was blocked because the selected cohort included already-published/public-exposed slugs and runtime projection/truth gaps while the manifest structure was correct."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to Career 80 readiness selection gating, manifest compatibility guard, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "80-READINESS-3 rerun read-only 80 readiness with rollout-candidate gate",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+
+      ]
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2431,3 +2431,43 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-80-READINESS-SELECTION-2
+    repo: fap-api
+    depends_on:
+      - 80-ROLLOUT-DRY-RUN-1
+    branch: fix/career-80-readiness-selection-runtime-gate
+    title: "fix(api): tighten career 80 readiness candidate selection"
+    name: "Exclude already-published and runtime-missing slugs from Career 80 readiness selection"
+    scope:
+      - Add a rollout-candidate gate to Career 80 readiness selection.
+      - Exclude already-published/public-exposed slugs and slugs missing projection/truth candidate evidence.
+      - Keep manifest generation and rollout apply out of scope.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonical80CohortReadiness.php
+      - backend/app/Console/Commands/CareerGenerateCanonicalExpansionManifestTrain.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout or rollout dry-run.
+      - Run apply, backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Run 300/800/2786 expansion.
+    validation:
+      - php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi
+      - php artisan test --filter=CareerGenerateCanonicalExpansionManifestTrain --no-ansi
+      - php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi
+      - php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- tighten Career 80 readiness selection with a rollout-candidate gate
- exclude already-published/public-exposed slugs from selected readiness cohorts
- exclude candidates missing projection/truth evidence or carrying blocked/mismatched runtime state
- preserve excluded rows in readiness output via `rollout_candidate_gate`
- make manifest train refuse blocked or ineligible readiness artifacts

## Non-goals
- no rollout dry-run
- no rollout apply
- no apply
- no DB mutation
- no deploy
- no fap-web

## Tests
- `php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi` (passed; PHPUnit emitted temp-worktree file_get_contents warnings)
- `php artisan test --filter=CareerGenerateCanonicalExpansionManifestTrain --no-ansi` (passed; PHPUnit emitted temp-worktree file_get_contents warnings)
- `php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi`
- `php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi` (passed; PHPUnit emitted temp-worktree file_get_contents warnings)
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi` (passed; PHPUnit emitted temp-worktree file_get_contents warnings)
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-repair80-selection.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Optional smoke
Read-only smoke against `/tmp/career_2786_canonical_eligibility_audit_after_minimum_index_apply_v2.json` now blocks as expected:
- `readiness_pass=false`
- `selected_count=0`
- exclusions: `already_published=29`, `projection_row_missing=37`, `projection_state_mismatch=14`, `runtime_state_blocked=14`, `truth_row_missing=51`

## Next step
80-READINESS-3 rerun read-only 80 readiness with rollout-candidate gate.
