### PR TITLE
feat(api): add career 80 runtime candidate pool planner

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php
@@ -1,0 +1,797 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\Career2786ReadinessPolicyClassifier;
+use App\Domain\Career\Audit\Career2786ReadinessPolicyRow;
+use App\Domain\Career\Audit\Career80RolloutCandidateGate;
+use App\Domain\Career\Audit\CareerCanonical80CandidateSelectionRow;
+use App\Domain\Career\Audit\CareerCanonical80CandidateSelector;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityReport;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+final class CareerPlanCanonical80RuntimeCandidatePool extends Command
+{
+    private const SCHEMA_VERSION = 'career_80_runtime_candidate_pool_plan.v1';
+
+    protected $signature = 'career:plan-canonical-80-runtime-candidate-pool
+        {--audit= : Required post-apply Career canonical eligibility audit JSON artifact}
+        {--projection= : Required runtime projection JSON artifact}
+        {--truth= : Required runtime truth JSON artifact}
+        {--ledger= : Required full release ledger JSON artifact}
+        {--target=80 : Target runtime candidate pool size}
+        {--locales=en,zh : Comma-separated locales required for each candidate}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for candidate pool plan JSON}
+        {--strict : Fail on malformed or ambiguous artifacts}';
+
+    protected $description = 'Plan the read-only Career 80 pre-promotion runtime candidate pool from audit, projection, truth, and ledger artifacts.';
+
+    public function handle(): int
+    {
+        try {
+            $auditPath = $this->requiredOption('audit');
+            $projectionPath = $this->requiredOption('projection');
+            $truthPath = $this->requiredOption('truth');
+            $ledgerPath = $this->requiredOption('ledger');
+            $target = $this->positiveIntOption('target', 80);
+            $locales = $this->localesOption();
+
+            [$audit, $report] = $this->readAudit($auditPath);
+            $projection = $this->readArtifact($projectionPath, 'projection');
+            $truth = $this->readArtifact($truthPath, 'truth');
+            $ledger = $this->readArtifact($ledgerPath, 'ledger');
+
+            $payload = $this->buildPlan(
+                auditPath: $auditPath,
+                projectionPath: $projectionPath,
+                truthPath: $truthPath,
+                ledgerPath: $ledgerPath,
+                audit: $audit,
+                report: $report,
+                projection: $projection,
+                truth: $truth,
+                ledger: $ledger,
+                target: $target,
+                locales: $locales,
+            );
+
+            return $this->finish($payload, $payload['pool_pass'] === true ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish($this->blockedPayload($this->reasonKey($exception->getMessage()), $exception->getMessage()), self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function positiveIntOption(string $name, int $default): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return $default;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function localesOption(): array
+    {
+        $raw = trim((string) ($this->option('locales') ?? 'en,zh'));
+        $locales = array_values(array_unique(array_filter(array_map(
+            static fn (string $locale): string => trim($locale),
+            explode(',', $raw)
+        ))));
+
+        if ($locales === []) {
+            throw new RuntimeException('locales_missing');
+        }
+
+        sort($locales);
+
+        return $locales;
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: CareerCanonicalEligibilityReport}
+     */
+    private function readAudit(string $path): array
+    {
+        $decoded = $this->readArtifact($path, 'audit');
+
+        try {
+            $report = CareerCanonicalEligibilityReport::fromArray($decoded);
+        } catch (InvalidArgumentException $exception) {
+            if ((bool) $this->option('strict')) {
+                throw new RuntimeException('audit_artifact_shape_invalid');
+            }
+
+            throw new RuntimeException($exception->getMessage());
+        }
+
+        return [$decoded, $report];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readArtifact(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException($kind.'_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException($kind.'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $audit
+     * @param  array<string, mixed>  $projection
+     * @param  array<string, mixed>  $truth
+     * @param  array<string, mixed>  $ledger
+     * @param  list<string>  $locales
+     * @return array<string, mixed>
+     */
+    private function buildPlan(
+        string $auditPath,
+        string $projectionPath,
+        string $truthPath,
+        string $ledgerPath,
+        array $audit,
+        CareerCanonicalEligibilityReport $report,
+        array $projection,
+        array $truth,
+        array $ledger,
+        int $target,
+        array $locales,
+    ): array {
+        $policy = (new Career2786ReadinessPolicyClassifier)->classify($report, $target);
+        $policyRowsBySlug = [];
+        foreach ($policy->rows as $row) {
+            $policyRowsBySlug[$row->canonicalSlug] = $row;
+        }
+
+        $projectionBySlug = $this->rowsBySlugLocale($this->artifactRows($projection, ['items', 'rows']));
+        $truthBySlug = $this->rowsBySlugLocale($this->artifactRows($truth, ['items', 'rows']));
+        $ledgerBySlug = $this->ledgerBySlug($this->artifactRows($ledger, ['members', 'items', 'rows']));
+        $auditRowsBySlug = $this->auditRowsBySlug($report);
+        $selection = (new CareerCanonical80CandidateSelector)->select($report, $target);
+
+        $eligible = [];
+        $excluded = [];
+        $exclusionsByReason = [];
+        $baseCandidateCount = 0;
+        $auditGate = new Career80RolloutCandidateGate;
+
+        foreach ($selection->rows as $row) {
+            $policyRow = $policyRowsBySlug[$row->canonicalSlug] ?? null;
+            if (! $policyRow instanceof Career2786ReadinessPolicyRow) {
+                continue;
+            }
+
+            if (! $this->isBaseCandidate($row, $policyRow)) {
+                continue;
+            }
+
+            $baseCandidateCount++;
+            $gate = $this->evaluateRuntimeCandidate(
+                slug: $row->canonicalSlug,
+                locales: $locales,
+                projectionRows: $projectionBySlug[$row->canonicalSlug] ?? [],
+                truthRows: $truthBySlug[$row->canonicalSlug] ?? [],
+                ledgerMember: $ledgerBySlug[$row->canonicalSlug] ?? null,
+                auditGate: $auditGate->evaluate($auditRowsBySlug[$row->canonicalSlug] ?? []),
+            );
+
+            if ($gate['eligible'] === true) {
+                $eligible[] = $this->eligibleRow($row, $policyRow, $gate);
+
+                continue;
+            }
+
+            foreach ($gate['reasons'] as $reason) {
+                $exclusionsByReason[$reason] = ($exclusionsByReason[$reason] ?? 0) + 1;
+            }
+            ksort($exclusionsByReason);
+            $excluded[] = $this->excludedRow($row, $policyRow, $gate);
+        }
+
+        $selected = array_slice($eligible, 0, $target);
+        $blockers = $this->blockers($report, $target, count($eligible), count($selected));
+        $poolPass = $blockers === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $poolPass ? 'pass' : 'blocked',
+            'pool_pass' => $poolPass,
+            'read_only' => true,
+            'writes_database' => false,
+            'target' => $target,
+            'locales' => $locales,
+            'base_candidate_count' => $baseCandidateCount,
+            'eligible_count' => count($eligible),
+            'selected_count' => count($selected),
+            'excluded_count' => count($excluded),
+            'exclusions_by_reason' => $exclusionsByReason,
+            'source_artifacts' => [
+                'audit' => $this->sourceArtifact($auditPath, [
+                    'status' => $report->status,
+                    'expected_occupations' => $report->expectedOccupations,
+                    'audited_occupations' => $report->auditedOccupations,
+                ]),
+                'projection' => $this->sourceArtifact($projectionPath, [
+                    'row_count' => count($this->artifactRows($projection, ['items', 'rows'])),
+                    'published_candidate_count' => $this->stateCount($projection, 'runtime_publish_state', Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE),
+                ]),
+                'truth' => $this->sourceArtifact($truthPath, [
+                    'row_count' => count($this->artifactRows($truth, ['items', 'rows'])),
+                    'published_candidate_count' => $this->stateCount($truth, 'projection_state', Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE),
+                ]),
+                'ledger' => $this->sourceArtifact($ledgerPath, [
+                    'member_count' => count($this->artifactRows($ledger, ['members', 'items', 'rows'])),
+                ]),
+            ],
+            'runtime_candidate_gate' => [
+                'required' => true,
+                'expected_runtime_state' => Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE,
+                'eligible_count' => count($eligible),
+                'excluded_count' => count($excluded),
+                'exclusions_by_reason' => $exclusionsByReason,
+                'selected_slugs' => array_map(
+                    static fn (array $row): string => (string) $row['slug'],
+                    $selected
+                ),
+                'eligible_rows' => $eligible,
+                'excluded_rows' => $excluded,
+            ],
+            'selection' => [
+                'strategy' => 'runtime_published_candidate_pool_ranked',
+                'slugs' => array_map(
+                    static fn (array $row): string => (string) $row['slug'],
+                    $selected
+                ),
+                'rows' => $selected,
+            ],
+            'recovery_plan' => $this->recoveryPlan($target, count($eligible), $exclusionsByReason),
+            'blockers' => $blockers,
+            'rollout' => [
+                'manifest_generation_allowed' => $poolPass,
+                'dry_run_allowed' => $poolPass,
+                'apply_allowed' => false,
+                'reason' => 'runtime candidate pool planning only; rollout apply requires separate approval',
+            ],
+            'next_required_action' => $poolPass ? '80_READINESS_RERUN_WITH_RUNTIME_POOL' : 'FIX_RUNTIME_CANDIDATE_POOL',
+        ];
+    }
+
+    private function isBaseCandidate(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow): bool
+    {
+        if (! in_array($row->candidateStatus, [
+            CareerCanonical80CandidateSelectionRow::STATUS_READY,
+            CareerCanonical80CandidateSelectionRow::STATUS_NEAR_ELIGIBLE,
+        ], true)) {
+            return false;
+        }
+
+        return $row->hardBlockers === []
+            && $policyRow->hardBlockerReasons === []
+            && $policyRow->remediationRequiredReasons === []
+            && ($policyRow->nearEligible || $policyRow->eligibleCandidate);
+    }
+
+    /**
+     * @param  array<string, list<array<string, mixed>>>  $projectionRows
+     * @param  array<string, list<array<string, mixed>>>  $truthRows
+     * @param  array<string, mixed>|null  $ledgerMember
+     * @param  array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $auditGate
+     * @param  list<string>  $locales
+     * @return array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}
+     */
+    private function evaluateRuntimeCandidate(
+        string $slug,
+        array $locales,
+        array $projectionRows,
+        array $truthRows,
+        ?array $ledgerMember,
+        array $auditGate,
+    ): array {
+        $reasons = [];
+        $evidence = [
+            'slug' => $slug,
+            'required_locales' => $locales,
+            'ledger_member_exists' => $ledgerMember !== null,
+            'ledger_release_cohort' => $ledgerMember['release_cohort'] ?? null,
+            'ledger_public_index_state' => $ledgerMember['public_index_state'] ?? null,
+            'projection_states' => [],
+            'truth_states' => [],
+            'projection_locales_present' => [],
+            'truth_locales_present' => [],
+        ];
+
+        if ($ledgerMember === null) {
+            $reasons[] = 'ledger_member_missing';
+        } elseif (in_array($ledgerMember['release_cohort'] ?? null, ['review_needed', 'family_handoff'], true)) {
+            $reasons[] = 'ledger_not_candidate_ready';
+        }
+
+        foreach ($locales as $locale) {
+            $projectionLocaleRows = $projectionRows[$locale] ?? [];
+            $truthLocaleRows = $truthRows[$locale] ?? [];
+            if ($projectionLocaleRows === []) {
+                $reasons[] = 'projection_row_missing';
+            } else {
+                $evidence['projection_locales_present'][] = $locale;
+                foreach ($projectionLocaleRows as $projectionRow) {
+                    $this->evaluateProjectionRow($projectionRow, $reasons, $evidence);
+                }
+            }
+
+            if ($truthLocaleRows === []) {
+                $reasons[] = 'truth_row_missing';
+            } else {
+                $evidence['truth_locales_present'][] = $locale;
+                foreach ($truthLocaleRows as $truthRow) {
+                    $this->evaluateTruthRow($truthRow, $reasons, $evidence);
+                }
+            }
+        }
+
+        foreach ($auditGate['reasons'] as $reason) {
+            $reasons[] = $reason;
+        }
+
+        $reasons = $this->normalizeStrings($reasons);
+        $evidence['projection_states'] = $this->normalizeStrings($evidence['projection_states']);
+        $evidence['truth_states'] = $this->normalizeStrings($evidence['truth_states']);
+        $evidence['projection_locales_present'] = $this->normalizeStrings($evidence['projection_locales_present']);
+        $evidence['truth_locales_present'] = $this->normalizeStrings($evidence['truth_locales_present']);
+
+        return [
+            'eligible' => $reasons === [],
+            'reasons' => $reasons,
+            'evidence' => $evidence,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @param  list<string>  $reasons
+     * @param  array<string, mixed>  $evidence
+     */
+    private function evaluateProjectionRow(array $row, array &$reasons, array &$evidence): void
+    {
+        $state = $this->stringValue($row, 'runtime_publish_state');
+        if ($state === null) {
+            $state = $this->stringValue($row, 'projection_state');
+        }
+        if ($state !== null) {
+            $evidence['projection_states'][] = $state;
+        }
+
+        if ($state === 'published') {
+            $reasons[] = 'already_published';
+        } elseif ($state === 'blocked') {
+            $reasons[] = 'runtime_state_blocked';
+        } elseif ($state !== Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE) {
+            $reasons[] = 'projection_state_mismatch';
+        }
+
+        if (($this->stringValue($row, 'public_resolution_type') ?? '') !== 'public_canonical_job') {
+            $reasons[] = 'projection_state_mismatch';
+        }
+
+        if (($row['detail_route_enabled'] ?? false) === true) {
+            $reasons[] = 'unexpected_route_exposure';
+        }
+        if (($row['dataset_visible'] ?? false) === true || ($row['search_visible'] ?? false) === true) {
+            $reasons[] = 'unexpected_api_exposure';
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @param  list<string>  $reasons
+     * @param  array<string, mixed>  $evidence
+     */
+    private function evaluateTruthRow(array $row, array &$reasons, array &$evidence): void
+    {
+        $state = $this->stringValue($row, 'projection_state');
+        if ($state === null) {
+            $state = $this->stringValue($row, 'runtime_publish_state');
+        }
+        if ($state !== null) {
+            $evidence['truth_states'][] = $state;
+        }
+
+        if ($state === 'published') {
+            $reasons[] = 'already_published';
+        } elseif ($state === 'blocked') {
+            $reasons[] = 'runtime_state_blocked';
+        } elseif ($state !== Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE) {
+            $reasons[] = 'truth_state_mismatch';
+        }
+
+        if (($this->stringValue($row, 'public_resolution_type') ?? '') !== 'public_canonical_job') {
+            $reasons[] = 'truth_state_mismatch';
+        }
+
+        if (($row['candidate_pre_route_expected'] ?? null) !== true) {
+            $reasons[] = 'pre_route_not_expected';
+        }
+        if (($row['route_exists'] ?? false) === true || ($row['final_200'] ?? false) === true) {
+            $reasons[] = 'unexpected_route_exposure';
+        }
+        if (($row['dataset_visible'] ?? false) === true || ($row['search_visible'] ?? false) === true) {
+            $reasons[] = 'unexpected_api_exposure';
+        }
+
+        $exposures = $row['candidate_unexpected_exposures'] ?? [];
+        if (is_array($exposures)) {
+            if (in_array('api', $exposures, true)) {
+                $reasons[] = 'unexpected_api_exposure';
+            }
+            if (in_array('route', $exposures, true)) {
+                $reasons[] = 'unexpected_route_exposure';
+            }
+        }
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function blockers(CareerCanonicalEligibilityReport $report, int $target, int $eligibleCount, int $selectedCount): array
+    {
+        $blockers = [];
+        if ($report->expectedOccupations !== 2786) {
+            $blockers[] = $this->blocker('expected_occupations_mismatch', 'Audit artifact must cover the 2786 Career canonical program.', [
+                'expected_occupations' => $report->expectedOccupations,
+            ]);
+        }
+        if ($report->auditedOccupations !== 2786) {
+            $blockers[] = $this->blocker('audited_occupations_mismatch', 'Audit artifact must include 2786 audited occupations.', [
+                'audited_occupations' => $report->auditedOccupations,
+            ]);
+        }
+        if ($eligibleCount < $target || $selectedCount < $target) {
+            $blockers[] = $this->blocker('insufficient_runtime_candidate_pool', 'Fewer than the target published_candidate runtime candidates can be evaluated.', [
+                'target' => $target,
+                'eligible_count' => $eligibleCount,
+                'selected_count' => $selectedCount,
+            ]);
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @param  array<string, int>  $exclusionsByReason
+     * @return array<string, mixed>
+     */
+    private function recoveryPlan(int $target, int $eligibleCount, array $exclusionsByReason): array
+    {
+        return [
+            'required' => $eligibleCount < $target,
+            'needed_additional_count' => max(0, $target - $eligibleCount),
+            'reason' => $eligibleCount >= $target
+                ? 'runtime candidate pool has enough published_candidate rows'
+                : 'candidate-state remediation or a larger valid candidate pool is required before readiness can pass',
+            'buckets' => [
+                'exclude_already_published' => $exclusionsByReason['already_published'] ?? 0,
+                'ledger_admission_needed' => $exclusionsByReason['ledger_member_missing'] ?? 0,
+                'candidate_state_repair_needed' => ($exclusionsByReason['projection_row_missing'] ?? 0)
+                    + ($exclusionsByReason['truth_row_missing'] ?? 0)
+                    + ($exclusionsByReason['projection_state_mismatch'] ?? 0)
+                    + ($exclusionsByReason['truth_state_mismatch'] ?? 0)
+                    + ($exclusionsByReason['runtime_state_blocked'] ?? 0)
+                    + ($exclusionsByReason['ledger_not_candidate_ready'] ?? 0),
+            ],
+            'approval_gated_apply_ready' => false,
+            'approval_gate_reason' => 'This planner is read-only and only produces evidence for a later reviewed explicit-slug remediation artifact.',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function sourceArtifact(string $path, array $extra = []): array
+    {
+        return [
+            'path' => $path,
+            'sha256' => hash_file('sha256', $path) ?: null,
+            ...$extra,
+        ];
+    }
+
+    /**
+     * @return array<string, list<\App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow>>
+     */
+    private function auditRowsBySlug(CareerCanonicalEligibilityReport $report): array
+    {
+        $rowsBySlug = [];
+        foreach ($report->rows as $row) {
+            $rowsBySlug[$row->slug] ??= [];
+            $rowsBySlug[$row->slug][] = $row;
+        }
+
+        return $rowsBySlug;
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @param  list<string>  $keys
+     * @return list<array<string, mixed>>
+     */
+    private function artifactRows(array $artifact, array $keys): array
+    {
+        foreach ($keys as $key) {
+            if (isset($artifact[$key]) && is_array($artifact[$key]) && array_is_list($artifact[$key])) {
+                return array_values(array_filter(
+                    $artifact[$key],
+                    static fn (mixed $row): bool => is_array($row) && ! array_is_list($row)
+                ));
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, array<string, list<array<string, mixed>>>>
+     */
+    private function rowsBySlugLocale(array $rows): array
+    {
+        $bySlug = [];
+        foreach ($rows as $row) {
+            $slug = $this->stringValue($row, 'slug');
+            $locale = $this->stringValue($row, 'locale');
+            if ($slug === null || $locale === null) {
+                continue;
+            }
+
+            $bySlug[$slug] ??= [];
+            $bySlug[$slug][$locale] ??= [];
+            $bySlug[$slug][$locale][] = $row;
+        }
+
+        return $bySlug;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $members
+     * @return array<string, array<string, mixed>>
+     */
+    private function ledgerBySlug(array $members): array
+    {
+        $bySlug = [];
+        foreach ($members as $member) {
+            $slug = $this->stringValue($member, 'canonical_slug') ?? $this->stringValue($member, 'slug');
+            if ($slug !== null) {
+                $bySlug[$slug] = $member;
+            }
+        }
+
+        return $bySlug;
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     */
+    private function stateCount(array $artifact, string $key, string $state): int
+    {
+        $count = 0;
+        foreach ($this->artifactRows($artifact, ['items', 'rows']) as $row) {
+            if (($this->stringValue($row, $key) ?? '') === $state) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function stringValue(array $row, string $key): ?string
+    {
+        $value = $row[$key] ?? null;
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        return trim($value);
+    }
+
+    /**
+     * @param  array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $gate
+     * @return array<string, mixed>
+     */
+    private function eligibleRow(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow, array $gate): array
+    {
+        return [
+            'slug' => $row->canonicalSlug,
+            'locales' => $policyRow->locales,
+            'score' => $row->score,
+            'rank' => $row->rank,
+            'rollout_candidate_eligible' => true,
+            'runtime_state_evidence' => $gate['evidence'],
+            'policy_classification' => $policyRow->classification,
+            'deferred_until_candidate' => $policyRow->deferredUntilCandidateReasons,
+            'expected_not_ready' => $policyRow->expectedNotReadyReasons,
+        ];
+    }
+
+    /**
+     * @param  array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $gate
+     * @return array<string, mixed>
+     */
+    private function excludedRow(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow, array $gate): array
+    {
+        return [
+            'slug' => $row->canonicalSlug,
+            'locales' => $policyRow->locales,
+            'score' => $row->score,
+            'rank' => $row->rank,
+            'candidate_status' => $row->candidateStatus,
+            'policy_classification' => $policyRow->classification,
+            'exclusion_reasons' => $gate['reasons'],
+            'runtime_state_evidence' => $gate['evidence'],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, string $message, array $evidence = []): array
+    {
+        return [
+            'reason' => $reason,
+            'message' => $message,
+            'evidence' => $evidence,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blockedPayload(string $reason, string $message): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'blocked',
+            'pool_pass' => false,
+            'read_only' => true,
+            'writes_database' => false,
+            'target' => 80,
+            'locales' => ['en', 'zh'],
+            'base_candidate_count' => 0,
+            'eligible_count' => 0,
+            'selected_count' => 0,
+            'excluded_count' => 0,
+            'exclusions_by_reason' => [],
+            'source_artifacts' => null,
+            'runtime_candidate_gate' => [
+                'required' => true,
+                'expected_runtime_state' => Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE,
+                'eligible_count' => 0,
+                'excluded_count' => 0,
+                'exclusions_by_reason' => [],
+                'selected_slugs' => [],
+                'eligible_rows' => [],
+                'excluded_rows' => [],
+            ],
+            'selection' => [
+                'strategy' => 'runtime_published_candidate_pool_ranked',
+                'slugs' => [],
+                'rows' => [],
+            ],
+            'recovery_plan' => [
+                'required' => true,
+                'needed_additional_count' => 80,
+                'reason' => 'command blocked before candidate pool planning completed',
+                'buckets' => [],
+                'approval_gated_apply_ready' => false,
+            ],
+            'blockers' => [$this->blocker($reason, $message)],
+            'rollout' => [
+                'manifest_generation_allowed' => false,
+                'dry_run_allowed' => false,
+                'apply_allowed' => false,
+                'reason' => 'runtime candidate pool planning only; rollout apply requires separate approval',
+            ],
+            'next_required_action' => 'FIX_RUNTIME_CANDIDATE_POOL',
+        ];
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $value = strtolower(trim($message));
+        $value = preg_replace('/[^a-z0-9_]+/', '_', $value) ?: 'command_failed';
+
+        return trim($value, '_') ?: 'command_failed';
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function normalizeStrings(array $values): array
+    {
+        $normalized = [];
+        foreach ($values as $value) {
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                $normalized[] = $trimmed;
+            }
+        }
+
+        sort($normalized);
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            File::put($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('pool_pass='.(($payload['pool_pass'] ?? false) ? 'true' : 'false'));
+        }
+
+        return $exitCode;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -42,6 +42,7 @@ use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerNormalizeLegacyDisplayAssets;
 use App\Console\Commands\CareerPlanCanonical80CohortReadiness;
+use App\Console\Commands\CareerPlanCanonical80RuntimeCandidatePool;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRemediateCanonicalIndexState;
@@ -204,6 +205,7 @@ class Kernel extends ConsoleKernel
         CareerImportSelectedDisplayAssets::class,
         CareerNormalizeLegacyDisplayAssets::class,
         CareerPlanCanonical80CohortReadiness::class,
+        CareerPlanCanonical80RuntimeCandidatePool::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
         CareerReleaseGateNoindexCleanup::class,
         CareerRemediateCanonicalIndexState::class,

--- a/backend/docs/career/audits/80_runtime_candidate_pool.md
+++ b/backend/docs/career/audits/80_runtime_candidate_pool.md
@@ -1,0 +1,77 @@
+# Career 80 Runtime Candidate Pool Planner
+
+`career:plan-canonical-80-runtime-candidate-pool` is a read-only planner for the first Career 80 canonical expansion cohort.
+
+It exists after the rollout-candidate gate proved that `near_eligible` is not enough for rollout planning. A slug must also have pre-promotion runtime evidence as a `published_candidate` in the runtime projection and truth artifacts.
+
+## Usage
+
+```bash
+php artisan career:plan-canonical-80-runtime-candidate-pool \
+  --audit=/tmp/career_2786_canonical_eligibility_audit_after_minimum_index_apply_v2.json \
+  --projection=/tmp/career_2786_runtime_projection.json \
+  --truth=/tmp/career_2786_runtime_truth.json \
+  --ledger=/tmp/career_2786_full_release_ledger.json \
+  --target=80 \
+  --locales=en,zh \
+  --json \
+  --output=/tmp/career_2786_80_runtime_candidate_pool_plan.json
+```
+
+## Inputs
+
+- `--audit`: full canonical eligibility audit artifact.
+- `--projection`: runtime publish projection artifact.
+- `--truth`: runtime truth artifact.
+- `--ledger`: full release ledger artifact.
+- `--target`: cohort size, default `80`.
+- `--locales`: required locale rows for each candidate, default `en,zh`.
+
+All inputs are JSON artifacts. The command does not query the database.
+
+## Output
+
+The command emits `career_80_runtime_candidate_pool_plan.v1`:
+
+- `pool_pass`: true only when at least `target` slugs are valid runtime candidates.
+- `eligible_count` / `selected_count`: count of valid `published_candidate` slugs.
+- `exclusions_by_reason`: stable counts for rejected slugs.
+- `runtime_candidate_gate`: selected, eligible, and excluded evidence.
+- `recovery_plan`: read-only remediation buckets for a later reviewed explicit-slug plan.
+- `rollout.apply_allowed`: always false.
+
+## Candidate Rules
+
+A selected slug must:
+
+- be a policy near-eligible or eligible candidate from the audit;
+- have no hard blockers or remediation-required reasons;
+- exist in the release ledger;
+- have projection rows for every required locale;
+- have truth rows for every required locale;
+- have `runtime_publish_state` / `projection_state` equal to `published_candidate`;
+- use `public_canonical_job`;
+- have no route/API exposure before promotion.
+
+The command excludes:
+
+- already-published slugs;
+- missing ledger members;
+- missing projection rows;
+- missing truth rows;
+- projection/truth state mismatches;
+- blocked or review-state runtime rows;
+- unexpected API or route exposure.
+
+## Non-goals
+
+- No DB mutation.
+- No apply.
+- No backfill.
+- No rollback or quarantine.
+- No manifest generation.
+- No rollout dry-run.
+- No rollout apply.
+- No fap-web action.
+
+If the planner blocks, the next step is a scoped planner/remediation PR or a reviewed approval-gated candidate-state task, not rollout.

--- a/backend/tests/Feature/Console/CareerPlanCanonical80RuntimeCandidatePoolCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical80RuntimeCandidatePoolCommandTest.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCase
+{
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:plan-canonical-80-runtime-candidate-pool', Artisan::all());
+    }
+
+    public function test_missing_audit_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--audit' => sys_get_temp_dir().'/missing-career-audit.json',
+            '--projection' => $this->writeProjection([]),
+            '--truth' => $this->writeTruth([]),
+            '--ledger' => $this->writeLedger([]),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertFalse($payload['pool_pass']);
+        $this->assertSame('audit_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_invalid_projection_json_blocks(): void
+    {
+        $audit = $this->writeAudit(['alpha-career']);
+        $projection = $this->tempPath('projection');
+        file_put_contents($projection, '{not json');
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--projection' => $projection,
+            '--truth' => $this->writeTruth([]),
+            '--ledger' => $this->writeLedger([]),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('projection_artifact_json_invalid', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_passes_with_target_override_and_writes_output(): void
+    {
+        $slugs = ['zeta-career', 'alpha-career', 'beta-career'];
+        $audit = $this->writeAudit($slugs);
+        $output = $this->tempPath('runtime-pool-output');
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--projection' => $this->writeProjection($slugs),
+            '--truth' => $this->writeTruth($slugs),
+            '--ledger' => $this->writeLedger($slugs),
+            '--target' => 2,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['pool_pass']);
+        $this->assertSame(3, $payload['eligible_count']);
+        $this->assertSame(2, $payload['selected_count']);
+        $this->assertSame(['alpha-career', 'beta-career'], $payload['selection']['slugs']);
+        $this->assertTrue($payload['rollout']['manifest_generation_allowed']);
+        $this->assertTrue($payload['rollout']['dry_run_allowed']);
+        $this->assertFalse($payload['rollout']['apply_allowed']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_excludes_runtime_invalid_candidates(): void
+    {
+        $slugs = [
+            'valid-candidate',
+            'already-published',
+            'missing-ledger',
+            'missing-projection',
+            'missing-truth',
+            'blocked-runtime',
+            'route-exposed',
+        ];
+        $audit = $this->writeAudit($slugs);
+        $projection = $this->writeProjection([
+            'valid-candidate',
+            'already-published' => 'published',
+            'missing-ledger',
+            'missing-truth',
+            'blocked-runtime' => 'blocked',
+            'route-exposed' => 'published_candidate',
+        ], routeExposedSlugs: ['route-exposed']);
+        $truth = $this->writeTruth([
+            'valid-candidate',
+            'already-published' => 'published',
+            'missing-ledger',
+            'missing-projection',
+            'blocked-runtime' => 'blocked',
+            'route-exposed',
+        ], routeExposedSlugs: ['route-exposed']);
+        $ledger = $this->writeLedger([
+            'valid-candidate',
+            'already-published',
+            'missing-projection',
+            'missing-truth',
+            'blocked-runtime',
+            'route-exposed',
+        ], blockedSlugs: ['blocked-runtime']);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--projection' => $projection,
+            '--truth' => $truth,
+            '--ledger' => $ledger,
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(['valid-candidate'], $payload['selection']['slugs']);
+        $this->assertSame(1, $payload['eligible_count']);
+        $this->assertSame(6, $payload['excluded_count']);
+        $this->assertSame(1, $payload['exclusions_by_reason']['already_published']);
+        $this->assertSame(1, $payload['exclusions_by_reason']['ledger_member_missing']);
+        $this->assertSame(1, $payload['exclusions_by_reason']['projection_row_missing']);
+        $this->assertSame(1, $payload['exclusions_by_reason']['truth_row_missing']);
+        $this->assertSame(1, $payload['exclusions_by_reason']['runtime_state_blocked']);
+        $this->assertSame(1, $payload['exclusions_by_reason']['ledger_not_candidate_ready']);
+        $this->assertSame(1, $payload['exclusions_by_reason']['unexpected_route_exposure']);
+    }
+
+    public function test_blocks_when_fewer_than_target_runtime_candidates_exist(): void
+    {
+        $audit = $this->writeAudit(['valid-candidate', 'already-published']);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--projection' => $this->writeProjection(['valid-candidate', 'already-published' => 'published']),
+            '--truth' => $this->writeTruth(['valid-candidate', 'already-published' => 'published']),
+            '--ledger' => $this->writeLedger(['valid-candidate', 'already-published']),
+            '--target' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['pool_pass']);
+        $this->assertSame(1, $payload['selected_count']);
+        $this->assertSame('insufficient_runtime_candidate_pool', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['rollout']['manifest_generation_allowed']);
+        $this->assertFalse($payload['rollout']['dry_run_allowed']);
+    }
+
+    public function test_schema_is_stable_and_never_allows_apply(): void
+    {
+        $audit = $this->writeAudit(['alpha-career']);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--projection' => $this->writeProjection(['alpha-career']),
+            '--truth' => $this->writeTruth(['alpha-career']),
+            '--ledger' => $this->writeLedger(['alpha-career']),
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame([
+            'schema_version',
+            'status',
+            'pool_pass',
+            'read_only',
+            'writes_database',
+            'target',
+            'locales',
+            'base_candidate_count',
+            'eligible_count',
+            'selected_count',
+            'excluded_count',
+            'exclusions_by_reason',
+            'source_artifacts',
+            'runtime_candidate_gate',
+            'selection',
+            'recovery_plan',
+            'blockers',
+            'rollout',
+            'next_required_action',
+        ], array_keys($payload));
+        $this->assertSame('career_80_runtime_candidate_pool_plan.v1', $payload['schema_version']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['rollout']['apply_allowed']);
+        $this->assertFalse($payload['recovery_plan']['approval_gated_apply_ready']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:plan-canonical-80-runtime-candidate-pool', array_merge([
+            '--json' => true,
+        ], $options));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  list<string>  $nearEligibleSlugs
+     */
+    private function writeAudit(array $nearEligibleSlugs): string
+    {
+        $rows = [];
+        foreach (array_values(array_unique($nearEligibleSlugs)) as $slug) {
+            $rows[] = $this->row($slug, 'en');
+            $rows[] = $this->row($slug, 'zh');
+        }
+
+        $path = $this->tempPath('audit');
+        file_put_contents($path, json_encode([
+            'status' => 'blocked',
+            'scope' => 'all',
+            'expected_occupations' => 2786,
+            'audited_occupations' => 2786,
+            'eligible_count' => 0,
+            'blocked_count' => count($rows),
+            'by_reason' => [
+                'llms_expected_not_ready' => count($rows),
+                'surface_unverified' => count($rows),
+            ],
+            'context_summary' => ['surface_context' => 'supplied'],
+            'policy_summary' => ['near_eligible_count' => count($nearEligibleSlugs)],
+            'rows' => $rows,
+            'sidecars' => [],
+        ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function row(string $slug, string $locale): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'source_scope' => 'all',
+            'entity_status' => $this->layer('entity', 'pass'),
+            'baseline_status' => $this->layer('baseline', 'pass'),
+            'index_status' => $this->layer('index', 'pass'),
+            'runtime_status' => $this->layer('runtime', 'pass', [
+                ['runtime_publish_state' => 'published_candidate'],
+                ['truth_state' => 'published_candidate'],
+                ['canonical_public_type' => 'public_canonical_job'],
+                ['candidate_pre_route_expected' => true],
+            ]),
+            'seo_geo_status' => $this->layer('seo_geo', 'blocked', [], ['llms_expected_not_ready']),
+            'surface_status' => $this->layer('surface', 'blocked', [], ['surface_unverified']),
+            'safety_status' => $this->layer('safety', 'pass'),
+            'overall_status' => 'blocked',
+            'severity' => 'high',
+            'reasons' => ['llms_expected_not_ready', 'surface_unverified'],
+            'evidence' => [['slug' => $slug]],
+            'sidecars' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function layer(string $layer, string $status, array $evidence = [], array $reasons = []): array
+    {
+        return [
+            'layer' => $layer,
+            'status' => $status,
+            'reasons' => $status === 'pass' ? [] : $reasons,
+            'evidence' => $evidence,
+            'source' => 'synthetic_test_fixture',
+        ];
+    }
+
+    /**
+     * @param  list<string>|array<string, string>  $slugs
+     * @param  list<string>  $routeExposedSlugs
+     */
+    private function writeProjection(array $slugs, array $routeExposedSlugs = []): string
+    {
+        $rows = [];
+        foreach ($slugs as $key => $value) {
+            $slug = is_string($key) ? $key : $value;
+            $state = is_string($key) ? $value : 'published_candidate';
+            foreach (['en', 'zh'] as $locale) {
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'public_resolution_type' => $state === 'blocked' ? 'blocked_until_governance_approval' : 'public_canonical_job',
+                    'runtime_publish_state' => $state,
+                    'detail_route_enabled' => in_array($slug, $routeExposedSlugs, true),
+                    'dataset_visible' => false,
+                    'search_visible' => false,
+                ];
+            }
+        }
+
+        return $this->writeJson('projection', ['items' => $rows]);
+    }
+
+    /**
+     * @param  list<string>|array<string, string>  $slugs
+     * @param  list<string>  $routeExposedSlugs
+     */
+    private function writeTruth(array $slugs, array $routeExposedSlugs = []): string
+    {
+        $rows = [];
+        foreach ($slugs as $key => $value) {
+            $slug = is_string($key) ? $key : $value;
+            $state = is_string($key) ? $value : 'published_candidate';
+            foreach (['en', 'zh'] as $locale) {
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'public_resolution_type' => $state === 'blocked' ? 'blocked_until_governance_approval' : 'public_canonical_job',
+                    'projection_state' => $state,
+                    'route_exists' => in_array($slug, $routeExposedSlugs, true),
+                    'final_200' => false,
+                    'dataset_visible' => false,
+                    'search_visible' => false,
+                    'candidate_pre_route_expected' => $state === 'published_candidate',
+                    'candidate_unexpected_exposures' => in_array($slug, $routeExposedSlugs, true) ? ['route'] : [],
+                ];
+            }
+        }
+
+        return $this->writeJson('truth', ['items' => $rows]);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $blockedSlugs
+     */
+    private function writeLedger(array $slugs, array $blockedSlugs = []): string
+    {
+        $members = [];
+        foreach ($slugs as $slug) {
+            $members[] = [
+                'canonical_slug' => $slug,
+                'release_cohort' => in_array($slug, $blockedSlugs, true) ? 'review_needed' : 'public_detail_conservative',
+                'public_index_state' => in_array($slug, $blockedSlugs, true) ? 'noindex' : 'indexable',
+            ];
+        }
+
+        return $this->writeJson('ledger', ['members' => $members]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-80-runtime-pool-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -983,7 +983,7 @@
       "sidecar_issues": [
         {
           "sidecar_id": "IQ-SIDECAR-COMMERCE-DEFERRED-001",
-          "title": "defer(iq): commerce unlock ¥1.99 / ¥5 implementation",
+          "title": "defer(iq): commerce unlock \u00a51.99 / \u00a55 implementation",
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
@@ -1002,7 +1002,7 @@
             "api/v0.3/webhooks/payment/*"
           ],
           "evidence": [
-            "User intentionally deferred the ¥1.99 / ¥5 commerce PR.",
+            "User intentionally deferred the \u00a51.99 / \u00a55 commerce PR.",
             "Paid unlock is not required for identity/scoring/report/SVG provenance foundation.",
             "The train can continue without checkout/SKU/webhook changes."
           ],
@@ -4217,7 +4217,7 @@
         },
         "forbidden_runtime_claim_grep": {
           "status": "pass",
-          "command": "rg -n \"Matches|career recommendation|job fit|success prediction|success probability|hiring suitability|140Q more accurate|raw score delta|更准确|更准|岗位匹配|职业推荐|职业成功\" backend/app/Services/Riasec/RiasecPublicProjectionService.php backend/app/Services/Report/RiasecReportComposer.php || true",
+          "command": "rg -n \"Matches|career recommendation|job fit|success prediction|success probability|hiring suitability|140Q more accurate|raw score delta|\u66f4\u51c6\u786e|\u66f4\u51c6|\u5c97\u4f4d\u5339\u914d|\u804c\u4e1a\u63a8\u8350|\u804c\u4e1a\u6210\u529f\" backend/app/Services/Riasec/RiasecPublicProjectionService.php backend/app/Services/Report/RiasecReportComposer.php || true",
           "evidence": "No runtime service hits."
         },
         "diff_check": {
@@ -4663,6 +4663,60 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "REPAIR-80-CANDIDATE-RUNTIME-POOL-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-80-candidate-runtime-pool-1",
+      "title": "feat(api): add career 80 runtime candidate pool planner",
+      "name": "Add read-only Career 80 runtime candidate pool planner",
+      "status": "in_progress",
+      "depends_on": [
+        "80-READINESS-3"
+      ],
+      "scope_type": "80_runtime_candidate_pool_planner_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout",
+        "no rollout dry-run",
+        "no manifest generation",
+        "no apply",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change",
+        "no 300/800/2786 expansion execution"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-80-CANDIDATE-RUNTIME-POOL-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "80-READINESS-3 blocked correctly with rollout_candidate_eligible_count=0, and SCAN-12 determined a read-only runtime candidate pool planner is the next remediation step."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Allowed scope is limited to read-only runtime candidate pool planning, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "80-CANDIDATE-RUNTIME-POOL-RUN-1 read-only pool planning",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4695,8 +4695,8 @@
         "no fap-web change",
         "no 300/800/2786 expansion execution"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "5fa41979140482e6c53a3eac549d1823338b48fc",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1379",
       "checks": {
         "authorization": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4695,7 +4695,7 @@
         "no fap-web change",
         "no 300/800/2786 expansion execution"
       ],
-      "commit_sha": "5fa41979140482e6c53a3eac549d1823338b48fc",
+      "commit_sha": "972071868d8ba44e57d4152376610624309ae2b9",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1379",
       "checks": {
         "authorization": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2501,3 +2501,43 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-80-CANDIDATE-RUNTIME-POOL-1
+    repo: fap-api
+    depends_on:
+      - 80-READINESS-3
+    branch: codex/repair-80-candidate-runtime-pool-1
+    title: "feat(api): add career 80 runtime candidate pool planner"
+    name: "Add read-only Career 80 runtime candidate pool planner"
+    scope:
+      - Add a read-only Career 80 runtime candidate pool planner command.
+      - Consume audit, runtime projection, runtime truth, and release ledger artifacts.
+      - Report whether 80 published_candidate pre-promotion candidates exist and classify exclusions.
+      - Keep manifest generation, rollout dry-run, rollout apply, and DB mutation out of scope.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout or rollout dry-run.
+      - Run apply, backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Run manifest generation.
+    validation:
+      - php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
+      - php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi
+      - php artisan test --filter=CareerGenerateCanonicalExpansionManifestTrain --no-ansi
+      - php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi
+      - php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds read-only `career:plan-canonical-80-runtime-candidate-pool` command.
- Consumes audit, runtime projection, runtime truth, and release ledger artifacts.
- Reports whether 80 `published_candidate` pre-promotion candidates exist and classifies exclusions.
- Keeps manifest generation, rollout dry-run, rollout apply, and DB mutation out of scope.

## Runtime / production safety
- No production touched.
- No DB mutation.
- No rollout dry-run or rollout apply.
- No apply/backfill/rollback/quarantine.
- No fap-web changes.
- `rollout.apply_allowed` is always false.

## Validation
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi`
- `php artisan test --filter=CareerGenerateCanonicalExpansionManifestTrain --no-ansi`
- `php artisan test --filter=CareerCanonical80CandidateSelector --no-ansi`
- `php artisan test --filter=Career2786ReadinessPolicyClassifier --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-repair-80-candidate-runtime-pool-1.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Local smoke
Read-only smoke against current `/tmp` Career artifacts produced blocked output, as expected:
- `pool_pass=false`
- `eligible_count=0`
- `selected_count=0`
- `apply_allowed=false`
- output: `/tmp/career_2786_80_runtime_candidate_pool_plan_local_smoke.json`

## Next step
`80-CANDIDATE-RUNTIME-POOL-RUN-1` read-only pool planning.
