### PR TITLE
fix(api): add career 80 target delta decomposition

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonical80TargetDelta.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical80TargetDelta.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\Career80TargetDeltaPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerPlanCanonical80TargetDelta extends Command
+{
+    protected $signature = 'career:plan-canonical-80-target-delta
+        {--readiness= : Required Career 80 readiness JSON artifact}
+        {--delta-slugs= : Required reviewed 51-slug delta artifact JSON path}
+        {--runtime-pool= : Optional runtime candidate pool JSON artifact for already-published evidence}
+        {--target=80 : Target public total}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for target delta plan JSON}';
+
+    protected $description = 'Plan the read-only Career 80 target decomposition into published baseline and delta promotion slugs.';
+
+    public function handle(): int
+    {
+        try {
+            $readinessPath = $this->requiredOption('readiness');
+            $deltaPath = $this->requiredOption('delta-slugs');
+            $runtimePoolPath = $this->pathOption('runtime-pool');
+            $target = $this->positiveIntOption('target', 80);
+
+            $result = app(Career80TargetDeltaPlanner::class)->plan(
+                readiness: $this->readJson($readinessPath, 'readiness'),
+                deltaArtifact: $this->readJson($deltaPath, 'delta_slug'),
+                runtimePool: $runtimePoolPath === null ? null : $this->readJson($runtimePoolPath, 'runtime_pool'),
+                target: $target,
+            )->toArray();
+
+            return $this->finish($result, ($result['status'] ?? null) === 'pass' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => Career80TargetDeltaPlanner::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                ]],
+            ], self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
+    private function positiveIntOption(string $name, int $default): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return $default;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException($kind.'_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException($kind.'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $output = $this->option('output');
+        if (is_string($output) && trim($output) !== '') {
+            File::put(trim($output), json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            $this->line('status='.($payload['status'] ?? 'unknown'));
+            $this->line('published_baseline_count='.(string) ($payload['published_baseline_count'] ?? 0));
+            $this->line('delta_promotion_count='.(string) ($payload['delta_promotion_count'] ?? 0));
+            $this->line('target_public_total='.(string) ($payload['target_public_total'] ?? 0));
+        }
+
+        return $exitCode;
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $key = strtolower(trim($message));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $key) ?? 'target_delta_error';
+        $key = trim($key, '_');
+
+        return $key === '' ? 'target_delta_error' : $key;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -43,6 +43,7 @@ use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerNormalizeLegacyDisplayAssets;
 use App\Console\Commands\CareerPlanCanonical80CohortReadiness;
 use App\Console\Commands\CareerPlanCanonical80RuntimeCandidatePool;
+use App\Console\Commands\CareerPlanCanonical80TargetDelta;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRemediateCanonicalIndexState;
@@ -206,6 +207,7 @@ class Kernel extends ConsoleKernel
         CareerNormalizeLegacyDisplayAssets::class,
         CareerPlanCanonical80CohortReadiness::class,
         CareerPlanCanonical80RuntimeCandidatePool::class,
+        CareerPlanCanonical80TargetDelta::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
         CareerReleaseGateNoindexCleanup::class,
         CareerRemediateCanonicalIndexState::class,

--- a/backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php
+++ b/backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use RuntimeException;
+
+final class Career80TargetDeltaPlanner
+{
+    public const SCHEMA_VERSION = 'career_80_target_delta.v1';
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @param  array<string, mixed>  $deltaArtifact
+     * @param  array<string, mixed>|null  $runtimePool
+     */
+    public function plan(array $readiness, array $deltaArtifact, ?array $runtimePool = null, int $target = 80): Career80TargetDeltaResult
+    {
+        if ($target < 1) {
+            throw new RuntimeException('target_invalid');
+        }
+
+        $previousSelection = $this->selectedSlugs($readiness);
+        $deltaSlugs = $this->deltaSlugs($deltaArtifact);
+        $baselineSlugs = array_values(array_diff($previousSelection, $deltaSlugs));
+        sort($baselineSlugs);
+
+        $deltaInPrevious = array_values(array_intersect($deltaSlugs, $previousSelection));
+        sort($deltaInPrevious);
+        $baselineInPrevious = array_values(array_intersect($baselineSlugs, $previousSelection));
+        sort($baselineInPrevious);
+        $unexpectedSelection = array_values(array_diff($previousSelection, $baselineSlugs, $deltaSlugs));
+        sort($unexpectedSelection);
+        $deltaMissingFromSelection = array_values(array_diff($deltaSlugs, $previousSelection));
+        sort($deltaMissingFromSelection);
+
+        $alreadyPublishedEvidence = $runtimePool === null ? [] : $this->alreadyPublishedSlugs($runtimePool);
+        $blockers = $this->blockers(
+            target: $target,
+            previousSelection: $previousSelection,
+            baselineSlugs: $baselineSlugs,
+            deltaSlugs: $deltaSlugs,
+            unexpectedSelection: $unexpectedSelection,
+            deltaMissingFromSelection: $deltaMissingFromSelection,
+            alreadyPublishedEvidence: $alreadyPublishedEvidence,
+        );
+        $pass = $blockers === [];
+
+        return new Career80TargetDeltaResult([
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $pass ? 'pass' : 'blocked',
+            'read_only' => true,
+            'writes_database' => false,
+            'target_public_total' => $target,
+            'published_baseline_count' => count($baselineSlugs),
+            'delta_promotion_count' => count($deltaSlugs),
+            'previous_80_selected_count' => count($previousSelection),
+            'published_baseline_slugs' => $baselineSlugs,
+            'delta_promotion_slugs' => $deltaSlugs,
+            'recommended_rollout_delta_slugs' => $deltaSlugs,
+            'validation' => [
+                'baseline_plus_delta_count' => count($baselineSlugs) + count($deltaSlugs),
+                'baseline_delta_overlap_count' => count(array_intersect($baselineSlugs, $deltaSlugs)),
+                'delta_in_previous_80_count' => count($deltaInPrevious),
+                'published_baseline_in_previous_80_count' => count($baselineInPrevious),
+                'previous_80_not_baseline_or_delta' => $unexpectedSelection,
+                'delta_not_in_previous_80' => $deltaMissingFromSelection,
+                'already_published_evidence_count' => count($alreadyPublishedEvidence),
+                'baseline_matches_already_published_evidence' => $alreadyPublishedEvidence === [] ? null : $baselineSlugs === $alreadyPublishedEvidence,
+            ],
+            'overlap' => [
+                'published_baseline_in_previous_80' => $baselineInPrevious,
+                'delta_in_previous_80' => $deltaInPrevious,
+            ],
+            'blockers' => $blockers,
+            'rollout' => [
+                'delta_manifest_allowed' => $pass,
+                'rollout_dry_run_allowed' => false,
+                'apply_allowed' => false,
+                'reason' => 'target decomposition only; rollout dry-run and apply require separate later gates',
+            ],
+            'next_required_action' => $pass ? 'RUNTIME_CANDIDATE_PREP_PLAN_READ_ONLY' : 'FIX_TARGET_DELTA_BLOCKERS',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @return list<string>
+     */
+    private function selectedSlugs(array $readiness): array
+    {
+        $slugs = data_get($readiness, 'selection.slugs');
+        if (! is_array($slugs) || ! array_is_list($slugs)) {
+            throw new RuntimeException('readiness_selection_slugs_missing');
+        }
+
+        return $this->normalizedUniqueSlugs($slugs, 'readiness_selection');
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return list<string>
+     */
+    private function deltaSlugs(array $artifact): array
+    {
+        $slugs = $artifact['slugs'] ?? null;
+        if (! is_array($slugs) || ! array_is_list($slugs)) {
+            throw new RuntimeException('delta_slug_list_missing');
+        }
+
+        $normalized = $this->normalizedUniqueSlugs($slugs, 'delta_slug');
+        $declaredCount = $artifact['count'] ?? $artifact['slug_count'] ?? data_get($artifact, 'target.slug_count');
+        if ($declaredCount !== null && (int) $declaredCount !== count($normalized)) {
+            throw new RuntimeException('delta_slug_count_declared_mismatch');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  list<mixed>  $slugs
+     * @return list<string>
+     */
+    private function normalizedUniqueSlugs(array $slugs, string $context): array
+    {
+        $normalized = [];
+        $seen = [];
+        foreach ($slugs as $index => $slug) {
+            if (! is_string($slug)) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            $value = strtolower(trim($slug));
+            if ($value === '' || str_contains($value, '*')) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            if (isset($seen[$value])) {
+                throw new RuntimeException($context.'_duplicate_'.$value);
+            }
+
+            $seen[$value] = true;
+            $normalized[] = $value;
+        }
+
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $runtimePool
+     * @return list<string>
+     */
+    private function alreadyPublishedSlugs(array $runtimePool): array
+    {
+        $rows = data_get($runtimePool, 'runtime_candidate_gate.excluded_rows');
+        if (! is_array($rows)) {
+            return [];
+        }
+
+        $slugs = [];
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $reasons = $row['exclusion_reasons'] ?? [];
+            if (! is_array($reasons) || ! in_array('already_published', $reasons, true)) {
+                continue;
+            }
+            $slug = strtolower(trim((string) ($row['slug'] ?? '')));
+            if ($slug !== '') {
+                $slugs[] = $slug;
+            }
+        }
+
+        return $this->normalizedUniqueSlugs($slugs, 'already_published_evidence');
+    }
+
+    /**
+     * @param  list<string>  $previousSelection
+     * @param  list<string>  $baselineSlugs
+     * @param  list<string>  $deltaSlugs
+     * @param  list<string>  $unexpectedSelection
+     * @param  list<string>  $deltaMissingFromSelection
+     * @param  list<string>  $alreadyPublishedEvidence
+     * @return list<array<string, mixed>>
+     */
+    private function blockers(
+        int $target,
+        array $previousSelection,
+        array $baselineSlugs,
+        array $deltaSlugs,
+        array $unexpectedSelection,
+        array $deltaMissingFromSelection,
+        array $alreadyPublishedEvidence,
+    ): array {
+        $blockers = [];
+
+        if (count($previousSelection) !== $target) {
+            $blockers[] = $this->blocker('previous_selection_count_mismatch', [
+                'expected' => $target,
+                'actual' => count($previousSelection),
+            ]);
+        }
+
+        if (count(array_intersect($baselineSlugs, $deltaSlugs)) > 0) {
+            $blockers[] = $this->blocker('baseline_delta_overlap', [
+                'overlap' => array_values(array_intersect($baselineSlugs, $deltaSlugs)),
+            ]);
+        }
+
+        if (count($baselineSlugs) + count($deltaSlugs) !== $target) {
+            $blockers[] = $this->blocker('target_total_mismatch', [
+                'target' => $target,
+                'baseline_count' => count($baselineSlugs),
+                'delta_count' => count($deltaSlugs),
+            ]);
+        }
+
+        if ($unexpectedSelection !== []) {
+            $blockers[] = $this->blocker('previous_selection_contains_unknown_slugs', [
+                'slugs' => $unexpectedSelection,
+            ]);
+        }
+
+        if ($deltaMissingFromSelection !== []) {
+            $blockers[] = $this->blocker('delta_slugs_missing_from_previous_selection', [
+                'slugs' => $deltaMissingFromSelection,
+            ]);
+        }
+
+        if ($alreadyPublishedEvidence !== [] && $baselineSlugs !== $alreadyPublishedEvidence) {
+            $blockers[] = $this->blocker('published_baseline_evidence_mismatch', [
+                'baseline_count' => count($baselineSlugs),
+                'already_published_evidence_count' => count($alreadyPublishedEvidence),
+            ]);
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, array $evidence): array
+    {
+        return [
+            'reason' => $reason,
+            'evidence' => $evidence,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php
+++ b/backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class Career80TargetDeltaResult
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(
+        private readonly array $payload,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+
+    public function passed(): bool
+    {
+        return ($this->payload['status'] ?? null) === 'pass';
+    }
+}

--- a/backend/docs/career/audits/80_target_delta.md
+++ b/backend/docs/career/audits/80_target_delta.md
@@ -1,0 +1,47 @@
+# Career 80 Target Delta Decomposition
+
+The Career 80 target is not 80 new promotion candidates. It is the sum of:
+
+- 29 already-published baseline slugs.
+- 51 delta promotion slugs.
+
+`career:plan-canonical-80-target-delta` produces a read-only artifact that makes this accounting explicit before runtime candidate preparation, delta manifests, rollout dry-runs, or live acceptance.
+
+## Usage
+
+```bash
+php artisan career:plan-canonical-80-target-delta \
+  --readiness=/tmp/career_2786_80_readiness_plan.json \
+  --delta-slugs=/tmp/career_2786_minimum_index_state_slugs_for_80.json \
+  --runtime-pool=/tmp/career_2786_80_runtime_candidate_pool_plan.json \
+  --target=80 \
+  --json \
+  --output=/tmp/career_80_target_delta_plan.json
+```
+
+## Output
+
+The output schema is `career_80_target_delta.v1` and includes:
+
+- `target_public_total`
+- `published_baseline_count`
+- `delta_promotion_count`
+- `previous_80_selected_count`
+- `published_baseline_slugs`
+- `delta_promotion_slugs`
+- `recommended_rollout_delta_slugs`
+- validation evidence and blockers
+
+The command is read-only. It never queries production, mutates the database, generates a manifest, runs rollout dry-run, or applies rollout.
+
+## Gates
+
+A passing target decomposition only allows the next read-only planning step: runtime candidate preparation planning for the 51 delta slugs. It does not approve candidate preparation apply, rollout dry-run, rollout apply, deploy, live crawl, or publication expansion.
+
+## Non-goals
+
+- No runtime candidate preparation.
+- No database writes.
+- No manifest generation.
+- No rollout dry-run or rollout apply.
+- No fap-web changes.

--- a/backend/tests/Feature/Console/CareerPlanCanonical80TargetDeltaCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical80TargetDeltaCommandTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerPlanCanonical80TargetDeltaCommandTest extends TestCase
+{
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:plan-canonical-80-target-delta', Artisan::all());
+    }
+
+    public function test_missing_readiness_blocks(): void
+    {
+        $exitCode = Artisan::call('career:plan-canonical-80-target-delta', [
+            '--readiness' => sys_get_temp_dir().'/missing-readiness.json',
+            '--delta-slugs' => $this->writeDelta(['delta-001']),
+            '--json' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('readiness_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_generates_target_delta_plan_and_writes_output(): void
+    {
+        $baseline = $this->slugs('baseline', 2);
+        $delta = $this->slugs('delta', 3);
+        $output = $this->tempPath('output');
+
+        $exitCode = Artisan::call('career:plan-canonical-80-target-delta', [
+            '--readiness' => $this->writeReadiness([...$baseline, ...$delta]),
+            '--delta-slugs' => $this->writeDelta($delta),
+            '--runtime-pool' => $this->writeRuntimePool($baseline),
+            '--target' => 5,
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('career_80_target_delta.v1', $payload['schema_version']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(2, $payload['published_baseline_count']);
+        $this->assertSame(3, $payload['delta_promotion_count']);
+        $this->assertSame(5, $payload['target_public_total']);
+        $this->assertSame($delta, $payload['recommended_rollout_delta_slugs']);
+        $this->assertTrue($payload['rollout']['delta_manifest_allowed']);
+        $this->assertFalse($payload['rollout']['apply_allowed']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_blocks_malformed_delta_artifact(): void
+    {
+        $exitCode = Artisan::call('career:plan-canonical-80-target-delta', [
+            '--readiness' => $this->writeReadiness(['baseline-001']),
+            '--delta-slugs' => $this->writeJson('bad-delta', ['not_slugs' => []]),
+            '--json' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('delta_slug_list_missing', $payload['blockers'][0]['reason']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%03d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeReadiness(array $slugs): string
+    {
+        sort($slugs);
+
+        return $this->writeJson('readiness', [
+            'schema_version' => 'career_80_cohort_readiness.v1',
+            'status' => 'pass',
+            'readiness_pass' => true,
+            'target' => count($slugs),
+            'selection' => [
+                'strategy' => 'test',
+                'slugs' => $slugs,
+                'rows' => [],
+            ],
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeDelta(array $slugs): string
+    {
+        return $this->writeJson('delta', [
+            'schema_version' => 'career_minimum_index_state_remediation.v1',
+            'count' => count($slugs),
+            'slugs' => $slugs,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $alreadyPublished
+     */
+    private function writeRuntimePool(array $alreadyPublished): string
+    {
+        return $this->writeJson('runtime-pool', [
+            'schema_version' => 'career_80_runtime_candidate_pool_plan.v1',
+            'runtime_candidate_gate' => [
+                'excluded_rows' => array_map(static fn (string $slug): array => [
+                    'slug' => $slug,
+                    'exclusion_reasons' => ['already_published'],
+                ], $alreadyPublished),
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-80-target-delta-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/Career80TargetDeltaPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career80TargetDeltaPlannerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\Career80TargetDeltaPlanner;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class Career80TargetDeltaPlannerTest extends TestCase
+{
+    public function test_passes_for_29_baseline_plus_51_delta(): void
+    {
+        $baseline = $this->slugs('baseline', 29);
+        $delta = $this->slugs('delta', 51);
+
+        $payload = (new Career80TargetDeltaPlanner)->plan(
+            readiness: $this->readiness([...$baseline, ...$delta]),
+            deltaArtifact: $this->deltaArtifact($delta),
+            runtimePool: $this->runtimePool($baseline),
+            target: 80,
+        )->toArray();
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(29, $payload['published_baseline_count']);
+        $this->assertSame(51, $payload['delta_promotion_count']);
+        $this->assertSame(80, $payload['target_public_total']);
+        $this->assertSame(80, $payload['validation']['baseline_plus_delta_count']);
+        $this->assertTrue($payload['validation']['baseline_matches_already_published_evidence']);
+        $this->assertSame($delta, $payload['recommended_rollout_delta_slugs']);
+        $this->assertFalse($payload['rollout']['apply_allowed']);
+    }
+
+    public function test_blocks_duplicate_delta_slugs(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('delta_slug_duplicate_delta-001');
+
+        (new Career80TargetDeltaPlanner)->plan(
+            readiness: $this->readiness(['baseline-001', 'delta-001']),
+            deltaArtifact: $this->deltaArtifact(['delta-001', 'delta-001']),
+            target: 2,
+        );
+    }
+
+    public function test_blocks_when_total_does_not_equal_target(): void
+    {
+        $payload = (new Career80TargetDeltaPlanner)->plan(
+            readiness: $this->readiness(['baseline-001', 'delta-001']),
+            deltaArtifact: $this->deltaArtifact(['delta-001']),
+            target: 3,
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('previous_selection_count_mismatch', $payload['blockers'][0]['reason']);
+        $this->assertSame('target_total_mismatch', $payload['blockers'][1]['reason']);
+    }
+
+    public function test_blocks_when_delta_missing_from_previous_selection(): void
+    {
+        $payload = (new Career80TargetDeltaPlanner)->plan(
+            readiness: $this->readiness(['baseline-001', 'delta-001']),
+            deltaArtifact: $this->deltaArtifact(['delta-001', 'delta-002']),
+            target: 2,
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('delta_slugs_missing_from_previous_selection', array_column($payload['blockers'], 'reason'));
+    }
+
+    public function test_blocks_when_already_published_evidence_does_not_match_baseline(): void
+    {
+        $payload = (new Career80TargetDeltaPlanner)->plan(
+            readiness: $this->readiness(['baseline-001', 'delta-001']),
+            deltaArtifact: $this->deltaArtifact(['delta-001']),
+            runtimePool: $this->runtimePool(['wrong-baseline']),
+            target: 2,
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('published_baseline_evidence_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%03d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function readiness(array $slugs): array
+    {
+        sort($slugs);
+
+        return [
+            'schema_version' => 'career_80_cohort_readiness.v1',
+            'status' => 'pass',
+            'readiness_pass' => true,
+            'target' => count($slugs),
+            'selection' => [
+                'strategy' => 'test',
+                'slugs' => $slugs,
+                'rows' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function deltaArtifact(array $slugs): array
+    {
+        return [
+            'schema_version' => 'career_minimum_index_state_remediation.v1',
+            'count' => count($slugs),
+            'slugs' => $slugs,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $alreadyPublished
+     * @return array<string, mixed>
+     */
+    private function runtimePool(array $alreadyPublished): array
+    {
+        return [
+            'schema_version' => 'career_80_runtime_candidate_pool_plan.v1',
+            'runtime_candidate_gate' => [
+                'excluded_rows' => array_map(static fn (string $slug): array => [
+                    'slug' => $slug,
+                    'exclusion_reasons' => ['already_published'],
+                ], $alreadyPublished),
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -402,6 +402,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_career_80_cohort_readiness_plan_changes(): void
     {
         $changed = [
+            'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
+            'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',
@@ -1846,6 +1848,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCareer80CohortReadinessPlanFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
+            'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2575,8 +2575,8 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "eca8f4a0f1001d79df5f82931a908e1949a1aae1",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1380",
       "checks": {
         "authorization": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -983,7 +983,7 @@
       "sidecar_issues": [
         {
           "sidecar_id": "IQ-SIDECAR-COMMERCE-DEFERRED-001",
-          "title": "defer(iq): commerce unlock \u00a51.99 / \u00a55 implementation",
+          "title": "defer(iq): commerce unlock ¥1.99 / ¥5 implementation",
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
@@ -1002,7 +1002,7 @@
             "api/v0.3/webhooks/payment/*"
           ],
           "evidence": [
-            "User intentionally deferred the \u00a51.99 / \u00a55 commerce PR.",
+            "User intentionally deferred the ¥1.99 / ¥5 commerce PR.",
             "Paid unlock is not required for identity/scoring/report/SVG provenance foundation.",
             "The train can continue without checkout/SKU/webhook changes."
           ],
@@ -4217,7 +4217,7 @@
         },
         "forbidden_runtime_claim_grep": {
           "status": "pass",
-          "command": "rg -n \"Matches|career recommendation|job fit|success prediction|success probability|hiring suitability|140Q more accurate|raw score delta|\u66f4\u51c6\u786e|\u66f4\u51c6|\u5c97\u4f4d\u5339\u914d|\u804c\u4e1a\u63a8\u8350|\u804c\u4e1a\u6210\u529f\" backend/app/Services/Riasec/RiasecPublicProjectionService.php backend/app/Services/Report/RiasecReportComposer.php || true",
+          "command": "rg -n \"Matches|career recommendation|job fit|success prediction|success probability|hiring suitability|140Q more accurate|raw score delta|更准确|更准|岗位匹配|职业推荐|职业成功\" backend/app/Services/Riasec/RiasecPublicProjectionService.php backend/app/Services/Report/RiasecReportComposer.php || true",
           "evidence": "No runtime service hits."
         },
         "diff_check": {
@@ -4713,6 +4713,60 @@
       },
       "failure_reason": null,
       "next_pr": "80-CANDIDATE-RUNTIME-POOL-RUN-1 read-only pool planning",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
+    "REPAIR-80-TARGET-DELTA-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-80-target-delta-decomposition-1",
+      "title": "fix(api): add career 80 target delta decomposition",
+      "name": "Represent Career 80 as published baseline plus delta promotion slugs",
+      "status": "in_progress",
+      "depends_on": [
+        "SCAN-14"
+      ],
+      "scope_type": "80_target_delta_decomposition_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonical80TargetDelta.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no runtime candidate preparation",
+        "no manifest generation",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no apply",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json as needed for the current PR item in the 7-PR train."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SCAN-14 established the Career 80 target should be represented as 29 already-published baseline slugs plus 51 delta promotion slugs."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to read-only target delta decomposition, tests/docs, command registration, and train metadata."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-RUNTIME-CANDIDATE-PREP-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2541,3 +2541,39 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-80-TARGET-DELTA-1
+    repo: fap-api
+    depends_on:
+      - SCAN-14
+    branch: fix/career-80-target-delta-decomposition-1
+    title: "fix(api): add career 80 target delta decomposition"
+    name: "Represent Career 80 as published baseline plus delta promotion slugs"
+    scope:
+      - Add a read-only Career 80 target delta decomposition planner.
+      - Separate already-published baseline slugs from 51 delta promotion slugs.
+      - Preserve 80 total public target accounting without candidate preparation, manifest generation, rollout, apply, or DB mutation.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonical80TargetDelta.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout or rollout dry-run.
+      - Run apply, backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Prepare runtime candidates.
+    validation:
+      - php artisan test --filter=Career80TargetDelta --no-ansi
+      - php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- adds a read-only Career 80 target delta planner and Artisan command
- models the 80 target as 29 already-published baseline slugs plus 51 delta promotion slugs
- validates baseline/delta accounting, overlap, delta membership, and optional already-published evidence
- registers REPAIR-80-TARGET-DELTA-1 in the PR train metadata

## Non-goals
- no candidate preparation
- no apply
- no rollout or rollout dry-run
- no DB mutation
- no deploy
- no fap-web changes

## Validation
- php artisan test --filter=Career80TargetDelta --no-ansi
- php artisan test --filter=CareerPlanCanonical80TargetDelta --no-ansi
- php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
- php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi
- php artisan test --filter=CareerGenerateCanonicalExpansionManifestTrain --no-ansi
- php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
- php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-80-delta-pr1.sqlite php artisan migrate --force --no-ansi
- vendor/bin/pint --test
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh

## Repository rule impact
- route changes: none
- migrations: none
- middleware: none
- DB writes: none
- production touched: no

## Next
REPAIR-RUNTIME-CANDIDATE-PREP-1