### PR TITLE
fix(api): add career runtime candidate preparation planner

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerRuntimeCandidatePrepPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerPlanCanonicalRuntimeCandidatePrep extends Command
+{
+    protected $signature = 'career:plan-canonical-runtime-candidate-prep
+        {--target-delta= : Required Career 80 target delta JSON artifact}
+        {--projection= : Optional runtime projection JSON artifact}
+        {--truth= : Optional runtime truth JSON artifact}
+        {--ledger= : Optional full release ledger JSON artifact}
+        {--locales=en,zh : Comma-separated locales to prepare}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for runtime candidate preparation plan JSON}';
+
+    protected $description = 'Plan read-only Career runtime published_candidate preparation rows for explicit delta slugs.';
+
+    public function handle(): int
+    {
+        try {
+            $targetDeltaPath = $this->requiredOption('target-delta');
+            $payload = app(CareerRuntimeCandidatePrepPlanner::class)->plan(
+                targetDeltaPlan: $this->readJson($targetDeltaPath, 'target_delta'),
+                projection: $this->optionalJson('projection'),
+                truth: $this->optionalJson('truth'),
+                ledger: $this->optionalJson('ledger'),
+                locales: $this->localesOption(),
+            )->toArray();
+
+            return $this->finish($payload, ($payload['status'] ?? null) === 'planned' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => CareerRuntimeCandidatePrepPlanner::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'target' => 'career_80_delta',
+                'delta_slug_count' => 0,
+                'planned_candidate_rows_count' => 0,
+                'planned_candidate_rows' => [],
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                ]],
+                'apply_allowed' => false,
+                'next_required_action' => 'FIX_RUNTIME_CANDIDATE_PREP_PLAN',
+            ], self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function localesOption(): array
+    {
+        $raw = trim((string) ($this->option('locales') ?? 'en,zh'));
+        $locales = array_values(array_unique(array_filter(array_map(
+            static fn (string $locale): string => strtolower(trim($locale)),
+            explode(',', $raw)
+        ))));
+        sort($locales);
+
+        if ($locales === []) {
+            throw new RuntimeException('locales_missing');
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function optionalJson(string $option): ?array
+    {
+        $path = trim((string) ($this->option($option) ?? ''));
+
+        return $path === '' ? null : $this->readJson($path, $option);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException($kind.'_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException($kind.'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            File::put($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('delta_slug_count='.(string) ($payload['delta_slug_count'] ?? 0));
+            $this->line('planned_candidate_rows_count='.(string) ($payload['planned_candidate_rows_count'] ?? 0));
+        }
+
+        return $exitCode;
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $key = strtolower(trim($message));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $key) ?? 'runtime_candidate_prep_error';
+        $key = trim($key, '_');
+
+        return $key === '' ? 'runtime_candidate_prep_error' : $key;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -45,6 +45,7 @@ use App\Console\Commands\CareerPlanCanonical80CohortReadiness;
 use App\Console\Commands\CareerPlanCanonical80RuntimeCandidatePool;
 use App\Console\Commands\CareerPlanCanonical80TargetDelta;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
+use App\Console\Commands\CareerPlanCanonicalRuntimeCandidatePrep;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRemediateCanonicalIndexState;
 use App\Console\Commands\CareerRunAssetBatch;
@@ -209,6 +210,7 @@ class Kernel extends ConsoleKernel
         CareerPlanCanonical80RuntimeCandidatePool::class,
         CareerPlanCanonical80TargetDelta::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
+        CareerPlanCanonicalRuntimeCandidatePrep::class,
         CareerReleaseGateNoindexCleanup::class,
         CareerRemediateCanonicalIndexState::class,
         CareerValidateAssetImport::class,

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use RuntimeException;
+
+final class CareerRuntimeCandidatePrepPlanner
+{
+    public const SCHEMA_VERSION = 'career_runtime_candidate_prep_plan.v1';
+
+    /**
+     * @param  array<string, mixed>  $targetDeltaPlan
+     * @param  array<string, mixed>|null  $projection
+     * @param  array<string, mixed>|null  $truth
+     * @param  array<string, mixed>|null  $ledger
+     * @param  list<string>  $locales
+     */
+    public function plan(
+        array $targetDeltaPlan,
+        ?array $projection = null,
+        ?array $truth = null,
+        ?array $ledger = null,
+        array $locales = ['en', 'zh'],
+    ): CareerRuntimeCandidatePrepResult {
+        $deltaSlugs = $this->deltaSlugs($targetDeltaPlan);
+        $locales = $this->normalizedUniqueStrings($locales, 'locale');
+
+        $projectionBySlugLocale = $this->rowsBySlugLocale($this->artifactRows($projection, ['items', 'rows']));
+        $truthBySlugLocale = $this->rowsBySlugLocale($this->artifactRows($truth, ['items', 'rows']));
+        $ledgerBySlug = $this->ledgerBySlug($this->artifactRows($ledger, ['members', 'items', 'rows']));
+
+        $plannedRows = [];
+        $slugRows = [];
+        $missingLedger = [];
+        $missingProjection = [];
+        $missingTruth = [];
+        $stateRepairNeeded = [];
+
+        foreach ($deltaSlugs as $slug) {
+            $slugEvidence = [
+                'slug' => $slug,
+                'ledger_member_exists' => isset($ledgerBySlug[$slug]),
+                'ledger_release_cohort' => $ledgerBySlug[$slug]['release_cohort'] ?? null,
+                'projection_locales_present' => [],
+                'truth_locales_present' => [],
+                'projection_states' => [],
+                'truth_states' => [],
+                'required_actions' => [],
+            ];
+
+            if (! isset($ledgerBySlug[$slug])) {
+                $missingLedger[] = $slug;
+                $slugEvidence['required_actions'][] = 'create_or_update_ledger_candidate_member';
+            }
+
+            foreach ($locales as $locale) {
+                $projectionRows = $projectionBySlugLocale[$slug][$locale] ?? [];
+                $truthRows = $truthBySlugLocale[$slug][$locale] ?? [];
+                $projectionState = $this->runtimeState($projectionRows, 'runtime_publish_state', 'projection_state');
+                $truthState = $this->runtimeState($truthRows, 'projection_state', 'runtime_publish_state');
+
+                if ($projectionRows === []) {
+                    $missingProjection[] = $slug;
+                    $slugEvidence['required_actions'][] = 'create_projection_candidate_row';
+                } else {
+                    $slugEvidence['projection_locales_present'][] = $locale;
+                    if ($projectionState !== null) {
+                        $slugEvidence['projection_states'][] = $projectionState;
+                    }
+                    if ($projectionState !== Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE) {
+                        $stateRepairNeeded[] = $slug;
+                        $slugEvidence['required_actions'][] = 'repair_projection_candidate_state';
+                    }
+                }
+
+                if ($truthRows === []) {
+                    $missingTruth[] = $slug;
+                    $slugEvidence['required_actions'][] = 'create_truth_candidate_row';
+                } else {
+                    $slugEvidence['truth_locales_present'][] = $locale;
+                    if ($truthState !== null) {
+                        $slugEvidence['truth_states'][] = $truthState;
+                    }
+                    if ($truthState !== Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE) {
+                        $stateRepairNeeded[] = $slug;
+                        $slugEvidence['required_actions'][] = 'repair_truth_candidate_state';
+                    }
+                }
+
+                $plannedRows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'runtime_publish_state' => Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE,
+                    'projection_state' => Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE,
+                    'public_resolution_type' => 'public_canonical_job',
+                    'candidate_pre_route_expected' => true,
+                    'source' => 'career_80_delta_runtime_candidate_prep',
+                    'write_intent' => 'planned_only',
+                ];
+            }
+
+            $slugEvidence['projection_locales_present'] = $this->normalizedUniqueStrings($slugEvidence['projection_locales_present'], 'projection_locale_present', allowEmpty: true);
+            $slugEvidence['truth_locales_present'] = $this->normalizedUniqueStrings($slugEvidence['truth_locales_present'], 'truth_locale_present', allowEmpty: true);
+            $slugEvidence['projection_states'] = $this->normalizedUniqueStrings($slugEvidence['projection_states'], 'projection_state', allowEmpty: true);
+            $slugEvidence['truth_states'] = $this->normalizedUniqueStrings($slugEvidence['truth_states'], 'truth_state', allowEmpty: true);
+            $slugEvidence['required_actions'] = $this->normalizedUniqueStrings($slugEvidence['required_actions'], 'required_action', allowEmpty: true);
+            $slugRows[] = $slugEvidence;
+        }
+
+        $blockers = $this->blockers($targetDeltaPlan, $deltaSlugs);
+        $status = $blockers === [] ? 'planned' : 'blocked';
+
+        return new CareerRuntimeCandidatePrepResult([
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $status,
+            'read_only' => true,
+            'writes_database' => false,
+            'target' => 'career_80_delta',
+            'target_public_total' => (int) ($targetDeltaPlan['target_public_total'] ?? 80),
+            'delta_slug_count' => count($deltaSlugs),
+            'locales' => $locales,
+            'expected_locale_rows' => count($deltaSlugs) * count($locales),
+            'planned_candidate_rows_count' => count($plannedRows),
+            'planned_candidate_rows' => $plannedRows,
+            'slug_rows' => $slugRows,
+            'context_summary' => [
+                'ledger_member_missing_count' => count(array_unique($missingLedger)),
+                'projection_row_missing_count' => count(array_unique($missingProjection)),
+                'truth_row_missing_count' => count(array_unique($missingTruth)),
+                'candidate_state_repair_needed_count' => count(array_unique($stateRepairNeeded)),
+            ],
+            'context_slug_sets' => [
+                'ledger_member_missing' => $this->normalizedUniqueStrings($missingLedger, 'ledger_missing', allowEmpty: true),
+                'projection_row_missing' => $this->normalizedUniqueStrings($missingProjection, 'projection_missing', allowEmpty: true),
+                'truth_row_missing' => $this->normalizedUniqueStrings($missingTruth, 'truth_missing', allowEmpty: true),
+                'candidate_state_repair_needed' => $this->normalizedUniqueStrings($stateRepairNeeded, 'state_repair_needed', allowEmpty: true),
+            ],
+            'blockers' => $blockers,
+            'approval_gate' => [
+                'apply_allowed' => false,
+                'approval_required_for_apply' => true,
+                'reason' => 'runtime candidate preparation is planned only; apply requires a separate explicit approval gate',
+            ],
+            'apply_allowed' => false,
+            'next_required_action' => $status === 'planned' ? 'RUNTIME_CANDIDATE_PREP_DRY_RUN' : 'FIX_RUNTIME_CANDIDATE_PREP_PLAN',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDeltaPlan
+     * @return list<string>
+     */
+    private function deltaSlugs(array $targetDeltaPlan): array
+    {
+        $slugs = $targetDeltaPlan['recommended_rollout_delta_slugs']
+            ?? $targetDeltaPlan['delta_promotion_slugs']
+            ?? $targetDeltaPlan['slugs']
+            ?? null;
+
+        if (! is_array($slugs) || ! array_is_list($slugs)) {
+            throw new RuntimeException('delta_slug_list_missing');
+        }
+
+        return $this->normalizedUniqueStrings($slugs, 'delta_slug');
+    }
+
+    /**
+     * @param  list<mixed>  $values
+     * @return list<string>
+     */
+    private function normalizedUniqueStrings(array $values, string $context, bool $allowEmpty = false): array
+    {
+        $normalized = [];
+        $seen = [];
+        foreach ($values as $index => $value) {
+            if (! is_string($value)) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            $trimmed = strtolower(trim($value));
+            if ($trimmed === '') {
+                if ($allowEmpty) {
+                    continue;
+                }
+
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            if (isset($seen[$trimmed])) {
+                if ($allowEmpty) {
+                    continue;
+                }
+
+                throw new RuntimeException($context.'_duplicate_'.$trimmed);
+            }
+
+            $seen[$trimmed] = true;
+            $normalized[] = $trimmed;
+        }
+
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $artifact
+     * @param  list<string>  $keys
+     * @return list<array<string, mixed>>
+     */
+    private function artifactRows(?array $artifact, array $keys): array
+    {
+        if ($artifact === null) {
+            return [];
+        }
+
+        foreach ($keys as $key) {
+            if (isset($artifact[$key]) && is_array($artifact[$key]) && array_is_list($artifact[$key])) {
+                return array_values(array_filter(
+                    $artifact[$key],
+                    static fn (mixed $row): bool => is_array($row) && ! array_is_list($row)
+                ));
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, array<string, list<array<string, mixed>>>>
+     */
+    private function rowsBySlugLocale(array $rows): array
+    {
+        $bySlug = [];
+        foreach ($rows as $row) {
+            $slug = $this->stringValue($row, 'slug');
+            $locale = $this->stringValue($row, 'locale');
+            if ($slug === null || $locale === null) {
+                continue;
+            }
+
+            $bySlug[$slug] ??= [];
+            $bySlug[$slug][$locale] ??= [];
+            $bySlug[$slug][$locale][] = $row;
+        }
+
+        return $bySlug;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $members
+     * @return array<string, array<string, mixed>>
+     */
+    private function ledgerBySlug(array $members): array
+    {
+        $bySlug = [];
+        foreach ($members as $member) {
+            $slug = $this->stringValue($member, 'canonical_slug') ?? $this->stringValue($member, 'slug');
+            if ($slug !== null) {
+                $bySlug[$slug] = $member;
+            }
+        }
+
+        return $bySlug;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function runtimeState(array $rows, string $preferredKey, string $fallbackKey): ?string
+    {
+        foreach ($rows as $row) {
+            $state = $this->stringValue($row, $preferredKey) ?? $this->stringValue($row, $fallbackKey);
+            if ($state !== null) {
+                return $state;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function stringValue(array $row, string $key): ?string
+    {
+        $value = $row[$key] ?? null;
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        return strtolower(trim($value));
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDeltaPlan
+     * @param  list<string>  $deltaSlugs
+     * @return list<array<string, mixed>>
+     */
+    private function blockers(array $targetDeltaPlan, array $deltaSlugs): array
+    {
+        $blockers = [];
+        if (($targetDeltaPlan['status'] ?? null) !== 'pass') {
+            $blockers[] = [
+                'reason' => 'target_delta_plan_not_pass',
+                'message' => 'Target delta plan must pass before runtime candidate preparation can be planned.',
+            ];
+        }
+
+        $declaredDeltaCount = $targetDeltaPlan['delta_promotion_count'] ?? $targetDeltaPlan['delta_slug_count'] ?? null;
+        if ($declaredDeltaCount !== null && (int) $declaredDeltaCount !== count($deltaSlugs)) {
+            $blockers[] = [
+                'reason' => 'delta_slug_count_mismatch',
+                'message' => 'Declared delta slug count does not match the explicit delta slug list.',
+                'evidence' => [
+                    'declared' => (int) $declaredDeltaCount,
+                    'actual' => count($deltaSlugs),
+                ],
+            ];
+        }
+
+        return $blockers;
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepResult.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final readonly class CareerRuntimeCandidatePrepResult
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(private array $payload) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+
+    public function planned(): bool
+    {
+        return ($this->payload['status'] ?? null) === 'planned';
+    }
+}

--- a/backend/docs/career/audits/runtime_candidate_prep.md
+++ b/backend/docs/career/audits/runtime_candidate_prep.md
@@ -1,0 +1,47 @@
+# Career Runtime Candidate Preparation Plan
+
+`career:plan-canonical-runtime-candidate-prep` is a read-only planner for the Career 80 delta path. It consumes the target-delta artifact that separates the 29 already-published baseline slugs from the 51 delta promotion slugs, then emits the `published_candidate` runtime rows that a later approval-gated preparation step would need.
+
+The command does not write the database, run rollout, run rollout dry-run, publish occupations, or generate rollout manifests.
+
+## Usage
+
+```bash
+php artisan career:plan-canonical-runtime-candidate-prep \
+  --target-delta=/tmp/career_80_target_delta_plan.json \
+  --projection=/tmp/career_2786_runtime_projection.json \
+  --truth=/tmp/career_2786_runtime_truth.json \
+  --ledger=/tmp/career_2786_full_release_ledger.json \
+  --locales=en,zh \
+  --json \
+  --output=/tmp/career_80_delta_runtime_candidate_prep_plan.json
+```
+
+The projection, truth, and ledger inputs are optional for local planning, but supplying them gives the plan useful context counts for missing ledger members, missing projection rows, missing truth rows, and candidate state repairs.
+
+## Output
+
+The output schema is `career_runtime_candidate_prep_plan.v1`.
+
+Key fields:
+
+- `status`: `planned` when the target-delta input is valid, otherwise `blocked`.
+- `read_only`: always `true`.
+- `writes_database`: always `false`.
+- `target`: `career_80_delta`.
+- `delta_slug_count`: expected to be 51 for the first delta.
+- `expected_locale_rows`: `delta_slug_count * locale_count`, expected to be 102 for 51 slugs and `en,zh`.
+- `planned_candidate_rows`: the planned `published_candidate` rows.
+- `context_summary`: counts for missing ledger/projection/truth and candidate state repair needs.
+- `apply_allowed`: always `false`.
+- `next_required_action`: `RUNTIME_CANDIDATE_PREP_DRY_RUN` when planned.
+
+## Non-goals
+
+- No DB mutation.
+- No candidate preparation apply.
+- No rollout dry-run.
+- No rollout apply.
+- No manifest generation.
+- No deploy.
+- No fap-web changes.

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerPlanCanonicalRuntimeCandidatePrepCommandTest extends TestCase
+{
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:plan-canonical-runtime-candidate-prep', Artisan::all());
+    }
+
+    public function test_missing_target_delta_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => sys_get_temp_dir().'/missing-target-delta.json',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('target_delta_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_invalid_projection_json_blocks(): void
+    {
+        $projection = $this->tempPath('bad-projection');
+        file_put_contents($projection, '{not json');
+
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeTargetDelta(['delta-001']),
+            '--projection' => $projection,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('projection_artifact_json_invalid', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_generates_prep_plan_and_writes_output(): void
+    {
+        $slugs = $this->slugs('delta', 51);
+        $output = $this->tempPath('output');
+
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeTargetDelta($slugs),
+            '--projection' => $this->writeProjection([]),
+            '--truth' => $this->writeTruth([]),
+            '--ledger' => $this->writeLedger([]),
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame(51, $payload['delta_slug_count']);
+        $this->assertSame(102, $payload['expected_locale_rows']);
+        $this->assertSame(102, $payload['planned_candidate_rows_count']);
+        $this->assertSame(51, $payload['context_summary']['ledger_member_missing_count']);
+        $this->assertSame(51, $payload['context_summary']['projection_row_missing_count']);
+        $this->assertSame(51, $payload['context_summary']['truth_row_missing_count']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_target_locales_can_be_overridden(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeTargetDelta(['delta-001', 'delta-002']),
+            '--locales' => 'en',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(['en'], $payload['locales']);
+        $this->assertSame(2, $payload['expected_locale_rows']);
+        $this->assertSame(2, $payload['planned_candidate_rows_count']);
+    }
+
+    public function test_no_db_mutation_or_apply_is_exposed(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeTargetDelta(['delta-001']),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFalse($payload['approval_gate']['apply_allowed']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:plan-canonical-runtime-candidate-prep', array_merge([
+            '--json' => true,
+        ], $options));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%03d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeTargetDelta(array $slugs): string
+    {
+        return $this->writeJson('target-delta', [
+            'schema_version' => 'career_80_target_delta.v1',
+            'status' => 'pass',
+            'target_public_total' => 80,
+            'delta_promotion_count' => count($slugs),
+            'recommended_rollout_delta_slugs' => $slugs,
+        ]);
+    }
+
+    /**
+     * @param  array<string, string>  $states
+     */
+    private function writeProjection(array $states): string
+    {
+        return $this->writeJson('projection', ['items' => $this->runtimeRows($states, 'runtime_publish_state')]);
+    }
+
+    /**
+     * @param  array<string, string>  $states
+     */
+    private function writeTruth(array $states): string
+    {
+        return $this->writeJson('truth', ['items' => $this->runtimeRows($states, 'projection_state')]);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeLedger(array $slugs): string
+    {
+        return $this->writeJson('ledger', [
+            'members' => array_map(static fn (string $slug): array => [
+                'canonical_slug' => $slug,
+                'release_cohort' => 'public_detail_conservative',
+            ], $slugs),
+        ]);
+    }
+
+    /**
+     * @param  array<string, string>  $states
+     * @return list<array<string, mixed>>
+     */
+    private function runtimeRows(array $states, string $stateKey): array
+    {
+        $rows = [];
+        foreach ($states as $slug => $state) {
+            foreach (['en', 'zh'] as $locale) {
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    $stateKey => $state,
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-runtime-candidate-prep-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerRuntimeCandidatePrepPlanner;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
+{
+    public function test_plans_51_delta_slug_rows(): void
+    {
+        $slugs = $this->slugs('delta', 51);
+
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: $this->targetDelta($slugs),
+            projection: $this->projection([]),
+            truth: $this->truth([]),
+            ledger: $this->ledger([]),
+        )->toArray();
+
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('career_runtime_candidate_prep_plan.v1', $payload['schema_version']);
+        $this->assertSame(51, $payload['delta_slug_count']);
+        $this->assertSame(102, $payload['expected_locale_rows']);
+        $this->assertSame(102, $payload['planned_candidate_rows_count']);
+        $this->assertSame('published_candidate', $payload['planned_candidate_rows'][0]['runtime_publish_state']);
+        $this->assertTrue($payload['planned_candidate_rows'][0]['candidate_pre_route_expected']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+    }
+
+    public function test_blocks_target_delta_plan_that_did_not_pass(): void
+    {
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: [
+                ...$this->targetDelta(['delta-001']),
+                'status' => 'blocked',
+            ],
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('target_delta_plan_not_pass', $payload['blockers'][0]['reason']);
+        $this->assertSame(2, $payload['planned_candidate_rows_count']);
+    }
+
+    public function test_blocks_duplicate_delta_slugs(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('delta_slug_duplicate_delta-001');
+
+        (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: [
+                ...$this->targetDelta(['delta-001']),
+                'recommended_rollout_delta_slugs' => ['delta-001', 'delta-001'],
+            ],
+        );
+    }
+
+    public function test_counts_existing_context_gaps_and_repairs(): void
+    {
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: $this->targetDelta(['delta-001', 'delta-002']),
+            projection: $this->projection([
+                'delta-001' => 'blocked',
+            ]),
+            truth: $this->truth([
+                'delta-001' => 'published_candidate',
+            ]),
+            ledger: $this->ledger(['delta-001']),
+        )->toArray();
+
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame(1, $payload['context_summary']['ledger_member_missing_count']);
+        $this->assertSame(1, $payload['context_summary']['projection_row_missing_count']);
+        $this->assertSame(1, $payload['context_summary']['truth_row_missing_count']);
+        $this->assertSame(1, $payload['context_summary']['candidate_state_repair_needed_count']);
+        $this->assertSame(['delta-002'], $payload['context_slug_sets']['ledger_member_missing']);
+        $this->assertSame(['delta-001'], $payload['context_slug_sets']['candidate_state_repair_needed']);
+    }
+
+    public function test_schema_is_stable(): void
+    {
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: $this->targetDelta(['delta-001']),
+        )->toArray();
+
+        $this->assertSame([
+            'schema_version',
+            'status',
+            'read_only',
+            'writes_database',
+            'target',
+            'target_public_total',
+            'delta_slug_count',
+            'locales',
+            'expected_locale_rows',
+            'planned_candidate_rows_count',
+            'planned_candidate_rows',
+            'slug_rows',
+            'context_summary',
+            'context_slug_sets',
+            'blockers',
+            'approval_gate',
+            'apply_allowed',
+            'next_required_action',
+        ], array_keys($payload));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%03d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function targetDelta(array $slugs): array
+    {
+        return [
+            'schema_version' => 'career_80_target_delta.v1',
+            'status' => 'pass',
+            'target_public_total' => 80,
+            'delta_promotion_count' => count($slugs),
+            'recommended_rollout_delta_slugs' => $slugs,
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $states
+     * @return array<string, mixed>
+     */
+    private function projection(array $states): array
+    {
+        return ['items' => $this->runtimeRows($states, 'runtime_publish_state')];
+    }
+
+    /**
+     * @param  array<string, string>  $states
+     * @return array<string, mixed>
+     */
+    private function truth(array $states): array
+    {
+        return ['items' => $this->runtimeRows($states, 'projection_state')];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function ledger(array $slugs): array
+    {
+        return [
+            'members' => array_map(static fn (string $slug): array => [
+                'canonical_slug' => $slug,
+                'release_cohort' => 'public_detail_conservative',
+            ], $slugs),
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $states
+     * @return list<array<string, mixed>>
+     */
+    private function runtimeRows(array $states, string $stateKey): array
+    {
+        $rows = [];
+        foreach ($states as $slug => $state) {
+            foreach (['en', 'zh'] as $locale) {
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    $stateKey => $state,
+                ];
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -404,6 +404,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',
@@ -1850,6 +1852,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4802,7 +4802,7 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
+      "commit_sha": "8e64f57d9fc67f2cb967b2d072d67032f2711ab8",
       "pr_url": null,
       "checks": {
         "authorization": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4771,6 +4771,59 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "REPAIR-RUNTIME-CANDIDATE-PREP-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-runtime-candidate-prep-plan-1",
+      "title": "fix(api): add career runtime candidate preparation planner",
+      "name": "Add read-only runtime candidate preparation planner for 51 delta slugs",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-80-TARGET-DELTA-1"
+      ],
+      "scope_type": "runtime_candidate_prep_planner_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no runtime candidate preparation apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no manifest generation",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json as needed for current PR items in the 7-PR train."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR #1380 added the read-only Career 80 target delta decomposition model used as this planner input."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to read-only runtime candidate preparation planning, command registration, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-RUNTIME-CANDIDATE-PREP-APPLY-GATE-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4803,7 +4803,7 @@
         "no fap-web change"
       ],
       "commit_sha": "8e64f57d9fc67f2cb967b2d072d67032f2711ab8",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1381",
       "checks": {
         "authorization": {
           "status": "pass",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2577,3 +2577,39 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-RUNTIME-CANDIDATE-PREP-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-80-TARGET-DELTA-1
+    branch: fix/career-runtime-candidate-prep-plan-1
+    title: "fix(api): add career runtime candidate preparation planner"
+    name: "Add read-only runtime candidate preparation planner for 51 delta slugs"
+    scope:
+      - Add a read-only Career runtime candidate preparation planner.
+      - Consume the Career 80 target delta artifact and optional projection/truth/ledger artifacts.
+      - Emit planned published_candidate rows for explicit 51 delta slugs without DB writes, apply, or rollout.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout or rollout dry-run.
+      - Run apply, backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Prepare runtime candidates in production.
+    validation:
+      - php artisan test --filter=CareerRuntimeCandidatePrep --no-ansi
+      - php artisan test --filter=Career80TargetDelta --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- adds read-only `career:plan-canonical-runtime-candidate-prep`
- consumes the Career 80 target-delta artifact and optional projection/truth/ledger artifacts
- emits `career_runtime_candidate_prep_plan.v1` with planned `published_candidate` rows for explicit 51 delta slugs
- records missing ledger/projection/truth and candidate state repair context
- does not apply, mutate DB, generate manifest, run rollout dry-run, or run rollout apply

## Tests
- `php artisan test --filter=CareerRuntimeCandidatePrep --no-ansi`
- `php artisan test --filter=CareerPlanCanonicalRuntimeCandidatePrep --no-ansi`
- `php artisan test --filter=Career80TargetDelta --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80CohortReadiness --no-ansi`
- `php artisan test --filter=CareerGenerateCanonicalExpansionManifestTrain --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-80-delta-pr2.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Non-goals
- no deploy
- no production DB query or mutation
- no apply/backfill/rollback/quarantine
- no rollout dry-run or rollout apply
- no manifest generation
- no fap-web changes

Next step: `REPAIR-RUNTIME-CANDIDATE-PREP-APPLY-GATE-1`.