### PR TITLE
fix(api): relax editorial package gate boundary contexts

### DIFF
--- a/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
+++ b/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
@@ -95,6 +95,64 @@ final class EditorialPackageDraftImporter
         '录用概率' => '职业准备线索',
     ];
 
+    private const EVERGREEN_DEFINITION_HEADING_TERMS = [
+        'definition',
+        'what does',
+        'measure',
+        '定义',
+        '是什么',
+        '测什么',
+    ];
+
+    private const EVERGREEN_METHOD_HEADING_TERMS = [
+        'method',
+        'theory',
+        'model',
+        'framework',
+        'science',
+        'measure',
+        '方法',
+        '理论',
+        '模型',
+        '框架',
+        '科学',
+        '逻辑',
+        '如何正确使用',
+    ];
+
+    private const CLAIM_BOUNDARY_CONTEXT_TERMS = [
+        '不能',
+        '不应',
+        '不应该',
+        '不会',
+        '不得',
+        '不要',
+        '不是',
+        '避免',
+        '不说',
+        '不宣称',
+        '不代表',
+        '不等于',
+        '无法',
+        '并不',
+        '边界',
+        '规避',
+        'overclaim',
+        'cannot',
+        "can't",
+        'does not',
+        'do not',
+        'should not',
+        'is not',
+        'not a',
+        'not claim',
+        'not say',
+        'not imply',
+        'not predict',
+        'doesnt',
+        'dont',
+    ];
+
     public function __construct(
         private readonly ArticleTranslationRevisionWorkspace $revisionWorkspace,
     ) {}
@@ -432,7 +490,7 @@ final class EditorialPackageDraftImporter
 
         $claimMatches = $this->claimMatches($package);
         foreach ($claimMatches as $match) {
-            if ($allowClaimWarnings) {
+            if (($match['boundary_context'] ?? false) === true || $allowClaimWarnings) {
                 $warnings[] = $match;
             } else {
                 $errors[] = $match;
@@ -456,10 +514,10 @@ final class EditorialPackageDraftImporter
         $headingText = mb_strtolower(implode("\n", $headings));
 
         if ($package['content_track'] === 'evergreen_knowledge') {
-            if (! str_contains($headingText, 'definition') && ! str_contains($headingText, '定义') && ! str_contains($headingText, '是什么')) {
+            if (! $this->containsAny($headingText, self::EVERGREEN_DEFINITION_HEADING_TERMS)) {
                 $errors[] = $this->issue('body_markdown', 'evergreen_definition_required', 'evergreen_knowledge requires a definition section.');
             }
-            if (! str_contains($headingText, 'method') && ! str_contains($headingText, 'theory') && ! str_contains($headingText, '方法') && ! str_contains($headingText, '理论')) {
+            if (! $this->containsAny($headingText, self::EVERGREEN_METHOD_HEADING_TERMS)) {
                 $errors[] = $this->issue('body_markdown', 'evergreen_method_required', 'evergreen_knowledge requires method or theory explanation.');
             }
             if (! str_contains($headingText, 'faq') && ! str_contains($headingText, '常见问题') && ! str_contains($headingText, 'key questions')) {
@@ -547,11 +605,33 @@ final class EditorialPackageDraftImporter
                     'phrase' => $phrase,
                     'suggested_replacement' => $replacement,
                     'snippet' => mb_substr($text, max(0, $position - 24), mb_strlen($phrase) + 48),
+                    'boundary_context' => $this->hasClaimBoundaryContext($text, $position, mb_strlen($phrase)),
                 ];
             }
         }
 
         return $matches;
+    }
+
+    /**
+     * @param  list<string>  $needles
+     */
+    private function containsAny(string $haystack, array $needles): bool
+    {
+        foreach ($needles as $needle) {
+            if ($needle !== '' && str_contains($haystack, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasClaimBoundaryContext(string $text, int $position, int $phraseLength): bool
+    {
+        $window = mb_strtolower(mb_substr($text, max(0, $position - 80), $phraseLength + 160));
+
+        return $this->containsAny($window, self::CLAIM_BOUNDARY_CONTEXT_TERMS);
     }
 
     private function existingArticle(array $package): ?Article

--- a/backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
@@ -197,6 +197,28 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
         $this->assertSame('warning', data_get($warningLog->claim_result_json, 'status'));
     }
 
+    public function test_evergreen_semantic_headings_and_boundary_claim_context_pass_as_warnings(): void
+    {
+        $path = $this->writePackage($this->evergreenPackage([
+            'slug' => 'riasec-semantic-evergreen-draft',
+            'body_markdown' => "# 霍兰德职业兴趣测试能告诉你什么？\n\n## 执行摘要\n\n霍兰德测试不能告诉你唯一最适合的职业，也不能预测你的职业成功率。\n\n## 霍兰德职业兴趣测试到底测什么？\n\nRIASEC 是一种职业兴趣结构入口，用来解释人与工作环境之间的兴趣线索。\n\n## 如何正确使用霍兰德测试结果？\n\n它应该作为职业探索的第一层证据，也不能说某职业一定适合你一生。\n\n## FAQ\n\n### 霍兰德测试能直接决定职业吗？\n\n不能。\n\n## 结论\n\nRIASEC 应作为职业探索入口，而不是最终职业答案.",
+        ]));
+
+        $this->artisan('articles:import-editorial-package', [
+            '--file' => $path,
+            '--locale' => 'zh-CN',
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('action=will_create')
+            ->expectsOutputToContain('errors_count=0')
+            ->expectsOutputToContain('claim_warning=body_markdown:claim_boundary_forbidden_phrase')
+            ->expectsOutputToContain('claim_matches_count=3')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
+    }
+
     public function test_track_and_answer_surface_validation_block_invalid_packages_without_writes(): void
     {
         $invalidEvergreenPath = $this->writePackage($this->evergreenPackage([


### PR DESCRIPTION
## What changed
- Allow evergreen article gates to recognize semantic zh/en headings such as `测什么`, `measure`, model/framework/science, and usage-oriented method sections.
- Downgrade claim-linter hits to warnings when the forbidden phrase appears in explicit negation or boundary-context copy.
- Add regression coverage for RIASEC-style evergreen headings and boundary claim copy.

## Why
The Holland/RIASEC bilingual editorial packages use approved editorial boundary language like `不能告诉你唯一最适合的职业` and semantic evergreen headings instead of literal `Definition` / `Method` headings. The importer should allow those packages as CMS drafts while still blocking unsafe standalone overclaims.

## Validation
- `php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi`
- Real package dry-run against temporary SQLite DB for zh-CN/en
- Real package draft import against temporary SQLite DB for zh-CN/en
- `vendor/bin/pint --test app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `git diff --check`

## Deferred
- Production draft import is deferred until this PR is merged and deployed, so production uses the updated gate.
- No article publish, revalidate, fap-web change, or production content mutation is included.

## Repository rule impact
- No content authority change. This keeps CMS/backend Article draft import as the authority and only adjusts validation semantics.