### PR TITLE
fix(api): add guarded runtime candidate preparation command

### DIFF
--- a/backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php
+++ b/backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php
@@ -1,0 +1,774 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\IndexStateValue;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+final class CareerPrepareCanonicalRuntimeCandidates extends Command
+{
+    private const SOURCE = 'career_80_delta_runtime_candidate_preparation';
+
+    private const TARGET_INDEX_STATE = IndexStateValue::PROMOTION_CANDIDATE;
+
+    private const TARGET_RUNTIME_STATE = 'published_candidate';
+
+    private const DEFAULT_MAX_SLUGS = 100;
+
+    protected $signature = 'career:prepare-canonical-runtime-candidates
+        {--plan= : Reviewed runtime candidate preparation plan JSON path}
+        {--slug-artifact= : Reviewed explicit slug artifact JSON path}
+        {--dry-run : Plan without writing}
+        {--apply : Execute guarded published_candidate preparation writes}
+        {--batch-id= : Reviewed preparation batch id}
+        {--reason= : Explicit preparation reason}
+        {--max-slugs=100 : Maximum allowed explicit slugs}
+        {--expect-slug-count= : Required for --apply; expected slug count}
+        {--confirm-artifact-sha256= : Required for --apply; must match source artifact sha256}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for JSON payload}';
+
+    protected $description = 'Guarded explicit-slug Career runtime published_candidate preparation dry-run/apply gate.';
+
+    public function handle(): int
+    {
+        try {
+            $mode = $this->mode();
+            $sourcePath = $this->sourcePath();
+            $batchId = $this->requiredOption('batch-id');
+            $reason = $this->requiredOption('reason');
+            $maxSlugs = $this->positiveIntOption('max-slugs', self::DEFAULT_MAX_SLUGS);
+            $expectedSlugCount = $this->nullablePositiveIntOption('expect-slug-count');
+
+            [$artifact, $artifactSha] = $this->readSourceArtifact($sourcePath);
+            $slugs = $artifact['slugs'];
+            $slugCount = count($slugs);
+
+            $blockers = [
+                ...$this->confirmationBlockers($mode, $artifactSha, $slugCount, $expectedSlugCount),
+                ...$this->artifactSafetyBlockers($slugCount, $maxSlugs),
+            ];
+
+            $plan = $this->plan($slugs, $artifact['locales'], $batchId, $reason, $sourcePath, $artifactSha);
+            $blockers = [
+                ...$blockers,
+                ...$plan['blockers'],
+            ];
+
+            if ($mode === 'dry-run') {
+                return $this->finish($this->dryRunPayload(
+                    $plan,
+                    $artifact,
+                    $sourcePath,
+                    $artifactSha,
+                    $batchId,
+                    $reason,
+                    $maxSlugs,
+                    $expectedSlugCount,
+                    $blockers
+                ), $blockers === [] ? self::SUCCESS : self::FAILURE);
+            }
+
+            if ($blockers !== []) {
+                return $this->finish($this->blockedApplyPayload(
+                    $plan,
+                    $artifact,
+                    $sourcePath,
+                    $artifactSha,
+                    $batchId,
+                    $reason,
+                    $maxSlugs,
+                    $expectedSlugCount,
+                    $blockers
+                ), self::FAILURE);
+            }
+
+            $payload = $this->apply($plan, $artifact, $sourcePath, $artifactSha, $batchId, $reason, $maxSlugs, $expectedSlugCount);
+
+            return $this->finish($payload, ($payload['status'] ?? null) === 'applied' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            $reason = $this->reasonKey($exception->getMessage());
+
+            return $this->finish([
+                'status' => 'blocked',
+                'dry_run' => false,
+                'writes_database' => false,
+                'write_verified' => false,
+                'blockers' => [[
+                    'reason' => $reason,
+                    'message' => $exception->getMessage(),
+                    'evidence' => [],
+                ]],
+                'by_reason' => [$reason => 1],
+            ], self::FAILURE);
+        }
+    }
+
+    private function mode(): string
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $apply = (bool) $this->option('apply');
+
+        if ($dryRun === $apply) {
+            throw new RuntimeException('exactly_one_of_dry_run_or_apply_required');
+        }
+
+        return $apply ? 'apply' : 'dry-run';
+    }
+
+    private function sourcePath(): string
+    {
+        $plan = trim((string) ($this->option('plan') ?? ''));
+        $slugArtifact = trim((string) ($this->option('slug-artifact') ?? ''));
+
+        if (($plan === '') === ($slugArtifact === '')) {
+            throw new RuntimeException('exactly_one_of_plan_or_slug_artifact_required');
+        }
+
+        return $plan !== '' ? $plan : $slugArtifact;
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function positiveIntOption(string $name, int $default): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return $default;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    private function nullablePositiveIntOption(string $name): ?int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return null;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    private function readSourceArtifact(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('runtime_candidate_prep_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException('runtime_candidate_prep_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException('runtime_candidate_prep_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded)) {
+            throw new RuntimeException('runtime_candidate_prep_artifact_shape_invalid');
+        }
+
+        [$slugs, $locales] = $this->slugsAndLocales($decoded);
+        $declaredCount = $this->declaredCount($decoded);
+        if ($declaredCount !== null && $declaredCount !== count($slugs)) {
+            throw new RuntimeException('slug_count_declared_mismatch');
+        }
+
+        $status = strtolower(trim((string) ($decoded['status'] ?? '')));
+        if ($status !== '' && ! in_array($status, ['planned', 'pass'], true)) {
+            throw new RuntimeException('runtime_candidate_prep_plan_not_planned');
+        }
+
+        return [[
+            'schema_version' => is_array($decoded) && ! array_is_list($decoded) ? ($decoded['schema_version'] ?? null) : 'slug_list.v1',
+            'source_kind' => $this->option('plan') !== null && trim((string) $this->option('plan')) !== '' ? 'plan' : 'slug_artifact',
+            'declared_count' => $declaredCount ?? count($slugs),
+            'slugs' => $slugs,
+            'locales' => $locales,
+            'raw_summary' => is_array($decoded) && ! array_is_list($decoded) ? [
+                'status' => $decoded['status'] ?? null,
+                'target' => $decoded['target'] ?? null,
+                'delta_slug_count' => $decoded['delta_slug_count'] ?? null,
+                'expected_locale_rows' => $decoded['expected_locale_rows'] ?? null,
+            ] : null,
+        ], hash('sha256', $contents)];
+    }
+
+    /**
+     * @param  array<string, mixed>|list<mixed>  $decoded
+     * @return array{0: list<string>, 1: list<string>}
+     */
+    private function slugsAndLocales(array $decoded): array
+    {
+        $locales = ['en', 'zh'];
+
+        if (isset($decoded['locales']) && is_array($decoded['locales']) && array_is_list($decoded['locales'])) {
+            $locales = $this->normalizedUniqueStrings($decoded['locales'], 'locale');
+        }
+
+        if (array_is_list($decoded)) {
+            return [$this->normalizedUniqueStrings($decoded, 'slug'), $locales];
+        }
+
+        $slugList = $decoded['slugs']
+            ?? $decoded['recommended_rollout_delta_slugs']
+            ?? $decoded['delta_promotion_slugs']
+            ?? null;
+
+        if (is_array($slugList) && array_is_list($slugList)) {
+            return [$this->normalizedUniqueStrings($slugList, 'slug'), $locales];
+        }
+
+        $slugRows = $decoded['slug_rows'] ?? null;
+        if (is_array($slugRows) && array_is_list($slugRows)) {
+            return [$this->normalizedRowSlugs($slugRows), $locales];
+        }
+
+        $plannedRows = $decoded['planned_candidate_rows'] ?? null;
+        if (is_array($plannedRows) && array_is_list($plannedRows)) {
+            return [$this->normalizedRowSlugs($plannedRows), $locales];
+        }
+
+        throw new RuntimeException('slug_list_missing');
+    }
+
+    /**
+     * @param  list<mixed>  $rows
+     * @return list<string>
+     */
+    private function normalizedRowSlugs(array $rows): array
+    {
+        $slugs = [];
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException('slug_row_invalid_at_'.$index);
+            }
+
+            $slug = $row['slug'] ?? null;
+            if (! is_string($slug)) {
+                throw new RuntimeException('slug_row_missing_at_'.$index);
+            }
+
+            $slugs[] = $slug;
+        }
+
+        return $this->normalizedUniqueStrings($slugs, 'slug', collapseDuplicates: true);
+    }
+
+    /**
+     * @param  list<mixed>  $values
+     * @return list<string>
+     */
+    private function normalizedUniqueStrings(array $values, string $context, bool $collapseDuplicates = false): array
+    {
+        $normalized = [];
+        $seen = [];
+        foreach ($values as $index => $value) {
+            if (! is_string($value)) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            $trimmed = strtolower(trim($value));
+            if ($trimmed === '' || str_contains($trimmed, '*')) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            if (isset($seen[$trimmed])) {
+                if ($collapseDuplicates) {
+                    continue;
+                }
+
+                throw new RuntimeException('duplicate_'.$context.'_'.$trimmed);
+            }
+
+            $seen[$trimmed] = true;
+            $normalized[] = $trimmed;
+        }
+
+        if ($normalized === []) {
+            throw new RuntimeException($context.'_list_empty');
+        }
+
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>|list<mixed>  $decoded
+     */
+    private function declaredCount(array $decoded): ?int
+    {
+        if (array_is_list($decoded)) {
+            return count($decoded);
+        }
+
+        $raw = $decoded['count']
+            ?? $decoded['slug_count']
+            ?? $decoded['delta_slug_count']
+            ?? data_get($decoded, 'target.slug_count')
+            ?? data_get($decoded, 'target.needed_additional_count');
+
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+
+        return (int) $raw;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function confirmationBlockers(string $mode, string $artifactSha, int $slugCount, ?int $expectedSlugCount): array
+    {
+        $blockers = [];
+
+        if ($mode === 'apply') {
+            $confirmedSha = trim((string) ($this->option('confirm-artifact-sha256') ?? ''));
+            if ($confirmedSha === '') {
+                $blockers[] = $this->blocker('confirm_artifact_sha256_missing', 'Apply requires --confirm-artifact-sha256.');
+            } elseif (! hash_equals($artifactSha, $confirmedSha)) {
+                $blockers[] = $this->blocker('artifact_sha256_mismatch', 'Artifact sha256 confirmation does not match.');
+            }
+
+            if ($expectedSlugCount === null) {
+                $blockers[] = $this->blocker('expect_slug_count_missing', 'Apply requires --expect-slug-count.');
+            }
+        }
+
+        if ($expectedSlugCount !== null && $expectedSlugCount !== $slugCount) {
+            $blockers[] = $this->blocker('expect_slug_count_mismatch', 'Expected slug count does not match artifact slug count.');
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function artifactSafetyBlockers(int $slugCount, int $maxSlugs): array
+    {
+        if ($slugCount > $maxSlugs) {
+            return [$this->blocker('slug_count_exceeds_max_slugs', 'Artifact slug count exceeds --max-slugs guard.')];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return array{slugs: list<string>, locales: list<string>, missing_occupations: list<string>, existing_latest_states: list<array<string, mixed>>, planned_writes: list<array<string, mixed>>, blockers: list<array<string, mixed>>}
+     */
+    private function plan(array $slugs, array $locales, string $batchId, string $reason, string $artifactPath, string $artifactSha): array
+    {
+        $occupations = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->with(['indexStates' => fn ($query) => $query
+                ->orderByDesc('changed_at')
+                ->orderByDesc('created_at')
+                ->orderByDesc('updated_at')])
+            ->get()
+            ->keyBy(fn (Occupation $occupation): string => strtolower((string) $occupation->getAttribute('canonical_slug')));
+
+        $missing = [];
+        $existing = [];
+        $writes = [];
+        $blockers = [];
+
+        foreach ($slugs as $slug) {
+            /** @var Occupation|null $occupation */
+            $occupation = $occupations->get($slug);
+            if ($occupation === null) {
+                $missing[] = $slug;
+                $blockers[] = $this->blocker('occupation_missing', 'Occupation is required before runtime candidate preparation apply.', ['canonical_slug' => $slug]);
+
+                continue;
+            }
+
+            /** @var IndexState|null $latest */
+            $latest = $occupation->indexStates->first();
+            $existing[] = $this->latestIndexStatePayload($slug, $latest);
+
+            $writes[] = [
+                'canonical_slug' => $slug,
+                'occupation_id' => (string) $occupation->getAttribute('id'),
+                'target_index_state' => self::TARGET_INDEX_STATE,
+                'index_eligible' => true,
+                'canonical_path' => '/career/jobs/'.$slug,
+                'canonical_target' => null,
+                'reason_codes' => $this->reasonCodes($batchId, $reason, $artifactPath, $artifactSha),
+                'row_fingerprint' => $this->rowFingerprint($slug, $batchId, $artifactSha),
+            ];
+        }
+
+        return [
+            'slugs' => $slugs,
+            'locales' => $locales,
+            'missing_occupations' => $missing,
+            'existing_latest_states' => $existing,
+            'planned_writes' => $writes,
+            'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function reasonCodes(string $batchId, string $reason, string $artifactPath, string $artifactSha): array
+    {
+        return [
+            self::SOURCE,
+            'prepare_published_candidate_runtime_rows',
+            'batch_id:'.$batchId,
+            'reason:'.Str::slug($reason, '_'),
+            'artifact_sha256:'.$artifactSha,
+            'artifact_basename:'.basename($artifactPath),
+            'target_runtime_state:'.self::TARGET_RUNTIME_STATE,
+            'target_index_state:'.self::TARGET_INDEX_STATE,
+        ];
+    }
+
+    private function rowFingerprint(string $slug, string $batchId, string $artifactSha): string
+    {
+        return hash('sha256', json_encode([
+            'source' => self::SOURCE,
+            'canonical_slug' => $slug,
+            'target_index_state' => self::TARGET_INDEX_STATE,
+            'target_runtime_state' => self::TARGET_RUNTIME_STATE,
+            'batch_id' => $batchId,
+            'artifact_sha256' => $artifactSha,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    private function latestIndexStatePayload(string $slug, ?IndexState $latest): array
+    {
+        if ($latest === null) {
+            return [
+                'canonical_slug' => $slug,
+                'index_state_id' => null,
+                'index_state' => null,
+                'index_eligible' => false,
+                'public_facing_state' => null,
+                'runtime_publish_state' => null,
+                'changed_at' => null,
+                'reason_codes' => [],
+            ];
+        }
+
+        $state = (string) $latest->getAttribute('index_state');
+        $eligible = (bool) $latest->getAttribute('index_eligible');
+
+        return [
+            'canonical_slug' => $slug,
+            'index_state_id' => (string) $latest->getAttribute('id'),
+            'index_state' => $state,
+            'index_eligible' => $eligible,
+            'public_facing_state' => IndexStateValue::publicFacing($state, $eligible),
+            'runtime_publish_state' => $state === self::TARGET_INDEX_STATE && $eligible ? self::TARGET_RUNTIME_STATE : null,
+            'changed_at' => $latest->getAttribute('changed_at')?->toISOString(),
+            'reason_codes' => $latest->getAttribute('reason_codes') ?? [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @param  array<string, mixed>  $artifact
+     * @param  list<array<string, mixed>>  $blockers
+     * @return array<string, mixed>
+     */
+    private function dryRunPayload(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount, array $blockers): array
+    {
+        return [
+            'status' => $blockers === [] ? 'planned' : 'blocked',
+            'mode' => 'dry_run',
+            'dry_run' => true,
+            'writes_database' => false,
+            'write_verified' => false,
+            'target_runtime_state' => self::TARGET_RUNTIME_STATE,
+            'target_index_state' => self::TARGET_INDEX_STATE,
+            'batch_id' => $batchId,
+            'reason' => $reason,
+            'source_artifact' => $artifactPath,
+            'source_kind' => $artifact['source_kind'],
+            'artifact_schema_version' => $artifact['schema_version'],
+            'artifact_sha256' => $artifactSha,
+            'slug_count' => count($plan['slugs']),
+            'locales' => $plan['locales'],
+            'expected_locale_rows' => count($plan['slugs']) * count($plan['locales']),
+            'max_slugs' => $maxSlugs,
+            'expect_slug_count' => $expectedSlugCount,
+            'slugs' => $plan['slugs'],
+            'missing_occupations' => $plan['missing_occupations'],
+            'existing_latest_states' => $plan['existing_latest_states'],
+            'planned_writes' => $plan['planned_writes'],
+            'planned_write_count' => count($plan['planned_writes']),
+            'blockers' => $blockers,
+            'by_reason' => $this->byReason($blockers),
+            'approval_phrase_template' => 'I explicitly approve Career 80 delta runtime candidate preparation apply for reviewed artifact <ARTIFACT> with sha256 <SHA256> and <COUNT> slugs on <ENVIRONMENT>; no deploy, rollout, backfill, rollback, quarantine, publication expansion, or fap-web change is approved.',
+            'non_goals' => [
+                'no_rollout_apply',
+                'no_rollout_dry_run',
+                'no_backfill',
+                'no_promotion_to_published',
+                'no_publication_expansion',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @param  array<string, mixed>  $artifact
+     * @param  list<array<string, mixed>>  $blockers
+     * @return array<string, mixed>
+     */
+    private function blockedApplyPayload(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount, array $blockers): array
+    {
+        return [
+            'status' => 'blocked',
+            'mode' => 'apply',
+            'dry_run' => false,
+            'writes_database' => false,
+            'write_verified' => false,
+            'target_runtime_state' => self::TARGET_RUNTIME_STATE,
+            'target_index_state' => self::TARGET_INDEX_STATE,
+            'batch_id' => $batchId,
+            'reason' => $reason,
+            'source_artifact' => $artifactPath,
+            'source_kind' => $artifact['source_kind'],
+            'artifact_schema_version' => $artifact['schema_version'],
+            'artifact_sha256' => $artifactSha,
+            'slug_count' => count($plan['slugs']),
+            'locales' => $plan['locales'],
+            'expected_locale_rows' => count($plan['slugs']) * count($plan['locales']),
+            'max_slugs' => $maxSlugs,
+            'expect_slug_count' => $expectedSlugCount,
+            'slugs' => $plan['slugs'],
+            'missing_occupations' => $plan['missing_occupations'],
+            'planned_writes' => $plan['planned_writes'],
+            'planned_write_count' => count($plan['planned_writes']),
+            'created_count' => 0,
+            'verified_count' => 0,
+            'failures' => [],
+            'blockers' => $blockers,
+            'by_reason' => $this->byReason($blockers),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, mixed>
+     */
+    private function apply(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount): array
+    {
+        $created = [];
+        $failures = [];
+
+        DB::transaction(function () use ($plan, &$created, &$failures): void {
+            foreach ($plan['planned_writes'] as $write) {
+                try {
+                    /** @var IndexState $indexState */
+                    $indexState = IndexState::query()->create([
+                        'occupation_id' => $write['occupation_id'],
+                        'index_state' => $write['target_index_state'],
+                        'index_eligible' => $write['index_eligible'],
+                        'canonical_path' => $write['canonical_path'],
+                        'canonical_target' => $write['canonical_target'],
+                        'reason_codes' => $write['reason_codes'],
+                        'changed_at' => now(),
+                        'row_fingerprint' => $write['row_fingerprint'],
+                    ]);
+
+                    $created[] = [
+                        'canonical_slug' => $write['canonical_slug'],
+                        'index_state_id' => (string) $indexState->getAttribute('id'),
+                        'runtime_publish_state' => self::TARGET_RUNTIME_STATE,
+                    ];
+                } catch (Throwable $exception) {
+                    $failures[] = [
+                        'canonical_slug' => $write['canonical_slug'],
+                        'reason' => 'runtime_candidate_preparation_write_failed',
+                        'message' => $exception->getMessage(),
+                    ];
+                }
+            }
+
+            if ($failures !== []) {
+                throw new RuntimeException('runtime_candidate_preparation_write_failed');
+            }
+        });
+
+        $verification = $this->verifyWrites($plan['slugs'], $artifactSha);
+        $blockers = $verification['blockers'];
+
+        return [
+            'status' => $blockers === [] ? 'applied' : 'blocked',
+            'mode' => 'apply',
+            'dry_run' => false,
+            'writes_database' => true,
+            'write_verified' => $blockers === [],
+            'target_runtime_state' => self::TARGET_RUNTIME_STATE,
+            'target_index_state' => self::TARGET_INDEX_STATE,
+            'batch_id' => $batchId,
+            'reason' => $reason,
+            'source_artifact' => $artifactPath,
+            'source_kind' => $artifact['source_kind'],
+            'artifact_schema_version' => $artifact['schema_version'],
+            'artifact_sha256' => $artifactSha,
+            'slug_count' => count($plan['slugs']),
+            'locales' => $plan['locales'],
+            'expected_locale_rows' => count($plan['slugs']) * count($plan['locales']),
+            'max_slugs' => $maxSlugs,
+            'expect_slug_count' => $expectedSlugCount,
+            'created_count' => count($created),
+            'verified_count' => $verification['verified_count'],
+            'created' => $created,
+            'failures' => $failures,
+            'blockers' => $blockers,
+            'by_reason' => $this->byReason($blockers),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{verified_count: int, blockers: list<array<string, mixed>>}
+     */
+    private function verifyWrites(array $slugs, string $artifactSha): array
+    {
+        $occupations = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->with(['indexStates' => fn ($query) => $query
+                ->orderByDesc('changed_at')
+                ->orderByDesc('created_at')
+                ->orderByDesc('updated_at')])
+            ->get()
+            ->keyBy(fn (Occupation $occupation): string => strtolower((string) $occupation->getAttribute('canonical_slug')));
+
+        $verified = 0;
+        $blockers = [];
+
+        foreach ($slugs as $slug) {
+            /** @var Occupation|null $occupation */
+            $occupation = $occupations->get($slug);
+            /** @var IndexState|null $latest */
+            $latest = $occupation?->indexStates->first();
+            $state = (string) ($latest?->getAttribute('index_state') ?? '');
+            $eligible = (bool) ($latest?->getAttribute('index_eligible') ?? false);
+            $reasonCodes = $latest?->getAttribute('reason_codes') ?? [];
+
+            if ($latest === null || $state !== self::TARGET_INDEX_STATE || ! $eligible) {
+                $blockers[] = $this->blocker('write_verification_failed', 'Latest index_state is not a prepared published_candidate runtime row.', ['canonical_slug' => $slug]);
+
+                continue;
+            }
+
+            if (! in_array(self::SOURCE, $reasonCodes, true) || ! in_array('artifact_sha256:'.$artifactSha, $reasonCodes, true)) {
+                $blockers[] = $this->blocker('write_metadata_verification_failed', 'Latest prepared candidate row is missing source or artifact metadata.', ['canonical_slug' => $slug]);
+
+                continue;
+            }
+
+            $verified++;
+        }
+
+        return ['verified_count' => $verified, 'blockers' => $blockers];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $blockers
+     * @return array<string, int>
+     */
+    private function byReason(array $blockers): array
+    {
+        $counts = [];
+        foreach ($blockers as $blocker) {
+            $reason = (string) ($blocker['reason'] ?? 'unknown');
+            $counts[$reason] = ($counts[$reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, string $message, array $evidence = []): array
+    {
+        return [
+            'reason' => $reason,
+            'message' => $message,
+            'evidence' => $evidence,
+        ];
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $value = strtolower(trim($message));
+        $value = preg_replace('/[^a-z0-9_]+/', '_', $value) ?: 'command_failed';
+
+        return trim($value, '_') ?: 'command_failed';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            file_put_contents($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('writes_database='.(($payload['writes_database'] ?? false) ? 'true' : 'false'));
+        }
+
+        return $exitCode;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -46,6 +46,7 @@ use App\Console\Commands\CareerPlanCanonical80RuntimeCandidatePool;
 use App\Console\Commands\CareerPlanCanonical80TargetDelta;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerPlanCanonicalRuntimeCandidatePrep;
+use App\Console\Commands\CareerPrepareCanonicalRuntimeCandidates;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRemediateCanonicalIndexState;
 use App\Console\Commands\CareerRunAssetBatch;
@@ -211,6 +212,7 @@ class Kernel extends ConsoleKernel
         CareerPlanCanonical80TargetDelta::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
         CareerPlanCanonicalRuntimeCandidatePrep::class,
+        CareerPrepareCanonicalRuntimeCandidates::class,
         CareerReleaseGateNoindexCleanup::class,
         CareerRemediateCanonicalIndexState::class,
         CareerValidateAssetImport::class,

--- a/backend/docs/career/audits/runtime_candidate_prep_apply_gate.md
+++ b/backend/docs/career/audits/runtime_candidate_prep_apply_gate.md
@@ -1,0 +1,89 @@
+# Career Runtime Candidate Preparation Apply Gate
+
+`career:prepare-canonical-runtime-candidates` is the guarded dry-run/apply command for preparing the 51 Career 80 delta slugs as runtime `published_candidate` inventory.
+
+The command consumes either:
+
+- `--plan=/tmp/career_80_delta_runtime_candidate_prep_plan.json`
+- `--slug-artifact=/tmp/<reviewed-explicit-slugs>.json`
+
+It never selects slugs implicitly and has no all-2786 mode. The source artifact is hashed with SHA-256 and apply requires that hash to be confirmed.
+
+## Usage
+
+Dry-run:
+
+```bash
+php artisan career:prepare-canonical-runtime-candidates \
+  --plan=/tmp/career_80_delta_runtime_candidate_prep_plan.json \
+  --dry-run \
+  --batch-id=career_80_delta_candidate_prep_001 \
+  --reason=career_80_delta_runtime_candidate_prep \
+  --expect-slug-count=51 \
+  --json \
+  --output=/tmp/career_80_delta_runtime_candidate_prep_dry_run.json
+```
+
+Apply, only after explicit production approval:
+
+```bash
+php artisan career:prepare-canonical-runtime-candidates \
+  --plan=/tmp/career_80_delta_runtime_candidate_prep_plan.json \
+  --apply \
+  --batch-id=career_80_delta_candidate_prep_001 \
+  --reason=career_80_delta_runtime_candidate_prep \
+  --expect-slug-count=51 \
+  --confirm-artifact-sha256=<reviewed_sha256> \
+  --max-slugs=100 \
+  --json \
+  --output=/tmp/career_80_delta_runtime_candidate_prep_apply.json
+```
+
+## Guards
+
+- Exactly one of `--plan` or `--slug-artifact` is required.
+- Exactly one of `--dry-run` or `--apply` is required.
+- `--batch-id` and `--reason` are required.
+- `--apply` requires `--confirm-artifact-sha256`.
+- `--apply` requires `--expect-slug-count`.
+- `--max-slugs` defaults to 100.
+- Duplicate, empty, wildcard, or missing slug lists block.
+- Missing `Occupation` rows block before writes.
+
+## Output
+
+Dry-run outputs:
+
+- `status`
+- `dry_run=true`
+- `writes_database=false`
+- `slug_count`
+- `expected_locale_rows`
+- `planned_writes`
+- `planned_write_count`
+- `blockers`
+- `artifact_sha256`
+- `approval_phrase_template`
+
+Apply outputs:
+
+- `status`
+- `dry_run=false`
+- `writes_database=true`
+- `write_verified`
+- `created_count`
+- `verified_count`
+- `failures`
+- `artifact_sha256`
+
+The apply path writes `promotion_candidate` index-state rows with `index_eligible=true`. In the current runtime projection semantics, that is the persisted authority that prepares a hidden pre-route `published_candidate` row. It does not promote the slug to `published`.
+
+## Non-goals
+
+- No rollout dry-run.
+- No rollout apply.
+- No backfill.
+- No rollback or quarantine.
+- No promotion to `published`.
+- No deploy.
+- No fap-web change.

--- a/backend/tests/Feature/Console/CareerPrepareCanonicalRuntimeCandidatesCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPrepareCanonicalRuntimeCandidatesCommandTest.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\IndexStateValue;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerPrepareCanonicalRuntimeCandidatesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:prepare-canonical-runtime-candidates', Artisan::all());
+    }
+
+    public function test_missing_plan_or_slug_artifact_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(['exactly_one_of_plan_or_slug_artifact_required' => 1], $payload['by_reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_missing_source_file_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => sys_get_temp_dir().'/missing-runtime-candidate-slugs.json',
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['runtime_candidate_prep_artifact_missing' => 1], $payload['by_reason']);
+    }
+
+    public function test_invalid_json_blocks(): void
+    {
+        $path = $this->tempPath('invalid');
+        file_put_contents($path, '{not json');
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $path,
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['runtime_candidate_prep_artifact_json_invalid' => 1], $payload['by_reason']);
+    }
+
+    public function test_empty_slug_list_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $this->writeSlugArtifact([]),
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['slug_list_empty' => 1], $payload['by_reason']);
+    }
+
+    public function test_duplicate_slugs_block(): void
+    {
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $this->writeSlugArtifact(['actuaries', 'actuaries'], countOverride: 2),
+            '--dry-run' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['duplicate_slug_actuaries' => 1], $payload['by_reason']);
+    }
+
+    public function test_dry_run_does_not_write_and_emits_sha_and_approval_phrase(): void
+    {
+        $this->createOccupation('actuaries');
+        $artifact = $this->writeSlugArtifact(['actuaries']);
+        $before = IndexState::query()->count();
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--dry-run' => true,
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertSame($before, IndexState::query()->count());
+        $this->assertSame(hash_file('sha256', $artifact), $payload['artifact_sha256']);
+        $this->assertSame(1, $payload['slug_count']);
+        $this->assertSame(2, $payload['expected_locale_rows']);
+        $this->assertSame(1, $payload['planned_write_count']);
+        $this->assertStringContainsString('I explicitly approve Career 80 delta runtime candidate preparation apply', $payload['approval_phrase_template']);
+    }
+
+    public function test_apply_requires_artifact_sha_and_expected_slug_count(): void
+    {
+        $this->createOccupation('actuaries');
+        $artifact = $this->writeSlugArtifact(['actuaries']);
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--apply' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertSame(1, $payload['by_reason']['confirm_artifact_sha256_missing']);
+        $this->assertSame(1, $payload['by_reason']['expect_slug_count_missing']);
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    public function test_apply_rejects_sha_mismatch_count_mismatch_and_slug_count_above_max(): void
+    {
+        $this->createOccupation('actuaries');
+        $this->createOccupation('actors');
+        $artifact = $this->writeSlugArtifact(['actuaries', 'actors']);
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--apply' => true,
+            '--confirm-artifact-sha256' => str_repeat('0', 64),
+            '--expect-slug-count' => 1,
+            '--max-slugs' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(1, $payload['by_reason']['artifact_sha256_mismatch']);
+        $this->assertSame(1, $payload['by_reason']['expect_slug_count_mismatch']);
+        $this->assertSame(1, $payload['by_reason']['slug_count_exceeds_max_slugs']);
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    public function test_apply_writes_only_explicit_slugs_and_verifies_candidate_rows(): void
+    {
+        $actuaries = $this->createOccupation('actuaries');
+        $actors = $this->createOccupation('actors');
+        $unlisted = $this->createOccupation('unlisted-career');
+        $this->createIndexState($actuaries, IndexStateValue::NOINDEX, false, ['legacy_noindex'], now()->subDay());
+        $this->createIndexState($unlisted, IndexStateValue::NOINDEX, false, ['legacy_noindex'], now()->subDay());
+        $artifact = $this->writeSlugArtifact(['actuaries', 'actors']);
+        $sha = hash_file('sha256', $artifact);
+        $occupationCountBefore = Occupation::query()->count();
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--apply' => true,
+            '--confirm-artifact-sha256' => $sha,
+            '--expect-slug-count' => 2,
+            '--max-slugs' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('applied', $payload['status']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['writes_database']);
+        $this->assertTrue($payload['write_verified']);
+        $this->assertSame(2, $payload['created_count']);
+        $this->assertSame(2, $payload['verified_count']);
+        $this->assertSame($occupationCountBefore, Occupation::query()->count());
+
+        $this->assertLatestPreparedCandidate('actuaries', $sha);
+        $this->assertLatestPreparedCandidate('actors', $sha);
+        $this->assertSame(IndexStateValue::NOINDEX, $unlisted->indexStates()->latest('changed_at')->firstOrFail()->index_state);
+    }
+
+    public function test_missing_occupation_blocks_apply_before_any_write(): void
+    {
+        $this->createOccupation('actuaries');
+        $artifact = $this->writeSlugArtifact(['actuaries', 'missing-career']);
+        $before = IndexState::query()->count();
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $artifact,
+            '--apply' => true,
+            '--confirm-artifact-sha256' => hash_file('sha256', $artifact),
+            '--expect-slug-count' => 2,
+            '--max-slugs' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['occupation_missing' => 1], $payload['by_reason']);
+        $this->assertSame($before, IndexState::query()->count());
+        $this->assertSame(['missing-career'], $payload['missing_occupations']);
+    }
+
+    public function test_plan_artifact_input_is_supported_and_json_shape_is_stable(): void
+    {
+        $this->createOccupation('actuaries');
+        $plan = $this->writePlanArtifact(['actuaries']);
+
+        $exitCode = $this->callCommand([
+            '--plan' => $plan,
+            '--dry-run' => true,
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame([
+            'status',
+            'mode',
+            'dry_run',
+            'writes_database',
+            'write_verified',
+            'target_runtime_state',
+            'target_index_state',
+            'batch_id',
+            'reason',
+            'source_artifact',
+            'source_kind',
+            'artifact_schema_version',
+            'artifact_sha256',
+            'slug_count',
+            'locales',
+            'expected_locale_rows',
+            'max_slugs',
+            'expect_slug_count',
+            'slugs',
+            'missing_occupations',
+            'existing_latest_states',
+            'planned_writes',
+            'planned_write_count',
+            'blockers',
+            'by_reason',
+            'approval_phrase_template',
+            'non_goals',
+        ], array_keys($payload));
+        $this->assertSame('plan', $payload['source_kind']);
+        $this->assertSame('published_candidate', $payload['target_runtime_state']);
+        $this->assertSame(IndexStateValue::PROMOTION_CANDIDATE, $payload['target_index_state']);
+        $this->assertContains('no_rollout_apply', $payload['non_goals']);
+        $this->assertContains('no_backfill', $payload['non_goals']);
+        $this->assertContains('no_promotion_to_published', $payload['non_goals']);
+    }
+
+    public function test_command_writes_output_file(): void
+    {
+        $this->createOccupation('actuaries');
+        $output = $this->tempPath('output');
+
+        $exitCode = $this->callCommand([
+            '--slug-artifact' => $this->writeSlugArtifact(['actuaries']),
+            '--dry-run' => true,
+            '--output' => $output,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertFileExists($output);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:prepare-canonical-runtime-candidates', array_merge([
+            '--batch-id' => 'career_80_delta_candidate_prep_001',
+            '--reason' => 'reviewed runtime candidate prep',
+            '--json' => true,
+        ], $options));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeSlugArtifact(array $slugs, ?int $countOverride = null): string
+    {
+        return $this->writeJson('runtime-candidate-slugs', [
+            'schema_version' => 'career_80_delta_runtime_candidate_prep_slugs.v1',
+            'count' => $countOverride ?? count($slugs),
+            'slugs' => $slugs,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writePlanArtifact(array $slugs): string
+    {
+        $rows = [];
+        foreach ($slugs as $slug) {
+            foreach (['en', 'zh'] as $locale) {
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'runtime_publish_state' => 'published_candidate',
+                    'projection_state' => 'published_candidate',
+                ];
+            }
+        }
+
+        return $this->writeJson('runtime-candidate-plan', [
+            'schema_version' => 'career_runtime_candidate_prep_plan.v1',
+            'status' => 'planned',
+            'target' => 'career_80_delta',
+            'delta_slug_count' => count($slugs),
+            'locales' => ['en', 'zh'],
+            'planned_candidate_rows' => $rows,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-prepare-runtime-candidates-'.Str::uuid().'-'.$name.'.json';
+    }
+
+    private function createOccupation(string $slug): Occupation
+    {
+        /** @var Occupation $occupation */
+        $occupation = Occupation::query()->create([
+            'family_id' => $this->occupationFamily()->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'canonical_rollout_batch',
+            'canonical_title_en' => Str::title(str_replace('-', ' ', $slug)),
+            'canonical_title_zh' => '职业',
+            'search_h1_zh' => '职业',
+        ]);
+
+        return $occupation;
+    }
+
+    /**
+     * @param  list<string>  $reasonCodes
+     */
+    private function createIndexState(Occupation $occupation, string $state, bool $eligible, array $reasonCodes = [], mixed $changedAt = null): IndexState
+    {
+        /** @var IndexState $indexState */
+        $indexState = IndexState::query()->create([
+            'occupation_id' => $occupation->id,
+            'index_state' => $state,
+            'index_eligible' => $eligible,
+            'canonical_path' => '/career/jobs/'.$occupation->canonical_slug,
+            'canonical_target' => null,
+            'reason_codes' => $reasonCodes,
+            'changed_at' => $changedAt ?? now(),
+        ]);
+
+        return $indexState;
+    }
+
+    private function assertLatestPreparedCandidate(string $slug, string $sha): void
+    {
+        /** @var Occupation $occupation */
+        $occupation = Occupation::query()->where('canonical_slug', $slug)->firstOrFail();
+        /** @var IndexState $latest */
+        $latest = $occupation->indexStates()
+            ->orderByDesc('changed_at')
+            ->orderByDesc('created_at')
+            ->firstOrFail();
+
+        $this->assertSame(IndexStateValue::PROMOTION_CANDIDATE, $latest->index_state);
+        $this->assertTrue($latest->index_eligible);
+        $this->assertSame(IndexStateValue::TRUST_LIMITED, IndexStateValue::publicFacing($latest->index_state, (bool) $latest->index_eligible));
+        $this->assertContains('career_80_delta_runtime_candidate_preparation', $latest->reason_codes);
+        $this->assertContains('prepare_published_candidate_runtime_rows', $latest->reason_codes);
+        $this->assertContains('batch_id:career_80_delta_candidate_prep_001', $latest->reason_codes);
+        $this->assertContains('reason:reviewed_runtime_candidate_prep', $latest->reason_codes);
+        $this->assertContains('artifact_sha256:'.$sha, $latest->reason_codes);
+        $this->assertContains('target_runtime_state:published_candidate', $latest->reason_codes);
+        $this->assertContains('target_index_state:promotion_candidate', $latest->reason_codes);
+    }
+
+    private function occupationFamily(): OccupationFamily
+    {
+        /** @var OccupationFamily $family */
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'runtime-candidate-prep-family'],
+            [
+                'title_en' => 'Runtime Candidate Prep Family',
+                'title_zh' => 'Runtime Candidate Prep Family',
+            ]
+        );
+
+        return $family;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2630,7 +2630,7 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": null,
+      "commit_sha": "5ac4aef963fa184c3f52ee12f0e716a9ee0db799",
       "pr_url": null,
       "checks": {
         "authorization": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2630,7 +2630,7 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": "5ac4aef963fa184c3f52ee12f0e716a9ee0db799",
+      "commit_sha": null,
       "pr_url": null,
       "checks": {
         "authorization": {
@@ -4857,8 +4857,8 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "5ac4aef963fa184c3f52ee12f0e716a9ee0db799",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1383",
       "checks": {
         "authorization": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4824,6 +4824,61 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "REPAIR-RUNTIME-CANDIDATE-PREP-APPLY-GATE-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-runtime-candidate-prep-apply-gate-1",
+      "title": "fix(api): add guarded runtime candidate preparation command",
+      "name": "Add guarded runtime candidate preparation dry-run/apply command",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-RUNTIME-CANDIDATE-PREP-1"
+      ],
+      "scope_type": "runtime_candidate_prep_apply_gate_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php",
+        "backend/app/Console/Kernel.php",
+        "backend/tests/Feature/Console/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no apply outside local tests",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no promotion to published",
+        "no backfill",
+        "no rollback",
+        "no quarantine",
+        "no DB mutation outside local tests",
+        "no production command",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly requested REPAIR-RUNTIME-CANDIDATE-PREP-APPLY-GATE-1 and authorized current train metadata updates."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR #1381 merged the read-only runtime candidate preparation planner."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to the guarded runtime candidate preparation command, registration, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-RUNTIME-ARTIFACT-REFRESH-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2613,3 +2613,42 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-RUNTIME-CANDIDATE-PREP-APPLY-GATE-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-RUNTIME-CANDIDATE-PREP-1
+    branch: fix/career-runtime-candidate-prep-apply-gate-1
+    title: "fix(api): add guarded runtime candidate preparation command"
+    name: "Add guarded runtime candidate preparation dry-run/apply command"
+    scope:
+      - Add an explicit-slug Career runtime candidate preparation command.
+      - Support dry-run planning with artifact SHA and approval phrase output.
+      - Support apply only behind explicit SHA, slug-count, max-slug, batch-id, and reason guards.
+      - Prepare only published_candidate runtime authority rows via promotion_candidate index_state writes for reviewed explicit slugs.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php
+      - backend/app/Console/Kernel.php
+      - backend/tests/Feature/Console/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run apply outside local tests.
+      - Run rollout or rollout dry-run.
+      - Promote candidates to published.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerPrepareCanonicalRuntimeCandidates --no-ansi
+      - php artisan test --filter=CareerRuntimeCandidate --no-ansi
+      - php artisan test --filter=Career80TargetDelta --no-ansi
+      - php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds `career:prepare-canonical-runtime-candidates` for explicit-slug runtime candidate preparation.
- Supports dry-run planning and guarded local/test apply behavior for reviewed delta slugs.
- Requires explicit source artifact/plan, batch id, reason, expected slug count, artifact sha confirmation, and max slug guard before apply.
- Writes only explicit slugs as `promotion_candidate` / runtime `published_candidate` preparation rows; it does not promote to published.

## Safety / non-goals
- No production command execution.
- No deploy, SSH, production DB query, production DB mutation, backfill, rollback, quarantine, rollout, rollout dry-run, manifest generation, 80 readiness, or fap-web work.
- Apply path is implemented but was not executed outside local PHPUnit tests.

## Validation
- `php artisan test --filter=CareerPrepareCanonicalRuntimeCandidates --no-ansi`
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=Career80TargetDelta --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=CareerCanonicalEligibilityAuditSchema --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-pr3.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`

## Next
- `REPAIR-RUNTIME-ARTIFACT-REFRESH-1`
