### PR TITLE
fix(api): add career runtime artifact refresh plan

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerRuntimeArtifactRefreshPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
+{
+    protected $signature = 'career:plan-canonical-runtime-artifact-refresh
+        {--target=career_80_delta : Refresh target}
+        {--delta-plan= : Optional Career 80 target delta artifact}
+        {--candidate-prep-plan= : Optional runtime candidate prep plan artifact}
+        {--candidate-prep-apply= : Optional runtime candidate prep apply artifact}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for runtime artifact refresh plan JSON}';
+
+    protected $description = 'Plan the read-only Career runtime artifact refresh sequence after candidate preparation apply.';
+
+    public function handle(): int
+    {
+        try {
+            $payload = app(CareerRuntimeArtifactRefreshPlanner::class)->plan(
+                target: trim((string) ($this->option('target') ?? 'career_80_delta')),
+                deltaPlan: $this->optionalJson('delta-plan'),
+                candidatePrepPlan: $this->optionalJson('candidate-prep-plan'),
+                candidatePrepApply: $this->optionalJson('candidate-prep-apply'),
+            )->toArray();
+
+            return $this->finish($payload, in_array(($payload['status'] ?? null), ['planned', 'blocked'], true) ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => CareerRuntimeArtifactRefreshPlanner::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'target' => 'career_80_delta',
+                'phase' => 'blocked',
+                'delta_slug_count' => 0,
+                'candidate_prep_required' => true,
+                'candidate_prep_apply_required' => true,
+                'writes_database' => false,
+                'read_only' => true,
+                'required_inputs' => [],
+                'required_outputs' => [],
+                'commands' => [],
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                    'evidence' => [],
+                ]],
+                'approval_gates' => [],
+                'next_required_action' => 'FIX_RUNTIME_ARTIFACT_REFRESH_PLAN',
+            ], self::FAILURE);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function optionalJson(string $option): ?array
+    {
+        $path = trim((string) ($this->option($option) ?? ''));
+
+        return $path === '' ? null : $this->readJson($path, $option);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException(str_replace('-', '_', $kind).'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException(str_replace('-', '_', $kind).'_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException(str_replace('-', '_', $kind).'_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException(str_replace('-', '_', $kind).'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            File::put($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('phase='.(string) ($payload['phase'] ?? 'unknown'));
+            $this->line('writes_database='.json_encode((bool) ($payload['writes_database'] ?? false)));
+        }
+
+        return $exitCode;
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $key = strtolower(trim($message));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $key) ?? 'runtime_artifact_refresh_error';
+        $key = trim($key, '_');
+
+        return $key === '' ? 'runtime_artifact_refresh_error' : $key;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -45,6 +45,7 @@ use App\Console\Commands\CareerPlanCanonical80CohortReadiness;
 use App\Console\Commands\CareerPlanCanonical80RuntimeCandidatePool;
 use App\Console\Commands\CareerPlanCanonical80TargetDelta;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
+use App\Console\Commands\CareerPlanCanonicalRuntimeArtifactRefresh;
 use App\Console\Commands\CareerPlanCanonicalRuntimeCandidatePrep;
 use App\Console\Commands\CareerPrepareCanonicalRuntimeCandidates;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
@@ -211,6 +212,7 @@ class Kernel extends ConsoleKernel
         CareerPlanCanonical80RuntimeCandidatePool::class,
         CareerPlanCanonical80TargetDelta::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
+        CareerPlanCanonicalRuntimeArtifactRefresh::class,
         CareerPlanCanonicalRuntimeCandidatePrep::class,
         CareerPrepareCanonicalRuntimeCandidates::class,
         CareerReleaseGateNoindexCleanup::class,

--- a/backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerRuntimeArtifactRefreshPlanner
+{
+    public const SCHEMA_VERSION = 'career_runtime_artifact_refresh_plan.v1';
+
+    private const TARGET = 'career_80_delta';
+
+    private const DELTA_SLUG_COUNT = 51;
+
+    private const PROJECTION_OUTPUT = '/tmp/career_80_delta_runtime_projection_after_candidate_prep.json';
+
+    private const TRUTH_OUTPUT = '/tmp/career_80_delta_runtime_truth_after_candidate_prep.json';
+
+    private const LEDGER_OUTPUT = '/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json';
+
+    private const SUMMARY_OUTPUT = '/tmp/career_80_delta_runtime_artifact_refresh_summary.json';
+
+    /**
+     * @param  array<string, mixed>|null  $deltaPlan
+     * @param  array<string, mixed>|null  $candidatePrepPlan
+     * @param  array<string, mixed>|null  $candidatePrepApply
+     */
+    public function plan(
+        string $target = self::TARGET,
+        ?array $deltaPlan = null,
+        ?array $candidatePrepPlan = null,
+        ?array $candidatePrepApply = null,
+    ): CareerRuntimeArtifactRefreshResult {
+        $blockers = [];
+
+        if ($target !== self::TARGET) {
+            $blockers[] = $this->blocker('target_unsupported', 'Only the Career 80 delta artifact refresh target is supported.', [
+                'target' => $target,
+            ]);
+        }
+
+        if ($deltaPlan === null) {
+            $blockers[] = $this->blocker('target_delta_plan_missing', 'The Career 80 target delta plan is required for runtime artifact refresh planning.', []);
+        }
+
+        if ($candidatePrepPlan === null) {
+            $blockers[] = $this->blocker('candidate_prep_plan_missing', 'The runtime candidate preparation plan is required for runtime artifact refresh planning.', []);
+        }
+
+        $deltaSlugCount = $this->deltaSlugCount($deltaPlan, $candidatePrepPlan);
+        if ($deltaSlugCount !== self::DELTA_SLUG_COUNT) {
+            $blockers[] = $this->blocker('delta_slug_count_not_51', 'The runtime artifact refresh plan is scoped to exactly 51 delta slugs.', [
+                'delta_slug_count' => $deltaSlugCount,
+                'expected' => self::DELTA_SLUG_COUNT,
+            ]);
+        }
+
+        $phase = 'pre_apply';
+        if ($candidatePrepApply === null) {
+            $blockers[] = $this->blocker('candidate_prep_apply_artifact_missing', 'A verified candidate preparation apply artifact is required before runtime artifacts can be refreshed.', []);
+        } elseif (($candidatePrepApply['write_verified'] ?? null) !== true) {
+            $phase = 'blocked';
+            $blockers[] = $this->blocker('candidate_prep_apply_not_verified', 'Candidate preparation apply artifact must have write_verified=true before refreshing runtime artifacts.', [
+                'write_verified' => $candidatePrepApply['write_verified'] ?? null,
+                'status' => $candidatePrepApply['status'] ?? null,
+            ]);
+        } else {
+            $phase = 'post_apply_ready';
+        }
+
+        $status = $blockers === [] ? 'planned' : 'blocked';
+
+        return new CareerRuntimeArtifactRefreshResult([
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $status,
+            'target' => self::TARGET,
+            'phase' => $phase,
+            'delta_slug_count' => $deltaSlugCount,
+            'candidate_prep_required' => true,
+            'candidate_prep_apply_required' => true,
+            'writes_database' => false,
+            'read_only' => true,
+            'required_inputs' => $this->requiredInputs($deltaPlan, $candidatePrepPlan, $candidatePrepApply),
+            'required_outputs' => $this->requiredOutputs(),
+            'commands' => $this->commands(),
+            'blockers' => $blockers,
+            'approval_gates' => $this->approvalGates($status, $phase),
+            'next_required_action' => $this->nextRequiredAction($status, $phase),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $deltaPlan
+     * @param  array<string, mixed>|null  $candidatePrepPlan
+     */
+    private function deltaSlugCount(?array $deltaPlan, ?array $candidatePrepPlan): int
+    {
+        $count = $candidatePrepPlan['delta_slug_count']
+            ?? $deltaPlan['delta_promotion_count']
+            ?? $deltaPlan['delta_slug_count']
+            ?? null;
+
+        if (is_numeric($count)) {
+            return (int) $count;
+        }
+
+        $slugs = $candidatePrepPlan['slugs']
+            ?? $candidatePrepPlan['recommended_rollout_delta_slugs']
+            ?? $candidatePrepPlan['delta_promotion_slugs']
+            ?? $deltaPlan['recommended_rollout_delta_slugs']
+            ?? $deltaPlan['delta_promotion_slugs']
+            ?? $deltaPlan['slugs']
+            ?? null;
+
+        return is_array($slugs) && array_is_list($slugs) ? count(array_unique($slugs)) : self::DELTA_SLUG_COUNT;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $deltaPlan
+     * @param  array<string, mixed>|null  $candidatePrepPlan
+     * @param  array<string, mixed>|null  $candidatePrepApply
+     * @return list<array<string, mixed>>
+     */
+    private function requiredInputs(?array $deltaPlan, ?array $candidatePrepPlan, ?array $candidatePrepApply): array
+    {
+        return [
+            [
+                'name' => 'target_delta_plan',
+                'required' => true,
+                'supplied' => $deltaPlan !== null,
+                'purpose' => 'Preserves 29 baseline plus 51 delta target accounting.',
+            ],
+            [
+                'name' => 'runtime_candidate_prep_plan',
+                'required' => true,
+                'supplied' => $candidatePrepPlan !== null,
+                'purpose' => 'Supplies the explicit 51 delta candidate preparation plan.',
+            ],
+            [
+                'name' => 'runtime_candidate_prep_apply_artifact',
+                'required' => true,
+                'supplied' => $candidatePrepApply !== null,
+                'write_verified' => $candidatePrepApply['write_verified'] ?? null,
+                'purpose' => 'Proves candidate preparation writes were applied and verified before read-only refresh.',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function requiredOutputs(): array
+    {
+        return [
+            [
+                'kind' => 'projection',
+                'path' => self::PROJECTION_OUTPUT,
+                'required_for' => '51-delta rollout dry-run',
+            ],
+            [
+                'kind' => 'truth',
+                'path' => self::TRUTH_OUTPUT,
+                'required_for' => '51-delta rollout dry-run',
+            ],
+            [
+                'kind' => 'ledger',
+                'path' => self::LEDGER_OUTPUT,
+                'required_for' => '51-delta rollout dry-run',
+            ],
+            [
+                'kind' => 'summary',
+                'path' => self::SUMMARY_OUTPUT,
+                'required_for' => 'operator review and downstream artifact provenance',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function commands(): array
+    {
+        return [
+            [
+                'command' => 'career:export-full-release-ledger',
+                'output' => self::LEDGER_OUTPUT,
+                'read_only' => true,
+                'execution' => 'future_read_only_run_after_candidate_prep_apply',
+            ],
+            [
+                'command' => 'career:export-runtime-publish-projection',
+                'output' => self::PROJECTION_OUTPUT,
+                'read_only' => true,
+                'requires' => [self::LEDGER_OUTPUT],
+                'execution' => 'future_read_only_run_after_candidate_prep_apply',
+            ],
+            [
+                'command' => 'career:export-canonical-runtime-truth',
+                'output' => self::TRUTH_OUTPUT,
+                'read_only' => true,
+                'requires' => [self::LEDGER_OUTPUT, self::PROJECTION_OUTPUT],
+                'execution' => 'future_read_only_run_after_candidate_prep_apply',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function approvalGates(string $status, string $phase): array
+    {
+        $refreshReady = $status === 'planned' && $phase === 'post_apply_ready';
+
+        return [
+            [
+                'id' => 'RUNTIME_CANDIDATE_PREP_APPLY_51',
+                'required_before' => 'RUNTIME_ARTIFACT_REFRESH_READ_ONLY',
+                'currently_ready' => false,
+                'satisfied' => $phase === 'post_apply_ready',
+                'forbidden_actions' => ['rollout', 'rollout_apply', 'backfill', 'rollback', 'quarantine', 'deploy'],
+            ],
+            [
+                'id' => 'RUNTIME_ARTIFACT_REFRESH_READ_ONLY',
+                'required_before' => 'DELTA_ROLLOUT_DRY_RUN_51',
+                'currently_ready' => $refreshReady,
+                'satisfied' => false,
+                'forbidden_actions' => ['apply', 'rollout_apply', 'db_mutation', 'deploy'],
+            ],
+            [
+                'id' => 'DELTA_ROLLOUT_DRY_RUN_51',
+                'required_before' => 'ROLLOUT_APPLY_51_DELTA',
+                'currently_ready' => false,
+                'satisfied' => false,
+                'forbidden_actions' => ['rollout_apply', 'db_mutation', 'deploy'],
+            ],
+        ];
+    }
+
+    private function nextRequiredAction(string $status, string $phase): string
+    {
+        if ($status === 'planned' && $phase === 'post_apply_ready') {
+            return 'RUNTIME_ARTIFACT_REFRESH_READ_ONLY';
+        }
+
+        return 'RUNTIME_CANDIDATE_PREP_DRY_RUN';
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, string $message, array $evidence): array
+    {
+        return [
+            'reason' => $reason,
+            'message' => $message,
+            'evidence' => $evidence,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshResult.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final readonly class CareerRuntimeArtifactRefreshResult
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(private array $payload) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+
+    public function planned(): bool
+    {
+        return ($this->payload['status'] ?? null) === 'planned';
+    }
+}

--- a/backend/docs/career/audits/runtime_artifact_refresh.md
+++ b/backend/docs/career/audits/runtime_artifact_refresh.md
@@ -1,0 +1,65 @@
+# Career Runtime Artifact Refresh Plan
+
+`career:plan-canonical-runtime-artifact-refresh` defines the read-only artifact refresh sequence required after a separately approved Career 80 delta runtime candidate preparation apply.
+
+The plan exists because the 51 delta slugs must first be prepared as runtime `published_candidate` inventory, then projection, truth, and ledger artifacts must be refreshed before any 51-delta rollout dry-run is attempted.
+
+## Usage
+
+Pre-apply informational plan:
+
+```bash
+php artisan career:plan-canonical-runtime-artifact-refresh \
+  --target=career_80_delta \
+  --delta-plan=/tmp/career_80_target_delta_plan.json \
+  --candidate-prep-plan=/tmp/career_80_delta_runtime_candidate_prep_plan.json \
+  --json \
+  --output=/tmp/career_80_delta_runtime_artifact_refresh_plan.json
+```
+
+Post-apply refresh-ready plan, only after candidate preparation apply is explicitly approved and write-verified:
+
+```bash
+php artisan career:plan-canonical-runtime-artifact-refresh \
+  --target=career_80_delta \
+  --delta-plan=/tmp/career_80_target_delta_plan.json \
+  --candidate-prep-plan=/tmp/career_80_delta_runtime_candidate_prep_plan.json \
+  --candidate-prep-apply=/tmp/career_80_delta_runtime_candidate_prep_apply.json \
+  --json \
+  --output=/tmp/career_80_delta_runtime_artifact_refresh_plan_after_apply.json
+```
+
+## Output
+
+The output schema is `career_runtime_artifact_refresh_plan.v1`.
+
+Key fields:
+
+- `status`: `planned` only when the supplied candidate-prep apply artifact has `write_verified=true`; otherwise `blocked`.
+- `phase`: `pre_apply`, `blocked`, or `post_apply_ready`.
+- `writes_database`: always `false`.
+- `required_outputs`:
+  - `/tmp/career_80_delta_runtime_projection_after_candidate_prep.json`
+  - `/tmp/career_80_delta_runtime_truth_after_candidate_prep.json`
+  - `/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json`
+  - `/tmp/career_80_delta_runtime_artifact_refresh_summary.json`
+- `commands`: the read-only export sequence to run later, after candidate-prep apply has passed.
+- `approval_gates`: the apply and read-only gates that must remain separate from rollout apply.
+
+## Approval Gates
+
+- `RUNTIME_CANDIDATE_PREP_APPLY_51`: creates or verifies the 51 delta `published_candidate` runtime inventory after explicit approval.
+- `RUNTIME_ARTIFACT_REFRESH_READ_ONLY`: refreshes projection, truth, and ledger artifacts after candidate-prep write verification.
+- `DELTA_ROLLOUT_DRY_RUN_51`: future dry-run that consumes refreshed artifacts and the 51-delta manifest.
+
+## Non-goals
+
+- No artifact export execution.
+- No candidate preparation apply.
+- No DB mutation.
+- No rollout dry-run.
+- No rollout apply.
+- No backfill.
+- No rollback or quarantine.
+- No deploy.
+- No fap-web change.

--- a/backend/docs/career/audits/runtime_candidate_prep_apply_gate.md
+++ b/backend/docs/career/audits/runtime_candidate_prep_apply_gate.md
@@ -78,6 +78,18 @@ Apply outputs:
 
 The apply path writes `promotion_candidate` index-state rows with `index_eligible=true`. In the current runtime projection semantics, that is the persisted authority that prepares a hidden pre-route `published_candidate` row. It does not promote the slug to `published`.
 
+After a future approved apply returns `write_verified=true`, run the read-only artifact refresh planner before any delta rollout dry-run:
+
+```bash
+php artisan career:plan-canonical-runtime-artifact-refresh \
+  --target=career_80_delta \
+  --delta-plan=/tmp/career_80_target_delta_plan.json \
+  --candidate-prep-plan=/tmp/career_80_delta_runtime_candidate_prep_plan.json \
+  --candidate-prep-apply=/tmp/career_80_delta_runtime_candidate_prep_apply.json \
+  --json \
+  --output=/tmp/career_80_delta_runtime_artifact_refresh_plan_after_apply.json
+```
+
 ## Non-goals
 
 - No rollout dry-run.

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCase
+{
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:plan-canonical-runtime-artifact-refresh', Artisan::all());
+    }
+
+    public function test_missing_candidate_prep_apply_blocks_refresh_readiness(): void
+    {
+        $exitCode = $this->callCommand([
+            '--delta-plan' => $this->writeJson('delta-plan', $this->deltaPlan()),
+            '--candidate-prep-plan' => $this->writeJson('prep-plan', $this->candidatePrepPlan()),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('candidate_prep_apply_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_invalid_candidate_prep_apply_json_blocks(): void
+    {
+        $path = $this->tempPath('bad-apply');
+        file_put_contents($path, '{not json');
+
+        $exitCode = $this->callCommand([
+            '--candidate-prep-apply' => $path,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('candidate_prep_apply_artifact_json_invalid', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_verified_candidate_prep_apply_allows_read_only_refresh_plan(): void
+    {
+        $exitCode = $this->callCommand([
+            '--delta-plan' => $this->writeJson('delta-plan', $this->deltaPlan()),
+            '--candidate-prep-plan' => $this->writeJson('prep-plan', $this->candidatePrepPlan()),
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApply(writeVerified: true)),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('post_apply_ready', $payload['phase']);
+        $this->assertSame('RUNTIME_ARTIFACT_REFRESH_READ_ONLY', $payload['next_required_action']);
+        $this->assertSame([], $payload['blockers']);
+    }
+
+    public function test_unverified_candidate_prep_apply_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--delta-plan' => $this->writeJson('delta-plan', $this->deltaPlan()),
+            '--candidate-prep-plan' => $this->writeJson('prep-plan', $this->candidatePrepPlan()),
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApply(writeVerified: false)),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('candidate_prep_apply_not_verified', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_writes_output_file_without_executing_exports(): void
+    {
+        $output = $this->tempPath('output');
+        $projectionOutput = '/tmp/career_80_delta_runtime_projection_after_candidate_prep.json';
+        $truthOutput = '/tmp/career_80_delta_runtime_truth_after_candidate_prep.json';
+        $ledgerOutput = '/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json';
+
+        $before = $this->fileFingerprints([$projectionOutput, $truthOutput, $ledgerOutput]);
+
+        $exitCode = $this->callCommand([
+            '--delta-plan' => $this->writeJson('delta-plan', $this->deltaPlan()),
+            '--candidate-prep-plan' => $this->writeJson('prep-plan', $this->candidatePrepPlan()),
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApply(writeVerified: true)),
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertFileExists($output);
+        $this->assertSame($before, $this->fileFingerprints([$projectionOutput, $truthOutput, $ledgerOutput]));
+        $this->assertSame([true, true, true], array_column($payload['commands'], 'read_only'));
+    }
+
+    public function test_json_output_shape_is_stable(): void
+    {
+        $this->callCommand([]);
+        $payload = $this->payload();
+
+        $this->assertSame([
+            'schema_version',
+            'status',
+            'target',
+            'phase',
+            'delta_slug_count',
+            'candidate_prep_required',
+            'candidate_prep_apply_required',
+            'writes_database',
+            'read_only',
+            'required_inputs',
+            'required_outputs',
+            'commands',
+            'blockers',
+            'approval_gates',
+            'next_required_action',
+        ], array_keys($payload));
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:plan-canonical-runtime-artifact-refresh', array_merge([
+            '--json' => true,
+        ], $options));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function deltaPlan(): array
+    {
+        return [
+            'schema_version' => 'career_80_target_delta.v1',
+            'status' => 'pass',
+            'target_public_total' => 80,
+            'delta_promotion_count' => 51,
+            'recommended_rollout_delta_slugs' => $this->slugs(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidatePrepPlan(): array
+    {
+        return [
+            'schema_version' => 'career_runtime_candidate_prep_plan.v1',
+            'status' => 'planned',
+            'target' => 'career_80_delta',
+            'delta_slug_count' => 51,
+            'planned_candidate_rows_count' => 102,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidatePrepApply(bool $writeVerified): array
+    {
+        return [
+            'status' => $writeVerified ? 'applied' : 'blocked',
+            'writes_database' => $writeVerified,
+            'write_verified' => $writeVerified,
+            'created_count' => $writeVerified ? 51 : 0,
+            'verified_count' => $writeVerified ? 51 : 0,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= 51; $i++) {
+            $slugs[] = sprintf('delta-%03d', $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-runtime-artifact-refresh-'.Str::uuid().'-'.$name.'.json';
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return array<string, string|null>
+     */
+    private function fileFingerprints(array $paths): array
+    {
+        clearstatcache();
+
+        $fingerprints = [];
+        foreach ($paths as $path) {
+            $fingerprints[$path] = is_file($path) ? filemtime($path).':'.filesize($path) : null;
+        }
+
+        return $fingerprints;
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerRuntimeArtifactRefreshPlanner;
+use PHPUnit\Framework\TestCase;
+
+final class CareerRuntimeArtifactRefreshPlannerTest extends TestCase
+{
+    public function test_emits_required_projection_truth_and_ledger_paths(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            deltaPlan: $this->deltaPlan(),
+            candidatePrepPlan: $this->candidatePrepPlan(),
+            candidatePrepApply: $this->candidatePrepApply(writeVerified: true),
+        )->toArray();
+
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('career_runtime_artifact_refresh_plan.v1', $payload['schema_version']);
+        $this->assertSame('/tmp/career_80_delta_runtime_projection_after_candidate_prep.json', $payload['required_outputs'][0]['path']);
+        $this->assertSame('/tmp/career_80_delta_runtime_truth_after_candidate_prep.json', $payload['required_outputs'][1]['path']);
+        $this->assertSame('/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json', $payload['required_outputs'][2]['path']);
+        $this->assertSame('/tmp/career_80_delta_runtime_artifact_refresh_summary.json', $payload['required_outputs'][3]['path']);
+    }
+
+    public function test_blocks_until_candidate_prep_apply_artifact_exists(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            deltaPlan: $this->deltaPlan(),
+            candidatePrepPlan: $this->candidatePrepPlan(),
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('pre_apply', $payload['phase']);
+        $this->assertSame('candidate_prep_apply_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertSame('RUNTIME_CANDIDATE_PREP_DRY_RUN', $payload['next_required_action']);
+    }
+
+    public function test_passes_when_candidate_prep_apply_is_write_verified(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            deltaPlan: $this->deltaPlan(),
+            candidatePrepPlan: $this->candidatePrepPlan(),
+            candidatePrepApply: $this->candidatePrepApply(writeVerified: true),
+        )->toArray();
+
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('post_apply_ready', $payload['phase']);
+        $this->assertSame([], $payload['blockers']);
+        $this->assertSame('RUNTIME_ARTIFACT_REFRESH_READ_ONLY', $payload['next_required_action']);
+        $this->assertTrue($payload['approval_gates'][1]['currently_ready']);
+    }
+
+    public function test_blocks_when_candidate_prep_apply_is_not_write_verified(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            deltaPlan: $this->deltaPlan(),
+            candidatePrepPlan: $this->candidatePrepPlan(),
+            candidatePrepApply: $this->candidatePrepApply(writeVerified: false),
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('blocked', $payload['phase']);
+        $this->assertSame('candidate_prep_apply_not_verified', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_marks_writes_database_false_and_commands_read_only(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            deltaPlan: $this->deltaPlan(),
+            candidatePrepPlan: $this->candidatePrepPlan(),
+            candidatePrepApply: $this->candidatePrepApply(writeVerified: true),
+        )->toArray();
+
+        $this->assertFalse($payload['writes_database']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertSame([
+            'career:export-full-release-ledger',
+            'career:export-runtime-publish-projection',
+            'career:export-canonical-runtime-truth',
+        ], array_column($payload['commands'], 'command'));
+        $this->assertSame([true, true, true], array_column($payload['commands'], 'read_only'));
+    }
+
+    public function test_schema_is_stable(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            deltaPlan: $this->deltaPlan(),
+            candidatePrepPlan: $this->candidatePrepPlan(),
+        )->toArray();
+
+        $this->assertSame([
+            'schema_version',
+            'status',
+            'target',
+            'phase',
+            'delta_slug_count',
+            'candidate_prep_required',
+            'candidate_prep_apply_required',
+            'writes_database',
+            'read_only',
+            'required_inputs',
+            'required_outputs',
+            'commands',
+            'blockers',
+            'approval_gates',
+            'next_required_action',
+        ], array_keys($payload));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function deltaPlan(): array
+    {
+        return [
+            'schema_version' => 'career_80_target_delta.v1',
+            'status' => 'pass',
+            'target_public_total' => 80,
+            'delta_promotion_count' => 51,
+            'recommended_rollout_delta_slugs' => $this->slugs(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidatePrepPlan(): array
+    {
+        return [
+            'schema_version' => 'career_runtime_candidate_prep_plan.v1',
+            'status' => 'planned',
+            'target' => 'career_80_delta',
+            'delta_slug_count' => 51,
+            'planned_candidate_rows_count' => 102,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidatePrepApply(bool $writeVerified): array
+    {
+        return [
+            'status' => $writeVerified ? 'applied' : 'blocked',
+            'writes_database' => $writeVerified,
+            'write_verified' => $writeVerified,
+            'created_count' => $writeVerified ? 51 : 0,
+            'verified_count' => $writeVerified ? 51 : 0,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= 51; $i++) {
+            $slugs[] = sprintf('delta-%03d', $i);
+        }
+
+        return $slugs;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -404,6 +404,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
@@ -1852,6 +1854,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2630,7 +2630,7 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": null,
+      "commit_sha": "8589f43480d69100ba6d7333e4032dba039bf924",
       "pr_url": null,
       "checks": {
         "authorization": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4879,6 +4879,59 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "REPAIR-RUNTIME-ARTIFACT-REFRESH-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-runtime-artifact-refresh-flow-1",
+      "title": "fix(api): add career runtime artifact refresh plan",
+      "name": "Add Career runtime artifact refresh plan for 51 delta candidate prep",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-RUNTIME-CANDIDATE-PREP-APPLY-GATE-1"
+      ],
+      "scope_type": "runtime_artifact_refresh_plan_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no artifact export execution",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly requested REPAIR-RUNTIME-ARTIFACT-REFRESH-1 and authorized current train metadata updates."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR #1383 merged the guarded runtime candidate preparation dry-run/apply command."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to read-only runtime artifact refresh planning, command registration, tests/docs, train metadata, and optional freeze classifier allowlist if required."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-51-DELTA-ROLLOUT-MANIFEST-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -707,7 +707,7 @@
         "backend-email-gated-report-read"
       ],
       "commit_sha": "32f35c17a0f29758f0f700010ac1b0c7492ffb6c",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1384",
       "checks": {},
       "sidecar_issues": [],
       "failure_reason": null,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2652,3 +2652,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-RUNTIME-ARTIFACT-REFRESH-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-RUNTIME-CANDIDATE-PREP-APPLY-GATE-1
+    branch: fix/career-runtime-artifact-refresh-flow-1
+    title: "fix(api): add career runtime artifact refresh plan"
+    name: "Add Career runtime artifact refresh plan for 51 delta candidate prep"
+    scope:
+      - Add a read-only Career runtime artifact refresh planner.
+      - Define projection, truth, ledger, and summary artifact outputs after candidate prep apply.
+      - Require a write-verified candidate prep apply artifact before refresh readiness.
+      - Register a read-only planning command that does not execute exports, apply, rollout, or DB writes.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Execute artifact exports.
+      - Run candidate preparation apply.
+      - Run rollout or rollout dry-run.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi
+      - php artisan test --filter=CareerPrepareCanonicalRuntimeCandidates --no-ansi
+      - php artisan test --filter=CareerRuntimeCandidate --no-ansi
+      - php artisan test --filter=Career80TargetDelta --no-ansi
+      - php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds a read-only Career runtime artifact refresh planner for the 51-delta candidate prep flow.
- Defines the projection, truth, ledger, and summary artifacts required after a future write-verified candidate prep apply.
- Adds `career:plan-canonical-runtime-artifact-refresh` to emit the reproducible refresh plan without executing exports.

## Safety / Non-goals
- Does not execute artifact exports.
- Does not run candidate prep apply.
- Does not mutate DB.
- Does not run rollout dry-run or rollout apply.
- Does not deploy or touch fap-web.

## Next Step
- `REPAIR-51-DELTA-ROLLOUT-MANIFEST-1`

## Validation
- `php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi`
- `php artisan test --filter=CareerPlanCanonicalRuntimeArtifactRefresh --no-ansi`
- `php artisan test --filter=CareerPrepareCanonicalRuntimeCandidates --no-ansi`
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=Career80TargetDelta --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-pr4.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Scope Notes
- No production commands were run.
- The synthetic local planner run wrote only `/tmp/career_test_runtime_artifact_refresh_plan.json` and performed no exports.
