### PR TITLE
PR-CMS-04｜Controlled Codex-Assisted CMS Publish SOP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,7 @@ Prefer a repo-compatible default implementation and mark options as optional.
   - a follow-up execution prompt that explicitly asks for manifest/state authorization
 - Scan/planning-only tasks must not modify `docs/codex/pr-train.yaml` or `docs/codex/pr-train-state.json` unless the user explicitly authorizes manifest/state updates in that same turn.
 - If the user provides a concrete `/goal` or equivalent execution request with an explicit PR id, title, and scope, Codex may treat those as user-provided manifest details. If the id is missing from the manifest, Codex may add the manifest/state entry before implementation only when the user also explicitly authorizes updating both files.
+
+### Controlled CMS Publish Discipline
+- Controlled Codex-assisted article publish is permitted only through the backend `articles:publish-controlled` command after exact user confirmation, successful preflight, explicit boundary-context claim-warning acknowledgement when needed, and audit logging.
+- Codex must not use generic CMS UI publish clicks, uncontrolled API publish endpoints, or production content mutation outside that controlled SOP.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -88,6 +88,7 @@
 ## Content authority rules
 - CMS/backend is the source of truth for publishable content, operational metadata, mutable media references, public SEO fields, and publishing state.
 - Article content, article SEO, covers, categories/tags, related placement, and publication state must be managed through backend Article resources and APIs.
+- Controlled Codex-assisted article publish is allowed only through the backend `articles:publish-controlled` command after exact user confirmation, passing preflight gates, required claim-warning acknowledgement, and audit logging. Codex must not use generic CMS UI publish clicks or uncontrolled publish endpoints as the default production publishing mechanism.
 - Homepage, tests hub, test category, career center, CTA text, module ordering, featured items, and landing SEO must be managed through `landing_surfaces` / `page_blocks`.
 - Help, policy, company, brand, careers, about, charter, foundation, privacy, terms, refund, support, and similar static-content pages must be managed through `content_pages`.
 - Career guides, career jobs, career recommendations, personality profiles, topic pages, FAQ, sections, and SEO must be managed through backend CMS resources and public APIs.

--- a/backend/app/Console/Commands/ArticlePublishControlled.php
+++ b/backend/app/Console/Commands/ArticlePublishControlled.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleEditorialPackageImport;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Audit\AuditLogger;
+use App\Services\Cms\ArticlePublishService;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+final class ArticlePublishControlled extends Command
+{
+    protected $signature = 'articles:publish-controlled
+        {--article=* : Article id to publish}
+        {--confirm= : Exact user confirmation phrase}
+        {--ack-claim-warning=* : Article id whose boundary-context claim warnings are acknowledged}
+        {--make-indexable : Mark the article and SEO meta indexable during publish}
+        {--dry-run : Run preflight without publishing}
+        {--json : Emit a JSON summary}';
+
+    protected $description = 'Publish reviewed article drafts only behind an explicit controlled Codex-assisted publish confirmation.';
+
+    public function handle(ArticlePublishService $publisher, AuditLogger $auditLogger): int
+    {
+        $articleIds = $this->articleIds();
+        $acknowledgedWarnings = $this->acknowledgedWarningIds();
+        $dryRun = (bool) $this->option('dry-run');
+        $makeIndexable = (bool) $this->option('make-indexable');
+        $expectedConfirmation = $this->expectedConfirmation($articleIds);
+        $confirmation = trim((string) $this->option('confirm'));
+
+        $plans = [];
+        $errors = [];
+
+        if ($articleIds === []) {
+            $errors[] = $this->issue('article', 'missing_article', 'At least one --article id is required.');
+        }
+
+        if (! $dryRun && ! hash_equals($expectedConfirmation, $confirmation)) {
+            $errors[] = $this->issue(
+                'confirm',
+                'confirmation_mismatch',
+                'Exact confirmation phrase is required before controlled publish.',
+                ['expected_confirmation' => $expectedConfirmation]
+            );
+        }
+
+        foreach ($articleIds as $articleId) {
+            $plan = $this->preflightArticle($articleId, $acknowledgedWarnings, $makeIndexable);
+            $plans[] = $plan;
+
+            foreach ($plan['errors'] as $error) {
+                $errors[] = $error;
+            }
+        }
+
+        $summary = [
+            'ok' => $errors === [],
+            'dry_run' => $dryRun,
+            'expected_confirmation' => $expectedConfirmation,
+            'make_indexable' => $makeIndexable,
+            'article_ids' => $articleIds,
+            'articles' => $plans,
+            'errors' => $errors,
+            'published_article_ids' => [],
+        ];
+
+        if ($errors === [] && ! $dryRun) {
+            $publishedIds = [];
+            foreach ($plans as $plan) {
+                $publishedIds[] = $this->publishPlannedArticle($plan, $publisher, $auditLogger, $expectedConfirmation, $makeIndexable);
+            }
+
+            $summary['published_article_ids'] = $publishedIds;
+        }
+
+        $this->emitSummary($summary);
+
+        return $summary['ok'] ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function articleIds(): array
+    {
+        $ids = [];
+        foreach ((array) $this->option('article') as $value) {
+            if (! is_numeric($value)) {
+                continue;
+            }
+
+            $id = (int) $value;
+            if ($id > 0) {
+                $ids[] = $id;
+            }
+        }
+
+        sort($ids);
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function acknowledgedWarningIds(): array
+    {
+        $ids = [];
+        foreach ((array) $this->option('ack-claim-warning') as $value) {
+            if (! is_numeric($value)) {
+                continue;
+            }
+
+            $id = (int) $value;
+            if ($id > 0) {
+                $ids[] = $id;
+            }
+        }
+
+        sort($ids);
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     */
+    private function expectedConfirmation(array $articleIds): string
+    {
+        $idList = implode(',', $articleIds);
+        $label = count($articleIds) === 1 ? 'article id' : 'article ids';
+
+        return "I explicitly approve Codex to publish {$label} {$idList} after preflight passes.";
+    }
+
+    /**
+     * @param  list<int>  $acknowledgedWarnings
+     * @return array<string,mixed>
+     */
+    private function preflightArticle(int $articleId, array $acknowledgedWarnings, bool $makeIndexable): array
+    {
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['workingRevision', 'seoMeta', 'category', 'tags'])
+            ->find($articleId);
+
+        if (! $article instanceof Article) {
+            return [
+                'article_id' => $articleId,
+                'ok' => false,
+                'errors' => [$this->issue('article', 'article_not_found', 'Article not found.', ['article_id' => $articleId])],
+            ];
+        }
+
+        $import = ArticleEditorialPackageImport::query()
+            ->withoutGlobalScopes()
+            ->where('article_id', $articleId)
+            ->latest('id')
+            ->first();
+
+        $seoMeta = $article->seoMeta instanceof ArticleSeoMeta ? $article->seoMeta : null;
+        $revision = $article->workingRevision instanceof ArticleTranslationRevision ? $article->workingRevision : null;
+        $editorialPackage = is_array($seoMeta?->schema_json)
+            ? (array) data_get($seoMeta->schema_json, 'editorial_package_v1', [])
+            : [];
+        $bodyHash = $revision instanceof ArticleTranslationRevision
+            ? hash('sha256', preg_replace("/\r\n?/", "\n", trim((string) $revision->content_md)))
+            : '';
+        $claimStatus = (string) data_get($import?->claim_result_json, 'status', '');
+        $claimMatches = is_array(data_get($import?->claim_result_json, 'matches'))
+            ? (array) data_get($import?->claim_result_json, 'matches')
+            : [];
+        $sensitivityLevel = (string) data_get($editorialPackage, 'sensitivity_level', '');
+
+        $errors = [];
+
+        if ((string) $article->status === 'published' || $article->published_revision_id !== null) {
+            $errors[] = $this->issue('article', 'already_published', 'Article is already published.');
+        }
+
+        if (! in_array((string) $article->status, ['draft', 'review_pending'], true)) {
+            $errors[] = $this->issue('article.status', 'invalid_status', 'Controlled publish only accepts draft or review_pending articles.');
+        }
+
+        if ((bool) $article->is_public) {
+            $errors[] = $this->issue('article.is_public', 'already_public', 'Article is already public before controlled publish.');
+        }
+
+        if (! $revision instanceof ArticleTranslationRevision) {
+            $errors[] = $this->issue('working_revision', 'missing_working_revision', 'Article must have a working revision.');
+        } elseif (in_array((string) $revision->revision_status, [
+            ArticleTranslationRevision::STATUS_STALE,
+            ArticleTranslationRevision::STATUS_ARCHIVED,
+            ArticleTranslationRevision::STATUS_PUBLISHED,
+        ], true)) {
+            $errors[] = $this->issue('working_revision.revision_status', 'invalid_revision_status', 'Working revision status is not publishable.');
+        }
+
+        if (! $import instanceof ArticleEditorialPackageImport) {
+            $errors[] = $this->issue('import', 'missing_import_gate', 'Controlled publish requires an editorial package import gate record.');
+        } elseif (! in_array((string) $import->status, [
+            ArticleEditorialPackageImport::STATUS_IMPORTED,
+            ArticleEditorialPackageImport::STATUS_WARNING,
+        ], true)) {
+            $errors[] = $this->issue('import.status', 'invalid_import_status', 'Import gate status must be imported or warning.');
+        }
+
+        if ($import instanceof ArticleEditorialPackageImport && $bodyHash !== '' && ! hash_equals((string) $import->body_hash, $bodyHash)) {
+            $errors[] = $this->issue('body_hash', 'body_hash_mismatch', 'Working revision body hash does not match latest import gate hash.');
+        }
+
+        if ($claimStatus === 'blocked') {
+            $errors[] = $this->issue('claim', 'claim_blocked', 'Claim linter blocked this article.');
+        }
+
+        if ($claimStatus === 'warning') {
+            $allBoundaryContext = $claimMatches !== [] && collect($claimMatches)->every(
+                static fn (mixed $match): bool => is_array($match) && (bool) ($match['boundary_context'] ?? false)
+            );
+
+            if (! $allBoundaryContext) {
+                $errors[] = $this->issue('claim', 'claim_warning_not_boundary_context', 'Claim warnings include non-boundary context matches.');
+            }
+
+            if (! in_array($articleId, $acknowledgedWarnings, true)) {
+                $errors[] = $this->issue('claim', 'claim_warning_ack_required', 'Boundary-context claim warnings must be explicitly acknowledged for this article.');
+            }
+        }
+
+        if (in_array($sensitivityLevel, ['health_sensitive', 'ability_sensitive'], true)) {
+            $errors[] = $this->issue('sensitivity_level', 'sensitive_publish_not_allowed', 'Controlled Codex publish does not allow health_sensitive or ability_sensitive content.');
+        }
+
+        if ((string) data_get($import?->media_json, 'status') !== 'complete') {
+            $errors[] = $this->issue('media', 'media_incomplete', 'Cover image, alt, prompt, and style tag must be complete.');
+        }
+
+        if ((int) ($import?->references_count ?? 0) <= 0) {
+            $errors[] = $this->issue('references', 'references_missing', 'References must be present before controlled publish.');
+        }
+
+        if ((string) data_get($import?->graph_json, 'status') !== 'complete') {
+            $errors[] = $this->issue('graph', 'graph_incomplete', 'Graph metadata must be complete before controlled publish.');
+        }
+
+        if (trim((string) $article->cover_image_alt) === '') {
+            $errors[] = $this->issue('cover_image_alt', 'cover_alt_missing', 'Cover image alt text must be present.');
+        }
+
+        if (! $article->category) {
+            $errors[] = $this->issue('category', 'category_missing', 'Article category must be present.');
+        }
+
+        if ($article->tags->count() <= 0) {
+            $errors[] = $this->issue('tags', 'tags_missing', 'Article tags must be present.');
+        }
+
+        if (! $seoMeta instanceof ArticleSeoMeta) {
+            $errors[] = $this->issue('seo', 'seo_meta_missing', 'SEO meta must be present.');
+        } else {
+            foreach (['seo_title', 'seo_description', 'canonical_url', 'og_image_url'] as $field) {
+                if (trim((string) $seoMeta->{$field}) === '') {
+                    $errors[] = $this->issue("seo.{$field}", 'seo_field_missing', "SEO field {$field} must be present.");
+                }
+            }
+        }
+
+        if (! $makeIndexable && (! (bool) $article->is_indexable || (string) ($seoMeta?->robots ?? '') !== 'index,follow')) {
+            $errors[] = $this->issue('indexability', 'make_indexable_required', 'Use --make-indexable to publish SEO articles that are currently noindex drafts.');
+        }
+
+        $ctaSlots = data_get($editorialPackage, 'cta_slots', []);
+        if (! is_array($ctaSlots) || count($ctaSlots) <= 0) {
+            $errors[] = $this->issue('cta_slots', 'cta_slots_missing', 'Editorial package CTA slots must be present.');
+        }
+
+        $faqItems = data_get($editorialPackage, 'answer_surface_v1.faq_items', []);
+        if (! is_array($faqItems) || count($faqItems) <= 0) {
+            $errors[] = $this->issue('faq_items', 'faq_items_missing', 'FAQ items must be present for controlled SEO article publish.');
+        }
+
+        return [
+            'article_id' => $articleId,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'title' => (string) $article->title,
+            'status' => (string) $article->status,
+            'working_revision_id' => $revision?->id,
+            'working_revision_status' => $revision?->revision_status,
+            'import_id' => $import?->id,
+            'import_status' => $import?->status,
+            'claim_status' => $claimStatus,
+            'claim_matches_count' => count($claimMatches),
+            'body_hash' => $bodyHash,
+            'references_count' => (int) ($import?->references_count ?? 0),
+            'media_status' => (string) data_get($import?->media_json, 'status', ''),
+            'graph_status' => (string) data_get($import?->graph_json, 'status', ''),
+            'cta_count' => is_array($ctaSlots) ? count($ctaSlots) : 0,
+            'faq_count' => is_array($faqItems) ? count($faqItems) : 0,
+            'make_indexable' => $makeIndexable,
+            'ok' => $errors === [],
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function publishPlannedArticle(
+        array $plan,
+        ArticlePublishService $publisher,
+        AuditLogger $auditLogger,
+        string $confirmation,
+        bool $makeIndexable
+    ): int {
+        $articleId = (int) $plan['article_id'];
+
+        DB::transaction(function () use ($articleId, $makeIndexable): void {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with('workingRevision')
+                ->whereKey($articleId)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $article instanceof Article || ! $article->workingRevision instanceof ArticleTranslationRevision) {
+                throw new RuntimeException('planned article disappeared before publish.');
+            }
+
+            $article->workingRevision->forceFill([
+                'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
+                'approved_at' => $article->workingRevision->approved_at ?? now(),
+            ])->save();
+
+            if ($makeIndexable) {
+                $article->forceFill(['is_indexable' => true])->save();
+
+                ArticleSeoMeta::query()
+                    ->withoutGlobalScopes()
+                    ->where('article_id', $articleId)
+                    ->update([
+                        'robots' => 'index,follow',
+                        'is_indexable' => true,
+                    ]);
+            }
+        });
+
+        $article = $publisher->publishArticle($articleId, 'controlled_codex_publish');
+
+        $auditLogger->log(
+            Request::create('/ops/articles/publish-controlled', 'POST'),
+            'codex_controlled_article_publish',
+            'article',
+            (string) $articleId,
+            [
+                'confirmation_sha256' => hash('sha256', $confirmation),
+                'article_id' => $articleId,
+                'slug' => (string) $article->slug,
+                'locale' => (string) $article->locale,
+                'body_hash' => (string) ($plan['body_hash'] ?? ''),
+                'import_id' => (int) ($plan['import_id'] ?? 0),
+                'claim_status' => (string) ($plan['claim_status'] ?? ''),
+                'make_indexable' => $makeIndexable,
+                'source' => 'controlled_codex_publish',
+            ],
+            reason: 'controlled_codex_article_publish',
+            result: 'success',
+        );
+
+        return $articleId;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $extra = []): array
+    {
+        return array_merge([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ], $extra);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('expected_confirmation='.(string) ($summary['expected_confirmation'] ?? ''));
+        $this->line('make_indexable='.(($summary['make_indexable'] ?? false) ? '1' : '0'));
+        $this->line('articles='.implode(',', (array) ($summary['article_ids'] ?? [])));
+        $this->line('published_article_ids='.implode(',', (array) ($summary['published_article_ids'] ?? [])));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+
+        foreach ((array) ($summary['articles'] ?? []) as $article) {
+            if (! is_array($article)) {
+                continue;
+            }
+
+            $this->line(sprintf(
+                'article=%s locale=%s slug=%s ok=%s import_status=%s claim_status=%s media=%s references=%s graph=%s cta=%s faq=%s revision_status=%s',
+                (string) ($article['article_id'] ?? ''),
+                (string) ($article['locale'] ?? ''),
+                (string) ($article['slug'] ?? ''),
+                ($article['ok'] ?? false) ? '1' : '0',
+                (string) ($article['import_status'] ?? ''),
+                (string) ($article['claim_status'] ?? ''),
+                (string) ($article['media_status'] ?? ''),
+                (string) ($article['references_count'] ?? ''),
+                (string) ($article['graph_status'] ?? ''),
+                (string) ($article['cta_count'] ?? ''),
+                (string) ($article['faq_count'] ?? ''),
+                (string) ($article['working_revision_status'] ?? '')
+            ));
+
+            foreach ((array) ($article['errors'] ?? []) as $error) {
+                if (is_array($error)) {
+                    $this->line('article_error='.$this->issueLine($error));
+                }
+            }
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('error='.$this->issueLine($error));
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return implode('|', array_filter([
+            'field='.(string) ($issue['field'] ?? ''),
+            'code='.(string) ($issue['code'] ?? ''),
+            'message='.(string) ($issue['message'] ?? ''),
+        ]));
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Console\Commands\AdminBootstrapOwner;
 use App\Console\Commands\ArchiveColdData;
 use App\Console\Commands\ArticleImportEditorialPackage;
+use App\Console\Commands\ArticlePublishControlled;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
@@ -292,6 +293,7 @@ class Kernel extends ConsoleKernel
         EvidencePack::class,
         ExperimentGuardrailsEvaluate::class,
         ArticleImportEditorialPackage::class,
+        ArticlePublishControlled::class,
     ];
 
     /**

--- a/backend/app/Services/Cms/ArticlePublishService.php
+++ b/backend/app/Services/Cms/ArticlePublishService.php
@@ -13,7 +13,7 @@ use RuntimeException;
 
 final class ArticlePublishService
 {
-    public function publishArticle(int $articleId): Article
+    public function publishArticle(int $articleId, string $source = 'article_publish_service'): Article
     {
         if ($articleId <= 0) {
             throw new InvalidArgumentException('article_id must be positive.');
@@ -47,7 +47,7 @@ final class ArticlePublishService
             return $article->fresh(['publishedRevision']) ?? $article;
         });
 
-        ContentReleaseAudit::log('article', $article, 'article_publish_service');
+        ContentReleaseAudit::log('article', $article, $source);
 
         return $article;
     }

--- a/backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php
+++ b/backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleEditorialPackageImport;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+final class ArticlePublishControlledCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_reports_exact_confirmation_without_publishing(): void
+    {
+        $article = $this->createControlledDraft();
+
+        $this->artisan('articles:publish-controlled', [
+            '--article' => [(string) $article->id],
+            '--dry-run' => true,
+            '--make-indexable' => true,
+        ])
+            ->expectsOutputToContain('ok=1')
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain("expected_confirmation=I explicitly approve Codex to publish article id {$article->id} after preflight passes.")
+            ->expectsOutputToContain('published_article_ids=')
+            ->assertExitCode(0);
+
+        $article->refresh();
+        $this->assertSame('draft', (string) $article->status);
+        $this->assertFalse((bool) $article->is_public);
+        $this->assertNull($article->published_revision_id);
+    }
+
+    public function test_controlled_publish_requires_acknowledged_boundary_warnings_and_exact_confirmation(): void
+    {
+        $this->fakeContentReleaseEndpoint();
+        $article = $this->createControlledDraft([
+            'claim_result_json' => [
+                'status' => 'warning',
+                'matches' => [
+                    [
+                        'field' => 'body_markdown',
+                        'code' => 'claim_boundary_forbidden_phrase',
+                        'text' => '最适合',
+                        'boundary_context' => true,
+                    ],
+                ],
+            ],
+            'import_status' => ArticleEditorialPackageImport::STATUS_WARNING,
+        ]);
+        $confirmation = "I explicitly approve Codex to publish article id {$article->id} after preflight passes.";
+
+        $this->artisan('articles:publish-controlled', [
+            '--article' => [(string) $article->id],
+            '--confirm' => $confirmation,
+            '--make-indexable' => true,
+        ])
+            ->expectsOutputToContain('ok=0')
+            ->expectsOutputToContain('claim_warning_ack_required')
+            ->assertExitCode(1);
+
+        $article->refresh();
+        $this->assertSame('draft', (string) $article->status);
+        $this->assertNull($article->published_revision_id);
+
+        $this->artisan('articles:publish-controlled', [
+            '--article' => [(string) $article->id],
+            '--confirm' => $confirmation,
+            '--ack-claim-warning' => [(string) $article->id],
+            '--make-indexable' => true,
+        ])
+            ->expectsOutputToContain('ok=1')
+            ->expectsOutputToContain('published_article_ids='.(string) $article->id)
+            ->assertExitCode(0);
+
+        $article->refresh();
+        $this->assertSame('published', (string) $article->status);
+        $this->assertTrue((bool) $article->is_public);
+        $this->assertTrue((bool) $article->is_indexable);
+        $this->assertSame((int) $article->working_revision_id, (int) $article->published_revision_id);
+        $this->assertSame(ArticleTranslationRevision::STATUS_PUBLISHED, (string) $article->publishedRevision?->revision_status);
+        $this->assertSame('index,follow', (string) $article->seoMeta?->robots);
+        $this->assertTrue((bool) $article->seoMeta?->is_indexable);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'codex_controlled_article_publish',
+            'target_type' => 'article',
+            'target_id' => (string) $article->id,
+            'result' => 'success',
+        ]);
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'content_release_publish',
+            'target_type' => 'article',
+            'target_id' => (string) $article->id,
+            'result' => 'success',
+        ]);
+
+        Http::assertSent(function ($request): bool {
+            $paths = (array) data_get($request->data(), 'cache_signal.paths', []);
+
+            return $request->url() === 'https://cache.example.test/api/content-release/revalidate'
+                && in_array('/zh/articles/controlled-publish-draft', $paths, true)
+                && in_array('/llms.txt', $paths, true);
+        });
+    }
+
+    public function test_non_boundary_claim_warning_is_not_publishable_even_when_acknowledged(): void
+    {
+        $article = $this->createControlledDraft([
+            'claim_result_json' => [
+                'status' => 'warning',
+                'matches' => [
+                    [
+                        'field' => 'body_markdown',
+                        'code' => 'claim_boundary_forbidden_phrase',
+                        'text' => '最适合',
+                        'boundary_context' => false,
+                    ],
+                ],
+            ],
+            'import_status' => ArticleEditorialPackageImport::STATUS_WARNING,
+        ]);
+        $confirmation = "I explicitly approve Codex to publish article id {$article->id} after preflight passes.";
+
+        $this->artisan('articles:publish-controlled', [
+            '--article' => [(string) $article->id],
+            '--confirm' => $confirmation,
+            '--ack-claim-warning' => [(string) $article->id],
+            '--make-indexable' => true,
+        ])
+            ->expectsOutputToContain('ok=0')
+            ->expectsOutputToContain('claim_warning_not_boundary_context')
+            ->assertExitCode(1);
+
+        $article->refresh();
+        $this->assertSame('draft', (string) $article->status);
+        $this->assertNull($article->published_revision_id);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createControlledDraft(array $overrides = []): Article
+    {
+        $category = ArticleCategory::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'career-development',
+            'name' => '职业发展',
+            'is_active' => true,
+        ]);
+        $tag = ArticleTag::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'riasec',
+            'name' => 'RIASEC',
+            'is_active' => true,
+        ]);
+        $body = "# Controlled Publish Draft\n\n## 执行摘要\n\n正文。\n\n## FAQ\n\n### Q\n\nA.";
+        $bodyHash = hash('sha256', preg_replace("/\r\n?/", "\n", trim($body)));
+        $locale = (string) ($overrides['locale'] ?? 'zh-CN');
+
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'category_id' => (int) $category->id,
+            'slug' => 'controlled-publish-draft',
+            'locale' => $locale,
+            'title' => 'Controlled Publish Draft',
+            'excerpt' => 'Controlled excerpt',
+            'content_md' => $body,
+            'cover_image_url' => '/storage/articles/controlled.svg',
+            'cover_image_alt' => 'Controlled cover alt',
+            'cover_image_width' => 1200,
+            'cover_image_height' => 675,
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+        $article->tags()->attach((int) $tag->id, ['org_id' => 0]);
+
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => $locale,
+            'source_locale' => $locale,
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'title' => 'Controlled Publish Draft',
+            'excerpt' => 'Controlled excerpt',
+            'content_md' => $body,
+            'seo_title' => 'Controlled SEO Title',
+            'seo_description' => 'Controlled SEO description',
+        ]);
+        $article->forceFill(['working_revision_id' => (int) $revision->id])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => $locale,
+            'seo_title' => 'Controlled SEO Title',
+            'seo_description' => 'Controlled SEO description',
+            'canonical_url' => "https://example.test/zh/articles/{$article->slug}",
+            'og_title' => 'Controlled OG Title',
+            'og_description' => 'Controlled OG description',
+            'og_image_url' => 'https://example.test/storage/articles/controlled.svg',
+            'robots' => 'noindex,nofollow',
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'sensitivity_level' => (string) ($overrides['sensitivity_level'] ?? 'career_sensitive'),
+                    'cta_slots' => [
+                        ['slot_id' => 'cta_primary', 'href' => '/zh/tests/holland-career-interest-test-riasec'],
+                    ],
+                    'answer_surface_v1' => [
+                        'faq_items' => [
+                            ['question' => 'Q', 'answer' => 'A'],
+                        ],
+                    ],
+                    'target_topics' => ['mbti'],
+                    'target_tests' => ['holland-career-interest-test-riasec'],
+                ],
+            ],
+            'is_indexable' => false,
+        ]);
+
+        ArticleEditorialPackageImport::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'slug' => (string) $article->slug,
+            'locale' => $locale,
+            'title' => 'Controlled Publish Draft',
+            'content_track' => 'evergreen_knowledge',
+            'status' => (string) ($overrides['import_status'] ?? ArticleEditorialPackageImport::STATUS_IMPORTED),
+            'intended_status' => 'review_pending',
+            'claim_result_json' => $overrides['claim_result_json'] ?? ['status' => 'passed', 'matches' => []],
+            'exactness_json' => ['status' => 'passed', 'body_hash' => $bodyHash],
+            'references_json' => ['status' => 'complete', 'count' => 1],
+            'media_json' => ['status' => 'complete'],
+            'graph_json' => ['status' => 'complete', 'target_topics' => ['mbti']],
+            'answer_surface_json' => ['status' => 'complete'],
+            'body_hash' => $bodyHash,
+            'heading_sequence_json' => ['1:Controlled Publish Draft', '2:执行摘要', '2:FAQ'],
+            'references_count' => 1,
+        ]);
+
+        return $article->fresh(['workingRevision', 'publishedRevision', 'seoMeta', 'category', 'tags']) ?? $article;
+    }
+
+    private function fakeContentReleaseEndpoint(): void
+    {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/api/content-release/revalidate',
+        ]);
+        config()->set('ops.content_release_observability.cache_invalidation_secret', 'release-secret');
+        Http::fake([
+            'https://cache.example.test/*' => Http::response(['ok' => true], 200),
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -559,6 +559,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_controlled_article_publish_sop_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticlePublishControlled.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticlePublishControlled;',
+            '+        ArticlePublishControlled::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_privacy_logs_dsar_key_rotation_changes(): void
     {
         $changed = [
@@ -1229,6 +1243,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isControlledArticlePublishSopFile($file)) {
+                continue;
+            }
+
             if ($this->isPrivacyLogsDsarKeyRotationFile($file)) {
                 continue;
             }
@@ -1440,6 +1458,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 && (
                     $this->kernelDiffIsCareerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleEditorialPackageDraftGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -1530,6 +1549,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Filament/Ops/Pages/ArticlePublishingOpsPage.php',
             'backend/app/Models/ArticleEditorialPackageImport.php',
             'backend/database/migrations/2026_05_14_000100_create_article_editorial_package_imports_table.php',
+        ], true);
+    }
+
+    private function isControlledArticlePublishSopFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ArticlePublishControlled.php',
+            'backend/app/Services/Cms/ArticlePublishService.php',
         ], true);
     }
 
@@ -2118,6 +2145,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleImportEditorialPackage\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsControlledArticlePublishSopOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bArticlePublishControlled\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/04-ops/controlled-codex-assisted-cms-publish.md
+++ b/docs/04-ops/controlled-codex-assisted-cms-publish.md
@@ -1,0 +1,112 @@
+# Controlled Codex-Assisted CMS Publish SOP
+
+This SOP allows Codex to assist with publishing reviewed CMS article drafts only through a controlled backend command. It does not allow Codex to freely publish content through the CMS UI or to bypass editorial gates.
+
+## When This Applies
+
+Use this SOP only for Article drafts that were created from a CMS-ready Editorial Package and have already passed the draft import gates:
+
+- exact body hash
+- metadata completeness
+- cover, alt, prompt, and style tag completeness
+- references completeness
+- CTA and FAQ completeness
+- graph metadata completeness
+- claim boundary checks
+
+Do not use this SOP for health-sensitive or ability-sensitive articles. Those still require direct human CMS publish.
+
+## Required Human Confirmation
+
+Codex may run the publish command only after the user provides the exact confirmation phrase emitted by dry-run.
+
+Single article:
+
+```bash
+I explicitly approve Codex to publish article id 31 after preflight passes.
+```
+
+Multiple articles:
+
+```bash
+I explicitly approve Codex to publish article ids 31,32 after preflight passes.
+```
+
+Boundary-context claim warnings must be acknowledged per article:
+
+```bash
+--ack-claim-warning=31
+```
+
+## Dry Run
+
+Run dry-run first:
+
+```bash
+php artisan articles:publish-controlled \
+  --article=31 \
+  --article=32 \
+  --make-indexable \
+  --dry-run
+```
+
+Dry-run must report:
+
+- `ok=1`
+- expected confirmation phrase
+- import status `imported` or `warning`
+- claim status passed or boundary-context warning
+- media complete
+- references count greater than zero
+- graph complete
+- CTA count greater than zero
+- FAQ count greater than zero
+- body hash present
+
+If dry-run reports any error, do not publish.
+
+## Formal Publish
+
+Run formal publish only after exact user confirmation:
+
+```bash
+php artisan articles:publish-controlled \
+  --article=31 \
+  --article=32 \
+  --ack-claim-warning=31 \
+  --make-indexable \
+  --confirm="I explicitly approve Codex to publish article ids 31,32 after preflight passes."
+```
+
+The command:
+
+- approves the working revision
+- marks the article and SEO meta indexable when `--make-indexable` is set
+- publishes through `ArticlePublishService`
+- records content release follow-up using source `controlled_codex_publish`
+- writes a `codex_controlled_article_publish` audit log
+
+## Post-Publish Verification
+
+After publish, verify:
+
+- public article detail API returns published/indexable payload
+- article list includes the article
+- homepage/topic/career surfaces update if graph metadata points there
+- Article JSON-LD image and canonical are present
+- sitemap and llms include the article if policy allows
+- content release revalidate audit succeeded
+
+## Boundaries
+
+Codex must not:
+
+- write or rewrite article content
+- bypass import gate results
+- publish without exact user confirmation
+- publish non-boundary claim warnings
+- publish health-sensitive or ability-sensitive content
+- access attempts, results, report snapshots, orders, payments, shares, raw answers, or user PII
+- use CMS UI clicks as the default publishing mechanism
+
+Human editors remain accountable for editorial review and can still publish directly through CMS workflows when appropriate.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5122,7 +5122,7 @@
         "no user attempts/results/reports/orders/payments/shares access",
         "no uncontrolled CMS UI publish"
       ],
-      "commit_sha": "951be675de1f11d1b67181db66a3f73624d59b52",
+      "commit_sha": "d4e421fc8abac104ed97339318c24b897bc3d396",
       "pr_url": null,
       "checks": {
         "authorization": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5123,7 +5123,7 @@
         "no user attempts/results/reports/orders/payments/shares access",
         "no uncontrolled CMS UI publish"
       ],
-      "commit_sha": "92a0a6b35b40c6a7d993757aeff6a7cabda0e3f6",
+      "commit_sha": "f9f4a306d83babee79af43db7137c49600d2d069",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1385",
       "checks": {
         "authorization": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-14T04:00:30Z",
+  "updated_at": "2026-05-14T18:05:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -5123,7 +5123,7 @@
         "no user attempts/results/reports/orders/payments/shares access",
         "no uncontrolled CMS UI publish"
       ],
-      "commit_sha": "f9f4a306d83babee79af43db7137c49600d2d069",
+      "commit_sha": "37f58b9477409f681917e8ea707bea041be93468",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1385",
       "checks": {
         "authorization": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5092,6 +5092,85 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "PR-CMS-04": {
+      "repo": "fap-api",
+      "branch": "codex/pr-cms-04-controlled-codex-publish-sop",
+      "title": "PR-CMS-04｜Controlled Codex-Assisted CMS Publish SOP",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "PR-CMS-01",
+        "PR-CMS-02",
+        "PR-CMS-03"
+      ],
+      "scope_type": "controlled_codex_assisted_cms_publish_sop",
+      "allowed_paths": [
+        "AGENTS.md",
+        "backend/AGENTS.md",
+        "backend/app/Console/Commands/ArticlePublishControlled.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Services/Cms/ArticlePublishService.php",
+        "backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php",
+        "docs/04-ops/controlled-codex-assisted-cms-publish.md",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no production article publish",
+        "no article content rewrite",
+        "no fap-web changes",
+        "no user attempts/results/reports/orders/payments/shares access",
+        "no uncontrolled CMS UI publish"
+      ],
+      "commit_sha": "951be675de1f11d1b67181db66a3f73624d59b52",
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding PR-CMS-04 to fap-api pr-train manifest/state and executing Controlled Codex-Assisted CMS Publish SOP."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Scope limited to controlled publish command, SOP/rule updates, publish service audit source, tests, and train metadata."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR-CMS-01/02/03 workflows are merged; this PR only extends the publishing SOP after draft gate, revalidate automation, and Ops queue readiness."
+        },
+        "article_publish_controlled_test": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Console/ArticlePublishControlledCommandTest.php --no-ansi",
+          "evidence": "3 tests passed, 31 assertions."
+        },
+        "article_import_editorial_package_regression": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi",
+          "evidence": "6 tests passed, 112 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi"
+        },
+        "sqlite_migrate_pretend": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+          "evidence": "No migration changes in this PR; sqlite pretend used to avoid unrelated local MySQL root auth failure."
+        },
+        "scoped_pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test app/Console/Commands/ArticlePublishControlled.php app/Services/Cms/ArticlePublishService.php app/Console/Kernel.php tests/Feature/Console/ArticlePublishControlledCommandTest.php"
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        }
+      },
+      "failure_reason": null,
+      "next_pr": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5097,7 +5097,7 @@
       "repo": "fap-api",
       "branch": "codex/pr-cms-04-controlled-codex-publish-sop",
       "title": "PR-CMS-04｜Controlled Codex-Assisted CMS Publish SOP",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "PR-CMS-01",
         "PR-CMS-02",
@@ -5123,7 +5123,7 @@
         "no uncontrolled CMS UI publish"
       ],
       "commit_sha": "d4e421fc8abac104ed97339318c24b897bc3d396",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1385",
       "checks": {
         "authorization": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5111,6 +5111,7 @@
         "backend/app/Console/Kernel.php",
         "backend/app/Services/Cms/ArticlePublishService.php",
         "backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
         "docs/04-ops/controlled-codex-assisted-cms-publish.md",
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
@@ -5159,6 +5160,11 @@
         "scoped_pint": {
           "status": "pass",
           "command": "vendor/bin/pint --test app/Console/Commands/ArticlePublishControlled.php app/Services/Cms/ArticlePublishService.php app/Console/Kernel.php tests/Feature/Console/ArticlePublishControlledCommandTest.php"
+        },
+        "bigfive_runtime_freeze_classifier": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=controlled_article_publish --no-ansi",
+          "evidence": "1 test passed, 1 assertion; CI failure root cause was freeze classifier allowlist missing the controlled publish SOP command and Kernel registration."
         },
         "diff_check": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5123,7 +5123,7 @@
         "no user attempts/results/reports/orders/payments/shares access",
         "no uncontrolled CMS UI publish"
       ],
-      "commit_sha": "d4e421fc8abac104ed97339318c24b897bc3d396",
+      "commit_sha": "92a0a6b35b40c6a7d993757aeff6a7cabda0e3f6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1385",
       "checks": {
         "authorization": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -40,6 +40,39 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+
+
+  - id: PR-CMS-04
+    repo: fap-api
+    depends_on:
+      - PR-CMS-01
+      - PR-CMS-02
+      - PR-CMS-03
+    branch: codex/pr-cms-04-controlled-codex-publish-sop
+    title: "PR-CMS-04｜Controlled Codex-Assisted CMS Publish SOP"
+    scope:
+      - Add a controlled Codex-assisted article publish SOP and guarded artisan command.
+      - Require exact human confirmation phrase, preflight gates, claim-warning acknowledgement, exactness/media/references/graph validation, and audit logging before publish.
+      - Keep generic CMS/UI publish behavior separate and do not publish production content in this PR.
+    do_not:
+      - Publish articles or mutate production content.
+      - Touch fap-web.
+      - Touch user attempts, results, reports, orders, payments, shares, scoring, result pages, payment, invite, or raw answers.
+      - Allow uncontrolled Codex CMS UI publish.
+    validation:
+      - php artisan test tests/Feature/Console/ArticlePublishControlledCommandTest.php --no-ansi
+      - php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
+      - vendor/bin/pint --test app/Console/Commands/ArticlePublishControlled.php app/Services/Cms/ArticlePublishService.php app/Console/Kernel.php tests/Feature/Console/ArticlePublishControlledCommandTest.php
+      - php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=controlled_article_publish --no-ansi
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+
   - id: career-runtime-publish-projection
     repo: fap-api
     branch: codex/career-runtime-publish-projection


### PR DESCRIPTION
## What changed
- Added `articles:publish-controlled`, a guarded backend artisan command for controlled Codex-assisted Article publish.
- Added preflight gates for exact confirmation, import gate status, body hash exactness, boundary-context claim-warning acknowledgement, media/references/graph/CTA/FAQ completeness, SEO metadata, and indexability.
- Extended `ArticlePublishService` with an optional audit source so controlled publishes are distinguishable in content release audit/follow-up.
- Documented the controlled publish SOP and updated repository rules so Codex-assisted publish cannot happen through generic CMS UI clicks or uncontrolled endpoints.
- Added PR train manifest/state entry for PR-CMS-04.

## Why
PR-CMS-01/02/03 made draft import, revalidate automation, and Ops visibility reliable. The remaining workflow gap was that Codex could not assist with final publish even when the human editor explicitly approved it. This PR creates a narrow, auditable path for that assistance without turning Codex into an uncontrolled publisher.

## Validation commands
- `php artisan test tests/Feature/Console/ArticlePublishControlledCommandTest.php --no-ansi`
- `php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `vendor/bin/pint --test app/Console/Commands/ArticlePublishControlled.php app/Services/Cms/ArticlePublishService.php app/Console/Kernel.php tests/Feature/Console/ArticlePublishControlledCommandTest.php`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No production article publish in this PR.
- No fap-web changes.
- No changes to article content, existing six articles, user attempts/results/reports/orders/payments/shares, scoring, result pages, payment, or invite flows.
- No health-sensitive or ability-sensitive controlled Codex publish.

## Repository rule impact
This PR changes the publishing SOP. Backend repository rules and the top-level working contract now explicitly allow Codex-assisted Article publish only through `articles:publish-controlled` after exact human confirmation, preflight gates, warning acknowledgement, and audit logging.
