### PR TITLE
fix(api): add candidate-aware runtime artifact refresh

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Domain\Career\Audit\CareerRuntimeArtifactRefreshPlanner;
+use App\Domain\Career\Audit\CareerRuntimeCandidateAwareArtifactRefresh;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use RuntimeException;
@@ -17,6 +18,14 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
         {--delta-plan= : Optional Career 80 target delta artifact}
         {--candidate-prep-plan= : Optional runtime candidate prep plan artifact}
         {--candidate-prep-apply= : Optional runtime candidate prep apply artifact}
+        {--projection= : Optional source runtime projection artifact for candidate-aware refresh}
+        {--truth= : Optional source runtime truth artifact for candidate-aware refresh}
+        {--ledger= : Optional source full release ledger artifact for candidate-aware refresh}
+        {--candidate-aware : Emit candidate-aware projection/truth/ledger artifacts from a verified candidate prep apply overlay}
+        {--projection-output=/tmp/career_80_delta_runtime_projection_candidate_aware.json : Candidate-aware projection output path}
+        {--truth-output=/tmp/career_80_delta_runtime_truth_candidate_aware.json : Candidate-aware truth output path}
+        {--ledger-output=/tmp/career_80_delta_full_release_ledger_candidate_aware.json : Candidate-aware ledger output path}
+        {--expect-slug-count=51 : Expected verified candidate prep apply slug count in candidate-aware mode}
         {--json : Emit JSON output}
         {--output= : Optional output path for runtime artifact refresh plan JSON}';
 
@@ -25,6 +34,10 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
     public function handle(): int
     {
         try {
+            if ((bool) $this->option('candidate-aware')) {
+                return $this->handleCandidateAwareRefresh();
+            }
+
             $payload = app(CareerRuntimeArtifactRefreshPlanner::class)->plan(
                 target: trim((string) ($this->option('target') ?? 'career_80_delta')),
                 deltaPlan: $this->optionalJson('delta-plan'),
@@ -54,6 +67,83 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
                 ]],
                 'approval_gates' => [],
                 'next_required_action' => 'FIX_RUNTIME_ARTIFACT_REFRESH_PLAN',
+            ], self::FAILURE);
+        }
+    }
+
+    private function handleCandidateAwareRefresh(): int
+    {
+        $candidatePrepApplyPath = $this->requiredPathOption('candidate-prep-apply');
+        $projectionPath = $this->requiredPathOption('projection');
+        $truthPath = $this->requiredPathOption('truth');
+        $ledgerPath = $this->requiredPathOption('ledger');
+        $projectionOutputPath = $this->requiredPathOption('projection-output');
+        $truthOutputPath = $this->requiredPathOption('truth-output');
+        $ledgerOutputPath = $this->requiredPathOption('ledger-output');
+        $expectedSlugCount = $this->positiveIntOption('expect-slug-count', 51);
+
+        try {
+            $result = app(CareerRuntimeCandidateAwareArtifactRefresh::class)->build(
+                candidatePrepApply: $this->readJson($candidatePrepApplyPath, 'candidate-prep-apply'),
+                candidatePrepApplyPath: $candidatePrepApplyPath,
+                candidatePrepApplyFileSha256: hash_file('sha256', $candidatePrepApplyPath) ?: null,
+                projection: $this->readJson($projectionPath, 'projection'),
+                projectionPath: $projectionPath,
+                truth: $this->readJson($truthPath, 'truth'),
+                truthPath: $truthPath,
+                ledger: $this->readJson($ledgerPath, 'ledger'),
+                ledgerPath: $ledgerPath,
+                projectionOutputPath: $projectionOutputPath,
+                truthOutputPath: $truthOutputPath,
+                ledgerOutputPath: $ledgerOutputPath,
+                expectedSlugCount: $expectedSlugCount,
+            );
+
+            $this->writeJson($projectionOutputPath, $result['projection']);
+            $this->writeJson($truthOutputPath, $result['truth']);
+            $this->writeJson($ledgerOutputPath, $result['ledger']);
+
+            return $this->finish($result['summary'], self::SUCCESS);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => CareerRuntimeCandidateAwareArtifactRefresh::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'source_apply_artifact' => [
+                    'path' => $candidatePrepApplyPath,
+                    'write_verified' => null,
+                    'slug_count' => 0,
+                    'artifact_sha256' => null,
+                ],
+                'target' => 'career_80_delta',
+                'delta_slug_count' => 0,
+                'expected_delta_locale_rows' => 0,
+                'projection' => [
+                    'source_path' => $projectionPath,
+                    'output_path' => $projectionOutputPath,
+                    'overlay_rows' => 0,
+                    'source' => CareerRuntimeCandidateAwareArtifactRefresh::OVERLAY_SOURCE,
+                ],
+                'truth' => [
+                    'source_path' => $truthPath,
+                    'output_path' => $truthOutputPath,
+                    'overlay_rows' => 0,
+                    'source' => CareerRuntimeCandidateAwareArtifactRefresh::OVERLAY_SOURCE,
+                ],
+                'ledger' => [
+                    'source_path' => $ledgerPath,
+                    'output_path' => $ledgerOutputPath,
+                    'overlay_members' => 0,
+                    'source' => CareerRuntimeCandidateAwareArtifactRefresh::OVERLAY_SOURCE,
+                ],
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                    'evidence' => [],
+                ]],
+                'writes_database' => false,
+                'read_only' => true,
+                'apply_allowed' => false,
+                'next_required_action' => 'REPAIR_RUNTIME_CANDIDATE_ARTIFACT_REFRESH',
             ], self::FAILURE);
         }
     }
@@ -93,6 +183,44 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
         }
 
         return $decoded;
+    }
+
+    private function requiredPathOption(string $name): string
+    {
+        $path = trim((string) ($this->option($name) ?? ''));
+        if ($path === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $path;
+    }
+
+    private function positiveIntOption(string $name, int $default): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return $default;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $path, array $payload): void
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('failed_to_encode_json_payload');
+        }
+
+        File::put($path, $encoded.PHP_EOL);
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php
@@ -1,0 +1,557 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use RuntimeException;
+
+final class CareerRuntimeCandidateAwareArtifactRefresh
+{
+    public const SCHEMA_VERSION = 'career_runtime_candidate_aware_artifact_refresh.v1';
+
+    public const OVERLAY_SOURCE = 'candidate_prep_apply_overlay';
+
+    private const TARGET = 'career_80_delta';
+
+    private const RUNTIME_STATE = 'published_candidate';
+
+    private const DEFAULT_LOCALES = ['en', 'zh'];
+
+    /**
+     * @param  array<string, mixed>  $candidatePrepApply
+     * @param  array<string, mixed>  $projection
+     * @param  array<string, mixed>  $truth
+     * @param  array<string, mixed>  $ledger
+     * @return array{summary: array<string, mixed>, projection: array<string, mixed>, truth: array<string, mixed>, ledger: array<string, mixed>}
+     */
+    public function build(
+        array $candidatePrepApply,
+        string $candidatePrepApplyPath,
+        ?string $candidatePrepApplyFileSha256,
+        array $projection,
+        string $projectionPath,
+        array $truth,
+        string $truthPath,
+        array $ledger,
+        string $ledgerPath,
+        string $projectionOutputPath,
+        string $truthOutputPath,
+        string $ledgerOutputPath,
+        int $expectedSlugCount = 51,
+    ): array {
+        $source = $this->verifiedSource($candidatePrepApply, $candidatePrepApplyPath, $candidatePrepApplyFileSha256, $expectedSlugCount);
+        $slugs = $source['slugs'];
+        $locales = $source['locales'];
+
+        $projectionArtifact = $this->projectionArtifact($projection, $slugs, $locales, $source, $projectionPath);
+        $truthArtifact = $this->truthArtifact($truth, $slugs, $locales, $source, $truthPath);
+        $ledgerArtifact = $this->ledgerArtifact($ledger, $slugs, $source, $ledgerPath);
+
+        return [
+            'summary' => [
+                'schema_version' => self::SCHEMA_VERSION,
+                'status' => 'pass',
+                'source_apply_artifact' => [
+                    'path' => $candidatePrepApplyPath,
+                    'status' => $candidatePrepApply['status'] ?? null,
+                    'write_verified' => true,
+                    'slug_count' => count($slugs),
+                    'verified_count' => $candidatePrepApply['verified_count'] ?? null,
+                    'artifact_sha256' => $source['artifact_sha256'],
+                    'file_sha256' => $candidatePrepApplyFileSha256,
+                ],
+                'target' => self::TARGET,
+                'delta_slug_count' => count($slugs),
+                'expected_delta_locale_rows' => count($slugs) * count($locales),
+                'locales' => $locales,
+                'projection' => [
+                    'source_path' => $projectionPath,
+                    'output_path' => $projectionOutputPath,
+                    'overlay_rows' => count($slugs) * count($locales),
+                    'source' => self::OVERLAY_SOURCE,
+                ],
+                'truth' => [
+                    'source_path' => $truthPath,
+                    'output_path' => $truthOutputPath,
+                    'overlay_rows' => count($slugs) * count($locales),
+                    'source' => self::OVERLAY_SOURCE,
+                ],
+                'ledger' => [
+                    'source_path' => $ledgerPath,
+                    'output_path' => $ledgerOutputPath,
+                    'overlay_members' => count($slugs),
+                    'source' => self::OVERLAY_SOURCE,
+                ],
+                'blockers' => [],
+                'writes_database' => false,
+                'read_only' => true,
+                'apply_allowed' => false,
+                'next_required_action' => '51_DELTA_ROLLOUT_DRY_RUN',
+            ],
+            'projection' => $projectionArtifact,
+            'truth' => $truthArtifact,
+            'ledger' => $ledgerArtifact,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidatePrepApply
+     * @return array{slugs: list<string>, locales: list<string>, artifact_sha256: string|null}
+     */
+    private function verifiedSource(array $candidatePrepApply, string $path, ?string $fileSha256, int $expectedSlugCount): array
+    {
+        if (($candidatePrepApply['status'] ?? null) !== 'applied') {
+            throw new RuntimeException('candidate_prep_apply_not_applied');
+        }
+
+        if (($candidatePrepApply['write_verified'] ?? null) !== true) {
+            throw new RuntimeException('candidate_prep_apply_not_verified');
+        }
+
+        $failures = $candidatePrepApply['failures'] ?? [];
+        if ($failures !== null && (! is_array($failures) || count($failures) > 0)) {
+            throw new RuntimeException('candidate_prep_apply_failures_present');
+        }
+
+        $slugs = $this->applySlugs($candidatePrepApply);
+        if (count($slugs) !== $expectedSlugCount) {
+            throw new RuntimeException('candidate_prep_apply_slug_count_mismatch');
+        }
+
+        foreach (['slug_count', 'created_count', 'verified_count'] as $key) {
+            $value = $candidatePrepApply[$key] ?? null;
+            if (! is_numeric($value) || (int) $value !== $expectedSlugCount) {
+                throw new RuntimeException('candidate_prep_apply_'.$key.'_mismatch');
+            }
+        }
+
+        return [
+            'slugs' => $slugs,
+            'locales' => $this->locales($candidatePrepApply),
+            'artifact_sha256' => is_string($candidatePrepApply['artifact_sha256'] ?? null)
+                ? trim((string) $candidatePrepApply['artifact_sha256'])
+                : $fileSha256,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidatePrepApply
+     * @return list<string>
+     */
+    private function applySlugs(array $candidatePrepApply): array
+    {
+        $rawSlugs = [];
+
+        $created = $candidatePrepApply['created'] ?? null;
+        if (is_array($created) && array_is_list($created)) {
+            foreach ($created as $row) {
+                if (is_array($row) && is_string($row['canonical_slug'] ?? null)) {
+                    $rawSlugs[] = trim((string) $row['canonical_slug']);
+                }
+            }
+        }
+
+        if ($rawSlugs === [] && isset($candidatePrepApply['slugs']) && is_array($candidatePrepApply['slugs']) && array_is_list($candidatePrepApply['slugs'])) {
+            foreach ($candidatePrepApply['slugs'] as $slug) {
+                if (is_string($slug)) {
+                    $rawSlugs[] = trim($slug);
+                }
+            }
+        }
+
+        $slugs = array_values(array_filter($rawSlugs, static fn (string $slug): bool => $slug !== ''));
+        $unique = array_values(array_unique($slugs));
+        sort($unique);
+
+        if ($slugs === []) {
+            throw new RuntimeException('candidate_prep_apply_slugs_missing');
+        }
+        if (count($slugs) !== count($unique)) {
+            throw new RuntimeException('candidate_prep_apply_duplicate_slugs');
+        }
+
+        return $unique;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidatePrepApply
+     * @return list<string>
+     */
+    private function locales(array $candidatePrepApply): array
+    {
+        $rawLocales = $candidatePrepApply['locales'] ?? self::DEFAULT_LOCALES;
+        if (! is_array($rawLocales) || ! array_is_list($rawLocales)) {
+            return self::DEFAULT_LOCALES;
+        }
+
+        $locales = [];
+        foreach ($rawLocales as $locale) {
+            if (is_string($locale) && trim($locale) !== '') {
+                $locales[] = trim($locale);
+            }
+        }
+
+        $locales = array_values(array_unique($locales));
+        sort($locales);
+
+        return $locales === [] ? self::DEFAULT_LOCALES : $locales;
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array{artifact_sha256: string|null, slugs: list<string>, locales: list<string>}  $source
+     * @return array<string, mixed>
+     */
+    private function projectionArtifact(array $projection, array $slugs, array $locales, array $source, string $sourcePath): array
+    {
+        $rows = [
+            ...$this->nonOverlayRows($this->artifactRows($projection, ['items', 'rows']), $slugs),
+            ...$this->projectionOverlayRows($slugs, $locales, $source),
+        ];
+
+        $projection['projection_kind'] = 'career_runtime_publish_projection_candidate_aware';
+        $projection['projection_version'] = 'v1';
+        $projection['source_authority'] = [
+            'base' => $projection['source_authority'] ?? null,
+            'candidate_overlay' => self::OVERLAY_SOURCE,
+            'source_path' => $sourcePath,
+            'canonical_ledger_authority_claimed' => false,
+        ];
+        $projection['candidate_aware_overlay'] = $this->overlaySummary($slugs, $locales, $source);
+        $projection['items'] = $rows;
+        unset($projection['rows']);
+        $projection['counts'] = $this->projectionCounts($rows);
+
+        return $projection;
+    }
+
+    /**
+     * @param  array<string, mixed>  $truth
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array{artifact_sha256: string|null, slugs: list<string>, locales: list<string>}  $source
+     * @return array<string, mixed>
+     */
+    private function truthArtifact(array $truth, array $slugs, array $locales, array $source, string $sourcePath): array
+    {
+        $rows = [
+            ...$this->nonOverlayRows($this->artifactRows($truth, ['items', 'rows']), $slugs),
+            ...$this->truthOverlayRows($slugs, $locales, $source),
+        ];
+
+        $truth['truth_kind'] = 'career_canonical_runtime_truth_candidate_aware';
+        $truth['truth_version'] = 'v1';
+        $truth['source_authority'] = [
+            'base' => $truth['source_authority'] ?? null,
+            'candidate_overlay' => self::OVERLAY_SOURCE,
+            'source_path' => $sourcePath,
+            'canonical_ledger_authority_claimed' => false,
+        ];
+        $truth['candidate_aware_overlay'] = $this->overlaySummary($slugs, $locales, $source);
+        $truth['items'] = $rows;
+        unset($truth['rows']);
+        $truth['counts'] = $this->truthCounts($rows);
+
+        return $truth;
+    }
+
+    /**
+     * @param  array<string, mixed>  $ledger
+     * @param  list<string>  $slugs
+     * @param  array{artifact_sha256: string|null, slugs: list<string>, locales: list<string>}  $source
+     * @return array<string, mixed>
+     */
+    private function ledgerArtifact(array $ledger, array $slugs, array $source, string $sourcePath): array
+    {
+        $members = [
+            ...$this->nonOverlayMembers($this->artifactRows($ledger, ['members', 'items', 'rows']), $slugs),
+            ...$this->ledgerOverlayMembers($slugs, $source),
+        ];
+
+        $ledger['ledger_kind'] = 'career_candidate_aware_full_release_ledger';
+        $ledger['ledger_version'] = 'v1';
+        $ledger['source_authority'] = [
+            'base' => $ledger['source_authority'] ?? 'CareerFullReleaseLedger',
+            'candidate_overlay' => self::OVERLAY_SOURCE,
+            'source_path' => $sourcePath,
+            'canonical_ledger_authority_claimed' => false,
+        ];
+        $ledger['candidate_aware_overlay'] = $this->overlaySummary($slugs, [], $source);
+        $ledger['members'] = $members;
+        unset($ledger['items'], $ledger['rows']);
+        $ledger['counts'] = $this->ledgerCounts($ledger['counts'] ?? [], $members, count($slugs));
+
+        return $ledger;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array{artifact_sha256: string|null}  $source
+     * @return array<string, mixed>
+     */
+    private function overlaySummary(array $slugs, array $locales, array $source): array
+    {
+        return [
+            'source' => self::OVERLAY_SOURCE,
+            'runtime_publish_state' => self::RUNTIME_STATE,
+            'slug_count' => count($slugs),
+            'locale_count' => count($locales),
+            'expected_locale_rows' => $locales === [] ? null : count($slugs) * count($locales),
+            'artifact_sha256' => $source['artifact_sha256'],
+            'canonical_ledger_authority_claimed' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @param  list<string>  $slugs
+     * @return list<array<string, mixed>>
+     */
+    private function nonOverlayRows(array $rows, array $slugs): array
+    {
+        return array_values(array_filter($rows, static function (array $row) use ($slugs): bool {
+            $slug = $row['slug'] ?? null;
+
+            return ! is_string($slug) || ! in_array($slug, $slugs, true);
+        }));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $members
+     * @param  list<string>  $slugs
+     * @return list<array<string, mixed>>
+     */
+    private function nonOverlayMembers(array $members, array $slugs): array
+    {
+        return array_values(array_filter($members, static function (array $member) use ($slugs): bool {
+            $slug = $member['canonical_slug'] ?? $member['slug'] ?? null;
+
+            return ! is_string($slug) || ! in_array($slug, $slugs, true);
+        }));
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array{artifact_sha256: string|null}  $source
+     * @return list<array<string, mixed>>
+     */
+    private function projectionOverlayRows(array $slugs, array $locales, array $source): array
+    {
+        $rows = [];
+        foreach ($slugs as $slug) {
+            foreach ($locales as $locale) {
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'public_resolution_type' => 'public_canonical_job',
+                    'runtime_publish_state' => self::RUNTIME_STATE,
+                    'detail_route_enabled' => false,
+                    'dataset_visible' => false,
+                    'search_visible' => false,
+                    'sitemap_live' => false,
+                    'llms_live' => false,
+                    'llms_full_live' => false,
+                    'canonical_url' => null,
+                    'canonical_self' => false,
+                    'robots_indexable' => false,
+                    'release_gate_pass' => false,
+                    'blockers' => [],
+                    'overlay_source' => self::OVERLAY_SOURCE,
+                    'source_artifact_sha256' => $source['artifact_sha256'],
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array{artifact_sha256: string|null}  $source
+     * @return list<array<string, mixed>>
+     */
+    private function truthOverlayRows(array $slugs, array $locales, array $source): array
+    {
+        $rows = [];
+        foreach ($slugs as $slug) {
+            foreach ($locales as $locale) {
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'public_resolution_type' => 'public_canonical_job',
+                    'projection_state' => self::RUNTIME_STATE,
+                    'route_exists' => false,
+                    'final_200' => false,
+                    'robots_indexable' => false,
+                    'canonical_self' => false,
+                    'dataset_visible' => false,
+                    'search_visible' => false,
+                    'sitemap_live' => false,
+                    'llms_live' => false,
+                    'llms_full_live' => false,
+                    'release_gate_pass' => false,
+                    'canonical_url' => null,
+                    'fully_live' => false,
+                    'candidate_pre_route_expected' => true,
+                    'candidate_route_expectation' => 'expected_pre_route',
+                    'candidate_release_gate_applicability' => 'not_applicable_before_promotion',
+                    'candidate_unexpected_exposures' => [],
+                    'overlay_source' => self::OVERLAY_SOURCE,
+                    'source_artifact_sha256' => $source['artifact_sha256'],
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  array{artifact_sha256: string|null}  $source
+     * @return list<array<string, mixed>>
+     */
+    private function ledgerOverlayMembers(array $slugs, array $source): array
+    {
+        return array_map(static fn (string $slug): array => [
+            'member_kind' => 'career_runtime_candidate_prep_overlay',
+            'canonical_slug' => $slug,
+            'current_index_state' => 'promotion_candidate',
+            'public_index_state' => 'trust_limited',
+            'index_eligible' => true,
+            'release_cohort' => 'public_detail_conservative',
+            'blocker_reasons' => [],
+            'runtime_publish_state' => self::RUNTIME_STATE,
+            'overlay_source' => self::OVERLAY_SOURCE,
+            'source_artifact_sha256' => $source['artifact_sha256'],
+            'canonical_ledger_authority_claimed' => false,
+            'evidence_refs' => [
+                'candidate_prep_apply' => [
+                    'kind' => self::OVERLAY_SOURCE,
+                    'write_verified' => true,
+                    'artifact_sha256' => $source['artifact_sha256'],
+                ],
+            ],
+        ], $slugs);
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @param  list<string>  $keys
+     * @return list<array<string, mixed>>
+     */
+    private function artifactRows(array $artifact, array $keys): array
+    {
+        foreach ($keys as $key) {
+            if (isset($artifact[$key]) && is_array($artifact[$key]) && array_is_list($artifact[$key])) {
+                return array_values(array_filter(
+                    $artifact[$key],
+                    static fn (mixed $row): bool => is_array($row) && ! array_is_list($row)
+                ));
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, int>
+     */
+    private function projectionCounts(array $rows): array
+    {
+        return [
+            'projection_rows' => count($rows),
+            'canonical_published' => $this->countRows($rows, 'public_resolution_type', 'public_canonical_job'),
+            'dataset_visible' => $this->countTrue($rows, 'dataset_visible'),
+            'search_visible' => $this->countTrue($rows, 'search_visible'),
+            'detail_route_enabled' => $this->countTrue($rows, 'detail_route_enabled'),
+            'sitemap_live' => $this->countTrue($rows, 'sitemap_live'),
+            'llms_live' => $this->countTrue($rows, 'llms_live'),
+            'llms_full_live' => $this->countTrue($rows, 'llms_full_live'),
+            'blocked' => $this->countRows($rows, 'runtime_publish_state', 'blocked'),
+            'published_candidate' => $this->countRows($rows, 'runtime_publish_state', self::RUNTIME_STATE),
+            'published' => $this->countRows($rows, 'runtime_publish_state', 'published'),
+            'quarantined' => $this->countRows($rows, 'runtime_publish_state', 'quarantined'),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, int>
+     */
+    private function truthCounts(array $rows): array
+    {
+        return [
+            'canonical_projection_rows' => $this->countRows($rows, 'public_resolution_type', 'public_canonical_job'),
+            'excluded_non_canonical_rows' => count($rows) - $this->countRows($rows, 'public_resolution_type', 'public_canonical_job'),
+            'published' => $this->countRows($rows, 'projection_state', 'published'),
+            'published_candidate' => $this->countRows($rows, 'projection_state', self::RUNTIME_STATE),
+            'blocked' => $this->countRows($rows, 'projection_state', 'blocked'),
+            'quarantined' => $this->countRows($rows, 'projection_state', 'quarantined'),
+            'route_exists' => $this->countTrue($rows, 'route_exists'),
+            'final_200' => $this->countTrue($rows, 'final_200'),
+            'robots_indexable' => $this->countTrue($rows, 'robots_indexable'),
+            'canonical_self' => $this->countTrue($rows, 'canonical_self'),
+            'dataset_visible' => $this->countTrue($rows, 'dataset_visible'),
+            'search_visible' => $this->countTrue($rows, 'search_visible'),
+            'sitemap_live' => $this->countTrue($rows, 'sitemap_live'),
+            'llms_live' => $this->countTrue($rows, 'llms_live'),
+            'llms_full_live' => $this->countTrue($rows, 'llms_full_live'),
+            'release_gate_pass' => $this->countTrue($rows, 'release_gate_pass'),
+            'fully_live' => $this->countTrue($rows, 'fully_live'),
+            'candidate_pre_route_expected_count' => $this->countTrue($rows, 'candidate_pre_route_expected'),
+            'candidate_release_gate_not_applicable_count' => $this->countRows($rows, 'candidate_release_gate_applicability', 'not_applicable_before_promotion'),
+            'candidate_unexpected_route_exposure_count' => 0,
+            'candidate_unexpected_api_exposure_count' => 0,
+            'candidate_unexpected_dataset_exposure_count' => 0,
+            'candidate_unexpected_search_exposure_count' => 0,
+            'candidate_unexpected_sitemap_exposure_count' => 0,
+            'candidate_unexpected_llms_exposure_count' => 0,
+            'candidate_unexpected_llms_full_exposure_count' => 0,
+            'candidate_unexpected_indexable_exposure_count' => 0,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $members
+     * @return array<string, mixed>
+     */
+    private function ledgerCounts(mixed $existingCounts, array $members, int $overlayCount): array
+    {
+        $releaseCounts = [];
+        foreach ($members as $member) {
+            $cohort = is_string($member['release_cohort'] ?? null) ? $member['release_cohort'] : 'unknown';
+            $releaseCounts[$cohort] = ($releaseCounts[$cohort] ?? 0) + 1;
+        }
+        ksort($releaseCounts);
+
+        $counts = is_array($existingCounts) && ! array_is_list($existingCounts) ? $existingCounts : [];
+        $counts['member_count'] = count($members);
+        $counts['candidate_prep_overlay_members'] = $overlayCount;
+        $counts['release_counts'] = $releaseCounts;
+
+        return $counts;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function countTrue(array $rows, string $key): int
+    {
+        return count(array_filter($rows, static fn (array $row): bool => ($row[$key] ?? null) === true));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function countRows(array $rows, string $key, string $value): int
+    {
+        return count(array_filter($rows, static fn (array $row): bool => ($row[$key] ?? null) === $value));
+    }
+}

--- a/backend/docs/career/audits/runtime_artifact_refresh.md
+++ b/backend/docs/career/audits/runtime_artifact_refresh.md
@@ -29,6 +29,22 @@ php artisan career:plan-canonical-runtime-artifact-refresh \
   --output=/tmp/career_80_delta_runtime_artifact_refresh_plan_after_apply.json
 ```
 
+Candidate-aware read-only artifact refresh after `write_verified=true`:
+
+```bash
+php artisan career:plan-canonical-runtime-artifact-refresh \
+  --candidate-prep-apply=/tmp/career_80_delta_runtime_candidate_prep_apply.json \
+  --projection=/tmp/career_80_delta_runtime_projection_after_candidate_prep.json \
+  --truth=/tmp/career_80_delta_runtime_truth_after_candidate_prep.json \
+  --ledger=/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json \
+  --candidate-aware \
+  --projection-output=/tmp/career_80_delta_runtime_projection_candidate_aware.json \
+  --truth-output=/tmp/career_80_delta_runtime_truth_candidate_aware.json \
+  --ledger-output=/tmp/career_80_delta_full_release_ledger_candidate_aware.json \
+  --json \
+  --output=/tmp/career_80_delta_runtime_artifact_refresh_candidate_aware.json
+```
+
 ## Output
 
 The output schema is `career_runtime_artifact_refresh_plan.v1`.
@@ -45,6 +61,19 @@ Key fields:
   - `/tmp/career_80_delta_runtime_artifact_refresh_summary.json`
 - `commands`: the read-only export sequence to run later, after candidate-prep apply has passed.
 - `approval_gates`: the apply and read-only gates that must remain separate from rollout apply.
+
+Candidate-aware refresh output schema is `career_runtime_candidate_aware_artifact_refresh.v1`.
+
+The candidate-aware mode consumes the verified candidate-prep apply artifact and overlays its 51 verified slugs into read-only projection, truth, and ledger artifacts as hidden pre-route `published_candidate` rows. Overlay rows and members carry `candidate_prep_apply_overlay` provenance and explicitly set `canonical_ledger_authority_claimed=false`. This matters because the canonical full release ledger exporter alone may omit newly prepared candidate rows or keep previously tracked members in `review_needed` / `family_handoff`; candidate-aware artifacts are planning artifacts derived from write verification, not a replacement claim that those rows originated from canonical ledger authority.
+
+Candidate-aware artifact paths:
+
+- `/tmp/career_80_delta_runtime_projection_candidate_aware.json`
+- `/tmp/career_80_delta_runtime_truth_candidate_aware.json`
+- `/tmp/career_80_delta_full_release_ledger_candidate_aware.json`
+- `/tmp/career_80_delta_runtime_artifact_refresh_candidate_aware.json`
+
+The candidate-aware artifacts are intended for the next read-only 51-delta rollout dry-run. They do not publish pages, do not run rollout, and do not mutate the database.
 
 ## Approval Gates
 

--- a/backend/docs/career/audits/runtime_candidate_prep_apply_gate.md
+++ b/backend/docs/career/audits/runtime_candidate_prep_apply_gate.md
@@ -90,6 +90,22 @@ php artisan career:plan-canonical-runtime-artifact-refresh \
   --output=/tmp/career_80_delta_runtime_artifact_refresh_plan_after_apply.json
 ```
 
+If the canonical projection/truth/ledger export does not include the verified 51 prepared candidates as hidden `published_candidate` rows, use the candidate-aware refresh mode. It overlays only the verified apply artifact slugs, marks every overlay row with `candidate_prep_apply_overlay`, and does not claim canonical full release ledger authority:
+
+```bash
+php artisan career:plan-canonical-runtime-artifact-refresh \
+  --candidate-prep-apply=/tmp/career_80_delta_runtime_candidate_prep_apply.json \
+  --projection=/tmp/career_80_delta_runtime_projection_after_candidate_prep.json \
+  --truth=/tmp/career_80_delta_runtime_truth_after_candidate_prep.json \
+  --ledger=/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json \
+  --candidate-aware \
+  --projection-output=/tmp/career_80_delta_runtime_projection_candidate_aware.json \
+  --truth-output=/tmp/career_80_delta_runtime_truth_candidate_aware.json \
+  --ledger-output=/tmp/career_80_delta_full_release_ledger_candidate_aware.json \
+  --json \
+  --output=/tmp/career_80_delta_runtime_artifact_refresh_candidate_aware.json
+```
+
 ## Non-goals
 
 - No rollout dry-run.

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
@@ -96,6 +96,150 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
         $this->assertSame([true, true, true], array_column($payload['commands'], 'read_only'));
     }
 
+    public function test_candidate_aware_mode_blocks_when_source_projection_is_missing(): void
+    {
+        $exitCode = $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApplyForSlugs(['delta-001'])),
+            '--projection' => sys_get_temp_dir().'/missing-candidate-aware-projection.json',
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('projection_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+    }
+
+    public function test_candidate_aware_mode_blocks_unverified_apply_artifact(): void
+    {
+        $exitCode = $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', [
+                ...$this->candidatePrepApplyForSlugs(['delta-001']),
+                'write_verified' => false,
+            ]),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('candidate_prep_apply_not_verified', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_candidate_aware_mode_blocks_apply_artifact_with_failures(): void
+    {
+        $exitCode = $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApplyForSlugs(['delta-001'], failures: [['reason' => 'write_failed']])),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('candidate_prep_apply_failures_present', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_candidate_aware_mode_blocks_slug_count_mismatch(): void
+    {
+        $exitCode = $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApplyForSlugs(['delta-001'])),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--expect-slug-count' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('candidate_prep_apply_slug_count_mismatch', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_candidate_aware_mode_writes_overlay_artifacts(): void
+    {
+        $projectionOutput = $this->tempPath('candidate-aware-projection');
+        $truthOutput = $this->tempPath('candidate-aware-truth');
+        $ledgerOutput = $this->tempPath('candidate-aware-ledger');
+
+        $exitCode = $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApplyForSlugs(['delta-001', 'delta-002'])),
+            '--projection' => $this->writeJson('projection', $this->sourceProjection()),
+            '--truth' => $this->writeJson('truth', $this->sourceTruth()),
+            '--ledger' => $this->writeJson('ledger', $this->sourceLedger()),
+            '--projection-output' => $projectionOutput,
+            '--truth-output' => $truthOutput,
+            '--ledger-output' => $ledgerOutput,
+            '--expect-slug-count' => 2,
+        ]);
+        $payload = $this->payload();
+        $projection = json_decode((string) file_get_contents($projectionOutput), true, flags: JSON_THROW_ON_ERROR);
+        $truth = json_decode((string) file_get_contents($truthOutput), true, flags: JSON_THROW_ON_ERROR);
+        $ledger = json_decode((string) file_get_contents($ledgerOutput), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('career_runtime_candidate_aware_artifact_refresh.v1', $payload['schema_version']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertSame(4, $payload['projection']['overlay_rows']);
+        $this->assertSame(4, $payload['truth']['overlay_rows']);
+        $this->assertSame(2, $payload['ledger']['overlay_members']);
+        $this->assertSame('candidate_prep_apply_overlay', $projection['items'][1]['overlay_source']);
+        $this->assertSame('published_candidate', $projection['items'][1]['runtime_publish_state']);
+        $this->assertSame('candidate_prep_apply_overlay', $truth['items'][1]['overlay_source']);
+        $this->assertTrue($truth['items'][1]['candidate_pre_route_expected']);
+        $this->assertSame('candidate_prep_apply_overlay', $ledger['members'][1]['overlay_source']);
+        $this->assertFalse($ledger['members'][1]['canonical_ledger_authority_claimed']);
+    }
+
+    public function test_candidate_aware_artifacts_pass_runtime_candidate_pool_synthetic_integration(): void
+    {
+        $slugs = ['alpha-career', 'beta-career'];
+        $projectionOutput = $this->tempPath('candidate-aware-projection');
+        $truthOutput = $this->tempPath('candidate-aware-truth');
+        $ledgerOutput = $this->tempPath('candidate-aware-ledger');
+
+        $exitCode = $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApplyForSlugs($slugs)),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--projection-output' => $projectionOutput,
+            '--truth-output' => $truthOutput,
+            '--ledger-output' => $ledgerOutput,
+            '--expect-slug-count' => 2,
+        ]);
+        $this->assertSame(0, $exitCode, Artisan::output());
+
+        $poolExitCode = Artisan::call('career:plan-canonical-80-runtime-candidate-pool', [
+            '--audit' => $this->writeAudit($slugs),
+            '--projection' => $projectionOutput,
+            '--truth' => $truthOutput,
+            '--ledger' => $ledgerOutput,
+            '--target' => 2,
+            '--json' => true,
+        ]);
+        $pool = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $poolExitCode, Artisan::output());
+        $this->assertTrue($pool['pool_pass']);
+        $this->assertSame(2, $pool['selected_count']);
+        $this->assertSame($slugs, $pool['selection']['slugs']);
+    }
+
     public function test_json_output_shape_is_stable(): void
     {
         $this->callCommand([]);
@@ -116,6 +260,37 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
             'commands',
             'blockers',
             'approval_gates',
+            'next_required_action',
+        ], array_keys($payload));
+    }
+
+    public function test_candidate_aware_json_output_shape_is_stable(): void
+    {
+        $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApplyForSlugs(['delta-001'])),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame([
+            'schema_version',
+            'status',
+            'source_apply_artifact',
+            'target',
+            'delta_slug_count',
+            'expected_delta_locale_rows',
+            'locales',
+            'projection',
+            'truth',
+            'ledger',
+            'blockers',
+            'writes_database',
+            'read_only',
+            'apply_allowed',
             'next_required_action',
         ], array_keys($payload));
     }
@@ -177,6 +352,163 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
             'write_verified' => $writeVerified,
             'created_count' => $writeVerified ? 51 : 0,
             'verified_count' => $writeVerified ? 51 : 0,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<array<string, mixed>>  $failures
+     * @return array<string, mixed>
+     */
+    private function candidatePrepApplyForSlugs(array $slugs, bool $writeVerified = true, array $failures = []): array
+    {
+        return [
+            'status' => $writeVerified ? 'applied' : 'blocked',
+            'writes_database' => $writeVerified,
+            'write_verified' => $writeVerified,
+            'slug_count' => count($slugs),
+            'expected_locale_rows' => count($slugs) * 2,
+            'created_count' => $writeVerified ? count($slugs) : 0,
+            'verified_count' => $writeVerified ? count($slugs) : 0,
+            'failures' => $failures,
+            'locales' => ['en', 'zh'],
+            'artifact_sha256' => 'fixture-sha',
+            'created' => array_map(static fn (string $slug): array => [
+                'canonical_slug' => $slug,
+                'index_state_id' => 'fixture-'.$slug,
+                'runtime_publish_state' => 'published_candidate',
+            ], $slugs),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourceProjection(): array
+    {
+        return [
+            'projection_kind' => 'career_runtime_publish_projection',
+            'items' => [[
+                'slug' => 'published-baseline',
+                'locale' => 'en',
+                'public_resolution_type' => 'public_canonical_job',
+                'runtime_publish_state' => 'published',
+                'detail_route_enabled' => true,
+                'dataset_visible' => true,
+                'search_visible' => true,
+            ]],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourceTruth(): array
+    {
+        return [
+            'truth_kind' => 'career_canonical_runtime_truth',
+            'items' => [[
+                'slug' => 'published-baseline',
+                'locale' => 'en',
+                'public_resolution_type' => 'public_canonical_job',
+                'projection_state' => 'published',
+                'route_exists' => true,
+                'final_200' => true,
+                'dataset_visible' => true,
+                'search_visible' => true,
+                'candidate_pre_route_expected' => false,
+                'candidate_unexpected_exposures' => [],
+            ]],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourceLedger(): array
+    {
+        return [
+            'ledger_kind' => 'career_full_release_ledger',
+            'members' => [[
+                'member_kind' => 'career_tracked_occupation',
+                'canonical_slug' => 'published-baseline',
+                'release_cohort' => 'public_detail_indexable',
+                'public_index_state' => 'indexable',
+            ]],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $nearEligibleSlugs
+     */
+    private function writeAudit(array $nearEligibleSlugs): string
+    {
+        $rows = [];
+        foreach (array_values(array_unique($nearEligibleSlugs)) as $slug) {
+            $rows[] = $this->auditRow($slug, 'en');
+            $rows[] = $this->auditRow($slug, 'zh');
+        }
+
+        return $this->writeJson('audit', [
+            'status' => 'blocked',
+            'scope' => 'all',
+            'expected_occupations' => 2786,
+            'audited_occupations' => 2786,
+            'eligible_count' => 0,
+            'blocked_count' => count($rows),
+            'by_reason' => [
+                'llms_expected_not_ready' => count($rows),
+                'surface_unverified' => count($rows),
+            ],
+            'context_summary' => ['surface_context' => 'supplied'],
+            'policy_summary' => ['near_eligible_count' => count($nearEligibleSlugs)],
+            'rows' => $rows,
+            'sidecars' => [],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function auditRow(string $slug, string $locale): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'source_scope' => 'all',
+            'entity_status' => $this->layer('entity', 'pass'),
+            'baseline_status' => $this->layer('baseline', 'pass'),
+            'index_status' => $this->layer('index', 'pass'),
+            'runtime_status' => $this->layer('runtime', 'pass', [
+                ['runtime_publish_state' => 'published_candidate'],
+                ['truth_state' => 'published_candidate'],
+                ['canonical_public_type' => 'public_canonical_job'],
+                ['candidate_pre_route_expected' => true],
+            ]),
+            'seo_geo_status' => $this->layer('seo_geo', 'blocked', [], ['llms_expected_not_ready']),
+            'surface_status' => $this->layer('surface', 'blocked', [], ['surface_unverified']),
+            'safety_status' => $this->layer('safety', 'pass'),
+            'overall_status' => 'blocked',
+            'severity' => 'high',
+            'reasons' => ['llms_expected_not_ready', 'surface_unverified'],
+            'evidence' => [['slug' => $slug]],
+            'sidecars' => [],
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $evidence
+     * @param  list<string>  $reasons
+     * @return array<string, mixed>
+     */
+    private function layer(string $layer, string $status, array $evidence = [], array $reasons = []): array
+    {
+        return [
+            'layer' => $layer,
+            'status' => $status,
+            'reasons' => $status === 'pass' ? [] : $reasons,
+            'evidence' => $evidence,
+            'source' => 'synthetic_test_fixture',
         ];
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -404,6 +404,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php',
@@ -1887,6 +1888,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5093,6 +5093,64 @@
       "local_cleanup_executed": false,
       "sidecar_issues": []
     },
+    "REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2": {
+      "repo": "fap-api",
+      "branch": "fix/career-runtime-candidate-artifact-refresh-2",
+      "title": "fix(api): add candidate-aware runtime artifact refresh",
+      "name": "Add candidate-aware runtime artifact refresh after verified candidate prep apply",
+      "status": "in_progress",
+      "depends_on": [
+        "RUNTIME-CANDIDATE-PREP-APPLY-1",
+        "REPAIR-RUNTIME-ARTIFACT-REFRESH-1"
+      ],
+      "scope_type": "candidate_aware_runtime_artifact_refresh_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php",
+        "backend/app/Console/Commands/CareerRefreshCanonicalRuntimeArtifactsCandidateAware.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/*",
+        "backend/tests/Feature/Console/*",
+        "backend/tests/Unit/Domain/Career/Audit/*",
+        "backend/tests/Feature/Domain/Career/Audit/*",
+        "backend/docs/career/audits/*",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no DB mutation",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no backfill",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized docs/codex/pr-train.yaml and docs/codex/pr-train-state.json updates for REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "Candidate prep apply succeeded with write_verified=true, and SCAN-15 identified that canonical refresh artifacts did not consume the verified apply artifact."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Scope is limited to read-only candidate-aware artifact refresh semantics, tests, docs, and train metadata."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "RUNTIME-CANDIDATE-ARTIFACT-REFRESH-RUN-2",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
     "PR-CMS-04": {
       "repo": "fap-api",
       "branch": "codex/pr-cms-04-controlled-codex-publish-sop",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -40,6 +40,51 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
+    repo: fap-api
+    depends_on:
+      - RUNTIME-CANDIDATE-PREP-APPLY-1
+      - REPAIR-RUNTIME-ARTIFACT-REFRESH-1
+    branch: fix/career-runtime-candidate-artifact-refresh-2
+    title: "fix(api): add candidate-aware runtime artifact refresh"
+    name: "Add candidate-aware runtime artifact refresh after verified candidate prep apply"
+    scope:
+      - Extend the read-only runtime artifact refresh path with explicit candidate-aware overlay mode.
+      - Consume a verified candidate prep apply artifact and source projection/truth/ledger artifacts.
+      - Emit candidate-aware projection, truth, and ledger artifacts for the 51 delta slugs.
+      - Mark overlay provenance as candidate_prep_apply_overlay without claiming canonical ledger authority.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
+      - backend/app/Console/Commands/CareerRefreshCanonicalRuntimeArtifactsCandidateAware.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/tests/Feature/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Query or mutate production DB.
+      - Run candidate preparation apply.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi
+      - php artisan test --filter=CareerRuntimeCandidate --no-ansi
+      - php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
+      - php artisan test --filter=CareerPrepareCanonicalRuntimeCandidates --no-ansi
+      - php artisan test --filter=Career80TargetDelta --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
 
 
   - id: PR-CMS-04


### PR DESCRIPTION
## Summary
- Adds candidate-aware read-only runtime artifact refresh mode to `career:plan-canonical-runtime-artifact-refresh`.
- Consumes a verified candidate prep apply artifact and source projection/truth/ledger artifacts.
- Emits candidate-aware projection/truth/ledger artifacts for the 51 delta slugs.
- Marks overlay provenance explicitly as `candidate_prep_apply_overlay` and does not claim canonical full release ledger authority for overlaid rows.

## Safety / non-goals
- Does not mutate DB.
- Does not run candidate prep apply.
- Does not run rollout dry-run or rollout apply.
- Does not deploy.
- Does not touch fap-web.

## Tests
- `php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi`
- `php artisan test tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php --no-ansi`
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan test --filter=CareerPrepareCanonicalRuntimeCandidates --no-ansi`
- `php artisan test --filter=Career80TargetDelta --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=career_80_cohort_readiness_plan --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `git diff --cached --check`

## Next step
`RUNTIME-CANDIDATE-ARTIFACT-REFRESH-RUN-2`
