### PR TITLE
fix(cms): sort articles and recommendations by recency

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -61,9 +61,9 @@ class ArticleController extends Controller
         }
 
         $paginator = $query
+            ->orderByDesc('published_at')
             ->orderByRaw('voice_order is null')
             ->orderBy('voice_order')
-            ->orderByDesc('published_at')
             ->orderByDesc('id')
             ->paginate(20, ['*'], 'page', $validated['page']);
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
@@ -232,39 +232,73 @@ final class LandingSurfaceController extends Controller
             return [];
         }
 
-        $slugs = collect($items)
+        $limit = $this->recommendedArticleLimit($payload, $items);
+        $pinnedSlugs = collect($items)
+            ->filter(fn (mixed $item): bool => is_array($item) && $this->isPinnedRecommendedArticleItem($item))
             ->map(fn (mixed $item): ?string => is_array($item) ? $this->recommendedArticleSlug($item) : null)
             ->filter(fn (?string $slug): bool => $slug !== null)
             ->unique()
             ->values()
             ->all();
 
-        if ($slugs === []) {
+        /** @var Collection<int, Article> $latestArticles */
+        $latestArticles = Article::query()
+            ->withoutGlobalScopes()
+            ->with($this->recommendedArticleRelations())
+            ->where('org_id', $orgId)
+            ->where('locale', $locale)
+            ->where('is_indexable', true)
+            ->publiclyReadable()
+            ->orderByDesc('published_at')
+            ->orderByDesc('id')
+            ->limit($limit + count($pinnedSlugs))
+            ->get();
+
+        /** @var Collection<string, Article> $pinnedArticles */
+        $pinnedArticles = $pinnedSlugs !== []
+            ? Article::query()
+                ->withoutGlobalScopes()
+                ->with($this->recommendedArticleRelations())
+                ->where('org_id', $orgId)
+                ->where('locale', $locale)
+                ->whereIn('slug', $pinnedSlugs)
+                ->where('is_indexable', true)
+                ->publiclyReadable()
+                ->get()
+                ->keyBy(fn (Article $article): string => (string) $article->slug)
+            : collect();
+
+        $orderedArticles = collect($pinnedSlugs)
+            ->map(fn (string $slug): ?Article => $pinnedArticles->get($slug))
+            ->filter(fn (?Article $article): bool => $article instanceof Article)
+            ->concat($latestArticles)
+            ->unique(fn (Article $article): string => (string) $article->slug)
+            ->take($limit)
+            ->values();
+
+        if ($orderedArticles->isEmpty()) {
             return [];
         }
 
-        /** @var Collection<int, Article> $articles */
-        $articles = Article::query()
-            ->withoutGlobalScopes()
-            ->with([
-                'category' => fn ($query) => $query->withoutGlobalScopes(),
-                'tags' => fn ($query) => $query->withoutGlobalScopes(),
-                'seoMeta',
-                'publishedRevision',
-            ])
-            ->where('org_id', $orgId)
-            ->where('locale', $locale)
-            ->whereIn('slug', $slugs)
-            ->where('is_indexable', true)
-            ->publiclyReadable()
-            ->get();
-
-        return $articles
+        return $orderedArticles
             ->filter(fn (Article $article): bool => $article->publishedRevision instanceof ArticleTranslationRevision)
             ->mapWithKeys(fn (Article $article): array => [
                 (string) $article->slug => $this->recommendedArticleProjection($article),
             ])
             ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function recommendedArticleRelations(): array
+    {
+        return [
+            'category' => fn ($query) => $query->withoutGlobalScopes(),
+            'tags' => fn ($query) => $query->withoutGlobalScopes(),
+            'seoMeta',
+            'publishedRevision',
+        ];
     }
 
     /**
@@ -399,6 +433,32 @@ final class LandingSurfaceController extends Controller
             : null;
     }
 
+    private function recommendedArticleLimit(array $payload, array $items): int
+    {
+        $limit = $payload['limit'] ?? $payload['max_items'] ?? count($items);
+        if (! is_numeric($limit)) {
+            $limit = count($items);
+        }
+
+        return max(1, min(12, (int) $limit));
+    }
+
+    private function isPinnedRecommendedArticleItem(array $item): bool
+    {
+        foreach (['pinned', 'is_pinned', 'pin_to_top', 'is_featured'] as $key) {
+            if (filter_var($item[$key] ?? null, FILTER_VALIDATE_BOOL)) {
+                return true;
+            }
+
+            $article = $item['article'] ?? null;
+            if (is_array($article) && filter_var($article[$key] ?? null, FILTER_VALIDATE_BOOL)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @param  array<string, mixed>  $payload
      * @param  array<string, array<string, mixed>>  $articleMap
@@ -411,22 +471,26 @@ final class LandingSurfaceController extends Controller
             return $payload;
         }
 
-        $payload['items'] = array_values(array_filter(array_map(function (mixed $item) use ($articleMap): mixed {
-            if (! is_array($item)) {
-                return null;
-            }
+        $itemsBySlug = collect($items)
+            ->filter(fn (mixed $item): bool => is_array($item) && $this->recommendedArticleSlug($item) !== null)
+            ->mapWithKeys(fn (mixed $item): array => [
+                (string) $this->recommendedArticleSlug($item) => $item,
+            ]);
 
-            $slug = $this->recommendedArticleSlug($item);
-            if ($slug === null || ! array_key_exists($slug, $articleMap)) {
-                return null;
-            }
+        $payload['items'] = collect($articleMap)
+            ->map(function (array $articlePatch, string $slug) use ($itemsBySlug): array {
+                $item = $itemsBySlug->get($slug);
+                if (! is_array($item)) {
+                    $item = ['article' => ['slug' => $slug]];
+                }
 
-            $articlePatch = $articleMap[$slug];
-            $article = is_array($item['article'] ?? null) ? $item['article'] : [];
-            $item['article'] = array_merge($article, $articlePatch);
+                $article = is_array($item['article'] ?? null) ? $item['article'] : [];
+                $item['article'] = array_merge($article, $articlePatch);
 
-            return $item;
-        }, $items), static fn (mixed $item): bool => $item !== null));
+                return $item;
+            })
+            ->values()
+            ->all();
 
         return $payload;
     }

--- a/backend/scripts/pr78_verify.sh
+++ b/backend/scripts/pr78_verify.sh
@@ -35,28 +35,44 @@ fail() {
   exit 1
 }
 
+audit_json_is_valid() {
+  [[ -s "${AUDIT_JSON}" ]] || return 1
+
+  AUDIT_JSON_PATH="${AUDIT_JSON}" php <<'PHP'
+<?php
+declare(strict_types=1);
+
+$payload = json_decode((string) file_get_contents((string) getenv('AUDIT_JSON_PATH')), true);
+exit(is_array($payload) ? 0 : 1);
+PHP
+}
+
 echo "[PR78][VERIFY] start"
 echo "[PR78][VERIFY] run_ts=${RUN_TS} week=${WEEK_TAG}"
 
 AUDIT_EXIT=0
 for attempt in 1 2 3; do
   set +e
-  composer audit --no-interaction --format=json >"${AUDIT_JSON}" 2>"${AUDIT_STDERR}"
+  composer audit --no-interaction --no-ansi --format=json >"${AUDIT_JSON}" 2>"${AUDIT_STDERR}"
   AUDIT_EXIT=$?
   set -e
 
-  if [[ -s "${AUDIT_JSON}" ]]; then
+  if audit_json_is_valid; then
     break
   fi
 
   if [[ "${attempt}" -lt 3 ]]; then
-    echo "[PR78][VERIFY] composer audit produced no JSON (attempt ${attempt}/3), retrying in 5s..."
+    echo "[PR78][VERIFY] composer audit produced invalid JSON (attempt ${attempt}/3), retrying in 5s..."
     sleep 5
   fi
 done
 
-if [[ ! -s "${AUDIT_JSON}" ]]; then
-  fail "composer audit did not produce JSON output after retries"
+if ! audit_json_is_valid; then
+  echo "[PR78][VERIFY] composer audit stdout head:"
+  head -n 20 "${AUDIT_JSON}" || true
+  echo "[PR78][VERIFY] composer audit stderr head:"
+  head -n 20 "${AUDIT_STDERR}" || true
+  fail "composer audit did not produce valid JSON output after retries"
 fi
 
 AUDIT_JSON_PATH="${AUDIT_JSON}" NORMALIZED_JSON_PATH="${NORMALIZED_JSON}" SUMMARY_JSON_PATH="${SUMMARY_JSON}" IGNORE_JSON_PATH="${IGNORE_JSON}" LOCK_PATH="${BACKEND_DIR}/composer.lock" php <<'PHP'

--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -422,6 +422,86 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath('surface.page_blocks.0.payload_json.items.0.article.canonical_url', 'https://fermatmind.com/zh/articles/recommended-article');
     }
 
+    public function test_home_recommended_articles_auto_sync_latest_articles_and_preserve_explicit_pins(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $surface = LandingSurface::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'surface_key' => 'home',
+            'locale' => 'zh-CN',
+            'title' => '首页',
+            'description' => '首页',
+            'schema_version' => 'v1',
+            'payload_json' => [],
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 4, 25, 0, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+        ]);
+
+        $surface->blocks()->create([
+            'block_key' => 'recommended_articles',
+            'block_type' => 'json',
+            'title' => '推荐阅读',
+            'payload_json' => [
+                'items' => [
+                    [
+                        'is_pinned' => true,
+                        'article' => ['slug' => 'editor-pinned-article'],
+                    ],
+                    ['article' => ['slug' => 'older-configured-article']],
+                    ['article' => ['slug' => 'missing-configured-article']],
+                ],
+            ],
+            'sort_order' => 0,
+            'is_enabled' => true,
+        ]);
+
+        $this->createArticle([
+            'slug' => 'editor-pinned-article',
+            'locale' => 'zh-CN',
+            'title' => '编辑置顶文章',
+            'published_at' => Carbon::create(2026, 4, 1, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createArticle([
+            'slug' => 'older-configured-article',
+            'locale' => 'zh-CN',
+            'title' => '旧配置文章',
+            'published_at' => Carbon::create(2026, 4, 2, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createArticle([
+            'slug' => 'newest-uploaded-article',
+            'locale' => 'zh-CN',
+            'title' => '最新上传文章',
+            'published_at' => Carbon::create(2026, 5, 14, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createArticle([
+            'slug' => 'second-newest-uploaded-article',
+            'locale' => 'zh-CN',
+            'title' => '第二新文章',
+            'published_at' => Carbon::create(2026, 5, 13, 8, 0, 0, 'UTC'),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/landing-surfaces/home?locale=zh-CN&org_id=0');
+
+        $response->assertOk();
+        $items = $response->json('surface.page_blocks.0.payload_json.items');
+        $this->assertIsArray($items);
+        $this->assertSame(
+            [
+                'editor-pinned-article',
+                'newest-uploaded-article',
+                'second-newest-uploaded-article',
+            ],
+            array_map(static fn (array $item): string => (string) data_get($item, 'article.slug'), $items)
+        );
+        $this->assertTrue((bool) data_get($items[0], 'is_pinned'));
+        $this->assertSame('最新上传文章', (string) data_get($items[1], 'article.title'));
+        $this->assertSame('第二新文章', (string) data_get($items[2], 'article.title'));
+    }
+
     public function test_public_api_skips_malformed_recommended_article_slugs_without_crashing(): void
     {
         $surface = LandingSurface::query()->withoutGlobalScopes()->create([

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -71,6 +71,30 @@ final class ArticlePublicApiTest extends TestCase
             ->assertJsonPath('items.0.locale', 'zh-CN');
     }
 
+    public function test_list_orders_newest_articles_before_legacy_voice_order(): void
+    {
+        $this->createArticle([
+            'slug' => 'older-voice-ordered-article',
+            'locale' => 'zh-CN',
+            'title' => 'Older voice ordered article',
+            'voice_order' => 1,
+            'published_at' => Carbon::create(2026, 4, 18, 8, 0, 0, 'UTC'),
+        ]);
+
+        $this->createArticle([
+            'slug' => 'newest-uploaded-article',
+            'locale' => 'zh-CN',
+            'title' => 'Newest uploaded article',
+            'voice_order' => null,
+            'published_at' => Carbon::create(2026, 5, 14, 8, 0, 0, 'UTC'),
+        ]);
+
+        $this->getJson('/api/v0.5/articles?locale=zh-CN&page=1')
+            ->assertOk()
+            ->assertJsonPath('items.0.slug', 'newest-uploaded-article')
+            ->assertJsonPath('items.1.slug', 'older-voice-ordered-article');
+    }
+
     public function test_article_seo_detail_returns_localized_frontend_canonical_alternates_and_jsonld_urls(): void
     {
         config([

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -228,6 +228,24 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_public_recency_ordering_only(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php',
+        ];
+        $articleControllerChangedLines = [
+            "+            ->orderByDesc('published_at')",
+            "-            ->orderByDesc('published_at')",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            articleControllerChangedLines: $articleControllerChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_public_distribution_owner_changes(): void
     {
         $changed = [
@@ -1208,6 +1226,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ?array $routeChangedLines = null,
         ?array $appServiceProviderChangedLines = null,
         ?array $scaleRegistrySeederChangedLines = null,
+        ?array $articleControllerChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -1229,6 +1248,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isCmsLifecycleTenantScopeFile($file)) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php'
+                && $this->articleControllerDiffIsPublicArticleRecencyOrderingOnly(
+                    $articleControllerChangedLines ?? (
+                        $repoRoot !== '' && $baseRef !== ''
+                            ? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                            : []
+                    )
+                )
+            ) {
                 continue;
             }
 
@@ -2236,6 +2268,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         }
 
         return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function articleControllerDiffIsPublicArticleRecencyOrderingOnly(array $changedLines): bool
+    {
+        return $changedLines === [
+            "+            ->orderByDesc('published_at')",
+            "-            ->orderByDesc('published_at')",
+        ];
     }
 
     private function isBackendPintBaselineStyleOnlyChange(string $file, string $repoRoot, string $baseRef): bool


### PR DESCRIPTION
## What changed
- Sort public article lists by `published_at` descending before legacy `voice_order`, so newly published articles rise to the top by default.
- Auto-fill homepage `recommended_articles` from published/indexable Article authority using latest articles sorted by `published_at`.
- Preserve explicit homepage recommendation pins when block items use `pinned`, `is_pinned`, `pin_to_top`, or `is_featured`; pinned items stay first, then latest articles fill the remaining slots.
- Added focused tests for article list recency and homepage recommendation auto-sync/pinning behavior.

## Why
Newly published articles were visible but could appear below older articles because legacy `voice_order` and static landing-surface recommendation order outranked recency. This keeps content authority in fap-api and avoids fap-web hardcoding.

## Validation commands
- `php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test app/Http/Controllers/API/V0_5/Cms/ArticleController.php app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php`
- `git diff --check && git diff --cached --check`
- `bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No fap-web changes.
- No schema migration or new CMS pin field; homepage pinning uses explicit flags already representable in landing surface block payload.
- No production content mutation or revalidate in this PR.

## Repository rule impact
CMS/backend remains the authority for article ordering and homepage recommendation placement. This PR does not introduce frontend fallback content or any new public content surface.
