### PR TITLE
fix(api): accept candidate-aware runtime states for delta planning

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php
@@ -20,6 +20,63 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
 {
     private const SCHEMA_VERSION = 'career_80_runtime_candidate_pool_plan.v1';
 
+    private const CANDIDATE_AWARE_OVERLAY_SOURCE = 'candidate_prep_apply_overlay';
+
+    private const CANDIDATE_AWARE_INDEX_STATE = 'promotion_candidate';
+
+    /**
+     * These stale audit blockers specifically indicate a verified pre-promotion candidate overlay is required before
+     * rollout planning can treat promotion_candidate / published_candidate evidence as valid.
+     *
+     * @var list<string>
+     */
+    private const CANDIDATE_AWARE_STATE_POLICY_BLOCKERS = [
+        'index_state_not_indexed_like',
+        'runtime_publish_state_not_published',
+        'truth_state_not_published',
+    ];
+
+    /**
+     * Runtime candidate pool planning validates projection/truth/ledger state directly below. These audit reasons are
+     * expected stale/full-publication blockers for verified pre-promotion candidates and must not remove them before
+     * candidate-aware artifact evidence can be evaluated.
+     *
+     * @var list<string>
+     */
+    private const RUNTIME_POOL_SELECTOR_HARD_BLOCKERS = [
+        'occupation_missing',
+        'entity_field_missing',
+        'index_state_missing',
+        'projection_row_missing',
+        'truth_row_missing',
+        'locale_row_missing',
+        'ledger_member_missing',
+        'canonical_public_type_invalid',
+        'surface_context_missing',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const CANDIDATE_AWARE_ALLOWED_POLICY_BLOCKERS = [
+        'index_state_not_indexed_like',
+        'runtime_publish_state_not_published',
+        'truth_state_not_published',
+        'sitemap_expected_not_ready',
+        'llms_expected_not_ready',
+        'llms_full_expected_not_ready',
+        'sitemap_missing',
+        'llms_missing',
+        'llms_full_missing',
+        'structured_data_missing',
+        'citation_metadata_missing',
+        'surface_artifact_missing',
+        'surface_unverified',
+        'zh_baseline_missing',
+        'en_title_derivation_required',
+        'required_display_field_missing',
+    ];
+
     protected $signature = 'career:plan-canonical-80-runtime-candidate-pool
         {--audit= : Required post-apply Career canonical eligibility audit JSON artifact}
         {--projection= : Required runtime projection JSON artifact}
@@ -191,7 +248,11 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         $truthBySlug = $this->rowsBySlugLocale($this->artifactRows($truth, ['items', 'rows']));
         $ledgerBySlug = $this->ledgerBySlug($this->artifactRows($ledger, ['members', 'items', 'rows']));
         $auditRowsBySlug = $this->auditRowsBySlug($report);
-        $selection = (new CareerCanonical80CandidateSelector)->select($report, $target);
+        $selection = (new CareerCanonical80CandidateSelector)->select(
+            report: $report,
+            targetCount: $target,
+            hardBlockers: self::RUNTIME_POOL_SELECTOR_HARD_BLOCKERS,
+        );
 
         $eligible = [];
         $excluded = [];
@@ -205,7 +266,17 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 continue;
             }
 
-            if (! $this->isBaseCandidate($row, $policyRow)) {
+            $candidateAwareEvidence = $this->candidateAwarePlanningEvidence(
+                slug: $row->canonicalSlug,
+                locales: $locales,
+                projectionRows: $projectionBySlug[$row->canonicalSlug] ?? [],
+                truthRows: $truthBySlug[$row->canonicalSlug] ?? [],
+                ledgerMember: $ledgerBySlug[$row->canonicalSlug] ?? null,
+                auditRows: $auditRowsBySlug[$row->canonicalSlug] ?? [],
+                policyRow: $policyRow,
+            );
+
+            if (! $this->isBaseCandidate($row, $policyRow, $candidateAwareEvidence)) {
                 continue;
             }
 
@@ -217,6 +288,7 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 truthRows: $truthBySlug[$row->canonicalSlug] ?? [],
                 ledgerMember: $ledgerBySlug[$row->canonicalSlug] ?? null,
                 auditGate: $auditGate->evaluate($auditRowsBySlug[$row->canonicalSlug] ?? []),
+                candidateAwareEvidence: $candidateAwareEvidence,
             );
 
             if ($gate['eligible'] === true) {
@@ -300,13 +372,20 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         ];
     }
 
-    private function isBaseCandidate(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow): bool
+    /**
+     * @param  array{required: bool, eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $candidateAwareEvidence
+     */
+    private function isBaseCandidate(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow, array $candidateAwareEvidence): bool
     {
         if (! in_array($row->candidateStatus, [
             CareerCanonical80CandidateSelectionRow::STATUS_READY,
             CareerCanonical80CandidateSelectionRow::STATUS_NEAR_ELIGIBLE,
         ], true)) {
             return false;
+        }
+
+        if ($candidateAwareEvidence['required'] && $row->hardBlockers === [] && $this->policyOnlyHasCandidateAwarePlanningBlockers($policyRow)) {
+            return true;
         }
 
         return $row->hardBlockers === []
@@ -320,6 +399,7 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
      * @param  array<string, list<array<string, mixed>>>  $truthRows
      * @param  array<string, mixed>|null  $ledgerMember
      * @param  array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $auditGate
+     * @param  array{required: bool, eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $candidateAwareEvidence
      * @param  list<string>  $locales
      * @return array{eligible: bool, reasons: list<string>, evidence: array<string, mixed>}
      */
@@ -330,14 +410,16 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         array $truthRows,
         ?array $ledgerMember,
         array $auditGate,
+        array $candidateAwareEvidence,
     ): array {
-        $reasons = [];
+        $reasons = $candidateAwareEvidence['reasons'];
         $evidence = [
             'slug' => $slug,
             'required_locales' => $locales,
             'ledger_member_exists' => $ledgerMember !== null,
             'ledger_release_cohort' => $ledgerMember['release_cohort'] ?? null,
             'ledger_public_index_state' => $ledgerMember['public_index_state'] ?? null,
+            'candidate_aware_overlay' => $candidateAwareEvidence['evidence'],
             'projection_states' => [],
             'truth_states' => [],
             'projection_locales_present' => [],
@@ -470,6 +552,151 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 $reasons[] = 'unexpected_route_exposure';
             }
         }
+    }
+
+    /**
+     * @param  array<string, list<array<string, mixed>>>  $projectionRows
+     * @param  array<string, list<array<string, mixed>>>  $truthRows
+     * @param  array<string, mixed>|null  $ledgerMember
+     * @param  list<\App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return array{required: bool, eligible: bool, reasons: list<string>, evidence: array<string, mixed>}
+     */
+    private function candidateAwarePlanningEvidence(
+        string $slug,
+        array $locales,
+        array $projectionRows,
+        array $truthRows,
+        ?array $ledgerMember,
+        array $auditRows,
+        Career2786ReadinessPolicyRow $policyRow,
+    ): array {
+        $reasons = [];
+        $projectionOverlayRows = 0;
+        $truthOverlayRows = 0;
+        $sourceHashes = [];
+        $required = $this->candidateAwarePlanningRequired($policyRow);
+
+        $ledgerOverlay = $ledgerMember !== null
+            && ($this->stringValue($ledgerMember, 'overlay_source') ?? '') === self::CANDIDATE_AWARE_OVERLAY_SOURCE;
+        $writeVerified = $ledgerOverlay
+            && (bool) data_get($ledgerMember, 'evidence_refs.candidate_prep_apply.write_verified', false) === true;
+        $ledgerIndexState = $ledgerMember === null ? null : $this->stringValue($ledgerMember, 'current_index_state');
+        $ledgerRuntimeState = $ledgerMember === null ? null : $this->stringValue($ledgerMember, 'runtime_publish_state');
+
+        if (! $ledgerOverlay) {
+            $reasons[] = 'candidate_aware_overlay_missing';
+        }
+        if (! $writeVerified) {
+            $reasons[] = 'candidate_prep_apply_not_verified';
+        }
+        if ($ledgerIndexState !== self::CANDIDATE_AWARE_INDEX_STATE) {
+            $reasons[] = 'candidate_index_state_mismatch';
+        }
+        if ($ledgerRuntimeState !== Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE) {
+            $reasons[] = 'candidate_runtime_state_mismatch';
+        }
+
+        foreach ($locales as $locale) {
+            foreach ($projectionRows[$locale] ?? [] as $projectionRow) {
+                if (($this->stringValue($projectionRow, 'overlay_source') ?? '') === self::CANDIDATE_AWARE_OVERLAY_SOURCE) {
+                    $projectionOverlayRows++;
+                    $hash = $this->stringValue($projectionRow, 'source_artifact_sha256');
+                    if ($hash !== null) {
+                        $sourceHashes[] = $hash;
+                    }
+                }
+            }
+            foreach ($truthRows[$locale] ?? [] as $truthRow) {
+                if (($this->stringValue($truthRow, 'overlay_source') ?? '') === self::CANDIDATE_AWARE_OVERLAY_SOURCE) {
+                    $truthOverlayRows++;
+                    $hash = $this->stringValue($truthRow, 'source_artifact_sha256');
+                    if ($hash !== null) {
+                        $sourceHashes[] = $hash;
+                    }
+                }
+            }
+        }
+
+        if ($projectionOverlayRows < count($locales)) {
+            $reasons[] = 'candidate_aware_projection_overlay_missing';
+        }
+        if ($truthOverlayRows < count($locales)) {
+            $reasons[] = 'candidate_aware_truth_overlay_missing';
+        }
+        if (! $this->auditShowsCandidateAwareIndexState($auditRows)) {
+            $reasons[] = 'candidate_aware_audit_index_evidence_missing';
+        }
+        if (! $this->policyOnlyHasCandidateAwarePlanningBlockers($policyRow)) {
+            $reasons[] = 'candidate_policy_has_non_candidate_aware_blocker';
+        }
+
+        $reasons = $required ? $this->normalizeStrings($reasons) : [];
+
+        return [
+            'required' => $required,
+            'eligible' => $reasons === [],
+            'reasons' => $reasons,
+            'evidence' => [
+                'required' => $required,
+                'overlay_source' => self::CANDIDATE_AWARE_OVERLAY_SOURCE,
+                'ledger_overlay' => $ledgerOverlay,
+                'candidate_prep_apply_write_verified' => $writeVerified,
+                'ledger_index_state' => $ledgerIndexState,
+                'ledger_runtime_state' => $ledgerRuntimeState,
+                'projection_overlay_rows' => $projectionOverlayRows,
+                'truth_overlay_rows' => $truthOverlayRows,
+                'audit_index_state' => $this->auditIndexStates($auditRows),
+                'source_artifact_sha256_values' => $this->normalizeStrings($sourceHashes),
+            ],
+        ];
+    }
+
+    private function candidateAwarePlanningRequired(Career2786ReadinessPolicyRow $policyRow): bool
+    {
+        return array_intersect($policyRow->reasons, self::CANDIDATE_AWARE_STATE_POLICY_BLOCKERS) !== []
+            || array_intersect($policyRow->hardBlockerReasons, self::CANDIDATE_AWARE_STATE_POLICY_BLOCKERS) !== [];
+    }
+
+    private function policyOnlyHasCandidateAwarePlanningBlockers(Career2786ReadinessPolicyRow $policyRow): bool
+    {
+        $blockingReasons = $this->normalizeStrings(array_values(array_diff([
+            ...$policyRow->hardBlockerReasons,
+            ...$policyRow->remediationRequiredReasons,
+            ...$policyRow->reasons,
+        ], self::CANDIDATE_AWARE_ALLOWED_POLICY_BLOCKERS)));
+
+        return $blockingReasons === [];
+    }
+
+    /**
+     * @param  list<\App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow>  $auditRows
+     */
+    private function auditShowsCandidateAwareIndexState(array $auditRows): bool
+    {
+        return in_array(self::CANDIDATE_AWARE_INDEX_STATE, $this->auditIndexStates($auditRows), true);
+    }
+
+    /**
+     * @param  list<\App\Domain\Career\Audit\CareerCanonicalEligibilityAuditRow>  $auditRows
+     * @return list<string>
+     */
+    private function auditIndexStates(array $auditRows): array
+    {
+        $states = [];
+        foreach ($auditRows as $row) {
+            foreach ($row->indexStatus->evidence as $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
+
+                $state = $this->stringValue($item, 'latest_index_state');
+                if ($state !== null) {
+                    $states[] = $state;
+                }
+            }
+        }
+
+        return $this->normalizeStrings($states);
     }
 
     /**

--- a/backend/docs/career/audits/80_runtime_candidate_pool.md
+++ b/backend/docs/career/audits/80_runtime_candidate_pool.md
@@ -53,6 +53,16 @@ A selected slug must:
 - use `public_canonical_job`;
 - have no route/API exposure before promotion.
 
+Candidate-aware 51-delta planning has a narrower pre-promotion exception. A slug may pass the runtime candidate pool even when the refreshed audit still carries full-publication blockers such as `index_state_not_indexed_like`, `runtime_publish_state_not_published`, or `truth_state_not_published`, but only when the supplied planning artifacts prove all of the following:
+
+- the ledger member, projection rows, and truth rows are candidate-aware overlay rows with `overlay_source=candidate_prep_apply_overlay`;
+- the ledger evidence shows the candidate prep apply was `write_verified=true`;
+- the index evidence shows `latest_index_state=promotion_candidate`;
+- the projection/truth runtime state is `published_candidate` for every required locale;
+- the slug is evaluated as a delta pre-promotion candidate and not as an already-published baseline slug.
+
+This exception is only for rollout dry-run planning. It does not make the slug published, does not authorize apply, and does not satisfy final 80-total live acceptance.
+
 The command excludes:
 
 - already-published slugs;

--- a/backend/tests/Feature/Console/CareerPlanCanonical80RuntimeCandidatePoolCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical80RuntimeCandidatePoolCommandTest.php
@@ -53,7 +53,7 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
     public function test_passes_with_target_override_and_writes_output(): void
     {
         $slugs = ['zeta-career', 'alpha-career', 'beta-career'];
-        $audit = $this->writeAudit($slugs);
+        $audit = $this->writeCandidateAwareBlockedAudit($slugs);
         $output = $this->tempPath('runtime-pool-output');
 
         $exitCode = $this->callCommand([
@@ -72,10 +72,52 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
         $this->assertSame(3, $payload['eligible_count']);
         $this->assertSame(2, $payload['selected_count']);
         $this->assertSame(['alpha-career', 'beta-career'], $payload['selection']['slugs']);
+        $this->assertSame('promotion_candidate', $payload['selection']['rows'][0]['runtime_state_evidence']['candidate_aware_overlay']['ledger_index_state']);
+        $this->assertTrue($payload['selection']['rows'][0]['runtime_state_evidence']['candidate_aware_overlay']['candidate_prep_apply_write_verified']);
         $this->assertTrue($payload['rollout']['manifest_generation_allowed']);
         $this->assertTrue($payload['rollout']['dry_run_allowed']);
         $this->assertFalse($payload['rollout']['apply_allowed']);
         $this->assertFileExists($output);
+    }
+
+    public function test_requires_candidate_aware_overlay_source_for_delta_planning(): void
+    {
+        $audit = $this->writeCandidateAwareBlockedAudit(['alpha-career']);
+
+        $exitCode = $this->callCommand([
+            '--audit' => $audit,
+            '--projection' => $this->writeProjection(['alpha-career'], candidateAware: false),
+            '--truth' => $this->writeTruth(['alpha-career'], candidateAware: false),
+            '--ledger' => $this->writeLedger(['alpha-career'], candidateAware: false),
+            '--target' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['pool_pass']);
+        $this->assertSame(0, $payload['selected_count']);
+        $this->assertContains('candidate_aware_overlay_missing', $payload['runtime_candidate_gate']['excluded_rows'][0]['exclusion_reasons']);
+        $this->assertContains('candidate_prep_apply_not_verified', $payload['runtime_candidate_gate']['excluded_rows'][0]['exclusion_reasons']);
+    }
+
+    public function test_stale_full_publication_audit_reasons_do_not_veto_verified_candidate_aware_overlay(): void
+    {
+        $slugs = ['delta-001', 'delta-002'];
+
+        $exitCode = $this->callCommand([
+            '--audit' => $this->writeCandidateAwareBlockedAudit($slugs),
+            '--projection' => $this->writeProjection($slugs),
+            '--truth' => $this->writeTruth($slugs),
+            '--ledger' => $this->writeLedger($slugs),
+            '--target' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['pool_pass']);
+        $this->assertSame($slugs, $payload['selection']['slugs']);
+        $this->assertSame(2, $payload['eligible_count']);
+        $this->assertSame(0, $payload['excluded_count']);
     }
 
     public function test_excludes_runtime_invalid_candidates(): void
@@ -250,6 +292,37 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
     }
 
     /**
+     * @param  list<string>  $slugs
+     */
+    private function writeCandidateAwareBlockedAudit(array $slugs): string
+    {
+        $rows = [];
+        foreach (array_values(array_unique($slugs)) as $slug) {
+            $rows[] = $this->candidateAwareBlockedRow($slug, 'en');
+            $rows[] = $this->candidateAwareBlockedRow($slug, 'zh');
+        }
+
+        return $this->writeJson('audit', [
+            'status' => 'blocked',
+            'scope' => 'all',
+            'expected_occupations' => 2786,
+            'audited_occupations' => 2786,
+            'eligible_count' => 0,
+            'blocked_count' => count($rows),
+            'by_reason' => [
+                'index_state_not_indexed_like' => count($rows),
+                'runtime_publish_state_not_published' => count($rows),
+                'truth_state_not_published' => count($rows),
+                'surface_unverified' => count($rows),
+            ],
+            'context_summary' => ['surface_context' => 'supplied'],
+            'policy_summary' => ['near_eligible_count' => 0],
+            'rows' => $rows,
+            'sidecars' => [],
+        ]);
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function row(string $slug, string $locale): array
@@ -281,6 +354,52 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
     /**
      * @return array<string, mixed>
      */
+    private function candidateAwareBlockedRow(string $slug, string $locale): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'source_scope' => 'all',
+            'entity_status' => $this->layer('entity', 'pass'),
+            'baseline_status' => $this->layer('baseline', 'pass'),
+            'index_status' => $this->layer('index', 'blocked', [
+                [
+                    'latest_index_state' => 'promotion_candidate',
+                    'reason_codes' => [
+                        'prepare_published_candidate_runtime_rows',
+                        'target_runtime_state:published_candidate',
+                        'target_index_state:promotion_candidate',
+                    ],
+                ],
+            ], ['index_state_not_indexed_like']),
+            'runtime_status' => $this->layer('runtime', 'blocked', [
+                ['runtime_publish_state' => 'published_candidate'],
+                ['truth_state' => 'published_candidate'],
+                ['canonical_public_type' => 'public_canonical_job'],
+                ['candidate_pre_route_expected' => true],
+            ], ['runtime_publish_state_not_published', 'truth_state_not_published']),
+            'seo_geo_status' => $this->layer('seo_geo', 'blocked', [], ['sitemap_missing', 'llms_missing', 'llms_full_missing']),
+            'surface_status' => $this->layer('surface', 'blocked', [], ['surface_unverified']),
+            'safety_status' => $this->layer('safety', 'pass'),
+            'overall_status' => 'blocked',
+            'severity' => 'high',
+            'reasons' => [
+                'index_state_not_indexed_like',
+                'runtime_publish_state_not_published',
+                'truth_state_not_published',
+                'sitemap_missing',
+                'llms_missing',
+                'llms_full_missing',
+                'surface_unverified',
+            ],
+            'evidence' => [['slug' => $slug]],
+            'sidecars' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     private function layer(string $layer, string $status, array $evidence = [], array $reasons = []): array
     {
         return [
@@ -296,14 +415,14 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
      * @param  list<string>|array<string, string>  $slugs
      * @param  list<string>  $routeExposedSlugs
      */
-    private function writeProjection(array $slugs, array $routeExposedSlugs = []): string
+    private function writeProjection(array $slugs, array $routeExposedSlugs = [], bool $candidateAware = true): string
     {
         $rows = [];
         foreach ($slugs as $key => $value) {
             $slug = is_string($key) ? $key : $value;
             $state = is_string($key) ? $value : 'published_candidate';
             foreach (['en', 'zh'] as $locale) {
-                $rows[] = [
+                $row = [
                     'slug' => $slug,
                     'locale' => $locale,
                     'public_resolution_type' => $state === 'blocked' ? 'blocked_until_governance_approval' : 'public_canonical_job',
@@ -312,6 +431,11 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
                     'dataset_visible' => false,
                     'search_visible' => false,
                 ];
+                if ($candidateAware) {
+                    $row['overlay_source'] = 'candidate_prep_apply_overlay';
+                    $row['source_artifact_sha256'] = str_repeat('a', 64);
+                }
+                $rows[] = $row;
             }
         }
 
@@ -322,14 +446,14 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
      * @param  list<string>|array<string, string>  $slugs
      * @param  list<string>  $routeExposedSlugs
      */
-    private function writeTruth(array $slugs, array $routeExposedSlugs = []): string
+    private function writeTruth(array $slugs, array $routeExposedSlugs = [], bool $candidateAware = true): string
     {
         $rows = [];
         foreach ($slugs as $key => $value) {
             $slug = is_string($key) ? $key : $value;
             $state = is_string($key) ? $value : 'published_candidate';
             foreach (['en', 'zh'] as $locale) {
-                $rows[] = [
+                $row = [
                     'slug' => $slug,
                     'locale' => $locale,
                     'public_resolution_type' => $state === 'blocked' ? 'blocked_until_governance_approval' : 'public_canonical_job',
@@ -341,6 +465,11 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
                     'candidate_pre_route_expected' => $state === 'published_candidate',
                     'candidate_unexpected_exposures' => in_array($slug, $routeExposedSlugs, true) ? ['route'] : [],
                 ];
+                if ($candidateAware) {
+                    $row['overlay_source'] = 'candidate_prep_apply_overlay';
+                    $row['source_artifact_sha256'] = str_repeat('a', 64);
+                }
+                $rows[] = $row;
             }
         }
 
@@ -351,15 +480,30 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
      * @param  list<string>  $slugs
      * @param  list<string>  $blockedSlugs
      */
-    private function writeLedger(array $slugs, array $blockedSlugs = []): string
+    private function writeLedger(array $slugs, array $blockedSlugs = [], bool $candidateAware = true): string
     {
         $members = [];
         foreach ($slugs as $slug) {
-            $members[] = [
+            $member = [
                 'canonical_slug' => $slug,
                 'release_cohort' => in_array($slug, $blockedSlugs, true) ? 'review_needed' : 'public_detail_conservative',
                 'public_index_state' => in_array($slug, $blockedSlugs, true) ? 'noindex' : 'indexable',
+                'current_index_state' => 'promotion_candidate',
+                'runtime_publish_state' => 'published_candidate',
             ];
+            if ($candidateAware) {
+                $member['overlay_source'] = 'candidate_prep_apply_overlay';
+                $member['source_artifact_sha256'] = str_repeat('a', 64);
+                $member['canonical_ledger_authority_claimed'] = false;
+                $member['evidence_refs'] = [
+                    'candidate_prep_apply' => [
+                        'kind' => 'candidate_prep_apply_overlay',
+                        'write_verified' => true,
+                        'artifact_sha256' => str_repeat('a', 64),
+                    ],
+                ];
+            }
+            $members[] = $member;
         }
 
         return $this->writeJson('ledger', ['members' => $members]);

--- a/backend/tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php
@@ -77,6 +77,19 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
         $this->assertContains('live_acceptance_not_accepted', array_column($result['blockers'], 'reason'));
     }
 
+    public function test_candidate_planning_artifacts_do_not_replace_final_live_acceptance(): void
+    {
+        $result = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->targetDelta(),
+            deltaManifest: $this->deltaManifest(),
+        )->toArray();
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertFalse($result['accepted']);
+        $this->assertSame('RUN_80_TOTAL_LIVE_ACCEPTANCE_READ_ONLY', $result['next_required_action']);
+        $this->assertFalse($result['live_crawl_executed']);
+    }
+
     public function test_blocks_when_live_acceptance_expected_rows_do_not_match(): void
     {
         $result = (new Career80TotalLiveAcceptancePlanner)->plan(

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-14T18:05:00+08:00",
+  "updated_at": "2026-05-14T21:20:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -5231,6 +5231,57 @@
       },
       "failure_reason": null,
       "next_pr": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
+    "REPAIR-CANDIDATE-AWARE-AUDIT-POLICY-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-candidate-aware-audit-policy-1",
+      "title": "fix(api): accept candidate-aware runtime states for delta planning",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2"
+      ],
+      "scope_type": "candidate_aware_audit_policy_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/**",
+        "backend/app/Console/Commands/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout dry-run",
+        "no rollout apply",
+        "no candidate prep apply",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change",
+        "do not weaken final live acceptance"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User provided explicit PR id, scope, allowed paths, commit/PR instructions, and allowed docs/codex train metadata paths for REPAIR-CANDIDATE-AWARE-AUDIT-POLICY-1."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR #1389 candidate-aware runtime artifact refresh is merged; candidate-aware artifacts and audit/pool blocker evidence exist."
+        },
+        "scope": {
+          "status": "pending",
+          "evidence": "Implementation in progress; scope validation will run before commit."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "RUNTIME-CANDIDATE-AWARE-AUDIT-REFRESH-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2901,3 +2901,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-CANDIDATE-AWARE-AUDIT-POLICY-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
+    branch: fix/career-candidate-aware-audit-policy-1
+    title: "fix(api): accept candidate-aware runtime states for delta planning"
+    name: "Accept candidate-aware runtime states for delta planning"
+    scope:
+      - Allow verified candidate-aware 51-delta planning artifacts to satisfy runtime candidate pool pre-promotion state checks.
+      - Accept promotion_candidate index-state and published_candidate projection/truth state only for candidate-aware rollout dry-run planning.
+      - Require candidate_prep_apply_overlay provenance and write_verified candidate prep evidence.
+      - Preserve strict final published/live acceptance semantics.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/**
+      - backend/app/Console/Commands/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run candidate preparation apply.
+      - Run DB mutation, backfill, rollback, quarantine, or publication expansion.
+      - Deploy backend or frontend.
+      - Touch fap-web.
+      - Weaken final live acceptance or final published-state validation.
+    validation:
+      - php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
+      - php artisan test --filter=Career80RolloutCandidateGate --no-ansi
+      - php artisan test --filter=CareerRuntimeCandidate --no-ansi
+      - php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi
+      - php artisan test --filter=Career80TotalLiveAcceptance --no-ansi
+      - php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Accepts `promotion_candidate` index state and `published_candidate` projection/truth/runtime state only for candidate-aware 51-delta rollout planning.
- Requires verified `candidate_prep_apply_overlay` evidence before stale full-publication audit blockers can be bypassed for the runtime candidate pool.
- Keeps final 80-total live acceptance strict; candidate planning artifacts do not count as final published/live evidence.

## Safety / Non-goals
- No rollout dry-run run.
- No rollout apply run.
- No candidate prep apply run.
- No deploy run.
- No DB mutation.
- No fap-web changes.

## Tests
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan test --filter=Career80RolloutCandidateGate --no-ansi` (No tests found)
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi`
- `php artisan test --filter=Career80TotalLiveAcceptance --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`

## Next step
- `RUNTIME-CANDIDATE-AWARE-AUDIT-REFRESH-1` and runtime pool rerun.
