### PR TITLE
fix(api): repair career delta rollout apply batch authority

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerService.php
+++ b/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerService.php
@@ -53,6 +53,7 @@ final class CareerFullReleaseLedgerService
      */
     public function build(array $additionalSlugs = []): CareerFullReleaseLedger
     {
+        $explicitBatchSlugs = $this->slugSet($additionalSlugs);
         $firstWaveManifest = $this->firstWaveManifestReader->read();
         $firstWaveAuditPayload = $this->safeFirstWaveAudit();
         $firstWaveAudit = $firstWaveAuditPayload['audit'];
@@ -115,16 +116,23 @@ final class CareerFullReleaseLedgerService
             $blockedGovernanceStatus = $this->normalizeNullableString($auditRow['blocked_governance_status'] ?? null);
             $readinessStatus = $this->normalizeNullableString($auditRow['readiness_status'] ?? null);
 
-            $releaseCohort = $this->resolveReleaseCohort(
-                firstWaveMember: (bool) ($tracked['first_wave_member'] ?? false),
-                batchOrigin: $this->normalizeNullableString($tracked['batch_origin'] ?? null),
-                crosswalkMode: $currentCrosswalkMode,
-                readinessStatus: $readinessStatus,
-                blockedGovernanceStatus: $blockedGovernanceStatus,
-                publicIndexState: $publicIndexState,
-                queueRow: $queueRow,
-                resolvedRow: $resolvedRow,
-            );
+            $explicitBatchMember = isset($explicitBatchSlugs[$slug]);
+            $releaseCohort = $explicitBatchMember
+                ? $this->resolveExplicitBatchReleaseCohort(
+                    readinessStatus: $readinessStatus,
+                    blockedGovernanceStatus: $blockedGovernanceStatus,
+                    publicIndexState: $publicIndexState,
+                )
+                : $this->resolveReleaseCohort(
+                    firstWaveMember: (bool) ($tracked['first_wave_member'] ?? false),
+                    batchOrigin: $this->normalizeNullableString($tracked['batch_origin'] ?? null),
+                    crosswalkMode: $currentCrosswalkMode,
+                    readinessStatus: $readinessStatus,
+                    blockedGovernanceStatus: $blockedGovernanceStatus,
+                    publicIndexState: $publicIndexState,
+                    queueRow: $queueRow,
+                    resolvedRow: $resolvedRow,
+                );
 
             $blockerReasons = $this->buildBlockerReasons(
                 releaseCohort: $releaseCohort,
@@ -134,6 +142,7 @@ final class CareerFullReleaseLedgerService
                 publicIndexState: $publicIndexState,
                 queueRow: $queueRow,
                 firstWaveAuditAvailable: $firstWaveAuditAvailable,
+                suppressReviewHandoffReasons: $explicitBatchMember,
             );
 
             $releaseCounts[$releaseCohort]++;
@@ -161,7 +170,7 @@ final class CareerFullReleaseLedgerService
                 indexEligible: $indexEligible,
                 releaseCohort: $releaseCohort,
                 blockerReasons: $blockerReasons,
-                evidenceRefs: $this->buildEvidenceRefs($tracked, $queueRow, $resolvedRow),
+                evidenceRefs: $this->buildEvidenceRefs($tracked, $queueRow, $resolvedRow, $explicitBatchMember),
                 resolvedTargetKind: $this->normalizeNullableString($resolvedRow['resolved_target_kind'] ?? null),
                 resolvedTargetSlug: $this->normalizeNullableString($resolvedRow['resolved_target_slug'] ?? null),
                 reviewQueueStatus: is_array($queueRow) ? 'queued' : null,
@@ -520,6 +529,23 @@ final class CareerFullReleaseLedgerService
         return 'review_needed';
     }
 
+    private function resolveExplicitBatchReleaseCohort(
+        ?string $readinessStatus,
+        ?string $blockedGovernanceStatus,
+        string $publicIndexState,
+    ): string {
+        if (
+            $blockedGovernanceStatus !== null
+            || in_array((string) $readinessStatus, ['blocked_override_eligible', 'blocked_not_safely_remediable'], true)
+        ) {
+            return 'blocked';
+        }
+
+        return $publicIndexState === IndexStateValue::INDEXABLE
+            ? 'public_detail_indexable'
+            : 'public_detail_conservative';
+    }
+
     /**
      * @param  array<string, mixed>  $tracked
      * @param  array<string, mixed>|null  $queueRow
@@ -533,6 +559,7 @@ final class CareerFullReleaseLedgerService
         string $publicIndexState,
         ?array $queueRow,
         bool $firstWaveAuditAvailable,
+        bool $suppressReviewHandoffReasons = false,
     ): array {
         $reasons = [];
 
@@ -540,7 +567,7 @@ final class CareerFullReleaseLedgerService
             $reasons[] = 'blocked_governance';
         }
 
-        if (($tracked['first_wave_member'] ?? false) !== true) {
+        if (! $suppressReviewHandoffReasons && ($tracked['first_wave_member'] ?? false) !== true) {
             $reasons[] = 'full_scope_readiness_authority_not_materialized';
         }
         if (($tracked['first_wave_member'] ?? false) === true && $firstWaveAuditAvailable === false) {
@@ -560,11 +587,11 @@ final class CareerFullReleaseLedgerService
             $reasons[] = 'family_proxy_explorer_only';
         }
 
-        if ($releaseCohort === 'family_handoff') {
+        if ($releaseCohort === 'family_handoff' && ! $suppressReviewHandoffReasons) {
             $reasons[] = 'family_handoff_required';
         }
 
-        if ($releaseCohort === 'review_needed') {
+        if ($releaseCohort === 'review_needed' && ! $suppressReviewHandoffReasons) {
             $reasons[] = 'review_queue_required';
             if (is_array($queueRow)) {
                 foreach ((array) ($queueRow['queue_reason'] ?? []) as $reason) {
@@ -588,9 +615,13 @@ final class CareerFullReleaseLedgerService
      * @param  array<string, mixed>|null  $resolvedRow
      * @return array<string, mixed>
      */
-    private function buildEvidenceRefs(array $tracked, ?array $queueRow, ?array $resolvedRow): array
-    {
-        return [
+    private function buildEvidenceRefs(
+        array $tracked,
+        ?array $queueRow,
+        ?array $resolvedRow,
+        bool $explicitBatchMember = false,
+    ): array {
+        $refs = [
             'tracking_source' => [
                 'kind' => 'career_batch_coverage_set',
                 'path' => 'docs/career/batches/b71x_batch_set.json',
@@ -613,6 +644,16 @@ final class CareerFullReleaseLedgerService
                 'override_applied' => is_array($resolvedRow) ? (bool) ($resolvedRow['override_applied'] ?? false) : false,
             ],
         ];
+
+        if ($explicitBatchMember) {
+            $refs['explicit_rollout_batch'] = [
+                'kind' => 'canonical_rollout_batch_additional_slug_override',
+                'scope' => 'current_explicit_batch_only',
+                'authority_note' => 'Overrides review/family handoff cohort only for a separately approved explicit rollout batch.',
+            ];
+        }
+
+        return $refs;
     }
 
     private function normalizeIndexState(string $state): string
@@ -637,6 +678,24 @@ final class CareerFullReleaseLedgerService
         }
 
         return IndexStateValue::publicFacing($normalized, $indexEligible);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, true>
+     */
+    private function slugSet(array $slugs): array
+    {
+        $set = [];
+
+        foreach ($slugs as $slug) {
+            $normalized = strtolower(trim($slug));
+            if ($normalized !== '') {
+                $set[$normalized] = true;
+            }
+        }
+
+        return $set;
     }
 
     /**

--- a/backend/docs/career/audits/delta_rollout_apply_batch_authority.md
+++ b/backend/docs/career/audits/delta_rollout_apply_batch_authority.md
@@ -1,0 +1,26 @@
+# Career 51-Delta Rollout Apply Batch Authority
+
+This repair documents the authority boundary for explicit Career delta rollout apply verification.
+
+The 51-delta rollout dry-run can use candidate-aware projection artifacts to prove that the selected
+delta slugs are valid pre-promotion candidates. During apply, the executor writes indexed
+`index_state` rows and then rebuilds runtime projection/truth from backend authority before committing.
+
+For slugs already present in the full release ledger tracked set, the normal ledger cohort can still be
+`review_needed` or `family_handoff`. That strict default remains correct outside an explicit rollout
+batch. For a separately approved explicit rollout batch, the current batch slug list is also authority:
+those slugs may override review/family handoff during post-write verification only when they are passed
+as the explicit batch slug set.
+
+Rules:
+
+- No global review queue or family handoff bypass.
+- No final live acceptance weakening.
+- No frontend fallback authority.
+- No DB write is authorized by this document.
+- The override is limited to `CareerFullReleaseLedgerService::build($additionalSlugs)` callers that
+  pass explicit rollout batch slugs.
+- `indexed` batch slugs project as `published`.
+- `promotion_candidate` batch slugs project as `published_candidate` for rollback/candidate verification.
+
+After this repair, any failed apply must still stop. A fresh dry-run is required before retrying apply.

--- a/backend/tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Tests\Unit\Services\Career;
 
 use App\Domain\Career\Publish\CareerFullReleaseLedgerService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -62,5 +66,125 @@ final class CareerFullReleaseLedgerServiceTest extends TestCase
         $this->assertArrayNotHasKey('demand_signal', $sample);
         $this->assertArrayNotHasKey('novelty_score', $sample);
         $this->assertArrayNotHasKey('canonical_conflict', $sample);
+    }
+
+    public function test_explicit_rollout_batch_slugs_can_override_tracked_review_handoff_for_current_batch_only(): void
+    {
+        $service = app(CareerFullReleaseLedgerService::class);
+        $baseLedger = $service->build()->toArray();
+        $baseMember = collect((array) ($baseLedger['members'] ?? []))
+            ->first(static fn (array $member): bool => in_array($member['release_cohort'] ?? '', ['review_needed', 'family_handoff'], true));
+
+        $this->assertIsArray($baseMember);
+        $slug = (string) $baseMember['canonical_slug'];
+
+        $this->materializeIndexedOccupation($slug);
+
+        $strictLedger = $service->build()->toArray();
+        $strictMember = collect((array) ($strictLedger['members'] ?? []))
+            ->firstWhere('canonical_slug', $slug);
+
+        $this->assertContains($strictMember['release_cohort'] ?? null, ['review_needed', 'family_handoff']);
+        $this->assertArrayNotHasKey('explicit_rollout_batch', (array) ($strictMember['evidence_refs'] ?? []));
+
+        $batchLedger = $service->build([$slug])->toArray();
+        $batchMember = collect((array) ($batchLedger['members'] ?? []))
+            ->firstWhere('canonical_slug', $slug);
+
+        $this->assertSame('public_detail_indexable', $batchMember['release_cohort'] ?? null);
+        $this->assertSame('indexed', $batchMember['current_index_state'] ?? null);
+        $this->assertSame('indexable', $batchMember['public_index_state'] ?? null);
+        $this->assertSame([], $batchMember['blocker_reasons'] ?? null);
+        $this->assertSame(
+            'current_explicit_batch_only',
+            data_get($batchMember, 'evidence_refs.explicit_rollout_batch.scope')
+        );
+    }
+
+    public function test_explicit_rollout_batch_candidate_state_projects_as_conservative_candidate_for_tracked_members(): void
+    {
+        $service = app(CareerFullReleaseLedgerService::class);
+        $baseLedger = $service->build()->toArray();
+        $baseMember = collect((array) ($baseLedger['members'] ?? []))
+            ->first(static fn (array $member): bool => in_array($member['release_cohort'] ?? '', ['review_needed', 'family_handoff'], true));
+
+        $this->assertIsArray($baseMember);
+        $slug = (string) $baseMember['canonical_slug'];
+
+        $this->materializeIndexedOccupation($slug, 'promotion_candidate');
+
+        $batchLedger = $service->build([$slug])->toArray();
+        $batchMember = collect((array) ($batchLedger['members'] ?? []))
+            ->firstWhere('canonical_slug', $slug);
+
+        $this->assertSame('public_detail_conservative', $batchMember['release_cohort'] ?? null);
+        $this->assertSame('promotion_candidate', $batchMember['current_index_state'] ?? null);
+        $this->assertSame('trust_limited', $batchMember['public_index_state'] ?? null);
+        $this->assertSame(
+            'current_explicit_batch_only',
+            data_get($batchMember, 'evidence_refs.explicit_rollout_batch.scope')
+        );
+    }
+
+    public function test_explicit_rollout_batch_indexed_tracked_members_project_as_published(): void
+    {
+        $ledgerService = app(CareerFullReleaseLedgerService::class);
+        $baseLedger = $ledgerService->build()->toArray();
+        $baseMember = collect((array) ($baseLedger['members'] ?? []))
+            ->first(static fn (array $member): bool => in_array($member['release_cohort'] ?? '', ['review_needed', 'family_handoff'], true));
+
+        $this->assertIsArray($baseMember);
+        $slug = (string) $baseMember['canonical_slug'];
+
+        $this->materializeIndexedOccupation($slug);
+
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray(
+            $ledgerService->build([$slug])->toArray()
+        );
+        $rows = array_values(array_filter(
+            (array) ($projection['items'] ?? []),
+            static fn (array $item): bool => ($item['slug'] ?? null) === $slug,
+        ));
+
+        $this->assertCount(2, $rows);
+        foreach ($rows as $row) {
+            $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED, $row['runtime_publish_state']);
+            $this->assertTrue($row['detail_route_enabled']);
+            $this->assertTrue($row['release_gate_pass']);
+        }
+    }
+
+    private function materializeIndexedOccupation(string $slug, string $indexState = 'indexed'): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'test-family-'.$indexState,
+            'title_en' => 'Test Family',
+            'title_zh' => '测试族',
+        ]);
+
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'global_standard',
+            'canonical_title_en' => ucwords(str_replace('-', ' ', $slug)),
+            'canonical_title_zh' => $slug,
+            'search_h1_zh' => $slug,
+        ]);
+
+        IndexState::query()->create([
+            'occupation_id' => $occupation->id,
+            'index_state' => $indexState,
+            'index_eligible' => true,
+            'canonical_path' => '/career/jobs/'.$slug,
+            'canonical_target' => null,
+            'reason_codes' => [
+                'canonical_rollout_batch_promotion',
+                'batch_id:batch-001-test',
+            ],
+            'changed_at' => now(),
+        ]);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5291,7 +5291,7 @@
       "repo": "fap-api",
       "branch": "codex/repair-delta-rollout-apply-batch-authority-1",
       "title": "fix(api): repair career delta rollout apply batch authority",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "REPAIR-CANDIDATE-AWARE-AUDIT-POLICY-1"
       ],
@@ -5315,7 +5315,7 @@
         "do not weaken final live acceptance"
       ],
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1392",
       "checks": {
         "authorization": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-14T21:20:00+08:00",
+  "updated_at": "2026-05-14T22:56:43+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -5282,6 +5282,86 @@
       },
       "failure_reason": null,
       "next_pr": "RUNTIME-CANDIDATE-AWARE-AUDIT-REFRESH-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
+    "REPAIR-DELTA-ROLLOUT-APPLY-BATCH-AUTHORITY-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-delta-rollout-apply-batch-authority-1",
+      "title": "fix(api): repair career delta rollout apply batch authority",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-CANDIDATE-AWARE-AUDIT-POLICY-1"
+      ],
+      "scope_type": "delta_rollout_apply_batch_authority_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Expansion/**",
+        "backend/app/Domain/Career/Publish/**",
+        "backend/tests/Unit/Services/Career/**",
+        "backend/tests/Feature/Console/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no production apply retry",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web change",
+        "do not weaken final live acceptance"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-DELTA-ROLLOUT-APPLY-BATCH-AUTHORITY-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR #1391 is merged; SCAN-18 shows the remaining blocker is apply-time batch authority for tracked review/family handoff slugs."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are confined to explicit delta rollout apply batch authority, focused Career release ledger tests, documentation, and authorized PR train metadata."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerFullReleaseLedgerService --no-ansi && php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi && php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi && php artisan test --filter=Career80TotalLiveAcceptance --no-ansi && php artisan test --filter=CareerRuntimeCandidate --no-ansi && php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi && php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi",
+          "evidence": "Focused Career ledger, rollout executor, rollout command, runtime candidate pool, runtime candidate prep, audit, and final live acceptance strictness tests passed."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; no route changes were introduced."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-repair-delta-rollout.sqlite php artisan migrate --force --no-ansi",
+          "evidence": "Full sqlite migration path completed successfully."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "Pint passed after formatting the scoped Career release ledger files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check",
+          "evidence": "No whitespace errors."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full MBTI CI master chain exited 0."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "51-DELTA-ROLLOUT-DRY-RUN-RETRY-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -2943,3 +2943,42 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-DELTA-ROLLOUT-APPLY-BATCH-AUTHORITY-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-CANDIDATE-AWARE-AUDIT-POLICY-1
+    branch: codex/repair-delta-rollout-apply-batch-authority-1
+    title: "fix(api): repair career delta rollout apply batch authority"
+    name: "Fix 51-delta rollout apply batch authority for tracked candidates"
+    scope:
+      - Make explicit rollout batch slugs authority for post-apply projection verification.
+      - Allow tracked review_needed and family_handoff slugs in the current explicit batch to project from indexed state.
+      - Preserve strict default ledger behavior when no explicit rollout batch slugs are supplied.
+      - Preserve strict final live acceptance and public surface verification.
+    allowed_paths:
+      - backend/app/Domain/Career/Expansion/**
+      - backend/app/Domain/Career/Publish/**
+      - backend/tests/Unit/Services/Career/**
+      - backend/tests/Feature/Console/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout apply.
+      - Retry production apply.
+      - Run rollback or quarantine.
+      - Run deploy.
+      - Touch fap-web.
+      - Weaken final live acceptance.
+    validation:
+      - php artisan test --filter=CareerFullReleaseLedgerService --no-ansi
+      - php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi
+      - php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi
+      - php artisan test --filter=Career80TotalLiveAcceptance --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Repairs Career 51-delta rollout apply verification authority for explicit rollout batch slugs already tracked as `review_needed` or `family_handoff`.
- Keeps the override limited to `CareerFullReleaseLedgerService::build($additionalSlugs)` and marks explicit batch evidence as `current_explicit_batch_only`.
- Preserves strict default ledger behavior and final live acceptance; no production apply retry, rollback, quarantine, deploy, or fap-web change is included.

## Validation
- `php artisan test --filter=CareerFullReleaseLedgerService --no-ansi`
- `php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi`
- `php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi`
- `php artisan test --filter=Career80TotalLiveAcceptance --no-ansi`
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-repair-delta-rollout.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Next Step
After merge, rerun a fresh 51-delta rollout dry-run before any apply retry.
