### PR TITLE
fix(api): align career 80 live surface authority

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php
@@ -6,6 +6,11 @@ namespace App\Domain\Career\Publish;
 
 interface CareerRuntimePublishProjectionVisibility
 {
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function itemForSlug(string $slug, string $locale = 'en'): ?array;
+
     public function datasetVisible(string $slug): bool;
 
     public function searchVisible(string $slug): bool;

--- a/backend/app/Http/Resources/Career/CareerJobDetailResource.php
+++ b/backend/app/Http/Resources/Career/CareerJobDetailResource.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\DTO\Career\CareerJobDetailBundle;
 use App\Services\Career\Bundles\CareerJobDisplaySurfaceBuilder;
 use App\Services\Career\Bundles\CareerLocaleIntegrityGate;
+use App\Services\Career\Bundles\CareerRuntimePublishedDisplaySurfaceBuilder;
 use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -32,6 +34,11 @@ final class CareerJobDetailResource extends JsonResource
 
         $requestedLocale = is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN';
         $displaySurface = app(CareerJobDisplaySurfaceBuilder::class)->buildForBundle($bundle, $requestedLocale);
+        $runtimeProjectionItem = $this->runtimePublishedProjectionItem($bundle, $requestedLocale);
+        if ($displaySurface === null && $runtimeProjectionItem !== null) {
+            $displaySurface = app(CareerRuntimePublishedDisplaySurfaceBuilder::class)
+                ->build($bundle, $requestedLocale, $runtimeProjectionItem);
+        }
 
         if ($displaySurface !== null) {
             $payload['display_surface_v1'] = $displaySurface;
@@ -52,6 +59,41 @@ final class CareerJobDetailResource extends JsonResource
         }
 
         return $payload;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function runtimePublishedProjectionItem(CareerJobDetailBundle $bundle, string $locale): ?array
+    {
+        $slug = strtolower(trim((string) ($bundle->identity['canonical_slug'] ?? '')));
+        if ($slug === '') {
+            return null;
+        }
+
+        $item = app(CareerRuntimePublishProjectionVisibility::class)->itemForSlug($slug, $locale);
+        if (! is_array($item)) {
+            return null;
+        }
+
+        $state = (string) (
+            $item['runtime_publish_state']
+            ?? $item['runtime_state']
+            ?? $item['projection_state']
+            ?? $item['state']
+            ?? ''
+        );
+
+        if (
+            $state !== 'published'
+            || ($item['detail_route_enabled'] ?? false) !== true
+            || ($item['robots_indexable'] ?? false) !== true
+            || ($item['release_gate_pass'] ?? false) !== true
+        ) {
+            return null;
+        }
+
+        return $item;
     }
 
     /**

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -75,7 +75,8 @@ final class CareerJobDetailBundleBuilder
         }
 
         if ($occupation->crosswalk_mode === self::DIRECTORY_DRAFT_CROSSWALK_MODE) {
-            return $this->buildDisplayAssetBackedBundle($occupation, $normalizedSlug, $publicLocale);
+            return $this->buildDisplayAssetBackedBundle($occupation, $normalizedSlug, $publicLocale)
+                ?? $this->buildRuntimePublishedFallbackBundle($occupation, $normalizedSlug, $publicLocale);
         }
 
         $snapshot = RecommendationSnapshot::query()
@@ -106,7 +107,8 @@ final class CareerJobDetailBundleBuilder
                 return $displayAssetBackedBundle;
             }
 
-            return $this->buildFromPublishedDocxCareerJob($normalizedSlug, $publicLocale);
+            return $this->buildFromPublishedDocxCareerJob($normalizedSlug, $publicLocale)
+                ?? $this->buildRuntimePublishedFallbackBundle($occupation, $normalizedSlug, $publicLocale);
         }
 
         $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
@@ -259,6 +261,175 @@ final class CareerJobDetailBundleBuilder
                 'compile_refs' => $this->normalizeArray($payload['compile_refs'] ?? []),
             ],
             lifecycleCompanion: $this->feedbackTimelineAuthorityService->buildCompanionForJobSnapshot($snapshot),
+            lifecycleOperational: $lifecycleOperational,
+            shortlistContract: [
+                'enabled' => true,
+                'subject_kind' => 'job_slug',
+                'subject_slug' => $subjectSlug,
+                'source_page_type' => 'career_job_detail',
+                'state_endpoint' => '/api/v0.5/career/shortlist/state',
+                'write_endpoint' => '/api/v0.5/career/shortlist',
+            ],
+            conversionClosure: $conversionClosure,
+        );
+    }
+
+    private function buildRuntimePublishedFallbackBundle(Occupation $occupation, string $requestedSlug, ?string $publicLocale = null): ?CareerJobDetailBundle
+    {
+        $subjectSlug = strtolower((string) $occupation->canonical_slug);
+        if ($subjectSlug === '' || $subjectSlug !== strtolower($requestedSlug)) {
+            return null;
+        }
+
+        if (! $this->runtimeProjectionItemAllowsIndexing($subjectSlug, $publicLocale)) {
+            return null;
+        }
+
+        $canonicalTitleZh = $this->localeIntegrityGate->validZhAuthorityText($occupation->canonical_title_zh);
+        $searchH1Zh = $this->localeIntegrityGate->validZhAuthorityText($occupation->search_h1_zh)
+            ?? $canonicalTitleZh;
+        $scoreBundle = $this->displayAssetBackedScoreBundle();
+        $warnings = [
+            'red_flags' => [],
+            'amber_flags' => ['runtime_published_navigation_shell'],
+            'blocked_claims' => ['compiled_recommendation_claims_unavailable', 'display_asset_claims_unavailable'],
+        ];
+        $lifecycleOperational = $this->lifecycleOperationalSummaryService->buildForSlug($subjectSlug);
+        $conversionClosure = $this->conversionClosureBuilder->buildForSubjectSlug($subjectSlug);
+
+        return new CareerJobDetailBundle(
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $subjectSlug,
+                'entity_level' => $occupation->entity_level,
+                'family_uuid' => $occupation->family_id,
+                'parent_uuid' => $occupation->parent_id,
+            ],
+            localePolicy: [
+                'truth_market' => $occupation->truth_market,
+                'display_market' => $occupation->display_market,
+                'crosswalk_mode' => $occupation->crosswalk_mode,
+                'locale_warning' => 'runtime_published_navigation_shell',
+                'truth_notice_required' => true,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $canonicalTitleZh,
+                'search_h1_zh' => $searchH1Zh,
+                'short_title_en' => $occupation->canonical_title_en,
+                'short_title_zh' => $canonicalTitleZh,
+            ],
+            aliasIndex: $occupation->aliases
+                ->sortBy([
+                    ['lang', 'asc'],
+                    ['register', 'asc'],
+                    ['alias', 'asc'],
+                ])
+                ->values()
+                ->map(static fn ($alias): array => [
+                    'alias' => $alias->alias,
+                    'normalized' => $alias->normalized,
+                    'lang' => $alias->lang,
+                    'register' => $alias->register,
+                    'intent_scope' => $alias->intent_scope,
+                    'target_kind' => $alias->target_kind,
+                    'target_uuid' => $alias->occupation_id ?? $alias->family_id,
+                    'precision' => $alias->precision_score,
+                    'confidence' => $alias->confidence_score,
+                ])
+                ->all(),
+            ontology: [
+                'task_prototype_signature' => is_array($occupation->task_prototype_signature) ? $occupation->task_prototype_signature : [],
+                'structural_stability' => $occupation->structural_stability,
+                'market_semantics_gap' => $occupation->market_semantics_gap,
+                'regulatory_divergence' => $occupation->regulatory_divergence,
+                'toolchain_divergence' => $occupation->toolchain_divergence,
+                'skill_gap_threshold' => $occupation->skill_gap_threshold,
+                'trust_inheritance_scope' => is_array($occupation->trust_inheritance_scope) ? $occupation->trust_inheritance_scope : [],
+                'crosswalks' => $this->crosswalkPayload($occupation),
+            ],
+            truthLayer: [
+                'source_refs' => [],
+                'summary' => null,
+                'median_pay_usd_annual' => null,
+                'jobs_2024' => null,
+                'projected_jobs_2034' => null,
+                'employment_change' => null,
+                'outlook_pct_2024_2034' => null,
+                'outlook_description' => null,
+                'entry_education' => null,
+                'work_experience' => null,
+                'on_the_job_training' => null,
+                'ai_exposure' => null,
+                'ai_rationale' => null,
+                'truth_market' => $occupation->truth_market,
+                'truth_last_reviewed_at' => null,
+            ],
+            contentSections: [],
+            contentBodyMd: null,
+            trustManifest: [
+                'manifest_version' => 'trust_manifest.v1',
+                'entity_id' => $subjectSlug,
+                'page_type' => 'career_job_detail',
+                'page_slug' => $subjectSlug,
+                'content_version' => 'runtime_published_navigation_shell',
+                'data_version' => 'career_runtime_publish_projection',
+                'logic_version' => 'career.protocol.job_detail.runtime_published_shell.v1',
+                'locale_context' => [
+                    'truth_market' => $occupation->truth_market,
+                    'display_market' => $occupation->display_market,
+                ],
+                'methodology' => [
+                    'derivation_policy' => 'runtime_projection_release_gate_shell',
+                    'notes' => ['Runtime projection permits the route and indexing; public copy remains restricted until compiled/detail display authority exists.'],
+                ],
+                'reviewer_status' => 'runtime_projection_release_gate',
+                'reviewed_at' => null,
+                'ai_assistance' => [],
+                'quality' => [
+                    'complete' => false,
+                    'reviewed' => false,
+                    'stale' => false,
+                    'blocked_reasons' => ['compiled_recommendation_snapshot_missing', 'display_asset_claims_unavailable'],
+                ],
+                'last_substantive_update_at' => null,
+                'next_review_due_at' => null,
+            ],
+            scoreBundle: $scoreBundle,
+            whiteBoxScores: $this->whiteBoxScorePayloadBuilder->build($scoreBundle, $warnings),
+            warnings: $warnings,
+            claimPermissions: [
+                'allow_strong_claim' => false,
+                'allow_salary_comparison' => false,
+                'allow_ai_strategy' => false,
+                'allow_transition_recommendation' => false,
+                'allow_cross_market_pay_copy' => false,
+                'reason_codes' => ['runtime_published_shell_no_strong_claims'],
+            ],
+            integritySummary: [
+                'integrity_state' => 'runtime_published_shell',
+                'critical_missing_fields' => ['compiled_recommendation_snapshot', 'display_asset_claims'],
+                'confidence_cap' => 50,
+                'degradation_factor' => 1,
+            ],
+            seoContract: $this->buildRuntimeProjectionSeoContract($occupation, $publicLocale),
+            provenanceMeta: [
+                'content_version' => 'runtime_published_navigation_shell',
+                'data_version' => 'career_runtime_publish_projection',
+                'logic_version' => 'career.protocol.job_detail.runtime_published_shell.v1',
+                'compiler_version' => null,
+                'compiled_at' => null,
+                'truth_metric_id' => null,
+                'trust_manifest_id' => null,
+                'index_state_id' => null,
+                'compile_run_id' => null,
+                'import_run_id' => null,
+                'source_trace_id' => null,
+                'compile_refs' => [
+                    'runtime_publish_projection' => 'release_gate_pass',
+                ],
+            ],
+            lifecycleCompanion: [],
             lifecycleOperational: $lifecycleOperational,
             shortlistContract: [
                 'enabled' => true,
@@ -789,7 +960,7 @@ final class CareerJobDetailBundleBuilder
     private function buildDisplayAssetBackedSeoContract(Occupation $occupation, ?string $publicLocale = null): array
     {
         $canonicalPath = $this->canonicalPathForPublicLocale($publicLocale, (string) $occupation->canonical_slug);
-        $indexEligible = $this->runtimeProjectionAllowsIndexing((string) $occupation->canonical_slug);
+        $indexEligible = $this->runtimeProjectionVisibilityAllowsIndexing((string) $occupation->canonical_slug);
         $indexState = $indexEligible ? IndexStateValue::INDEXABLE : IndexStateValue::TRUST_LIMITED;
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
@@ -818,11 +989,66 @@ final class CareerJobDetailBundleBuilder
         ];
     }
 
-    private function runtimeProjectionAllowsIndexing(string $slug): bool
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildRuntimeProjectionSeoContract(Occupation $occupation, ?string $publicLocale = null): array
+    {
+        $canonicalPath = $this->canonicalPathForPublicLocale($publicLocale, (string) $occupation->canonical_slug);
+        $indexEligible = $this->runtimeProjectionItemAllowsIndexing((string) $occupation->canonical_slug, $publicLocale);
+        $indexState = $indexEligible ? IndexStateValue::INDEXABLE : IndexStateValue::TRUST_LIMITED;
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_job_detail_runtime_published_shell',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => $indexState,
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalPath,
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => $indexEligible
+                ? ['runtime_publish_projection', 'release_gate_pass', 'runtime_published_navigation_shell']
+                : ['runtime_projection_noindex'],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    private function runtimeProjectionVisibilityAllowsIndexing(string $slug): bool
     {
         return $this->runtimePublishProjection->detailRouteEnabled($slug)
             && $this->runtimePublishProjection->robotsIndexable($slug)
             && $this->runtimePublishProjection->releaseGatePass($slug);
+    }
+
+    private function runtimeProjectionItemAllowsIndexing(string $slug, ?string $publicLocale = null): bool
+    {
+        $item = $this->runtimePublishProjection->itemForSlug($slug, $publicLocale ?? 'en');
+        $state = is_array($item)
+            ? (string) (
+                $item['runtime_publish_state']
+                ?? $item['runtime_state']
+                ?? $item['projection_state']
+                ?? $item['state']
+                ?? ''
+            )
+            : '';
+
+        return is_array($item)
+            && $state === 'published'
+            && ($item['detail_route_enabled'] ?? false) === true
+            && ($item['robots_indexable'] ?? false) === true
+            && ($item['release_gate_pass'] ?? false) === true;
     }
 
     private function hasDisplayAssetBackedAuthority(Occupation $occupation): bool

--- a/backend/app/Services/Career/Bundles/CareerRuntimePublishedDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRuntimePublishedDisplaySurfaceBuilder.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerJobDetailBundle;
+
+final class CareerRuntimePublishedDisplaySurfaceBuilder
+{
+    private const COMPONENT_ORDER = [
+        'breadcrumb',
+        'hero',
+        'fermat_decision_card',
+        'primary_cta',
+        'career_snapshot_primary_locale',
+        'career_snapshot_secondary_locale',
+        'fit_decision_checklist',
+        'riasec_fit_block',
+        'personality_fit_block',
+        'definition_block',
+        'responsibilities_block',
+        'work_context_block',
+        'market_signal_card',
+        'adjacent_career_comparison_table',
+        'ai_impact_table',
+        'career_risk_cards',
+        'contract_project_risk_block',
+        'next_steps_block',
+        'faq_block',
+        'related_next_pages',
+        'source_card',
+        'review_validity_card',
+        'boundary_notice',
+        'final_cta',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $projectionItem
+     * @return array<string, mixed>
+     */
+    public function build(CareerJobDetailBundle $bundle, string $locale, array $projectionItem): array
+    {
+        $publicLocale = $this->publicLocale($locale);
+        $isZh = $publicLocale === 'zh-CN';
+        $slug = strtolower((string) ($bundle->identity['canonical_slug'] ?? ''));
+        $titleEn = trim((string) ($bundle->titles['canonical_en'] ?? $slug));
+        $titleZh = trim((string) ($bundle->titles['canonical_zh'] ?? ''));
+        $title = $isZh
+            ? ($titleZh !== '' ? $titleZh : $titleEn.' 职业路径')
+            : ($titleEn !== '' ? $titleEn : str($slug)->replace('-', ' ')->title()->toString());
+        $pathPrefix = $isZh ? '/zh' : '/en';
+        $path = $pathPrefix.'/career/jobs/'.$slug;
+        $testPath = $pathPrefix.'/tests/holland-career-interest-test-riasec';
+
+        return [
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'subject' => [
+                'occupation_uuid' => (string) ($bundle->identity['occupation_uuid'] ?? ''),
+                'canonical_slug' => $slug,
+                'soc_code' => null,
+                'onet_code' => null,
+            ],
+            'available_locales' => [$publicLocale],
+            'claim_permissions' => [
+                'integrity_state' => 'restricted',
+                'allow_strong_claim' => false,
+                'allow_ai_strategy' => false,
+                'allow_salary_comparison' => false,
+                'allow_market_signal' => false,
+                'allow_local_proxy_wage' => false,
+                'blocked_claims' => ['runtime_published_shell_no_strong_claims'],
+                'warnings' => ['Runtime projection marks this locale published; visible copy remains a restricted navigation shell.'],
+                'evidence_basis' => [
+                    'runtime_projection' => 'release_gate_pass',
+                    'surface_authority' => 'runtime_published_shell',
+                ],
+            ],
+            'page' => [
+                'locale' => $publicLocale,
+                'content' => $this->pageContent($slug, $title, $path, $testPath, $isZh),
+            ],
+            'component_order' => self::COMPONENT_ORDER,
+            'sources' => [
+                [
+                    'key' => 'runtime_publish_projection',
+                    'label' => 'Career runtime publish projection',
+                    'usage' => 'Runtime publication authority for this locale.',
+                ],
+            ],
+            'structured_data_from_visible_content' => [],
+            'implementation_contract' => [
+                'authority' => 'runtime_publish_projection',
+                'projection_state' => $projectionItem['runtime_publish_state'] ?? $projectionItem['state'] ?? null,
+                'release_gate_pass' => (bool) ($projectionItem['release_gate_pass'] ?? false),
+                'surface_policy' => 'restricted_runtime_published_navigation_shell',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pageContent(string $slug, string $title, string $path, string $testPath, bool $isZh): array
+    {
+        return [
+            'path' => $path,
+            'breadcrumb' => [],
+            'hero' => [
+                'h1' => $title,
+                'title' => $title,
+                'quick_answer' => $isZh
+                    ? $title.' 已进入公开职业路径。先用兴趣结构判断它是否值得继续比较。'
+                    : $title.' is available as a public career path. Start with interest fit before comparing options.',
+            ],
+            'primary_cta' => [
+                'label' => $isZh ? '测量我的职业兴趣' : 'Measure my career interests',
+                'href' => $testPath,
+                'test_slug' => 'holland-career-interest-test-riasec',
+                'subject_key' => $slug,
+                'subject_kind' => 'career_job',
+                'entry_surface' => 'career_job_detail',
+                'target_action' => 'start_riasec_test',
+                'source_page_type' => 'career_job_detail',
+            ],
+            'fermat_decision_card' => [
+                'title' => $isZh ? '先判断匹配，再比较职业' : 'Check fit before comparing careers',
+                'summary' => $isZh
+                    ? '这页只提供公开路径入口和兴趣测试导航，不提供未验证的薪资、录用或发展承诺。'
+                    : 'This page provides public navigation and interest-fit entry points without unverified salary, hiring, or outcome promises.',
+                'caveat' => $isZh ? '最终判断需要结合你的兴趣、能力和现实约束。' : 'Final decisions need your interests, abilities, and real constraints.',
+            ],
+            'definition_block' => $isZh
+                ? $title.' 是一个职业方向页面，用于连接职业探索和兴趣测评。'
+                : $title.' is a career direction page connecting career exploration with interest assessment.',
+            'fit_decision_checklist' => [
+                'checks' => [
+                    [
+                        'title' => $isZh ? '兴趣结构' : 'Interest structure',
+                        'question' => $isZh ? '你的 RIASEC 兴趣是否支持继续研究这条路径？' : 'Does your RIASEC profile support exploring this path?',
+                        'note' => $isZh ? '先测兴趣，再看具体职业证据。' : 'Assess interests before reading detailed career evidence.',
+                    ],
+                ],
+            ],
+            'riasec_fit_block' => [
+                'body' => [$isZh ? 'RIASEC 结果用于职业探索，不是录用或收入保证。' : 'RIASEC results guide exploration; they do not guarantee hiring or income.'],
+            ],
+            'next_steps_block' => [
+                'steps' => [
+                    [
+                        'title' => $isZh ? '开始兴趣测试' : 'Start the interest test',
+                        'items' => [$isZh ? '保存结果后再比较相邻职业。' : 'Save your result before comparing adjacent careers.'],
+                    ],
+                ],
+            ],
+            'faq_block' => [
+                'items' => [
+                    [
+                        'question' => $isZh ? '这页是否代表强推荐？' : 'Is this page a strong recommendation?',
+                        'answer' => $isZh ? '不是。它是职业探索入口，强推荐需要更多个人数据。' : 'No. It is an exploration entry point; strong recommendations need more personal data.',
+                    ],
+                ],
+            ],
+            'boundary_notice' => [
+                'body' => $isZh ? '本页面不提供医学、法律、财务或录用保证。' : 'This page does not provide medical, legal, financial, or hiring guarantees.',
+            ],
+            'final_cta' => [
+                'label' => $isZh ? '开始 RIASEC 测试' : 'Start the RIASEC test',
+                'href' => $testPath,
+            ],
+        ];
+    }
+
+    private function publicLocale(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh-CN' : 'en';
+    }
+}

--- a/backend/docs/career/audits/80_live_surface_authority.md
+++ b/backend/docs/career/audits/80_live_surface_authority.md
@@ -1,0 +1,34 @@
+# Career 80 Live Surface Authority
+
+## Purpose
+
+The 80-total live acceptance path uses runtime projection, runtime truth, and release-gate evidence as the final backend authority for public Career job detail routes.
+
+SCAN-20 found that the backend authority layer had already marked 160 locale rows as published and release-gate passing, but the live API surface still failed two ways:
+
+- some runtime-published zh locale rows were downgraded to `locale_not_ready`, which emitted `noindex` and omitted the RIASEC CTA surface;
+- a runtime-published occupation without a compiled/detail display asset returned 404.
+
+## Policy
+
+Runtime-published surface authority is allowed only when the locale-specific runtime projection item is explicit and all of these fields pass:
+
+- `runtime_publish_state` / `runtime_state` / `projection_state` is `published`;
+- `detail_route_enabled=true`;
+- `robots_indexable=true`;
+- `release_gate_pass=true`.
+
+When the normal display surface is unavailable for that locale, the API may emit a restricted `display_surface_v1` navigation shell. The shell is not a strong claim surface:
+
+- `allow_strong_claim=false`;
+- salary, AI strategy, and transition recommendation claims remain blocked;
+- provenance is marked as `runtime_publish_projection`;
+- the CTA remains attributed to `career_job_detail` and the explicit job slug.
+
+## Non-goals
+
+- No DB mutation.
+- No rollout apply.
+- No rollback or quarantine.
+- No fap-web change.
+- No weakening of final live acceptance or published-state validation.

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -338,7 +338,7 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('seo_contract.canonical_path', '/zh/career/jobs/display-backed-public-canonical');
     }
 
-    public function test_zh_display_asset_backed_bundle_holds_english_surface_without_blocking_en(): void
+    public function test_zh_display_asset_backed_bundle_uses_runtime_published_shell_when_locale_surface_is_english(): void
     {
         $this->configurePublicResolutionPlan([
             ['slug' => 'data-scientists', 'status' => 'already_imported_validated'],
@@ -363,17 +363,54 @@ final class CareerJobDetailApiTest extends TestCase
         $this->getJson('/api/v0.5/career/jobs/data-scientists?locale=zh-CN')
             ->assertOk()
             ->assertJsonPath('titles.canonical_zh', '展示资产职业')
-            ->assertJsonPath('seo_contract.index_state', 'locale_not_ready')
-            ->assertJsonPath('seo_contract.index_eligible', false)
-            ->assertJsonPath('seo_contract.robots_policy', 'noindex,follow')
-            ->assertJsonPath('locale_policy.locale_warning', 'zh_locale_not_ready')
-            ->assertJsonMissingPath('display_surface_v1');
+            ->assertJsonPath('seo_contract.index_state', 'indexable')
+            ->assertJsonPath('seo_contract.index_eligible', true)
+            ->assertJsonPath('seo_contract.robots_policy', 'index,follow')
+            ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN')
+            ->assertJsonPath('display_surface_v1.implementation_contract.authority', 'runtime_publish_projection')
+            ->assertJsonPath('display_surface_v1.claim_permissions.integrity_state', 'restricted');
 
         $this->getJson('/api/v0.5/career/jobs/data-scientists?locale=en')
             ->assertOk()
             ->assertJsonPath('seo_contract.index_state', 'indexable')
             ->assertJsonPath('display_surface_v1.page.locale', 'en')
             ->assertJsonPath('display_surface_v1.page.content.hero.title', 'Data scientist career fit');
+    }
+
+    public function test_runtime_published_occupation_without_display_or_docx_asset_returns_restricted_public_shell(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'agricultural-workers-all-other', 'status' => 'already_imported_validated'],
+        ]);
+
+        $this->createDisplayAssetBackedOccupation('agricultural-workers-all-other');
+
+        $this->getJson('/api/v0.5/career/jobs/agricultural-workers-all-other?locale=en')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'agricultural-workers-all-other')
+            ->assertJsonPath('trust_manifest.logic_version', 'career.protocol.job_detail.runtime_published_shell.v1')
+            ->assertJsonPath('seo_contract.canonical_path', '/en/career/jobs/agricultural-workers-all-other')
+            ->assertJsonPath('seo_contract.index_state', 'indexable')
+            ->assertJsonPath('seo_contract.robots_policy', 'index,follow')
+            ->assertJsonPath('display_surface_v1.page.locale', 'en')
+            ->assertJsonPath('display_surface_v1.implementation_contract.authority', 'runtime_publish_projection')
+            ->assertJsonPath('display_surface_v1.page.content.primary_cta.test_slug', 'holland-career-interest-test-riasec')
+            ->assertJsonPath('display_surface_v1.page.content.primary_cta.target_action', 'start_riasec_test')
+            ->assertJsonPath('display_surface_v1.page.content.primary_cta.subject_key', 'agricultural-workers-all-other');
+    }
+
+    public function test_runtime_shell_does_not_bypass_projection_release_gate(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'blocked-runtime-shell', 'status' => 'requires_governance_review'],
+        ]);
+
+        $this->createDisplayAssetBackedOccupation('blocked-runtime-shell');
+
+        $this->getJson('/api/v0.5/career/jobs/blocked-runtime-shell?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
     /**
@@ -393,6 +430,7 @@ final class CareerJobDetailApiTest extends TestCase
         $detailRouteEnabled = [];
         $robotsIndexable = [];
         $releaseGatePass = [];
+        $items = [];
         foreach ($rows as $row) {
             $slug = strtolower(trim((string) ($row['slug'] ?? '')));
             if ($slug === '') {
@@ -404,6 +442,18 @@ final class CareerJobDetailApiTest extends TestCase
             $detailRouteEnabled[$slug] = $enabled;
             $robotsIndexable[$slug] = $enabled;
             $releaseGatePass[$slug] = $enabled;
+            foreach (['en', 'zh'] as $locale) {
+                $items[$slug.'|'.$locale] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'dataset_visible' => $enabled,
+                    'search_visible' => $enabled,
+                    'detail_route_enabled' => $enabled,
+                    'robots_indexable' => $enabled,
+                    'release_gate_pass' => $enabled,
+                    'runtime_publish_state' => $enabled ? 'published' : 'blocked',
+                ];
+            }
         }
 
         $this->app->instance(
@@ -415,6 +465,7 @@ final class CareerJobDetailApiTest extends TestCase
                 detailRouteEnabled: $detailRouteEnabled,
                 robotsIndexable: $robotsIndexable,
                 releaseGatePass: $releaseGatePass,
+                items: $items,
             ),
         );
     }

--- a/backend/tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php
+++ b/backend/tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php
@@ -15,6 +15,7 @@ final class CareerRuntimePublishProjectionVisibilityFixture implements CareerRun
      * @param  array<string, bool>  $robotsIndexable
      * @param  array<string, bool>  $releaseGatePass
      * @param  array<string, bool>  $familyHubLive
+     * @param  array<string, array<string, mixed>>  $items
      */
     public function __construct(
         private readonly bool $defaultDatasetVisible = true,
@@ -29,7 +30,22 @@ final class CareerRuntimePublishProjectionVisibilityFixture implements CareerRun
         private readonly array $robotsIndexable = [],
         private readonly array $releaseGatePass = [],
         private readonly array $familyHubLive = [],
+        private readonly array $items = [],
     ) {}
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function itemForSlug(string $slug, string $locale = 'en'): ?array
+    {
+        $normalizedSlug = $this->normalizeSlug($slug);
+        $normalizedLocale = $this->normalizeLocale($locale);
+
+        return $this->items[$normalizedSlug.'|'.$normalizedLocale]
+            ?? $this->items[$normalizedSlug.'|en']
+            ?? $this->items[$normalizedSlug]
+            ?? null;
+    }
 
     public function datasetVisible(string $slug): bool
     {
@@ -64,5 +80,10 @@ final class CareerRuntimePublishProjectionVisibilityFixture implements CareerRun
     private function normalizeSlug(string $slug): string
     {
         return strtolower(trim($slug));
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -888,6 +888,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php',
             'backend/app/Http/Resources/Career/CareerJobDetailResource.php',
+            'backend/app/Services/Career/Bundles/CareerRuntimePublishedDisplaySurfaceBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
             'backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php',
             'backend/app/Services/Cms/CareerJobSeoService.php',
@@ -1743,6 +1744,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php',
             'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerRuntimePublishedDisplaySurfaceBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
             'backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php',
             'backend/app/Http/Resources/Career/CareerJobDetailResource.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T00:29:40+08:00",
+  "updated_at": "2026-05-15T01:41:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -5421,6 +5421,64 @@
       },
       "failure_reason": null,
       "next_pr": "POST-ROLLOUT-RUNTIME-PROJECTION-REFRESH-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
+    "REPAIR-80-LIVE-SURFACE-AUTHORITY-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-80-live-surface-authority-1",
+      "title": "fix(api): align career 80 live surface with runtime authority",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-POST-ROLLOUT-RUNTIME-PROJECTION-AUTHORITY-1"
+      ],
+      "scope_type": "career_80_live_surface_authority_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Publish/**",
+        "backend/app/Http/Resources/Career/**",
+        "backend/app/Services/Career/Bundles/**",
+        "backend/tests/Feature/Career/**",
+        "backend/tests/Fixtures/Career/**",
+        "backend/tests/Unit/Services/Career/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout apply",
+        "no production DB mutation",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web change",
+        "do not weaken final live acceptance",
+        "do not mark restricted runtime shells as human reviewed or strong-claim surfaces"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-80-LIVE-SURFACE-AUTHORITY-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR #1393 is merged/deployed into the current codebase; SCAN-20 shows remaining blockers are live API surface authority, noindex/CTA omissions, and one runtime-published 404."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": "Career detail API, display surface, bundle builder, runtime projection, ledger, live acceptance tests, route:list, sqlite migrate, Pint, git diff --check, and backend/scripts/ci_verify_mbti.sh passed locally."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to Career runtime publish visibility, Career job detail API/bundle surface authority, tests, audit docs, and authorized train metadata."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "POST-80-LIVE-ACCEPTANCE-RERUN-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -3022,3 +3022,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-80-LIVE-SURFACE-AUTHORITY-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-POST-ROLLOUT-RUNTIME-PROJECTION-AUTHORITY-1
+    branch: fix/career-80-live-surface-authority-1
+    title: "fix(api): align career 80 live surface with runtime authority"
+    name: "Repair Career 80 live surface authority after successful rollout"
+    scope:
+      - Align Career job detail API live surfaces with locale-specific runtime-published projection authority.
+      - Emit a restricted runtime-published display surface shell only when runtime projection explicitly passes route, robots, and release gate for the locale.
+      - Allow runtime-published occupations without compiled/detail display assets to return a restricted public shell instead of 404.
+      - Preserve strict final live acceptance and avoid strong claims on restricted shells.
+    allowed_paths:
+      - backend/app/Domain/Career/Publish/**
+      - backend/app/Http/Resources/Career/**
+      - backend/app/Services/Career/Bundles/**
+      - backend/tests/Feature/Career/**
+      - backend/tests/Fixtures/Career/**
+      - backend/tests/Unit/Services/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout apply.
+      - Run production DB mutation.
+      - Run rollback or quarantine.
+      - Run deploy.
+      - Touch fap-web.
+      - Weaken final live acceptance.
+      - Mark restricted runtime shells as human reviewed or strong-claim surfaces.
+    validation:
+      - php artisan test tests/Feature/Career/CareerJobDetailApiTest.php --no-ansi
+      - php artisan test tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php --no-ansi
+      - php artisan test --filter=CareerValidateCanonicalBatchLiveAcceptance --no-ansi
+      - php artisan test --filter=Career80TotalLiveAcceptance --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- aligns Career job detail live API surfaces with locale-specific runtime-published projection authority
- emits a restricted runtime-published `display_surface_v1` shell only when runtime projection explicitly passes route, robots, state, and release gate for the locale
- lets runtime-published occupations without compiled/detail display assets return a restricted public shell instead of 404
- documents the Career 80 live surface authority policy and registers the PR-train item

## Non-goals
- no deploy
- no DB mutation
- no rollout/apply/backfill/rollback/quarantine
- no fap-web changes
- does not weaken final live acceptance or mark restricted shells as strong-claim/human-reviewed surfaces

## Tests
- `php artisan test tests/Feature/Career/CareerJobDetailApiTest.php --no-ansi`
- `php artisan test tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php --no-ansi`
- `php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi`
- `php artisan test --filter=CareerValidateCanonicalBatchLiveAcceptance --no-ansi`
- `php artisan test --filter=Career80TotalLiveAcceptance --no-ansi`
- `php artisan test --filter=CareerFullReleaseLedgerService --no-ansi`
- `php artisan test --filter=CareerRuntimePublishProjection --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh`
