### PR TITLE
fix(api): add progressive career cohort delta planner

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalProgressiveCohortDelta.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalProgressiveCohortDelta.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerProgressiveCohortDeltaPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerPlanCanonicalProgressiveCohortDelta extends Command
+{
+    protected $signature = 'career:plan-canonical-progressive-cohort-delta
+        {--current-closeout= : Required accepted current cohort closeout JSON artifact}
+        {--current-slugs= : Optional accepted current public slug artifact; defaults to closeout total_slugs_path}
+        {--target-selection= : Required target cohort selection/readiness JSON artifact}
+        {--target= : Required target public total}
+        {--locales=en,zh : Comma-separated locale list}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for progressive cohort delta plan JSON}';
+
+    protected $description = 'Plan read-only progressive Career cohort target deltas such as 80 to 300, 300 to 800, and 800 to 2786.';
+
+    public function handle(): int
+    {
+        try {
+            $currentCloseoutPath = $this->requiredOption('current-closeout');
+            $targetSelectionPath = $this->requiredOption('target-selection');
+            $target = $this->positiveIntOption('target');
+            $currentCloseout = $this->readJson($currentCloseoutPath, 'current_closeout');
+            $currentSlugsPath = $this->pathOption('current-slugs')
+                ?? $this->pathFromCloseout($currentCloseout, 'total_slugs_path');
+
+            $result = app(CareerProgressiveCohortDeltaPlanner::class)->plan(
+                currentCloseout: $currentCloseout,
+                currentPublicSlugs: $this->readSlugList($currentSlugsPath, 'current_slug'),
+                targetSelection: $this->readJson($targetSelectionPath, 'target_selection'),
+                targetPublicTotal: $target,
+                locales: $this->localesOption(),
+            )->toArray();
+
+            return $this->finish($result, ($result['status'] ?? null) === 'pass' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => CareerProgressiveCohortDeltaPlanner::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                ]],
+            ], self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
+    private function positiveIntOption(string $name): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function localesOption(): array
+    {
+        $raw = trim((string) ($this->option('locales') ?? 'en,zh'));
+        $locales = array_values(array_filter(array_map(
+            static fn (string $locale): string => strtolower(trim($locale)),
+            explode(',', $raw),
+        )));
+
+        if ($locales === []) {
+            throw new RuntimeException('locales_missing');
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function pathFromCloseout(array $payload, string $key): string
+    {
+        $path = $payload[$key] ?? null;
+        if (! is_string($path) || trim($path) === '') {
+            throw new RuntimeException($key.'_missing');
+        }
+
+        return trim($path);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException($kind.'_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException($kind.'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readSlugList(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        $trimmed = trim($contents);
+        if ($trimmed === '') {
+            throw new RuntimeException($kind.'_artifact_empty');
+        }
+
+        if (str_starts_with($trimmed, '[') || str_starts_with($trimmed, '{')) {
+            try {
+                $decoded = json_decode($trimmed, true, flags: JSON_THROW_ON_ERROR);
+            } catch (Throwable) {
+                throw new RuntimeException($kind.'_artifact_json_invalid');
+            }
+
+            $slugs = is_array($decoded) && array_is_list($decoded)
+                ? $decoded
+                : (is_array($decoded) ? ($decoded['slugs'] ?? $decoded['current_public_slugs'] ?? null) : null);
+            if (! is_array($slugs) || ! array_is_list($slugs)) {
+                throw new RuntimeException($kind.'_artifact_shape_invalid');
+            }
+
+            return array_values(array_map(static fn (mixed $slug): string => (string) $slug, $slugs));
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (string $line): string => trim($line),
+            preg_split('/\\R/', $contents) ?: [],
+        )));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $output = $this->option('output');
+        if (is_string($output) && trim($output) !== '') {
+            File::put(trim($output), json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            $this->line('status='.($payload['status'] ?? 'unknown'));
+            $this->line('current_public_total='.(string) ($payload['current_public_total'] ?? 0));
+            $this->line('target_public_total='.(string) ($payload['target_public_total'] ?? 0));
+            $this->line('delta_slug_count='.(string) ($payload['delta_slug_count'] ?? 0));
+            $this->line('expected_delta_locale_rows='.(string) ($payload['expected_delta_locale_rows'] ?? 0));
+        }
+
+        return $exitCode;
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $key = strtolower(trim($message));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $key) ?? 'progressive_cohort_delta_error';
+        $key = trim($key, '_');
+
+        return $key === '' ? 'progressive_cohort_delta_error' : $key;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -47,6 +47,7 @@ use App\Console\Commands\CareerPlanCanonical80CohortReadiness;
 use App\Console\Commands\CareerPlanCanonical80RuntimeCandidatePool;
 use App\Console\Commands\CareerPlanCanonical80TargetDelta;
 use App\Console\Commands\CareerPlanCanonicalDeltaRolloutGate;
+use App\Console\Commands\CareerPlanCanonicalProgressiveCohortDelta;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerPlanCanonicalRuntimeArtifactRefresh;
 use App\Console\Commands\CareerPlanCanonicalRuntimeCandidatePrep;
@@ -216,6 +217,7 @@ class Kernel extends ConsoleKernel
         CareerPlanCanonical80RuntimeCandidatePool::class,
         CareerPlanCanonical80TargetDelta::class,
         CareerPlanCanonicalDeltaRolloutGate::class,
+        CareerPlanCanonicalProgressiveCohortDelta::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
         CareerPlanCanonicalRuntimeArtifactRefresh::class,
         CareerPlanCanonicalRuntimeCandidatePrep::class,

--- a/backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanResult.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerProgressiveCohortDeltaPlanResult
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(
+        private readonly array $payload,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+
+    public function passed(): bool
+    {
+        return ($this->payload['status'] ?? null) === 'pass';
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanner.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use RuntimeException;
+
+final class CareerProgressiveCohortDeltaPlanner
+{
+    public const SCHEMA_VERSION = 'career_progressive_cohort_delta_plan.v1';
+
+    /**
+     * @param  array<string, mixed>  $currentCloseout
+     * @param  list<string>  $currentPublicSlugs
+     * @param  array<string, mixed>  $targetSelection
+     * @param  list<string>  $locales
+     */
+    public function plan(
+        array $currentCloseout,
+        array $currentPublicSlugs,
+        array $targetSelection,
+        int $targetPublicTotal,
+        array $locales = ['en', 'zh'],
+    ): CareerProgressiveCohortDeltaPlanResult {
+        if ($targetPublicTotal < 1) {
+            throw new RuntimeException('target_public_total_invalid');
+        }
+
+        $locales = $this->normalizedLocales($locales);
+        $currentPublicSlugs = $this->normalizedUniqueSlugs($currentPublicSlugs, 'current_public_slug');
+        $targetSlugs = $this->targetSlugs($targetSelection);
+        $deltaSlugs = array_values(array_diff($targetSlugs, $currentPublicSlugs));
+        sort($deltaSlugs);
+        $missingCurrentFromTarget = array_values(array_diff($currentPublicSlugs, $targetSlugs));
+        sort($missingCurrentFromTarget);
+        $overlap = array_values(array_intersect($currentPublicSlugs, $deltaSlugs));
+        sort($overlap);
+
+        $blockers = $this->blockers(
+            currentCloseout: $currentCloseout,
+            currentPublicSlugs: $currentPublicSlugs,
+            targetSlugs: $targetSlugs,
+            targetPublicTotal: $targetPublicTotal,
+            deltaSlugs: $deltaSlugs,
+            missingCurrentFromTarget: $missingCurrentFromTarget,
+            overlap: $overlap,
+        );
+        $pass = $blockers === [];
+
+        return new CareerProgressiveCohortDeltaPlanResult([
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $pass ? 'pass' : 'blocked',
+            'read_only' => true,
+            'writes_database' => false,
+            'current_public_total' => count($currentPublicSlugs),
+            'target_public_total' => $targetPublicTotal,
+            'delta_slug_count' => count($deltaSlugs),
+            'locale_count' => count($locales),
+            'locales' => $locales,
+            'expected_delta_locale_rows' => count($deltaSlugs) * count($locales),
+            'expected_total_locale_rows' => $targetPublicTotal * count($locales),
+            'current_public_slugs' => $currentPublicSlugs,
+            'target_public_slugs' => $targetSlugs,
+            'delta_promotion_slugs' => $deltaSlugs,
+            'recommended_rollout_delta_slugs' => $deltaSlugs,
+            'validation' => [
+                'current_plus_delta_count' => count($currentPublicSlugs) + count($deltaSlugs),
+                'target_selection_count' => count($targetSlugs),
+                'current_target_overlap_count' => count(array_intersect($currentPublicSlugs, $targetSlugs)),
+                'current_missing_from_target_count' => count($missingCurrentFromTarget),
+                'current_delta_overlap_count' => count($overlap),
+                'target_total_validated' => count($targetSlugs) === $targetPublicTotal,
+                'delta_count_validated' => count($deltaSlugs) === ($targetPublicTotal - count($currentPublicSlugs)),
+            ],
+            'blockers' => $blockers,
+            'rollout' => [
+                'delta_manifest_allowed' => $pass,
+                'rollout_dry_run_allowed' => false,
+                'apply_allowed' => false,
+                'reason' => 'progressive target-delta planning only; rollout dry-run and apply require separate gates',
+            ],
+            'next_required_action' => $pass ? 'RUNTIME_CANDIDATE_PREP_PLAN_READ_ONLY' : 'FIX_PROGRESSIVE_COHORT_DELTA_BLOCKERS',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $selection
+     * @return list<string>
+     */
+    private function targetSlugs(array $selection): array
+    {
+        $slugs = data_get($selection, 'selection.slugs');
+        if (! is_array($slugs)) {
+            $slugs = $selection['selected_slugs'] ?? $selection['slugs'] ?? null;
+        }
+
+        if (! is_array($slugs)) {
+            $rows = $selection['rows'] ?? $selection['candidates'] ?? null;
+            if (is_array($rows)) {
+                $slugs = [];
+                foreach ($rows as $row) {
+                    if (! is_array($row)) {
+                        continue;
+                    }
+                    if (($row['selected'] ?? true) === false && ($row['eligible'] ?? true) === false) {
+                        continue;
+                    }
+                    $slugs[] = $row['slug'] ?? null;
+                }
+            }
+        }
+
+        if (! is_array($slugs) || ! array_is_list($slugs)) {
+            throw new RuntimeException('target_selection_slugs_missing');
+        }
+
+        return $this->normalizedUniqueSlugs($slugs, 'target_selection_slug');
+    }
+
+    /**
+     * @param  list<mixed>  $slugs
+     * @return list<string>
+     */
+    private function normalizedUniqueSlugs(array $slugs, string $context): array
+    {
+        $normalized = [];
+        $seen = [];
+        foreach ($slugs as $index => $slug) {
+            if (! is_string($slug)) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            $value = strtolower(trim($slug));
+            if ($value === '' || str_contains($value, '*')) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            if (isset($seen[$value])) {
+                throw new RuntimeException($context.'_duplicate_'.$value);
+            }
+
+            $seen[$value] = true;
+            $normalized[] = $value;
+        }
+
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return list<string>
+     */
+    private function normalizedLocales(array $locales): array
+    {
+        $normalized = [];
+        $seen = [];
+        foreach ($locales as $index => $locale) {
+            $value = strtolower(trim($locale));
+            if ($value === '') {
+                throw new RuntimeException('locale_invalid_at_'.$index);
+            }
+            if (isset($seen[$value])) {
+                throw new RuntimeException('locale_duplicate_'.$value);
+            }
+            $seen[$value] = true;
+            $normalized[] = $value;
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @param  array<string, mixed>  $currentCloseout
+     * @param  list<string>  $currentPublicSlugs
+     * @param  list<string>  $targetSlugs
+     * @param  list<string>  $deltaSlugs
+     * @param  list<string>  $missingCurrentFromTarget
+     * @param  list<string>  $overlap
+     * @return list<array<string, mixed>>
+     */
+    private function blockers(
+        array $currentCloseout,
+        array $currentPublicSlugs,
+        array $targetSlugs,
+        int $targetPublicTotal,
+        array $deltaSlugs,
+        array $missingCurrentFromTarget,
+        array $overlap,
+    ): array {
+        $blockers = [];
+
+        if (($currentCloseout['status'] ?? null) !== 'complete' || ($currentCloseout['accepted'] ?? false) !== true) {
+            $blockers[] = $this->blocker('current_closeout_not_accepted', [
+                'status' => $currentCloseout['status'] ?? null,
+                'accepted' => $currentCloseout['accepted'] ?? null,
+            ]);
+        }
+
+        $declaredCurrentTotal = $currentCloseout['total_slug_count'] ?? $currentCloseout['target_public_total'] ?? null;
+        if ($declaredCurrentTotal !== null && (int) $declaredCurrentTotal !== count($currentPublicSlugs)) {
+            $blockers[] = $this->blocker('current_public_total_mismatch', [
+                'declared' => $declaredCurrentTotal,
+                'actual' => count($currentPublicSlugs),
+            ]);
+        }
+
+        if ($targetPublicTotal <= count($currentPublicSlugs)) {
+            $blockers[] = $this->blocker('target_not_greater_than_current', [
+                'current_public_total' => count($currentPublicSlugs),
+                'target_public_total' => $targetPublicTotal,
+            ]);
+        }
+
+        if (count($targetSlugs) !== $targetPublicTotal) {
+            $blockers[] = $this->blocker('target_selection_count_mismatch', [
+                'expected' => $targetPublicTotal,
+                'actual' => count($targetSlugs),
+            ]);
+        }
+
+        if ($missingCurrentFromTarget !== []) {
+            $blockers[] = $this->blocker('current_public_missing_from_target_selection', [
+                'slugs' => $missingCurrentFromTarget,
+            ]);
+        }
+
+        if ($overlap !== []) {
+            $blockers[] = $this->blocker('current_delta_overlap', [
+                'slugs' => $overlap,
+            ]);
+        }
+
+        if (count($deltaSlugs) !== $targetPublicTotal - count($currentPublicSlugs)) {
+            $blockers[] = $this->blocker('delta_count_mismatch', [
+                'expected' => $targetPublicTotal - count($currentPublicSlugs),
+                'actual' => count($deltaSlugs),
+            ]);
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, array $evidence): array
+    {
+        return [
+            'reason' => $reason,
+            'evidence' => $evidence,
+        ];
+    }
+}

--- a/backend/docs/career/audits/progressive_cohort_delta.md
+++ b/backend/docs/career/audits/progressive_cohort_delta.md
@@ -1,0 +1,45 @@
+# Career Progressive Cohort Delta Plan
+
+`career:plan-canonical-progressive-cohort-delta` is a read-only planner for the post-80 expansion path:
+
+- 80 -> 300
+- 300 -> 800
+- 800 -> 2786
+
+It consumes an accepted current cohort closeout artifact plus an explicit target selection artifact, then emits the delta slugs needed to move from the current public total to the target public total.
+
+Example:
+
+```bash
+php artisan career:plan-canonical-progressive-cohort-delta \
+  --current-closeout=/tmp/career_80_closeout.json \
+  --target-selection=/tmp/career_300_target_selection.json \
+  --target=300 \
+  --locales=en,zh \
+  --json \
+  --output=/tmp/career_300_target_delta.json
+```
+
+The output schema is `career_progressive_cohort_delta_plan.v1` and includes:
+
+- `current_public_total`
+- `target_public_total`
+- `delta_slug_count`
+- `expected_delta_locale_rows`
+- `expected_total_locale_rows`
+- `current_public_slugs`
+- `target_public_slugs`
+- `delta_promotion_slugs`
+- `recommended_rollout_delta_slugs`
+- `writes_database=false`
+- `rollout.apply_allowed=false`
+
+Expected cohort arithmetic:
+
+| Current | Target | Delta slugs | Delta locale rows | Total locale rows |
+| --- | --- | ---: | ---: | ---: |
+| 80 | 300 | 220 | 440 | 600 |
+| 300 | 800 | 500 | 1000 | 1600 |
+| 800 | 2786 | 1986 | 3972 | 5572 |
+
+This command does not run candidate preparation, rollout dry-run, rollout apply, artifact export, deploy, rollback, quarantine, or DB mutation. Later steps must use the emitted explicit delta slug list and pass their own dry-run/apply guards.

--- a/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveCohortDeltaCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveCohortDeltaCommandTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerPlanCanonicalProgressiveCohortDelta;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerPlanCanonicalProgressiveCohortDeltaCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(CareerPlanCanonicalProgressiveCohortDelta::class),
+        );
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:plan-canonical-progressive-cohort-delta', Artisan::all());
+    }
+
+    public function test_missing_current_closeout_blocks(): void
+    {
+        $exitCode = Artisan::call('career:plan-canonical-progressive-cohort-delta', [
+            '--current-closeout' => sys_get_temp_dir().'/missing-closeout.json',
+            '--current-slugs' => $this->writeSlugText('current', ['current-001']),
+            '--target-selection' => $this->writeTargetSelection(['current-001', 'delta-001']),
+            '--target' => 2,
+            '--json' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('current_closeout_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_generates_80_to_300_plan_and_writes_output(): void
+    {
+        $current = $this->slugs('current', 80);
+        $delta = $this->slugs('delta', 220);
+        $currentSlugs = $this->writeSlugText('current', $current);
+        $output = $this->tempPath('output');
+
+        $exitCode = Artisan::call('career:plan-canonical-progressive-cohort-delta', [
+            '--current-closeout' => $this->writeCloseout(80, $currentSlugs),
+            '--target-selection' => $this->writeTargetSelection([...$current, ...$delta]),
+            '--target' => 300,
+            '--locales' => 'en,zh',
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('career_progressive_cohort_delta_plan.v1', $payload['schema_version']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(80, $payload['current_public_total']);
+        $this->assertSame(300, $payload['target_public_total']);
+        $this->assertSame(220, $payload['delta_slug_count']);
+        $this->assertSame(440, $payload['expected_delta_locale_rows']);
+        $this->assertSame(600, $payload['expected_total_locale_rows']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_current_slug_count_mismatch_blocks(): void
+    {
+        $currentSlugs = $this->writeSlugText('current', ['current-001']);
+
+        $exitCode = Artisan::call('career:plan-canonical-progressive-cohort-delta', [
+            '--current-closeout' => $this->writeCloseout(2, $currentSlugs),
+            '--target-selection' => $this->writeTargetSelection(['current-001', 'delta-001']),
+            '--target' => 2,
+            '--json' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('current_public_total_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%04d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeSlugText(string $name, array $slugs): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, implode(PHP_EOL, $slugs).PHP_EOL);
+
+        return $path;
+    }
+
+    private function writeCloseout(int $total, string $totalSlugsPath): string
+    {
+        return $this->writeJson('closeout', [
+            'schema_version' => 'career_progressive_cohort_closeout.v1',
+            'status' => 'complete',
+            'accepted' => true,
+            'target_public_total' => $total,
+            'total_slug_count' => $total,
+            'total_slugs_path' => $totalSlugsPath,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeTargetSelection(array $slugs): string
+    {
+        sort($slugs);
+
+        return $this->writeJson('target-selection', [
+            'schema_version' => 'career_progressive_target_selection.v1',
+            'status' => 'pass',
+            'selection' => [
+                'slugs' => $slugs,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-progressive-cohort-delta-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortDeltaPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortDeltaPlannerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerProgressiveCohortDeltaPlanner;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class CareerProgressiveCohortDeltaPlannerTest extends TestCase
+{
+    public function test_models_80_to_300_progressive_delta(): void
+    {
+        $current = $this->slugs('current', 80);
+        $delta = $this->slugs('delta', 220);
+
+        $payload = (new CareerProgressiveCohortDeltaPlanner)->plan(
+            currentCloseout: $this->closeout(80),
+            currentPublicSlugs: $current,
+            targetSelection: $this->targetSelection([...$current, ...$delta]),
+            targetPublicTotal: 300,
+            locales: ['en', 'zh'],
+        )->toArray();
+
+        $this->assertSame('career_progressive_cohort_delta_plan.v1', $payload['schema_version']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(80, $payload['current_public_total']);
+        $this->assertSame(300, $payload['target_public_total']);
+        $this->assertSame(220, $payload['delta_slug_count']);
+        $this->assertSame(440, $payload['expected_delta_locale_rows']);
+        $this->assertSame(600, $payload['expected_total_locale_rows']);
+        $this->assertSame($delta, $payload['recommended_rollout_delta_slugs']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['rollout']['apply_allowed']);
+    }
+
+    public function test_models_300_to_800_progressive_delta(): void
+    {
+        $current = $this->slugs('current', 300);
+        $delta = $this->slugs('delta', 500);
+
+        $payload = (new CareerProgressiveCohortDeltaPlanner)->plan(
+            currentCloseout: $this->closeout(300),
+            currentPublicSlugs: $current,
+            targetSelection: $this->targetSelection([...$current, ...$delta]),
+            targetPublicTotal: 800,
+        )->toArray();
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(500, $payload['delta_slug_count']);
+        $this->assertSame(1000, $payload['expected_delta_locale_rows']);
+        $this->assertSame(1600, $payload['expected_total_locale_rows']);
+    }
+
+    public function test_models_800_to_2786_progressive_delta(): void
+    {
+        $current = $this->slugs('current', 800);
+        $delta = $this->slugs('delta', 1986);
+
+        $payload = (new CareerProgressiveCohortDeltaPlanner)->plan(
+            currentCloseout: $this->closeout(800),
+            currentPublicSlugs: $current,
+            targetSelection: $this->targetSelection([...$current, ...$delta]),
+            targetPublicTotal: 2786,
+        )->toArray();
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(1986, $payload['delta_slug_count']);
+        $this->assertSame(3972, $payload['expected_delta_locale_rows']);
+        $this->assertSame(5572, $payload['expected_total_locale_rows']);
+    }
+
+    public function test_target_less_than_or_equal_to_current_blocks(): void
+    {
+        $current = $this->slugs('current', 80);
+
+        $payload = (new CareerProgressiveCohortDeltaPlanner)->plan(
+            currentCloseout: $this->closeout(80),
+            currentPublicSlugs: $current,
+            targetSelection: $this->targetSelection($current),
+            targetPublicTotal: 80,
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('target_not_greater_than_current', array_column($payload['blockers'], 'reason'));
+    }
+
+    public function test_current_slugs_must_remain_in_target_selection(): void
+    {
+        $current = ['current-001', 'current-002'];
+        $target = ['current-001', 'delta-001', 'delta-002'];
+
+        $payload = (new CareerProgressiveCohortDeltaPlanner)->plan(
+            currentCloseout: $this->closeout(2),
+            currentPublicSlugs: $current,
+            targetSelection: $this->targetSelection($target),
+            targetPublicTotal: 3,
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('current_public_missing_from_target_selection', array_column($payload['blockers'], 'reason'));
+    }
+
+    public function test_duplicate_target_selection_slug_blocks(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('target_selection_slug_duplicate_delta-001');
+
+        (new CareerProgressiveCohortDeltaPlanner)->plan(
+            currentCloseout: $this->closeout(1),
+            currentPublicSlugs: ['current-001'],
+            targetSelection: $this->targetSelection(['current-001', 'delta-001', 'delta-001']),
+            targetPublicTotal: 3,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%04d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function closeout(int $total): array
+    {
+        return [
+            'schema_version' => 'career_progressive_cohort_closeout.v1',
+            'status' => 'complete',
+            'accepted' => true,
+            'target_public_total' => $total,
+            'total_slug_count' => $total,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function targetSelection(array $slugs): array
+    {
+        sort($slugs);
+
+        return [
+            'schema_version' => 'career_progressive_target_selection.v1',
+            'status' => 'pass',
+            'selection' => [
+                'slugs' => $slugs,
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -424,6 +424,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshResult.php',
@@ -1926,6 +1928,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshResult.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5483,6 +5483,80 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "REPAIR-PROGRESSIVE-COHORT-TARGET-DELTA-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-progressive-cohort-target-delta-1",
+      "title": "fix(api): add progressive career cohort delta planner",
+      "status": "in_progress",
+      "depends_on": [
+        "80-CLOSEOUT-1"
+      ],
+      "scope_type": "progressive_cohort_target_delta_planning_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonicalProgressiveCohortDelta.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no candidate preparation",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no apply",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for the progressive expansion PR train."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "Career 80 closeout is complete and the next required action is 300 readiness/progressive expansion planning."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to read-only progressive target-delta planning, command registration, tests/docs, and train metadata."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": "CareerProgressiveCohortDelta, Career80TargetDelta, Career80TotalLiveAcceptance, route:list, sqlite migrate, Pint, and git diff --check passed locally."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "backend/scripts/ci_verify_mbti.sh failed only Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
+            "Current PR changed only Career progressive audit/command/test/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
+            "Targeted Career tests, route:list, sqlite migrate, Pint, and git diff --check passed."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "may_continue_train": true
+        }
+      ]
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -3064,3 +3064,40 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-COHORT-TARGET-DELTA-1
+    repo: fap-api
+    depends_on:
+      - 80-CLOSEOUT-1
+    branch: fix/career-progressive-cohort-target-delta-1
+    title: "fix(api): add progressive career cohort delta planner"
+    name: "Add progressive target-delta planner for 300, 800, and 2786 cohorts"
+    scope:
+      - Add a read-only progressive cohort target-delta planner.
+      - Model current accepted public total plus explicit target selection as a reusable delta slug artifact.
+      - Support 80 to 300, 300 to 800, and 800 to 2786 arithmetic without candidate preparation, rollout, apply, deploy, or DB mutation.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonicalProgressiveCohortDelta.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run candidate preparation.
+      - Run rollout or rollout dry-run.
+      - Run apply, backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerProgressiveCohortDelta --no-ansi
+      - php artisan test --filter=Career80TargetDelta --no-ansi
+      - php artisan test --filter=Career80TotalLiveAcceptance --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds read-only progressive Career cohort delta planning for 80 -> 300, 300 -> 800, and 800 -> 2786.
- Registers `career:plan-canonical-progressive-cohort-delta` and emits stable `career_progressive_cohort_delta_plan.v1` JSON.
- Records target/delta locale-row arithmetic, baseline exclusion, no-DB-write semantics, docs, tests, and current train metadata.

## Safety / Non-goals
- Does not run candidate prep, rollout dry-run/apply, deploy, backfill, rollback, quarantine, or production DB mutation.
- Does not touch fap-web.
- Keeps the existing Career 80 target delta planner unchanged.

## Validation
- `php artisan test --filter=CareerProgressiveCohortDelta --no-ansi` PASS
- `php artisan test --filter=CareerPlanCanonicalProgressiveCohortDelta --no-ansi` PASS
- `php artisan test --filter=Career80TargetDelta --no-ansi` PASS
- `php artisan test --filter=Career80TotalLiveAcceptance --no-ansi` PASS
- `php artisan route:list --no-ansi` PASS
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-progressive-expansion.sqlite php artisan migrate --force --no-ansi` PASS
- `vendor/bin/pint --test` PASS
- `vendor/bin/pint --test --dirty` PASS
- `git diff --check` PASS

## Sidecar
`backend/scripts/ci_verify_mbti.sh` was run locally. It passed the BigFive runtime freeze classifier and most MBTI/BigFive checks, but failed two unrelated content-pack publish/rollback tests at `File::isDirectory($target.'/compiled')` assertions:
- `Tests\Feature\Content\PacksPublishBig5Test`
- `Tests\Feature\Content\PacksRollbackBig5Test`

Classification: `pre_existing_external` / environment-related, external to this PR. This PR changes only Career progressive audit/command/test/docs/train metadata paths and does not touch content pack publish/rollback implementation or compiled assets.

## Next
REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1
