### PR TITLE
fix(api): generalize career runtime candidate preparation

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
@@ -14,6 +14,8 @@ final class CareerPlanCanonicalRuntimeCandidatePrep extends Command
 {
     protected $signature = 'career:plan-canonical-runtime-candidate-prep
         {--target-delta= : Required Career 80 target delta JSON artifact}
+        {--target-total= : Optional target public total guard for progressive cohorts}
+        {--cohort= : Optional cohort key such as career_80_to_300_delta}
         {--projection= : Optional runtime projection JSON artifact}
         {--truth= : Optional runtime truth JSON artifact}
         {--ledger= : Optional full release ledger JSON artifact}
@@ -33,6 +35,8 @@ final class CareerPlanCanonicalRuntimeCandidatePrep extends Command
                 truth: $this->optionalJson('truth'),
                 ledger: $this->optionalJson('ledger'),
                 locales: $this->localesOption(),
+                targetPublicTotal: $this->nullablePositiveIntOption('target-total'),
+                cohort: $this->nullableStringOption('cohort'),
             )->toArray();
 
             return $this->finish($payload, ($payload['status'] ?? null) === 'planned' ? self::SUCCESS : self::FAILURE);
@@ -61,6 +65,28 @@ final class CareerPlanCanonicalRuntimeCandidatePrep extends Command
         $value = trim((string) ($this->option($name) ?? ''));
         if ($value === '') {
             throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function nullableStringOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
+    private function nullablePositiveIntOption(string $name): ?int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return null;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
         }
 
         return $value;

--- a/backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php
+++ b/backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php
@@ -15,7 +15,7 @@ use Throwable;
 
 final class CareerPrepareCanonicalRuntimeCandidates extends Command
 {
-    private const SOURCE = 'career_80_delta_runtime_candidate_preparation';
+    private const DEFAULT_SOURCE = 'career_80_delta_runtime_candidate_preparation';
 
     private const TARGET_INDEX_STATE = IndexStateValue::PROMOTION_CANDIDATE;
 
@@ -26,6 +26,8 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
     protected $signature = 'career:prepare-canonical-runtime-candidates
         {--plan= : Reviewed runtime candidate preparation plan JSON path}
         {--slug-artifact= : Reviewed explicit slug artifact JSON path}
+        {--target-total= : Optional target public total guard for progressive cohorts}
+        {--cohort= : Optional cohort key such as career_80_to_300_delta}
         {--dry-run : Plan without writing}
         {--apply : Execute guarded published_candidate preparation writes}
         {--batch-id= : Reviewed preparation batch id}
@@ -51,13 +53,15 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
             [$artifact, $artifactSha] = $this->readSourceArtifact($sourcePath);
             $slugs = $artifact['slugs'];
             $slugCount = count($slugs);
+            $source = $this->sourceName($artifact);
 
             $blockers = [
                 ...$this->confirmationBlockers($mode, $artifactSha, $slugCount, $expectedSlugCount),
-                ...$this->artifactSafetyBlockers($slugCount, $maxSlugs),
+                ...$this->artifactSafetyBlockers($artifact, $slugCount, $maxSlugs),
+                ...$this->progressiveTargetBlockers($artifact),
             ];
 
-            $plan = $this->plan($slugs, $artifact['locales'], $batchId, $reason, $sourcePath, $artifactSha);
+            $plan = $this->plan($slugs, $artifact['locales'], $batchId, $reason, $sourcePath, $artifactSha, $source);
             $blockers = [
                 ...$blockers,
                 ...$plan['blockers'],
@@ -69,6 +73,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
                     $artifact,
                     $sourcePath,
                     $artifactSha,
+                    $source,
                     $batchId,
                     $reason,
                     $maxSlugs,
@@ -83,6 +88,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
                     $artifact,
                     $sourcePath,
                     $artifactSha,
+                    $source,
                     $batchId,
                     $reason,
                     $maxSlugs,
@@ -91,7 +97,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
                 ), self::FAILURE);
             }
 
-            $payload = $this->apply($plan, $artifact, $sourcePath, $artifactSha, $batchId, $reason, $maxSlugs, $expectedSlugCount);
+            $payload = $this->apply($plan, $artifact, $sourcePath, $artifactSha, $source, $batchId, $reason, $maxSlugs, $expectedSlugCount);
 
             return $this->finish($payload, ($payload['status'] ?? null) === 'applied' ? self::SUCCESS : self::FAILURE);
         } catch (Throwable $exception) {
@@ -220,6 +226,8 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
             'raw_summary' => is_array($decoded) && ! array_is_list($decoded) ? [
                 'status' => $decoded['status'] ?? null,
                 'target' => $decoded['target'] ?? null,
+                'current_public_total' => $decoded['current_public_total'] ?? null,
+                'target_public_total' => $decoded['target_public_total'] ?? null,
                 'delta_slug_count' => $decoded['delta_slug_count'] ?? null,
                 'expected_locale_rows' => $decoded['expected_locale_rows'] ?? null,
             ] : null,
@@ -378,13 +386,82 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
     /**
      * @return list<array<string, mixed>>
      */
-    private function artifactSafetyBlockers(int $slugCount, int $maxSlugs): array
+    private function artifactSafetyBlockers(array $artifact, int $slugCount, int $maxSlugs): array
     {
         if ($slugCount > $maxSlugs) {
             return [$this->blocker('slug_count_exceeds_max_slugs', 'Artifact slug count exceeds --max-slugs guard.')];
         }
 
+        if ($this->isProgressiveArtifact($artifact) && $slugCount !== $maxSlugs) {
+            return [$this->blocker('progressive_max_slugs_must_match_delta_count', 'Progressive cohort preparation requires --max-slugs to exactly match the cohort delta slug count.', [
+                'slug_count' => $slugCount,
+                'max_slugs' => $maxSlugs,
+            ])];
+        }
+
         return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return list<array<string, mixed>>
+     */
+    private function progressiveTargetBlockers(array $artifact): array
+    {
+        $blockers = [];
+        $targetTotal = $this->nullablePositiveIntOption('target-total');
+        $artifactTargetTotal = data_get($artifact, 'raw_summary.target_public_total');
+
+        if ($targetTotal !== null && is_numeric($artifactTargetTotal) && $targetTotal !== (int) $artifactTargetTotal) {
+            $blockers[] = $this->blocker('target_public_total_mismatch', 'Requested target public total does not match the preparation artifact.', [
+                'requested' => $targetTotal,
+                'artifact' => (int) $artifactTargetTotal,
+            ]);
+        }
+
+        $cohort = trim((string) ($this->option('cohort') ?? ''));
+        $artifactTarget = data_get($artifact, 'raw_summary.target');
+        if ($cohort !== '' && is_string($artifactTarget) && $artifactTarget !== '' && strtolower($cohort) !== strtolower($artifactTarget)) {
+            $blockers[] = $this->blocker('cohort_mismatch', 'Requested cohort does not match the preparation artifact target.', [
+                'requested' => strtolower($cohort),
+                'artifact' => strtolower($artifactTarget),
+            ]);
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     */
+    private function isProgressiveArtifact(array $artifact): bool
+    {
+        $schema = (string) ($artifact['schema_version'] ?? '');
+        $target = (string) data_get($artifact, 'raw_summary.target', '');
+        $targetTotal = data_get($artifact, 'raw_summary.target_public_total');
+
+        return $schema === 'career_progressive_cohort_delta_plan.v1'
+            || str_starts_with($target, 'career_progressive_')
+            || str_contains($target, '_to_')
+            || (is_numeric($targetTotal) && (int) $targetTotal > 80);
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     */
+    private function sourceName(array $artifact): string
+    {
+        $target = (string) data_get($artifact, 'raw_summary.target', '');
+        $target = strtolower(trim($target));
+
+        if ($target === '' || $target === 'career_80_delta') {
+            return self::DEFAULT_SOURCE;
+        }
+
+        $source = preg_replace('/[^a-z0-9]+/', '_', $target) ?? $target;
+        $source = trim($source, '_');
+
+        return ($source === '' ? 'career_progressive_delta' : $source).'_runtime_candidate_preparation';
     }
 
     /**
@@ -392,7 +469,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
      * @param  list<string>  $locales
      * @return array{slugs: list<string>, locales: list<string>, missing_occupations: list<string>, existing_latest_states: list<array<string, mixed>>, planned_writes: list<array<string, mixed>>, blockers: list<array<string, mixed>>}
      */
-    private function plan(array $slugs, array $locales, string $batchId, string $reason, string $artifactPath, string $artifactSha): array
+    private function plan(array $slugs, array $locales, string $batchId, string $reason, string $artifactPath, string $artifactSha, string $source): array
     {
         $occupations = Occupation::query()
             ->whereIn('canonical_slug', $slugs)
@@ -429,8 +506,8 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
                 'index_eligible' => true,
                 'canonical_path' => '/career/jobs/'.$slug,
                 'canonical_target' => null,
-                'reason_codes' => $this->reasonCodes($batchId, $reason, $artifactPath, $artifactSha),
-                'row_fingerprint' => $this->rowFingerprint($slug, $batchId, $artifactSha),
+                'reason_codes' => $this->reasonCodes($batchId, $reason, $artifactPath, $artifactSha, $source),
+                'row_fingerprint' => $this->rowFingerprint($slug, $batchId, $artifactSha, $source),
             ];
         }
 
@@ -447,10 +524,10 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
     /**
      * @return list<string>
      */
-    private function reasonCodes(string $batchId, string $reason, string $artifactPath, string $artifactSha): array
+    private function reasonCodes(string $batchId, string $reason, string $artifactPath, string $artifactSha, string $source): array
     {
         return [
-            self::SOURCE,
+            $source,
             'prepare_published_candidate_runtime_rows',
             'batch_id:'.$batchId,
             'reason:'.Str::slug($reason, '_'),
@@ -461,10 +538,10 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
         ];
     }
 
-    private function rowFingerprint(string $slug, string $batchId, string $artifactSha): string
+    private function rowFingerprint(string $slug, string $batchId, string $artifactSha, string $source): string
     {
         return hash('sha256', json_encode([
-            'source' => self::SOURCE,
+            'source' => $source,
             'canonical_slug' => $slug,
             'target_index_state' => self::TARGET_INDEX_STATE,
             'target_runtime_state' => self::TARGET_RUNTIME_STATE,
@@ -509,7 +586,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
      * @param  list<array<string, mixed>>  $blockers
      * @return array<string, mixed>
      */
-    private function dryRunPayload(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount, array $blockers): array
+    private function dryRunPayload(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $source, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount, array $blockers): array
     {
         return [
             'status' => $blockers === [] ? 'planned' : 'blocked',
@@ -522,6 +599,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
             'batch_id' => $batchId,
             'reason' => $reason,
             'source_artifact' => $artifactPath,
+            'preparation_source' => $source,
             'source_kind' => $artifact['source_kind'],
             'artifact_schema_version' => $artifact['schema_version'],
             'artifact_sha256' => $artifactSha,
@@ -554,7 +632,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
      * @param  list<array<string, mixed>>  $blockers
      * @return array<string, mixed>
      */
-    private function blockedApplyPayload(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount, array $blockers): array
+    private function blockedApplyPayload(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $source, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount, array $blockers): array
     {
         return [
             'status' => 'blocked',
@@ -567,6 +645,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
             'batch_id' => $batchId,
             'reason' => $reason,
             'source_artifact' => $artifactPath,
+            'preparation_source' => $source,
             'source_kind' => $artifact['source_kind'],
             'artifact_schema_version' => $artifact['schema_version'],
             'artifact_sha256' => $artifactSha,
@@ -592,7 +671,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
      * @param  array<string, mixed>  $artifact
      * @return array<string, mixed>
      */
-    private function apply(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount): array
+    private function apply(array $plan, array $artifact, string $artifactPath, string $artifactSha, string $source, string $batchId, string $reason, int $maxSlugs, ?int $expectedSlugCount): array
     {
         $created = [];
         $failures = [];
@@ -631,7 +710,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
             }
         });
 
-        $verification = $this->verifyWrites($plan['slugs'], $artifactSha);
+        $verification = $this->verifyWrites($plan['slugs'], $artifactSha, $source);
         $blockers = $verification['blockers'];
 
         return [
@@ -645,6 +724,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
             'batch_id' => $batchId,
             'reason' => $reason,
             'source_artifact' => $artifactPath,
+            'preparation_source' => $source,
             'source_kind' => $artifact['source_kind'],
             'artifact_schema_version' => $artifact['schema_version'],
             'artifact_sha256' => $artifactSha,
@@ -666,7 +746,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
      * @param  list<string>  $slugs
      * @return array{verified_count: int, blockers: list<array<string, mixed>>}
      */
-    private function verifyWrites(array $slugs, string $artifactSha): array
+    private function verifyWrites(array $slugs, string $artifactSha, string $source): array
     {
         $occupations = Occupation::query()
             ->whereIn('canonical_slug', $slugs)
@@ -695,7 +775,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
                 continue;
             }
 
-            if (! in_array(self::SOURCE, $reasonCodes, true) || ! in_array('artifact_sha256:'.$artifactSha, $reasonCodes, true)) {
+            if (! in_array($source, $reasonCodes, true) || ! in_array('artifact_sha256:'.$artifactSha, $reasonCodes, true)) {
                 $blockers[] = $this->blocker('write_metadata_verification_failed', 'Latest prepared candidate row is missing source or artifact metadata.', ['canonical_slug' => $slug]);
 
                 continue;

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
@@ -23,9 +23,15 @@ final class CareerRuntimeCandidatePrepPlanner
         ?array $truth = null,
         ?array $ledger = null,
         array $locales = ['en', 'zh'],
+        ?int $targetPublicTotal = null,
+        ?string $cohort = null,
     ): CareerRuntimeCandidatePrepResult {
         $deltaSlugs = $this->deltaSlugs($targetDeltaPlan);
         $locales = $this->normalizedUniqueStrings($locales, 'locale');
+        $artifactTargetPublicTotal = $this->artifactTargetPublicTotal($targetDeltaPlan);
+        $currentPublicTotal = $this->artifactCurrentPublicTotal($targetDeltaPlan);
+        $targetPublicTotal ??= $artifactTargetPublicTotal ?? 80;
+        $cohort = $this->cohortValue($cohort, $targetPublicTotal, $currentPublicTotal);
 
         $projectionBySlugLocale = $this->rowsBySlugLocale($this->artifactRows($projection, ['items', 'rows']));
         $truthBySlugLocale = $this->rowsBySlugLocale($this->artifactRows($truth, ['items', 'rows']));
@@ -96,7 +102,7 @@ final class CareerRuntimeCandidatePrepPlanner
                     'projection_state' => Career80RolloutCandidateGate::EXPECTED_RUNTIME_STATE,
                     'public_resolution_type' => 'public_canonical_job',
                     'candidate_pre_route_expected' => true,
-                    'source' => 'career_80_delta_runtime_candidate_prep',
+                    'source' => $cohort.'_runtime_candidate_prep',
                     'write_intent' => 'planned_only',
                 ];
             }
@@ -109,7 +115,7 @@ final class CareerRuntimeCandidatePrepPlanner
             $slugRows[] = $slugEvidence;
         }
 
-        $blockers = $this->blockers($targetDeltaPlan, $deltaSlugs);
+        $blockers = $this->blockers($targetDeltaPlan, $deltaSlugs, $targetPublicTotal, $artifactTargetPublicTotal);
         $status = $blockers === [] ? 'planned' : 'blocked';
 
         return new CareerRuntimeCandidatePrepResult([
@@ -117,11 +123,13 @@ final class CareerRuntimeCandidatePrepPlanner
             'status' => $status,
             'read_only' => true,
             'writes_database' => false,
-            'target' => 'career_80_delta',
-            'target_public_total' => (int) ($targetDeltaPlan['target_public_total'] ?? 80),
+            'target' => $cohort,
+            'current_public_total' => $currentPublicTotal,
+            'target_public_total' => $targetPublicTotal,
             'delta_slug_count' => count($deltaSlugs),
             'locales' => $locales,
             'expected_locale_rows' => count($deltaSlugs) * count($locales),
+            'expected_delta_locale_rows' => count($deltaSlugs) * count($locales),
             'planned_candidate_rows_count' => count($plannedRows),
             'planned_candidate_rows' => $plannedRows,
             'slug_rows' => $slugRows,
@@ -297,10 +305,46 @@ final class CareerRuntimeCandidatePrepPlanner
 
     /**
      * @param  array<string, mixed>  $targetDeltaPlan
+     */
+    private function artifactTargetPublicTotal(array $targetDeltaPlan): ?int
+    {
+        $value = $targetDeltaPlan['target_public_total'] ?? data_get($targetDeltaPlan, 'target.public_total');
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDeltaPlan
+     */
+    private function artifactCurrentPublicTotal(array $targetDeltaPlan): ?int
+    {
+        $value = $targetDeltaPlan['current_public_total'] ?? data_get($targetDeltaPlan, 'current.public_total');
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    private function cohortValue(?string $cohort, int $targetPublicTotal, ?int $currentPublicTotal): string
+    {
+        $normalized = strtolower(trim((string) $cohort));
+        if ($normalized !== '') {
+            $key = preg_replace('/[^a-z0-9]+/', '_', $normalized) ?? $normalized;
+
+            return trim($key, '_') ?: $normalized;
+        }
+
+        if ($currentPublicTotal !== null && $targetPublicTotal !== 80) {
+            return sprintf('career_%d_to_%d_delta', $currentPublicTotal, $targetPublicTotal);
+        }
+
+        return $targetPublicTotal === 80 ? 'career_80_delta' : sprintf('career_progressive_%d_delta', $targetPublicTotal);
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDeltaPlan
      * @param  list<string>  $deltaSlugs
      * @return list<array<string, mixed>>
      */
-    private function blockers(array $targetDeltaPlan, array $deltaSlugs): array
+    private function blockers(array $targetDeltaPlan, array $deltaSlugs, int $targetPublicTotal, ?int $artifactTargetPublicTotal): array
     {
         $blockers = [];
         if (($targetDeltaPlan['status'] ?? null) !== 'pass') {
@@ -318,6 +362,17 @@ final class CareerRuntimeCandidatePrepPlanner
                 'evidence' => [
                     'declared' => (int) $declaredDeltaCount,
                     'actual' => count($deltaSlugs),
+                ],
+            ];
+        }
+
+        if ($artifactTargetPublicTotal !== null && $artifactTargetPublicTotal !== $targetPublicTotal) {
+            $blockers[] = [
+                'reason' => 'target_public_total_mismatch',
+                'message' => 'Requested target public total does not match the target delta artifact.',
+                'evidence' => [
+                    'requested' => $targetPublicTotal,
+                    'artifact' => $artifactTargetPublicTotal,
                 ],
             ];
         }

--- a/backend/docs/career/audits/progressive_cohort_delta.md
+++ b/backend/docs/career/audits/progressive_cohort_delta.md
@@ -43,3 +43,27 @@ Expected cohort arithmetic:
 | 800 | 2786 | 1986 | 3972 | 5572 |
 
 This command does not run candidate preparation, rollout dry-run, rollout apply, artifact export, deploy, rollback, quarantine, or DB mutation. Later steps must use the emitted explicit delta slug list and pass their own dry-run/apply guards.
+
+## Candidate Preparation Handoff
+
+The runtime candidate preparation planner can consume this artifact directly:
+
+```bash
+php artisan career:plan-canonical-runtime-candidate-prep \
+  --target-delta=/tmp/career_300_target_delta.json \
+  --target-total=300 \
+  --cohort=career_80_to_300_delta \
+  --locales=en,zh \
+  --json \
+  --output=/tmp/career_300_runtime_candidate_prep_plan.json
+```
+
+For progressive cohorts, the guarded preparation dry-run/apply command must use the reviewed artifact with explicit count guards. The `--max-slugs` value must exactly match the cohort delta:
+
+| Cohort | `--expect-slug-count` | `--max-slugs` |
+| --- | ---: | ---: |
+| 80 -> 300 | 220 | 220 |
+| 300 -> 800 | 500 | 500 |
+| 800 -> 2786 | 1986 | 1986 |
+
+The preparation commands still do not select slugs implicitly and have no wildcard or all-2786 mode before the explicit 2786 phase artifact exists.

--- a/backend/docs/career/audits/runtime_candidate_prep_apply_gate.md
+++ b/backend/docs/career/audits/runtime_candidate_prep_apply_gate.md
@@ -1,6 +1,6 @@
 # Career Runtime Candidate Preparation Apply Gate
 
-`career:prepare-canonical-runtime-candidates` is the guarded dry-run/apply command for preparing the 51 Career 80 delta slugs as runtime `published_candidate` inventory.
+`career:prepare-canonical-runtime-candidates` is the guarded dry-run/apply command for preparing explicit Career delta slugs as runtime `published_candidate` inventory. It supports the completed 51 Career 80 delta path and progressive cohort deltas such as 80 -> 300, 300 -> 800, and 800 -> 2786.
 
 The command consumes either:
 
@@ -22,6 +22,22 @@ php artisan career:prepare-canonical-runtime-candidates \
   --expect-slug-count=51 \
   --json \
   --output=/tmp/career_80_delta_runtime_candidate_prep_dry_run.json
+```
+
+Progressive dry-run example:
+
+```bash
+php artisan career:prepare-canonical-runtime-candidates \
+  --plan=/tmp/career_300_runtime_candidate_prep_plan.json \
+  --target-total=300 \
+  --cohort=career_80_to_300_delta \
+  --dry-run \
+  --batch-id=career_300_candidate_prep_001 \
+  --reason=career_300_runtime_candidate_prep \
+  --expect-slug-count=220 \
+  --max-slugs=220 \
+  --json \
+  --output=/tmp/career_300_runtime_candidate_prep_dry_run.json
 ```
 
 Apply, only after explicit production approval:
@@ -47,6 +63,8 @@ php artisan career:prepare-canonical-runtime-candidates \
 - `--apply` requires `--confirm-artifact-sha256`.
 - `--apply` requires `--expect-slug-count`.
 - `--max-slugs` defaults to 100.
+- Progressive cohort artifacts require `--max-slugs` to exactly match the artifact delta slug count.
+- Optional `--target-total` and `--cohort` guards must match the reviewed artifact when supplied.
 - Duplicate, empty, wildcard, or missing slug lists block.
 - Missing `Occupation` rows block before writes.
 

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php
@@ -69,6 +69,38 @@ final class CareerPlanCanonicalRuntimeCandidatePrepCommandTest extends TestCase
         $this->assertFileExists($output);
     }
 
+    public function test_generates_progressive_220_prep_plan_with_target_guard(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeTargetDelta($this->slugs('delta', 220), currentTotal: 80, targetTotal: 300, schemaVersion: 'career_progressive_cohort_delta_plan.v1'),
+            '--target-total' => 300,
+            '--cohort' => 'career_80_to_300_delta',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('career_80_to_300_delta', $payload['target']);
+        $this->assertSame(80, $payload['current_public_total']);
+        $this->assertSame(300, $payload['target_public_total']);
+        $this->assertSame(220, $payload['delta_slug_count']);
+        $this->assertSame(440, $payload['expected_locale_rows']);
+        $this->assertSame(440, $payload['planned_candidate_rows_count']);
+    }
+
+    public function test_blocks_progressive_target_total_mismatch(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeTargetDelta($this->slugs('delta', 220), currentTotal: 80, targetTotal: 300, schemaVersion: 'career_progressive_cohort_delta_plan.v1'),
+            '--target-total' => 800,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('target_public_total_mismatch', $payload['blockers'][0]['reason']);
+    }
+
     public function test_target_locales_can_be_overridden(): void
     {
         $exitCode = $this->callCommand([
@@ -131,13 +163,15 @@ final class CareerPlanCanonicalRuntimeCandidatePrepCommandTest extends TestCase
     /**
      * @param  list<string>  $slugs
      */
-    private function writeTargetDelta(array $slugs): string
+    private function writeTargetDelta(array $slugs, int $currentTotal = 29, int $targetTotal = 80, string $schemaVersion = 'career_80_target_delta.v1'): string
     {
         return $this->writeJson('target-delta', [
-            'schema_version' => 'career_80_target_delta.v1',
+            'schema_version' => $schemaVersion,
             'status' => 'pass',
-            'target_public_total' => 80,
+            'current_public_total' => $currentTotal,
+            'target_public_total' => $targetTotal,
             'delta_promotion_count' => count($slugs),
+            'delta_slug_count' => count($slugs),
             'recommended_rollout_delta_slugs' => $slugs,
         ]);
     }

--- a/backend/tests/Feature/Console/CareerPrepareCanonicalRuntimeCandidatesCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPrepareCanonicalRuntimeCandidatesCommandTest.php
@@ -152,6 +152,75 @@ final class CareerPrepareCanonicalRuntimeCandidatesCommandTest extends TestCase
         $this->assertSame(0, IndexState::query()->count());
     }
 
+    public function test_progressive_dry_run_requires_max_slugs_to_match_delta_count(): void
+    {
+        $artifact = $this->writePlanArtifact($this->slugs('delta', 220), target: 'career_80_to_300_delta', targetTotal: 300);
+
+        $exitCode = $this->callCommand([
+            '--plan' => $artifact,
+            '--dry-run' => true,
+            '--expect-slug-count' => 220,
+            '--max-slugs' => 300,
+            '--target-total' => 300,
+            '--cohort' => 'career_80_to_300_delta',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(1, $payload['by_reason']['progressive_max_slugs_must_match_delta_count']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    public function test_progressive_dry_run_allows_exact_220_guard_without_writes(): void
+    {
+        $slugs = $this->slugs('delta', 220);
+        foreach ($slugs as $slug) {
+            $this->createOccupation($slug);
+        }
+        $artifact = $this->writePlanArtifact($slugs, target: 'career_80_to_300_delta', targetTotal: 300);
+        $before = IndexState::query()->count();
+
+        $exitCode = $this->callCommand([
+            '--plan' => $artifact,
+            '--dry-run' => true,
+            '--expect-slug-count' => 220,
+            '--max-slugs' => 220,
+            '--target-total' => 300,
+            '--cohort' => 'career_80_to_300_delta',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertSame(220, $payload['slug_count']);
+        $this->assertSame(440, $payload['expected_locale_rows']);
+        $this->assertSame(220, $payload['planned_write_count']);
+        $this->assertSame('career_80_to_300_delta_runtime_candidate_preparation', $payload['preparation_source']);
+        $this->assertSame($before, IndexState::query()->count());
+    }
+
+    public function test_progressive_target_guard_blocks_mismatch(): void
+    {
+        $artifact = $this->writePlanArtifact($this->slugs('delta', 220), target: 'career_80_to_300_delta', targetTotal: 300);
+
+        $exitCode = $this->callCommand([
+            '--plan' => $artifact,
+            '--dry-run' => true,
+            '--expect-slug-count' => 220,
+            '--max-slugs' => 220,
+            '--target-total' => 800,
+            '--cohort' => 'career_80_to_300_delta',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(1, $payload['by_reason']['target_public_total_mismatch']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
     public function test_apply_writes_only_explicit_slugs_and_verifies_candidate_rows(): void
     {
         $actuaries = $this->createOccupation('actuaries');
@@ -231,6 +300,7 @@ final class CareerPrepareCanonicalRuntimeCandidatesCommandTest extends TestCase
             'batch_id',
             'reason',
             'source_artifact',
+            'preparation_source',
             'source_kind',
             'artifact_schema_version',
             'artifact_sha256',
@@ -250,6 +320,7 @@ final class CareerPrepareCanonicalRuntimeCandidatesCommandTest extends TestCase
             'non_goals',
         ], array_keys($payload));
         $this->assertSame('plan', $payload['source_kind']);
+        $this->assertSame('career_80_delta_runtime_candidate_preparation', $payload['preparation_source']);
         $this->assertSame('published_candidate', $payload['target_runtime_state']);
         $this->assertSame(IndexStateValue::PROMOTION_CANDIDATE, $payload['target_index_state']);
         $this->assertContains('no_rollout_apply', $payload['non_goals']);
@@ -293,6 +364,19 @@ final class CareerPrepareCanonicalRuntimeCandidatesCommandTest extends TestCase
     }
 
     /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%03d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
      * @param  list<string>  $slugs
      */
     private function writeSlugArtifact(array $slugs, ?int $countOverride = null): string
@@ -307,7 +391,7 @@ final class CareerPrepareCanonicalRuntimeCandidatesCommandTest extends TestCase
     /**
      * @param  list<string>  $slugs
      */
-    private function writePlanArtifact(array $slugs): string
+    private function writePlanArtifact(array $slugs, string $target = 'career_80_delta', int $targetTotal = 80): string
     {
         $rows = [];
         foreach ($slugs as $slug) {
@@ -324,9 +408,11 @@ final class CareerPrepareCanonicalRuntimeCandidatesCommandTest extends TestCase
         return $this->writeJson('runtime-candidate-plan', [
             'schema_version' => 'career_runtime_candidate_prep_plan.v1',
             'status' => 'planned',
-            'target' => 'career_80_delta',
+            'target' => $target,
+            'target_public_total' => $targetTotal,
             'delta_slug_count' => count($slugs),
             'locales' => ['en', 'zh'],
+            'expected_locale_rows' => count($slugs) * 2,
             'planned_candidate_rows' => $rows,
         ]);
     }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
@@ -23,6 +23,7 @@ final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
 
         $this->assertSame('planned', $payload['status']);
         $this->assertSame('career_runtime_candidate_prep_plan.v1', $payload['schema_version']);
+        $this->assertSame('career_80_delta', $payload['target']);
         $this->assertSame(51, $payload['delta_slug_count']);
         $this->assertSame(102, $payload['expected_locale_rows']);
         $this->assertSame(102, $payload['planned_candidate_rows_count']);
@@ -30,6 +31,44 @@ final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
         $this->assertTrue($payload['planned_candidate_rows'][0]['candidate_pre_route_expected']);
         $this->assertFalse($payload['writes_database']);
         $this->assertFalse($payload['apply_allowed']);
+    }
+
+    public function test_plans_220_delta_rows_for_300_progressive_target(): void
+    {
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: $this->targetDelta($this->slugs('delta', 220), currentTotal: 80, targetTotal: 300, schemaVersion: 'career_progressive_cohort_delta_plan.v1'),
+            targetPublicTotal: 300,
+            cohort: 'career_80_to_300_delta',
+        )->toArray();
+
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('career_80_to_300_delta', $payload['target']);
+        $this->assertSame(80, $payload['current_public_total']);
+        $this->assertSame(300, $payload['target_public_total']);
+        $this->assertSame(220, $payload['delta_slug_count']);
+        $this->assertSame(440, $payload['expected_locale_rows']);
+        $this->assertSame(440, $payload['expected_delta_locale_rows']);
+        $this->assertSame(440, $payload['planned_candidate_rows_count']);
+        $this->assertSame('career_80_to_300_delta_runtime_candidate_prep', $payload['planned_candidate_rows'][0]['source']);
+    }
+
+    public function test_plans_500_and_1986_progressive_delta_rows(): void
+    {
+        $fiveHundred = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: $this->targetDelta($this->slugs('delta', 500), currentTotal: 300, targetTotal: 800, schemaVersion: 'career_progressive_cohort_delta_plan.v1'),
+        )->toArray();
+
+        $this->assertSame('career_300_to_800_delta', $fiveHundred['target']);
+        $this->assertSame(500, $fiveHundred['delta_slug_count']);
+        $this->assertSame(1000, $fiveHundred['expected_delta_locale_rows']);
+
+        $full = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: $this->targetDelta($this->slugs('delta', 1986), currentTotal: 800, targetTotal: 2786, schemaVersion: 'career_progressive_cohort_delta_plan.v1'),
+        )->toArray();
+
+        $this->assertSame('career_800_to_2786_delta', $full['target']);
+        $this->assertSame(1986, $full['delta_slug_count']);
+        $this->assertSame(3972, $full['expected_delta_locale_rows']);
     }
 
     public function test_blocks_target_delta_plan_that_did_not_pass(): void
@@ -44,6 +83,17 @@ final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
         $this->assertSame('blocked', $payload['status']);
         $this->assertSame('target_delta_plan_not_pass', $payload['blockers'][0]['reason']);
         $this->assertSame(2, $payload['planned_candidate_rows_count']);
+    }
+
+    public function test_blocks_target_public_total_mismatch(): void
+    {
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: $this->targetDelta($this->slugs('delta', 220), currentTotal: 80, targetTotal: 300, schemaVersion: 'career_progressive_cohort_delta_plan.v1'),
+            targetPublicTotal: 800,
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('target_public_total_mismatch', $payload['blockers'][0]['reason']);
     }
 
     public function test_blocks_duplicate_delta_slugs(): void
@@ -93,10 +143,12 @@ final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
             'read_only',
             'writes_database',
             'target',
+            'current_public_total',
             'target_public_total',
             'delta_slug_count',
             'locales',
             'expected_locale_rows',
+            'expected_delta_locale_rows',
             'planned_candidate_rows_count',
             'planned_candidate_rows',
             'slug_rows',
@@ -126,13 +178,15 @@ final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
      * @param  list<string>  $slugs
      * @return array<string, mixed>
      */
-    private function targetDelta(array $slugs): array
+    private function targetDelta(array $slugs, int $currentTotal = 29, int $targetTotal = 80, string $schemaVersion = 'career_80_target_delta.v1'): array
     {
         return [
-            'schema_version' => 'career_80_target_delta.v1',
+            'schema_version' => $schemaVersion,
             'status' => 'pass',
-            'target_public_total' => 80,
+            'current_public_total' => $currentTotal,
+            'target_public_total' => $targetTotal,
             'delta_promotion_count' => count($slugs),
+            'delta_slug_count' => count($slugs),
             'recommended_rollout_delta_slugs' => $slugs,
         ];
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5488,7 +5488,7 @@
       "repo": "fap-api",
       "branch": "fix/career-progressive-cohort-target-delta-1",
       "title": "fix(api): add progressive career cohort delta planner",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "80-CLOSEOUT-1"
       ],
@@ -5513,8 +5513,8 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "bb3f9444646533f18a874c44716b5c6b9d5f3711",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1395",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -5535,6 +5535,83 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1",
+      "merged_at": "2026-05-14T19:26:45Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "backend/scripts/ci_verify_mbti.sh failed only Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
+            "Current PR changed only Career progressive audit/command/test/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
+            "Targeted Career tests, route:list, sqlite migrate, Pint, and git diff --check passed."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "may_continue_train": true
+        }
+      ]
+    },
+    "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-progressive-runtime-candidate-prep-1",
+      "title": "fix(api): generalize career runtime candidate preparation",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-COHORT-TARGET-DELTA-1"
+      ],
+      "scope_type": "progressive_runtime_candidate_preparation_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php",
+        "backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no backfill",
+        "no rollback",
+        "no quarantine",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for the progressive expansion PR train."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-COHORT-TARGET-DELTA-1 merged as PR #1395 and provides explicit progressive delta artifacts."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to progressive runtime candidate preparation planning/guards, tests/docs, and train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_sidecar",
+          "evidence": "CareerRuntimeCandidate, CareerProgressiveCohortDelta, Career80TargetDelta, CareerAuditCanonicalEligibility, route:list, sqlite migrate, Pint, and git diff --check passed locally. backend/scripts/ci_verify_mbti.sh still fails the pre-existing BigFive content pack publish/rollback compiled directory assertions outside this PR scope."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-PROGRESSIVE-RUNTIME-ARTIFACT-REFRESH-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -5548,8 +5625,8 @@
           "affected_slugs": [],
           "affected_locales": [],
           "evidence": [
-            "backend/scripts/ci_verify_mbti.sh failed only Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
-            "Current PR changed only Career progressive audit/command/test/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
+            "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
+            "Current PR changed only Career runtime candidate prep command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
             "Targeted Career tests, route:list, sqlite migrate, Pint, and git diff --check passed."
           ],
           "severity": "medium",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -40,6 +40,43 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-COHORT-TARGET-DELTA-1
+    branch: fix/career-progressive-runtime-candidate-prep-1
+    title: "fix(api): generalize career runtime candidate preparation"
+    name: "Generalize runtime candidate preparation for progressive Career cohorts"
+    scope:
+      - Extend runtime candidate preparation planning to consume progressive cohort delta artifacts.
+      - Support explicit 220, 500, and 1986 slug deltas without wildcard or all-2786 selection.
+      - Preserve guarded dry-run/apply SHA, expected count, and max-slugs controls without running production writes.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
+      - backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run candidate preparation apply.
+      - Run rollout or rollout dry-run.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerRuntimeCandidate --no-ansi
+      - php artisan test --filter=CareerProgressiveCohortDelta --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- generalizes runtime candidate preparation planning for progressive Career cohort deltas after PR #1395
- adds target-total/cohort guards and exact max-slugs matching for progressive artifacts
- preserves 51-delta behavior and keeps apply guarded by explicit SHA/count options
- records external BigFive content-pack publish/rollback local ci_verify_mbti sidecar without staging unrelated files

## Non-goals
- no candidate prep apply
- no rollout dry-run/apply
- no DB mutation
- no deploy
- no fap-web change

## Tests
- php artisan test --filter=CareerRuntimeCandidatePrepPlanner --no-ansi
- php artisan test --filter=CareerPlanCanonicalRuntimeCandidatePrep --no-ansi
- php artisan test --filter=CareerPrepareCanonicalRuntimeCandidates --no-ansi
- php artisan test --filter=CareerRuntimeCandidate --no-ansi
- php artisan test --filter=CareerProgressiveCohortDelta --no-ansi
- php artisan test --filter=Career80TargetDelta --no-ansi
- php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-progressive-expansion-pr2.sqlite php artisan migrate --force --no-ansi
- vendor/bin/pint --test
- git diff --check

## Sidecar
- backend/scripts/ci_verify_mbti.sh still fails Tests\Feature\Content\PacksPublishBig5Test and Tests\Feature\Content\PacksRollbackBig5Test at File::isDirectory($target./compiled) assertions. This is external to current PR scope; current PR did not touch content-pack publish/rollback code or generated content assets.