### PR TITLE
fix(api): generalize career runtime artifact refresh

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
@@ -14,7 +14,7 @@ use Throwable;
 final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
 {
     protected $signature = 'career:plan-canonical-runtime-artifact-refresh
-        {--target=career_80_delta : Refresh target}
+        {--target=career_80_delta : Refresh target or progressive cohort key}
         {--delta-plan= : Optional Career 80 target delta artifact}
         {--candidate-prep-plan= : Optional runtime candidate prep plan artifact}
         {--candidate-prep-apply= : Optional runtime candidate prep apply artifact}
@@ -81,6 +81,7 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
         $truthOutputPath = $this->requiredPathOption('truth-output');
         $ledgerOutputPath = $this->requiredPathOption('ledger-output');
         $expectedSlugCount = $this->positiveIntOption('expect-slug-count', 51);
+        $target = trim((string) ($this->option('target') ?? 'career_80_delta')) ?: 'career_80_delta';
 
         try {
             $result = app(CareerRuntimeCandidateAwareArtifactRefresh::class)->build(
@@ -97,6 +98,7 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
                 truthOutputPath: $truthOutputPath,
                 ledgerOutputPath: $ledgerOutputPath,
                 expectedSlugCount: $expectedSlugCount,
+                target: $target,
             );
 
             $this->writeJson($projectionOutputPath, $result['projection']);
@@ -114,7 +116,7 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
                     'slug_count' => 0,
                     'artifact_sha256' => null,
                 ],
-                'target' => 'career_80_delta',
+                'target' => $target,
                 'delta_slug_count' => 0,
                 'expected_delta_locale_rows' => 0,
                 'projection' => [

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php
@@ -12,7 +12,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
 
     public const OVERLAY_SOURCE = 'candidate_prep_apply_overlay';
 
-    private const TARGET = 'career_80_delta';
+    private const DEFAULT_TARGET = 'career_80_delta';
 
     private const RUNTIME_STATE = 'published_candidate';
 
@@ -39,6 +39,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
         string $truthOutputPath,
         string $ledgerOutputPath,
         int $expectedSlugCount = 51,
+        string $target = self::DEFAULT_TARGET,
     ): array {
         $source = $this->verifiedSource($candidatePrepApply, $candidatePrepApplyPath, $candidatePrepApplyFileSha256, $expectedSlugCount);
         $slugs = $source['slugs'];
@@ -61,7 +62,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
                     'artifact_sha256' => $source['artifact_sha256'],
                     'file_sha256' => $candidatePrepApplyFileSha256,
                 ],
-                'target' => self::TARGET,
+                'target' => $this->target($target),
                 'delta_slug_count' => count($slugs),
                 'expected_delta_locale_rows' => count($slugs) * count($locales),
                 'locales' => $locales,
@@ -87,12 +88,33 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
                 'writes_database' => false,
                 'read_only' => true,
                 'apply_allowed' => false,
-                'next_required_action' => '51_DELTA_ROLLOUT_DRY_RUN',
+                'next_required_action' => $this->nextRequiredAction($target),
             ],
             'projection' => $projectionArtifact,
             'truth' => $truthArtifact,
             'ledger' => $ledgerArtifact,
         ];
+    }
+
+    private function target(string $target): string
+    {
+        $normalized = strtolower(trim($target));
+        if ($normalized === '') {
+            return self::DEFAULT_TARGET;
+        }
+
+        $key = preg_replace('/[^a-z0-9]+/', '_', $normalized) ?? $normalized;
+
+        return trim($key, '_') ?: self::DEFAULT_TARGET;
+    }
+
+    private function nextRequiredAction(string $target): string
+    {
+        $target = $this->target($target);
+
+        return $target === self::DEFAULT_TARGET
+            ? '51_DELTA_ROLLOUT_DRY_RUN'
+            : 'PROGRESSIVE_ROLLOUT_DRY_RUN';
     }
 
     /**

--- a/backend/docs/career/audits/runtime_artifact_refresh.md
+++ b/backend/docs/career/audits/runtime_artifact_refresh.md
@@ -1,8 +1,8 @@
 # Career Runtime Artifact Refresh Plan
 
-`career:plan-canonical-runtime-artifact-refresh` defines the read-only artifact refresh sequence required after a separately approved Career 80 delta runtime candidate preparation apply.
+`career:plan-canonical-runtime-artifact-refresh` defines the read-only artifact refresh sequence required after a separately approved Career runtime candidate preparation apply.
 
-The plan exists because the 51 delta slugs must first be prepared as runtime `published_candidate` inventory, then projection, truth, and ledger artifacts must be refreshed before any 51-delta rollout dry-run is attempted.
+The plan exists because delta slugs must first be prepared as runtime `published_candidate` inventory, then projection, truth, and ledger artifacts must be refreshed before any rollout dry-run is attempted. It supports the 51 Career 80 delta path and progressive cohort deltas such as 220, 500, and 1986 slugs.
 
 ## Usage
 
@@ -45,6 +45,24 @@ php artisan career:plan-canonical-runtime-artifact-refresh \
   --output=/tmp/career_80_delta_runtime_artifact_refresh_candidate_aware.json
 ```
 
+Progressive candidate-aware refresh uses the same command with an explicit target, expected slug count, and cohort-specific outputs:
+
+```bash
+php artisan career:plan-canonical-runtime-artifact-refresh \
+  --target=career_80_to_300_delta \
+  --candidate-prep-apply=/tmp/career_300_runtime_candidate_prep_apply.json \
+  --projection=/tmp/career_300_runtime_projection_after_candidate_prep.json \
+  --truth=/tmp/career_300_runtime_truth_after_candidate_prep.json \
+  --ledger=/tmp/career_300_full_release_ledger_after_candidate_prep.json \
+  --candidate-aware \
+  --expect-slug-count=220 \
+  --projection-output=/tmp/career_300_runtime_projection_candidate_aware.json \
+  --truth-output=/tmp/career_300_runtime_truth_candidate_aware.json \
+  --ledger-output=/tmp/career_300_full_release_ledger_candidate_aware.json \
+  --json \
+  --output=/tmp/career_300_runtime_artifact_refresh_candidate_aware.json
+```
+
 ## Output
 
 The output schema is `career_runtime_artifact_refresh_plan.v1`.
@@ -64,7 +82,7 @@ Key fields:
 
 Candidate-aware refresh output schema is `career_runtime_candidate_aware_artifact_refresh.v1`.
 
-The candidate-aware mode consumes the verified candidate-prep apply artifact and overlays its 51 verified slugs into read-only projection, truth, and ledger artifacts as hidden pre-route `published_candidate` rows. Overlay rows and members carry `candidate_prep_apply_overlay` provenance and explicitly set `canonical_ledger_authority_claimed=false`. This matters because the canonical full release ledger exporter alone may omit newly prepared candidate rows or keep previously tracked members in `review_needed` / `family_handoff`; candidate-aware artifacts are planning artifacts derived from write verification, not a replacement claim that those rows originated from canonical ledger authority.
+The candidate-aware mode consumes the verified candidate-prep apply artifact and overlays its verified slugs into read-only projection, truth, and ledger artifacts as hidden pre-route `published_candidate` rows. Overlay rows equal `delta_slug_count * locale_count`, and ledger overlay members equal `delta_slug_count`. Overlay rows and members carry `candidate_prep_apply_overlay` provenance and explicitly set `canonical_ledger_authority_claimed=false`. This matters because the canonical full release ledger exporter alone may omit newly prepared candidate rows or keep previously tracked members in `review_needed` / `family_handoff`; candidate-aware artifacts are planning artifacts derived from write verification, not a replacement claim that those rows originated from canonical ledger authority.
 
 Candidate-aware artifact paths:
 
@@ -73,7 +91,7 @@ Candidate-aware artifact paths:
 - `/tmp/career_80_delta_full_release_ledger_candidate_aware.json`
 - `/tmp/career_80_delta_runtime_artifact_refresh_candidate_aware.json`
 
-The candidate-aware artifacts are intended for the next read-only 51-delta rollout dry-run. They do not publish pages, do not run rollout, and do not mutate the database.
+The candidate-aware artifacts are intended for the next read-only rollout dry-run for the current delta cohort. They do not publish pages, do not run rollout, and do not mutate the database.
 
 ## Approval Gates
 

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
@@ -204,6 +204,37 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
         $this->assertFalse($ledger['members'][1]['canonical_ledger_authority_claimed']);
     }
 
+    public function test_candidate_aware_mode_supports_220_delta_progressive_overlay(): void
+    {
+        $payload = $this->runCandidateAwareProgressiveOverlay(220, 'career_80_to_300_delta');
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame('career_80_to_300_delta', $payload['target']);
+        $this->assertSame(220, $payload['delta_slug_count']);
+        $this->assertSame(440, $payload['expected_delta_locale_rows']);
+        $this->assertSame(440, $payload['projection']['overlay_rows']);
+        $this->assertSame(440, $payload['truth']['overlay_rows']);
+        $this->assertSame(220, $payload['ledger']['overlay_members']);
+        $this->assertSame('PROGRESSIVE_ROLLOUT_DRY_RUN', $payload['next_required_action']);
+    }
+
+    public function test_candidate_aware_mode_supports_500_and_1986_delta_progressive_overlays(): void
+    {
+        $fiveHundred = $this->runCandidateAwareProgressiveOverlay(500, 'career_300_to_800_delta');
+
+        $this->assertSame(500, $fiveHundred['delta_slug_count']);
+        $this->assertSame(1000, $fiveHundred['projection']['overlay_rows']);
+        $this->assertSame(1000, $fiveHundred['truth']['overlay_rows']);
+        $this->assertSame(500, $fiveHundred['ledger']['overlay_members']);
+
+        $full = $this->runCandidateAwareProgressiveOverlay(1986, 'career_800_to_2786_delta');
+
+        $this->assertSame(1986, $full['delta_slug_count']);
+        $this->assertSame(3972, $full['projection']['overlay_rows']);
+        $this->assertSame(3972, $full['truth']['overlay_rows']);
+        $this->assertSame(1986, $full['ledger']['overlay_members']);
+    }
+
     public function test_candidate_aware_artifacts_pass_runtime_candidate_pool_synthetic_integration(): void
     {
         $slugs = ['alpha-career', 'beta-career'];
@@ -303,6 +334,39 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
         return Artisan::call('career:plan-canonical-runtime-artifact-refresh', array_merge([
             '--json' => true,
         ], $options));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runCandidateAwareProgressiveOverlay(int $count, string $target): array
+    {
+        $projectionOutput = $this->tempPath($target.'-projection');
+        $truthOutput = $this->tempPath($target.'-truth');
+        $ledgerOutput = $this->tempPath($target.'-ledger');
+        $summaryOutput = $this->tempPath($target.'-summary');
+
+        $exitCode = $this->callCommand([
+            '--target' => $target,
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApplyForSlugs($this->slugs($count))),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--projection-output' => $projectionOutput,
+            '--truth-output' => $truthOutput,
+            '--ledger-output' => $ledgerOutput,
+            '--expect-slug-count' => $count,
+            '--output' => $summaryOutput,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertFileExists($summaryOutput);
+        $this->assertFileExists($projectionOutput);
+        $this->assertFileExists($truthOutput);
+        $this->assertFileExists($ledgerOutput);
+
+        return json_decode((string) file_get_contents($summaryOutput), true, flags: JSON_THROW_ON_ERROR);
     }
 
     /**
@@ -515,10 +579,10 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
     /**
      * @return list<string>
      */
-    private function slugs(): array
+    private function slugs(int $count = 51): array
     {
         $slugs = [];
-        for ($i = 1; $i <= 51; $i++) {
+        for ($i = 1; $i <= $count; $i++) {
             $slugs[] = sprintf('delta-%03d', $i);
         }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T01:41:30+08:00",
+  "updated_at": "2026-05-15T03:17:20+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -5562,7 +5562,7 @@
       "repo": "fap-api",
       "branch": "fix/career-progressive-runtime-candidate-prep-1",
       "title": "fix(api): generalize career runtime candidate preparation",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "REPAIR-PROGRESSIVE-COHORT-TARGET-DELTA-1"
       ],
@@ -5590,8 +5590,8 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "211592e62275664043e2bd82b1ca19a269e03a60",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1396",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -5612,6 +5612,83 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-PROGRESSIVE-RUNTIME-ARTIFACT-REFRESH-1",
+      "merged_at": "2026-05-14T19:45:48Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
+            "Current PR changed only Career runtime candidate prep command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
+            "Targeted Career tests, route:list, sqlite migrate, Pint, and git diff --check passed."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "may_continue_train": true
+        }
+      ]
+    },
+    "REPAIR-PROGRESSIVE-RUNTIME-ARTIFACT-REFRESH-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-progressive-runtime-artifact-refresh-1",
+      "title": "fix(api): generalize career runtime artifact refresh",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1"
+      ],
+      "scope_type": "progressive_runtime_artifact_refresh_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no production artifact export",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no backfill",
+        "no rollback",
+        "no quarantine",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for the progressive expansion PR train."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1 merged as PR #1396 and provides progressive candidate prep artifacts and guards."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to read-only progressive runtime artifact refresh semantics, tests/docs, and train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_sidecar",
+          "evidence": "CareerPlanCanonicalRuntimeArtifactRefresh, CareerRuntimeArtifactRefresh, CareerRuntimeCandidate, CareerPlanCanonical80RuntimeCandidatePool, route:list, sqlite migrate, Pint, and git diff --check passed locally. backend/scripts/ci_verify_mbti.sh still fails the pre-existing BigFive content pack publish/rollback compiled directory assertions outside this PR scope."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-PROGRESSIVE-ROLLOUT-MANIFEST-GATE-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -5626,7 +5703,7 @@
           "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
-            "Current PR changed only Career runtime candidate prep command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
+            "Current PR changed only Career runtime artifact refresh command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
             "Targeted Career tests, route:list, sqlite migrate, Pint, and git diff --check passed."
           ],
           "severity": "medium",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -77,6 +77,44 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-RUNTIME-ARTIFACT-REFRESH-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1
+    branch: fix/career-progressive-runtime-artifact-refresh-1
+    title: "fix(api): generalize career runtime artifact refresh"
+    name: "Generalize candidate-aware runtime artifact refresh for progressive Career cohorts"
+    scope:
+      - Extend candidate-aware runtime artifact refresh to support progressive cohort deltas.
+      - Support 220, 500, and 1986 slug overlays with delta slug count multiplied by locale count.
+      - Preserve candidate_prep_apply_overlay provenance and avoid canonical ledger authority claims.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run artifact export against production.
+      - Run candidate preparation apply.
+      - Run rollout or rollout dry-run.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi
+      - php artisan test --filter=CareerRuntimeCandidate --no-ansi
+      - php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- generalizes candidate-aware runtime artifact refresh target metadata for progressive cohorts
- supports 220 / 500 / 1986 delta overlay sizing while preserving `candidate_prep_apply_overlay` provenance
- keeps the refresh command read-only and writes only explicit projection/truth/ledger/summary artifacts

## Non-goals
- no production artifact export execution
- no candidate prep apply
- no rollout dry-run or rollout apply
- no DB mutation, deploy, rollback, quarantine, or fap-web change

## Tests
- `php artisan test --filter=CareerPlanCanonicalRuntimeArtifactRefresh --no-ansi`
- `php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi`
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-progressive-expansion-pr3.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh` reproduced external sidecar: `Tests\Feature\Content\PacksPublishBig5Test` and `Tests\Feature\Content\PacksRollbackBig5Test` fail at `File::isDirectory($target.'/compiled')`; current PR does not touch content pack publish/rollback code or compiled assets.

## Scope
Changed files are limited to Career runtime artifact refresh command/domain/test/docs and train metadata.

## Next
REPAIR-PROGRESSIVE-ROLLOUT-MANIFEST-GATE-1