### PR TITLE
fix(api): generalize career progressive rollout manifest gate

### DIFF
--- a/backend/app/Console/Commands/CareerGenerateCanonicalProgressiveRolloutManifest.php
+++ b/backend/app/Console/Commands/CareerGenerateCanonicalProgressiveRolloutManifest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerDeltaRolloutManifestPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerGenerateCanonicalProgressiveRolloutManifest extends Command
+{
+    protected $signature = 'career:generate-canonical-progressive-rollout-manifest
+        {--target-delta= : Required progressive cohort target-delta JSON artifact}
+        {--candidate-prep-plan= : Optional runtime candidate prep plan JSON artifact}
+        {--current-public-total= : Current accepted public total before rollout}
+        {--target-public-total= : Target public total after rollout; defaults to target-delta target_public_total}
+        {--expect-delta-count= : Expected delta promotion slug count; defaults to target-delta delta slug count}
+        {--target= : Optional target key; defaults to career_<current>_to_<target>_delta}
+        {--batch-id= : Optional batch id; defaults to career_<current>_to_<target>_canonical_001}
+        {--locales=en,zh : Comma-separated locale list}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for progressive rollout manifest JSON}';
+
+    protected $description = 'Generate a read-only Career progressive canonical rollout manifest for 300, 800, or 2786 cohorts.';
+
+    public function handle(): int
+    {
+        try {
+            $targetDeltaPath = $this->requiredOption('target-delta');
+            $targetDelta = $this->readJson($targetDeltaPath, 'target_delta');
+            $candidatePrepPlanPath = $this->pathOption('candidate-prep-plan');
+            $currentPublicTotal = $this->currentPublicTotal($targetDelta);
+            $targetPublicTotal = $this->targetPublicTotal($targetDelta);
+            $expectedDeltaCount = $this->expectedDeltaCount($targetDelta);
+            $target = $this->target($currentPublicTotal, $targetPublicTotal);
+
+            $payload = app(CareerDeltaRolloutManifestPlanner::class)->plan(
+                targetDeltaPlan: $targetDelta,
+                candidatePrepPlan: $candidatePrepPlanPath === null ? null : $this->readJson($candidatePrepPlanPath, 'candidate_prep_plan'),
+                targetPublicTotal: $targetPublicTotal,
+                expectedDeltaCount: $expectedDeltaCount,
+                locales: $this->locales(),
+                batchId: $this->batchId($currentPublicTotal, $targetPublicTotal),
+                targetDeltaPath: $targetDeltaPath,
+                candidatePrepPlanPath: $candidatePrepPlanPath,
+                target: $target,
+            )->toArray();
+
+            return $this->finish($payload, ($payload['status'] ?? null) === 'pass' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => CareerDeltaRolloutManifestPlanner::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'target' => 'career_progressive_delta',
+                'read_only' => true,
+                'writes_database' => false,
+                'rollout_allowed' => false,
+                'dry_run_allowed' => false,
+                'apply_allowed' => false,
+                'rollout_dry_run_executed' => false,
+                'rollout_apply_executed' => false,
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                ]],
+                'next_required_action' => 'FIX_DELTA_ROLLOUT_MANIFEST_BLOCKERS',
+            ], self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDelta
+     */
+    private function currentPublicTotal(array $targetDelta): int
+    {
+        return $this->positiveIntOption('current-public-total')
+            ?? $this->positiveIntValue($targetDelta['current_public_total'] ?? null, 'current_public_total');
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDelta
+     */
+    private function targetPublicTotal(array $targetDelta): int
+    {
+        return $this->positiveIntOption('target-public-total')
+            ?? $this->positiveIntValue($targetDelta['target_public_total'] ?? null, 'target_public_total');
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDelta
+     */
+    private function expectedDeltaCount(array $targetDelta): int
+    {
+        return $this->positiveIntOption('expect-delta-count')
+            ?? $this->positiveIntValue($targetDelta['delta_slug_count'] ?? $targetDelta['delta_promotion_count'] ?? null, 'delta_slug_count');
+    }
+
+    private function positiveIntOption(string $name): ?int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return null;
+        }
+
+        return $this->positiveIntValue($raw, str_replace('-', '_', $name));
+    }
+
+    private function positiveIntValue(mixed $raw, string $name): int
+    {
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException($name.'_invalid');
+        }
+
+        return $value;
+    }
+
+    private function target(int $currentPublicTotal, int $targetPublicTotal): string
+    {
+        $target = trim((string) ($this->option('target') ?? ''));
+        if ($target === '') {
+            $target = 'career_'.$currentPublicTotal.'_to_'.$targetPublicTotal.'_delta';
+        }
+
+        $normalized = preg_replace('/[^a-z0-9]+/', '_', strtolower($target)) ?? $target;
+
+        return trim($normalized, '_') ?: 'career_'.$targetPublicTotal.'_delta';
+    }
+
+    private function batchId(int $currentPublicTotal, int $targetPublicTotal): string
+    {
+        $batchId = trim((string) ($this->option('batch-id') ?? ''));
+        if ($batchId !== '') {
+            return $batchId;
+        }
+
+        return 'career_'.$currentPublicTotal.'_to_'.$targetPublicTotal.'_canonical_001';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function locales(): array
+    {
+        $raw = trim((string) ($this->option('locales') ?? 'en,zh'));
+        $locales = [];
+        foreach (explode(',', $raw) as $locale) {
+            $normalized = strtolower(trim($locale));
+            if ($normalized !== '' && ! in_array($normalized, $locales, true)) {
+                $locales[] = $normalized;
+            }
+        }
+
+        sort($locales);
+        if ($locales === []) {
+            throw new RuntimeException('locales_missing');
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException($kind.'_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException($kind.'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            File::put($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('delta_slug_count='.(string) ($payload['delta_slug_count'] ?? 0));
+            $this->line('target_public_total='.(string) ($payload['target_public_total'] ?? 0));
+        }
+
+        return $exitCode;
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $key = strtolower(trim($message));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $key) ?? 'progressive_rollout_manifest_error';
+        $key = trim($key, '_');
+
+        return $key === '' ? 'progressive_rollout_manifest_error' : $key;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -37,6 +37,7 @@ use App\Console\Commands\CareerFinalizeCanonicalRuntimeTruth;
 use App\Console\Commands\CareerFullDisplayWorkbookValidator;
 use App\Console\Commands\CareerGenerateCanonicalDeltaRolloutManifest;
 use App\Console\Commands\CareerGenerateCanonicalExpansionManifestTrain;
+use App\Console\Commands\CareerGenerateCanonicalProgressiveRolloutManifest;
 use App\Console\Commands\CareerImportActorsDisplayAsset;
 use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
@@ -246,6 +247,7 @@ class Kernel extends ConsoleKernel
         CareerCrosswalkOps::class,
         CareerGenerateCanonicalDeltaRolloutManifest::class,
         CareerGenerateCanonicalExpansionManifestTrain::class,
+        CareerGenerateCanonicalProgressiveRolloutManifest::class,
         CareerExportCanonicalExpansionManifest::class,
         CareerExportCanonicalEligibilityDbContext::class,
         CareerExportCanonicalEligibilitySurfaceContext::class,

--- a/backend/app/Domain/Career/Audit/CareerDeltaRolloutGatePlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerDeltaRolloutGatePlanner.php
@@ -18,6 +18,7 @@ final class CareerDeltaRolloutGatePlanner
         int $targetPublicTotal = 80,
         int $expectedDeltaCount = 51,
         ?string $manifestPath = null,
+        ?string $target = null,
     ): CareerDeltaRolloutGateResult {
         if ($targetPublicTotal < 1) {
             throw new RuntimeException('target_public_total_invalid');
@@ -45,11 +46,12 @@ final class CareerDeltaRolloutGatePlanner
             expectedRows: $expectedRows,
         );
         $pass = $blockers === [];
+        $target = $this->target($target, $manifest, $targetPublicTotal);
 
         return new CareerDeltaRolloutGateResult([
             'schema_version' => self::SCHEMA_VERSION,
             'status' => $pass ? 'pass' : 'blocked',
-            'target' => 'career_80_delta',
+            'target' => $target,
             'read_only' => true,
             'writes_database' => false,
             'target_public_total' => $targetPublicTotal,
@@ -99,8 +101,30 @@ final class CareerDeltaRolloutGatePlanner
             'rollout_apply_executed' => false,
             'blockers' => $blockers,
             'sidecars' => [],
-            'next_required_action' => $pass ? 'DELTA_ROLLOUT_DRY_RUN_51' : 'FIX_DELTA_ROLLOUT_GATE_BLOCKERS',
+            'next_required_action' => $pass ? $this->nextRequiredAction($target) : 'FIX_DELTA_ROLLOUT_GATE_BLOCKERS',
         ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     */
+    private function target(?string $target, array $manifest, int $targetPublicTotal): string
+    {
+        $candidate = trim((string) ($target ?? ($manifest['target'] ?? '')));
+        if ($candidate === '') {
+            $candidate = $targetPublicTotal === 80 ? 'career_80_delta' : 'career_'.$targetPublicTotal.'_delta';
+        }
+
+        $normalized = preg_replace('/[^a-z0-9]+/', '_', strtolower($candidate)) ?? $candidate;
+
+        return trim($normalized, '_') ?: 'career_80_delta';
+    }
+
+    private function nextRequiredAction(string $target): string
+    {
+        return $target === 'career_80_delta'
+            ? 'DELTA_ROLLOUT_DRY_RUN_51'
+            : 'PROGRESSIVE_ROLLOUT_DRY_RUN';
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerDeltaRolloutManifestPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerDeltaRolloutManifestPlanner.php
@@ -24,6 +24,7 @@ final class CareerDeltaRolloutManifestPlanner
         string $batchId = 'career_80_delta_canonical_001',
         ?string $targetDeltaPath = null,
         ?string $candidatePrepPlanPath = null,
+        ?string $target = null,
     ): CareerDeltaRolloutManifestResult {
         if ($targetPublicTotal < 1) {
             throw new RuntimeException('target_public_total_invalid');
@@ -51,10 +52,11 @@ final class CareerDeltaRolloutManifestPlanner
             locales: $locales,
         );
         $pass = $blockers === [];
-        $members = array_map(static fn (string $slug): array => [
+        $target = $this->target($target, $targetDeltaPlan, $targetPublicTotal);
+        $members = array_map(fn (string $slug): array => [
             'slug' => $slug,
             'locales' => $locales,
-            'source' => 'career_80_delta_target_delta',
+            'source' => $target.'_target_delta',
             'baseline_included' => false,
             'reasons' => [],
             'sidecars' => [],
@@ -63,7 +65,7 @@ final class CareerDeltaRolloutManifestPlanner
         return new CareerDeltaRolloutManifestResult([
             'schema_version' => self::SCHEMA_VERSION,
             'status' => $pass ? 'pass' : 'blocked',
-            'target' => 'career_80_delta',
+            'target' => $target,
             'target_public_total' => $targetPublicTotal,
             'published_baseline_count' => count($baselineSlugs),
             'delta_slug_count' => count($deltaSlugs),
@@ -85,6 +87,7 @@ final class CareerDeltaRolloutManifestPlanner
                 'path' => $targetDeltaPath,
                 'schema_version' => $targetDeltaPlan['schema_version'] ?? null,
                 'status' => $targetDeltaPlan['status'] ?? null,
+                'current_public_total' => $targetDeltaPlan['current_public_total'] ?? null,
                 'target_public_total' => $targetDeltaPlan['target_public_total'] ?? null,
                 'published_baseline_count' => $targetDeltaPlan['published_baseline_count'] ?? null,
                 'delta_promotion_count' => $targetDeltaPlan['delta_promotion_count'] ?? null,
@@ -106,7 +109,7 @@ final class CareerDeltaRolloutManifestPlanner
             ],
             'batches' => [[
                 'batch_id' => $batchId,
-                'target' => 'career_80_delta',
+                'target' => $target,
                 'target_public_total' => $targetPublicTotal,
                 'published_baseline_count' => count($baselineSlugs),
                 'delta_slug_count' => count($deltaSlugs),
@@ -121,8 +124,35 @@ final class CareerDeltaRolloutManifestPlanner
             ]],
             'blockers' => $blockers,
             'sidecars' => [],
-            'next_required_action' => $pass ? 'DELTA_ROLLOUT_DRY_RUN_51' : 'FIX_DELTA_ROLLOUT_MANIFEST_BLOCKERS',
+            'next_required_action' => $pass ? $this->nextRequiredAction($target) : 'FIX_DELTA_ROLLOUT_MANIFEST_BLOCKERS',
         ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDeltaPlan
+     */
+    private function target(?string $target, array $targetDeltaPlan, int $targetPublicTotal): string
+    {
+        $candidate = trim((string) ($target ?? ($targetDeltaPlan['target'] ?? '')));
+        if ($candidate === '') {
+            $currentTotal = $targetDeltaPlan['current_public_total'] ?? null;
+            if (is_numeric($currentTotal)) {
+                $candidate = 'career_'.(int) $currentTotal.'_to_'.$targetPublicTotal.'_delta';
+            } else {
+                $candidate = $targetPublicTotal === 80 ? 'career_80_delta' : 'career_'.$targetPublicTotal.'_delta';
+            }
+        }
+
+        $normalized = preg_replace('/[^a-z0-9]+/', '_', strtolower($candidate)) ?? $candidate;
+
+        return trim($normalized, '_') ?: 'career_80_delta';
+    }
+
+    private function nextRequiredAction(string $target): string
+    {
+        return $target === 'career_80_delta'
+            ? 'DELTA_ROLLOUT_DRY_RUN_51'
+            : 'PROGRESSIVE_ROLLOUT_DRY_RUN';
     }
 
     /**

--- a/backend/docs/career/audits/progressive_rollout_manifest_gate.md
+++ b/backend/docs/career/audits/progressive_rollout_manifest_gate.md
@@ -1,0 +1,33 @@
+# Progressive rollout manifest gate
+
+`career:generate-canonical-progressive-rollout-manifest` creates the read-only rollout manifest for progressive Career cohorts after the current cohort has been accepted.
+
+Supported targets:
+
+- 80 to 300: 220 delta slugs, 440 locale rows for `en,zh`
+- 300 to 800: 500 delta slugs, 1000 locale rows for `en,zh`
+- 800 to 2786: 1986 delta slugs, 3972 locale rows for `en,zh`
+
+The command consumes a progressive target-delta artifact and, optionally, a runtime candidate prep plan artifact. It does not run rollout dry-run, rollout apply, candidate preparation apply, backfill, rollback, quarantine, deploy, or any database mutation.
+
+Example:
+
+```bash
+php artisan career:generate-canonical-progressive-rollout-manifest \
+  --target-delta=/tmp/career_80_to_300_delta_plan.json \
+  --target-public-total=300 \
+  --expect-delta-count=220 \
+  --json \
+  --output=/tmp/career_80_to_300_rollout_manifest.json
+```
+
+The generated manifest keeps `apply_allowed=false` and only sets `dry_run_allowed=true` when:
+
+- the source target-delta plan passed
+- the current/baseline slug count plus delta slug count equals the target total
+- the delta slug count matches the explicit expected count
+- no current/baseline slug appears in the delta list
+- `rollback_group` is the explicit delta slug list
+- expected locale rows equal `delta_slug_count * locale_count`
+
+The manifest remains planning evidence only. A later rollout dry-run must use the explicit `slugs` and `rollback_group` values, and rollout apply remains separately guarded.

--- a/backend/tests/Feature/Console/CareerGenerateCanonicalProgressiveRolloutManifestCommandTest.php
+++ b/backend/tests/Feature/Console/CareerGenerateCanonicalProgressiveRolloutManifestCommandTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerGenerateCanonicalProgressiveRolloutManifest;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerGenerateCanonicalProgressiveRolloutManifestCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Artisan::registerCommand(app(CareerGenerateCanonicalProgressiveRolloutManifest::class));
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:generate-canonical-progressive-rollout-manifest', Artisan::all());
+    }
+
+    public function test_generates_220_delta_manifest_for_300_target(): void
+    {
+        $output = $this->tempPath('manifest');
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeProgressiveTargetDelta($this->slugs('current', 80), $this->slugs('delta', 220), 300),
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('career_delta_rollout_manifest.v1', $payload['schema_version']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame('career_80_to_300_delta', $payload['target']);
+        $this->assertSame(300, $payload['target_public_total']);
+        $this->assertSame(80, $payload['published_baseline_count']);
+        $this->assertSame(220, $payload['delta_slug_count']);
+        $this->assertSame(440, $payload['expected_delta_locale_rows']);
+        $this->assertSame('career_80_to_300_canonical_001', $payload['batch_id']);
+        $this->assertSame($payload['slugs'], $payload['rollback_group']);
+        $this->assertTrue($payload['dry_run_allowed']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_generates_500_and_1986_delta_progressive_manifests(): void
+    {
+        $eightHundred = $this->runManifest($this->slugs('current', 300), $this->slugs('delta', 500), 800);
+
+        $this->assertSame('career_300_to_800_delta', $eightHundred['target']);
+        $this->assertSame(500, $eightHundred['delta_slug_count']);
+        $this->assertSame(1000, $eightHundred['expected_delta_locale_rows']);
+
+        $full = $this->runManifest($this->slugs('current', 800), $this->slugs('delta', 1986), 2786);
+
+        $this->assertSame('career_800_to_2786_delta', $full['target']);
+        $this->assertSame(1986, $full['delta_slug_count']);
+        $this->assertSame(3972, $full['expected_delta_locale_rows']);
+    }
+
+    public function test_rejects_baseline_slug_in_delta_list(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeProgressiveTargetDelta(['shared-slug'], ['shared-slug'], 2),
+            '--current-public-total' => 1,
+            '--target-public-total' => 2,
+            '--expect-delta-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('baseline_slug_in_delta_manifest', array_column($payload['blockers'], 'reason'));
+        $this->assertFalse($payload['dry_run_allowed']);
+        $this->assertFalse($payload['apply_allowed']);
+    }
+
+    public function test_rejects_duplicate_delta_slugs(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeProgressiveTargetDelta(['current-001'], ['delta-001', 'delta-001'], 3),
+            '--current-public-total' => 1,
+            '--target-public-total' => 3,
+            '--expect-delta-count' => 2,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('delta_slug_duplicate_delta_001', $payload['blockers'][0]['reason']);
+    }
+
+    /**
+     * @param  list<string>  $current
+     * @param  list<string>  $delta
+     * @return array<string, mixed>
+     */
+    private function runManifest(array $current, array $delta, int $target): array
+    {
+        $output = $this->tempPath('manifest');
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeProgressiveTargetDelta($current, $delta, $target),
+            '--output' => $output,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertFileExists($output);
+
+        return json_decode((string) file_get_contents($output), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:generate-canonical-progressive-rollout-manifest', [
+            '--json' => true,
+            ...$options,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%03d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $current
+     * @param  list<string>  $delta
+     */
+    private function writeProgressiveTargetDelta(array $current, array $delta, int $target, string $status = 'pass'): string
+    {
+        sort($current);
+        sort($delta);
+
+        return $this->writeJson('target-delta', [
+            'schema_version' => 'career_progressive_cohort_delta_plan.v1',
+            'status' => $status,
+            'read_only' => true,
+            'writes_database' => false,
+            'current_public_total' => count($current),
+            'target_public_total' => $target,
+            'delta_slug_count' => count($delta),
+            'expected_delta_locale_rows' => count($delta) * 2,
+            'published_baseline_slugs' => $current,
+            'current_public_slugs' => $current,
+            'delta_promotion_slugs' => $delta,
+            'recommended_rollout_delta_slugs' => $delta,
+            'rollout' => [
+                'delta_manifest_allowed' => true,
+                'apply_allowed' => false,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-progressive-rollout-manifest-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/CareerDeltaRolloutGatePlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerDeltaRolloutGatePlannerTest.php
@@ -84,6 +84,32 @@ final class CareerDeltaRolloutGatePlannerTest extends TestCase
         $this->assertSame(6, $result['validation']['expected_delta_locale_rows']);
     }
 
+    public function test_accepts_progressive_manifest_with_explicit_rollback_group(): void
+    {
+        $manifest = $this->manifest(
+            baseline: $this->slugs('current', 80),
+            delta: $this->slugs('delta', 220),
+            target: 300,
+        );
+        $manifest['target'] = 'career_80_to_300_delta';
+        $manifest['batch_id'] = 'career_80_to_300_canonical_001';
+
+        $result = (new CareerDeltaRolloutGatePlanner)->plan(
+            $manifest,
+            targetPublicTotal: 300,
+            expectedDeltaCount: 220,
+        )->toArray();
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertSame('career_80_to_300_delta', $result['target']);
+        $this->assertSame(220, $result['delta_slug_count']);
+        $this->assertSame(440, $result['expected_delta_locale_rows']);
+        $this->assertSame(220, $result['validation']['rollback_group_count']);
+        $this->assertSame($result['delta_slugs'], $result['rollback_group']);
+        $this->assertSame('PROGRESSIVE_ROLLOUT_DRY_RUN', $result['next_required_action']);
+        $this->assertFalse($result['rollout_apply_allowed']);
+    }
+
     public function test_rejects_total_public_target_mismatch(): void
     {
         $result = (new CareerDeltaRolloutGatePlanner)->plan(

--- a/backend/tests/Unit/Domain/Career/Audit/CareerDeltaRolloutManifestPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerDeltaRolloutManifestPlannerTest.php
@@ -29,6 +29,51 @@ final class CareerDeltaRolloutManifestPlannerTest extends TestCase
         $this->assertFalse($result['writes_database']);
     }
 
+    public function test_generates_220_delta_manifest_for_300_total_progressive_cohort(): void
+    {
+        $result = (new CareerDeltaRolloutManifestPlanner)->plan(
+            targetDeltaPlan: $this->progressiveTargetDeltaPlan($this->slugs('current', 80), $this->slugs('delta', 220), 300),
+            targetPublicTotal: 300,
+            expectedDeltaCount: 220,
+            batchId: 'career_80_to_300_canonical_001',
+        )->toArray();
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertSame('career_80_to_300_delta', $result['target']);
+        $this->assertSame(300, $result['target_public_total']);
+        $this->assertSame(80, $result['published_baseline_count']);
+        $this->assertSame(220, $result['delta_slug_count']);
+        $this->assertSame(440, $result['expected_delta_locale_rows']);
+        $this->assertSame(220, $result['validation']['rollback_group_count']);
+        $this->assertSame($result['slugs'], $result['rollback_group']);
+        $this->assertTrue($result['dry_run_allowed']);
+        $this->assertFalse($result['apply_allowed']);
+        $this->assertSame('PROGRESSIVE_ROLLOUT_DRY_RUN', $result['next_required_action']);
+    }
+
+    public function test_generates_500_and_1986_delta_progressive_manifests(): void
+    {
+        $eightHundred = (new CareerDeltaRolloutManifestPlanner)->plan(
+            targetDeltaPlan: $this->progressiveTargetDeltaPlan($this->slugs('current', 300), $this->slugs('delta', 500), 800),
+            targetPublicTotal: 800,
+            expectedDeltaCount: 500,
+        )->toArray();
+
+        $this->assertSame('career_300_to_800_delta', $eightHundred['target']);
+        $this->assertSame(500, $eightHundred['delta_slug_count']);
+        $this->assertSame(1000, $eightHundred['expected_delta_locale_rows']);
+
+        $full = (new CareerDeltaRolloutManifestPlanner)->plan(
+            targetDeltaPlan: $this->progressiveTargetDeltaPlan($this->slugs('current', 800), $this->slugs('delta', 1986), 2786),
+            targetPublicTotal: 2786,
+            expectedDeltaCount: 1986,
+        )->toArray();
+
+        $this->assertSame('career_800_to_2786_delta', $full['target']);
+        $this->assertSame(1986, $full['delta_slug_count']);
+        $this->assertSame(3972, $full['expected_delta_locale_rows']);
+    }
+
     public function test_blocks_when_target_delta_is_not_passed(): void
     {
         $plan = $this->targetDeltaPlan(['baseline-001'], ['delta-001'], target: 2);
@@ -158,6 +203,36 @@ final class CareerDeltaRolloutManifestPlannerTest extends TestCase
             'published_baseline_count' => count($baseline),
             'delta_promotion_count' => count($delta),
             'published_baseline_slugs' => $baseline,
+            'delta_promotion_slugs' => $delta,
+            'recommended_rollout_delta_slugs' => $delta,
+            'rollout' => [
+                'delta_manifest_allowed' => true,
+                'apply_allowed' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $current
+     * @param  list<string>  $delta
+     * @return array<string, mixed>
+     */
+    private function progressiveTargetDeltaPlan(array $current, array $delta, int $target): array
+    {
+        sort($current);
+        sort($delta);
+
+        return [
+            'schema_version' => 'career_progressive_cohort_delta_plan.v1',
+            'status' => 'pass',
+            'read_only' => true,
+            'writes_database' => false,
+            'current_public_total' => count($current),
+            'target_public_total' => $target,
+            'delta_slug_count' => count($delta),
+            'expected_delta_locale_rows' => count($delta) * 2,
+            'current_public_slugs' => $current,
+            'published_baseline_slugs' => $current,
             'delta_promotion_slugs' => $delta,
             'recommended_rollout_delta_slugs' => $delta,
             'rollout' => [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T03:17:20+08:00",
+  "updated_at": "2026-05-15T04:17:10+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -5639,7 +5639,7 @@
       "repo": "fap-api",
       "branch": "fix/career-progressive-runtime-artifact-refresh-1",
       "title": "fix(api): generalize career runtime artifact refresh",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1"
       ],
@@ -5667,8 +5667,8 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "37c881e5ba1a6131f5ebaef6fe09b6bf1101d236",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1397",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -5689,6 +5689,82 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-PROGRESSIVE-ROLLOUT-MANIFEST-GATE-1",
+      "merged_at": "2026-05-14T20:03:52Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
+            "Current PR changed only Career runtime artifact refresh command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
+            "Targeted Career tests, route:list, sqlite migrate, Pint, and git diff --check passed."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "may_continue_train": true
+        }
+      ]
+    },
+    "REPAIR-PROGRESSIVE-ROLLOUT-MANIFEST-GATE-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-progressive-rollout-manifest-gate-1",
+      "title": "fix(api): generalize career progressive rollout manifest gate",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-RUNTIME-ARTIFACT-REFRESH-1"
+      ],
+      "scope_type": "progressive_rollout_manifest_gate_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/**",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout dry-run",
+        "no rollout apply",
+        "no candidate prep apply",
+        "no backfill",
+        "no rollback",
+        "no quarantine",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for the progressive expansion PR train."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-RUNTIME-ARTIFACT-REFRESH-1 merged as PR #1397 and provides progressive candidate-aware artifact refresh."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to read-only progressive rollout manifest/gate semantics, tests/docs, command registration, and train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_sidecar",
+          "evidence": "CareerDeltaRolloutManifest, CareerGenerateCanonicalProgressiveRolloutManifest, CareerDeltaRolloutGate, CareerProgressiveCohortDelta, route:list, sqlite migrate, Pint, and git diff --check passed locally. backend/scripts/ci_verify_mbti.sh still fails the pre-existing BigFive content pack publish/rollback compiled directory assertions outside this PR scope."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-PROGRESSIVE-LIVE-ACCEPTANCE-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -5703,7 +5779,7 @@
           "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
-            "Current PR changed only Career runtime artifact refresh command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
+            "Current PR changed only Career progressive rollout manifest/gate command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
             "Targeted Career tests, route:list, sqlite migrate, Pint, and git diff --check passed."
           ],
           "severity": "medium",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -115,6 +115,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-ROLLOUT-MANIFEST-GATE-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-RUNTIME-ARTIFACT-REFRESH-1
+    branch: fix/career-progressive-rollout-manifest-gate-1
+    title: "fix(api): generalize career progressive rollout manifest gate"
+    name: "Generalize rollout manifest and gate for progressive Career cohorts"
+    scope:
+      - Extend rollout manifest planning to support 300, 800, and 2786 target totals.
+      - Support explicit 220, 500, and 1986 slug delta manifests with rollback_group equal to the delta slug list.
+      - Keep baseline/current public slugs excluded from the delta promotion scope.
+      - Keep dry_run_allowed true only for valid manifests and apply_allowed false.
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run candidate preparation apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerDeltaRolloutManifest --no-ansi
+      - php artisan test --filter=CareerGenerateCanonicalProgressiveRolloutManifest --no-ansi
+      - php artisan test --filter=CareerDeltaRolloutGate --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- adds `career:generate-canonical-progressive-rollout-manifest` for 300 / 800 / 2786 cohort rollout manifests
- generalizes rollout manifest and gate planners so target metadata, rollback groups, and next actions work beyond the 51-delta path
- keeps rollback_group as the explicit delta slug list and keeps `apply_allowed=false`

## Non-goals
- no rollout dry-run or rollout apply
- no candidate prep apply
- no DB mutation, deploy, rollback, quarantine, backfill, or fap-web change

## Tests
- `php artisan test --filter=CareerDeltaRolloutManifest --no-ansi`
- `php artisan test --filter=CareerGenerateCanonicalProgressiveRolloutManifest --no-ansi`
- `php artisan test --filter=CareerDeltaRolloutGate --no-ansi`
- `php artisan test --filter=CareerProgressiveCohortDelta --no-ansi`
- `php artisan test --filter=CareerGenerateCanonicalDeltaRolloutManifest --no-ansi`
- `php artisan test --filter=CareerPlanCanonicalDeltaRolloutGate --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-progressive-expansion-pr4.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh` reproduced external sidecar: `Tests\Feature\Content\PacksPublishBig5Test` and `Tests\Feature\Content\PacksRollbackBig5Test` fail at `File::isDirectory($target.'/compiled')`; this PR does not touch content pack publish/rollback code or compiled assets.

## Scope
Changed files are limited to Career rollout manifest/gate command/domain/test/docs and train metadata.

## Next
REPAIR-PROGRESSIVE-LIVE-ACCEPTANCE-1