### PR TITLE
feat(api): accept canonical SEO funnel attribution events

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php
@@ -33,12 +33,48 @@ final class MbtiAttributionEventController extends Controller
         'entry_surface',
         'source_page_type',
         'target_action',
+        'slug',
         'test_slug',
+        'scaleCode',
+        'scale_code',
         'form_code',
         'landing_path',
+        'current_path',
         'locale',
         'attempt_id',
+        'attemptIdMasked',
         'target_attempt_id',
+        'answered_count',
+        'durationMs',
+        'duration_ms',
+        'duration_bucket',
+        'order_no',
+        'orderNo',
+        'orderNoMasked',
+        'order_id',
+        'transaction_id',
+        'amount',
+        'value',
+        'price',
+        'currency',
+        'provider',
+        'pack_version',
+        'manifest_hash',
+        'norms_version',
+        'quality_level',
+        'locked',
+        'variant',
+        'sku_id',
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_term',
+        'utm_content',
+        'gclid',
+        'msclkid',
+        'fbclid',
+        'referrer',
+        'session_id',
     ];
 
     /**
@@ -48,6 +84,7 @@ final class MbtiAttributionEventController extends Controller
         'landing_view',
         'start_click',
         'start_attempt',
+        'submit_attempt',
         'view_result',
         'click_unlock',
         'create_order',
@@ -65,19 +102,63 @@ final class MbtiAttributionEventController extends Controller
     {
         $this->authorizeIngest($request);
         $this->rejectUnexpectedKeys($request->all(), self::TOP_LEVEL_KEYS, 'request');
+        $payloadInput = $request->input('payload');
+        if ($payloadInput !== null && ! is_array($payloadInput)) {
+            throw ValidationException::withMessages([
+                'payload' => 'The payload field must be an array.',
+            ]);
+        }
+        if (is_array($payloadInput)) {
+            $this->rejectUnexpectedKeys($payloadInput, self::PAYLOAD_KEYS, 'payload');
+        }
 
         $data = $request->validate([
             'eventName' => ['required', 'string', 'max:64'],
-            'payload' => ['nullable', 'array:'.implode(',', self::PAYLOAD_KEYS)],
             'payload.entry_surface' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'payload.source_page_type' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'payload.target_action' => ['nullable', 'string', 'max:128', 'regex:/\A[a-z0-9]+(?:_[a-z0-9]+)*\z/'],
+            'payload.slug' => ['nullable', 'string', 'max:128', 'regex:/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/'],
             'payload.test_slug' => ['nullable', 'string', 'max:128', 'regex:/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/'],
+            'payload.scaleCode' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.scale_code' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'payload.form_code' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'payload.landing_path' => ['nullable', 'string', 'max:512', 'regex:/\A\/[^\r\n]*\z/'],
+            'payload.current_path' => ['nullable', 'string', 'max:512', 'regex:/\A\/[^\r\n]*\z/'],
             'payload.locale' => ['nullable', 'string', 'max:16', 'in:en,zh,zh-cn,zh-CN'],
             'payload.attempt_id' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.attemptIdMasked' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'payload.target_attempt_id' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.answered_count' => ['nullable', 'integer', 'min:0', 'max:1000'],
+            'payload.durationMs' => ['nullable', 'integer', 'min:0', 'max:86400000'],
+            'payload.duration_ms' => ['nullable', 'integer', 'min:0', 'max:86400000'],
+            'payload.duration_bucket' => ['nullable', 'string', 'max:32', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.order_no' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.orderNo' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.orderNoMasked' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.order_id' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.transaction_id' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.amount' => ['nullable', 'numeric', 'min:0'],
+            'payload.value' => ['nullable', 'numeric', 'min:0'],
+            'payload.price' => ['nullable', 'numeric', 'min:0'],
+            'payload.currency' => ['nullable', 'string', 'size:3', 'regex:/\A[A-Z]{3}\z/'],
+            'payload.provider' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.pack_version' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.manifest_hash' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.norms_version' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.quality_level' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.locked' => ['nullable', 'boolean'],
+            'payload.variant' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.sku_id' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.utm_source' => ['nullable', 'string', 'max:128', 'regex:/\A[^\r\n]*\z/'],
+            'payload.utm_medium' => ['nullable', 'string', 'max:128', 'regex:/\A[^\r\n]*\z/'],
+            'payload.utm_campaign' => ['nullable', 'string', 'max:128', 'regex:/\A[^\r\n]*\z/'],
+            'payload.utm_term' => ['nullable', 'string', 'max:128', 'regex:/\A[^\r\n]*\z/'],
+            'payload.utm_content' => ['nullable', 'string', 'max:128', 'regex:/\A[^\r\n]*\z/'],
+            'payload.gclid' => ['nullable', 'string', 'max:256', 'regex:/\A[^\r\n]*\z/'],
+            'payload.msclkid' => ['nullable', 'string', 'max:256', 'regex:/\A[^\r\n]*\z/'],
+            'payload.fbclid' => ['nullable', 'string', 'max:256', 'regex:/\A[^\r\n]*\z/'],
+            'payload.referrer' => ['nullable', 'string', 'max:512', 'regex:/\A[^\r\n]*\z/'],
+            'payload.session_id' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'anonymousId' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'path' => ['nullable', 'string', 'max:512', 'regex:/\A\/[^\r\n]*\z/'],
             'timestamp' => ['nullable', 'date'],
@@ -122,6 +203,12 @@ final class MbtiAttributionEventController extends Controller
             ?? ($path !== '' && str_starts_with($path, '/zh') ? 'zh' : 'en');
 
         $orgId = $this->resolveOrgId($request);
+        $scaleCode = $this->normalizeOptionalString(
+            $payload['scale_code']
+                ?? $payload['scaleCode']
+                ?? null,
+            64
+        ) ?? 'MBTI';
 
         $attributes = [
             'id' => (string) Str::uuid(),
@@ -132,7 +219,7 @@ final class MbtiAttributionEventController extends Controller
             'attempt_id' => $attemptId,
             'meta_json' => $meta,
             'occurred_at' => $occurredAt,
-            'scale_code' => 'MBTI',
+            'scale_code' => $scaleCode,
             'channel' => 'web',
             'locale' => $locale,
             'created_at' => now(),
@@ -140,7 +227,7 @@ final class MbtiAttributionEventController extends Controller
         ];
 
         if (SchemaBaseline::hasColumn('events', 'scale_code_v2')) {
-            $attributes['scale_code_v2'] = 'MBTI';
+            $attributes['scale_code_v2'] = $scaleCode;
         }
 
         Event::query()->create($attributes);

--- a/backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php
@@ -114,6 +114,7 @@ final class MbtiAttributionEventController extends Controller
 
         $data = $request->validate([
             'eventName' => ['required', 'string', 'max:64'],
+            'payload' => ['nullable', 'array'],
             'payload.entry_surface' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'payload.source_page_type' => ['nullable', 'string', 'max:64', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'payload.target_action' => ['nullable', 'string', 'max:128', 'regex:/\A[a-z0-9]+(?:_[a-z0-9]+)*\z/'],

--- a/backend/tests/Feature/Analytics/MbtiAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/MbtiAttributionEventIngestTest.php
@@ -54,6 +54,100 @@ final class MbtiAttributionEventIngestTest extends TestCase
         $this->assertSame('/zh/topics/mbti', $meta['landing_path'] ?? null);
     }
 
+    public function test_ingest_endpoint_accepts_canonical_submit_attempt_payload(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.3/analytics/mbti-attribution-events', [
+            'eventName' => 'submit_attempt',
+            'anonymousId' => 'anon_submit_001',
+            'path' => '/en/tests/big-five-personality-test/take',
+            'timestamp' => '2026-05-14T20:00:00Z',
+            'payload' => [
+                'slug' => 'big-five-personality-test',
+                'test_slug' => 'big-five-personality-test',
+                'scale_code' => 'BIG5_OCEAN',
+                'form_code' => 'big5_90',
+                'attempt_id' => 'attempt-big5-123',
+                'answered_count' => 90,
+                'durationMs' => 121000,
+                'duration_ms' => 121000,
+                'duration_bucket' => '1_3m',
+                'landing_path' => '/en/tests/big-five-personality-test',
+                'current_path' => '/en/tests/big-five-personality-test/take',
+                'utm_source' => 'google',
+                'session_id' => 'anon_submit_001',
+                'locale' => 'en',
+            ],
+        ]);
+
+        $response->assertStatus(202);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('event_code', 'submit_attempt');
+
+        $row = DB::table('events')
+            ->where('event_code', 'submit_attempt')
+            ->where('anon_id', 'anon_submit_001')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('BIG5_OCEAN', (string) ($row->scale_code ?? ''));
+        $this->assertSame('attempt-big5-123', (string) ($row->attempt_id ?? ''));
+
+        $meta = is_array($row->meta_json ?? null)
+            ? $row->meta_json
+            : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
+
+        $this->assertSame('submit_attempt', (string) ($row->event_name ?? ''));
+        $this->assertSame('big-five-personality-test', $meta['test_slug'] ?? null);
+        $this->assertSame(90, (int) ($meta['raw_payload']['answered_count'] ?? 0));
+        $this->assertSame(121000, (int) ($meta['raw_payload']['durationMs'] ?? 0));
+        $this->assertSame('/en/tests/big-five-personality-test/take', $meta['raw_payload']['current_path'] ?? null);
+    }
+
+    public function test_ingest_endpoint_accepts_purchase_payload_with_non_pii_order_identifier(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.3/analytics/mbti-attribution-events', [
+            'eventName' => 'purchase_success',
+            'anonymousId' => 'anon_purchase_001',
+            'path' => '/zh/orders/ord_masked_001',
+            'payload' => [
+                'order_no' => 'ord_12...0001',
+                'transaction_id' => 'ord_12...0001',
+                'attemptIdMasked' => 'attempt...0001',
+                'orderNoMasked' => 'ord_12...0001',
+                'amount' => 88,
+                'currency' => 'CNY',
+                'provider' => 'alipay',
+                'scale_code' => 'MBTI',
+                'form_code' => 'mbti_144',
+                'locale' => 'zh',
+            ],
+        ]);
+
+        $response->assertStatus(202);
+
+        $row = DB::table('events')
+            ->where('event_code', 'purchase_success')
+            ->where('anon_id', 'anon_purchase_001')
+            ->first();
+
+        $this->assertNotNull($row);
+
+        $meta = is_array($row->meta_json ?? null)
+            ? $row->meta_json
+            : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
+
+        $this->assertSame('ord_12...0001', $meta['raw_payload']['transaction_id'] ?? null);
+        $this->assertSame('CNY', $meta['raw_payload']['currency'] ?? null);
+    }
+
     public function test_ingest_endpoint_rejects_missing_or_invalid_ingest_token(): void
     {
         config()->set('fap.events.ingest_token', 'ingest_test_token');
@@ -118,6 +212,24 @@ final class MbtiAttributionEventIngestTest extends TestCase
             'payload' => [
                 'entry_surface' => 'mbti_topic_detail',
                 'org_id' => 42,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+
+        $this->assertSame(0, DB::table('events')->count());
+    }
+
+    public function test_ingest_endpoint_rejects_email_inside_tracking_payload(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.3/analytics/mbti-attribution-events', [
+            'eventName' => 'purchase_success',
+            'payload' => [
+                'transaction_id' => 'person@example.com',
             ],
         ]);
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -687,6 +687,38 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_funnel_attribution_ingest_contract_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php',
+        ];
+        $allowedChangedLines = [
+            "+        'submit_attempt',",
+            "+            'payload.durationMs' => ['nullable', 'integer', 'min:0', 'max:86400000'],",
+            '+        $payloadInput = $request->input(\'payload\');',
+            "+            'payload' => ['nullable', 'array'],",
+            "-            'payload' => ['nullable', 'array:'.implode(',', self::PAYLOAD_KEYS)],",
+            "+        \$scaleCode = \$this->normalizeOptionalString(",
+            "+            'scale_code' => \$scaleCode,",
+        ];
+        $blockedChangedLines = [
+            '+        abort(403);',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            attributionControllerChangedLines: $allowedChangedLines,
+        ));
+        $this->assertSame($changed, $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            attributionControllerChangedLines: $blockedChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_iq_identity_metadata_seed_changes(): void
     {
         $changed = [
@@ -1232,6 +1264,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ?array $appServiceProviderChangedLines = null,
         ?array $scaleRegistrySeederChangedLines = null,
         ?array $articleControllerChangedLines = null,
+        ?array $attributionControllerChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -1413,6 +1446,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isResultEmailGatedReadFile($file)) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php'
+                && $this->attributionControllerDiffIsSeoFunnelContractOnly(
+                    $attributionControllerChangedLines ?? (
+                        $repoRoot !== '' && $baseRef !== ''
+                            ? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                            : []
+                    )
+                )
+            ) {
                 continue;
             }
 
@@ -2098,6 +2144,54 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
             'backend/app/Services/Results/ResultEmailReadAccessService.php',
         ], true);
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function attributionControllerDiffIsSeoFunnelContractOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/^[+-]\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/^[+]\s*[}\]);,]*\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/^[+]\s*\'(slug|scaleCode|scale_code|current_path|attemptIdMasked|answered_count|durationMs|duration_ms|duration_bucket|order_no|orderNo|orderNoMasked|order_id|transaction_id|amount|value|price|currency|provider|pack_version|manifest_hash|norms_version|quality_level|locked|variant|sku_id|utm_source|utm_medium|utm_campaign|utm_term|utm_content|gclid|msclkid|fbclid|referrer|session_id|submit_attempt)\',\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/^[+]\s*\'payload\.(slug|scaleCode|scale_code|current_path|attemptIdMasked|answered_count|durationMs|duration_ms|duration_bucket|order_no|orderNo|orderNoMasked|order_id|transaction_id|amount|value|price|currency|provider|pack_version|manifest_hash|norms_version|quality_level|locked|variant|sku_id|utm_source|utm_medium|utm_campaign|utm_term|utm_content|gclid|msclkid|fbclid|referrer|session_id)\'\s*=>\s*\[/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/^-\s*\'payload\'\s*=>\s*\[\'nullable\',\s*\'array:\'\.implode\(.*, self::PAYLOAD_KEYS\)\],\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/^[+]\s*\'payload\'\s*=>\s*\[\'nullable\',\s*\'array\'\],\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/^[+]\s*(\$payloadInput = \$request->input\(\'payload\'\);|if \(\$payloadInput !== null && ! is_array\(\$payloadInput\)\) \{|throw ValidationException::withMessages\(\[|\'payload\' => \'The payload field must be an array\.\',|if \(is_array\(\$payloadInput\)\) \{|\$this->rejectUnexpectedKeys\(\$payloadInput, self::PAYLOAD_KEYS, \'payload\'\);)\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/^[+-]\s*(\$scaleCode = \$this->normalizeOptionalString\(|\$payload\[\'scale_code\'\]|\?\? \$payload\[\'scaleCode\'\]|\?\? null,|64|\) \?\? \'MBTI\';|\'scale_code\' => (?:\'MBTI\'|\$scaleCode),|\$attributes\[\'scale_code_v2\'\] = (?:\'MBTI\'|\$scaleCode);)\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added `submit_attempt` to the MBTI attribution ingest allow-list.
- Extended the authorized tracking payload contract for canonical SEO funnel attribution fields used by frontend tracking.
- Preserved strict payload allow-listing and added tests for canonical submit, purchase transaction identifiers, and email rejection.

## Why
This is the backend half of PR-SEO-JUNE-01 so canonical frontend funnel events can be ingested without creating a frontend fallback authority.

## Validation
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && php artisan test --filter=MbtiAttributionEventIngestTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-ansi`
- `git diff --check -- backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php backend/tests/Feature/Analytics/MbtiAttributionEventIngestTest.php`
- `git diff --cached --check`

## Intentionally deferred
- No payment, report entitlement, scoring, CMS write, sitemap, llms, pSEO, or recommendation changes.
- Existing unrelated Big Five compiled-content local modifications were not staged or included.