### PR TITLE
fix(api): generalize career progressive live acceptance

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCanonicalProgressiveLiveAcceptance.php
+++ b/backend/app/Console/Commands/CareerValidateCanonicalProgressiveLiveAcceptance.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\Career80TotalLiveAcceptancePlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerValidateCanonicalProgressiveLiveAcceptance extends Command
+{
+    protected $signature = 'career:validate-canonical-progressive-live-acceptance
+        {--target-delta= : Required progressive cohort target-delta JSON artifact}
+        {--delta-manifest= : Optional progressive rollout manifest JSON artifact}
+        {--live-acceptance= : Optional progressive live acceptance JSON artifact}
+        {--target-public-total= : Target public total; defaults to target-delta target_public_total}
+        {--target= : Optional target key; defaults to career_<target_public_total>_total}
+        {--locales=en,zh : Comma-separated target locales}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for progressive live acceptance report JSON}';
+
+    protected $description = 'Plan read-only Career progressive live acceptance accounting for 300, 800, or 2786 cohorts.';
+
+    public function handle(): int
+    {
+        try {
+            $targetDeltaPath = $this->requiredOption('target-delta');
+            $targetDelta = $this->readJson($targetDeltaPath, 'target_delta');
+            $deltaManifestPath = $this->pathOption('delta-manifest');
+            $liveAcceptancePath = $this->pathOption('live-acceptance');
+            $targetPublicTotal = $this->targetPublicTotal($targetDelta);
+
+            $payload = app(Career80TotalLiveAcceptancePlanner::class)->plan(
+                targetDelta: $targetDelta,
+                deltaManifest: $deltaManifestPath === null ? null : $this->readJson($deltaManifestPath, 'delta_manifest'),
+                liveAcceptance: $liveAcceptancePath === null ? null : $this->readJson($liveAcceptancePath, 'live_acceptance'),
+                targetPublicTotal: $targetPublicTotal,
+                locales: $this->csvOption('locales', 'en,zh'),
+                targetDeltaPath: $targetDeltaPath,
+                deltaManifestPath: $deltaManifestPath,
+                liveAcceptancePath: $liveAcceptancePath,
+                target: $this->target($targetPublicTotal),
+            )->toArray();
+
+            return $this->finish($payload, ($payload['status'] ?? null) === 'pass' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => Career80TotalLiveAcceptancePlanner::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'target' => 'career_progressive_total',
+                'accepted' => false,
+                'read_only' => true,
+                'writes_database' => false,
+                'apply_allowed' => false,
+                'rollout_allowed' => false,
+                'live_crawl_executed' => false,
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                ]],
+                'sidecars' => [],
+                'next_required_action' => 'FIX_PROGRESSIVE_LIVE_ACCEPTANCE_INPUTS',
+            ], self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDelta
+     */
+    private function targetPublicTotal(array $targetDelta): int
+    {
+        $raw = $this->option('target-public-total');
+        if ($raw === null || trim((string) $raw) === '') {
+            $raw = $targetDelta['target_public_total'] ?? null;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException('target_public_total_invalid');
+        }
+
+        return $value;
+    }
+
+    private function target(int $targetPublicTotal): string
+    {
+        $target = trim((string) ($this->option('target') ?? ''));
+        if ($target === '') {
+            return 'career_'.$targetPublicTotal.'_total';
+        }
+
+        $normalized = preg_replace('/[^a-z0-9]+/', '_', strtolower($target)) ?? $target;
+
+        return trim($normalized, '_') ?: 'career_'.$targetPublicTotal.'_total';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function csvOption(string $name, string $default): array
+    {
+        $raw = trim((string) ($this->option($name) ?? $default));
+        $values = $raw === '' ? [] : array_map(static fn (string $value): string => trim($value), explode(',', $raw));
+        $values = array_values(array_filter($values, static fn (string $value): bool => $value !== ''));
+        if ($values === []) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new RuntimeException($kind.'_artifact_json_invalid');
+        }
+
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException($kind.'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            File::put($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('target='.(string) ($payload['target'] ?? 'career_progressive_total'));
+            $this->line('accepted='.(($payload['accepted'] ?? false) ? 'true' : 'false'));
+            $this->line('expected_locale_rows='.(string) ($payload['expected_locale_rows'] ?? 0));
+        }
+
+        return $exitCode;
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $key = strtolower(trim($message));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $key) ?? 'career_progressive_live_acceptance_error';
+        $key = trim($key, '_');
+
+        return $key === '' ? 'career_progressive_live_acceptance_error' : $key;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -62,6 +62,7 @@ use App\Console\Commands\CareerValidateBroadGroupFamilyMap;
 use App\Console\Commands\CareerValidateCanonical80TotalLiveAcceptance;
 use App\Console\Commands\CareerValidateCanonicalBatchLiveAcceptance;
 use App\Console\Commands\CareerValidateCanonicalPostPromotionReleaseGate;
+use App\Console\Commands\CareerValidateCanonicalProgressiveLiveAcceptance;
 use App\Console\Commands\CareerValidateCanonicalRolloutGovernance;
 use App\Console\Commands\CareerValidateCanonicalRuntimeTruth;
 use App\Console\Commands\CareerValidateCnAuthorityPolicy;
@@ -230,6 +231,7 @@ class Kernel extends ConsoleKernel
         CareerValidateCanonicalRuntimeTruth::class,
         CareerValidateCanonicalBatchLiveAcceptance::class,
         CareerValidateCanonical80TotalLiveAcceptance::class,
+        CareerValidateCanonicalProgressiveLiveAcceptance::class,
         CareerValidateCanonicalPostPromotionReleaseGate::class,
         CareerValidateCanonicalRolloutGovernance::class,
         CareerValidateCnAuthorityPolicy::class,

--- a/backend/app/Domain/Career/Audit/Career80TotalLiveAcceptancePlanner.php
+++ b/backend/app/Domain/Career/Audit/Career80TotalLiveAcceptancePlanner.php
@@ -25,17 +25,19 @@ final class Career80TotalLiveAcceptancePlanner
         ?string $targetDeltaPath = null,
         ?string $deltaManifestPath = null,
         ?string $liveAcceptancePath = null,
+        ?string $target = null,
     ): Career80TotalLiveAcceptanceResult {
         if ($targetPublicTotal < 1) {
             throw new RuntimeException('target_public_total_invalid');
         }
 
         $locales = $this->stringList($locales, 'locale');
-        $baselineSlugs = $this->slugList($targetDelta, 'published_baseline_slugs');
+        $baselineSlugs = $this->baselineSlugs($targetDelta);
         $deltaSlugs = $this->deltaSlugs($targetDelta);
         $combinedSlugs = array_values(array_unique([...$baselineSlugs, ...$deltaSlugs]));
         sort($combinedSlugs);
         $expectedLocaleRows = count($combinedSlugs) * count($locales);
+        $target = $this->target($target, $targetDelta, $targetPublicTotal);
         $blockers = $this->blockers(
             targetDelta: $targetDelta,
             deltaManifest: $deltaManifest,
@@ -54,7 +56,7 @@ final class Career80TotalLiveAcceptancePlanner
         return new Career80TotalLiveAcceptanceResult([
             'schema_version' => self::SCHEMA_VERSION,
             'status' => $status,
-            'target' => 'career_80_total',
+            'target' => $target,
             'target_public_total' => $targetPublicTotal,
             'baseline_count' => count($baselineSlugs),
             'delta_count' => count($deltaSlugs),
@@ -74,6 +76,7 @@ final class Career80TotalLiveAcceptancePlanner
                 'path' => $targetDeltaPath,
                 'schema_version' => $targetDelta['schema_version'] ?? null,
                 'status' => $targetDelta['status'] ?? null,
+                'current_public_total' => $targetDelta['current_public_total'] ?? null,
                 'target_public_total' => $targetDelta['target_public_total'] ?? null,
             ],
             'source_delta_manifest' => [
@@ -88,7 +91,7 @@ final class Career80TotalLiveAcceptancePlanner
                 'supplied' => $acceptanceSupplied,
                 'status' => $liveAcceptance['status'] ?? null,
                 'accepted' => $liveAcceptance['accepted'] ?? null,
-                'expected_rows' => $liveAcceptance['expected_rows'] ?? null,
+                'expected_rows' => $this->liveAcceptanceExpectedRows($liveAcceptance),
             ],
             'requirements' => $this->requirements(),
             'validation' => [
@@ -101,8 +104,37 @@ final class Career80TotalLiveAcceptancePlanner
             ],
             'blockers' => $blockers,
             'sidecars' => [],
-            'next_required_action' => $accepted ? '80_TOTAL_LIVE_ACCEPTANCE_COMPLETE' : 'RUN_80_TOTAL_LIVE_ACCEPTANCE_READ_ONLY',
+            'next_required_action' => $accepted ? $this->completeAction($target) : $this->runAction($target),
         ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDelta
+     */
+    private function target(?string $target, array $targetDelta, int $targetPublicTotal): string
+    {
+        $candidate = trim((string) ($target ?? ($targetDelta['target'] ?? '')));
+        if ($candidate === '') {
+            $candidate = $targetPublicTotal === 80 ? 'career_80_total' : 'career_'.$targetPublicTotal.'_total';
+        }
+
+        $normalized = preg_replace('/[^a-z0-9]+/', '_', strtolower($candidate)) ?? $candidate;
+
+        return trim($normalized, '_') ?: 'career_80_total';
+    }
+
+    private function completeAction(string $target): string
+    {
+        return $target === 'career_80_total'
+            ? '80_TOTAL_LIVE_ACCEPTANCE_COMPLETE'
+            : 'PROGRESSIVE_LIVE_ACCEPTANCE_COMPLETE';
+    }
+
+    private function runAction(string $target): string
+    {
+        return $target === 'career_80_total'
+            ? 'RUN_80_TOTAL_LIVE_ACCEPTANCE_READ_ONLY'
+            : 'RUN_PROGRESSIVE_LIVE_ACCEPTANCE_READ_ONLY';
     }
 
     /**
@@ -128,9 +160,13 @@ final class Career80TotalLiveAcceptancePlanner
     ): array {
         $blockers = [];
 
-        if (($targetDelta['schema_version'] ?? null) !== Career80TargetDeltaPlanner::SCHEMA_VERSION) {
+        $schemaVersion = $targetDelta['schema_version'] ?? null;
+        if (! in_array($schemaVersion, [
+            Career80TargetDeltaPlanner::SCHEMA_VERSION,
+            CareerProgressiveCohortDeltaPlanner::SCHEMA_VERSION,
+        ], true)) {
             $blockers[] = $this->blocker('target_delta_schema_mismatch', [
-                'schema_version' => $targetDelta['schema_version'] ?? null,
+                'schema_version' => $schemaVersion,
             ]);
         }
 
@@ -182,15 +218,31 @@ final class Career80TotalLiveAcceptancePlanner
                     'accepted' => $liveAcceptance['accepted'] ?? null,
                 ]);
             }
-            if ((int) ($liveAcceptance['expected_rows'] ?? 0) !== $expectedLocaleRows) {
+            if ($this->liveAcceptanceExpectedRows($liveAcceptance) !== $expectedLocaleRows) {
                 $blockers[] = $this->blocker('live_acceptance_expected_rows_mismatch', [
                     'expected' => $expectedLocaleRows,
-                    'actual' => $liveAcceptance['expected_rows'] ?? null,
+                    'actual' => $this->liveAcceptanceExpectedRows($liveAcceptance),
                 ]);
             }
         }
 
         return $blockers;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $liveAcceptance
+     */
+    private function liveAcceptanceExpectedRows(?array $liveAcceptance): ?int
+    {
+        if ($liveAcceptance === null) {
+            return null;
+        }
+
+        $value = $liveAcceptance['expected_rows']
+            ?? $liveAcceptance['expected_locale_rows']
+            ?? null;
+
+        return is_numeric($value) ? (int) $value : null;
     }
 
     /**
@@ -228,6 +280,22 @@ final class Career80TotalLiveAcceptancePlanner
         }
 
         return $this->stringList($slugs, 'delta_slug');
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<string>
+     */
+    private function baselineSlugs(array $payload): array
+    {
+        $slugs = $payload['published_baseline_slugs']
+            ?? $payload['current_public_slugs']
+            ?? null;
+        if (! is_array($slugs) || ! array_is_list($slugs)) {
+            throw new RuntimeException('published_baseline_slugs_missing');
+        }
+
+        return $this->stringList($slugs, 'published_baseline_slugs');
     }
 
     /**

--- a/backend/docs/career/audits/progressive_live_acceptance.md
+++ b/backend/docs/career/audits/progressive_live_acceptance.md
@@ -1,0 +1,26 @@
+# Progressive live acceptance
+
+`career:validate-canonical-progressive-live-acceptance` creates a read-only acceptance accounting artifact for progressive Career cohorts after a rollout has been applied and independently verified.
+
+Supported target totals:
+
+- 300: 600 locale rows for `en,zh`
+- 800: 1600 locale rows for `en,zh`
+- 2786: 5572 locale rows for `en,zh`
+
+The command consumes a progressive target-delta artifact and optional rollout manifest and live acceptance artifact. It validates that the current public cohort plus the explicit delta cohort equals the target total and that any supplied live acceptance artifact reports the expected locale row count.
+
+Example:
+
+```bash
+php artisan career:validate-canonical-progressive-live-acceptance \
+  --target-delta=/tmp/career_80_to_300_delta_plan.json \
+  --delta-manifest=/tmp/career_80_to_300_rollout_manifest.json \
+  --live-acceptance=/tmp/career_300_live_acceptance.json \
+  --json \
+  --output=/tmp/career_300_progressive_live_acceptance_plan.json
+```
+
+This command does not execute a live crawl, rollout dry-run, rollout apply, candidate preparation apply, backfill, rollback, quarantine, deploy, or database mutation. Large-cohort HTTP verification remains a later guarded run that supplies the live acceptance artifact consumed here.
+
+The command keeps `writes_database=false`, `apply_allowed=false`, `rollout_allowed=false`, and `live_crawl_executed=false`. Passing the accounting artifact means the supplied evidence is internally consistent; it does not replace final live HTML verification.

--- a/backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerValidateCanonicalProgressiveLiveAcceptance;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(CareerValidateCanonicalProgressiveLiveAcceptance::class),
+        );
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:validate-canonical-progressive-live-acceptance', Artisan::all());
+    }
+
+    public function test_missing_target_delta_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => sys_get_temp_dir().'/missing-progressive-target-delta.json',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('target_delta_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFalse($payload['live_crawl_executed']);
+    }
+
+    public function test_generates_300_progressive_report_and_writes_output_file(): void
+    {
+        $output = $this->tempPath('report');
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(80, 300, 220)),
+            '--delta-manifest' => $this->writeJson('manifest', $this->deltaManifest(80, 300, 220)),
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('career_80_total_live_acceptance.v1', $payload['schema_version']);
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('career_300_total', $payload['target']);
+        $this->assertSame(300, $payload['target_public_total']);
+        $this->assertSame(80, $payload['baseline_count']);
+        $this->assertSame(220, $payload['delta_count']);
+        $this->assertSame(600, $payload['expected_locale_rows']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['live_crawl_executed']);
+        $this->assertSame('RUN_PROGRESSIVE_LIVE_ACCEPTANCE_READ_ONLY', $payload['next_required_action']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_800_target_expected_rows_are_computed(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(300, 800, 500)),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame(800, $payload['target_public_total']);
+        $this->assertSame(1600, $payload['expected_locale_rows']);
+    }
+
+    public function test_2786_target_expected_rows_are_computed(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(800, 2786, 1986)),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame(2786, $payload['target_public_total']);
+        $this->assertSame(5572, $payload['expected_locale_rows']);
+    }
+
+    public function test_passes_when_accepted_live_acceptance_artifact_is_supplied(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(80, 300, 220)),
+            '--live-acceptance' => $this->writeJson('live-acceptance', $this->liveAcceptance(accepted: true, expectedRows: 600)),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['accepted']);
+        $this->assertSame('PROGRESSIVE_LIVE_ACCEPTANCE_COMPLETE', $payload['next_required_action']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_live_acceptance_expected_rows_mismatch_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(80, 300, 220)),
+            '--live-acceptance' => $this->writeJson('live-acceptance', $this->liveAcceptance(accepted: true, expectedRows: 160)),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('live_acceptance_expected_rows_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:validate-canonical-progressive-live-acceptance', [
+            '--json' => true,
+            ...$options,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%04d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function progressiveTargetDelta(int $current, int $target, int $delta): array
+    {
+        $currentSlugs = $this->slugs('current', $current);
+        $deltaSlugs = $this->slugs('delta', $delta);
+
+        return [
+            'schema_version' => 'career_progressive_cohort_delta_plan.v1',
+            'status' => 'pass',
+            'read_only' => true,
+            'writes_database' => false,
+            'current_public_total' => $current,
+            'target_public_total' => $target,
+            'delta_slug_count' => $delta,
+            'current_public_slugs' => $currentSlugs,
+            'delta_promotion_slugs' => $deltaSlugs,
+            'recommended_rollout_delta_slugs' => $deltaSlugs,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function deltaManifest(int $current, int $target, int $delta): array
+    {
+        $deltaSlugs = $this->slugs('delta', $delta);
+
+        return [
+            'schema_version' => 'career_delta_rollout_manifest.v1',
+            'status' => 'pass',
+            'target' => 'career_'.$current.'_to_'.$target.'_delta',
+            'target_public_total' => $target,
+            'published_baseline_count' => $current,
+            'delta_slug_count' => $delta,
+            'slugs' => $deltaSlugs,
+            'rollback_group' => $deltaSlugs,
+            'apply_allowed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function liveAcceptance(bool $accepted, int $expectedRows): array
+    {
+        return [
+            'status' => $accepted ? 'pass' : 'fail',
+            'accepted' => $accepted,
+            'expected_rows' => $expectedRows,
+            'read_only' => true,
+            'writes_database' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-progressive-live-acceptance-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php
@@ -40,6 +40,64 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
         $this->assertSame('80_TOTAL_LIVE_ACCEPTANCE_COMPLETE', $result['next_required_action']);
     }
 
+    public function test_plans_300_progressive_live_acceptance_rows(): void
+    {
+        $result = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->progressiveTargetDelta(current: 80, target: 300, delta: 220),
+            targetPublicTotal: 300,
+        )->toArray();
+
+        $this->assertSame('career_300_total', $result['target']);
+        $this->assertSame('planned', $result['status']);
+        $this->assertSame(80, $result['baseline_count']);
+        $this->assertSame(220, $result['delta_count']);
+        $this->assertSame(300, $result['total_slug_count']);
+        $this->assertSame(600, $result['expected_locale_rows']);
+        $this->assertSame('RUN_PROGRESSIVE_LIVE_ACCEPTANCE_READ_ONLY', $result['next_required_action']);
+        $this->assertFalse($result['writes_database']);
+    }
+
+    public function test_plans_800_progressive_live_acceptance_rows(): void
+    {
+        $result = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->progressiveTargetDelta(current: 300, target: 800, delta: 500),
+            targetPublicTotal: 800,
+        )->toArray();
+
+        $this->assertSame('career_800_total', $result['target']);
+        $this->assertSame(300, $result['baseline_count']);
+        $this->assertSame(500, $result['delta_count']);
+        $this->assertSame(800, $result['total_slug_count']);
+        $this->assertSame(1600, $result['expected_locale_rows']);
+    }
+
+    public function test_plans_2786_progressive_live_acceptance_rows(): void
+    {
+        $result = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->progressiveTargetDelta(current: 800, target: 2786, delta: 1986),
+            targetPublicTotal: 2786,
+        )->toArray();
+
+        $this->assertSame('career_2786_total', $result['target']);
+        $this->assertSame(800, $result['baseline_count']);
+        $this->assertSame(1986, $result['delta_count']);
+        $this->assertSame(2786, $result['total_slug_count']);
+        $this->assertSame(5572, $result['expected_locale_rows']);
+    }
+
+    public function test_passes_progressive_acceptance_when_artifact_is_accepted(): void
+    {
+        $result = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->progressiveTargetDelta(current: 80, target: 300, delta: 220),
+            liveAcceptance: $this->liveAcceptance(accepted: true, expectedRows: 600),
+            targetPublicTotal: 300,
+        )->toArray();
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertTrue($result['accepted']);
+        $this->assertSame('PROGRESSIVE_LIVE_ACCEPTANCE_COMPLETE', $result['next_required_action']);
+    }
+
     public function test_blocks_when_target_total_does_not_match_combined_slugs(): void
     {
         $result = (new Career80TotalLiveAcceptancePlanner)->plan(
@@ -135,6 +193,31 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
             'published_baseline_slugs' => $baseline,
             'delta_promotion_slugs' => $delta,
             'recommended_rollout_delta_slugs' => $delta,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function progressiveTargetDelta(int $current, int $target, int $delta): array
+    {
+        $currentSlugs = $this->slugs('current', $current);
+        $deltaSlugs = $this->slugs('delta', $delta);
+
+        return [
+            'schema_version' => 'career_progressive_cohort_delta_plan.v1',
+            'status' => 'pass',
+            'read_only' => true,
+            'writes_database' => false,
+            'current_public_total' => $current,
+            'target_public_total' => $target,
+            'delta_slug_count' => $delta,
+            'locale_count' => 2,
+            'expected_delta_locale_rows' => $delta * 2,
+            'expected_total_locale_rows' => $target * 2,
+            'current_public_slugs' => $currentSlugs,
+            'delta_promotion_slugs' => $deltaSlugs,
+            'recommended_rollout_delta_slugs' => $deltaSlugs,
         ];
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5716,7 +5716,7 @@
       "repo": "fap-api",
       "branch": "fix/career-progressive-rollout-manifest-gate-1",
       "title": "fix(api): generalize career progressive rollout manifest gate",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "REPAIR-PROGRESSIVE-RUNTIME-ARTIFACT-REFRESH-1"
       ],
@@ -5743,8 +5743,8 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "a1c740f8694d549da90ae538bd64c949fa2bc72e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1398",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -5765,9 +5765,9 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-PROGRESSIVE-LIVE-ACCEPTANCE-1",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-14T20:26:12Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "sidecar_id": "SIDECAR-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
@@ -5784,6 +5784,100 @@
           ],
           "severity": "medium",
           "next_goal": "SCAN-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "may_continue_train": true
+        }
+      ]
+    },
+    "REPAIR-PROGRESSIVE-LIVE-ACCEPTANCE-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-progressive-live-acceptance-1",
+      "title": "fix(api): generalize career progressive live acceptance",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-ROLLOUT-MANIFEST-GATE-1"
+      ],
+      "scope_type": "progressive_live_acceptance_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/**",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no live crawl",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no candidate prep apply",
+        "no backfill",
+        "no rollback",
+        "no quarantine",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for the progressive expansion PR train."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-ROLLOUT-MANIFEST-GATE-1 merged as PR #1398 and provides read-only progressive rollout manifest/gate artifacts."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to read-only progressive live acceptance accounting, tests/docs, command registration, and train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_sidecar",
+          "evidence": "Career80TotalLiveAcceptance, CareerValidateCanonicalProgressiveLiveAcceptance, CareerProgressiveCohortDelta, route:list, sqlite migrate, command list, Pint, and git diff --check passed locally. backend/scripts/ci_verify_mbti.sh fails pre-existing/out-of-scope BigFive content pack publish/rollback compiled directory assertions and a runtime freeze diff for MbtiAttributionEventController outside current PR scope."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "REPAIR-PROGRESSIVE-CLOSEOUT-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
+            "Current PR changed only Career progressive live acceptance command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
+            "Targeted Career tests, route:list, sqlite migrate, command list, Pint, and git diff --check passed."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
+          "may_continue_train": true
+        },
+        {
+          "sidecar_id": "SIDECAR-BIG5-RUNTIME-FREEZE-EXTERNAL-MBTI-ATTRIBUTION-1",
+          "title": "ci_verify_mbti runtime freeze reports out-of-scope MbtiAttributionEventController diff",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "backend/scripts/ci_verify_mbti.sh failed Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
+            "Current PR does not modify backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
+            "Manual git diff from merge-base origin/main to HEAD for backend/app/routes/database/content_packs/frontend/selector_ready_assets is empty before staging current PR changes."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-RUNTIME-FREEZE-EXTERNAL-MBTI-ATTRIBUTION-1",
           "may_continue_train": true
         }
       ]

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -154,6 +154,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-LIVE-ACCEPTANCE-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-ROLLOUT-MANIFEST-GATE-1
+    branch: fix/career-progressive-live-acceptance-1
+    title: "fix(api): generalize career progressive live acceptance"
+    name: "Generalize full live acceptance accounting for progressive Career cohorts"
+    scope:
+      - Extend live acceptance planning to support 300, 800, and 2786 target totals.
+      - Validate current public baseline plus explicit delta equals the target public total.
+      - Compute expected locale rows from target total and locale count without running live crawls.
+      - Preserve read-only final acceptance semantics and require separate live evidence artifacts for pass status.
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run live crawl.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run candidate preparation apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=Career80TotalLiveAcceptance --no-ansi
+      - php artisan test --filter=CareerValidateCanonicalProgressiveLiveAcceptance --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- adds read-only progressive live acceptance command for 300/800/2786 cohort accounting
- generalizes Career 80 live acceptance planner to consume progressive target-delta artifacts while preserving 80 behavior
- documents progressive live acceptance as accounting only; no live crawl, rollout, apply, deploy, or DB mutation

## Tests
- php artisan test --filter=Career80TotalLiveAcceptance --no-ansi
- php artisan test --filter=CareerValidateCanonicalProgressiveLiveAcceptance --no-ansi
- php artisan test --filter=CareerProgressiveCohortDelta --no-ansi
- php artisan test --filter=CareerValidateCanonical80TotalLiveAcceptance --no-ansi
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-progressive-expansion-pr5.sqlite php artisan migrate --force --no-ansi
- php artisan list | grep "career:validate-canonical-progressive-live-acceptance"
- vendor/bin/pint --test
- git diff --check

## Sidecars
- backend/scripts/ci_verify_mbti.sh fails outside current PR scope on BigFive content pack publish/rollback compiled directory assertions and an out-of-scope MbtiAttributionEventController runtime-freeze diff. Current PR changed only Career progressive live acceptance command/planner/tests/docs/train metadata paths.

## Non-goals
- no live crawl
- no rollout dry-run/apply
- no candidate prep apply
- no production DB mutation
- no deploy
- no fap-web change

Next: REPAIR-PROGRESSIVE-CLOSEOUT-1