### PR TITLE
fix(api): add chunked career live verification scaling

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalProgressiveLiveVerification.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalProgressiveLiveVerification.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerProgressiveLiveVerificationScalingPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerPlanCanonicalProgressiveLiveVerification extends Command
+{
+    protected $signature = 'career:plan-canonical-progressive-live-verification
+        {--target-public-total= : Required target total: 300, 800, or 2786}
+        {--slugs= : Required newline, comma, or JSON slug artifact}
+        {--locales=en,zh : Comma-separated locales}
+        {--base-url=https://www.fermatmind.com : Public base URL for later read-only verification}
+        {--chunk-size=100 : Number of slugs per chunk}
+        {--resume-from-chunk=1 : First chunk number to plan for execution}
+        {--request-rate-per-second=1 : Guarded request rate, max 1}
+        {--timeout-seconds=20 : Guarded timeout, max 20}
+        {--retries=1 : Guarded retry count, max 1}
+        {--output-dir=/tmp : Directory for later chunk and merged artifacts}
+        {--partial= : Optional partial progress JSON artifact}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for scaling plan JSON}';
+
+    protected $description = 'Plan chunked, rate-limited read-only Career progressive live verification without executing HTTP requests.';
+
+    public function handle(): int
+    {
+        try {
+            $partialPath = $this->pathOption('partial');
+            $payload = app(CareerProgressiveLiveVerificationScalingPlanner::class)->plan(
+                targetPublicTotal: $this->intOption('target-public-total'),
+                slugs: $this->readSlugs($this->requiredOption('slugs')),
+                locales: $this->csvOption('locales', 'en,zh'),
+                baseUrl: $this->stringOption('base-url', 'https://www.fermatmind.com'),
+                chunkSize: $this->intOption('chunk-size'),
+                resumeFromChunk: $this->intOption('resume-from-chunk'),
+                requestRatePerSecond: $this->floatOption('request-rate-per-second'),
+                timeoutSeconds: $this->intOption('timeout-seconds'),
+                retries: $this->intOption('retries'),
+                outputDir: $this->stringOption('output-dir', '/tmp'),
+                partial: $partialPath === null ? null : $this->readJson($partialPath, 'partial'),
+            )->toArray();
+
+            return $this->finish($payload, ($payload['status'] ?? null) === 'planned' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => CareerProgressiveLiveVerificationScalingPlanner::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'apply_allowed' => false,
+                'rollout_allowed' => false,
+                'live_crawl_executed' => false,
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                ]],
+                'sidecars' => [],
+                'next_required_action' => 'FIX_PROGRESSIVE_LIVE_VERIFICATION_PLAN_INPUTS',
+            ], self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
+    private function stringOption(string $name, string $default): string
+    {
+        $value = trim((string) ($this->option($name) ?? $default));
+
+        return $value === '' ? $default : $value;
+    }
+
+    private function intOption(string $name): int
+    {
+        $value = filter_var($this->option($name), FILTER_VALIDATE_INT);
+        if (! is_int($value)) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    private function floatOption(string $name): float
+    {
+        $value = filter_var($this->option($name), FILTER_VALIDATE_FLOAT);
+        if (! is_float($value)) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function csvOption(string $name, string $default): array
+    {
+        $raw = trim((string) ($this->option($name) ?? $default));
+        $values = $raw === '' ? [] : array_map(static fn (string $value): string => trim($value), explode(',', $raw));
+
+        return array_values(array_filter($values, static fn (string $value): bool => $value !== ''));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readSlugs(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('slug_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException('slug_artifact_unreadable');
+        }
+
+        $trimmed = trim($contents);
+        if ($trimmed === '') {
+            throw new RuntimeException('slug_artifact_empty');
+        }
+
+        if (str_starts_with($trimmed, '[') || str_starts_with($trimmed, '{')) {
+            $decoded = json_decode($trimmed, true, flags: JSON_THROW_ON_ERROR);
+            $values = is_array($decoded) && array_is_list($decoded)
+                ? $decoded
+                : (is_array($decoded) ? ($decoded['slugs'] ?? $decoded['combined_slugs'] ?? $decoded['total_slugs'] ?? []) : []);
+        } else {
+            $values = preg_split('/[\r\n,]+/', $trimmed) ?: [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($values) ? $values : [],
+        ), static fn (string $value): bool => $value !== ''));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException($kind.'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            File::put($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('target_public_total='.(string) ($payload['target_public_total'] ?? 0));
+            $this->line('chunk_count='.(string) ($payload['chunk_count'] ?? 0));
+        }
+
+        return $exitCode;
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $key = strtolower(trim($message));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $key) ?? 'career_progressive_live_verification_error';
+        $key = trim($key, '_');
+
+        return $key === '' ? 'career_progressive_live_verification_error' : $key;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -50,6 +50,7 @@ use App\Console\Commands\CareerPlanCanonical80RuntimeCandidatePool;
 use App\Console\Commands\CareerPlanCanonical80TargetDelta;
 use App\Console\Commands\CareerPlanCanonicalDeltaRolloutGate;
 use App\Console\Commands\CareerPlanCanonicalProgressiveCohortDelta;
+use App\Console\Commands\CareerPlanCanonicalProgressiveLiveVerification;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerPlanCanonicalRuntimeArtifactRefresh;
 use App\Console\Commands\CareerPlanCanonicalRuntimeCandidatePrep;
@@ -222,6 +223,7 @@ class Kernel extends ConsoleKernel
         CareerPlanCanonical80TargetDelta::class,
         CareerPlanCanonicalDeltaRolloutGate::class,
         CareerPlanCanonicalProgressiveCohortDelta::class,
+        CareerPlanCanonicalProgressiveLiveVerification::class,
         CareerPlanCanonicalRolloutBatchTransition::class,
         CareerPlanCanonicalRuntimeArtifactRefresh::class,
         CareerPlanCanonicalRuntimeCandidatePrep::class,

--- a/backend/app/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingPlanner.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerProgressiveLiveVerificationScalingPlanner
+{
+    public const SCHEMA_VERSION = 'career_progressive_live_verification_scaling_plan.v1';
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  array<string, mixed>|null  $partial
+     */
+    public function plan(
+        int $targetPublicTotal,
+        array $slugs,
+        array $locales = ['en', 'zh'],
+        string $baseUrl = 'https://www.fermatmind.com',
+        int $chunkSize = 100,
+        int $resumeFromChunk = 1,
+        float $requestRatePerSecond = 1.0,
+        int $timeoutSeconds = 20,
+        int $retries = 1,
+        string $outputDir = '/tmp',
+        ?array $partial = null,
+    ): CareerProgressiveLiveVerificationScalingResult {
+        $slugs = $this->stringList($slugs);
+        $locales = $this->stringList($locales);
+        $outputDir = rtrim($outputDir, '/') ?: '/tmp';
+        $target = 'career_'.$targetPublicTotal.'_total';
+        $expectedLocaleRows = count($slugs) * count($locales);
+        $blockers = $this->blockers(
+            targetPublicTotal: $targetPublicTotal,
+            slugCount: count($slugs),
+            localeCount: count($locales),
+            chunkSize: $chunkSize,
+            resumeFromChunk: $resumeFromChunk,
+            requestRatePerSecond: $requestRatePerSecond,
+            timeoutSeconds: $timeoutSeconds,
+            retries: $retries,
+            baseUrl: $baseUrl,
+        );
+        $chunks = $this->chunks(
+            targetPublicTotal: $targetPublicTotal,
+            slugs: $slugs,
+            locales: $locales,
+            baseUrl: $baseUrl,
+            chunkSize: max(1, $chunkSize),
+            resumeFromChunk: max(1, $resumeFromChunk),
+            outputDir: $outputDir,
+            completedChunks: $this->completedChunks($partial),
+        );
+
+        return new CareerProgressiveLiveVerificationScalingResult([
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $blockers === [] ? 'planned' : 'blocked',
+            'target' => $target,
+            'target_public_total' => $targetPublicTotal,
+            'slug_count' => count($slugs),
+            'locales' => $locales,
+            'locale_count' => count($locales),
+            'expected_locale_rows' => $expectedLocaleRows,
+            'chunk_size' => $chunkSize,
+            'chunk_count' => count($chunks),
+            'resume_from_chunk' => $resumeFromChunk,
+            'resume_completed_chunk_count' => count($this->completedChunks($partial)),
+            'request_policy' => [
+                'methods' => ['GET', 'HEAD'],
+                'max_request_rate_per_second' => 1.0,
+                'request_rate_per_second' => $requestRatePerSecond,
+                'timeout_seconds' => $timeoutSeconds,
+                'retries' => $retries,
+                'private_endpoints_allowed' => false,
+                'live_http_execution' => false,
+            ],
+            'output_paths' => [
+                'output_dir' => $outputDir,
+                'final_summary' => $outputDir.'/career_'.$targetPublicTotal.'_live_verification_summary.json',
+                'merged_result' => $outputDir.'/career_'.$targetPublicTotal.'_live_verification_merged.json',
+            ],
+            'chunks' => $chunks,
+            'writes_database' => false,
+            'apply_allowed' => false,
+            'rollout_allowed' => false,
+            'live_crawl_executed' => false,
+            'blockers' => $blockers,
+            'sidecars' => [],
+            'next_required_action' => $blockers === [] ? 'RUN_PROGRESSIVE_LIVE_VERIFICATION_CHUNKS' : 'FIX_PROGRESSIVE_LIVE_VERIFICATION_PLAN',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function stringList(array $values): array
+    {
+        $normalized = array_values(array_unique(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            $values,
+        ), static fn (string $value): bool => $value !== '')));
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function blockers(
+        int $targetPublicTotal,
+        int $slugCount,
+        int $localeCount,
+        int $chunkSize,
+        int $resumeFromChunk,
+        float $requestRatePerSecond,
+        int $timeoutSeconds,
+        int $retries,
+        string $baseUrl,
+    ): array {
+        $blockers = [];
+
+        if (! in_array($targetPublicTotal, [300, 800, 2786], true)) {
+            $blockers[] = $this->blocker('target_public_total_unsupported', ['target_public_total' => $targetPublicTotal]);
+        }
+        if ($slugCount !== $targetPublicTotal) {
+            $blockers[] = $this->blocker('slug_count_target_mismatch', [
+                'slug_count' => $slugCount,
+                'target_public_total' => $targetPublicTotal,
+            ]);
+        }
+        if ($localeCount < 1) {
+            $blockers[] = $this->blocker('locales_missing', []);
+        }
+        if ($chunkSize < 1) {
+            $blockers[] = $this->blocker('chunk_size_invalid', ['chunk_size' => $chunkSize]);
+        }
+        if ($resumeFromChunk < 1) {
+            $blockers[] = $this->blocker('resume_from_chunk_invalid', ['resume_from_chunk' => $resumeFromChunk]);
+        }
+        if ($requestRatePerSecond <= 0 || $requestRatePerSecond > 1.0) {
+            $blockers[] = $this->blocker('request_rate_exceeds_guard', ['request_rate_per_second' => $requestRatePerSecond]);
+        }
+        if ($timeoutSeconds < 1 || $timeoutSeconds > 20) {
+            $blockers[] = $this->blocker('timeout_exceeds_guard', ['timeout_seconds' => $timeoutSeconds]);
+        }
+        if ($retries < 0 || $retries > 1) {
+            $blockers[] = $this->blocker('retries_exceed_guard', ['retries' => $retries]);
+        }
+        if (! str_starts_with($baseUrl, 'https://')) {
+            $blockers[] = $this->blocker('base_url_must_be_https', ['base_url' => $baseUrl]);
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  list<int>  $completedChunks
+     * @return list<array<string, mixed>>
+     */
+    private function chunks(
+        int $targetPublicTotal,
+        array $slugs,
+        array $locales,
+        string $baseUrl,
+        int $chunkSize,
+        int $resumeFromChunk,
+        string $outputDir,
+        array $completedChunks,
+    ): array {
+        $chunks = [];
+        foreach (array_chunk($slugs, $chunkSize) as $index => $chunkSlugs) {
+            $chunkNumber = $index + 1;
+            $status = in_array($chunkNumber, $completedChunks, true)
+                ? 'completed_from_partial'
+                : ($chunkNumber < $resumeFromChunk ? 'resume_skipped' : 'planned');
+
+            $chunks[] = [
+                'chunk_number' => $chunkNumber,
+                'status' => $status,
+                'slug_count' => count($chunkSlugs),
+                'locale_count' => count($locales),
+                'expected_locale_rows' => count($chunkSlugs) * count($locales),
+                'first_slug' => $chunkSlugs[0] ?? null,
+                'last_slug' => $chunkSlugs[count($chunkSlugs) - 1] ?? null,
+                'methods' => ['GET', 'HEAD'],
+                'base_url' => $baseUrl,
+                'output_path' => sprintf('%s/career_%d_live_verification_chunk_%04d.json', $outputDir, $targetPublicTotal, $chunkNumber),
+            ];
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $partial
+     * @return list<int>
+     */
+    private function completedChunks(?array $partial): array
+    {
+        $raw = $partial['completed_chunks'] ?? [];
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        $chunks = array_values(array_filter(array_map(
+            static fn (mixed $value): int => is_numeric($value) ? (int) $value : 0,
+            $raw,
+        ), static fn (int $value): bool => $value > 0));
+        sort($chunks);
+
+        return array_values(array_unique($chunks));
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function blocker(string $reason, array $context): array
+    {
+        return [
+            'reason' => $reason,
+            'context' => $context,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingResult.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingResult.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerProgressiveLiveVerificationScalingResult
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(private readonly array $payload) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+}

--- a/backend/docs/career/audits/progressive_live_verification_scaling.md
+++ b/backend/docs/career/audits/progressive_live_verification_scaling.md
@@ -1,0 +1,63 @@
+# Progressive live verification scaling
+
+`career:plan-canonical-progressive-live-verification` creates a read-only chunk plan for large Career cohort live verification.
+
+Supported target totals:
+
+- 300: 300 slugs, 600 locale rows for `en,zh`
+- 800: 800 slugs, 1600 locale rows for `en,zh`
+- 2786: 2786 slugs, 5572 locale rows for `en,zh`
+
+The command plans chunk output files, final merged result paths, request method limits, and resume state. It does not execute HTTP requests and does not mutate the database.
+
+Guard defaults:
+
+- methods: `GET`, `HEAD`
+- request rate: `<= 1` request per second
+- timeout: `<= 20` seconds
+- retries: `<= 1`
+- output paths under `/tmp` by default
+- private endpoints are not allowed
+
+Example:
+
+```bash
+php artisan career:plan-canonical-progressive-live-verification \
+  --target-public-total=300 \
+  --slugs=/tmp/career_300_total_slugs.txt \
+  --chunk-size=100 \
+  --json \
+  --output=/tmp/career_300_live_verification_scaling_plan.json
+```
+
+Resume planning can consume a partial artifact:
+
+```json
+{
+  "completed_chunks": [1, 2]
+}
+```
+
+Then:
+
+```bash
+php artisan career:plan-canonical-progressive-live-verification \
+  --target-public-total=300 \
+  --slugs=/tmp/career_300_total_slugs.txt \
+  --chunk-size=100 \
+  --resume-from-chunk=3 \
+  --partial=/tmp/career_300_live_verification_partial.json \
+  --json \
+  --output=/tmp/career_300_live_verification_scaling_plan_resume.json
+```
+
+Non-goals:
+
+- no live crawl in the planning command
+- no rollout dry-run or apply
+- no candidate preparation apply
+- no backfill, rollback, or quarantine
+- no deploy
+- no fap-web change
+
+The generated scaling plan feeds later guarded read-only live verification runs and the progressive live acceptance artifact consumed by closeout.

--- a/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveLiveVerificationCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveLiveVerificationCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerPlanCanonicalProgressiveLiveVerification;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerPlanCanonicalProgressiveLiveVerificationCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(CareerPlanCanonicalProgressiveLiveVerification::class),
+        );
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:plan-canonical-progressive-live-verification', Artisan::all());
+    }
+
+    public function test_missing_slug_artifact_blocks(): void
+    {
+        $output = '/tmp/career_progressive_live_verification_missing_test.json';
+        @unlink($output);
+
+        $exitCode = $this->callCommand([
+            '--target-public-total' => '300',
+            '--slugs' => '/tmp/missing-career-progressive-slugs.txt',
+            '--output' => $output,
+        ]);
+
+        $payload = $this->readJson($output);
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('slug_artifact_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
+    public function test_writes_chunked_300_plan(): void
+    {
+        $slugs = '/tmp/career_progressive_live_verification_slugs_300.txt';
+        $output = '/tmp/career_progressive_live_verification_plan_300.json';
+        File::put($slugs, implode(PHP_EOL, $this->slugs(300)).PHP_EOL);
+        @unlink($output);
+
+        $exitCode = $this->callCommand([
+            '--target-public-total' => '300',
+            '--slugs' => $slugs,
+            '--chunk-size' => '120',
+            '--output' => $output,
+        ]);
+
+        $payload = $this->readJson($output);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame(3, $payload['chunk_count']);
+        $this->assertSame(600, $payload['expected_locale_rows']);
+        $this->assertSame('/tmp/career_300_live_verification_chunk_0001.json', $payload['chunks'][0]['output_path']);
+        $this->assertFalse($payload['live_crawl_executed']);
+    }
+
+    public function test_partial_progress_marks_completed_chunks(): void
+    {
+        $slugs = '/tmp/career_progressive_live_verification_slugs_partial_300.json';
+        $partial = '/tmp/career_progressive_live_verification_partial_300.json';
+        $output = '/tmp/career_progressive_live_verification_plan_partial_300.json';
+        File::put($slugs, json_encode(['slugs' => $this->slugs(300)], JSON_THROW_ON_ERROR));
+        File::put($partial, json_encode(['completed_chunks' => [1, 2]], JSON_THROW_ON_ERROR));
+        @unlink($output);
+
+        $exitCode = $this->callCommand([
+            '--target-public-total' => '300',
+            '--slugs' => $slugs,
+            '--chunk-size' => '100',
+            '--resume-from-chunk' => '3',
+            '--partial' => $partial,
+            '--output' => $output,
+        ]);
+
+        $payload = $this->readJson($output);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('completed_from_partial', $payload['chunks'][0]['status']);
+        $this->assertSame('completed_from_partial', $payload['chunks'][1]['status']);
+        $this->assertSame('planned', $payload['chunks'][2]['status']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function callCommand(array $options): int
+    {
+        return Artisan::call('career:plan-canonical-progressive-live-verification', [
+            '--json' => true,
+            ...$options,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('career-%04d', $i);
+        }
+
+        return $slugs;
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingPlannerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerProgressiveLiveVerificationScalingPlanner;
+use Tests\TestCase;
+
+final class CareerProgressiveLiveVerificationScalingPlannerTest extends TestCase
+{
+    public function test_plans_300_chunked_live_verification(): void
+    {
+        $result = (new CareerProgressiveLiveVerificationScalingPlanner)->plan(
+            targetPublicTotal: 300,
+            slugs: $this->slugs(300),
+            chunkSize: 100,
+        )->toArray();
+
+        $this->assertSame('career_progressive_live_verification_scaling_plan.v1', $result['schema_version']);
+        $this->assertSame('planned', $result['status']);
+        $this->assertSame(300, $result['target_public_total']);
+        $this->assertSame(600, $result['expected_locale_rows']);
+        $this->assertSame(3, $result['chunk_count']);
+        $this->assertSame(200, $result['chunks'][1]['expected_locale_rows']);
+        $this->assertFalse($result['writes_database']);
+        $this->assertFalse($result['live_crawl_executed']);
+        $this->assertSame(['GET', 'HEAD'], $result['request_policy']['methods']);
+    }
+
+    public function test_plans_800_chunked_live_verification(): void
+    {
+        $result = (new CareerProgressiveLiveVerificationScalingPlanner)->plan(
+            targetPublicTotal: 800,
+            slugs: $this->slugs(800),
+            chunkSize: 250,
+        )->toArray();
+
+        $this->assertSame(1600, $result['expected_locale_rows']);
+        $this->assertSame(4, $result['chunk_count']);
+    }
+
+    public function test_plans_2786_chunked_live_verification(): void
+    {
+        $result = (new CareerProgressiveLiveVerificationScalingPlanner)->plan(
+            targetPublicTotal: 2786,
+            slugs: $this->slugs(2786),
+            chunkSize: 500,
+        )->toArray();
+
+        $this->assertSame(5572, $result['expected_locale_rows']);
+        $this->assertSame(6, $result['chunk_count']);
+        $this->assertSame(572, $result['chunks'][5]['expected_locale_rows']);
+    }
+
+    public function test_resume_marks_previous_chunks_without_running_http(): void
+    {
+        $result = (new CareerProgressiveLiveVerificationScalingPlanner)->plan(
+            targetPublicTotal: 300,
+            slugs: $this->slugs(300),
+            chunkSize: 100,
+            resumeFromChunk: 3,
+            partial: ['completed_chunks' => [1]],
+        )->toArray();
+
+        $this->assertSame('completed_from_partial', $result['chunks'][0]['status']);
+        $this->assertSame('resume_skipped', $result['chunks'][1]['status']);
+        $this->assertSame('planned', $result['chunks'][2]['status']);
+        $this->assertSame(1, $result['resume_completed_chunk_count']);
+        $this->assertFalse($result['request_policy']['live_http_execution']);
+    }
+
+    public function test_blocks_when_request_guard_is_exceeded(): void
+    {
+        $result = (new CareerProgressiveLiveVerificationScalingPlanner)->plan(
+            targetPublicTotal: 300,
+            slugs: $this->slugs(300),
+            requestRatePerSecond: 2.0,
+            timeoutSeconds: 25,
+            retries: 2,
+        )->toArray();
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['blockers'], 'reason');
+        $this->assertContains('request_rate_exceeds_guard', $reasons);
+        $this->assertContains('timeout_exceeds_guard', $reasons);
+        $this->assertContains('retries_exceed_guard', $reasons);
+    }
+
+    public function test_blocks_when_slug_count_does_not_match_target(): void
+    {
+        $result = (new CareerProgressiveLiveVerificationScalingPlanner)->plan(
+            targetPublicTotal: 300,
+            slugs: $this->slugs(299),
+        )->toArray();
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertContains('slug_count_target_mismatch', array_column($result['blockers'], 'reason'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('career-%04d', $i);
+        }
+
+        return $slugs;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -439,6 +439,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/Career80TotalLiveAcceptanceResult.php',
             'backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlanner.php',
             'backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutResult.php',
+            'backend/app/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',
@@ -700,7 +702,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             '+        $payloadInput = $request->input(\'payload\');',
             "+            'payload' => ['nullable', 'array'],",
             "-            'payload' => ['nullable', 'array:'.implode(',', self::PAYLOAD_KEYS)],",
-            "+        \$scaleCode = \$this->normalizeOptionalString(",
+            '+        $scaleCode = $this->normalizeOptionalString(',
             "+            'scale_code' => \$scaleCode,",
         ];
         $blockedChangedLines = [
@@ -1991,6 +1993,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/Career80TotalLiveAcceptanceResult.php',
             'backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlanner.php',
             'backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutResult.php',
+            'backend/app/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingPlanner.php',
+            'backend/app/Domain/Career/Audit/CareerProgressiveLiveVerificationScalingResult.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessIssue.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessPlanner.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CohortReadinessResult.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5886,7 +5886,7 @@
       "repo": "fap-api",
       "branch": "fix/career-progressive-closeout-1",
       "title": "fix(api): add career progressive cohort closeout",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "REPAIR-PROGRESSIVE-LIVE-ACCEPTANCE-1"
       ],
@@ -5915,8 +5915,8 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "e803b6fbbc373d929cd1f3107aed10f86b2bf874",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1401",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -5937,9 +5937,9 @@
       },
       "failure_reason": null,
       "next_pr": "REPAIR-PROGRESSIVE-LIVE-VERIFICATION-SCALING-1",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-14T21:09:18Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "sidecar_id": "SIDECAR-BIG5-CONTENT-PACK-PUBLISH-ROLLBACK-ENV-1",
@@ -5973,6 +5973,83 @@
           ],
           "severity": "medium",
           "next_goal": "SCAN-BIG5-RUNTIME-FREEZE-EXTERNAL-MBTI-ATTRIBUTION-1",
+          "may_continue_train": true
+        }
+      ]
+    },
+    "REPAIR-PROGRESSIVE-LIVE-VERIFICATION-SCALING-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-progressive-live-verification-scaling-1",
+      "title": "fix(api): add chunked career live verification scaling",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-CLOSEOUT-1"
+      ],
+      "scope_type": "progressive_live_verification_scaling_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/**",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no live crawl",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no candidate prep apply",
+        "no backfill",
+        "no rollback",
+        "no quarantine",
+        "no DB mutation",
+        "no deploy",
+        "no fap-web change"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for the progressive expansion PR train."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-CLOSEOUT-1 merged as PR #1401 and provides accepted cohort closeout records for progressive baselines."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Current PR scope is limited to read-only progressive live verification scaling artifacts, tests/docs, command registration, freeze allowlist, and train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_sidecar",
+          "evidence": "CareerProgressiveLiveVerification, CareerPlanCanonicalProgressiveLiveVerification, BigFiveResultPageV2CoreBodyPreviewTest, Career80TotalLiveAcceptance, route:list, sqlite migrate, Pint, git diff --check, JSON/YAML metadata validation passed. backend/scripts/ci_verify_mbti.sh failed only known Big5 pack publish/rollback compiled-directory assertions outside this Career PR scope."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "300-READINESS-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-PR7",
+          "title": "Local MBTI CI Big5 pack publish and rollback compiled-directory assertions fail",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at tests/Feature/Content/PacksPublishBig5Test.php:94 asserting File::isDirectory($target.'/compiled').",
+            "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at tests/Feature/Content/PacksRollbackBig5Test.php:97 asserting File::isDirectory($target.'/compiled').",
+            "Current PR only adds Career progressive live verification scaling planner/command/tests/docs and BigFive runtime freeze allowlist entries; it does not modify Big5 pack publish/rollback code or content package publish semantics."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-1",
           "may_continue_train": true
         }
       ]

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -233,6 +233,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-LIVE-VERIFICATION-SCALING-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-CLOSEOUT-1
+    branch: fix/career-progressive-live-verification-scaling-1
+    title: "fix(api): add chunked career live verification scaling"
+    name: "Add chunked and rate-limited live verification planning for progressive Career cohorts"
+    scope:
+      - Add read-only chunk planning for 300, 800, and 2786 live verification.
+      - Represent request rate, timeout, retry, output, and resume guards without executing HTTP requests.
+      - Support partial progress artifacts and final merged summary paths for later guarded live verification runs.
+      - Keep large cohort verification under GET/HEAD-only, public-endpoint, no-mutation constraints.
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run live crawl.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run candidate preparation apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerProgressiveLiveVerification --no-ansi
+      - php artisan test --filter=CareerPlanCanonicalProgressiveLiveVerification --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- adds a read-only progressive live verification scaling planner and command for 300/800/2786 Career cohorts
- chunks explicit total slug artifacts, records output paths, and supports resume from partial progress artifacts
- enforces GET/HEAD-only planning with request rate <= 1/sec, timeout <= 20s, retries <= 1, and no live HTTP execution

## Tests
- `php artisan test --filter=CareerProgressiveLiveVerification --no-ansi`
- `php artisan test --filter=CareerPlanCanonicalProgressiveLiveVerification --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `php artisan test --filter=Career80TotalLiveAcceptance --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-progressive-expansion-pr7.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh` failed only external Big5 pack publish/rollback compiled-directory assertions unrelated to this Career PR scope; recorded as sidecar in train state.

## Non-goals
- no live crawl
- no rollout dry-run/apply
- no candidate prep apply
- no DB mutation
- no deploy
- no fap-web change

Next: `300-READINESS-1`
