### PR TITLE
fix(api): make progressive readiness selection occupation-aware

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php
@@ -19,6 +19,7 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
         {--current-total= : Required current public total}
         {--target-total= : Required target public total: 300, 800, or 2786}
         {--locales=en,zh : Comma-separated locales}
+        {--entity-context= : Optional production-derived entity context JSON; if supplied, selected delta slugs must have occupation_exists=true}
         {--exclude-slugs= : Optional newline, comma, or JSON slug artifact to exclude}
         {--strict : Fail on source-plan validation issues}
         {--json : Emit JSON output}
@@ -43,6 +44,7 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
             $closeout = $this->readJson($closeoutPath, 'closeout');
             $baselinePath = $this->pathFromCloseout($closeout, 'total_slugs_path');
             $excludePath = $this->pathOption('exclude-slugs');
+            $entityContextPath = $this->pathOption('entity-context');
             $payload = app(CareerProgressiveReadinessSelector::class)->select(
                 sourcePlan: $sourcePlan,
                 currentCloseout: $closeout,
@@ -51,10 +53,14 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
                 targetPublicTotal: $this->intOption('target-total'),
                 locales: $this->localesOption(),
                 excludeSlugs: $excludePath === null ? [] : $this->readSlugList($excludePath, 'exclude_slug'),
+                occupationExistingSlugs: $entityContextPath === null ? null : $this->readOccupationExistingSlugs($entityContextPath),
                 strict: (bool) $this->option('strict'),
             )->toArray();
 
             $payload['source_plan']['validation_issue_count'] = count($sourcePlanValidation->issues);
+            if ($entityContextPath !== null) {
+                $payload['entity_context']['source_path'] = $entityContextPath;
+            }
 
             return $this->finish($payload, ($payload['status'] ?? null) === 'pass' ? self::SUCCESS : self::FAILURE);
         } catch (Throwable $exception) {
@@ -195,6 +201,46 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
             static fn (mixed $slug): string => trim((string) $slug),
             is_array($slugs) ? $slugs : [],
         ), static fn (string $slug): bool => $slug !== ''));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readOccupationExistingSlugs(string $path): array
+    {
+        $payload = $this->readJson($path, 'entity_context');
+        $rows = $payload['rows'] ?? null;
+        if (! is_array($rows) || ! array_is_list($rows)) {
+            throw new RuntimeException('entity_context_rows_missing');
+        }
+
+        $slugs = [];
+        $seen = [];
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException('entity_context_row_invalid_at_'.$index);
+            }
+            if (($row['occupation_exists'] ?? false) !== true) {
+                continue;
+            }
+
+            $slug = $row['canonical_slug'] ?? $row['slug'] ?? null;
+            if (! is_string($slug) || trim($slug) === '') {
+                throw new RuntimeException('entity_context_slug_missing_at_'.$index);
+            }
+
+            $slug = strtolower(trim($slug));
+            if (! isset($seen[$slug])) {
+                $seen[$slug] = true;
+                $slugs[] = $slug;
+            }
+        }
+
+        if ($slugs === []) {
+            throw new RuntimeException('entity_context_occupation_exists_slugs_missing');
+        }
+
+        return $slugs;
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerProgressiveReadinessSelector.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveReadinessSelector.php
@@ -14,6 +14,7 @@ final class CareerProgressiveReadinessSelector
      * @param  list<string>  $currentPublicSlugs
      * @param  list<string>  $locales
      * @param  list<string>  $excludeSlugs
+     * @param  list<string>|null  $occupationExistingSlugs
      */
     public function select(
         CareerPublicResolutionPlan $sourcePlan,
@@ -23,13 +24,19 @@ final class CareerProgressiveReadinessSelector
         int $targetPublicTotal,
         array $locales = ['en', 'zh'],
         array $excludeSlugs = [],
+        ?array $occupationExistingSlugs = null,
         bool $strict = false,
     ): CareerProgressiveReadinessSelectionResult {
         $locales = $this->normalizedStringList($locales, 'locale');
         $baselineSlugs = $this->normalizedSlugList($currentPublicSlugs, 'baseline_slug');
         $excludeSlugs = $this->normalizedSlugList($excludeSlugs, 'exclude_slug');
+        $occupationExistingSlugs = $occupationExistingSlugs === null
+            ? null
+            : $this->normalizedSlugList($occupationExistingSlugs, 'occupation_existing_slug');
         $baselineSet = array_fill_keys($baselineSlugs, true);
         $excludeSet = array_fill_keys($excludeSlugs, true);
+        $occupationExistingSet = $occupationExistingSlugs === null ? [] : array_fill_keys($occupationExistingSlugs, true);
+        $requiresOccupationExists = $occupationExistingSlugs !== null;
         $deltaNeeded = max(0, $targetPublicTotal - $currentPublicTotal);
         $issues = $this->initialIssues($currentCloseout, $baselineSlugs, $currentPublicTotal, $targetPublicTotal);
         $candidates = [];
@@ -37,6 +44,8 @@ final class CareerProgressiveReadinessSelector
         $duplicateSourceSlugs = [];
         $seenSourceSlugs = [];
         $sourceReadyCount = 0;
+        $selectableCandidateCount = 0;
+        $occupationMissingExcludedCount = 0;
         $excludedByReason = [];
 
         foreach ($sourcePlan->rows as $position => $row) {
@@ -70,10 +79,23 @@ final class CareerProgressiveReadinessSelector
             if ($sourceReady && ! $baselineExcluded && ! isset($excludeSet[$slug])) {
                 $sourceReadyCount++;
             }
+            $occupationMissing = $requiresOccupationExists
+                && $sourceReady
+                && ! $baselineExcluded
+                && ! isset($excludeSet[$slug])
+                && ! isset($occupationExistingSet[$slug]);
+            if ($occupationMissing) {
+                $reasons[] = 'occupation_missing';
+                $occupationMissingExcludedCount++;
+            }
+            if ($sourceReady && ! $baselineExcluded && ! isset($excludeSet[$slug]) && ! $occupationMissing) {
+                $selectableCandidateCount++;
+            }
 
             $selected = $sourceReady
                 && ! $baselineExcluded
                 && ! isset($excludeSet[$slug])
+                && ! $occupationMissing
                 && count($selectedSlugs) < $deltaNeeded
                 && $issues === [];
 
@@ -115,6 +137,8 @@ final class CareerProgressiveReadinessSelector
                     'required_delta_slug_count' => $deltaNeeded,
                     'selected_count' => count($selectedSlugs),
                     'source_ready_delta_count' => $sourceReadyCount,
+                    'selectable_candidate_count' => $selectableCandidateCount,
+                    'occupation_missing_excluded_count' => $occupationMissingExcludedCount,
                 ],
             );
         }
@@ -140,7 +164,8 @@ final class CareerProgressiveReadinessSelector
             'baseline_count' => count($baselineSlugs),
             'delta_slug_count' => $deltaNeeded,
             'selected_count' => count($selectedSlugs),
-            'candidate_count' => $sourceReadyCount,
+            'candidate_count' => $selectableCandidateCount,
+            'source_ready_count' => $sourceReadyCount,
             'locale_count' => count($locales),
             'locales' => $locales,
             'expected_delta_locale_rows' => $deltaNeeded * count($locales),
@@ -165,6 +190,11 @@ final class CareerProgressiveReadinessSelector
                 'source_path' => $sourcePlan->sourcePath,
                 'checksum' => $sourcePlan->checksum,
                 'row_count' => count($sourcePlan->rows),
+            ],
+            'entity_context' => [
+                'required_for_selection' => $requiresOccupationExists,
+                'occupation_exists_count' => $occupationExistingSlugs === null ? null : count($occupationExistingSlugs),
+                'occupation_missing_excluded_count' => $occupationMissingExcludedCount,
             ],
             'excluded' => [
                 'excluded_by_reason' => $excludedByReason,

--- a/backend/docs/career/audits/progressive_readiness_selection.md
+++ b/backend/docs/career/audits/progressive_readiness_selection.md
@@ -13,6 +13,12 @@ The selector starts from an accepted closeout baseline and a 2786 public
 resolution/source plan. It excludes the already-public baseline slugs and picks
 the next deterministic source-ready delta slugs for the requested target.
 
+For runtime candidate prep readiness, the command can also consume a
+production-derived entity context with `--entity-context`. When supplied, delta
+selection requires `occupation_exists=true`; source-ready rows whose canonical
+occupation is absent from production are excluded with `occupation_missing` so
+they do not block the later candidate-prep dry-run.
+
 ## Readiness Selection vs Rollout Validation
 
 This step is intentionally earlier than rollout-candidate validation. It does
@@ -30,6 +36,8 @@ projection/truth/ledger artifacts and explicit rollout gates.
 - 2786 public-resolution/source plan.
 - Current and target public totals.
 - Locale list, normally `en,zh`.
+- Optional production-derived entity context from
+  `career:export-canonical-eligibility-db-context`.
 
 ## Output
 
@@ -49,6 +57,11 @@ The command emits stable JSON using:
     "slugs": [],
     "delta_slugs": []
   },
+  "entity_context": {
+    "required_for_selection": true,
+    "occupation_exists_count": 2469,
+    "occupation_missing_excluded_count": 27
+  },
   "writes_database": false,
   "apply_allowed": false,
   "next_required_action": "PROGRESSIVE_RUNTIME_CANDIDATE_PREP"
@@ -58,6 +71,19 @@ The command emits stable JSON using:
 `selected_slugs` and `selection.delta_slugs` are the new delta. `selection.slugs`
 is the full target cohort, baseline plus delta, so it can feed
 `career:plan-canonical-progressive-cohort-delta`.
+
+## Occupation-Aware Selection
+
+`--entity-context` is read-only. It does not query the database. It reads an
+existing JSON artifact and builds an allowlist from rows where
+`occupation_exists=true`. This preserves deterministic source ordering while
+skipping source-plan rows that cannot enter runtime candidate preparation yet.
+
+This selection rule is only for the pre-candidate-prep readiness stage. It does
+not publish occupations, does not create missing occupations, and does not
+weaken rollout or live-acceptance validation. Missing production occupations
+remain explicit exclusions until a later source/import repair chooses to add
+them.
 
 ## Non-Goals
 

--- a/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php
@@ -73,6 +73,61 @@ final class CareerPlanCanonicalProgressiveReadinessSelectionCommandTest extends 
         $this->assertFileExists($output);
     }
 
+    public function test_entity_context_excludes_missing_occupations_from_selection(): void
+    {
+        $current = $this->slugs('current', 80);
+        $delta = $this->slugs('delta', 225);
+        $missing = array_slice($delta, 0, 5);
+        $occupationExisting = array_values(array_diff($delta, $missing));
+        $currentSlugs = $this->writeSlugs('current', $current);
+        $output = $this->tempPath('output');
+
+        $exitCode = Artisan::call('career:plan-canonical-progressive-readiness-selection', [
+            '--source-plan' => $this->writeSourcePlan([...$current, ...$delta]),
+            '--closeout' => $this->writeCloseout(80, $currentSlugs),
+            '--current-total' => '80',
+            '--target-total' => '300',
+            '--locales' => 'en,zh',
+            '--entity-context' => $this->writeEntityContext([...$current, ...$occupationExisting], $missing),
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(220, $payload['selected_count']);
+        $this->assertSame($occupationExisting, $payload['selected_slugs']);
+        $this->assertSame(5, $payload['excluded']['excluded_by_reason']['occupation_missing']);
+        $this->assertTrue($payload['entity_context']['required_for_selection']);
+        $this->assertSame(300, $payload['entity_context']['occupation_exists_count']);
+        $this->assertSame(5, $payload['entity_context']['occupation_missing_excluded_count']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_entity_context_with_no_existing_occupations_blocks_without_mutation(): void
+    {
+        $current = $this->slugs('current', 80);
+        $delta = $this->slugs('delta', 220);
+        $currentSlugs = $this->writeSlugs('current', $current);
+
+        $exitCode = Artisan::call('career:plan-canonical-progressive-readiness-selection', [
+            '--source-plan' => $this->writeSourcePlan([...$current, ...$delta]),
+            '--closeout' => $this->writeCloseout(80, $currentSlugs),
+            '--current-total' => '80',
+            '--target-total' => '300',
+            '--entity-context' => $this->writeEntityContext([], [...$current, ...$delta]),
+            '--json' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('entity_context_occupation_exists_slugs_missing', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+    }
+
     public function test_target_less_than_current_blocks_without_mutation(): void
     {
         $currentSlugs = $this->writeSlugs('current', $this->slugs('current', 80));
@@ -156,6 +211,34 @@ final class CareerPlanCanonicalProgressiveReadinessSelectionCommandTest extends 
         return $this->writeJson('source-plan', [
             'schema_version' => 'career_public_resolution_plan.v1',
             'expected_rows' => count($rows),
+            'rows' => $rows,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $existingSlugs
+     * @param  list<string>  $missingSlugs
+     */
+    private function writeEntityContext(array $existingSlugs, array $missingSlugs = []): string
+    {
+        $rows = [];
+        foreach ($existingSlugs as $slug) {
+            $rows[] = [
+                'canonical_slug' => $slug,
+                'occupation_exists' => true,
+                'occupation_id' => 'occ-'.$slug,
+            ];
+        }
+        foreach ($missingSlugs as $slug) {
+            $rows[] = [
+                'canonical_slug' => $slug,
+                'occupation_exists' => false,
+                'occupation_id' => null,
+            ];
+        }
+
+        return $this->writeJson('entity-context', [
+            'schema_version' => 'career_entity_context.v1',
             'rows' => $rows,
         ]);
     }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveReadinessSelectionTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveReadinessSelectionTest.php
@@ -124,6 +124,53 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
         $this->assertSame($delta, $deltaPlan['recommended_rollout_delta_slugs']);
     }
 
+    public function test_entity_context_occupation_exists_filter_replaces_missing_occupations(): void
+    {
+        $baseline = $this->slugs('current', 80);
+        $delta = $this->slugs('delta', 225);
+        $missing = array_slice($delta, 0, 5);
+        $occupationExisting = array_values(array_diff($delta, $missing));
+
+        $payload = $this->select(
+            baseline: $baseline,
+            sourceSlugs: [...$baseline, ...$delta],
+            currentTotal: 80,
+            targetTotal: 300,
+            occupationExistingSlugs: $occupationExisting,
+        );
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(220, $payload['selected_count']);
+        $this->assertSame($occupationExisting, $payload['selected_slugs']);
+        $this->assertSame(225, $payload['source_ready_count']);
+        $this->assertSame(220, $payload['candidate_count']);
+        $this->assertSame(5, $payload['excluded']['excluded_by_reason']['occupation_missing']);
+        $this->assertTrue($payload['entity_context']['required_for_selection']);
+        $this->assertSame(220, $payload['entity_context']['occupation_exists_count']);
+        $this->assertSame(5, $payload['entity_context']['occupation_missing_excluded_count']);
+    }
+
+    public function test_entity_context_blocks_when_not_enough_occupation_present_candidates(): void
+    {
+        $baseline = $this->slugs('current', 80);
+        $delta = $this->slugs('delta', 220);
+        $occupationExisting = array_slice($delta, 0, 219);
+
+        $payload = $this->select(
+            baseline: $baseline,
+            sourceSlugs: [...$baseline, ...$delta],
+            currentTotal: 80,
+            targetTotal: 300,
+            occupationExistingSlugs: $occupationExisting,
+        );
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(219, $payload['selected_count']);
+        $this->assertContains('insufficient_source_ready_delta_slugs', array_column($payload['blockers'], 'reason'));
+        $this->assertSame(1, $payload['blockers'][0]['evidence']['occupation_missing_excluded_count']);
+        $this->assertSame(219, $payload['blockers'][0]['evidence']['selectable_candidate_count']);
+    }
+
     public function test_readiness_selection_does_not_require_rollout_candidate_runtime_state(): void
     {
         $payload = $this->select(['career-001'], ['career-001', 'career-002'], 1, 300);
@@ -136,10 +183,16 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
     /**
      * @param  list<string>  $baseline
      * @param  list<string>  $sourceSlugs
+     * @param  list<string>|null  $occupationExistingSlugs
      * @return array<string, mixed>
      */
-    private function select(array $baseline, array $sourceSlugs, int $currentTotal, int $targetTotal): array
-    {
+    private function select(
+        array $baseline,
+        array $sourceSlugs,
+        int $currentTotal,
+        int $targetTotal,
+        ?array $occupationExistingSlugs = null,
+    ): array {
         return (new CareerProgressiveReadinessSelector)->select(
             sourcePlan: $this->sourcePlan($sourceSlugs),
             currentCloseout: $this->closeout($currentTotal),
@@ -147,6 +200,7 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
             currentPublicTotal: $currentTotal,
             targetPublicTotal: $targetTotal,
             locales: ['en', 'zh'],
+            occupationExistingSlugs: $occupationExistingSlugs,
         )->toArray();
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6109,6 +6109,64 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-progressive-readiness-occupation-aware-selection-1",
+      "title": "fix(api): make progressive readiness selection occupation-aware",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-READINESS-SELECTION-1"
+      ],
+      "scope_type": "progressive_readiness_occupation_aware_selection_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/**",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no DB mutation",
+        "no candidate prep dry-run",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no deploy",
+        "no fap-web",
+        "no production DB query",
+        "no live crawl"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-READINESS-SELECTION-1 is present on main as commit 9a2032ebcd593deb2e2ad7537775b96855badad4."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to occupation-aware progressive readiness selection logic, command tests/docs, docs, and train metadata."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": "CareerProgressiveReadinessSelection tests passed; CareerPlanCanonicalProgressiveReadinessSelection tests passed; CareerProgressive and CareerProgressiveCohort filters passed; CareerRuntimeCandidate and CareerAuditCanonicalEligibility filters passed; route:list passed; sqlite migrate passed; Pint --test passed; git diff --check passed; bash backend/scripts/ci_verify_mbti.sh exited 0."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "300-READINESS-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -313,6 +313,46 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-READINESS-SELECTION-1
+    branch: codex/repair-progressive-readiness-occupation-aware-selection-1
+    title: "fix(api): make progressive readiness selection occupation-aware"
+    name: "Add occupation-aware progressive Career readiness selection"
+    scope:
+      - Add optional production-derived entity context input to progressive readiness selection.
+      - Require occupation_exists=true for runtime-candidate-prep readiness when entity context is supplied.
+      - Preserve deterministic source ordering while replacing source-ready rows missing production occupations.
+      - Keep readiness selection read-only and separate from rollout/apply/live-acceptance validation.
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run 300 readiness execution.
+      - Run candidate prep dry-run or apply.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi
+      - php artisan test --filter=CareerPlanCanonicalProgressiveReadinessSelection --no-ansi
+      - php artisan test --filter=CareerProgressive --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- adds optional `--entity-context` support to progressive readiness selection
- requires `occupation_exists=true` before selecting delta slugs for runtime-candidate-prep readiness when entity context is supplied
- keeps deterministic source ordering while replacing source-ready rows missing production occupations
- documents the read-only occupation-aware selection semantics and registers the PR train item

## Non-goals
- no DB mutation
- no candidate prep dry-run/apply
- no rollout dry-run/apply
- no deploy
- no fap-web
- no live crawl

## Validation
- `php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi`
- `php artisan test --filter=CareerPlanCanonicalProgressiveReadinessSelection --no-ansi`
- `php artisan test --filter=CareerProgressive --no-ansi`
- `php artisan test --filter=CareerProgressiveCohort --no-ansi`
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-repair-progressive-readiness-occupation-aware.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`
- `curl -I --max-time 20 https://www.fermatmind.com`

## Next step
300-READINESS-1 with production-derived entity context, then 300 runtime candidate prep plan/dry-run.
