### PR TITLE
fix(api): consume progressive delta slugs in runtime candidate pool

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php
@@ -83,6 +83,10 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         {--truth= : Required runtime truth JSON artifact}
         {--ledger= : Required full release ledger JSON artifact}
         {--target=80 : Target runtime candidate pool size}
+        {--delta-slugs= : Optional explicit progressive delta slug artifact for 300/800/2786 pool planning}
+        {--readiness-plan= : Optional progressive readiness plan artifact containing selected_slugs}
+        {--target-total= : Optional progressive target public total metadata}
+        {--cohort= : Optional progressive cohort identifier}
         {--locales=en,zh : Comma-separated locales required for each candidate}
         {--json : Emit JSON output}
         {--output= : Optional output path for candidate pool plan JSON}
@@ -98,7 +102,10 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
             $truthPath = $this->requiredOption('truth');
             $ledgerPath = $this->requiredOption('ledger');
             $target = $this->positiveIntOption('target', 80);
+            $targetTotal = $this->optionalPositiveIntOption('target-total');
+            $cohort = $this->optionalStringOption('cohort');
             $locales = $this->localesOption();
+            $explicitDeltaSelection = $this->explicitDeltaSelection($target, $targetTotal, $cohort);
 
             [$audit, $report] = $this->readAudit($auditPath);
             $projection = $this->readArtifact($projectionPath, 'projection');
@@ -116,6 +123,7 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 truth: $truth,
                 ledger: $ledger,
                 target: $target,
+                explicitDeltaSelection: $explicitDeltaSelection,
                 locales: $locales,
             );
 
@@ -150,6 +158,28 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         return $value;
     }
 
+    private function optionalPositiveIntOption(string $name): ?int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return null;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    private function optionalStringOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
     /**
      * @return list<string>
      */
@@ -168,6 +198,155 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         sort($locales);
 
         return $locales;
+    }
+
+    /**
+     * @return array{strategy: string, path: string, sha256: string|null, slug_count: int, slugs: list<string>, target_total: int|null, cohort: string|null}|null
+     */
+    private function explicitDeltaSelection(int $target, ?int $targetTotal, ?string $cohort): ?array
+    {
+        $readinessPlanPath = $this->optionalStringOption('readiness-plan');
+        $deltaSlugsPath = $this->optionalStringOption('delta-slugs');
+
+        if ($readinessPlanPath === null && $deltaSlugsPath === null) {
+            return null;
+        }
+
+        if ($readinessPlanPath !== null) {
+            $readinessPlan = $this->readArtifact($readinessPlanPath, 'readiness_plan');
+            $slugs = $this->extractSlugListFromArtifact($readinessPlan);
+
+            if ($slugs === []) {
+                throw new RuntimeException('readiness_plan_selected_slugs_missing');
+            }
+
+            if ($targetTotal !== null && (int) ($readinessPlan['target_public_total'] ?? 0) !== $targetTotal) {
+                throw new RuntimeException('readiness_plan_target_total_mismatch');
+            }
+
+            if (isset($readinessPlan['blockers']) && is_array($readinessPlan['blockers']) && $readinessPlan['blockers'] !== []) {
+                throw new RuntimeException('readiness_plan_blocked');
+            }
+
+            $slugs = $this->normalizeSlugList($slugs, 'readiness_plan_selected_slugs');
+            $this->assertExplicitDeltaCount($slugs, $target);
+
+            return [
+                'strategy' => 'progressive_readiness_plan_selected_slugs',
+                'path' => $readinessPlanPath,
+                'sha256' => hash_file('sha256', $readinessPlanPath) ?: null,
+                'slug_count' => count($slugs),
+                'slugs' => $slugs,
+                'target_total' => $targetTotal,
+                'cohort' => $cohort,
+            ];
+        }
+
+        $slugs = $this->normalizeSlugList($this->readSlugArtifact($deltaSlugsPath), 'delta_slugs');
+        $this->assertExplicitDeltaCount($slugs, $target);
+
+        return [
+            'strategy' => 'progressive_delta_slug_artifact',
+            'path' => $deltaSlugsPath,
+            'sha256' => hash_file('sha256', $deltaSlugsPath) ?: null,
+            'slug_count' => count($slugs),
+            'slugs' => $slugs,
+            'target_total' => $targetTotal,
+            'cohort' => $cohort,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readSlugArtifact(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('delta_slugs_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException('delta_slugs_artifact_unreadable');
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            $decoded = null;
+        }
+
+        if (is_array($decoded)) {
+            if (array_is_list($decoded)) {
+                return $decoded;
+            }
+
+            return $this->extractSlugListFromArtifact($decoded);
+        }
+
+        return preg_split('/[\s,]+/', trim($contents)) ?: [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return list<string>
+     */
+    private function extractSlugListFromArtifact(array $artifact): array
+    {
+        foreach ([
+            ['selected_slugs'],
+            ['delta_slugs'],
+            ['slugs'],
+            ['selection', 'slugs'],
+            ['runtime_candidate_gate', 'selected_slugs'],
+        ] as $path) {
+            $value = data_get($artifact, implode('.', $path));
+            if (is_array($value) && array_is_list($value)) {
+                return $value;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<mixed>  $values
+     * @return list<string>
+     */
+    private function normalizeSlugList(array $values, string $context): array
+    {
+        $slugs = [];
+        $seen = [];
+
+        foreach ($values as $value) {
+            if (! is_string($value) || trim($value) === '') {
+                throw new RuntimeException($context.'_invalid_slug');
+            }
+
+            $slug = trim($value);
+            if (isset($seen[$slug])) {
+                throw new RuntimeException($context.'_duplicate_slug');
+            }
+
+            $seen[$slug] = true;
+            $slugs[] = $slug;
+        }
+
+        if ($slugs === []) {
+            throw new RuntimeException($context.'_missing');
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function assertExplicitDeltaCount(array $slugs, int $target): void
+    {
+        if (count($slugs) !== $target) {
+            throw new RuntimeException('explicit_delta_slug_count_mismatch');
+        }
     }
 
     /**
@@ -236,6 +415,7 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         array $truth,
         array $ledger,
         int $target,
+        ?array $explicitDeltaSelection,
         array $locales,
     ): array {
         $policy = (new Career2786ReadinessPolicyClassifier)->classify($report, $target);
@@ -248,11 +428,14 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         $truthBySlug = $this->rowsBySlugLocale($this->artifactRows($truth, ['items', 'rows']));
         $ledgerBySlug = $this->ledgerBySlug($this->artifactRows($ledger, ['members', 'items', 'rows']));
         $auditRowsBySlug = $this->auditRowsBySlug($report);
-        $selection = (new CareerCanonical80CandidateSelector)->select(
-            report: $report,
-            targetCount: $target,
-            hardBlockers: self::RUNTIME_POOL_SELECTOR_HARD_BLOCKERS,
-        );
+        $explicitProgressiveDelta = $explicitDeltaSelection !== null;
+        $selectionRows = $explicitProgressiveDelta
+            ? $this->explicitProgressiveSelectionRows($explicitDeltaSelection['slugs'])
+            : (new CareerCanonical80CandidateSelector)->select(
+                report: $report,
+                targetCount: $target,
+                hardBlockers: self::RUNTIME_POOL_SELECTOR_HARD_BLOCKERS,
+            )->rows;
 
         $eligible = [];
         $excluded = [];
@@ -260,7 +443,7 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         $baseCandidateCount = 0;
         $auditGate = new Career80RolloutCandidateGate;
 
-        foreach ($selection->rows as $row) {
+        foreach ($selectionRows as $row) {
             $policyRow = $policyRowsBySlug[$row->canonicalSlug] ?? null;
             if (! $policyRow instanceof Career2786ReadinessPolicyRow) {
                 continue;
@@ -274,9 +457,10 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 ledgerMember: $ledgerBySlug[$row->canonicalSlug] ?? null,
                 auditRows: $auditRowsBySlug[$row->canonicalSlug] ?? [],
                 policyRow: $policyRow,
+                explicitProgressiveDelta: $explicitProgressiveDelta,
             );
 
-            if (! $this->isBaseCandidate($row, $policyRow, $candidateAwareEvidence)) {
+            if (! $this->isBaseCandidate($row, $policyRow, $candidateAwareEvidence, $explicitProgressiveDelta)) {
                 continue;
             }
 
@@ -289,6 +473,7 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 ledgerMember: $ledgerBySlug[$row->canonicalSlug] ?? null,
                 auditGate: $auditGate->evaluate($auditRowsBySlug[$row->canonicalSlug] ?? []),
                 candidateAwareEvidence: $candidateAwareEvidence,
+                explicitProgressiveDelta: $explicitProgressiveDelta,
             );
 
             if ($gate['eligible'] === true) {
@@ -338,6 +523,7 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 'ledger' => $this->sourceArtifact($ledgerPath, [
                     'member_count' => count($this->artifactRows($ledger, ['members', 'items', 'rows'])),
                 ]),
+                'explicit_delta_selection' => $explicitDeltaSelection,
             ],
             'runtime_candidate_gate' => [
                 'required' => true,
@@ -353,7 +539,9 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 'excluded_rows' => $excluded,
             ],
             'selection' => [
-                'strategy' => 'runtime_published_candidate_pool_ranked',
+                'strategy' => $explicitProgressiveDelta
+                    ? 'progressive_explicit_delta_runtime_candidate_pool'
+                    : 'runtime_published_candidate_pool_ranked',
                 'slugs' => array_map(
                     static fn (array $row): string => (string) $row['slug'],
                     $selected
@@ -368,20 +556,26 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 'apply_allowed' => false,
                 'reason' => 'runtime candidate pool planning only; rollout apply requires separate approval',
             ],
-            'next_required_action' => $poolPass ? '80_READINESS_RERUN_WITH_RUNTIME_POOL' : 'FIX_RUNTIME_CANDIDATE_POOL',
+            'next_required_action' => $poolPass
+                ? ($explicitProgressiveDelta ? 'PROGRESSIVE_ROLLOUT_MANIFEST' : '80_READINESS_RERUN_WITH_RUNTIME_POOL')
+                : 'FIX_RUNTIME_CANDIDATE_POOL',
         ];
     }
 
     /**
      * @param  array{required: bool, eligible: bool, reasons: list<string>, evidence: array<string, mixed>}  $candidateAwareEvidence
      */
-    private function isBaseCandidate(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow, array $candidateAwareEvidence): bool
+    private function isBaseCandidate(CareerCanonical80CandidateSelectionRow $row, Career2786ReadinessPolicyRow $policyRow, array $candidateAwareEvidence, bool $explicitProgressiveDelta): bool
     {
         if (! in_array($row->candidateStatus, [
             CareerCanonical80CandidateSelectionRow::STATUS_READY,
             CareerCanonical80CandidateSelectionRow::STATUS_NEAR_ELIGIBLE,
         ], true)) {
             return false;
+        }
+
+        if ($explicitProgressiveDelta) {
+            return $row->hardBlockers === [] && $candidateAwareEvidence['required'];
         }
 
         if ($candidateAwareEvidence['required'] && $row->hardBlockers === [] && $this->policyOnlyHasCandidateAwarePlanningBlockers($policyRow)) {
@@ -411,6 +605,7 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         ?array $ledgerMember,
         array $auditGate,
         array $candidateAwareEvidence,
+        bool $explicitProgressiveDelta,
     ): array {
         $reasons = $candidateAwareEvidence['reasons'];
         $evidence = [
@@ -454,8 +649,10 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
             }
         }
 
-        foreach ($auditGate['reasons'] as $reason) {
-            $reasons[] = $reason;
+        if (! ($explicitProgressiveDelta && $candidateAwareEvidence['eligible'])) {
+            foreach ($auditGate['reasons'] as $reason) {
+                $reasons[] = $reason;
+            }
         }
 
         $reasons = $this->normalizeStrings($reasons);
@@ -569,12 +766,13 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         ?array $ledgerMember,
         array $auditRows,
         Career2786ReadinessPolicyRow $policyRow,
+        bool $explicitProgressiveDelta,
     ): array {
         $reasons = [];
         $projectionOverlayRows = 0;
         $truthOverlayRows = 0;
         $sourceHashes = [];
-        $required = $this->candidateAwarePlanningRequired($policyRow);
+        $required = $explicitProgressiveDelta || $this->candidateAwarePlanningRequired($policyRow);
 
         $ledgerOverlay = $ledgerMember !== null
             && ($this->stringValue($ledgerMember, 'overlay_source') ?? '') === self::CANDIDATE_AWARE_OVERLAY_SOURCE;
@@ -623,10 +821,10 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
         if ($truthOverlayRows < count($locales)) {
             $reasons[] = 'candidate_aware_truth_overlay_missing';
         }
-        if (! $this->auditShowsCandidateAwareIndexState($auditRows)) {
+        if (! $explicitProgressiveDelta && ! $this->auditShowsCandidateAwareIndexState($auditRows)) {
             $reasons[] = 'candidate_aware_audit_index_evidence_missing';
         }
-        if (! $this->policyOnlyHasCandidateAwarePlanningBlockers($policyRow)) {
+        if (! $explicitProgressiveDelta && ! $this->policyOnlyHasCandidateAwarePlanningBlockers($policyRow)) {
             $reasons[] = 'candidate_policy_has_non_candidate_aware_blocker';
         }
 
@@ -646,6 +844,9 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
                 'projection_overlay_rows' => $projectionOverlayRows,
                 'truth_overlay_rows' => $truthOverlayRows,
                 'audit_index_state' => $this->auditIndexStates($auditRows),
+                'explicit_progressive_delta' => $explicitProgressiveDelta,
+                'audit_index_evidence_required' => ! $explicitProgressiveDelta,
+                'policy_blocker_veto_required' => ! $explicitProgressiveDelta,
                 'source_artifact_sha256_values' => $this->normalizeStrings($sourceHashes),
             ],
         ];
@@ -674,6 +875,37 @@ final class CareerPlanCanonical80RuntimeCandidatePool extends Command
     private function auditShowsCandidateAwareIndexState(array $auditRows): bool
     {
         return in_array(self::CANDIDATE_AWARE_INDEX_STATE, $this->auditIndexStates($auditRows), true);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return list<CareerCanonical80CandidateSelectionRow>
+     */
+    private function explicitProgressiveSelectionRows(array $slugs): array
+    {
+        $rows = [];
+        foreach ($slugs as $index => $slug) {
+            $rows[] = new CareerCanonical80CandidateSelectionRow(
+                canonicalSlug: $slug,
+                rank: $index + 1,
+                score: max(1, count($slugs) - $index),
+                candidateStatus: CareerCanonical80CandidateSelectionRow::STATUS_NEAR_ELIGIBLE,
+                selected: false,
+                hardBlocked: false,
+                passedLocaleCount: 0,
+                blockedLocaleCount: 0,
+                locales: [],
+                reasons: [],
+                hardBlockers: [],
+                layerStatuses: [],
+                evidence: [[
+                    'source' => 'progressive_explicit_delta_slug_artifact',
+                    'selection_order' => $index + 1,
+                ]],
+            );
+        }
+
+        return $rows;
     }
 
     /**

--- a/backend/docs/career/audits/80_runtime_candidate_pool.md
+++ b/backend/docs/career/audits/80_runtime_candidate_pool.md
@@ -18,6 +18,25 @@ php artisan career:plan-canonical-80-runtime-candidate-pool \
   --output=/tmp/career_2786_80_runtime_candidate_pool_plan.json
 ```
 
+For progressive cohorts after candidate preparation and candidate-aware artifact
+refresh, pass the explicit readiness delta slug artifact instead of relying on
+the legacy 80 near-eligible selector:
+
+```bash
+php artisan career:plan-canonical-80-runtime-candidate-pool \
+  --audit=/tmp/career_2786_canonical_eligibility_audit_candidate_aware_300.json \
+  --projection=/tmp/career_300_runtime_projection_candidate_aware.json \
+  --truth=/tmp/career_300_runtime_truth_candidate_aware.json \
+  --ledger=/tmp/career_300_full_release_ledger_candidate_aware.json \
+  --target=220 \
+  --target-total=300 \
+  --cohort=career_80_to_300_delta \
+  --delta-slugs=/tmp/career_300_delta_slugs.txt \
+  --locales=en,zh \
+  --json \
+  --output=/tmp/career_300_runtime_candidate_pool_after_refresh.json
+```
+
 ## Inputs
 
 - `--audit`: full canonical eligibility audit artifact.
@@ -25,6 +44,12 @@ php artisan career:plan-canonical-80-runtime-candidate-pool \
 - `--truth`: runtime truth artifact.
 - `--ledger`: full release ledger artifact.
 - `--target`: cohort size, default `80`.
+- `--delta-slugs`: optional explicit progressive delta slug artifact for
+  300/800/2786 pool planning.
+- `--readiness-plan`: optional progressive readiness artifact containing
+  `selected_slugs`.
+- `--target-total`: optional progressive target public total metadata.
+- `--cohort`: optional progressive cohort identifier.
 - `--locales`: required locale rows for each candidate, default `en,zh`.
 
 All inputs are JSON artifacts. The command does not query the database.
@@ -62,6 +87,16 @@ Candidate-aware 51-delta planning has a narrower pre-promotion exception. A slug
 - the slug is evaluated as a delta pre-promotion candidate and not as an already-published baseline slug.
 
 This exception is only for rollout dry-run planning. It does not make the slug published, does not authorize apply, and does not satisfy final 80-total live acceptance.
+
+Progressive 300/800/2786 planning uses the same candidate-aware runtime gate but
+changes the candidate source. When `--delta-slugs` or `--readiness-plan` is
+present, the planner evaluates exactly that explicit delta set. This avoids
+reusing the old 80 near-eligible source pool after a larger cohort has already
+passed readiness and candidate preparation. In explicit progressive mode, stale
+audit/index evidence is not allowed to veto a slug that has verified
+`candidate_prep_apply_overlay` projection, truth, and ledger rows; missing
+projection/truth/ledger rows, blocked runtime state, already-published state,
+and unexpected route/API exposure still block selection.
 
 The command excludes:
 

--- a/backend/tests/Feature/Console/CareerPlanCanonical80RuntimeCandidatePoolCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical80RuntimeCandidatePoolCommandTest.php
@@ -120,6 +120,104 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
         $this->assertSame(0, $payload['excluded_count']);
     }
 
+    public function test_explicit_progressive_delta_slugs_drive_pool_selection_instead_of_legacy_80_candidates(): void
+    {
+        $legacySlugs = ['legacy-near-eligible-001', 'legacy-near-eligible-002'];
+        $progressiveSlugs = ['progressive-delta-001', 'progressive-delta-002', 'progressive-delta-003'];
+
+        $exitCode = $this->callCommand([
+            '--audit' => $this->writeProgressiveStaleAudit($progressiveSlugs, $legacySlugs),
+            '--projection' => $this->writeProjection($progressiveSlugs),
+            '--truth' => $this->writeTruth($progressiveSlugs),
+            '--ledger' => $this->writeLedger($progressiveSlugs),
+            '--target' => 3,
+            '--target-total' => 300,
+            '--cohort' => 'career_80_to_300_delta',
+            '--delta-slugs' => $this->writeSlugArtifact($progressiveSlugs),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['pool_pass']);
+        $this->assertSame('progressive_explicit_delta_runtime_candidate_pool', $payload['selection']['strategy']);
+        $this->assertSame($progressiveSlugs, $payload['selection']['slugs']);
+        $this->assertSame(3, $payload['base_candidate_count']);
+        $this->assertSame(3, $payload['eligible_count']);
+        $this->assertSame('progressive_delta_slug_artifact', $payload['source_artifacts']['explicit_delta_selection']['strategy']);
+        $this->assertSame(3, $payload['source_artifacts']['explicit_delta_selection']['slug_count']);
+        $this->assertSame('PROGRESSIVE_ROLLOUT_MANIFEST', $payload['next_required_action']);
+        $this->assertTrue($payload['selection']['rows'][0]['runtime_state_evidence']['candidate_aware_overlay']['explicit_progressive_delta']);
+        $this->assertFalse($payload['selection']['rows'][0]['runtime_state_evidence']['candidate_aware_overlay']['audit_index_evidence_required']);
+    }
+
+    public function test_readiness_plan_selected_slugs_can_feed_progressive_pool_selection(): void
+    {
+        $slugs = ['progressive-plan-001', 'progressive-plan-002'];
+
+        $exitCode = $this->callCommand([
+            '--audit' => $this->writeProgressiveStaleAudit($slugs),
+            '--projection' => $this->writeProjection($slugs),
+            '--truth' => $this->writeTruth($slugs),
+            '--ledger' => $this->writeLedger($slugs),
+            '--target' => 2,
+            '--target-total' => 300,
+            '--readiness-plan' => $this->writeJson('readiness-plan', [
+                'status' => 'pass',
+                'readiness_pass' => true,
+                'target_public_total' => 300,
+                'delta_slug_count' => 2,
+                'selected_slugs' => $slugs,
+                'blockers' => [],
+            ]),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame($slugs, $payload['selection']['slugs']);
+        $this->assertSame('progressive_readiness_plan_selected_slugs', $payload['source_artifacts']['explicit_delta_selection']['strategy']);
+        $this->assertSame(2, $payload['selected_count']);
+    }
+
+    public function test_explicit_progressive_delta_selection_still_requires_verified_candidate_overlay(): void
+    {
+        $slugs = ['progressive-missing-overlay'];
+
+        $exitCode = $this->callCommand([
+            '--audit' => $this->writeProgressiveStaleAudit($slugs),
+            '--projection' => $this->writeProjection($slugs, candidateAware: false),
+            '--truth' => $this->writeTruth($slugs, candidateAware: false),
+            '--ledger' => $this->writeLedger($slugs, candidateAware: false),
+            '--target' => 1,
+            '--target-total' => 300,
+            '--delta-slugs' => $this->writeSlugArtifact($slugs),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['pool_pass']);
+        $this->assertSame(0, $payload['selected_count']);
+        $this->assertContains('candidate_aware_overlay_missing', $payload['runtime_candidate_gate']['excluded_rows'][0]['exclusion_reasons']);
+        $this->assertContains('candidate_prep_apply_not_verified', $payload['runtime_candidate_gate']['excluded_rows'][0]['exclusion_reasons']);
+    }
+
+    public function test_explicit_progressive_delta_slug_count_mismatch_blocks(): void
+    {
+        $exitCode = $this->callCommand([
+            '--audit' => $this->writeProgressiveStaleAudit(['progressive-delta-001']),
+            '--projection' => $this->writeProjection(['progressive-delta-001']),
+            '--truth' => $this->writeTruth(['progressive-delta-001']),
+            '--ledger' => $this->writeLedger(['progressive-delta-001']),
+            '--target' => 2,
+            '--delta-slugs' => $this->writeSlugArtifact(['progressive-delta-001']),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('explicit_delta_slug_count_mismatch', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+    }
+
     public function test_excludes_runtime_invalid_candidates(): void
     {
         $slugs = [
@@ -323,6 +421,43 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
     }
 
     /**
+     * @param  list<string>  $progressiveSlugs
+     * @param  list<string>  $legacyNearEligibleSlugs
+     */
+    private function writeProgressiveStaleAudit(array $progressiveSlugs, array $legacyNearEligibleSlugs = []): string
+    {
+        $rows = [];
+        foreach (array_values(array_unique($legacyNearEligibleSlugs)) as $slug) {
+            $rows[] = $this->row($slug, 'en');
+            $rows[] = $this->row($slug, 'zh');
+        }
+
+        foreach (array_values(array_unique($progressiveSlugs)) as $slug) {
+            $rows[] = $this->progressiveStaleRow($slug, 'en');
+            $rows[] = $this->progressiveStaleRow($slug, 'zh');
+        }
+
+        return $this->writeJson('audit', [
+            'status' => 'blocked',
+            'scope' => 'all',
+            'expected_occupations' => 2786,
+            'audited_occupations' => 2786,
+            'eligible_count' => 0,
+            'blocked_count' => count($rows),
+            'by_reason' => [
+                'index_state_missing' => count($progressiveSlugs) * 2,
+                'runtime_publish_state_not_published' => count($progressiveSlugs) * 2,
+                'truth_state_not_published' => count($progressiveSlugs) * 2,
+                'surface_unverified' => count($rows),
+            ],
+            'context_summary' => ['surface_context' => 'supplied'],
+            'policy_summary' => ['near_eligible_count' => count($legacyNearEligibleSlugs)],
+            'rows' => $rows,
+            'sidecars' => [],
+        ]);
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function row(string $slug, string $locale): array
@@ -385,6 +520,43 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
             'severity' => 'high',
             'reasons' => [
                 'index_state_not_indexed_like',
+                'runtime_publish_state_not_published',
+                'truth_state_not_published',
+                'sitemap_missing',
+                'llms_missing',
+                'llms_full_missing',
+                'surface_unverified',
+            ],
+            'evidence' => [['slug' => $slug]],
+            'sidecars' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function progressiveStaleRow(string $slug, string $locale): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'source_scope' => 'all',
+            'entity_status' => $this->layer('entity', 'pass'),
+            'baseline_status' => $this->layer('baseline', 'pass'),
+            'index_status' => $this->layer('index', 'blocked', [], ['index_state_missing']),
+            'runtime_status' => $this->layer('runtime', 'blocked', [
+                ['runtime_publish_state' => 'published_candidate'],
+                ['truth_state' => 'published_candidate'],
+                ['canonical_public_type' => 'public_canonical_job'],
+                ['candidate_pre_route_expected' => true],
+            ], ['runtime_publish_state_not_published', 'truth_state_not_published']),
+            'seo_geo_status' => $this->layer('seo_geo', 'blocked', [], ['sitemap_missing', 'llms_missing', 'llms_full_missing']),
+            'surface_status' => $this->layer('surface', 'blocked', [], ['surface_unverified']),
+            'safety_status' => $this->layer('safety', 'pass'),
+            'overall_status' => 'blocked',
+            'severity' => 'high',
+            'reasons' => [
+                'index_state_missing',
                 'runtime_publish_state_not_published',
                 'truth_state_not_published',
                 'sitemap_missing',
@@ -516,6 +688,17 @@ final class CareerPlanCanonical80RuntimeCandidatePoolCommandTest extends TestCas
     {
         $path = $this->tempPath($name);
         file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeSlugArtifact(array $slugs): string
+    {
+        $path = $this->tempPath('delta-slugs');
+        file_put_contents($path, implode(PHP_EOL, $slugs).PHP_EOL);
 
         return $path;
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T04:17:10+08:00",
+  "updated_at": "2026-05-15T12:47:49+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6163,6 +6163,63 @@
       },
       "failure_reason": null,
       "next_pr": "300-READINESS-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
+    "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-progressive-runtime-candidate-pool-selection-1",
+      "title": "fix(api): consume progressive delta slugs in runtime candidate pool",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1"
+      ],
+      "scope_type": "progressive_runtime_candidate_pool_selection_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no DB mutation",
+        "no candidate prep dry-run",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no deploy",
+        "no fap-web",
+        "no production DB query",
+        "no live crawl"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1 is present on main before this PR started."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to explicit progressive delta slug consumption in runtime candidate pool planning, command tests/docs, and train metadata."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": "CareerPlanCanonical80RuntimeCandidatePool tests passed; CareerRuntimeCandidate tests passed; CareerProgressive tests passed; CareerAuditCanonicalEligibility tests passed; route:list passed; sqlite migrate passed; Pint --test passed; git diff --check passed; bash backend/scripts/ci_verify_mbti.sh exited 0. Default php artisan migrate is blocked by local MySQL credentials."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "300-RUNTIME-CANDIDATE-POOL-RERUN-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -353,6 +353,44 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1
+    branch: codex/repair-progressive-runtime-candidate-pool-selection-1
+    title: "fix(api): consume progressive delta slugs in runtime candidate pool"
+    name: "Use explicit progressive readiness delta slugs for runtime candidate pool selection"
+    scope:
+      - Extend runtime candidate pool planning to consume explicit progressive readiness delta slug artifacts.
+      - Keep legacy 80 near-eligible selection unchanged when no progressive delta artifact is supplied.
+      - Require verified candidate_prep_apply_overlay projection, truth, and ledger evidence for explicit progressive deltas.
+      - Preserve read-only planning semantics and do not weaken final live acceptance.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonical80RuntimeCandidatePool.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run candidate prep dry-run or apply.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+    validation:
+      - php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi
+      - php artisan test --filter=CareerRuntimeCandidate --no-ansi
+      - php artisan test --filter=CareerProgressive --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- Extends `career:plan-canonical-80-runtime-candidate-pool` with explicit progressive delta inputs via `--delta-slugs` and `--readiness-plan`.
- Keeps legacy 80 near-eligible selection unchanged when no progressive delta artifact is provided.
- Requires verified `candidate_prep_apply_overlay` projection/truth/ledger evidence for explicit progressive deltas and keeps rollout apply disabled.
- Updates tests, audit docs, and PR train metadata for REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1.

## Validation
- `php artisan test --filter=CareerPlanCanonical80RuntimeCandidatePool --no-ansi`
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=CareerProgressive --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`

Default `php artisan migrate --no-ansi` is blocked locally by MySQL credentials: `SQLSTATE[HY000] [1045] Access denied for user root@localhost`. SQLite migration passes.

## Local smoke
- Ran read-only local 300 pool smoke with `/tmp/career_300_delta_slugs.txt`.
- Result: `pool_pass=true`, `selected_count=220`, `next_required_action=PROGRESSIVE_ROLLOUT_MANIFEST`.

## Non-goals
- No DB mutation.
- No candidate prep dry-run/apply.
- No rollout dry-run/apply.
- No deploy.
- No fap-web changes.

Next step after merge: rerun `300-RUNTIME-CANDIDATE-POOL-RERUN-1` with the explicit 300 delta slug artifact.