### PR TITLE
fix(api): exclude CN proxy rows from progressive readiness

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerProgressiveReadinessSelector.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveReadinessSelector.php
@@ -347,6 +347,11 @@ final class CareerProgressiveReadinessSelector
     private function hardBlockerReasons(CareerPublicResolutionPlanRow $row): array
     {
         $reasons = [];
+        $slug = strtolower(trim((string) $row->canonicalSlug));
+        if (str_starts_with($slug, 'cn-')) {
+            $reasons[] = 'cn_proxy_excluded_from_canonical_rollout';
+        }
+
         $state = strtolower(trim((string) $row->publicResolutionState));
         if (in_array($state, [
             'occupation_missing',
@@ -356,6 +361,8 @@ final class CareerProgressiveReadinessSelector
             'do_not_publish',
             'not_public',
             'excluded',
+            'cn_proxy_hold',
+            'blocked_until_cn_authority_policy',
         ], true)) {
             $reasons[] = 'source_state_'.$state;
         }
@@ -364,11 +371,19 @@ final class CareerProgressiveReadinessSelector
         if (in_array($publicType, ['non_public', 'private', 'excluded'], true)) {
             $reasons[] = 'source_public_type_'.$publicType;
         }
+        if (in_array($publicType, ['public_cn_proxy_page', 'public_cn_proxy_page_candidate'], true)) {
+            $reasons[] = 'cn_proxy_excluded_from_canonical_rollout';
+        }
 
         foreach (['occupation_missing', 'missing_occupation', 'hard_blocked', 'safety_blocked'] as $key) {
             if (($row->raw[$key] ?? false) === true) {
                 $reasons[] = $key;
             }
+        }
+
+        $recommendedResolution = strtolower(trim((string) ($row->raw['recommended_resolution'] ?? '')));
+        if (in_array($recommendedResolution, ['public_cn_proxy_page', 'public_cn_proxy_page_candidate'], true)) {
+            $reasons[] = 'cn_proxy_excluded_from_canonical_rollout';
         }
 
         foreach (['hard_blockers', 'safety_blockers'] as $key) {

--- a/backend/docs/career/audits/progressive_readiness_selection.md
+++ b/backend/docs/career/audits/progressive_readiness_selection.md
@@ -19,6 +19,14 @@ selection requires `occupation_exists=true`; source-ready rows whose canonical
 occupation is absent from production are excluded with `occupation_missing` so
 they do not block the later candidate-prep dry-run.
 
+Canonical progressive rollout readiness also excludes CN proxy rows. Slugs with
+the `cn-` prefix and rows marked as `public_cn_proxy_page` or
+`public_cn_proxy_page_candidate` are not eligible for the canonical US rollout
+delta. They are reported as
+`cn_proxy_excluded_from_canonical_rollout` and replaced by later source-ready
+non-CN rows when enough candidates exist. This keeps readiness selection aligned
+with the rollout executor, which rejects CN proxy promotion before any write.
+
 ## Readiness Selection vs Rollout Validation
 
 This step is intentionally earlier than rollout-candidate validation. It does
@@ -62,6 +70,12 @@ The command emits stable JSON using:
     "occupation_exists_count": 2469,
     "occupation_missing_excluded_count": 27
   },
+  "excluded": {
+    "excluded_by_reason": {
+      "already_public_baseline": 80,
+      "cn_proxy_excluded_from_canonical_rollout": 120
+    }
+  },
   "writes_database": false,
   "apply_allowed": false,
   "next_required_action": "PROGRESSIVE_RUNTIME_CANDIDATE_PREP"
@@ -84,6 +98,24 @@ not publish occupations, does not create missing occupations, and does not
 weaken rollout or live-acceptance validation. Missing production occupations
 remain explicit exclusions until a later source/import repair chooses to add
 them.
+
+## CN Proxy Exclusion
+
+CN proxy rows are governed by a separate CN authority policy. They must not enter
+the canonical US rollout promotion path for 300, 800, or 2786 cohorts. The
+selector therefore treats these rows as hard readiness exclusions when:
+
+- the canonical slug starts with `cn-`;
+- `canonical_public_type` / `public_resolution_type` is `public_cn_proxy_page`
+  or `public_cn_proxy_page_candidate`;
+- `recommended_resolution` is `public_cn_proxy_page` or
+  `public_cn_proxy_page_candidate`; or
+- the source state is `CN_proxy_hold` / `blocked_until_CN_authority_policy`.
+
+This exclusion is not a rollout executor relaxation. The executor and rollback
+gate must continue to reject CN proxy slugs if they appear in a manifest or
+manual override artifact. The selector simply prevents those rows from being
+chosen earlier in the progressive readiness pipeline.
 
 ## Non-Goals
 

--- a/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveReadinessSelectionTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveReadinessSelectionTest.php
@@ -92,6 +92,64 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
         $this->assertContains('insufficient_source_ready_delta_slugs', array_column($payload['blockers'], 'reason'));
     }
 
+    public function test_excludes_cn_proxy_rows_from_canonical_rollout_selection(): void
+    {
+        $baseline = $this->slugs('current', 80);
+        $cnProxy = $this->slugs('cn-1-01', 120);
+        $replacementDelta = $this->slugs('delta', 220);
+
+        $payload = $this->select($baseline, [...$baseline, ...$cnProxy, ...$replacementDelta], 80, 300);
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(220, $payload['selected_count']);
+        $this->assertSame($replacementDelta, $payload['selected_slugs']);
+        $this->assertSame(120, $payload['excluded']['excluded_by_reason']['cn_proxy_excluded_from_canonical_rollout']);
+        $this->assertSame([], array_values(array_filter(
+            $payload['selected_slugs'],
+            static fn (string $slug): bool => str_starts_with($slug, 'cn-'),
+        )));
+    }
+
+    public function test_cn_proxy_public_type_rows_are_excluded_even_without_cn_slug_prefix(): void
+    {
+        $baseline = $this->slugs('current', 80);
+        $replacementDelta = $this->slugs('delta', 220);
+        $rows = [
+            ...$this->sourceRows($baseline),
+            [
+                'canonical_slug' => 'china-proxy-001',
+                'canonical_public_type' => 'public_cn_proxy_page',
+            ],
+            [
+                'canonical_slug' => 'china-proxy-002',
+                'recommended_resolution' => 'public_cn_proxy_page_candidate',
+            ],
+            ...$this->sourceRows($replacementDelta),
+        ];
+
+        $payload = $this->selectFromRows($baseline, $rows, 80, 300);
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame($replacementDelta, $payload['selected_slugs']);
+        $this->assertSame(2, $payload['excluded']['excluded_by_reason']['cn_proxy_excluded_from_canonical_rollout']);
+    }
+
+    public function test_blocks_when_cn_proxy_exclusion_leaves_insufficient_non_cn_candidates(): void
+    {
+        $baseline = $this->slugs('current', 80);
+        $cnProxy = $this->slugs('cn-1-01', 120);
+        $replacementDelta = $this->slugs('delta', 219);
+
+        $payload = $this->select($baseline, [...$baseline, ...$cnProxy, ...$replacementDelta], 80, 300);
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(219, $payload['selected_count']);
+        $this->assertContains('insufficient_source_ready_delta_slugs', array_column($payload['blockers'], 'reason'));
+        $this->assertSame(120, $payload['excluded']['excluded_by_reason']['cn_proxy_excluded_from_canonical_rollout']);
+        $this->assertSame(219, $payload['blockers'][0]['evidence']['source_ready_delta_count']);
+        $this->assertSame(219, $payload['blockers'][0]['evidence']['selectable_candidate_count']);
+    }
+
     public function test_preserves_deterministic_source_order(): void
     {
         $baseline = $this->slugs('current', 80);
@@ -205,22 +263,65 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
     }
 
     /**
+     * @param  list<string>  $baseline
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, mixed>
+     */
+    private function selectFromRows(array $baseline, array $rows, int $currentTotal, int $targetTotal): array
+    {
+        return (new CareerProgressiveReadinessSelector)->select(
+            sourcePlan: new CareerPublicResolutionPlan('/tmp/synthetic-career-source-plan.json', null, array_map(
+                static fn (array $row, int $index): CareerPublicResolutionPlanRow => CareerPublicResolutionPlanRow::fromRaw([
+                    'row_number' => $index + 1,
+                    'status' => 'ready_for_pilot',
+                    'canonical_public_type' => 'public_canonical_job',
+                    'locales' => ['en', 'zh'],
+                    ...$row,
+                ]),
+                $rows,
+                array_keys($rows),
+            )),
+            currentCloseout: $this->closeout($currentTotal),
+            currentPublicSlugs: $baseline,
+            currentPublicTotal: $currentTotal,
+            targetPublicTotal: $targetTotal,
+            locales: ['en', 'zh'],
+        )->toArray();
+    }
+
+    /**
      * @param  list<string>  $slugs
      */
     private function sourcePlan(array $slugs): CareerPublicResolutionPlan
     {
+        return new CareerPublicResolutionPlan(
+            '/tmp/synthetic-career-source-plan.json',
+            null,
+            array_map(
+                static fn (array $row): CareerPublicResolutionPlanRow => CareerPublicResolutionPlanRow::fromRaw($row),
+                $this->sourceRows($slugs),
+            ),
+        );
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return list<array<string, mixed>>
+     */
+    private function sourceRows(array $slugs): array
+    {
         $rows = [];
         foreach ($slugs as $index => $slug) {
-            $rows[] = CareerPublicResolutionPlanRow::fromRaw([
+            $rows[] = [
                 'row_number' => $index + 1,
                 'canonical_slug' => $slug,
                 'status' => 'ready_for_pilot',
                 'canonical_public_type' => 'public_canonical_job',
                 'locales' => ['en', 'zh'],
-            ]);
+            ];
         }
 
-        return new CareerPublicResolutionPlan('/tmp/synthetic-career-source-plan.json', null, $rows);
+        return $rows;
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T12:47:49+08:00",
+  "updated_at": "2026-05-15T13:35:35+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6220,6 +6220,75 @@
       },
       "failure_reason": null,
       "next_pr": "300-RUNTIME-CANDIDATE-POOL-RERUN-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
+    "REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-progressive-readiness-cn-proxy-exclusion-1",
+      "title": "fix(api): exclude CN proxy rows from progressive readiness",
+      "name": "Exclude CN proxy rows from canonical progressive rollout readiness",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1"
+      ],
+      "scope_type": "progressive_readiness_cn_proxy_exclusion_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no DB mutation",
+        "no candidate prep dry-run",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no deploy",
+        "no fap-web",
+        "no production DB query",
+        "no live crawl",
+        "no weakening CN proxy rollout rejection"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1 is present on main as PR #1405 before this PR started."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files remain within backend Career audit selector/tests/docs and docs/codex train metadata."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": [
+            "php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi: pass (15 tests, 64 assertions)",
+            "php artisan test --filter=CareerPlanCanonicalProgressiveReadinessSelection --no-ansi: pass with non-blocking temp path warnings",
+            "php artisan test --filter=CareerProgressive --no-ansi: pass with non-blocking temp path warnings",
+            "php artisan test --filter=CareerRuntimeCandidate --no-ansi: pass (8 tests, 40 assertions)",
+            "php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi: pass with non-blocking temp path warnings",
+            "php artisan route:list --no-ansi: pass",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cn-proxy-exclusion.sqlite php artisan migrate --force --no-ansi: pass",
+            "vendor/bin/pint --test: pass",
+            "bash backend/scripts/ci_verify_mbti.sh: pass",
+            "git diff --check: pass"
+          ]
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "300-READINESS-1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T13:35:35+08:00",
+  "updated_at": "2026-05-15T13:37:12+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6230,7 +6230,7 @@
       "branch": "codex/repair-progressive-readiness-cn-proxy-exclusion-1",
       "title": "fix(api): exclude CN proxy rows from progressive readiness",
       "name": "Exclude CN proxy rows from canonical progressive rollout readiness",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1"
       ],
@@ -6256,8 +6256,8 @@
         "no live crawl",
         "no weakening CN proxy rollout rejection"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "fc3eda2ddc513b319bff0643f1be37fc221a62c7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1406",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -6285,6 +6285,10 @@
             "bash backend/scripts/ci_verify_mbti.sh: pass",
             "git diff --check: pass"
           ]
+        },
+        "github_pr": {
+          "status": "opened",
+          "evidence": "https://github.com/fermatmind/fap-api/pull/1406"
         }
       },
       "failure_reason": null,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -391,6 +391,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1
+    branch: codex/repair-progressive-readiness-cn-proxy-exclusion-1
+    title: "fix(api): exclude CN proxy rows from progressive readiness"
+    name: "Exclude CN proxy rows from canonical progressive rollout readiness"
+    scope:
+      - Exclude cn-* and CN proxy public type rows from 300, 800, and 2786 canonical rollout readiness selections.
+      - Replace excluded CN proxy rows with later source-ready non-CN rows when enough candidates exist.
+      - Preserve read-only readiness selection semantics and explicit operator exclusions.
+      - Preserve rollout executor and rollback gate CN proxy rejection.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run 300 readiness execution.
+      - Run candidate prep dry-run or apply.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Weaken CN proxy rollout rejection.
+    validation:
+      - php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi
+      - php artisan test --filter=CareerProgressive --no-ansi
+      - php artisan test --filter=CareerPlanCanonicalProgressiveReadinessSelection --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- excludes `cn-*` and CN proxy public-type rows from progressive readiness selection before canonical rollout planning
- replaces excluded CN proxy rows with later source-ready non-CN rows when enough candidates exist
- documents CN proxy exclusion semantics and registers `REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1` in the PR train metadata

## Safety / non-goals
- read-only selector/planner logic only
- no DB mutation
- no candidate prep dry-run/apply
- no rollout dry-run/apply
- no deploy
- no fap-web changes
- does not weaken rollout executor or rollback gate CN proxy rejection

## Validation
- `php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi`
- `php artisan test --filter=CareerPlanCanonicalProgressiveReadinessSelection --no-ansi` (passed with non-blocking temp path warnings)
- `php artisan test --filter=CareerProgressive --no-ansi` (passed with non-blocking temp path warnings)
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi` (passed with non-blocking temp path warnings)
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cn-proxy-exclusion.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Next step
- `300-READINESS-1` after merge and backend deployment if production needs this command behavior.