### PR TITLE
fix(api): select newest career runtime projection artifact

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
@@ -172,29 +172,10 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
      */
     private function latestMaterializedProjection(): ?array
     {
-        $root = storage_path('app/private/career_runtime_publish_projection');
-        if (! is_dir($root)) {
-            return null;
-        }
-
-        $directories = glob($root.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR);
-        if (! is_array($directories) || $directories === []) {
-            return null;
-        }
-
-        rsort($directories, SORT_STRING);
-        foreach ($directories as $directory) {
-            $path = $directory.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME;
-            if (! is_file($path)) {
-                continue;
-            }
-
-            $payload = json_decode((string) file_get_contents($path), true);
-
-            return is_array($payload) ? $payload : null;
-        }
-
-        return null;
+        return $this->latestMaterializedJsonPayload(
+            storage_path('app/private/career_runtime_publish_projection'),
+            CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME,
+        );
     }
 
     /**
@@ -202,7 +183,17 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
      */
     private function latestMaterializedFullReleaseLedger(): ?array
     {
-        $root = storage_path('app/private/career_release_ledger');
+        return $this->latestMaterializedJsonPayload(
+            storage_path('app/private/career_release_ledger'),
+            CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function latestMaterializedJsonPayload(string $root, string $filename): ?array
+    {
         if (! is_dir($root)) {
             return null;
         }
@@ -212,18 +203,39 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
             return null;
         }
 
-        rsort($directories, SORT_STRING);
+        $candidates = [];
         foreach ($directories as $directory) {
-            $path = $directory.DIRECTORY_SEPARATOR.CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME;
+            $path = $directory.DIRECTORY_SEPARATOR.$filename;
             if (! is_file($path)) {
                 continue;
             }
 
             $payload = json_decode((string) file_get_contents($path), true);
+            if (! is_array($payload)) {
+                continue;
+            }
 
-            return is_array($payload) ? $payload : null;
+            clearstatcache(true, $path);
+            $candidates[] = [
+                'path' => $path,
+                'mtime' => filemtime($path) ?: 0,
+                'payload' => $payload,
+            ];
         }
 
-        return null;
+        if ($candidates === []) {
+            return null;
+        }
+
+        usort($candidates, static function (array $left, array $right): int {
+            $mtimeComparison = $right['mtime'] <=> $left['mtime'];
+            if ($mtimeComparison !== 0) {
+                return $mtimeComparison;
+            }
+
+            return strcmp((string) $right['path'], (string) $left['path']);
+        });
+
+        return $candidates[0]['payload'];
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
@@ -13,6 +13,18 @@ final class CareerRuntimePublishProjectionLookupTest extends TestCase
 {
     private string $projectionTimestamp = '99999999T999999Z';
 
+    /**
+     * @var list<string>
+     */
+    private array $projectionDirectories = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        File::deleteDirectory(storage_path('app/private/career_runtime_publish_projection'));
+    }
+
     public function test_it_reads_materialized_projection_visibility_by_slug_and_locale(): void
     {
         $this->writeProjection($this->projectionTimestamp, [
@@ -63,9 +75,48 @@ final class CareerRuntimePublishProjectionLookupTest extends TestCase
         $this->assertFalse($lookup->familyHubLive('computer-and-information-technology'));
     }
 
+    public function test_it_uses_newest_valid_projection_artifact_instead_of_lexical_directory_order(): void
+    {
+        $this->writeProjection('career_post_rollout_runtime_projection_authority_20260515_65e4fdbd', [
+            [
+                'slug' => 'architectural-and-civil-drafters',
+                'locale' => 'en',
+                'runtime_publish_state' => 'quarantined',
+                'detail_route_enabled' => false,
+                'dataset_visible' => false,
+                'search_visible' => false,
+                'robots_indexable' => false,
+                'release_gate_pass' => false,
+            ],
+        ], 1_000);
+        $this->writeInvalidProjection('zzzz-invalid-newer-directory', 3_000);
+        $this->writeProjection('20260515T064326Z', [
+            [
+                'slug' => 'architectural-and-civil-drafters',
+                'locale' => 'en',
+                'runtime_publish_state' => 'published',
+                'detail_route_enabled' => true,
+                'dataset_visible' => true,
+                'search_visible' => true,
+                'robots_indexable' => true,
+                'release_gate_pass' => true,
+            ],
+        ], 2_000);
+
+        $lookup = app(CareerRuntimePublishProjectionLookup::class);
+
+        $this->assertTrue($lookup->detailRouteEnabled('architectural-and-civil-drafters'));
+        $this->assertTrue($lookup->datasetVisible('architectural-and-civil-drafters'));
+        $this->assertTrue($lookup->searchVisible('architectural-and-civil-drafters'));
+        $this->assertTrue($lookup->robotsIndexable('architectural-and-civil-drafters'));
+        $this->assertTrue($lookup->releaseGatePass('architectural-and-civil-drafters'));
+    }
+
     protected function tearDown(): void
     {
-        File::deleteDirectory(storage_path('app/private/career_runtime_publish_projection/'.$this->projectionTimestamp));
+        foreach ($this->projectionDirectories as $directory) {
+            File::deleteDirectory($directory);
+        }
 
         parent::tearDown();
     }
@@ -73,16 +124,37 @@ final class CareerRuntimePublishProjectionLookupTest extends TestCase
     /**
      * @param  list<array<string, mixed>>  $items
      */
-    private function writeProjection(string $timestamp, array $items): void
+    private function writeProjection(string $timestamp, array $items, ?int $mtime = null): void
     {
         $dir = storage_path('app/private/career_runtime_publish_projection/'.$timestamp);
         File::ensureDirectoryExists($dir);
+        $this->projectionDirectories[] = $dir;
+        $path = $dir.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME;
         File::put(
-            $dir.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME,
+            $path,
             (string) json_encode([
                 'projection_kind' => 'career_runtime_publish_projection',
                 'items' => $items,
             ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
         );
+
+        if ($mtime !== null) {
+            touch($path, $mtime);
+            clearstatcache(true, $path);
+        }
+    }
+
+    private function writeInvalidProjection(string $timestamp, ?int $mtime = null): void
+    {
+        $dir = storage_path('app/private/career_runtime_publish_projection/'.$timestamp);
+        File::ensureDirectoryExists($dir);
+        $this->projectionDirectories[] = $dir;
+        $path = $dir.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME;
+        File::put($path, '{invalid');
+
+        if ($mtime !== null) {
+            touch($path, $mtime);
+            clearstatcache(true, $path);
+        }
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T14:33:19+08:00",
+  "updated_at": "2026-05-15T15:16:53+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -1783,7 +1783,7 @@
       "branch": "fix/career-80-cohort-readiness-audit10",
       "title": "feat(api): add career 80 cohort readiness plan",
       "name": "Career 80-Cohort Readiness Plan",
-      "status": "in_progress",
+      "status": "draft_pr_open",
       "depends_on": [
         "AUDIT-9"
       ],
@@ -2631,7 +2631,7 @@
         "no deploy"
       ],
       "commit_sha": "8589f43480d69100ba6d7333e4032dba039bf924",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1408",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -6297,6 +6297,90 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "REPAIR-RUNTIME-PROJECTION-LOOKUP-LATEST-SELECTION-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-runtime-projection-lookup-latest-selection-1",
+      "title": "fix(api): select newest career runtime projection artifact",
+      "name": "Fix latest materialized Career runtime projection lookup selection",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1"
+      ],
+      "scope_type": "runtime_projection_lookup_latest_selection_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Publish/**",
+        "backend/tests/Unit/Services/Career/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout apply",
+        "no production DB mutation",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web change",
+        "do not weaken final live acceptance",
+        "do not treat candidate-aware planning artifacts as final published authority"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-RUNTIME-PROJECTION-LOOKUP-LATEST-SELECTION-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SCAN-27 showed 300 runtime/release authority is green and the remaining blocker is stale runtime projection lookup selection after REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to Career runtime projection lookup, its focused unit test, and authorized train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_ci_sidecar",
+          "evidence": [
+            "php artisan test --filter=CareerRuntimePublishProjectionLookup --no-ansi: pass (2 tests, 16 assertions)",
+            "php artisan test --filter=CareerJobDetail --no-ansi: pass (15 tests, 147 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-runtime-projection-lookup.sqlite php artisan migrate --force --no-ansi: pass",
+            "vendor/bin/pint --test: pass (3260 files)",
+            "git diff --check && git diff --cached --check: pass",
+            "bash backend/scripts/ci_verify_mbti.sh: external failure in Big5 pack publish/rollback compiled directory assertions, outside this Career runtime projection lookup PR scope"
+          ]
+        },
+        "github_pr": {
+          "status": "draft_open_waiting_for_checks",
+          "evidence": "Draft PR opened at https://github.com/fermatmind/fap-api/pull/1408; hygiene checks passed and verify-mbti-v2 / verify-mbti-legacy were still in progress at last poll."
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "BACKEND-DEPLOY-THEN-300-TOTAL-LIVE-ACCEPTANCE-RERUN",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-20260515",
+          "title": "Local MBTI CI Big5 pack publish/rollback compiled directory assertions fail in temporary worktree",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksPublishBig5Test at compiled directory assertion.",
+            "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksRollbackBig5Test at compiled directory assertion.",
+            "Current PR changed only Career runtime projection lookup logic/tests and train metadata; no Big5 content pack publish/rollback code was modified."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-LOCAL-CI",
+          "may_continue_train": true
+        }
+      ]
     },
     "PR-CMS-FIX-MASTER": {
       "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -430,6 +430,41 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-RUNTIME-PROJECTION-LOOKUP-LATEST-SELECTION-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1
+    branch: fix/career-runtime-projection-lookup-latest-selection-1
+    title: "fix(api): select newest career runtime projection artifact"
+    name: "Fix latest materialized Career runtime projection lookup selection"
+    scope:
+      - Select the newest valid materialized Career runtime projection artifact by artifact freshness instead of raw directory-name lexical order.
+      - Skip invalid or incomplete materialized projection directories.
+      - Preserve strict runtime visibility, release gate, and final live acceptance semantics.
+      - Keep frontend behavior backend-authoritative through the existing runtime projection lookup.
+    allowed_paths:
+      - backend/app/Domain/Career/Publish/**
+      - backend/tests/Unit/Services/Career/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout apply.
+      - Run production DB mutation.
+      - Run rollback or quarantine.
+      - Run deploy.
+      - Touch fap-web.
+      - Weaken final live acceptance.
+      - Treat candidate-aware planning artifacts as final published authority.
+    validation:
+      - php artisan test --filter=CareerRuntimePublishProjectionLookup --no-ansi
+      - php artisan test --filter=CareerJobDetail --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- Fixes Career runtime projection lookup latest-artifact selection so it chooses the newest valid materialized JSON artifact by file freshness instead of raw directory-name lexical ordering.
- Skips invalid/incomplete materialized projection directories.
- Preserves strict runtime visibility, release gate, and final live acceptance semantics.

## Why
SCAN-27 showed production had the 300 post-apply projection materialized at `20260515T064326Z`, but lookup selected an older `career_post_rollout_runtime_projection_authority_*` directory because that name sorts later lexically. That kept 218 newly promoted 300 slugs invisible to the public detail API/live surface.

## Non-goals
- No DB mutation.
- No rollout dry-run/apply.
- No deploy.
- No rollback/quarantine.
- No fap-web changes.

## Validation
Passed:
- `php artisan test --filter=CareerRuntimePublishProjectionLookup --no-ansi`
- `php artisan test --filter=CareerJobDetail --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-runtime-projection-lookup.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test --no-ansi`
- `git diff --check && git diff --cached --check`

External local CI sidecar:
- `bash backend/scripts/ci_verify_mbti.sh` failed in `Tests\Feature\Content\PacksPublishBig5Test` and `Tests\Feature\Content\PacksRollbackBig5Test` on compiled directory assertions.
- This PR does not change Big5 pack publish/rollback code or content pack authority files.
- This draft PR should not be merged until required GitHub checks are green or that external failure is resolved/classified by repo maintainers.

## Next Step
After merge and guarded backend deploy, rerun `300-TOTAL-LIVE-ACCEPTANCE-RUN-1`.
