### PR TITLE
fix(api): normalize candidate-aware rollout projection artifacts

### DIFF
--- a/backend/app/Console/Commands/CareerExecuteCanonicalRolloutBatch.php
+++ b/backend/app/Console/Commands/CareerExecuteCanonicalRolloutBatch.php
@@ -127,6 +127,10 @@ final class CareerExecuteCanonicalRolloutBatch extends Command
             throw new \RuntimeException('projection artifact is not valid JSON: '.$path);
         }
 
+        if (is_array($payload['items'] ?? null)) {
+            return $payload;
+        }
+
         return is_array($payload['projection'] ?? null) ? $payload['projection'] : $payload;
     }
 

--- a/backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php
+++ b/backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php
@@ -78,6 +78,56 @@ final class CareerExecuteCanonicalRolloutBatchTest extends TestCase
         $this->assertSame(['actuaries'], $payload['promoted_slugs'] ?? []);
     }
 
+    public function test_command_prefers_candidate_aware_top_level_items_over_projection_metadata(): void
+    {
+        $candidateProjection = $this->candidateProjection(['actuaries']);
+        $staleProjectionMetadata = $this->publishedProjection(['actuaries']);
+        $candidateAwareProjection = [
+            'status' => 'pass',
+            'projection_kind' => 'career_runtime_publish_projection_candidate_aware',
+            'source_authority' => 'candidate_prep_apply_overlay',
+            'candidate_aware_overlay' => [
+                'source' => 'candidate_prep_apply_overlay',
+                'runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+                'slug_count' => 1,
+                'locale_count' => 2,
+                'expected_locale_rows' => 2,
+                'canonical_ledger_authority_claimed' => false,
+            ],
+            'items' => $candidateProjection['items'],
+            'projection' => [
+                'projection_kind' => 'career_runtime_publish_projection',
+                'items' => $staleProjectionMetadata['items'],
+            ],
+        ];
+
+        $this->writeRawProjection($candidateAwareProjection);
+        $writtenProjection = json_decode((string) file_get_contents($this->tmpProjectionPath), true);
+        $this->assertSame(
+            CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            $writtenProjection['items'][0]['runtime_publish_state'] ?? null,
+        );
+
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'actuaries',
+            '--dry-run' => true,
+            '--projection' => $this->tmpProjectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $payload = json_decode(Artisan::output(), true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('planned', $payload['status'] ?? null);
+        $this->assertSame('pass', $payload['plan_validation']['status'] ?? null);
+        $this->assertSame(2, $payload['promoted_locale_rows'] ?? null);
+        $this->assertFalse($payload['writes_database'] ?? true);
+    }
+
     public function test_command_rejects_blocked_state(): void
     {
         $this->writeProjection($this->blockedProjection(['actuaries']));
@@ -300,6 +350,15 @@ final class CareerExecuteCanonicalRolloutBatchTest extends TestCase
      * @param  list<string>  $slugs
      * @return array<string, mixed>
      */
+    private function publishedProjection(array $slugs): array
+    {
+        return $this->buildProjection($slugs, CareerRuntimePublishProjectionService::STATE_PUBLISHED);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
     private function buildProjection(array $slugs, string $state): array
     {
         $items = [];
@@ -340,5 +399,13 @@ final class CareerExecuteCanonicalRolloutBatchTest extends TestCase
     {
         $payload = ['projection' => $projection];
         File::put($this->tmpProjectionPath, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     */
+    private function writeRawProjection(array $projection): void
+    {
+        File::put($this->tmpProjectionPath, json_encode($projection, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6387,7 +6387,7 @@
       "branch": "codex/repair-rollout-candidate-aware-projection-artifact-shape-1",
       "title": "fix(api): normalize candidate-aware rollout projection artifacts",
       "name": "Fix rollout candidate-aware projection artifact normalization",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "REPAIR-RUNTIME-PROJECTION-LOOKUP-LATEST-SELECTION-1"
       ],
@@ -6413,7 +6413,7 @@
         "do not treat candidate-aware planning artifacts as final published authority"
       ],
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1410",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -6441,6 +6441,10 @@
             "git diff --check: pass",
             "bash backend/scripts/ci_verify_mbti.sh: pass"
           ]
+        },
+        "github_pr": {
+          "status": "opened",
+          "evidence": "https://github.com/fermatmind/fap-api/pull/1410"
         }
       },
       "failure_reason": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6382,6 +6382,74 @@
         }
       ]
     },
+    "REPAIR-ROLLOUT-CANDIDATE-AWARE-PROJECTION-ARTIFACT-SHAPE-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-rollout-candidate-aware-projection-artifact-shape-1",
+      "title": "fix(api): normalize candidate-aware rollout projection artifacts",
+      "name": "Fix rollout candidate-aware projection artifact normalization",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-RUNTIME-PROJECTION-LOOKUP-LATEST-SELECTION-1"
+      ],
+      "scope_type": "rollout_command_candidate_aware_artifact_normalization_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerExecuteCanonicalRolloutBatch.php",
+        "backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout dry-run",
+        "no rollout apply",
+        "no candidate prep apply",
+        "no production DB mutation",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web",
+        "do not weaken final live acceptance",
+        "do not treat candidate-aware planning artifacts as final published authority"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-ROLLOUT-CANDIDATE-AWARE-PROJECTION-ARTIFACT-SHAPE-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SCAN-35 found 800 rollout dry-run is blocked because the rollout command consumes projection metadata instead of candidate-aware top-level items after REPAIR-RUNTIME-PROJECTION-LOOKUP-LATEST-SELECTION-1."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Scope is limited to rollout command artifact normalization, focused command test, and authorized train metadata."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": [
+            "composer dump-autoload refreshed stale local autoload that pointed to a previous /private/tmp worktree; no tracked vendor files changed.",
+            "php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi: pass (12 tests, 45 assertions)",
+            "php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi: pass (14 tests, 33 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-rollout-artifact-shape.sqlite php artisan migrate --force --no-ansi: pass",
+            "ruby YAML.load_file docs/codex/pr-train.yaml: pass",
+            "python3 -m json.tool docs/codex/pr-train-state.json: pass",
+            "vendor/bin/pint --test: pass",
+            "git diff --check: pass",
+            "bash backend/scripts/ci_verify_mbti.sh: pass"
+          ]
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "800-ROLLOUT-DRY-RUN-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
     "PR-CMS-FIX-MASTER": {
       "repo": "fap-api",
       "branch": "codex/pr-cms-fix-master-semantic-content-gate",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -465,6 +465,44 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-ROLLOUT-CANDIDATE-AWARE-PROJECTION-ARTIFACT-SHAPE-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-RUNTIME-PROJECTION-LOOKUP-LATEST-SELECTION-1
+    branch: codex/repair-rollout-candidate-aware-projection-artifact-shape-1
+    title: "fix(api): normalize candidate-aware rollout projection artifacts"
+    name: "Fix rollout candidate-aware projection artifact normalization"
+    scope:
+      - Make canonical rollout dry-run consume top-level candidate-aware projection items when a projection artifact also contains projection metadata.
+      - Preserve legacy projection-wrapped artifact support for existing rollout dry-run flows.
+      - Prevent metadata or stale nested projection rows from being treated as the candidate row authority.
+      - Preserve strict rollout gates and final live acceptance semantics.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerExecuteCanonicalRolloutBatch.php
+      - backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run candidate preparation apply.
+      - Run production DB mutation.
+      - Run rollback or quarantine.
+      - Run deploy.
+      - Touch fap-web.
+      - Weaken final live acceptance.
+      - Treat candidate-aware planning artifacts as final published authority.
+    validation:
+      - php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi
+      - php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- normalizes `career:execute-canonical-rollout-batch --projection` artifact loading so candidate-aware artifacts with top-level `items` are consumed as the row authority
- preserves legacy projection-wrapped artifact support when only `projection.items` exists
- adds a regression test where top-level candidate rows conflict with stale nested projection metadata, proving rollout dry-run uses the candidate-aware rows
- registers `REPAIR-ROLLOUT-CANDIDATE-AWARE-PROJECTION-ARTIFACT-SHAPE-1` in train metadata/state

## Non-goals
- no rollout dry-run run by this PR
- no rollout apply
- no candidate prep apply
- no DB mutation
- no deploy
- no rollback/quarantine
- no fap-web changes
- no weakening of final live acceptance

## Validation
- `composer dump-autoload` to refresh stale local autoload pointing at a previous `/private/tmp` worktree; no tracked vendor files changed
- `php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi`
- `php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-rollout-artifact-shape.sqlite php artisan migrate --force --no-ansi`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`
- `python3 -m json.tool docs/codex/pr-train-state.json`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Next step
- rerun `800-ROLLOUT-DRY-RUN-1`; if only `software-developers` remains blocked, run the scoped readiness exclusion repair.
