### PR TITLE
fix(attempts): handle result readiness before email bind gate

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -710,15 +710,18 @@ class AttemptReadController extends Controller
         $orgId = $this->currentOrgContext()->orgId();
         $attempt = $this->resolveAttemptForAccessRead($request, $orgId, $id);
         $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
-        $this->enforceEmailBindingForRead($request, $orgId, $attempt, $scaleCode);
-        $emailTokenActor = $this->resultEmailReadAccess()->tokenActorForRequest($request, $orgId, (string) $attempt->id);
-        $readUserId = $emailTokenActor['user_id'] ?? $this->resolveUserId($request);
-        $readAnonId = $emailTokenActor['anon_id'] ?? $this->resolveAnonId($request);
         $submissionPayload = $this->latestReadableSubmission($request, (string) $attempt->id);
         $resultExists = Result::query()
             ->where('org_id', $orgId)
             ->where('attempt_id', (string) $attempt->id)
             ->exists();
+        if ($resultExists) {
+            $this->enforceEmailBindingForRead($request, $orgId, $attempt, $scaleCode);
+        }
+
+        $emailTokenActor = $this->resultEmailReadAccess()->tokenActorForRequest($request, $orgId, (string) $attempt->id);
+        $readUserId = $emailTokenActor['user_id'] ?? $this->resolveUserId($request);
+        $readAnonId = $emailTokenActor['anon_id'] ?? $this->resolveAnonId($request);
         $repairFailed = false;
         $repairFailureCode = null;
         if ($resultExists && strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI') {

--- a/backend/app/Services/Attempts/AttemptEmailBindingService.php
+++ b/backend/app/Services/Attempts/AttemptEmailBindingService.php
@@ -52,10 +52,6 @@ final class AttemptEmailBindingService
             ->where('attempt_id', $attemptId)
             ->first();
 
-        if (! $result instanceof Result) {
-            throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
-        }
-
         $scaleCode = $this->resolveScaleCode($attempt, $result);
         if (in_array($scaleCode, self::EXCLUDED_SENSITIVE_SCALES, true)) {
             throw new ApiProblemException(422, 'EMAIL_BIND_UNSUPPORTED_SCALE', 'email result binding is not available for this scale.');
@@ -119,16 +115,17 @@ final class AttemptEmailBindingService
             'attempt_id' => $attemptId,
             'status' => AttemptEmailBinding::STATUS_ACTIVE,
             'binding_id' => (string) $binding->getKey(),
+            'result_ready' => $result instanceof Result,
             'result_url' => $this->localizedResultUrl($attemptId, $context['locale'] ?? null),
         ];
     }
 
-    private function resolveScaleCode(Attempt $attempt, Result $result): string
+    private function resolveScaleCode(Attempt $attempt, ?Result $result): string
     {
         $projected = $this->scaleCodeProjector->project(
-            (string) (($result->scale_code ?? null) ?: ($attempt->scale_code ?? '')),
-            (string) (($result->scale_code_v2 ?? null) ?: ($attempt->scale_code_v2 ?? '')),
-            ($result->scale_uid ?? null) !== null
+            (string) (($result?->scale_code ?? null) ?: ($attempt->scale_code ?? '')),
+            (string) (($result?->scale_code_v2 ?? null) ?: ($attempt->scale_code_v2 ?? '')),
+            ($result?->scale_uid ?? null) !== null
                 ? (string) $result->scale_uid
                 : (($attempt->scale_uid ?? null) !== null ? (string) $attempt->scale_uid : null)
         );

--- a/backend/docs/runbooks/email-result-readiness.md
+++ b/backend/docs/runbooks/email-result-readiness.md
@@ -1,0 +1,22 @@
+# Email Result Readiness Gate
+
+Public result email binding is gated by attempt ownership and result readiness.
+
+## Runtime order
+
+For public result scales such as MBTI, Big Five, Enneagram, and RIASEC:
+
+1. `report-access` resolves the attempt and caller ownership.
+2. `report-access` checks result/submission readiness before requiring email binding.
+3. If async submit is still pending/running, `report-access` returns the existing generating/pending report-access contract instead of `EMAIL_BIND_REQUIRED`.
+4. `EMAIL_BIND_REQUIRED` is returned only after the result is ready enough for public result read.
+
+## Email bind
+
+`email-bind` validates attempt ownership before binding. For supported public scales, an owned attempt can be email-bound before the result row exists. The binding is stored in `attempt_email_bindings`, so the user does not need to resubmit email after async result generation finishes.
+
+Sensitive/private scales remain excluded from public email binding.
+
+## Out of scope
+
+`lookup-by-email` remains a separate email access product surface and is not implemented by this readiness gate. This gate does not change scoring, recommendations, commerce, entitlement, SEO, or frontend behavior.

--- a/backend/tests/Feature/AttemptEmailBindingTest.php
+++ b/backend/tests/Feature/AttemptEmailBindingTest.php
@@ -68,6 +68,66 @@ final class AttemptEmailBindingTest extends TestCase
         $this->assertDatabaseCount('attempt_email_bindings', 0);
     }
 
+    public function test_owned_public_attempt_can_prebind_email_before_result_exists(): void
+    {
+        $anonId = 'anon_email_prebind_owner';
+        $attemptId = $this->seedAttemptWithoutResult($anonId, 'RIASEC');
+        $token = $this->seedFmToken($anonId);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/email-bind", [
+            'email' => 'prebind@example.test',
+            'locale' => 'zh-CN',
+            'surface' => 'result_gate',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('status', 'active');
+        $response->assertJsonPath('result_ready', false);
+        $response->assertJsonPath('result_url', "/zh/result/{$attemptId}");
+
+        $this->assertDatabaseHas('attempt_email_bindings', [
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'bound_anon_id' => $anonId,
+            'status' => 'active',
+            'source' => 'result_gate',
+        ]);
+    }
+
+    public function test_prebound_email_allows_riasec_report_access_after_result_exists(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $anonId = 'anon_email_prebind_riasec_ready';
+        $attemptId = $this->seedAttemptWithoutResult($anonId, 'RIASEC');
+        $token = $this->seedFmToken($anonId);
+
+        $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/email-bind", [
+            'email' => 'riasec-ready@example.test',
+            'locale' => 'zh-CN',
+            'surface' => 'result_gate',
+        ])->assertOk();
+
+        $this->seedResultForAttempt($attemptId, 'RIASEC', '');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'ready');
+        $response->assertJsonPath('report_state', 'ready');
+    }
+
     public function test_sensitive_clinical_attempt_cannot_bind_email(): void
     {
         $anonId = 'anon_email_bind_clinical';
@@ -108,6 +168,19 @@ final class AttemptEmailBindingTest extends TestCase
 
     private function seedAttemptWithResult(string $anonId, string $scaleCode): string
     {
+        $attemptId = $this->seedAttemptWithoutResult($anonId, $scaleCode);
+
+        $this->seedResultForAttempt(
+            $attemptId,
+            $scaleCode,
+            in_array($scaleCode, ['CLINICAL_COMBO_68', 'SDS_20'], true) ? '' : 'INTJ-A'
+        );
+
+        return $attemptId;
+    }
+
+    private function seedAttemptWithoutResult(string $anonId, string $scaleCode): string
+    {
         $attemptId = (string) Str::uuid();
 
         Attempt::create([
@@ -132,23 +205,26 @@ final class AttemptEmailBindingTest extends TestCase
             'calculation_snapshot_json' => ['seed' => true],
         ]);
 
+        return $attemptId;
+    }
+
+    private function seedResultForAttempt(string $attemptId, string $scaleCode, string $typeCode = 'INTJ-A'): void
+    {
         Result::create([
             'id' => (string) Str::uuid(),
             'attempt_id' => $attemptId,
             'org_id' => 0,
             'scale_code' => $scaleCode,
             'scale_version' => 'v0.3',
-            'type_code' => in_array($scaleCode, ['CLINICAL_COMBO_68', 'SDS_20'], true) ? '' : 'INTJ-A',
+            'type_code' => $typeCode,
             'scores_json' => ['seed' => 1],
             'profile_version' => 'test',
             'is_valid' => true,
             'computed_at' => now(),
             'result_json' => [
-                'type_code' => in_array($scaleCode, ['CLINICAL_COMBO_68', 'SDS_20'], true) ? '' : 'INTJ-A',
+                'type_code' => $typeCode,
             ],
         ]);
-
-        return $attemptId;
     }
 
     private function seedFmToken(string $anonId): string

--- a/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
@@ -332,6 +332,31 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
         $response->assertJsonPath('actions.wait_href', "/result/{$attemptId}");
     }
 
+    public function test_report_access_returns_result_readiness_before_email_gate_for_pending_riasec_submission(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_access_pending_riasec';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId, 'RIASEC');
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'pending');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'locked');
+        $response->assertJsonPath('report_state', 'pending');
+        $response->assertJsonPath('reason_code', 'submission_pending');
+        $response->assertJsonPath('payload.submission.id', $submissionId);
+        $response->assertJsonMissingPath('error_code');
+    }
+
     public function test_report_access_prefers_pending_submission_over_existing_ready_projection(): void
     {
         $attemptId = (string) Str::uuid();


### PR DESCRIPTION
## What changed
- Moves `report-access` email binding enforcement behind result readiness, so pending async submissions return the existing pending/generating access contract instead of `EMAIL_BIND_REQUIRED`.
- Allows owned bindable public-scale attempts, including RIASEC, to pre-bind email before the result row exists using the existing `attempt_email_bindings` storage.
- Adds regression coverage for RIASEC pending result readiness before email gate, pre-bind before result creation, pre-bound read after result creation, ownership protection, MBTI normal path, sensitive-scale exclusion, and lookup-by-email staying intentionally verification-required.
- Documents the runtime ordering in `backend/docs/runbooks/email-result-readiness.md`.

## Why
Async submit can acknowledge with `202 generating` before the `results` row exists. The previous ordering could ask for email before result readiness was known, then `email-bind` could hard 404 with `RESULT_NOT_FOUND`. This PR makes the backend stable for the result-readiness/email-bind ordering without changing frontend, scoring, recommendation, commerce, entitlement, SEO, or lookup-by-email behavior.

## Validation commands
- `php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php && php -l backend/app/Services/Attempts/AttemptEmailBindingService.php`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && php artisan migrate --pretend --no-ansi` *(blocked locally by MySQL root access: SQLSTATE[HY000] [1045]; no migrations are included in this PR)*
- `cd backend && php artisan test --filter=AttemptEmailBinding`
- `cd backend && php artisan test --filter=AttemptSubmissionFirstReadContractTest`
- `cd backend && php artisan test --filter=ResultEmailGatedReadTest`
- `cd backend && php artisan test --filter=ResultEmailLookupTest`
- `cd backend && php artisan test --filter=Riasec`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `git diff --check`
- `git diff --cached --check`

## Sidecar observed during broad local scan
- `cd backend && php artisan test --filter=Result` has unrelated existing MBTI cultural calibration expectation failures in `MbtiResultPersonalizationServiceTest` and `MbtiResultTelemetryContractTest` (`governance.v1` vs `runtime.locale_policy.v1`). These files and behavior are outside this PR scope and were not modified.

## Intentionally deferred
- Frontend RIASEC guest-token parity.
- CTA UTM / attempt attribution.
- Standard RIASEC funnel event instrumentation.
- MBTI commercial funnel live acceptance.
- `lookup-by-email` product listing implementation.
