### PR TITLE
PR-GRAPH-01｜Article Multi-Test Graph Edges

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Article;
 use App\Models\ArticleCategory;
 use App\Models\ArticleTag;
+use App\Models\ArticleTestEdge;
 use App\Models\ArticleTranslationRevision;
 use App\Services\Cms\ArticlePublishService;
 use App\Services\Cms\ArticleSeoService;
@@ -54,10 +55,32 @@ class ArticleController extends Controller
             $query->where('locale', $validated['locale']);
         }
         if ($validated['related_test_slug'] !== null) {
-            $query->where('related_test_slug', $validated['related_test_slug']);
+            $relatedTestSlug = $validated['related_test_slug'];
+            $query->where(static function ($relatedQuery) use ($relatedTestSlug, $validated): void {
+                $relatedQuery
+                    ->where('related_test_slug', $relatedTestSlug)
+                    ->orWhereHas('testEdges', static function ($edgeQuery) use ($relatedTestSlug, $validated): void {
+                        $edgeQuery
+                            ->where('test_slug', $relatedTestSlug)
+                            ->where('visibility', ArticleTestEdge::VISIBILITY_PUBLIC);
+
+                        if ($validated['locale'] !== null) {
+                            $edgeQuery->where('locale', $validated['locale']);
+                        }
+                    });
+            });
         }
         if ($validated['voice'] !== null) {
             $query->where('voice', $validated['voice']);
+        }
+
+        if ($validated['related_test_slug'] !== null) {
+            $query
+                ->orderByRaw('CASE WHEN related_test_slug = ? THEN 0 ELSE 1 END', [$validated['related_test_slug']])
+                ->orderByRaw(
+                    '(select min(sort_order) from article_test_edges where article_test_edges.article_id = articles.id and article_test_edges.test_slug = ? and article_test_edges.visibility = ?) asc',
+                    [$validated['related_test_slug'], ArticleTestEdge::VISIBILITY_PUBLIC]
+                );
         }
 
         $paginator = $query
@@ -769,6 +792,10 @@ class ArticleController extends Controller
             'tags' => static fn ($query) => $query->withoutGlobalScopes(),
             'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
             'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+            'testEdges' => static fn ($query) => $query->withoutGlobalScopes()
+                ->where('visibility', ArticleTestEdge::VISIBILITY_PUBLIC)
+                ->orderBy('sort_order')
+                ->orderBy('id'),
         ];
     }
 
@@ -835,6 +862,8 @@ class ArticleController extends Controller
             'cover_image_height' => $article->cover_image_height !== null ? (int) $article->cover_image_height : null,
             'cover_image_variants' => PublicMediaUrlGuard::sanitizeArrayFields($article->cover_image_variants, ['url']),
             'related_test_slug' => $article->related_test_slug,
+            'related_test_slugs' => $this->publicRelatedTestSlugs($article),
+            'test_edges' => $this->publicTestEdges($article),
             'voice' => $article->voice,
             'voice_order' => $article->voice_order !== null ? (int) $article->voice_order : null,
             'status' => (string) $article->status,
@@ -903,6 +932,8 @@ class ArticleController extends Controller
             'cover_image_height' => $article->cover_image_height !== null ? (int) $article->cover_image_height : null,
             'cover_image_variants' => PublicMediaUrlGuard::sanitizeArrayFields($article->cover_image_variants, ['url']),
             'related_test_slug' => $article->related_test_slug,
+            'related_test_slugs' => $this->publicRelatedTestSlugs($article),
+            'test_edges' => $this->publicTestEdges($article),
             'voice' => $article->voice,
             'voice_order' => $article->voice_order !== null ? (int) $article->voice_order : null,
             'status' => (string) $article->status,
@@ -943,6 +974,55 @@ class ArticleController extends Controller
 
         return $article->tags
             ->filter(static fn (ArticleTag $tag): bool => (int) $tag->org_id === (int) $article->org_id)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function publicRelatedTestSlugs(Article $article): array
+    {
+        $slugs = [];
+        if (filled($article->related_test_slug)) {
+            $slugs[] = (string) $article->related_test_slug;
+        }
+
+        foreach ($this->publicTestEdges($article) as $edge) {
+            $slug = (string) ($edge['test_slug'] ?? '');
+            if ($slug !== '') {
+                $slugs[] = $slug;
+            }
+        }
+
+        return array_values(array_unique($slugs));
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function publicTestEdges(Article $article): array
+    {
+        if (! $article->relationLoaded('testEdges')) {
+            return [];
+        }
+
+        return $article->testEdges
+            ->filter(static fn (ArticleTestEdge $edge): bool => (int) $edge->org_id === (int) $article->org_id
+                && (string) $edge->locale === (string) $article->locale
+                && (string) $edge->visibility === ArticleTestEdge::VISIBILITY_PUBLIC)
+            ->sortBy([
+                ['sort_order', 'asc'],
+                ['id', 'asc'],
+            ])
+            ->map(static fn (ArticleTestEdge $edge): array => [
+                'test_slug' => (string) $edge->test_slug,
+                'role' => (string) $edge->role,
+                'locale' => (string) $edge->locale,
+                'sort_order' => (int) $edge->sort_order,
+                'safety_level' => (string) $edge->safety_level,
+                'visibility' => (string) $edge->visibility,
+            ])
             ->values()
             ->all();
     }

--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -232,6 +232,11 @@ class Article extends Model
         return $this->hasOne(ArticleSeoMeta::class, 'article_id', 'id')->withoutGlobalScopes();
     }
 
+    public function testEdges(): HasMany
+    {
+        return $this->hasMany(ArticleTestEdge::class, 'article_id', 'id')->withoutGlobalScopes();
+    }
+
     public static function findBySlug(string $slug, string $locale = 'en'): ?self
     {
         return static::query()

--- a/backend/app/Models/ArticleTestEdge.php
+++ b/backend/app/Models/ArticleTestEdge.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ArticleTestEdge extends Model
+{
+    use HasOrgScope;
+
+    public const ROLE_PRIMARY = 'primary';
+
+    public const ROLE_SECONDARY = 'secondary';
+
+    public const ROLE_CONTEXTUAL = 'contextual';
+
+    public const SAFETY_NORMAL = 'normal';
+
+    public const SAFETY_SENSITIVE = 'sensitive';
+
+    public const VISIBILITY_PUBLIC = 'public';
+
+    public const VISIBILITY_REVIEW = 'review';
+
+    public const VISIBILITY_DISABLED = 'disabled';
+
+    protected $table = 'article_test_edges';
+
+    protected $fillable = [
+        'org_id',
+        'article_id',
+        'locale',
+        'test_slug',
+        'role',
+        'sort_order',
+        'safety_level',
+        'visibility',
+        'source',
+        'metadata_json',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'article_id' => 'integer',
+        'sort_order' => 'integer',
+        'metadata_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function article(): BelongsTo
+    {
+        return $this->belongsTo(Article::class, 'article_id', 'id')->withoutGlobalScopes();
+    }
+
+    public function scopePublicVisible(Builder $query): Builder
+    {
+        return $query->where('visibility', self::VISIBILITY_PUBLIC);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function roles(): array
+    {
+        return [
+            self::ROLE_PRIMARY,
+            self::ROLE_SECONDARY,
+            self::ROLE_CONTEXTUAL,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function safetyLevels(): array
+    {
+        return [
+            self::SAFETY_NORMAL,
+            self::SAFETY_SENSITIVE,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function visibilities(): array
+    {
+        return [
+            self::VISIBILITY_PUBLIC,
+            self::VISIBILITY_REVIEW,
+            self::VISIBILITY_DISABLED,
+        ];
+    }
+
+    public static function safetyLevelForTestSlug(string $testSlug): string
+    {
+        $normalized = strtolower(trim($testSlug));
+
+        return str_contains($normalized, 'depression')
+            || str_contains($normalized, 'anxiety')
+            || str_contains($normalized, 'clinical')
+                ? self::SAFETY_SENSITIVE
+                : self::SAFETY_NORMAL;
+    }
+}

--- a/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
+++ b/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
@@ -9,6 +9,7 @@ use App\Models\ArticleCategory;
 use App\Models\ArticleEditorialPackageImport;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTag;
+use App\Models\ArticleTestEdge;
 use App\Models\ArticleTranslationRevision;
 use App\Services\Cms\ArticleTranslationRevisionWorkspace;
 use App\Services\Cms\EditorialPackage\Config\EvergreenAnchors;
@@ -202,6 +203,7 @@ final class EditorialPackageDraftImporter
             $category = $this->resolveCategory((string) $package['category']);
             $tags = $this->resolveTags($package['tags']);
             $article = $this->existingArticle($package);
+            $primaryTestSlug = $this->primaryTestSlug($package);
 
             if ($article instanceof Article && $this->isPublishedOrPublic($article)) {
                 throw new RuntimeException('Existing published/public articles cannot be mutated by editorial package draft import.');
@@ -225,6 +227,7 @@ final class EditorialPackageDraftImporter
                     'cover_image_width' => null,
                     'cover_image_height' => null,
                     'cover_image_variants' => $this->editorialMetadata($package, $plan),
+                    'related_test_slug' => $primaryTestSlug,
                     'status' => 'draft',
                     'is_public' => false,
                     'is_indexable' => (bool) $package['indexability'],
@@ -246,6 +249,7 @@ final class EditorialPackageDraftImporter
                     'cover_image_url' => (string) $package['cover_image'],
                     'cover_image_alt' => (string) $package['cover_image_alt'],
                     'cover_image_variants' => $this->editorialMetadata($package, $plan),
+                    'related_test_slug' => $primaryTestSlug,
                     'status' => 'draft',
                     'is_public' => false,
                     'is_indexable' => (bool) $package['indexability'],
@@ -256,6 +260,7 @@ final class EditorialPackageDraftImporter
             }
 
             $article->tags()->sync($this->tagSyncPayload($tags));
+            $this->syncArticleTestEdges($article, $package);
 
             $revisionStatus = $this->workingRevisionStatus((string) $package['intended_status'], $plan['warnings'] ?? []);
             $revision = $this->revisionWorkspace->saveWorkingRevision($article, [
@@ -875,6 +880,151 @@ final class EditorialPackageDraftImporter
         }
 
         return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function primaryTestSlug(array $package): ?string
+    {
+        $edges = $this->articleTestEdgesFromPackage($package);
+        foreach ($edges as $edge) {
+            if (($edge['role'] ?? '') === ArticleTestEdge::ROLE_PRIMARY) {
+                return (string) $edge['test_slug'];
+            }
+        }
+
+        return isset($edges[0]['test_slug']) ? (string) $edges[0]['test_slug'] : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function syncArticleTestEdges(Article $article, array $package): void
+    {
+        $edges = $this->articleTestEdgesFromPackage($package);
+        ArticleTestEdge::query()
+            ->withoutGlobalScopes()
+            ->where('article_id', (int) $article->id)
+            ->delete();
+
+        foreach ($edges as $edge) {
+            ArticleTestEdge::query()->withoutGlobalScopes()->create([
+                'org_id' => (int) $article->org_id,
+                'article_id' => (int) $article->id,
+                'locale' => (string) $article->locale,
+                'test_slug' => (string) $edge['test_slug'],
+                'role' => (string) $edge['role'],
+                'sort_order' => (int) $edge['sort_order'],
+                'safety_level' => (string) $edge['safety_level'],
+                'visibility' => (string) $edge['visibility'],
+                'source' => (string) $edge['source'],
+                'metadata_json' => $edge['metadata_json'],
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return list<array<string,mixed>>
+     */
+    private function articleTestEdgesFromPackage(array $package): array
+    {
+        $candidates = [];
+        foreach ($this->stringList($package['target_tests'] ?? []) as $index => $testSlug) {
+            $candidates[] = [
+                'test_slug' => $testSlug,
+                'role' => $index === 0 ? ArticleTestEdge::ROLE_PRIMARY : ArticleTestEdge::ROLE_SECONDARY,
+                'sort_order' => ($index + 1) * 10,
+                'source' => 'target_tests',
+            ];
+        }
+
+        $graphEdges = is_array($package['graph_edges'] ?? null) ? $package['graph_edges'] : [];
+        foreach (['from_article_to_test', 'article_to_test'] as $field) {
+            foreach ($this->graphTestEdgeItems($graphEdges[$field] ?? []) as $item) {
+                $candidates[] = $item + ['source' => 'graph_edges.'.$field];
+            }
+        }
+
+        $edges = [];
+        foreach ($candidates as $candidate) {
+            $testSlug = Str::slug(trim((string) ($candidate['test_slug'] ?? '')));
+            if ($testSlug === '' || isset($edges[$testSlug])) {
+                continue;
+            }
+
+            $role = (string) ($candidate['role'] ?? ArticleTestEdge::ROLE_CONTEXTUAL);
+            if (! in_array($role, ArticleTestEdge::roles(), true)) {
+                $role = ArticleTestEdge::ROLE_CONTEXTUAL;
+            }
+
+            $visibility = (string) ($candidate['visibility'] ?? ArticleTestEdge::VISIBILITY_PUBLIC);
+            if (! in_array($visibility, ArticleTestEdge::visibilities(), true)) {
+                $visibility = ArticleTestEdge::VISIBILITY_PUBLIC;
+            }
+
+            $safetyLevel = (string) ($candidate['safety_level'] ?? ArticleTestEdge::safetyLevelForTestSlug($testSlug));
+            if (! in_array($safetyLevel, ArticleTestEdge::safetyLevels(), true)) {
+                $safetyLevel = ArticleTestEdge::safetyLevelForTestSlug($testSlug);
+            }
+
+            if (ArticleTestEdge::safetyLevelForTestSlug($testSlug) === ArticleTestEdge::SAFETY_SENSITIVE) {
+                $safetyLevel = ArticleTestEdge::SAFETY_SENSITIVE;
+            }
+
+            $edges[$testSlug] = [
+                'test_slug' => $testSlug,
+                'role' => $role,
+                'sort_order' => max(0, (int) ($candidate['sort_order'] ?? ((count($edges) + 1) * 10))),
+                'safety_level' => $safetyLevel,
+                'visibility' => $visibility,
+                'source' => (string) ($candidate['source'] ?? 'editorial_package'),
+                'metadata_json' => [
+                    'source' => (string) ($candidate['source'] ?? 'editorial_package'),
+                    'sensitive_guard_applied' => ArticleTestEdge::safetyLevelForTestSlug($testSlug) === ArticleTestEdge::SAFETY_SENSITIVE,
+                ],
+            ];
+        }
+
+        return array_values($edges);
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function graphTestEdgeItems(mixed $value): array
+    {
+        if (is_string($value)) {
+            return [['test_slug' => $value]];
+        }
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $index => $item) {
+            if (is_string($item)) {
+                $items[] = ['test_slug' => $item, 'role' => ArticleTestEdge::ROLE_CONTEXTUAL];
+
+                continue;
+            }
+
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $items[] = [
+                'test_slug' => $item['test_slug'] ?? $item['slug'] ?? $item['target_slug'] ?? $item['target'] ?? '',
+                'role' => $item['role'] ?? ArticleTestEdge::ROLE_CONTEXTUAL,
+                'sort_order' => $item['sort_order'] ?? (($index + 1) * 10),
+                'safety_level' => $item['safety_level'] ?? null,
+                'visibility' => $item['visibility'] ?? ArticleTestEdge::VISIBILITY_PUBLIC,
+            ];
+        }
+
+        return $items;
     }
 
     private function workingRevisionStatus(string $intendedStatus, array $warnings = []): string

--- a/backend/database/migrations/2026_05_15_000300_create_article_test_edges_table.php
+++ b/backend/database/migrations/2026_05_15_000300_create_article_test_edges_table.php
@@ -38,6 +38,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('article_test_edges');
+        // Intentionally non-destructive. Production rollback must preserve article graph data.
     }
 };

--- a/backend/database/migrations/2026_05_15_000300_create_article_test_edges_table.php
+++ b/backend/database/migrations/2026_05_15_000300_create_article_test_edges_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('article_test_edges')) {
+            return;
+        }
+
+        Schema::create('article_test_edges', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('org_id')->default(0)->index('article_test_edges_org_idx');
+            $table->foreignId('article_id')
+                ->constrained('articles')
+                ->cascadeOnDelete();
+            $table->string('locale', 16)->index('article_test_edges_locale_idx');
+            $table->string('test_slug', 127);
+            $table->string('role', 32)->default('contextual');
+            $table->unsignedSmallInteger('sort_order')->default(100);
+            $table->string('safety_level', 32)->default('normal');
+            $table->string('visibility', 32)->default('public');
+            $table->string('source', 64)->default('editorial_package');
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+
+            $table->unique(['article_id', 'locale', 'test_slug'], 'article_test_edges_article_locale_test_unique');
+            $table->index(['org_id', 'locale', 'test_slug', 'visibility'], 'article_test_edges_public_lookup_idx');
+            $table->index(['article_id', 'visibility', 'sort_order'], 'article_test_edges_article_visible_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('article_test_edges');
+    }
+};

--- a/backend/tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php
+++ b/backend/tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Cms;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTestEdge;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class ArticleMultiTestGraphEdgesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_article_list_filter_matches_visible_multi_test_edges(): void
+    {
+        $article = $this->publishedArticle('multi-signal-article', 'en', null);
+
+        ArticleTestEdge::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'test_slug' => 'big-five-personality-test',
+            'role' => ArticleTestEdge::ROLE_SECONDARY,
+            'sort_order' => 20,
+            'safety_level' => ArticleTestEdge::SAFETY_NORMAL,
+            'visibility' => ArticleTestEdge::VISIBILITY_PUBLIC,
+            'source' => 'test',
+        ]);
+
+        $this->getJson('/api/v0.5/articles?locale=en&org_id=0&related_test_slug=big-five-personality-test')
+            ->assertOk()
+            ->assertJsonPath('items.0.slug', 'multi-signal-article')
+            ->assertJsonPath('items.0.related_test_slug', null)
+            ->assertJsonPath('items.0.related_test_slugs.0', 'big-five-personality-test')
+            ->assertJsonPath('items.0.test_edges.0.test_slug', 'big-five-personality-test')
+            ->assertJsonPath('items.0.test_edges.0.role', ArticleTestEdge::ROLE_SECONDARY);
+    }
+
+    public function test_legacy_related_test_slug_still_filters_articles_without_edges(): void
+    {
+        $this->publishedArticle(
+            'legacy-primary-article',
+            'zh-CN',
+            'mbti-personality-test-16-personality-types'
+        );
+
+        $this->getJson('/api/v0.5/articles?locale=zh-CN&org_id=0&related_test_slug=mbti-personality-test-16-personality-types')
+            ->assertOk()
+            ->assertJsonPath('items.0.slug', 'legacy-primary-article')
+            ->assertJsonPath('items.0.related_test_slug', 'mbti-personality-test-16-personality-types')
+            ->assertJsonPath('items.0.related_test_slugs.0', 'mbti-personality-test-16-personality-types');
+    }
+
+    public function test_editorial_package_import_persists_multiple_test_edges_with_sensitive_guard(): void
+    {
+        $path = $this->writePackage([
+            'package_version' => 'editorial_package.v1',
+            'title' => 'What is an MBTI and Big Five combined guide?',
+            'slug' => 'multi-test-editorial-draft',
+            'locale' => 'en',
+            'author' => 'Fermat Institute',
+            'intended_status' => 'draft',
+            'body_markdown' => "# Multi-test guide\n\n## What is this guide?\n\nIt defines the concept.\n\n## Methodology and theory\n\nIt explains dimensions and method.\n\n## FAQ\n\n### Is this diagnostic?\n\nNo.\n\n## Conclusion\n\nUse it as one input.",
+            'references' => ['John et al. (2008). Big Five taxonomy.'],
+            'seo_title' => 'What is an MBTI and Big Five combined guide?',
+            'meta_description' => 'A careful guide to multiple personality signals.',
+            'excerpt' => 'A careful guide to multiple personality signals.',
+            'canonical' => '',
+            'indexability' => true,
+            'content_track' => 'evergreen_knowledge',
+            'category' => 'Personality Psychology',
+            'tags' => ['MBTI', 'Big Five'],
+            'topic_cluster' => 'mbti',
+            'content_series' => '',
+            'audience_intent' => 'self_understanding',
+            'commercial_priority' => 'medium',
+            'signal_source' => 'MBTI',
+            'signal_type' => 'identity',
+            'decision_domains' => ['self'],
+            'target_tests' => [
+                'mbti-personality-test-16-personality-types',
+                'big-five-personality-test',
+                'depression-screening-test-standard-edition',
+            ],
+            'target_topics' => ['mbti'],
+            'target_personality_pages' => [],
+            'target_career_pages' => [],
+            'target_reports' => [],
+            'next_action' => 'start_mbti_test',
+            'internal_links' => ['/en/tests/mbti-personality-test-16-personality-types', '/en/topics/mbti'],
+            'graph_edges' => [
+                'from_article_to_test' => [
+                    [
+                        'test_slug' => 'holland-career-interest-test-riasec',
+                        'role' => ArticleTestEdge::ROLE_CONTEXTUAL,
+                        'sort_order' => 40,
+                    ],
+                ],
+                'from_article_to_topic' => ['mbti'],
+            ],
+            'recommended_reverse_links' => [],
+            'cover_image' => 'https://api.fermatmind.com/static/articles/covers/multi-test-editorial-draft.svg',
+            'cover_image_alt' => 'Abstract personality map.',
+            'cover_image_prompt' => 'Academic editorial abstract personality map.',
+            'cover_image_style_tag' => 'academic-editorial',
+            'answer_surface_policy' => 'none',
+            'answer_surface_v1' => [],
+            'answer_surface_visibility' => 'disabled',
+            'cta_slots' => [
+                ['position' => 'after_summary', 'label' => 'Start MBTI', 'href' => '/en/tests/mbti-personality-test-16-personality-types'],
+            ],
+            'primary_cta' => 'Start MBTI',
+            'secondary_cta' => '',
+            'freemium_entry' => '',
+            'report_upsell_allowed' => false,
+            'claim_boundary_notes' => 'No diagnosis or prediction.',
+            'claim_level' => 'evidence_supported',
+            'sensitivity_level' => 'normal',
+            'medical_disclaimer_required' => false,
+            'ability_disclaimer_required' => false,
+            'external_references_required' => true,
+            'review_required_by' => ['editor'],
+        ]);
+
+        $this->artisan('articles:import-editorial-package', [
+            '--file' => $path,
+            '--locale' => 'en',
+        ])
+            ->expectsOutputToContain('errors_count=0')
+            ->assertExitCode(0);
+
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with('testEdges')
+            ->where('slug', 'multi-test-editorial-draft')
+            ->firstOrFail();
+
+        $this->assertSame('mbti-personality-test-16-personality-types', (string) $article->related_test_slug);
+        $this->assertSame(
+            [
+                'mbti-personality-test-16-personality-types',
+                'big-five-personality-test',
+                'depression-screening-test-standard-edition',
+                'holland-career-interest-test-riasec',
+            ],
+            $article->testEdges->pluck('test_slug')->values()->all()
+        );
+        $this->assertSame(ArticleTestEdge::ROLE_PRIMARY, (string) $article->testEdges[0]->role);
+        $this->assertSame(
+            ArticleTestEdge::SAFETY_SENSITIVE,
+            (string) $article->testEdges->firstWhere('test_slug', 'depression-screening-test-standard-edition')?->safety_level
+        );
+    }
+
+    private function publishedArticle(string $slug, string $locale, ?string $relatedTestSlug): Article
+    {
+        $category = ArticleCategory::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'name' => 'Personality Psychology',
+            'slug' => 'personality-psychology',
+        ]);
+
+        /** @var Article $article */
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'category_id' => (int) $category->id,
+            'author_name' => 'Fermat Institute',
+            'reading_minutes' => 4,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => 'Related article',
+            'excerpt' => 'Related article excerpt.',
+            'content_md' => "# Related article\n\nBody.",
+            'related_test_slug' => $relatedTestSlug,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::parse('2026-05-15 00:00:00', 'UTC'),
+        ]);
+
+        /** @var ArticleTranslationRevision $revision */
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => $locale,
+            'source_locale' => $locale,
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'published_at' => Carbon::parse('2026-05-15 00:00:00', 'UTC'),
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => $locale,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh() ?? $article;
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function writePackage(array $package): string
+    {
+        $path = storage_path('framework/testing/editorial-package-'.uniqid('', true).'.json');
+        if (! is_dir(dirname($path))) {
+            mkdir(dirname($path), 0777, true);
+        }
+
+        file_put_contents($path, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -246,6 +246,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_multi_test_graph_edge_files(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php',
+            'backend/app/Models/ArticleTestEdge.php',
+            'backend/database/migrations/2026_05_15_000300_create_article_test_edges_table.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_public_distribution_owner_changes(): void
     {
         $changed = [
@@ -1323,6 +1334,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleMultiTestGraphEdgeFile($file)) {
+                continue;
+            }
+
             if ($this->isControlledArticlePublishSopFile($file)) {
                 continue;
             }
@@ -1642,6 +1657,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Filament/Ops/Pages/ArticlePublishingOpsPage.php',
             'backend/app/Models/ArticleEditorialPackageImport.php',
             'backend/database/migrations/2026_05_14_000100_create_article_editorial_package_imports_table.php',
+        ], true);
+    }
+
+    private function isArticleMultiTestGraphEdgeFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php',
+            'backend/app/Models/ArticleTestEdge.php',
+            'backend/database/migrations/2026_05_15_000300_create_article_test_edges_table.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T19:13:32+08:00",
+  "updated_at": "2026-05-15T21:20:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6627,6 +6627,81 @@
         "github_ci_initial": {
           "status": "failed_fixed",
           "evidence": "GitHub verify-mbti jobs treated backend/app/Config/SEO/EvergreenAnchors.php as broad runtime diff; moved semantic anchors under the existing Article Editorial Package gate service path."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
+    "PR-GRAPH-01": {
+      "repo": "fap-api",
+      "branch": "codex/pr-graph-01-multi-test-edges",
+      "title": "PR-GRAPH-01｜Article Multi-Test Graph Edges",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "PR-CMS-01",
+        "PR-CMS-02",
+        "PR-CMS-03"
+      ],
+      "scope_type": "article_multi_test_graph_edges",
+      "allowed_paths": [
+        "backend/app/Models/Article.php",
+        "backend/app/Models/ArticleTestEdge.php",
+        "backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php",
+        "backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php",
+        "backend/database/migrations/**",
+        "backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php",
+        "backend/tests/Feature/Cms/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "non_goals": [
+        "no article body changes",
+        "no production content mutation",
+        "no user attempts/results/reports/orders/payments/shares access",
+        "no fap-web changes in backend PR",
+        "no removal of related_test_slug backward compatibility"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding PR-GRAPH-01 to fap-api and fap-web pr-train manifest/state and continuing execution."
+        },
+        "branch_preflight": {
+          "status": "pass",
+          "evidence": "Started from latest main and created branch codex/pr-graph-01-multi-test-edges."
+        },
+        "article_multi_test_graph_edges_test": {
+          "status": "pass",
+          "evidence": "php artisan test tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php --no-ansi"
+        },
+        "editorial_package_importer_regression": {
+          "status": "pass",
+          "evidence": "php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi"
+        },
+        "route_list": {
+          "status": "pass",
+          "evidence": "php artisan route:list --no-ansi"
+        },
+        "migrate_pretend_sqlite": {
+          "status": "pass",
+          "evidence": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
+        },
+        "pint": {
+          "status": "pass",
+          "evidence": "vendor/bin/pint --test scoped changed backend files"
+        },
+        "manifest_state_parse": {
+          "status": "pass",
+          "evidence": "ruby YAML.load_file + python3 -m json.tool"
+        },
+        "diff_check": {
+          "status": "pass",
+          "evidence": "git diff --check && git diff --cached --check"
         }
       },
       "failure_reason": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T21:20:00+08:00",
+  "updated_at": "2026-05-15T21:28:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6639,7 +6639,7 @@
       "repo": "fap-api",
       "branch": "codex/pr-graph-01-multi-test-edges",
       "title": "PR-GRAPH-01｜Article Multi-Test Graph Edges",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "PR-CMS-01",
         "PR-CMS-02",
@@ -6664,8 +6664,8 @@
         "no fap-web changes in backend PR",
         "no removal of related_test_slug backward compatibility"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "42c0bf2c05d46fbe55d29136cd6e4b2bc1e3444b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1413",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -6702,6 +6702,10 @@
         "diff_check": {
           "status": "pass",
           "evidence": "git diff --check && git diff --cached --check"
+        },
+        "github_pr_created": {
+          "status": "pass",
+          "evidence": "https://github.com/fermatmind/fap-api/pull/1413"
         }
       },
       "failure_reason": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T21:45:00+08:00",
+  "updated_at": "2026-05-15T21:52:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6719,6 +6719,14 @@
         "ci_failure_diagnosis": {
           "status": "pass",
           "evidence": "GitHub verify-mbti failed only because runtime freeze classifier needed to ignore backend article multi-test graph edge files."
+        },
+        "migration_safety": {
+          "status": "pass",
+          "evidence": "php artisan test tests/Unit/Migrations/MigrationSafetyTest.php tests/Sre/MigrationSafetyTest.php --no-ansi"
+        },
+        "pint_migration": {
+          "status": "pass",
+          "evidence": "vendor/bin/pint --test database/migrations/2026_05_15_000300_create_article_test_edges_table.php"
         }
       },
       "failure_reason": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T21:28:00+08:00",
+  "updated_at": "2026-05-15T21:45:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6639,7 +6639,7 @@
       "repo": "fap-api",
       "branch": "codex/pr-graph-01-multi-test-edges",
       "title": "PR-GRAPH-01｜Article Multi-Test Graph Edges",
-      "status": "pr_open",
+      "status": "ci_fix_local_checks_passed",
       "depends_on": [
         "PR-CMS-01",
         "PR-CMS-02",
@@ -6654,6 +6654,7 @@
         "backend/database/migrations/**",
         "backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php",
         "backend/tests/Feature/Cms/**",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
@@ -6706,6 +6707,18 @@
         "github_pr_created": {
           "status": "pass",
           "evidence": "https://github.com/fermatmind/fap-api/pull/1413"
+        },
+        "runtime_freeze_classifier": {
+          "status": "pass",
+          "evidence": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze_classifier --no-ansi"
+        },
+        "pint_runtime_freeze_classifier": {
+          "status": "pass",
+          "evidence": "vendor/bin/pint --test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        },
+        "ci_failure_diagnosis": {
+          "status": "pass",
+          "evidence": "GitHub verify-mbti failed only because runtime freeze classifier needed to ignore backend article multi-test graph edge files."
         }
       },
       "failure_reason": null,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -40,6 +40,47 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: PR-GRAPH-01
+    repo: fap-api
+    depends_on:
+      - PR-CMS-01
+      - PR-CMS-02
+      - PR-CMS-03
+    branch: codex/pr-graph-01-multi-test-edges
+    title: "PR-GRAPH-01｜Article Multi-Test Graph Edges"
+    scope:
+      - Add backend Article multi-test graph edge authority without replacing Article.
+      - Keep articles.related_test_slug as the primary/backward-compatible test relation.
+      - Let public article list filtering by related_test_slug also match visible multi-test graph edges.
+      - Persist editorial package target_tests and article-to-test graph intent as scoped article test edges.
+      - Add sensitive test guard metadata for Depression/Anxiety/clinical edges.
+    allowed_paths:
+      - backend/app/Models/Article.php
+      - backend/app/Models/ArticleTestEdge.php
+      - backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+      - backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
+      - backend/database/migrations/**
+      - backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+      - backend/tests/Feature/Cms/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify article body content.
+      - Publish, unpublish, import, or mutate production content.
+      - Touch attempts, results, reports, orders, payments, shares, scoring, result pages, payment, or invite flows.
+      - Remove or repurpose articles.related_test_slug.
+      - Add fap-web code in this backend PR.
+    validation:
+      - php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi
+      - php artisan test tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
+      - vendor/bin/pint --test app/Models/Article.php app/Models/ArticleTestEdge.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-PREP-1
     repo: fap-api
     depends_on:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -62,6 +62,7 @@ prs:
       - backend/database/migrations/**
       - backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
       - backend/tests/Feature/Cms/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
@@ -73,9 +74,10 @@ prs:
     validation:
       - php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi
       - php artisan test tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php --no-ansi
+      - php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze_classifier --no-ansi
       - php artisan route:list --no-ansi
       - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
-      - vendor/bin/pint --test app/Models/Article.php app/Models/ArticleTestEdge.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php
+      - vendor/bin/pint --test app/Models/Article.php app/Models/ArticleTestEdge.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - git diff --check
       - git diff --cached --check
     merge_policy:


### PR DESCRIPTION
## What changed
- Added backend `article_test_edges` as the multi-test article graph edge authority.
- Kept `articles.related_test_slug` as the primary test/backward compatibility field.
- Updated article public/CMS payloads and `related_test_slug` filtering to include public visible test edges.
- Extended editorial package import to persist multiple test edges and apply sensitive-test guard metadata.

## Why
A single `related_test_slug` cannot represent articles that legitimately support MBTI, Big Five, RIASEC, IQ/EQ/Enneagram, or sensitive test contexts. This adds an explicit graph edge layer without replacing existing article authority.

## Validation
- `php artisan test tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php --no-ansi`
- `php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `vendor/bin/pint --test ...scoped changed backend files`
- `ruby -e "require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")"`
- `python3 -m json.tool docs/codex/pr-train-state.json`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No production upsert/backfill in this PR.
- No article body or published content changes.
- No user report/payment/share data access.
- fap-web consumer support is handled in the paired fap-web PR.

## Repository rule impact
Article-to-test placement remains backend/CMS authoritative. This PR adds a backend graph edge table and does not introduce frontend content authority.