### PR TITLE
fix(api): honor explicit rollout batch ledger authority

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerService.php
+++ b/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerService.php
@@ -104,19 +104,34 @@ final class CareerFullReleaseLedgerService
             $queueRow = $reviewQueueBySlug[$slug] ?? null;
             $resolvedRow = $resolvedBySlug[$slug] ?? null;
             $indexRow = $indexStateBySlug[$slug] ?? null;
+            $explicitBatchMember = isset($explicitBatchSlugs[$slug]);
 
             $currentCrosswalkMode = $this->normalizeNullableString($tracked['crosswalk_mode'] ?? null);
-            $currentIndexState = $this->normalizeIndexState((string) ($auditRow['lifecycle_state'] ?? $indexRow['current_index_state'] ?? ''));
-            $indexEligible = (bool) ($auditRow['index_eligible'] ?? $indexRow['index_eligible'] ?? false);
-            $publicIndexState = $this->normalizePublicIndexState(
-                (string) ($auditRow['public_index_state'] ?? $indexRow['public_index_state'] ?? ''),
-                $indexEligible,
-            );
+            if ($explicitBatchMember && $indexRow !== null) {
+                $currentIndexState = $this->normalizeIndexState((string) ($indexRow['current_index_state'] ?? ''));
+                $indexEligible = (bool) ($indexRow['index_eligible'] ?? false);
+                $publicIndexState = $this->normalizePublicIndexState(
+                    (string) ($indexRow['public_index_state'] ?? ''),
+                    $indexEligible,
+                );
+            } else {
+                $currentIndexState = $this->normalizeIndexState((string) ($auditRow['lifecycle_state'] ?? $indexRow['current_index_state'] ?? ''));
+                $indexEligible = (bool) ($auditRow['index_eligible'] ?? $indexRow['index_eligible'] ?? false);
+                $publicIndexState = $this->normalizePublicIndexState(
+                    (string) ($auditRow['public_index_state'] ?? $indexRow['public_index_state'] ?? ''),
+                    $indexEligible,
+                );
+            }
 
             $blockedGovernanceStatus = $this->normalizeNullableString($auditRow['blocked_governance_status'] ?? null);
             $readinessStatus = $this->normalizeNullableString($auditRow['readiness_status'] ?? null);
 
-            $explicitBatchMember = isset($explicitBatchSlugs[$slug]);
+            $explicitBatchStaleGovernanceOverride = $explicitBatchMember
+                && $this->explicitBatchAuthorityOverridesStaleGovernance(
+                    readinessStatus: $readinessStatus,
+                    blockedGovernanceStatus: $blockedGovernanceStatus,
+                    publicIndexState: $publicIndexState,
+                );
             $releaseCohort = $explicitBatchMember
                 ? $this->resolveExplicitBatchReleaseCohort(
                     readinessStatus: $readinessStatus,
@@ -143,6 +158,7 @@ final class CareerFullReleaseLedgerService
                 queueRow: $queueRow,
                 firstWaveAuditAvailable: $firstWaveAuditAvailable,
                 suppressReviewHandoffReasons: $explicitBatchMember,
+                suppressStaleGovernanceReasons: $explicitBatchStaleGovernanceOverride,
             );
 
             $releaseCounts[$releaseCohort]++;
@@ -534,6 +550,16 @@ final class CareerFullReleaseLedgerService
         ?string $blockedGovernanceStatus,
         string $publicIndexState,
     ): string {
+        if ($this->explicitBatchAuthorityOverridesStaleGovernance(
+            readinessStatus: $readinessStatus,
+            blockedGovernanceStatus: $blockedGovernanceStatus,
+            publicIndexState: $publicIndexState,
+        )) {
+            return $publicIndexState === IndexStateValue::INDEXABLE
+                ? 'public_detail_indexable'
+                : 'public_detail_conservative';
+        }
+
         if (
             $blockedGovernanceStatus !== null
             || in_array((string) $readinessStatus, ['blocked_override_eligible', 'blocked_not_safely_remediable'], true)
@@ -544,6 +570,26 @@ final class CareerFullReleaseLedgerService
         return $publicIndexState === IndexStateValue::INDEXABLE
             ? 'public_detail_indexable'
             : 'public_detail_conservative';
+    }
+
+    private function explicitBatchAuthorityOverridesStaleGovernance(
+        ?string $readinessStatus,
+        ?string $blockedGovernanceStatus,
+        string $publicIndexState,
+    ): bool {
+        if (! in_array($publicIndexState, [IndexStateValue::INDEXABLE, IndexStateValue::TRUST_LIMITED], true)) {
+            return false;
+        }
+
+        if (
+            $readinessStatus === 'blocked_not_safely_remediable'
+            || $blockedGovernanceStatus === 'blocked_not_safely_remediable'
+        ) {
+            return false;
+        }
+
+        return $readinessStatus === 'blocked_override_eligible'
+            || $blockedGovernanceStatus === 'blocked_override_eligible';
     }
 
     /**
@@ -560,10 +606,11 @@ final class CareerFullReleaseLedgerService
         ?array $queueRow,
         bool $firstWaveAuditAvailable,
         bool $suppressReviewHandoffReasons = false,
+        bool $suppressStaleGovernanceReasons = false,
     ): array {
         $reasons = [];
 
-        if ($blockedGovernanceStatus !== null) {
+        if ($blockedGovernanceStatus !== null && ! $suppressStaleGovernanceReasons) {
             $reasons[] = 'blocked_governance';
         }
 

--- a/backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php
+++ b/backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php
@@ -29,7 +29,7 @@ final class CareerExecuteCanonicalRolloutBatchTest extends TestCase
             'title_zh' => '测试族',
         ]);
 
-        foreach (['actuaries', 'economists', 'web-developers', 'software-developers', 'cn-engineers'] as $slug) {
+        foreach (['actuaries', 'economists', 'financial-analysts', 'web-developers', 'software-developers', 'cn-engineers'] as $slug) {
             Occupation::query()->create([
                 'family_id' => $family->id,
                 'canonical_slug' => $slug,
@@ -258,6 +258,34 @@ final class CareerExecuteCanonicalRolloutBatchTest extends TestCase
         $this->assertIsArray($payload);
         $this->assertSame('planned', $payload['status'] ?? null);
         $this->assertSame(6, $payload['promoted_locale_rows'] ?? 0);
+    }
+
+    public function test_apply_uses_explicit_batch_ledger_authority_for_stale_blocked_override_member(): void
+    {
+        $this->writeProjection($this->candidateProjection(['financial-analysts']));
+
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-financial-analysts',
+            '--slugs' => 'financial-analysts',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'financial-analysts',
+            '--apply' => true,
+            '--projection' => $this->tmpProjectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $payload = json_decode(Artisan::output(), true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('promoted_success', $payload['status'] ?? null);
+        $this->assertTrue($payload['writes_database'] ?? false);
+        $this->assertTrue($payload['write_verified'] ?? false);
+        $this->assertSame(['financial-analysts'], $payload['promoted_slugs'] ?? null);
+        $this->assertSame(2, $payload['promoted_locale_rows'] ?? null);
+        $this->assertSame(2, data_get($payload, 'persistence_check.found_published'));
+        $this->assertSame(0, data_get($payload, 'persistence_check.not_published_count'));
+        $this->assertFalse($payload['rollback_required'] ?? true);
     }
 
     public function test_command_writes_audit_report(): void

--- a/backend/tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
@@ -170,6 +170,57 @@ final class CareerFullReleaseLedgerServiceTest extends TestCase
         }
     }
 
+    public function test_stale_first_wave_blocked_override_member_stays_blocked_without_explicit_batch_authority(): void
+    {
+        $slug = 'financial-analysts';
+        $this->materializeIndexedOccupation($slug);
+
+        $ledger = app(CareerFullReleaseLedgerService::class)->build()->toArray();
+        $member = collect((array) ($ledger['members'] ?? []))->firstWhere('canonical_slug', $slug);
+
+        $this->assertIsArray($member);
+        $this->assertSame('blocked', $member['release_cohort'] ?? null);
+        $this->assertContains('blocked_governance', $member['blocker_reasons'] ?? []);
+        $this->assertContains('first_wave_readiness_blocked_override_eligible', $member['blocker_reasons'] ?? []);
+        $this->assertArrayNotHasKey('explicit_rollout_batch', (array) ($member['evidence_refs'] ?? []));
+    }
+
+    public function test_explicit_rollout_batch_authority_overrides_stale_blocked_override_for_indexed_member(): void
+    {
+        $slug = 'financial-analysts';
+        $this->materializeIndexedOccupation($slug);
+
+        $ledger = app(CareerFullReleaseLedgerService::class)->build([$slug])->toArray();
+        $member = collect((array) ($ledger['members'] ?? []))->firstWhere('canonical_slug', $slug);
+
+        $this->assertIsArray($member);
+        $this->assertSame('public_detail_indexable', $member['release_cohort'] ?? null);
+        $this->assertSame('indexed', $member['current_index_state'] ?? null);
+        $this->assertSame('indexable', $member['public_index_state'] ?? null);
+        $this->assertSame([], $member['blocker_reasons'] ?? null);
+        $this->assertSame(
+            'current_explicit_batch_only',
+            data_get($member, 'evidence_refs.explicit_rollout_batch.scope')
+        );
+    }
+
+    public function test_explicit_rollout_batch_authority_keeps_stale_blocked_override_candidate_conservative(): void
+    {
+        $slug = 'financial-analysts';
+        $this->materializeIndexedOccupation($slug, 'promotion_candidate');
+
+        $ledger = app(CareerFullReleaseLedgerService::class)->build([$slug])->toArray();
+        $member = collect((array) ($ledger['members'] ?? []))->firstWhere('canonical_slug', $slug);
+
+        $this->assertIsArray($member);
+        $this->assertSame('public_detail_conservative', $member['release_cohort'] ?? null);
+        $this->assertSame('promotion_candidate', $member['current_index_state'] ?? null);
+        $this->assertSame('trust_limited', $member['public_index_state'] ?? null);
+        $this->assertContains('public_index_not_indexable', $member['blocker_reasons'] ?? []);
+        $this->assertNotContains('blocked_governance', $member['blocker_reasons'] ?? []);
+        $this->assertNotContains('first_wave_readiness_blocked_override_eligible', $member['blocker_reasons'] ?? []);
+    }
+
     public function test_verified_rollout_batch_execution_is_included_in_default_projection_authority(): void
     {
         $baseLedger = app(CareerFullReleaseLedgerService::class)->build()->toArray();

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6547,6 +6547,98 @@
         }
       ]
     },
+    "REPAIR-EXPLICIT-ROLLOUT-BATCH-LEDGER-AUTHORITY-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-explicit-rollout-batch-ledger-authority-1",
+      "title": "fix(api): honor explicit rollout batch ledger authority",
+      "name": "Repair explicit rollout batch ledger authority after 800 apply verification",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-PROGRESSIVE-READINESS-SOFTWARE-MANUAL-HOLD-EXCLUSION-1"
+      ],
+      "scope_type": "explicit_rollout_batch_ledger_authority_only",
+      "allowed_paths": [
+        "backend/app/Domain/Career/Publish/**",
+        "backend/tests/Unit/Services/Career/**",
+        "backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no rollout dry-run",
+        "no rollout apply",
+        "no candidate prep apply",
+        "no production DB mutation",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web",
+        "do not weaken final live acceptance",
+        "do not weaken software-developers or CN proxy rollout rejection"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-EXPLICIT-ROLLOUT-BATCH-LEDGER-AUTHORITY-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "REPAIR-PROGRESSIVE-READINESS-SOFTWARE-MANUAL-HOLD-EXCLUSION-1 is present on main as PR #1412 before this PR started."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to full release ledger explicit batch authority, focused rollout command tests, and authorized train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_mbti_sidecar",
+          "evidence": [
+            "composer dump-autoload refreshed the temporary worktree autoload mapping after symlinking vendor; no tracked vendor files changed.",
+            "php artisan test --filter=CareerFullReleaseLedgerService --no-ansi: pass (10 tests, 128 assertions)",
+            "php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi: pass (13 tests, 55 assertions)",
+            "php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi: pass (14 tests, 33 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-explicit-ledger-authority.sqlite php artisan migrate --force --no-ansi: pass",
+            "ruby YAML.load_file docs/codex/pr-train.yaml: pass",
+            "python3 -m json.tool docs/codex/pr-train-state.json: pass",
+            "vendor/bin/pint --test: pass",
+            "git diff --check: pass",
+            "bash backend/scripts/ci_verify_mbti.sh: external blocker in BigFive runtime freeze/pack publish/rollback checks; scoped Career tests pass and current PR does not modify BigFive runtime or content-pack publish/rollback code."
+          ]
+        },
+        "github_pr": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "800-ROLLOUT-DRY-RUN-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-RUNTIME-FREEZE-PACK-CI-20260515",
+          "title": "Local MBTI CI BigFive runtime freeze and pack compiled-directory checks fail outside current PR scope",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "bash backend/scripts/ci_verify_mbti.sh failed BigFiveResultPageV2CoreBodyPreviewTest::runtime_paths_have_no_uncommitted_diff while reporting CMS test-edge files from the parent worktree, not the current PR files.",
+            "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at compiled directory assertions.",
+            "Current PR changed only Career full release ledger explicit batch authority, focused Career rollout/ledger tests, and authorized train metadata."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-RUNTIME-FREEZE-PACK-CI",
+          "may_continue_train": true
+        }
+      ]
+    },
     "PR-CMS-FIX-MASTER": {
       "repo": "fap-api",
       "branch": "codex/pr-cms-fix-master-semantic-content-gate",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -542,6 +542,46 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-EXPLICIT-ROLLOUT-BATCH-LEDGER-AUTHORITY-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-PROGRESSIVE-READINESS-SOFTWARE-MANUAL-HOLD-EXCLUSION-1
+    branch: codex/repair-explicit-rollout-batch-ledger-authority-1
+    title: "fix(api): honor explicit rollout batch ledger authority"
+    name: "Repair explicit rollout batch ledger authority after 800 apply verification"
+    scope:
+      - Let the full release ledger honor explicit current-batch rollout authority for stale first-wave blocked_override_eligible members when the current DB index state is indexed or promotion_candidate.
+      - Preserve blocked_not_safely_remediable and non-explicit batch blocking semantics.
+      - Preserve final live acceptance strictness and hard rollout exclusions.
+      - Cover the financial-analysts 800 apply verification failure with focused ledger and rollout command tests.
+    allowed_paths:
+      - backend/app/Domain/Career/Publish/**
+      - backend/tests/Unit/Services/Career/**
+      - backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run candidate preparation apply.
+      - Run production DB mutation.
+      - Run rollback or quarantine.
+      - Run deploy.
+      - Touch fap-web.
+      - Weaken final live acceptance.
+      - Weaken software-developers or CN proxy rollout rejection.
+    validation:
+      - php artisan test --filter=CareerFullReleaseLedgerService --no-ansi
+      - php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi
+      - php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- honors explicit current-batch rollout authority in the full release ledger for stale first-wave `blocked_override_eligible` evidence when the current DB index state is `indexed` or `promotion_candidate`
- keeps non-explicit batch members and `blocked_not_safely_remediable` members blocked
- covers the `financial-analysts` 800 rollout apply verification failure path with focused ledger and rollout command tests

## Guardrails
- no production DB mutation
- no rollout dry-run or rollout apply
- no deploy
- no rollback or quarantine
- no fap-web changes
- final live acceptance strictness is not weakened
- software-developers and CN proxy rollout rejection are not weakened

## Tests
- `php artisan test --filter=CareerFullReleaseLedgerService --no-ansi`
- `php artisan test --filter=CareerExecuteCanonicalRolloutBatch --no-ansi`
- `php artisan test --filter=CanonicalBatchPromotionExecutorService --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-explicit-ledger-authority.sqlite php artisan migrate --force --no-ansi`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`
- `python3 -m json.tool docs/codex/pr-train-state.json`
- `vendor/bin/pint --test`
- `git diff --check`

## Sidecar
- `bash backend/scripts/ci_verify_mbti.sh` hit external BigFive runtime freeze / pack publish rollback compiled-directory failures unrelated to this PR scope. The scoped Career tests above passed.

## Next step
- rerun `800-ROLLOUT-DRY-RUN-1`, then use the normal apply approval gate if dry-run passes.
