### PR TITLE
fix(api): partition final career 2786 public resolution

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\Career2786PublicResolutionPartitionPlanner;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class CareerPlanCanonical2786PublicResolutionPartition extends Command
+{
+    protected $signature = 'career:plan-canonical-2786-public-resolution-partition
+        {--source-plan= : Required 2786 public-resolution/source plan JSON artifact}
+        {--closeout= : Required accepted 800 closeout JSON artifact}
+        {--current-total=800 : Current public total}
+        {--target-total=2786 : Target public total}
+        {--locales=en,zh : Comma-separated locales}
+        {--entity-context= : Optional entity context JSON; if supplied, rows without occupation_exists=true are partitioned for remediation}
+        {--strict : Fail on source-plan validation issues}
+        {--json : Emit JSON output}
+        {--output= : Optional output path for final 2786 partition JSON}';
+
+    protected $description = 'Plan the read-only final 2786 public-resolution partition before any candidate prep or rollout.';
+
+    public function handle(): int
+    {
+        try {
+            $sourcePlanPath = $this->requiredOption('source-plan');
+            $closeoutPath = $this->requiredOption('closeout');
+            $sourcePlanValidation = CareerPublicResolutionPlanResolver::fromPath(
+                $sourcePlanPath,
+                Career2786PublicResolutionPartitionPlanner::TARGET_PUBLIC_TOTAL,
+            );
+            $sourcePlan = $sourcePlanValidation->plan;
+            if ($sourcePlan === null) {
+                throw new RuntimeException('source_plan_invalid');
+            }
+            if ((bool) $this->option('strict') && $sourcePlanValidation->issues !== []) {
+                throw new RuntimeException('source_plan_validation_issues');
+            }
+
+            $closeout = $this->readJson($closeoutPath, 'closeout');
+            $entityContextPath = $this->pathOption('entity-context');
+            $payload = app(Career2786PublicResolutionPartitionPlanner::class)->partition(
+                sourcePlan: $sourcePlan,
+                currentCloseout: $closeout,
+                currentPublicSlugs: $this->readSlugList($this->pathFromCloseout($closeout, 'total_slugs_path'), 'baseline_slug'),
+                currentPublicTotal: $this->intOption('current-total'),
+                targetPublicTotal: $this->intOption('target-total'),
+                locales: $this->localesOption(),
+                occupationExistingSlugs: $entityContextPath === null ? null : $this->readOccupationExistingSlugs($entityContextPath),
+            )->toArray();
+
+            $payload['source_plan']['validation_issue_count'] = count($sourcePlanValidation->issues);
+            if ($entityContextPath !== null) {
+                $payload['entity_context']['source_path'] = $entityContextPath;
+            }
+
+            return $this->finish($payload, ($payload['status'] ?? null) === 'pass' ? self::SUCCESS : self::FAILURE);
+        } catch (Throwable $exception) {
+            return $this->finish([
+                'schema_version' => Career2786PublicResolutionPartitionPlanner::SCHEMA_VERSION,
+                'status' => 'blocked',
+                'readiness_pass' => false,
+                'read_only' => true,
+                'writes_database' => false,
+                'apply_allowed' => false,
+                'rollout_allowed' => false,
+                'candidate_prep_allowed' => false,
+                'blockers' => [[
+                    'reason' => $this->reasonKey($exception->getMessage()),
+                    'message' => $exception->getMessage(),
+                    'severity' => 'high',
+                    'evidence' => [],
+                ]],
+                'sidecars' => [],
+                'next_required_action' => 'FIX_2786_PUBLIC_RESOLUTION_PARTITION_INPUTS',
+            ], self::FAILURE);
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        return $value;
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
+    private function intOption(string $name): int
+    {
+        $raw = trim((string) ($this->option($name) ?? ''));
+        if ($raw === '') {
+            throw new RuntimeException(str_replace('-', '_', $name).'_missing');
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function localesOption(): array
+    {
+        $raw = trim((string) ($this->option('locales') ?? 'en,zh'));
+        $locales = array_values(array_filter(array_map(
+            static fn (string $locale): string => strtolower(trim($locale)),
+            explode(',', $raw),
+        )));
+        if ($locales === []) {
+            throw new RuntimeException('locales_missing');
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new RuntimeException($kind.'_artifact_shape_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function pathFromCloseout(array $payload, string $key): string
+    {
+        $path = $payload[$key] ?? null;
+        if (! is_string($path) || trim($path) === '') {
+            throw new RuntimeException($key.'_missing');
+        }
+
+        return trim($path);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readSlugList(string $path, string $kind): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($kind.'_artifact_missing');
+        }
+
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new RuntimeException($kind.'_artifact_unreadable');
+        }
+
+        $trimmed = trim($contents);
+        if ($trimmed === '') {
+            throw new RuntimeException($kind.'_artifact_empty');
+        }
+
+        if (str_starts_with($trimmed, '[') || str_starts_with($trimmed, '{')) {
+            $decoded = json_decode($trimmed, true, flags: JSON_THROW_ON_ERROR);
+            $slugs = is_array($decoded) && array_is_list($decoded)
+                ? $decoded
+                : (is_array($decoded) ? ($decoded['slugs'] ?? $decoded['selected_slugs'] ?? $decoded['total_slugs'] ?? []) : []);
+        } else {
+            $slugs = preg_split('/[\r\n,]+/', $trimmed) ?: [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $slug): string => trim((string) $slug),
+            is_array($slugs) ? $slugs : [],
+        ), static fn (string $slug): bool => $slug !== ''));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readOccupationExistingSlugs(string $path): array
+    {
+        $payload = $this->readJson($path, 'entity_context');
+        $rows = $payload['rows'] ?? null;
+        if (! is_array($rows) || ! array_is_list($rows)) {
+            throw new RuntimeException('entity_context_rows_missing');
+        }
+
+        $slugs = [];
+        $seen = [];
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException('entity_context_row_invalid_at_'.$index);
+            }
+            if (($row['occupation_exists'] ?? false) !== true) {
+                continue;
+            }
+
+            $slug = $row['canonical_slug'] ?? $row['slug'] ?? null;
+            if (! is_string($slug) || trim($slug) === '') {
+                throw new RuntimeException('entity_context_slug_missing_at_'.$index);
+            }
+
+            $slug = strtolower(trim($slug));
+            if (! isset($seen[$slug])) {
+                $seen[$slug] = true;
+                $slugs[] = $slug;
+            }
+        }
+
+        if ($slugs === []) {
+            throw new RuntimeException('entity_context_occupation_exists_slugs_missing');
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, int $exitCode): int
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed_to_encode_json_payload');
+
+            return self::FAILURE;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            File::put($outputPath, $encoded.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($encoded);
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+            $this->line('target_public_total='.(string) ($payload['target_public_total'] ?? 0));
+            $this->line('canonical_rollout_candidate_count='.(string) ($payload['canonical_rollout_candidate_count'] ?? 0));
+        }
+
+        return $exitCode;
+    }
+
+    private function reasonKey(string $message): string
+    {
+        $key = strtolower(trim($message));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $key) ?? 'career_2786_public_resolution_partition_error';
+        $key = trim($key, '_');
+
+        return $key === '' ? 'career_2786_public_resolution_partition_error' : $key;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -45,6 +45,7 @@ use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerNormalizeLegacyDisplayAssets;
+use App\Console\Commands\CareerPlanCanonical2786PublicResolutionPartition;
 use App\Console\Commands\CareerPlanCanonical80CohortReadiness;
 use App\Console\Commands\CareerPlanCanonical80RuntimeCandidatePool;
 use App\Console\Commands\CareerPlanCanonical80TargetDelta;
@@ -222,6 +223,7 @@ class Kernel extends ConsoleKernel
         CareerPlanCanonical80CohortReadiness::class,
         CareerPlanCanonical80RuntimeCandidatePool::class,
         CareerPlanCanonical80TargetDelta::class,
+        CareerPlanCanonical2786PublicResolutionPartition::class,
         CareerPlanCanonicalDeltaRolloutGate::class,
         CareerPlanCanonicalProgressiveCohortDelta::class,
         CareerPlanCanonicalProgressiveLiveVerification::class,

--- a/backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionPlanner.php
+++ b/backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionPlanner.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use RuntimeException;
+
+final class Career2786PublicResolutionPartitionPlanner
+{
+    public const SCHEMA_VERSION = 'career_2786_public_resolution_partition.v1';
+
+    public const TARGET_PUBLIC_TOTAL = 2786;
+
+    /**
+     * @param  list<string>  $currentPublicSlugs
+     * @param  list<string>  $locales
+     * @param  list<string>|null  $occupationExistingSlugs
+     */
+    public function partition(
+        CareerPublicResolutionPlan $sourcePlan,
+        array $currentCloseout,
+        array $currentPublicSlugs,
+        int $currentPublicTotal,
+        int $targetPublicTotal = self::TARGET_PUBLIC_TOTAL,
+        array $locales = ['en', 'zh'],
+        ?array $occupationExistingSlugs = null,
+    ): Career2786PublicResolutionPartitionResult {
+        $locales = $this->normalizedStringList($locales, 'locale');
+        $baselineSlugs = $this->normalizedSlugList($currentPublicSlugs, 'baseline_slug');
+        $occupationExistingSlugs = $occupationExistingSlugs === null
+            ? null
+            : $this->normalizedSlugList($occupationExistingSlugs, 'occupation_existing_slug');
+        $baselineSet = array_fill_keys($baselineSlugs, true);
+        $occupationExistingSet = $occupationExistingSlugs === null ? [] : array_fill_keys($occupationExistingSlugs, true);
+        $requiresOccupationExists = $occupationExistingSlugs !== null;
+        $seenSourceSlugs = [];
+        $duplicateSourceSlugs = [];
+        $sourceSlugMissingCount = 0;
+        $partitions = [
+            'already_public_baseline' => [],
+            'canonical_rollout_candidate' => [],
+            'occupation_missing_remediation' => [],
+            'cn_proxy_policy_asset' => [],
+            'software_manual_hold' => [],
+        ];
+        $rows = [];
+
+        foreach ($sourcePlan->rows as $position => $row) {
+            $slug = $this->normalizedSlug($row->canonicalSlug);
+            if ($slug === null) {
+                $sourceSlugMissingCount++;
+
+                continue;
+            }
+
+            if (isset($seenSourceSlugs[$slug])) {
+                $duplicateSourceSlugs[] = $slug;
+
+                continue;
+            }
+            $seenSourceSlugs[$slug] = true;
+
+            $partition = $this->partitionFor(
+                row: $row,
+                slug: $slug,
+                baselineSet: $baselineSet,
+                occupationExistingSet: $occupationExistingSet,
+                requiresOccupationExists: $requiresOccupationExists,
+            );
+            $partitions[$partition][] = $slug;
+            $rows[] = [
+                'slug' => $slug,
+                'source_position' => $position + 1,
+                'source_row_number' => $row->rowNumber,
+                'partition' => $partition,
+                'locales' => $row->locales === [] ? $locales : $row->locales,
+                'public_resolution_state' => $row->publicResolutionState,
+                'canonical_public_type' => $row->canonicalPublicType,
+                'source_code' => $row->sourceCode,
+                'title_en' => $row->titleEn,
+                'title_zh' => $row->titleZh,
+                'rollout_candidate' => $partition === 'canonical_rollout_candidate',
+                'canonical_rollout_candidate' => $partition === 'canonical_rollout_candidate',
+                'candidate_prep_allowed' => false,
+                'requires_policy_decision' => in_array($partition, ['cn_proxy_policy_asset', 'software_manual_hold'], true),
+                'requires_entity_remediation' => $partition === 'occupation_missing_remediation',
+            ];
+        }
+
+        $issues = $this->issues(
+            currentCloseout: $currentCloseout,
+            baselineSlugs: $baselineSlugs,
+            currentPublicTotal: $currentPublicTotal,
+            targetPublicTotal: $targetPublicTotal,
+            sourceRows: count($sourcePlan->rows),
+            partitionedRows: count($rows),
+            sourceSlugMissingCount: $sourceSlugMissingCount,
+            duplicateSourceSlugs: $duplicateSourceSlugs,
+        );
+        $partitionCounts = [];
+        foreach ($partitions as $partition => $slugs) {
+            $partitionCounts[$partition] = count($slugs);
+        }
+
+        $canonicalCandidateCount = $partitionCounts['canonical_rollout_candidate'];
+        $targetDeltaCount = max(0, $targetPublicTotal - $currentPublicTotal);
+        $status = $issues === [] ? 'pass' : 'blocked';
+        $canonicalRolloutCanReachTarget = count($baselineSlugs) + $canonicalCandidateCount >= $targetPublicTotal;
+        $occupationMissingCount = $partitionCounts['occupation_missing_remediation'];
+        $cnProxyCount = $partitionCounts['cn_proxy_policy_asset'];
+        $softwareManualHoldCount = $partitionCounts['software_manual_hold'];
+
+        return new Career2786PublicResolutionPartitionResult([
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $status,
+            'partition_pass' => $issues === [],
+            'partition_status' => $issues === [] ? 'partitioned' : 'blocked',
+            'readiness_pass' => false,
+            'read_only' => true,
+            'writes_database' => false,
+            'apply_allowed' => false,
+            'rollout_allowed' => false,
+            'candidate_prep_allowed' => false,
+            'current_public_total' => $currentPublicTotal,
+            'target_public_total' => $targetPublicTotal,
+            'baseline_count' => count($baselineSlugs),
+            'target_delta_count' => $targetDeltaCount,
+            'expected_total_locale_rows' => $targetPublicTotal * count($locales),
+            'locale_count' => count($locales),
+            'locales' => $locales,
+            'partition_counts' => $partitionCounts,
+            'canonical_rollout_candidate_count' => $canonicalCandidateCount,
+            'canonical_rollout_possible_total' => count($baselineSlugs) + $canonicalCandidateCount,
+            'canonical_rollout_shortfall' => max(0, $targetPublicTotal - count($baselineSlugs) - $canonicalCandidateCount),
+            'canonical_rollout_can_reach_target' => $canonicalRolloutCanReachTarget,
+            'occupation_missing_remediation_count' => $occupationMissingCount,
+            'cn_proxy_policy_asset_count' => $cnProxyCount,
+            'software_manual_hold_count' => $softwareManualHoldCount,
+            'policy_partition_required' => $cnProxyCount > 0 || $softwareManualHoldCount > 0,
+            'entity_remediation_required' => $occupationMissingCount > 0,
+            'partitions' => $partitions,
+            'rows' => $rows,
+            'source_plan' => [
+                'source_path' => $sourcePlan->sourcePath,
+                'checksum' => $sourcePlan->checksum,
+                'row_count' => count($sourcePlan->rows),
+            ],
+            'entity_context' => [
+                'required_for_partition' => $requiresOccupationExists,
+                'occupation_exists_count' => $occupationExistingSlugs === null ? null : count($occupationExistingSlugs),
+                'occupation_missing_remediation_count' => $occupationMissingCount,
+            ],
+            'blockers' => array_map(
+                static fn (CareerProgressiveReadinessSelectionIssue $issue): array => $issue->toArray(),
+                $issues,
+            ),
+            'sidecars' => [],
+            'next_required_actions' => $this->nextRequiredActions(
+                canonicalRolloutCanReachTarget: $canonicalRolloutCanReachTarget,
+                occupationMissingCount: $occupationMissingCount,
+                cnProxyCount: $cnProxyCount,
+                softwareManualHoldCount: $softwareManualHoldCount,
+            ),
+            'next_required_action' => $issues === []
+                ? '2786_PUBLIC_RESOLUTION_PARTITION_REVIEW'
+                : 'FIX_2786_PUBLIC_RESOLUTION_PARTITION_INPUTS',
+        ]);
+    }
+
+    /**
+     * @param  array<string, bool>  $baselineSet
+     * @param  array<string, bool>  $occupationExistingSet
+     */
+    private function partitionFor(
+        CareerPublicResolutionPlanRow $row,
+        string $slug,
+        array $baselineSet,
+        array $occupationExistingSet,
+        bool $requiresOccupationExists,
+    ): string {
+        if (isset($baselineSet[$slug])) {
+            return 'already_public_baseline';
+        }
+
+        if ($slug === 'software-developers') {
+            return 'software_manual_hold';
+        }
+
+        if ($this->isCnProxyPolicyRow($row, $slug)) {
+            return 'cn_proxy_policy_asset';
+        }
+
+        if ($requiresOccupationExists && ! isset($occupationExistingSet[$slug])) {
+            return 'occupation_missing_remediation';
+        }
+
+        return 'canonical_rollout_candidate';
+    }
+
+    private function isCnProxyPolicyRow(CareerPublicResolutionPlanRow $row, string $slug): bool
+    {
+        if (str_starts_with($slug, 'cn-')) {
+            return true;
+        }
+
+        $state = strtolower(trim((string) $row->publicResolutionState));
+        if (in_array($state, ['cn_proxy_hold', 'blocked_until_cn_authority_policy'], true)) {
+            return true;
+        }
+
+        $publicType = strtolower(trim((string) $row->canonicalPublicType));
+        if (in_array($publicType, ['public_cn_proxy_page', 'public_cn_proxy_page_candidate'], true)) {
+            return true;
+        }
+
+        $recommendedResolution = strtolower(trim((string) ($row->raw['recommended_resolution'] ?? '')));
+
+        return in_array($recommendedResolution, ['public_cn_proxy_page', 'public_cn_proxy_page_candidate'], true);
+    }
+
+    /**
+     * @param  list<string>  $baselineSlugs
+     * @param  list<string>  $duplicateSourceSlugs
+     * @return list<CareerProgressiveReadinessSelectionIssue>
+     */
+    private function issues(
+        array $currentCloseout,
+        array $baselineSlugs,
+        int $currentPublicTotal,
+        int $targetPublicTotal,
+        int $sourceRows,
+        int $partitionedRows,
+        int $sourceSlugMissingCount,
+        array $duplicateSourceSlugs,
+    ): array {
+        $issues = [];
+        if (($currentCloseout['status'] ?? null) !== 'complete' || ($currentCloseout['accepted'] ?? false) !== true) {
+            $issues[] = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'current_closeout_not_accepted',
+                message: 'Current closeout artifact must be complete and accepted.',
+                severity: 'blocker_for_publication',
+                evidence: [
+                    'status' => $currentCloseout['status'] ?? null,
+                    'accepted' => $currentCloseout['accepted'] ?? null,
+                ],
+            );
+        }
+
+        $declaredTotal = $currentCloseout['total_slug_count'] ?? $currentCloseout['target_public_total'] ?? null;
+        if ($declaredTotal !== null && (int) $declaredTotal !== count($baselineSlugs)) {
+            $issues[] = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'baseline_count_closeout_mismatch',
+                message: 'Baseline slug count does not match the closeout declared total.',
+                severity: 'high',
+                evidence: [
+                    'declared' => $declaredTotal,
+                    'actual' => count($baselineSlugs),
+                ],
+            );
+        }
+
+        if ($currentPublicTotal !== count($baselineSlugs)) {
+            $issues[] = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'current_public_total_baseline_mismatch',
+                message: 'Current public total must match the supplied accepted baseline slug count.',
+                severity: 'high',
+                evidence: [
+                    'current_public_total' => $currentPublicTotal,
+                    'baseline_count' => count($baselineSlugs),
+                ],
+            );
+        }
+
+        if ($targetPublicTotal !== self::TARGET_PUBLIC_TOTAL) {
+            $issues[] = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'target_public_total_unsupported',
+                message: 'Final public-resolution partition only supports target_public_total=2786.',
+                severity: 'high',
+                evidence: ['target_public_total' => $targetPublicTotal],
+            );
+        }
+
+        if ($sourceRows !== self::TARGET_PUBLIC_TOTAL) {
+            $issues[] = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'source_plan_row_count_mismatch',
+                message: 'Final public-resolution partition requires the complete 2786-row source plan.',
+                severity: 'high',
+                evidence: [
+                    'expected' => self::TARGET_PUBLIC_TOTAL,
+                    'actual' => $sourceRows,
+                ],
+            );
+        }
+
+        if ($sourceSlugMissingCount > 0) {
+            $issues[] = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'source_slug_missing',
+                message: 'Source plan contains rows without canonical slugs.',
+                severity: 'high',
+                evidence: ['count' => $sourceSlugMissingCount],
+            );
+        }
+
+        if ($duplicateSourceSlugs !== []) {
+            $issues[] = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'duplicate_source_slugs',
+                message: 'Source plan contains duplicate canonical slugs.',
+                severity: 'high',
+                evidence: ['slugs' => array_values(array_unique($duplicateSourceSlugs))],
+            );
+        }
+
+        if ($partitionedRows + $sourceSlugMissingCount + count($duplicateSourceSlugs) !== $sourceRows) {
+            $issues[] = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'partition_accounting_mismatch',
+                message: 'Partition accounting does not match source row count.',
+                severity: 'high',
+                evidence: [
+                    'source_rows' => $sourceRows,
+                    'partitioned_rows' => $partitionedRows,
+                    'source_slug_missing_count' => $sourceSlugMissingCount,
+                    'duplicate_source_slug_count' => count($duplicateSourceSlugs),
+                ],
+            );
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function nextRequiredActions(
+        bool $canonicalRolloutCanReachTarget,
+        int $occupationMissingCount,
+        int $cnProxyCount,
+        int $softwareManualHoldCount,
+    ): array {
+        $actions = [];
+        if (! $canonicalRolloutCanReachTarget) {
+            $actions[] = 'DO_NOT_RUN_2786_CANONICAL_CANDIDATE_PREP';
+        }
+        if ($occupationMissingCount > 0) {
+            $actions[] = '2786_OCCUPATION_ENTITY_REMEDIATION_1';
+        }
+        if ($cnProxyCount > 0) {
+            $actions[] = 'CN_PROXY_AUTHORITY_POLICY_DECISION_1';
+        }
+        if ($softwareManualHoldCount > 0) {
+            $actions[] = 'SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1';
+        }
+        $actions[] = '2786_READINESS_RERUN_AFTER_PARTITION_DECISIONS';
+
+        return $actions;
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function normalizedStringList(array $values, string $context): array
+    {
+        if (! array_is_list($values)) {
+            throw new RuntimeException($context.'_list_invalid');
+        }
+
+        $normalized = [];
+        $seen = [];
+        foreach ($values as $index => $value) {
+            if (! is_string($value)) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+            $value = strtolower(trim($value));
+            if ($value === '') {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+            if (! isset($seen[$value])) {
+                $seen[$value] = true;
+                $normalized[] = $value;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return list<string>
+     */
+    private function normalizedSlugList(array $slugs, string $context): array
+    {
+        $normalized = [];
+        $seen = [];
+        foreach ($slugs as $index => $slug) {
+            if (! is_string($slug)) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+            $slug = strtolower(trim($slug));
+            if ($slug === '' || str_contains($slug, '*')) {
+                throw new RuntimeException($context.'_invalid_at_'.$index);
+            }
+            if (isset($seen[$slug])) {
+                throw new RuntimeException($context.'_duplicate_'.$slug);
+            }
+            $seen[$slug] = true;
+            $normalized[] = $slug;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizedSlug(?string $slug): ?string
+    {
+        $slug = strtolower(trim((string) $slug));
+
+        return $slug === '' || str_contains($slug, '*') ? null : $slug;
+    }
+}

--- a/backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionResult.php
+++ b/backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionResult.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class Career2786PublicResolutionPartitionResult
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(private readonly array $payload) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+}

--- a/backend/docs/career/audits/2786_public_resolution_partition.md
+++ b/backend/docs/career/audits/2786_public_resolution_partition.md
@@ -1,0 +1,45 @@
+# Career 2786 Public Resolution Partition
+
+`career:plan-canonical-2786-public-resolution-partition` is a read-only planner for the final 800 to 2786 phase.
+
+The command does not treat every remaining source row as a canonical rollout candidate. It partitions the complete 2786 source plan against an accepted 800 closeout baseline and optional entity context.
+
+## Inputs
+
+- `--source-plan=` complete 2786 public-resolution source plan.
+- `--closeout=` accepted 800 closeout artifact.
+- `--current-total=800`
+- `--target-total=2786`
+- `--locales=en,zh`
+- `--entity-context=` optional entity context with `occupation_exists=true` evidence.
+
+## Partitions
+
+- `already_public_baseline`: slugs already accepted in the 800 closeout.
+- `canonical_rollout_candidate`: non-baseline rows that are not CN proxy rows, not manual hold rows, and have occupation evidence when entity context is supplied.
+- `occupation_missing_remediation`: rows that cannot enter candidate prep until occupation entity evidence exists.
+- `cn_proxy_policy_asset`: CN proxy rows, including `cn-*`, `public_cn_proxy_page`, `public_cn_proxy_page_candidate`, `CN_proxy_hold`, or `blocked_until_CN_authority_policy`.
+- `software_manual_hold`: `software-developers` manual hold.
+
+## Non-goals
+
+- No DB mutation.
+- No candidate prep apply.
+- No rollout dry-run.
+- No rollout apply.
+- No deploy.
+- No live crawl.
+- No weakening of CN proxy or manual-hold rollout executor gates.
+
+The top-level output always sets `writes_database=false`, `apply_allowed=false`, `rollout_allowed=false`, and `candidate_prep_allowed=false`.
+
+## Output
+
+The output schema is `career_2786_public_resolution_partition.v1`. A successful partition has:
+
+- `status=pass`
+- `partition_pass=true`
+- `partition_status=partitioned`
+- `readiness_pass=false`
+
+`readiness_pass=false` is intentional. The partition is evidence for the next remediation and policy work, not permission to run final 2786 candidate prep or rollout.

--- a/backend/tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerPlanCanonical2786PublicResolutionPartition;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerPlanCanonical2786PublicResolutionPartitionCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(CareerPlanCanonical2786PublicResolutionPartition::class),
+        );
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:plan-canonical-2786-public-resolution-partition', Artisan::all());
+    }
+
+    public function test_writes_final_2786_partition_output_without_mutation(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 85);
+        $occupationMissing = $this->slugs('missing-occupation', 237);
+        $cnProxy = $this->slugs('cn-policy', 1663, 'cn-');
+        $software = ['software-developers'];
+        $baselinePath = $this->writeSlugs('baseline', $baseline);
+        $output = $this->tempPath('output');
+
+        $exitCode = Artisan::call('career:plan-canonical-2786-public-resolution-partition', [
+            '--source-plan' => $this->writeSourcePlan([...$baseline, ...$canonical, ...$occupationMissing, ...$cnProxy, ...$software]),
+            '--closeout' => $this->writeCloseout($baselinePath),
+            '--current-total' => '800',
+            '--target-total' => '2786',
+            '--locales' => 'en,zh',
+            '--entity-context' => $this->writeEntityContext([...$baseline, ...$canonical, ...$cnProxy, ...$software], $occupationMissing),
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('career_2786_public_resolution_partition.v1', $payload['schema_version']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['partition_pass']);
+        $this->assertFalse($payload['readiness_pass']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFalse($payload['rollout_allowed']);
+        $this->assertFalse($payload['candidate_prep_allowed']);
+        $this->assertSame(800, $payload['partition_counts']['already_public_baseline']);
+        $this->assertSame(85, $payload['partition_counts']['canonical_rollout_candidate']);
+        $this->assertSame(237, $payload['partition_counts']['occupation_missing_remediation']);
+        $this->assertSame(1663, $payload['partition_counts']['cn_proxy_policy_asset']);
+        $this->assertSame(1, $payload['partition_counts']['software_manual_hold']);
+        $this->assertSame(5572, $payload['expected_total_locale_rows']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_missing_source_plan_blocks_without_mutation(): void
+    {
+        $baselinePath = $this->writeSlugs('baseline', $this->slugs('baseline', 800));
+
+        $exitCode = Artisan::call('career:plan-canonical-2786-public-resolution-partition', [
+            '--source-plan' => sys_get_temp_dir().'/missing-career-2786-source-plan.json',
+            '--closeout' => $this->writeCloseout($baselinePath),
+            '--json' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame('source_plan_invalid', $payload['blockers'][0]['reason']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['candidate_prep_allowed']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $name, int $count, string $prefix = ''): array
+    {
+        $slugs = [];
+        for ($index = 1; $index <= $count; $index++) {
+            $slugs[] = sprintf('%s%s-%04d', $prefix, $name, $index);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeSlugs(string $name, array $slugs): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, implode(PHP_EOL, $slugs).PHP_EOL);
+
+        return $path;
+    }
+
+    private function writeCloseout(string $baselinePath): string
+    {
+        return $this->writeJson('closeout', [
+            'schema_version' => 'career_progressive_cohort_closeout.v1',
+            'status' => 'complete',
+            'accepted' => true,
+            'target_public_total' => 800,
+            'total_slug_count' => 800,
+            'total_slugs_path' => $baselinePath,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function writeSourcePlan(array $slugs): string
+    {
+        $rows = [];
+        foreach ($slugs as $index => $slug) {
+            $rows[] = [
+                'row_number' => $index + 1,
+                'canonical_slug' => $slug,
+                'public_resolution_state' => str_starts_with($slug, 'cn-') ? 'CN_proxy_hold' : 'ready_for_pilot',
+                'canonical_public_type' => str_starts_with($slug, 'cn-') ? 'public_cn_proxy_page_candidate' : 'public_canonical_job',
+                'content_status' => 'approved',
+                'release_status' => 'ready_for_pilot',
+                'locales' => ['en', 'zh'],
+            ];
+        }
+
+        return $this->writeJson('source-plan', [
+            'schema_version' => 'career_public_resolution_plan.v1',
+            'expected_rows' => count($rows),
+            'rows' => $rows,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $existingSlugs
+     * @param  list<string>  $missingSlugs
+     */
+    private function writeEntityContext(array $existingSlugs, array $missingSlugs): string
+    {
+        $rows = [];
+        foreach ($existingSlugs as $slug) {
+            $rows[] = [
+                'canonical_slug' => $slug,
+                'occupation_exists' => true,
+                'occupation_id' => 'occ-'.$slug,
+            ];
+        }
+        foreach ($missingSlugs as $slug) {
+            $rows[] = [
+                'canonical_slug' => $slug,
+                'occupation_exists' => false,
+                'occupation_id' => null,
+            ];
+        }
+
+        return $this->writeJson('entity-context', [
+            'schema_version' => 'career_entity_context.v1',
+            'rows' => $rows,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $path = $this->tempPath($name);
+        file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function tempPath(string $name): string
+    {
+        return sys_get_temp_dir().'/career-2786-public-resolution-partition-'.Str::uuid().'-'.$name.'.json';
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/Career2786PublicResolutionPartitionPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career2786PublicResolutionPartitionPlannerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\Career2786PublicResolutionPartitionPlanner;
+use App\Domain\Career\Audit\CareerPublicResolutionPlan;
+use App\Domain\Career\Audit\CareerPublicResolutionPlanRow;
+use PHPUnit\Framework\TestCase;
+
+final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
+{
+    public function test_partitions_final_2786_source_without_allowing_final_readiness(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 85);
+        $occupationMissing = $this->slugs('missing-occupation', 237);
+        $cnProxy = $this->slugs('cn-policy', 1663, 'cn-');
+        $software = ['software-developers'];
+
+        $payload = $this->partition(
+            sourceSlugs: [...$baseline, ...$canonical, ...$occupationMissing, ...$cnProxy, ...$software],
+            baselineSlugs: $baseline,
+            occupationExistingSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+        );
+
+        $this->assertSame('career_2786_public_resolution_partition.v1', $payload['schema_version']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['partition_pass']);
+        $this->assertSame('partitioned', $payload['partition_status']);
+        $this->assertFalse($payload['readiness_pass']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFalse($payload['rollout_allowed']);
+        $this->assertFalse($payload['candidate_prep_allowed']);
+        $this->assertSame(800, $payload['partition_counts']['already_public_baseline']);
+        $this->assertSame(85, $payload['partition_counts']['canonical_rollout_candidate']);
+        $this->assertSame(237, $payload['partition_counts']['occupation_missing_remediation']);
+        $this->assertSame(1663, $payload['partition_counts']['cn_proxy_policy_asset']);
+        $this->assertSame(1, $payload['partition_counts']['software_manual_hold']);
+        $this->assertSame(85, $payload['canonical_rollout_candidate_count']);
+        $this->assertSame(885, $payload['canonical_rollout_possible_total']);
+        $this->assertSame(1901, $payload['canonical_rollout_shortfall']);
+        $this->assertFalse($payload['canonical_rollout_can_reach_target']);
+        $this->assertContains('DO_NOT_RUN_2786_CANONICAL_CANDIDATE_PREP', $payload['next_required_actions']);
+        $this->assertContains('2786_OCCUPATION_ENTITY_REMEDIATION_1', $payload['next_required_actions']);
+        $this->assertContains('CN_PROXY_AUTHORITY_POLICY_DECISION_1', $payload['next_required_actions']);
+        $this->assertContains('SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1', $payload['next_required_actions']);
+    }
+
+    public function test_cn_proxy_and_software_manual_hold_are_not_rollout_candidates(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 1984);
+        $cnProxy = ['cn-special-policy'];
+        $software = ['software-developers'];
+
+        $payload = $this->partition(
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+            baselineSlugs: $baseline,
+            occupationExistingSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+        );
+
+        $policyRows = array_values(array_filter(
+            $payload['rows'],
+            static fn (array $row): bool => in_array($row['slug'], ['cn-special-policy', 'software-developers'], true),
+        ));
+
+        $this->assertCount(2, $policyRows);
+        foreach ($policyRows as $row) {
+            $this->assertFalse($row['rollout_candidate']);
+            $this->assertFalse($row['canonical_rollout_candidate']);
+            $this->assertFalse($row['candidate_prep_allowed']);
+            $this->assertTrue($row['requires_policy_decision']);
+        }
+    }
+
+    public function test_blocks_when_source_plan_is_not_complete_2786(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $payload = $this->partition(
+            sourceSlugs: [...$baseline, ...$this->slugs('canonical', 100)],
+            baselineSlugs: $baseline,
+            occupationExistingSlugs: [...$baseline, ...$this->slugs('canonical', 100)],
+        );
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('source_plan_row_count_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
+    /**
+     * @param  list<string>  $sourceSlugs
+     * @param  list<string>  $baselineSlugs
+     * @param  list<string>  $occupationExistingSlugs
+     * @return array<string, mixed>
+     */
+    private function partition(array $sourceSlugs, array $baselineSlugs, array $occupationExistingSlugs): array
+    {
+        return (new Career2786PublicResolutionPartitionPlanner)->partition(
+            sourcePlan: new CareerPublicResolutionPlan(
+                sourcePath: '/tmp/synthetic-career-2786-source.json',
+                checksum: null,
+                rows: $this->sourceRows($sourceSlugs),
+            ),
+            currentCloseout: [
+                'schema_version' => 'career_progressive_closeout.v1',
+                'status' => 'complete',
+                'accepted' => true,
+                'target_public_total' => 800,
+                'total_slug_count' => 800,
+            ],
+            currentPublicSlugs: $baselineSlugs,
+            currentPublicTotal: 800,
+            targetPublicTotal: 2786,
+            locales: ['en', 'zh'],
+            occupationExistingSlugs: $occupationExistingSlugs,
+        )->toArray();
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return list<CareerPublicResolutionPlanRow>
+     */
+    private function sourceRows(array $slugs): array
+    {
+        $rows = [];
+        foreach ($slugs as $index => $slug) {
+            $rows[] = CareerPublicResolutionPlanRow::fromRaw([
+                'row_number' => $index + 1,
+                'canonical_slug' => $slug,
+                'public_resolution_state' => str_starts_with($slug, 'cn-') ? 'CN_proxy_hold' : 'ready_for_pilot',
+                'canonical_public_type' => str_starts_with($slug, 'cn-') ? 'public_cn_proxy_page_candidate' : 'canonical_career_page',
+                'content_status' => 'approved',
+                'release_status' => 'ready_for_pilot',
+                'locales' => ['en', 'zh'],
+                'title_en' => 'Career '.$slug,
+                'title_zh' => '职业 '.$slug,
+                'o_net_code' => '00-0000.00',
+            ]);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $name, int $count, string $prefix = ''): array
+    {
+        $slugs = [];
+        for ($index = 1; $index <= $count; $index++) {
+            $slugs[] = sprintf('%s%s-%04d', $prefix, $name, $index);
+        }
+
+        return $slugs;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -465,6 +465,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php',
             'backend/app/Domain/Career/Audit/Career80RolloutCandidateGate.php',
+            'backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionPlanner.php',
+            'backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionResult.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -2037,6 +2039,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelectionRow.php',
             'backend/app/Domain/Career/Audit/CareerCanonical80CandidateSelector.php',
             'backend/app/Domain/Career/Audit/Career80RolloutCandidateGate.php',
+            'backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionPlanner.php',
+            'backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionResult.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6639,6 +6639,107 @@
         }
       ]
     },
+    "REPAIR-2786-FINAL-PUBLIC-RESOLUTION-PARTITION-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-2786-final-public-resolution-partition-1-202605160412",
+      "title": "fix(api): partition final career 2786 public resolution",
+      "name": "Partition final 2786 public-resolution assets before candidate prep",
+      "status": "in_progress",
+      "depends_on": [
+        "800-CLOSEOUT-1"
+      ],
+      "scope_type": "final_2786_public_resolution_partition_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php",
+        "backend/app/Console/Kernel.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no 2786 readiness execution beyond read-only partition planning",
+        "no candidate prep dry-run",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no production DB mutation",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web",
+        "do not weaken CN proxy or software-developers rollout rejection",
+        "do not mark unresolved policy or occupation-missing rows as rollout candidates"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-2786-FINAL-PUBLIC-RESOLUTION-PARTITION-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "800 closeout artifacts were produced before the 2786 readiness blocker scan; this PR adds only read-only partition logic for the remaining 2786 assets."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to read-only Career 2786 partition command/domain logic, focused tests, audit docs, Kernel registration, and authorized train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_mbti_sidecar",
+          "evidence": [
+            "composer dump-autoload refreshed the temporary worktree autoload mapping after symlinking vendor; no tracked vendor files changed.",
+            "php artisan test --filter=Career2786PublicResolutionPartition --no-ansi: pass (3 tests, 33 assertions)",
+            "php artisan test tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php --no-ansi: pass (3 tests, 22 assertions)",
+            "php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi: pass (16 tests, 69 assertions)",
+            "php artisan test --filter=CareerProgressive --no-ansi: pass (34 tests, 142 assertions)",
+            "php artisan test --filter=Career80TotalLiveAcceptance --no-ansi: pass (11 tests, 49 assertions)",
+            "php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi: pass (27 tests, 138 assertions)",
+            "php artisan test --filter=CareerRuntimeCandidate --no-ansi: pass (8 tests, 40 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-2786-partition.sqlite php artisan migrate --force --no-ansi: pass",
+            "ruby YAML.load_file docs/codex/pr-train.yaml: pass",
+            "python3 -m json.tool docs/codex/pr-train-state.json: pass",
+            "vendor/bin/pint --test: pass after formatting Kernel import order",
+            "git diff --check: pass",
+            "bash backend/scripts/ci_verify_mbti.sh: external blocker in BigFive pack publish/rollback compiled-directory checks; scoped Career tests pass and current PR does not modify BigFive content pack publish/rollback code.",
+            "Local read-only smoke against /tmp 2786 artifacts: status=pass, canonical_rollout_candidate_count=85, occupation_missing_remediation_count=237, cn_proxy_policy_asset_count=1663, software_manual_hold_count=1, readiness_pass=false, writes_database=false."
+          ]
+        },
+        "github_pr": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "2786-PARTITION-REMEDIATION-PLAN-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-20260516",
+          "title": "Local MBTI CI BigFive pack publish and rollback compiled-directory assertions fail outside current PR scope",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
+            "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
+            "Current PR changes only Career 2786 partition command/domain tests/docs/metadata and does not modify BigFive pack publish or rollback implementation."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-LOCAL-CI",
+          "may_continue_train": true
+        }
+      ]
+    },
     "PR-CMS-FIX-MASTER": {
       "repo": "fap-api",
       "branch": "codex/pr-cms-fix-master-semantic-content-gate",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6707,6 +6707,8 @@
             "vendor/bin/pint --test: pass after formatting Kernel import order",
             "git diff --check: pass",
             "bash backend/scripts/ci_verify_mbti.sh: external blocker in BigFive pack publish/rollback compiled-directory checks; scoped Career tests pass and current PR does not modify BigFive content pack publish/rollback code.",
+            "GitHub verify-mbti initially failed because the BigFive runtime freeze classifier did not allow the new Career2786PublicResolutionPartition domain files; added scoped allowlist in the existing Career audit allowlist test.",
+            "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze_classifier --no-ansi: pass (65 tests, 69 assertions)",
             "Local read-only smoke against /tmp 2786 artifacts: status=pass, canonical_rollout_candidate_count=85, occupation_missing_remediation_count=237, cn_proxy_policy_asset_count=1663, software_manual_hold_count=1, readiness_pass=false, writes_database=false."
           ]
         },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3529,8 +3529,8 @@
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "3a3421333223dd45dd4b385432c6941f31205f17",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1415",
       "checks": {
         "content_registry_contract": {
           "status": "pass",
@@ -6610,8 +6610,8 @@
           ]
         },
         "github_pr": {
-          "status": "pending",
-          "evidence": null
+          "status": "created",
+          "evidence": "https://github.com/fermatmind/fap-api/pull/1415"
         }
       },
       "failure_reason": null,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -625,6 +625,48 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-2786-FINAL-PUBLIC-RESOLUTION-PARTITION-1
+    repo: fap-api
+    depends_on:
+      - 800-CLOSEOUT-1
+    branch: codex/repair-2786-final-public-resolution-partition-1
+    title: "fix(api): partition final career 2786 public resolution"
+    name: "Partition final 2786 public-resolution assets before candidate prep"
+    scope:
+      - Add a read-only 2786 public-resolution partition planner.
+      - Separate the accepted 800 baseline, canonical rollout candidates, CN proxy policy assets, occupation-missing remediation rows, and software manual-hold rows.
+      - Preserve CN proxy and software-developers rollout exclusions.
+      - Prevent final 2786 candidate prep from using unresolved policy or entity-remediation rows as canonical rollout candidates.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run 2786 readiness execution beyond read-only partition planning.
+      - Run candidate prep dry-run or apply.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Weaken CN proxy or software-developers rollout rejection.
+      - Mark unresolved policy or occupation-missing rows as rollout candidates.
+    validation:
+      - php artisan test --filter=Career2786PublicResolutionPartition --no-ansi
+      - php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi
+      - php artisan test --filter=CareerProgressive --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- adds a read-only final 2786 public-resolution partition planner and Artisan command
- separates accepted 800 baseline, canonical rollout candidates, CN proxy policy assets, occupation-missing remediation rows, and software manual-hold rows
- preserves CN proxy and software-developers rollout exclusions; unresolved policy/remediation rows are not rollout candidates

## Validation
- php artisan test --filter=Career2786PublicResolutionPartition --no-ansi
- php artisan test tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php --no-ansi
- php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi
- php artisan test --filter=CareerProgressive --no-ansi
- php artisan test --filter=Career80TotalLiveAcceptance --no-ansi
- php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi
- php artisan test --filter=CareerRuntimeCandidate --no-ansi
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-2786-partition.sqlite php artisan migrate --force --no-ansi
- vendor/bin/pint --test
- git diff --check && git diff --cached --check

## Notes
- No deploy, DB mutation, candidate prep, rollout dry-run, rollout apply, rollback, quarantine, or fap-web action was run.
- Local read-only smoke on /tmp 2786 artifacts produced canonical_rollout_candidate_count=85, occupation_missing_remediation_count=237, cn_proxy_policy_asset_count=1663, software_manual_hold_count=1, readiness_pass=false, writes_database=false.
- bash backend/scripts/ci_verify_mbti.sh still has external BigFive pack publish/rollback compiled-directory failures outside this PR scope; scoped Career tests and BigFive runtime freeze classifier passed.

## Next
2786-PARTITION-REMEDIATION-PLAN-1