### PR TITLE
fix(api): gate reviewed CN proxy public owner plan

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCnProxyPublicOwner.php
+++ b/backend/app/Console/Commands/CareerValidateCnProxyPublicOwner.php
@@ -11,8 +11,34 @@ final class CareerValidateCnProxyPublicOwner extends Command
 {
     private const EXPECTED_CN_PROXY_ROWS = 1663;
 
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_TRUST_MANIFEST_FIELDS = [
+        'claim_id',
+        'row_number',
+        'slug',
+        'public_resolution_type',
+        'claim_text',
+        'claim_locale',
+        'source_authority_model',
+        'evidence_refs',
+        'evidence_strength',
+        'reviewer',
+        'reviewed_at',
+        'schema_policy',
+        'indexability',
+        'sitemap_eligible',
+        'llms_eligible',
+        'llms_full_eligible',
+        'boundary_disclaimer',
+        'rollback_condition',
+        'last_validated_at',
+    ];
+
     protected $signature = 'career:validate-cn-proxy-public-owner
         {--scope= : Phase 2C CN proxy scope JSON artifact}
+        {--manifest= : Optional reviewed CN proxy trust manifest JSON artifact}
         {--dry-run : Validate without writing}
         {--json : Emit JSON output}
         {--output= : Optional JSON output artifact path}
@@ -25,7 +51,21 @@ final class CareerValidateCnProxyPublicOwner extends Command
         try {
             $scopePath = $this->resolveScopePath();
             $rows = $this->loadRows($scopePath);
-            $summary = $this->summarizeRows($rows);
+            $manifestPath = $this->resolveManifestPath();
+            $claims = $manifestPath === null ? [] : $this->loadClaims($manifestPath);
+            $summary = $this->summarizeRows($rows, $claims);
+            $reviewedTrustManifestComplete = $manifestPath !== null
+                && $summary['manifest_complete_rows'] === count($rows)
+                && $summary['missing_manifest_rows'] === 0
+                && $summary['missing_evidence_rows'] === 0
+                && $summary['missing_disclaimer_rows'] === 0
+                && $summary['missing_reviewer_reviewed_at_rows'] === 0
+                && $summary['missing_rollback_condition_rows'] === 0
+                && $summary['public_eligible_claim_rows'] === 0
+                && $summary['public_indexable_claim_rows'] === 0
+                && $summary['sitemap_eligible_claim_rows'] === 0
+                && $summary['llms_eligible_claim_rows'] === 0
+                && $summary['llms_full_eligible_claim_rows'] === 0;
 
             $payload = [
                 'status' => 'validated',
@@ -33,12 +73,26 @@ final class CareerValidateCnProxyPublicOwner extends Command
                 'dry_run' => true,
                 'did_write' => false,
                 'scope_path' => $scopePath,
+                'manifest_path' => $manifestPath,
                 'timestamp' => $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null),
                 'cn_proxy_rows' => count($rows),
+                'reviewed_trust_manifest_required' => true,
+                'reviewed_trust_manifest_rows' => count($claims),
+                'reviewed_trust_manifest_complete' => $reviewedTrustManifestComplete,
+                'manifest_complete_rows' => $manifestPath === null ? 0 : $summary['manifest_complete_rows'],
+                'required_trust_manifest_fields' => self::REQUIRED_TRUST_MANIFEST_FIELDS,
+                'missing_manifest_rows' => $manifestPath === null ? 0 : $summary['missing_manifest_rows'],
+                'missing_evidence_rows' => $manifestPath === null ? 0 : $summary['missing_evidence_rows'],
+                'missing_disclaimer_rows' => $manifestPath === null ? 0 : $summary['missing_disclaimer_rows'],
+                'missing_reviewer_reviewed_at_rows' => $manifestPath === null ? 0 : $summary['missing_reviewer_reviewed_at_rows'],
+                'missing_rollback_condition_rows' => $manifestPath === null ? 0 : $summary['missing_rollback_condition_rows'],
                 'route_owner_enabled' => false,
                 'public_pages_exposed' => 0,
                 'public_route_allowed' => false,
-                'guarded_public_owner_state' => 'disabled_until_CN_authority_policy_trust_manifest_disclaimer_and_release_gate',
+                'public_owner_plan_ready' => $reviewedTrustManifestComplete,
+                'guarded_public_owner_state' => $reviewedTrustManifestComplete
+                    ? 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train'
+                    : 'disabled_until_CN_authority_policy_trust_manifest_disclaimer_and_release_gate',
                 'ledger_decision_required' => true,
                 'CN_authority_policy_required' => true,
                 'trust_manifest_required' => true,
@@ -47,9 +101,11 @@ final class CareerValidateCnProxyPublicOwner extends Command
                 'rejects_rows_without_ledger_decision' => true,
                 'rejects_rows_without_trust_manifest' => true,
                 'rejects_rows_without_disclaimer' => true,
+                'reviewed_manifest_blocks_canonical_rollout' => true,
                 'CN_proxy_can_masquerade_as_US_canonical_job' => false,
                 'US_canonical_job_schema_returned' => false,
                 'noindex_default' => true,
+                'public_cn_proxy_page_rows' => $reviewedTrustManifestComplete ? count($rows) : 0,
                 'indexable_CN_proxy_rows' => 0,
                 'sitemap_CN_urls' => 0,
                 'llms_CN_urls' => 0,
@@ -65,8 +121,18 @@ final class CareerValidateCnProxyPublicOwner extends Command
                 count($rows) === self::EXPECTED_CN_PROXY_ROWS ? null : 'unexpected_CN_proxy_row_count',
                 $summary['non_cn_proxy_rows'] === 0 ? null : 'non_CN_proxy_rows_in_scope',
                 $summary['public_candidate_rows'] === 0 ? null : 'CN_proxy_public_resolution_present_before_public_owner_policy',
-                $summary['missing_disclaimer_rows'] === 0 ? null : 'CN_proxy_missing_disclaimer_requirement',
-                $summary['missing_trust_manifest_rows'] === 0 ? null : 'CN_proxy_missing_trust_manifest_requirement',
+                $summary['scope_missing_disclaimer_rows'] === 0 ? null : 'CN_proxy_missing_disclaimer_requirement',
+                $summary['scope_missing_trust_manifest_rows'] === 0 ? null : 'CN_proxy_missing_trust_manifest_requirement',
+                $manifestPath === null || $summary['missing_manifest_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_missing_rows',
+                $manifestPath === null || $summary['missing_evidence_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_evidence_missing',
+                $manifestPath === null || $summary['missing_disclaimer_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_disclaimer_missing',
+                $manifestPath === null || $summary['missing_reviewer_reviewed_at_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_reviewer_missing',
+                $manifestPath === null || $summary['missing_rollback_condition_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_rollback_condition_missing',
+                $manifestPath === null || $summary['public_eligible_claim_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_public_eligible_rows',
+                $manifestPath === null || $summary['public_indexable_claim_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_indexable_rows',
+                $manifestPath === null || $summary['sitemap_eligible_claim_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_sitemap_rows',
+                $manifestPath === null || $summary['llms_eligible_claim_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_llms_rows',
+                $manifestPath === null || $summary['llms_full_eligible_claim_rows'] === 0 ? null : 'CN_proxy_public_owner_manifest_llms_full_rows',
             ]));
 
             $this->writeOutputArtifact($payload);
@@ -108,6 +174,21 @@ final class CareerValidateCnProxyPublicOwner extends Command
         throw new \RuntimeException('career CN proxy scope artifact path is required');
     }
 
+    private function resolveManifestPath(): ?string
+    {
+        $value = $this->option('manifest');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        $path = trim((string) $value);
+        if (! is_file($path)) {
+            throw new \RuntimeException('career CN proxy reviewed trust manifest artifact not found: '.$path);
+        }
+
+        return $path;
+    }
+
     /**
      * @return list<array<string, mixed>>
      */
@@ -130,16 +211,61 @@ final class CareerValidateCnProxyPublicOwner extends Command
     }
 
     /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function loadClaims(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('career CN proxy reviewed trust manifest artifact is not valid JSON: '.$path);
+        }
+
+        $rows = data_get($payload, 'claims');
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'rows');
+        }
+        if (! is_array($rows)) {
+            throw new \RuntimeException('career CN proxy reviewed trust manifest artifact has no claims: '.$path);
+        }
+
+        $claims = [];
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->nullableString($row['slug'] ?? null) ?? $this->nullableString($row['source_slug'] ?? null);
+            if ($slug !== null) {
+                $claims[$slug] = $row;
+            }
+        }
+
+        return $claims;
+    }
+
+    /**
      * @param  list<array<string, mixed>>  $rows
+     * @param  array<string, array<string, mixed>>  $claims
      * @return array<string, int>
      */
-    private function summarizeRows(array $rows): array
+    private function summarizeRows(array $rows, array $claims): array
     {
         $summary = [
             'non_cn_proxy_rows' => 0,
             'public_candidate_rows' => 0,
+            'scope_missing_disclaimer_rows' => 0,
+            'scope_missing_trust_manifest_rows' => 0,
+            'manifest_complete_rows' => 0,
+            'missing_manifest_rows' => 0,
             'missing_disclaimer_rows' => 0,
-            'missing_trust_manifest_rows' => 0,
+            'missing_evidence_rows' => 0,
+            'missing_reviewer_reviewed_at_rows' => 0,
+            'missing_rollback_condition_rows' => 0,
+            'public_eligible_claim_rows' => 0,
+            'public_indexable_claim_rows' => 0,
+            'sitemap_eligible_claim_rows' => 0,
+            'llms_eligible_claim_rows' => 0,
+            'llms_full_eligible_claim_rows' => 0,
         ];
 
         foreach ($rows as $row) {
@@ -153,14 +279,89 @@ final class CareerValidateCnProxyPublicOwner extends Command
             }
 
             if (! (bool) ($row['disclaimer_required'] ?? false)) {
-                $summary['missing_disclaimer_rows']++;
+                $summary['scope_missing_disclaimer_rows']++;
             }
             if (! (bool) ($row['trust_manifest_required'] ?? false)) {
-                $summary['missing_trust_manifest_rows']++;
+                $summary['scope_missing_trust_manifest_rows']++;
+            }
+
+            $slug = $this->nullableString($row['source_slug'] ?? null) ?? $this->nullableString($row['slug'] ?? null);
+            $claim = $slug === null ? null : ($claims[$slug] ?? null);
+            if (! is_array($claim)) {
+                $summary['missing_manifest_rows']++;
+                $summary['missing_evidence_rows']++;
+                $summary['missing_disclaimer_rows']++;
+                $summary['missing_reviewer_reviewed_at_rows']++;
+                $summary['missing_rollback_condition_rows']++;
+
+                continue;
+            }
+
+            $missingFields = array_filter(self::REQUIRED_TRUST_MANIFEST_FIELDS, fn (string $field): bool => $this->fieldMissing($claim, $field));
+            if ($missingFields === []) {
+                $summary['manifest_complete_rows']++;
+            }
+
+            if ($this->fieldMissing($claim, 'evidence_refs') || $this->fieldMissing($claim, 'evidence_strength')) {
+                $summary['missing_evidence_rows']++;
+            }
+            if ($this->fieldMissing($claim, 'boundary_disclaimer')) {
+                $summary['missing_disclaimer_rows']++;
+            }
+            if ($this->fieldMissing($claim, 'reviewer') || $this->fieldMissing($claim, 'reviewed_at')) {
+                $summary['missing_reviewer_reviewed_at_rows']++;
+            }
+            if ($this->fieldMissing($claim, 'rollback_condition')) {
+                $summary['missing_rollback_condition_rows']++;
+            }
+            if ((bool) ($claim['public_eligible'] ?? false)) {
+                $summary['public_eligible_claim_rows']++;
+            }
+            if ($this->claimIsPublicIndexable($claim)) {
+                $summary['public_indexable_claim_rows']++;
+            }
+            if ((bool) ($claim['sitemap_eligible'] ?? false)) {
+                $summary['sitemap_eligible_claim_rows']++;
+            }
+            if ((bool) ($claim['llms_eligible'] ?? false)) {
+                $summary['llms_eligible_claim_rows']++;
+            }
+            if ((bool) ($claim['llms_full_eligible'] ?? false)) {
+                $summary['llms_full_eligible_claim_rows']++;
             }
         }
 
         return $summary;
+    }
+
+    /**
+     * @param  array<string, mixed>  $claim
+     */
+    private function claimIsPublicIndexable(array $claim): bool
+    {
+        $indexability = strtolower((string) ($claim['indexability'] ?? ''));
+
+        return in_array($indexability, ['indexable', 'public_indexable'], true);
+    }
+
+    /**
+     * @param  array<string, mixed>  $claim
+     */
+    private function fieldMissing(array $claim, string $field): bool
+    {
+        if (! array_key_exists($field, $claim)) {
+            return true;
+        }
+
+        $value = $claim[$field];
+        if (is_array($value)) {
+            return $value === [];
+        }
+        if (is_bool($value) || is_int($value) || is_float($value)) {
+            return false;
+        }
+
+        return $this->nullableString($value) === null;
     }
 
     private function normalizeTimestamp(?string $value): string
@@ -175,6 +376,17 @@ final class CareerValidateCnProxyPublicOwner extends Command
         }
 
         return $normalized;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
     }
 
     /**

--- a/backend/docs/career/audits/cn_proxy_public_owner.md
+++ b/backend/docs/career/audits/cn_proxy_public_owner.md
@@ -1,0 +1,52 @@
+# CN Proxy Public Owner Gate
+
+The CN proxy public owner gate is a read-only validation step for the non-canonical CN proxy partition in the Career 2786 release.
+
+CN proxy rows are not canonical rollout candidates. They must not enter candidate preparation, canonical rollout, sitemap generation, llms, llms-full, or US canonical job schema paths.
+
+## Inputs
+
+- Phase 2C CN proxy scope artifact.
+- Optional reviewed CN proxy trust manifest artifact.
+
+The reviewed trust manifest must include one claim per CN proxy row with evidence, reviewer, reviewed timestamp, disclaimer, rollback condition, and non-indexable policy fields.
+
+## Output
+
+`career:validate-cn-proxy-public-owner` emits a JSON validation payload. With no reviewed manifest it preserves the disabled owner state:
+
+- `public_owner_plan_ready=false`
+- `route_owner_enabled=false`
+- `public_route_allowed=false`
+- `public_pages_exposed=0`
+- `noindex_default=true`
+
+With a complete reviewed manifest it may mark the separate owner plan ready:
+
+- `reviewed_trust_manifest_complete=true`
+- `public_owner_plan_ready=true`
+- `guarded_public_owner_state=reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train`
+
+The command still keeps public route exposure disabled and reports zero sitemap, llms, llms-full, occupation, crosswalk, and display-asset deltas.
+
+## Blockers
+
+The gate blocks when:
+
+- the CN proxy row count is not 1663,
+- non-CN rows are present,
+- the source scope already marks CN proxy rows as public candidates,
+- the reviewed manifest is incomplete,
+- reviewer or reviewed timestamp is missing,
+- evidence, disclaimer, or rollback condition is missing,
+- any claim is public eligible, indexable, sitemap eligible, llms eligible, or llms-full eligible.
+
+## Non-goals
+
+- No DB mutation.
+- No deploy.
+- No rollout or rollout dry-run.
+- No candidate prep.
+- No public route exposure.
+- No canonical job schema for CN proxy rows.
+- No sitemap, llms, or llms-full eligibility.

--- a/backend/tests/Feature/Console/CareerValidateCnProxyPublicOwnerCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCnProxyPublicOwnerCommandTest.php
@@ -35,6 +35,9 @@ final class CareerValidateCnProxyPublicOwnerCommandTest extends TestCase
         $this->assertTrue((bool) ($payload['dry_run'] ?? false));
         $this->assertFalse((bool) ($payload['did_write'] ?? true));
         $this->assertSame(1663, (int) ($payload['cn_proxy_rows'] ?? 0));
+        $this->assertNull($payload['manifest_path'] ?? null);
+        $this->assertFalse((bool) ($payload['reviewed_trust_manifest_complete'] ?? true));
+        $this->assertFalse((bool) ($payload['public_owner_plan_ready'] ?? true));
         $this->assertFalse((bool) ($payload['route_owner_enabled'] ?? true));
         $this->assertSame(0, (int) ($payload['public_pages_exposed'] ?? -1));
         $this->assertFalse((bool) ($payload['public_route_allowed'] ?? true));
@@ -60,6 +63,96 @@ final class CareerValidateCnProxyPublicOwnerCommandTest extends TestCase
         $this->assertSame(0, (int) ($payload['occupation_crosswalks_delta'] ?? -1));
         $this->assertSame([], $payload['blockers'] ?? null);
         $this->assertFileExists($outputPath);
+    }
+
+    public function test_it_accepts_reviewed_noindex_trust_manifest_for_guarded_public_owner_plan(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture();
+        $manifestPath = $this->writeReviewedTrustManifestFixture();
+
+        $exitCode = Artisan::call('career:validate-cn-proxy-public-owner', [
+            '--scope' => $scopePath,
+            '--manifest' => $manifestPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame($manifestPath, $payload['manifest_path'] ?? null);
+        $this->assertSame(1663, (int) ($payload['reviewed_trust_manifest_rows'] ?? 0));
+        $this->assertSame(1663, (int) ($payload['manifest_complete_rows'] ?? 0));
+        $this->assertSame(0, (int) ($payload['missing_manifest_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['missing_evidence_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['missing_disclaimer_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['missing_reviewer_reviewed_at_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['missing_rollback_condition_rows'] ?? -1));
+        $this->assertTrue((bool) ($payload['reviewed_trust_manifest_complete'] ?? false));
+        $this->assertTrue((bool) ($payload['public_owner_plan_ready'] ?? false));
+        $this->assertSame('reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train', $payload['guarded_public_owner_state'] ?? null);
+        $this->assertSame(1663, (int) ($payload['public_cn_proxy_page_rows'] ?? 0));
+        $this->assertFalse((bool) ($payload['route_owner_enabled'] ?? true));
+        $this->assertSame(0, (int) ($payload['public_pages_exposed'] ?? -1));
+        $this->assertFalse((bool) ($payload['public_route_allowed'] ?? true));
+        $this->assertTrue((bool) ($payload['reviewed_manifest_blocks_canonical_rollout'] ?? false));
+        $this->assertTrue((bool) ($payload['noindex_default'] ?? false));
+        $this->assertSame(0, (int) ($payload['indexable_CN_proxy_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['sitemap_CN_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_CN_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_full_CN_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['display_asset_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['career_job_display_assets_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['occupations_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['occupation_crosswalks_delta'] ?? -1));
+        $this->assertSame([], $payload['blockers'] ?? null);
+    }
+
+    public function test_it_blocks_reviewed_manifest_missing_reviewer_fields(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture();
+        $manifestPath = $this->writeReviewedTrustManifestFixture(missingReviewerRows: 1);
+
+        $exitCode = Artisan::call('career:validate-cn-proxy-public-owner', [
+            '--scope' => $scopePath,
+            '--manifest' => $manifestPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertFalse((bool) ($payload['reviewed_trust_manifest_complete'] ?? true));
+        $this->assertFalse((bool) ($payload['public_owner_plan_ready'] ?? true));
+        $this->assertSame(1, (int) ($payload['missing_reviewer_reviewed_at_rows'] ?? 0));
+        $this->assertContains('CN_proxy_public_owner_manifest_reviewer_missing', (array) ($payload['blockers'] ?? []));
+    }
+
+    public function test_it_blocks_reviewed_manifest_that_attempts_index_sitemap_or_llms_eligibility(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture();
+        $manifestPath = $this->writeReviewedTrustManifestFixture(indexableRows: 1);
+
+        $exitCode = Artisan::call('career:validate-cn-proxy-public-owner', [
+            '--scope' => $scopePath,
+            '--manifest' => $manifestPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertFalse((bool) ($payload['reviewed_trust_manifest_complete'] ?? true));
+        $this->assertFalse((bool) ($payload['public_owner_plan_ready'] ?? true));
+        $this->assertContains('CN_proxy_public_owner_manifest_indexable_rows', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('CN_proxy_public_owner_manifest_sitemap_rows', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('CN_proxy_public_owner_manifest_llms_rows', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('CN_proxy_public_owner_manifest_llms_full_rows', (array) ($payload['blockers'] ?? []));
     }
 
     public function test_it_rejects_cn_public_candidates_before_public_owner_policy(): void
@@ -101,6 +194,48 @@ final class CareerValidateCnProxyPublicOwnerCommandTest extends TestCase
             'scope' => 'CN_proxy_hold',
             'count' => 1663,
             'rows' => $rows,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    private function writeReviewedTrustManifestFixture(int $missingReviewerRows = 0, int $indexableRows = 0): string
+    {
+        $path = storage_path('framework/testing/career-cn-proxy-reviewed-trust-manifest.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        $claims = [];
+        for ($index = 1; $index <= 1663; $index++) {
+            $slug = sprintf('cn-proxy-%04d', $index);
+            $claims[] = [
+                'claim_id' => sprintf('cn-proxy-claim-%04d', $index),
+                'row_number' => 794 + $index,
+                'slug' => $slug,
+                'public_resolution_type' => 'public_cn_proxy_page',
+                'claim_text' => sprintf('Reviewed CN proxy public owner claim %04d', $index),
+                'claim_locale' => 'zh-CN',
+                'source_authority_model' => 'reviewed_cn_proxy_trust_manifest',
+                'evidence_refs' => [
+                    sprintf('source-plan-row:%d', 794 + $index),
+                ],
+                'evidence_strength' => 'reviewed_source_trace',
+                'reviewer' => $index <= $missingReviewerRows ? '' : 'reviewer',
+                'reviewed_at' => $index <= $missingReviewerRows ? '' : '2026-05-15T21:30:56Z',
+                'schema_policy' => 'no_US_canonical_job_schema',
+                'indexability' => $index <= $indexableRows ? 'indexable' : 'noindex',
+                'public_eligible' => false,
+                'sitemap_eligible' => $index <= $indexableRows,
+                'llms_eligible' => $index <= $indexableRows,
+                'llms_full_eligible' => $index <= $indexableRows,
+                'boundary_disclaimer' => 'CN proxy page is not a US canonical occupation guide.',
+                'rollback_condition' => 'Rollback if CN public owner policy or reviewed evidence is invalidated.',
+                'last_validated_at' => '2026-05-15T21:30:56Z',
+            ];
+        }
+
+        File::put($path, (string) json_encode([
+            'schema_version' => 'career_2786_cn_proxy_trust_manifest_reviewed.v1',
+            'claims' => $claims,
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
         return $path;

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-15T21:52:00+08:00",
+  "updated_at": "2026-05-16T13:45:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6735,6 +6735,100 @@
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
             "Current PR changes only Career 2786 partition command/domain tests/docs/metadata and does not modify BigFive pack publish or rollback implementation."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-LOCAL-CI",
+          "may_continue_train": true
+        }
+      ]
+    },
+    "2786-CN-PROXY-PUBLIC-OWNER-PR-TRAIN-1": {
+      "repo": "fap-api",
+      "branch": "codex/2786-cn-proxy-public-owner-pr-train-1",
+      "title": "fix(api): gate reviewed CN proxy public owner plan",
+      "name": "Gate reviewed CN proxy public owner plan for 2786",
+      "status": "in_progress",
+      "depends_on": [
+        "REPAIR-2786-FINAL-PUBLIC-RESOLUTION-PARTITION-1",
+        "CN-PROXY-AUTHORITY-POLICY-DECISION-1",
+        "2786-CN-PROXY-TRUST-MANIFEST-REVIEW-1"
+      ],
+      "scope_type": "cn_proxy_public_owner_reviewed_manifest_gate_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerValidateCnProxyPublicOwner.php",
+        "backend/tests/Feature/Console/CareerValidateCnProxyPublicOwnerCommandTest.php",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no 2786 readiness execution",
+        "no candidate prep dry-run",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no production DB mutation",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web",
+        "do not enable CN proxy indexability, sitemap, llms, llms-full, or public route exposure",
+        "do not mark CN proxy rows as canonical rollout candidates"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for 2786-CN-PROXY-PUBLIC-OWNER-PR-TRAIN-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "2786 partition, CN proxy authority policy decision, and reviewed trust manifest artifacts were completed before this PR started."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to the CN proxy public-owner validator, focused Feature tests, audit docs, and authorized train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_mbti_sidecar",
+          "evidence": [
+            "php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi: pass (5 tests, 79 assertions)",
+            "php artisan test --filter=CareerValidateCnTrustManifest --no-ansi: pass (4 tests, 56 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cn-proxy-public-owner.sqlite php artisan migrate --force --no-ansi: pass",
+            "ruby YAML.load_file docs/codex/pr-train.yaml: pass",
+            "python3 -m json.tool docs/codex/pr-train-state.json: pass",
+            "vendor/bin/pint --test: pass",
+            "git diff --check: pass",
+            "Local read-only smoke against /tmp reviewed CN proxy trust manifest: status=validated, cn_proxy_rows=1663, reviewed_trust_manifest_complete=true, public_owner_plan_ready=true, route_owner_enabled=false, public_route_allowed=false, sitemap_CN_urls=0, llms_CN_urls=0, llms_full_CN_urls=0, did_write=false.",
+            "bash backend/scripts/ci_verify_mbti.sh: external blocker in BigFive pack publish/rollback compiled-directory checks; scoped Career tests pass and current PR does not modify BigFive content pack publish/rollback code."
+          ]
+        },
+        "github_pr": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "2786-CN-PROXY-PUBLIC-OWNER-PLAN-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-20260516-CN-PROXY-OWNER",
+          "title": "Local MBTI CI BigFive pack publish and rollback compiled-directory assertions fail outside CN proxy public-owner scope",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
+            "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
+            "Current PR changes only the Career CN proxy public-owner validator, focused console tests, audit docs, and authorized train metadata."
           ],
           "severity": "medium",
           "next_goal": "SCAN-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-LOCAL-CI",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -667,6 +667,46 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: 2786-CN-PROXY-PUBLIC-OWNER-PR-TRAIN-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-2786-FINAL-PUBLIC-RESOLUTION-PARTITION-1
+      - CN-PROXY-AUTHORITY-POLICY-DECISION-1
+      - 2786-CN-PROXY-TRUST-MANIFEST-REVIEW-1
+    branch: codex/2786-cn-proxy-public-owner-pr-train-1
+    title: "fix(api): gate reviewed CN proxy public owner plan"
+    name: "Gate reviewed CN proxy public owner plan for 2786"
+    scope:
+      - Extend the read-only CN proxy public owner validator to consume a reviewed trust manifest.
+      - Mark the separate noindex public CN proxy owner plan ready only when reviewed manifest evidence is complete.
+      - Preserve canonical rollout exclusion, noindex, sitemap, llms, llms-full, and no public route exposure semantics.
+      - Keep the command read-only with no DB mutation, deploy, candidate prep, rollout, or frontend change.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerValidateCnProxyPublicOwner.php
+      - backend/tests/Feature/Console/CareerValidateCnProxyPublicOwnerCommandTest.php
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run 2786 readiness execution.
+      - Run candidate prep dry-run or apply.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Enable CN proxy indexability, sitemap, llms, llms-full, or public route exposure.
+      - Mark CN proxy rows as canonical rollout candidates.
+    validation:
+      - php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi
+      - php artisan test --filter=CareerValidateCnTrustManifest --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- Adds reviewed trust-manifest input support to `career:validate-cn-proxy-public-owner`.
- Marks the separate noindex CN proxy public-owner plan ready only when all 1663 reviewed trust-manifest claims are complete.
- Preserves canonical rollout exclusion, no public route exposure, no sitemap, no llms, no llms-full, and no US canonical job schema for CN proxy rows.
- Registers `2786-CN-PROXY-PUBLIC-OWNER-PR-TRAIN-1` in the PR train metadata.

## Non-goals
- No DB mutation.
- No deploy.
- No candidate prep.
- No rollout dry-run or rollout apply.
- No fap-web changes.

## Validation
- `php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi` passed.
- `php artisan test --filter=CareerValidateCnTrustManifest --no-ansi` passed.
- `php artisan route:list --no-ansi` passed.
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cn-proxy-public-owner.sqlite php artisan migrate --force --no-ansi` passed.
- `vendor/bin/pint --test` passed.
- `git diff --check` passed.
- Local smoke with `/tmp/career_2786_cn_proxy_scope_with_source_slug.json` and `/tmp/career_2786_cn_proxy_trust_manifest_reviewed_validator_normalized.json` passed with `public_owner_plan_ready=true`, route exposure false, sitemap/llms counts zero, and `did_write=false`.

## Known External Sidecar
- `bash backend/scripts/ci_verify_mbti.sh` still fails in existing BigFive pack publish/rollback compiled-directory assertions. This PR does not modify BigFive pack publish/rollback code or generated content pack assets; generated local test artifacts were removed before staging.

## Next Step
- `2786-CN-PROXY-PUBLIC-OWNER-PLAN-1` once this PR is merged.
