### PR TITLE
fix(api): account reviewed public owner partition in 2786 readiness

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
@@ -20,6 +20,7 @@ final class CareerPlanCanonical2786PublicResolutionPartition extends Command
         {--target-total=2786 : Target public total}
         {--locales=en,zh : Comma-separated locales}
         {--entity-context= : Optional entity context JSON; if supplied, rows without occupation_exists=true are partitioned for remediation}
+        {--cn-proxy-public-owner-plan= : Optional reviewed CN proxy public-owner plan JSON for final 2786 partition accounting}
         {--strict : Fail on source-plan validation issues}
         {--json : Emit JSON output}
         {--output= : Optional output path for final 2786 partition JSON}';
@@ -45,6 +46,13 @@ final class CareerPlanCanonical2786PublicResolutionPartition extends Command
 
             $closeout = $this->readJson($closeoutPath, 'closeout');
             $entityContextPath = $this->pathOption('entity-context');
+            $cnProxyPublicOwnerPlanPath = $this->pathOption('cn-proxy-public-owner-plan');
+            $cnProxyPublicOwnerPlan = $cnProxyPublicOwnerPlanPath === null
+                ? null
+                : [
+                    ...$this->readJson($cnProxyPublicOwnerPlanPath, 'cn_proxy_public_owner_plan'),
+                    'source_path' => $cnProxyPublicOwnerPlanPath,
+                ];
             $payload = app(Career2786PublicResolutionPartitionPlanner::class)->partition(
                 sourcePlan: $sourcePlan,
                 currentCloseout: $closeout,
@@ -53,6 +61,7 @@ final class CareerPlanCanonical2786PublicResolutionPartition extends Command
                 targetPublicTotal: $this->intOption('target-total'),
                 locales: $this->localesOption(),
                 occupationExistingSlugs: $entityContextPath === null ? null : $this->readOccupationExistingSlugs($entityContextPath),
+                cnProxyPublicOwnerPlan: $cnProxyPublicOwnerPlan,
             )->toArray();
 
             $payload['source_plan']['validation_issue_count'] = count($sourcePlanValidation->issues);

--- a/backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php
@@ -20,6 +20,7 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
         {--target-total= : Required target public total: 300, 800, or 2786}
         {--locales=en,zh : Comma-separated locales}
         {--entity-context= : Optional production-derived entity context JSON; if supplied, selected delta slugs must have occupation_exists=true}
+        {--cn-proxy-public-owner-plan= : Optional reviewed CN proxy public-owner plan JSON for final 2786 partition accounting}
         {--exclude-slugs= : Optional newline, comma, or JSON slug artifact to exclude}
         {--strict : Fail on source-plan validation issues}
         {--json : Emit JSON output}
@@ -45,6 +46,13 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
             $baselinePath = $this->pathFromCloseout($closeout, 'total_slugs_path');
             $excludePath = $this->pathOption('exclude-slugs');
             $entityContextPath = $this->pathOption('entity-context');
+            $cnProxyPublicOwnerPlanPath = $this->pathOption('cn-proxy-public-owner-plan');
+            $cnProxyPublicOwnerPlan = $cnProxyPublicOwnerPlanPath === null
+                ? null
+                : [
+                    ...$this->readJson($cnProxyPublicOwnerPlanPath, 'cn_proxy_public_owner_plan'),
+                    'source_path' => $cnProxyPublicOwnerPlanPath,
+                ];
             $payload = app(CareerProgressiveReadinessSelector::class)->select(
                 sourcePlan: $sourcePlan,
                 currentCloseout: $closeout,
@@ -54,6 +62,7 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
                 locales: $this->localesOption(),
                 excludeSlugs: $excludePath === null ? [] : $this->readSlugList($excludePath, 'exclude_slug'),
                 occupationExistingSlugs: $entityContextPath === null ? null : $this->readOccupationExistingSlugs($entityContextPath),
+                cnProxyPublicOwnerPlan: $cnProxyPublicOwnerPlan,
                 strict: (bool) $this->option('strict'),
             )->toArray();
 

--- a/backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionPlanner.php
+++ b/backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionPlanner.php
@@ -25,6 +25,7 @@ final class Career2786PublicResolutionPartitionPlanner
         int $targetPublicTotal = self::TARGET_PUBLIC_TOTAL,
         array $locales = ['en', 'zh'],
         ?array $occupationExistingSlugs = null,
+        ?array $cnProxyPublicOwnerPlan = null,
     ): Career2786PublicResolutionPartitionResult {
         $locales = $this->normalizedStringList($locales, 'locale');
         $baselineSlugs = $this->normalizedSlugList($currentPublicSlugs, 'baseline_slug');
@@ -34,6 +35,7 @@ final class Career2786PublicResolutionPartitionPlanner
         $baselineSet = array_fill_keys($baselineSlugs, true);
         $occupationExistingSet = $occupationExistingSlugs === null ? [] : array_fill_keys($occupationExistingSlugs, true);
         $requiresOccupationExists = $occupationExistingSlugs !== null;
+        $cnProxyPublicOwnerAuthority = $this->cnProxyPublicOwnerAuthority($cnProxyPublicOwnerPlan, $targetPublicTotal);
         $seenSourceSlugs = [];
         $duplicateSourceSlugs = [];
         $sourceSlugMissingCount = 0;
@@ -98,6 +100,9 @@ final class Career2786PublicResolutionPartitionPlanner
             sourceSlugMissingCount: $sourceSlugMissingCount,
             duplicateSourceSlugs: $duplicateSourceSlugs,
         );
+        foreach ($cnProxyPublicOwnerAuthority['issues'] as $issue) {
+            $issues[] = $issue;
+        }
         $partitionCounts = [];
         foreach ($partitions as $partition => $slugs) {
             $partitionCounts[$partition] = count($slugs);
@@ -110,13 +115,19 @@ final class Career2786PublicResolutionPartitionPlanner
         $occupationMissingCount = $partitionCounts['occupation_missing_remediation'];
         $cnProxyCount = $partitionCounts['cn_proxy_policy_asset'];
         $softwareManualHoldCount = $partitionCounts['software_manual_hold'];
+        $cnProxyPublicOwnerCount = min((int) $cnProxyPublicOwnerAuthority['public_owner_count'], $cnProxyCount);
+        $cnProxyPolicyUnresolvedCount = max(0, $cnProxyCount - $cnProxyPublicOwnerCount);
+        $finalPublicAccountedTotal = count($baselineSlugs) + $canonicalCandidateCount + $cnProxyPublicOwnerCount;
+        $finalPublicShortfall = max(0, $targetPublicTotal - $finalPublicAccountedTotal);
+        $finalPublicCanReachTarget = $finalPublicShortfall === 0;
+        $readinessPass = $issues === [] && $finalPublicCanReachTarget;
 
         return new Career2786PublicResolutionPartitionResult([
             'schema_version' => self::SCHEMA_VERSION,
             'status' => $status,
             'partition_pass' => $issues === [],
             'partition_status' => $issues === [] ? 'partitioned' : 'blocked',
-            'readiness_pass' => false,
+            'readiness_pass' => $readinessPass,
             'read_only' => true,
             'writes_database' => false,
             'apply_allowed' => false,
@@ -134,11 +145,17 @@ final class Career2786PublicResolutionPartitionPlanner
             'canonical_rollout_possible_total' => count($baselineSlugs) + $canonicalCandidateCount,
             'canonical_rollout_shortfall' => max(0, $targetPublicTotal - count($baselineSlugs) - $canonicalCandidateCount),
             'canonical_rollout_can_reach_target' => $canonicalRolloutCanReachTarget,
+            'final_public_accounted_total' => $finalPublicAccountedTotal,
+            'final_public_shortfall' => $finalPublicShortfall,
+            'final_public_can_reach_target' => $finalPublicCanReachTarget,
             'occupation_missing_remediation_count' => $occupationMissingCount,
             'cn_proxy_policy_asset_count' => $cnProxyCount,
+            'cn_proxy_public_owner_plan_count' => $cnProxyPublicOwnerCount,
+            'cn_proxy_policy_asset_unresolved_count' => $cnProxyPolicyUnresolvedCount,
             'software_manual_hold_count' => $softwareManualHoldCount,
-            'policy_partition_required' => $cnProxyCount > 0 || $softwareManualHoldCount > 0,
+            'policy_partition_required' => $cnProxyPolicyUnresolvedCount > 0 || $softwareManualHoldCount > 0,
             'entity_remediation_required' => $occupationMissingCount > 0,
+            'cn_proxy_public_owner_plan' => $cnProxyPublicOwnerAuthority['summary'],
             'partitions' => $partitions,
             'rows' => $rows,
             'source_plan' => [
@@ -157,14 +174,16 @@ final class Career2786PublicResolutionPartitionPlanner
             ),
             'sidecars' => [],
             'next_required_actions' => $this->nextRequiredActions(
-                canonicalRolloutCanReachTarget: $canonicalRolloutCanReachTarget,
+                finalPublicCanReachTarget: $finalPublicCanReachTarget,
                 occupationMissingCount: $occupationMissingCount,
-                cnProxyCount: $cnProxyCount,
+                cnProxyUnresolvedCount: $cnProxyPolicyUnresolvedCount,
                 softwareManualHoldCount: $softwareManualHoldCount,
             ),
-            'next_required_action' => $issues === []
-                ? '2786_PUBLIC_RESOLUTION_PARTITION_REVIEW'
-                : 'FIX_2786_PUBLIC_RESOLUTION_PARTITION_INPUTS',
+            'next_required_action' => $readinessPass
+                ? '2786_RUNTIME_CANDIDATE_PREP_PLAN'
+                : ($issues === []
+                    ? '2786_PUBLIC_RESOLUTION_PARTITION_REVIEW'
+                    : 'FIX_2786_PUBLIC_RESOLUTION_PARTITION_INPUTS'),
         ]);
     }
 
@@ -329,22 +348,114 @@ final class Career2786PublicResolutionPartitionPlanner
     }
 
     /**
+     * @return array{ready: bool, public_owner_count: int, issues: list<CareerProgressiveReadinessSelectionIssue>, summary: array<string, mixed>}
+     */
+    private function cnProxyPublicOwnerAuthority(?array $plan, int $targetPublicTotal): array
+    {
+        $summary = [
+            'provided' => $plan !== null,
+            'ready' => false,
+            'public_owner_count' => 0,
+            'source_path' => $plan['source_path'] ?? null,
+            'guarded_public_owner_state' => $plan['guarded_public_owner_state'] ?? null,
+        ];
+
+        if ($plan === null) {
+            return [
+                'ready' => false,
+                'public_owner_count' => 0,
+                'issues' => [],
+                'summary' => $summary,
+            ];
+        }
+
+        if ($targetPublicTotal !== self::TARGET_PUBLIC_TOTAL) {
+            $issue = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'cn_proxy_public_owner_plan_target_scope_invalid',
+                message: 'CN proxy public-owner partition evidence is valid only for target_public_total=2786.',
+                severity: 'high',
+                evidence: ['target_public_total' => $targetPublicTotal],
+            );
+
+            return [
+                'ready' => false,
+                'public_owner_count' => 0,
+                'issues' => [$issue],
+                'summary' => $summary,
+            ];
+        }
+
+        $count = (int) ($plan['public_cn_proxy_page_rows'] ?? $plan['cn_proxy_rows'] ?? 0);
+        $required = [
+            'status' => ($plan['status'] ?? null) === 'validated',
+            'dry_run' => ($plan['dry_run'] ?? null) === true,
+            'did_write' => ($plan['did_write'] ?? null) === false,
+            'reviewed_trust_manifest_complete' => ($plan['reviewed_trust_manifest_complete'] ?? null) === true,
+            'public_owner_plan_ready' => ($plan['public_owner_plan_ready'] ?? null) === true,
+            'route_owner_enabled' => ($plan['route_owner_enabled'] ?? null) === false,
+            'public_route_allowed' => ($plan['public_route_allowed'] ?? null) === false,
+            'public_pages_exposed' => (int) ($plan['public_pages_exposed'] ?? -1) === 0,
+            'noindex_default' => ($plan['noindex_default'] ?? null) === true,
+            'indexable_CN_proxy_rows' => (int) ($plan['indexable_CN_proxy_rows'] ?? -1) === 0,
+            'sitemap_CN_urls' => (int) ($plan['sitemap_CN_urls'] ?? -1) === 0,
+            'llms_CN_urls' => (int) ($plan['llms_CN_urls'] ?? -1) === 0,
+            'llms_full_CN_urls' => (int) ($plan['llms_full_CN_urls'] ?? -1) === 0,
+            'blockers_empty' => ($plan['blockers'] ?? []) === [],
+            'public_owner_count_positive' => $count > 0,
+        ];
+        $failed = array_keys(array_filter($required, static fn (bool $passed): bool => ! $passed));
+        $summary = [
+            ...$summary,
+            'ready' => $failed === [],
+            'public_owner_count' => $failed === [] ? $count : 0,
+            'declared_public_owner_count' => $count,
+            'failed_requirements' => $failed,
+        ];
+
+        if ($failed === []) {
+            return [
+                'ready' => true,
+                'public_owner_count' => $count,
+                'issues' => [],
+                'summary' => $summary,
+            ];
+        }
+
+        $issue = new CareerProgressiveReadinessSelectionIssue(
+            reason: 'cn_proxy_public_owner_plan_invalid',
+            message: 'CN proxy public-owner plan cannot be used for final 2786 partition accounting.',
+            severity: 'blocker_for_publication',
+            evidence: [
+                'failed_requirements' => $failed,
+                'declared_public_owner_count' => $count,
+            ],
+        );
+
+        return [
+            'ready' => false,
+            'public_owner_count' => 0,
+            'issues' => [$issue],
+            'summary' => $summary,
+        ];
+    }
+
+    /**
      * @return list<string>
      */
     private function nextRequiredActions(
-        bool $canonicalRolloutCanReachTarget,
+        bool $finalPublicCanReachTarget,
         int $occupationMissingCount,
-        int $cnProxyCount,
+        int $cnProxyUnresolvedCount,
         int $softwareManualHoldCount,
     ): array {
         $actions = [];
-        if (! $canonicalRolloutCanReachTarget) {
+        if (! $finalPublicCanReachTarget) {
             $actions[] = 'DO_NOT_RUN_2786_CANONICAL_CANDIDATE_PREP';
         }
         if ($occupationMissingCount > 0) {
             $actions[] = '2786_OCCUPATION_ENTITY_REMEDIATION_1';
         }
-        if ($cnProxyCount > 0) {
+        if ($cnProxyUnresolvedCount > 0) {
             $actions[] = 'CN_PROXY_AUTHORITY_POLICY_DECISION_1';
         }
         if ($softwareManualHoldCount > 0) {

--- a/backend/app/Domain/Career/Audit/CareerProgressiveReadinessSelector.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveReadinessSelector.php
@@ -25,6 +25,7 @@ final class CareerProgressiveReadinessSelector
         array $locales = ['en', 'zh'],
         array $excludeSlugs = [],
         ?array $occupationExistingSlugs = null,
+        ?array $cnProxyPublicOwnerPlan = null,
         bool $strict = false,
     ): CareerProgressiveReadinessSelectionResult {
         $locales = $this->normalizedStringList($locales, 'locale');
@@ -39,6 +40,14 @@ final class CareerProgressiveReadinessSelector
         $requiresOccupationExists = $occupationExistingSlugs !== null;
         $deltaNeeded = max(0, $targetPublicTotal - $currentPublicTotal);
         $issues = $this->initialIssues($currentCloseout, $baselineSlugs, $currentPublicTotal, $targetPublicTotal);
+        $cnProxyPublicOwnerAuthority = $this->cnProxyPublicOwnerAuthority($cnProxyPublicOwnerPlan, $targetPublicTotal);
+        foreach ($cnProxyPublicOwnerAuthority['issues'] as $issue) {
+            $issues[] = $issue;
+        }
+        $publicOwnerDeltaCount = $cnProxyPublicOwnerAuthority['ready']
+            ? min((int) $cnProxyPublicOwnerAuthority['public_owner_count'], $deltaNeeded)
+            : 0;
+        $canonicalDeltaNeeded = max(0, $deltaNeeded - $publicOwnerDeltaCount);
         $candidates = [];
         $selectedSlugs = [];
         $duplicateSourceSlugs = [];
@@ -96,7 +105,7 @@ final class CareerProgressiveReadinessSelector
                 && ! $baselineExcluded
                 && ! isset($excludeSet[$slug])
                 && ! $occupationMissing
-                && count($selectedSlugs) < $deltaNeeded
+                && count($selectedSlugs) < $canonicalDeltaNeeded
                 && $issues === [];
 
             if ($selected) {
@@ -128,14 +137,24 @@ final class CareerProgressiveReadinessSelector
             );
         }
 
-        if (count($selectedSlugs) < $deltaNeeded) {
+        if (count($selectedSlugs) < $canonicalDeltaNeeded) {
+            $finalPublicAccountedCount = $currentPublicTotal + count($selectedSlugs) + $publicOwnerDeltaCount;
+            $reason = $publicOwnerDeltaCount > 0
+                ? 'insufficient_final_public_partition_authority'
+                : 'insufficient_source_ready_delta_slugs';
             $issues[] = new CareerProgressiveReadinessSelectionIssue(
-                reason: 'insufficient_source_ready_delta_slugs',
-                message: 'Fewer than the required progressive delta source-ready slugs are available.',
+                reason: $reason,
+                message: $publicOwnerDeltaCount > 0
+                    ? 'Final 2786 public accounting still has an unresolved partition shortfall after CN proxy public-owner evidence.'
+                    : 'Fewer than the required progressive delta source-ready slugs are available.',
                 severity: 'blocker_for_publication',
                 evidence: [
                     'required_delta_slug_count' => $deltaNeeded,
+                    'required_canonical_delta_slug_count' => $canonicalDeltaNeeded,
+                    'public_owner_delta_slug_count' => $publicOwnerDeltaCount,
                     'selected_count' => count($selectedSlugs),
+                    'final_public_accounted_count' => $finalPublicAccountedCount,
+                    'final_public_shortfall' => max(0, $targetPublicTotal - $finalPublicAccountedCount),
                     'source_ready_delta_count' => $sourceReadyCount,
                     'selectable_candidate_count' => $selectableCandidateCount,
                     'occupation_missing_excluded_count' => $occupationMissingExcludedCount,
@@ -150,6 +169,11 @@ final class CareerProgressiveReadinessSelector
         ksort($excludedByReason);
         $targetSlugs = [...$baselineSlugs, ...$selectedSlugs];
         $status = $issues === [] ? 'pass' : 'blocked';
+        $finalPublicAccountedCount = $currentPublicTotal + count($selectedSlugs) + $publicOwnerDeltaCount;
+        $finalPublicShortfall = max(0, $targetPublicTotal - $finalPublicAccountedCount);
+        $selectionStrategy = $publicOwnerDeltaCount > 0
+            ? 'progressive_source_ready_after_closeout_baseline_with_public_owner_partition'
+            : 'progressive_source_ready_after_closeout_baseline';
 
         return new CareerProgressiveReadinessSelectionResult([
             'schema_version' => self::SCHEMA_VERSION,
@@ -163,21 +187,29 @@ final class CareerProgressiveReadinessSelector
             'target_public_total' => $targetPublicTotal,
             'baseline_count' => count($baselineSlugs),
             'delta_slug_count' => $deltaNeeded,
+            'canonical_delta_slug_count' => $canonicalDeltaNeeded,
+            'public_owner_delta_slug_count' => $publicOwnerDeltaCount,
             'selected_count' => count($selectedSlugs),
             'candidate_count' => $selectableCandidateCount,
             'source_ready_count' => $sourceReadyCount,
             'locale_count' => count($locales),
             'locales' => $locales,
             'expected_delta_locale_rows' => $deltaNeeded * count($locales),
+            'expected_canonical_delta_locale_rows' => $canonicalDeltaNeeded * count($locales),
+            'expected_public_owner_locale_rows' => $publicOwnerDeltaCount * count($locales),
             'expected_total_locale_rows' => $targetPublicTotal * count($locales),
+            'final_public_accounted_count' => $finalPublicAccountedCount,
+            'final_public_shortfall' => $finalPublicShortfall,
             'baseline_slugs' => $baselineSlugs,
             'selected_slugs' => $selectedSlugs,
             'delta_promotion_slugs' => $selectedSlugs,
+            'canonical_rollout_slugs' => $selectedSlugs,
             'target_public_slugs' => $targetSlugs,
             'selection' => [
-                'strategy' => 'progressive_source_ready_after_closeout_baseline',
+                'strategy' => $selectionStrategy,
                 'slugs' => $targetSlugs,
                 'delta_slugs' => $selectedSlugs,
+                'canonical_delta_slugs' => $selectedSlugs,
                 'rows' => array_map(
                     static fn (CareerProgressiveReadinessCandidate $candidate): array => $candidate->toArray(),
                     array_values(array_filter(
@@ -196,6 +228,7 @@ final class CareerProgressiveReadinessSelector
                 'occupation_exists_count' => $occupationExistingSlugs === null ? null : count($occupationExistingSlugs),
                 'occupation_missing_excluded_count' => $occupationMissingExcludedCount,
             ],
+            'cn_proxy_public_owner_plan' => $cnProxyPublicOwnerAuthority['summary'],
             'excluded' => [
                 'excluded_by_reason' => $excludedByReason,
                 'baseline_excluded_count' => count($baselineSlugs),
@@ -339,6 +372,98 @@ final class CareerProgressiveReadinessSelector
         }
 
         return $issues;
+    }
+
+    /**
+     * @return array{ready: bool, public_owner_count: int, issues: list<CareerProgressiveReadinessSelectionIssue>, summary: array<string, mixed>}
+     */
+    private function cnProxyPublicOwnerAuthority(?array $plan, int $targetPublicTotal): array
+    {
+        $summary = [
+            'provided' => $plan !== null,
+            'ready' => false,
+            'public_owner_count' => 0,
+            'source_path' => $plan['source_path'] ?? null,
+            'guarded_public_owner_state' => $plan['guarded_public_owner_state'] ?? null,
+        ];
+
+        if ($plan === null) {
+            return [
+                'ready' => false,
+                'public_owner_count' => 0,
+                'issues' => [],
+                'summary' => $summary,
+            ];
+        }
+
+        if ($targetPublicTotal !== 2786) {
+            $issue = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'cn_proxy_public_owner_plan_target_scope_invalid',
+                message: 'CN proxy public-owner partition evidence is valid only for the final 2786 readiness target.',
+                severity: 'high',
+                evidence: ['target_public_total' => $targetPublicTotal],
+            );
+
+            return [
+                'ready' => false,
+                'public_owner_count' => 0,
+                'issues' => [$issue],
+                'summary' => $summary,
+            ];
+        }
+
+        $count = (int) ($plan['public_cn_proxy_page_rows'] ?? $plan['cn_proxy_rows'] ?? 0);
+        $required = [
+            'status' => ($plan['status'] ?? null) === 'validated',
+            'dry_run' => ($plan['dry_run'] ?? null) === true,
+            'did_write' => ($plan['did_write'] ?? null) === false,
+            'reviewed_trust_manifest_complete' => ($plan['reviewed_trust_manifest_complete'] ?? null) === true,
+            'public_owner_plan_ready' => ($plan['public_owner_plan_ready'] ?? null) === true,
+            'route_owner_enabled' => ($plan['route_owner_enabled'] ?? null) === false,
+            'public_route_allowed' => ($plan['public_route_allowed'] ?? null) === false,
+            'public_pages_exposed' => (int) ($plan['public_pages_exposed'] ?? -1) === 0,
+            'noindex_default' => ($plan['noindex_default'] ?? null) === true,
+            'indexable_CN_proxy_rows' => (int) ($plan['indexable_CN_proxy_rows'] ?? -1) === 0,
+            'sitemap_CN_urls' => (int) ($plan['sitemap_CN_urls'] ?? -1) === 0,
+            'llms_CN_urls' => (int) ($plan['llms_CN_urls'] ?? -1) === 0,
+            'llms_full_CN_urls' => (int) ($plan['llms_full_CN_urls'] ?? -1) === 0,
+            'blockers_empty' => ($plan['blockers'] ?? []) === [],
+            'public_owner_count_positive' => $count > 0,
+        ];
+        $failed = array_keys(array_filter($required, static fn (bool $passed): bool => ! $passed));
+        $summary = [
+            ...$summary,
+            'ready' => $failed === [],
+            'public_owner_count' => $failed === [] ? $count : 0,
+            'declared_public_owner_count' => $count,
+            'failed_requirements' => $failed,
+        ];
+
+        if ($failed === []) {
+            return [
+                'ready' => true,
+                'public_owner_count' => $count,
+                'issues' => [],
+                'summary' => $summary,
+            ];
+        }
+
+        $issue = new CareerProgressiveReadinessSelectionIssue(
+            reason: 'cn_proxy_public_owner_plan_invalid',
+            message: 'CN proxy public-owner plan cannot be used for final 2786 partition accounting.',
+            severity: 'blocker_for_publication',
+            evidence: [
+                'failed_requirements' => $failed,
+                'declared_public_owner_count' => $count,
+            ],
+        );
+
+        return [
+            'ready' => false,
+            'public_owner_count' => 0,
+            'issues' => [$issue],
+            'summary' => $summary,
+        ];
     }
 
     /**

--- a/backend/docs/career/audits/2786_public_resolution_partition.md
+++ b/backend/docs/career/audits/2786_public_resolution_partition.md
@@ -12,6 +12,7 @@ The command does not treat every remaining source row as a canonical rollout can
 - `--target-total=2786`
 - `--locales=en,zh`
 - `--entity-context=` optional entity context with `occupation_exists=true` evidence.
+- `--cn-proxy-public-owner-plan=` optional reviewed CN proxy public-owner plan.
 
 ## Partitions
 
@@ -20,6 +21,37 @@ The command does not treat every remaining source row as a canonical rollout can
 - `occupation_missing_remediation`: rows that cannot enter candidate prep until occupation entity evidence exists.
 - `cn_proxy_policy_asset`: CN proxy rows, including `cn-*`, `public_cn_proxy_page`, `public_cn_proxy_page_candidate`, `CN_proxy_hold`, or `blocked_until_CN_authority_policy`.
 - `software_manual_hold`: `software-developers` manual hold.
+
+## CN Proxy Public-Owner Authority
+
+The final 2786 partition can consume a reviewed CN proxy public-owner plan. This
+plan does not convert CN proxy rows into canonical rollout candidates. It only
+lets the partition account for those rows as a separate noindex public-owner
+partition when all of these guards pass:
+
+- `status=validated`
+- `dry_run=true`
+- `did_write=false`
+- reviewed trust manifest is complete
+- public owner plan is ready
+- route owner and public route exposure remain disabled
+- public pages exposed count is zero
+- noindex is the default
+- index, sitemap, llms, and llms-full CN counts are zero
+- blockers are empty
+
+When accepted, the output includes:
+
+- `cn_proxy_public_owner_plan_count`
+- `cn_proxy_policy_asset_unresolved_count`
+- `final_public_accounted_total`
+- `final_public_shortfall`
+- `final_public_can_reach_target`
+
+If the plan resolves all CN proxy policy assets, the next actions no longer
+include `CN_PROXY_AUTHORITY_POLICY_DECISION_1`. Other partitions, such as
+`software_manual_hold`, remain independent blockers until they have their own
+authority decision.
 
 ## Non-goals
 
@@ -40,6 +72,10 @@ The output schema is `career_2786_public_resolution_partition.v1`. A successful 
 - `status=pass`
 - `partition_pass=true`
 - `partition_status=partitioned`
-- `readiness_pass=false`
+- `readiness_pass=false` unless final public accounting reaches 2786 with all
+  partition evidence accepted.
 
-`readiness_pass=false` is intentional. The partition is evidence for the next remediation and policy work, not permission to run final 2786 candidate prep or rollout.
+`readiness_pass=false` remains the default while occupation, CN proxy, or
+manual-hold partitions are unresolved. When final accounting reaches 2786 with a
+reviewed public-owner partition, readiness can pass, but canonical candidate prep
+still receives only canonical rollout candidates.

--- a/backend/docs/career/audits/progressive_readiness_selection.md
+++ b/backend/docs/career/audits/progressive_readiness_selection.md
@@ -33,6 +33,13 @@ the rollout executor rejects it before any write. Readiness reports it as
 `software_developers_manual_hold_excluded_from_canonical_rollout` and selects a
 later eligible replacement when available.
 
+For the final 800 -> 2786 step, the selector may consume
+`--cn-proxy-public-owner-plan`. This artifact lets a reviewed, noindex CN proxy
+public-owner partition count toward final 2786 public accounting without adding
+those CN proxy rows to the canonical rollout delta. The plan is accepted only
+when it is read-only, reviewed, disabled for public route exposure, noindex by
+default, and absent from sitemap, llms, and llms-full outputs.
+
 ## Readiness Selection vs Rollout Validation
 
 This step is intentionally earlier than rollout-candidate validation. It does
@@ -52,6 +59,8 @@ projection/truth/ledger artifacts and explicit rollout gates.
 - Locale list, normally `en,zh`.
 - Optional production-derived entity context from
   `career:export-canonical-eligibility-db-context`.
+- Optional final-only CN proxy public-owner plan from
+  `career:validate-cn-proxy-public-owner`.
 
 ## Output
 
@@ -64,8 +73,14 @@ The command emits stable JSON using:
   "current_public_total": 80,
   "target_public_total": 300,
   "delta_slug_count": 220,
+  "canonical_delta_slug_count": 220,
+  "public_owner_delta_slug_count": 0,
   "expected_delta_locale_rows": 440,
+  "expected_canonical_delta_locale_rows": 440,
+  "expected_public_owner_locale_rows": 0,
   "selected_count": 220,
+  "final_public_accounted_count": 300,
+  "final_public_shortfall": 0,
   "selected_slugs": [],
   "selection": {
     "slugs": [],
@@ -75,6 +90,11 @@ The command emits stable JSON using:
     "required_for_selection": true,
     "occupation_exists_count": 2469,
     "occupation_missing_excluded_count": 27
+  },
+  "cn_proxy_public_owner_plan": {
+    "provided": false,
+    "ready": false,
+    "public_owner_count": 0
   },
   "excluded": {
     "excluded_by_reason": {
@@ -136,6 +156,28 @@ The rollout manifest gate also fails closed if `software-developers` appears in
 an explicit delta manifest. This is an earlier planning guard only; it does not
 weaken the existing rollout executor, rollback gate, or final live acceptance
 checks.
+
+## Final 2786 Public Owner Partition
+
+`--cn-proxy-public-owner-plan` is scoped to target `2786`. It does not apply to
+the 300 or 800 cohorts. When supplied and valid, the selector:
+
+- keeps CN proxy rows excluded from `selected_slugs`,
+  `delta_promotion_slugs`, and `canonical_rollout_slugs`;
+- records `public_owner_delta_slug_count` and
+  `expected_public_owner_locale_rows`;
+- reduces `canonical_delta_slug_count` to the remaining canonical rollout
+  shortfall after the public-owner partition; and
+- reports `final_public_accounted_count` / `final_public_shortfall`.
+
+The public-owner plan must be validated, read-only, write-free, reviewed, noindex
+by default, route-disabled, and absent from sitemap, llms, and llms-full outputs.
+Invalid public-owner evidence is reported as
+`cn_proxy_public_owner_plan_invalid` and is not counted toward the final target.
+
+This authority is accounting-only for final readiness. It does not publish CN
+proxy rows, does not permit canonical rollout promotion for CN proxy rows, and
+does not weaken final live acceptance.
 
 ## Non-Goals
 

--- a/backend/tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php
@@ -66,6 +66,43 @@ final class CareerPlanCanonical2786PublicResolutionPartitionCommandTest extends 
         $this->assertFileExists($output);
     }
 
+    public function test_command_accounts_reviewed_cn_proxy_public_owner_plan_without_unlocking_rollout_candidates(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->slugs('policy', 1663, 'cn-');
+        $software = ['software-developers'];
+        $baselinePath = $this->writeSlugs('baseline', $baseline);
+        $output = $this->tempPath('output');
+
+        $exitCode = Artisan::call('career:plan-canonical-2786-public-resolution-partition', [
+            '--source-plan' => $this->writeSourcePlan([...$baseline, ...$canonical, ...$cnProxy, ...$software]),
+            '--closeout' => $this->writeCloseout($baselinePath),
+            '--current-total' => '800',
+            '--target-total' => '2786',
+            '--locales' => 'en,zh',
+            '--entity-context' => $this->writeEntityContext([...$baseline, ...$canonical, ...$cnProxy, ...$software], []),
+            '--cn-proxy-public-owner-plan' => $this->writeCnProxyPublicOwnerPlan(1663),
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertFalse($payload['readiness_pass']);
+        $this->assertSame(322, $payload['canonical_rollout_candidate_count']);
+        $this->assertSame(1663, $payload['cn_proxy_policy_asset_count']);
+        $this->assertSame(1663, $payload['cn_proxy_public_owner_plan_count']);
+        $this->assertSame(0, $payload['cn_proxy_policy_asset_unresolved_count']);
+        $this->assertSame(2785, $payload['final_public_accounted_total']);
+        $this->assertSame(1, $payload['final_public_shortfall']);
+        $this->assertTrue($payload['cn_proxy_public_owner_plan']['ready']);
+        $this->assertNotContains('CN_PROXY_AUTHORITY_POLICY_DECISION_1', $payload['next_required_actions']);
+        $this->assertContains('SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1', $payload['next_required_actions']);
+        $this->assertFileExists($output);
+    }
+
     public function test_missing_source_plan_blocks_without_mutation(): void
     {
         $baselinePath = $this->writeSlugs('baseline', $this->slugs('baseline', 800));
@@ -178,6 +215,30 @@ final class CareerPlanCanonical2786PublicResolutionPartitionCommandTest extends 
         return $this->writeJson('entity-context', [
             'schema_version' => 'career_entity_context.v1',
             'rows' => $rows,
+        ]);
+    }
+
+    private function writeCnProxyPublicOwnerPlan(int $count): string
+    {
+        return $this->writeJson('cn-proxy-public-owner-plan', [
+            'schema_version' => 'career_2786_cn_proxy_public_owner_plan.v1',
+            'status' => 'validated',
+            'dry_run' => true,
+            'did_write' => false,
+            'cn_proxy_rows' => $count,
+            'public_cn_proxy_page_rows' => $count,
+            'reviewed_trust_manifest_complete' => true,
+            'public_owner_plan_ready' => true,
+            'route_owner_enabled' => false,
+            'public_route_allowed' => false,
+            'public_pages_exposed' => 0,
+            'noindex_default' => true,
+            'indexable_CN_proxy_rows' => 0,
+            'sitemap_CN_urls' => 0,
+            'llms_CN_urls' => 0,
+            'llms_full_CN_urls' => 0,
+            'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
+            'blockers' => [],
         ]);
     }
 

--- a/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php
@@ -105,6 +105,39 @@ final class CareerPlanCanonicalProgressiveReadinessSelectionCommandTest extends 
         $this->assertFileExists($output);
     }
 
+    public function test_final_2786_selection_uses_cn_proxy_public_owner_plan_for_partition_accounting_only(): void
+    {
+        $current = $this->slugs('current', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->prefixedSlugs('policy', 1663, 'cn-');
+        $currentSlugs = $this->writeSlugs('current', $current);
+        $output = $this->tempPath('output');
+
+        $exitCode = Artisan::call('career:plan-canonical-progressive-readiness-selection', [
+            '--source-plan' => $this->writeSourcePlan([...$current, ...$canonical, ...$cnProxy, 'software-developers']),
+            '--closeout' => $this->writeCloseout(800, $currentSlugs),
+            '--current-total' => '800',
+            '--target-total' => '2786',
+            '--locales' => 'en,zh',
+            '--cn-proxy-public-owner-plan' => $this->writeCnProxyPublicOwnerPlan(1663),
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(1986, $payload['delta_slug_count']);
+        $this->assertSame(323, $payload['canonical_delta_slug_count']);
+        $this->assertSame(1663, $payload['public_owner_delta_slug_count']);
+        $this->assertSame(322, $payload['selected_count']);
+        $this->assertSame(2785, $payload['final_public_accounted_count']);
+        $this->assertSame(1, $payload['final_public_shortfall']);
+        $this->assertTrue($payload['cn_proxy_public_owner_plan']['ready']);
+        $this->assertContains('insufficient_final_public_partition_authority', array_column($payload['blockers'], 'reason'));
+        $this->assertFileExists($output);
+    }
+
     public function test_entity_context_with_no_existing_occupations_blocks_without_mutation(): void
     {
         $current = $this->slugs('current', 80);
@@ -167,6 +200,17 @@ final class CareerPlanCanonicalProgressiveReadinessSelectionCommandTest extends 
         }
 
         return $slugs;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function prefixedSlugs(string $name, int $count, string $prefix): array
+    {
+        return array_map(
+            static fn (string $slug): string => $prefix.$slug,
+            $this->slugs($name, $count),
+        );
     }
 
     /**
@@ -240,6 +284,30 @@ final class CareerPlanCanonicalProgressiveReadinessSelectionCommandTest extends 
         return $this->writeJson('entity-context', [
             'schema_version' => 'career_entity_context.v1',
             'rows' => $rows,
+        ]);
+    }
+
+    private function writeCnProxyPublicOwnerPlan(int $count): string
+    {
+        return $this->writeJson('cn-proxy-public-owner-plan', [
+            'schema_version' => 'career_2786_cn_proxy_public_owner_plan.v1',
+            'status' => 'validated',
+            'dry_run' => true,
+            'did_write' => false,
+            'cn_proxy_rows' => $count,
+            'public_cn_proxy_page_rows' => $count,
+            'reviewed_trust_manifest_complete' => true,
+            'public_owner_plan_ready' => true,
+            'route_owner_enabled' => false,
+            'public_route_allowed' => false,
+            'public_pages_exposed' => 0,
+            'noindex_default' => true,
+            'indexable_CN_proxy_rows' => 0,
+            'sitemap_CN_urls' => 0,
+            'llms_CN_urls' => 0,
+            'llms_full_CN_urls' => 0,
+            'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
+            'blockers' => [],
         ]);
     }
 

--- a/backend/tests/Unit/Domain/Career/Audit/Career2786PublicResolutionPartitionPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career2786PublicResolutionPartitionPlannerTest.php
@@ -76,6 +76,82 @@ final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
         }
     }
 
+    public function test_reviewed_cn_proxy_public_owner_plan_accounts_for_cn_partition_without_making_it_rollout_candidate(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->slugs('policy', 1663, 'cn-');
+        $software = ['software-developers'];
+
+        $payload = $this->partition(
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+            baselineSlugs: $baseline,
+            occupationExistingSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+            cnProxyPublicOwnerPlan: $this->cnProxyPublicOwnerPlan(1663),
+        );
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertFalse($payload['readiness_pass']);
+        $this->assertSame(322, $payload['canonical_rollout_candidate_count']);
+        $this->assertSame(1663, $payload['cn_proxy_policy_asset_count']);
+        $this->assertSame(1663, $payload['cn_proxy_public_owner_plan_count']);
+        $this->assertSame(0, $payload['cn_proxy_policy_asset_unresolved_count']);
+        $this->assertSame(2785, $payload['final_public_accounted_total']);
+        $this->assertSame(1, $payload['final_public_shortfall']);
+        $this->assertTrue($payload['cn_proxy_public_owner_plan']['ready']);
+        $this->assertNotContains('CN_PROXY_AUTHORITY_POLICY_DECISION_1', $payload['next_required_actions']);
+        $this->assertContains('SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1', $payload['next_required_actions']);
+        $this->assertContains('DO_NOT_RUN_2786_CANONICAL_CANDIDATE_PREP', $payload['next_required_actions']);
+    }
+
+    public function test_reviewed_cn_proxy_public_owner_plan_allows_final_partition_readiness_when_accounting_is_complete(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 323);
+        $cnProxy = $this->slugs('policy', 1663, 'cn-');
+
+        $payload = $this->partition(
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy],
+            baselineSlugs: $baseline,
+            occupationExistingSlugs: [...$baseline, ...$canonical, ...$cnProxy],
+            cnProxyPublicOwnerPlan: $this->cnProxyPublicOwnerPlan(1663),
+        );
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['readiness_pass']);
+        $this->assertSame(2786, $payload['final_public_accounted_total']);
+        $this->assertSame(0, $payload['final_public_shortfall']);
+        $this->assertTrue($payload['final_public_can_reach_target']);
+        $this->assertSame('2786_RUNTIME_CANDIDATE_PREP_PLAN', $payload['next_required_action']);
+        $this->assertNotContains('DO_NOT_RUN_2786_CANONICAL_CANDIDATE_PREP', $payload['next_required_actions']);
+        $this->assertNotContains('CN_PROXY_AUTHORITY_POLICY_DECISION_1', $payload['next_required_actions']);
+    }
+
+    public function test_invalid_cn_proxy_public_owner_plan_blocks_final_partition_accounting(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 323);
+        $cnProxy = $this->slugs('policy', 1663, 'cn-');
+        $invalidPlan = [
+            ...$this->cnProxyPublicOwnerPlan(1663),
+            'sitemap_CN_urls' => 1,
+        ];
+
+        $payload = $this->partition(
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy],
+            baselineSlugs: $baseline,
+            occupationExistingSlugs: [...$baseline, ...$canonical, ...$cnProxy],
+            cnProxyPublicOwnerPlan: $invalidPlan,
+        );
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(0, $payload['cn_proxy_public_owner_plan_count']);
+        $this->assertSame(1663, $payload['cn_proxy_policy_asset_unresolved_count']);
+        $this->assertFalse($payload['cn_proxy_public_owner_plan']['ready']);
+        $this->assertContains('sitemap_CN_urls', $payload['cn_proxy_public_owner_plan']['failed_requirements']);
+        $this->assertContains('cn_proxy_public_owner_plan_invalid', array_column($payload['blockers'], 'reason'));
+    }
+
     public function test_blocks_when_source_plan_is_not_complete_2786(): void
     {
         $baseline = $this->slugs('baseline', 800);
@@ -95,8 +171,12 @@ final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
      * @param  list<string>  $occupationExistingSlugs
      * @return array<string, mixed>
      */
-    private function partition(array $sourceSlugs, array $baselineSlugs, array $occupationExistingSlugs): array
-    {
+    private function partition(
+        array $sourceSlugs,
+        array $baselineSlugs,
+        array $occupationExistingSlugs,
+        ?array $cnProxyPublicOwnerPlan = null,
+    ): array {
         return (new Career2786PublicResolutionPartitionPlanner)->partition(
             sourcePlan: new CareerPublicResolutionPlan(
                 sourcePath: '/tmp/synthetic-career-2786-source.json',
@@ -115,6 +195,7 @@ final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
             targetPublicTotal: 2786,
             locales: ['en', 'zh'],
             occupationExistingSlugs: $occupationExistingSlugs,
+            cnProxyPublicOwnerPlan: $cnProxyPublicOwnerPlan,
         )->toArray();
     }
 
@@ -154,5 +235,32 @@ final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
         }
 
         return $slugs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function cnProxyPublicOwnerPlan(int $count): array
+    {
+        return [
+            'schema_version' => 'career_2786_cn_proxy_public_owner_plan.v1',
+            'status' => 'validated',
+            'dry_run' => true,
+            'did_write' => false,
+            'cn_proxy_rows' => $count,
+            'public_cn_proxy_page_rows' => $count,
+            'reviewed_trust_manifest_complete' => true,
+            'public_owner_plan_ready' => true,
+            'route_owner_enabled' => false,
+            'public_route_allowed' => false,
+            'public_pages_exposed' => 0,
+            'noindex_default' => true,
+            'indexable_CN_proxy_rows' => 0,
+            'sitemap_CN_urls' => 0,
+            'llms_CN_urls' => 0,
+            'llms_full_CN_urls' => 0,
+            'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
+            'blockers' => [],
+        ];
     }
 }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveReadinessSelectionTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveReadinessSelectionTest.php
@@ -172,6 +172,90 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
         );
     }
 
+    public function test_2786_public_owner_plan_counts_cn_proxy_partition_without_selecting_it_for_rollout(): void
+    {
+        $baseline = $this->slugs('current', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->prefixedSlugs('cn-policy', 1663, 'cn-');
+
+        $payload = $this->select(
+            baseline: $baseline,
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy, 'software-developers'],
+            currentTotal: 800,
+            targetTotal: 2786,
+            cnProxyPublicOwnerPlan: $this->cnProxyPublicOwnerPlan(1663),
+        );
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(1986, $payload['delta_slug_count']);
+        $this->assertSame(323, $payload['canonical_delta_slug_count']);
+        $this->assertSame(1663, $payload['public_owner_delta_slug_count']);
+        $this->assertSame(322, $payload['selected_count']);
+        $this->assertSame(2785, $payload['final_public_accounted_count']);
+        $this->assertSame(1, $payload['final_public_shortfall']);
+        $this->assertSame('progressive_source_ready_after_closeout_baseline_with_public_owner_partition', $payload['selection']['strategy']);
+        $this->assertTrue($payload['cn_proxy_public_owner_plan']['ready']);
+        $this->assertSame(1663, $payload['cn_proxy_public_owner_plan']['public_owner_count']);
+        $this->assertSame(1663, $payload['excluded']['excluded_by_reason']['cn_proxy_excluded_from_canonical_rollout']);
+        $this->assertSame(1, $payload['excluded']['excluded_by_reason']['software_developers_manual_hold_excluded_from_canonical_rollout']);
+        $this->assertContains('insufficient_final_public_partition_authority', array_column($payload['blockers'], 'reason'));
+        $this->assertNotContains('software-developers', $payload['selected_slugs']);
+        $this->assertSame([], array_values(array_filter(
+            $payload['selected_slugs'],
+            static fn (string $slug): bool => str_starts_with($slug, 'cn-'),
+        )));
+    }
+
+    public function test_2786_public_owner_plan_allows_final_accounting_when_canonical_partition_covers_shortfall(): void
+    {
+        $baseline = $this->slugs('current', 800);
+        $canonical = $this->slugs('canonical', 323);
+        $cnProxy = $this->prefixedSlugs('cn-policy', 1663, 'cn-');
+
+        $payload = $this->select(
+            baseline: $baseline,
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy],
+            currentTotal: 800,
+            targetTotal: 2786,
+            cnProxyPublicOwnerPlan: $this->cnProxyPublicOwnerPlan(1663),
+        );
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['readiness_pass']);
+        $this->assertSame(323, $payload['canonical_delta_slug_count']);
+        $this->assertSame(1663, $payload['public_owner_delta_slug_count']);
+        $this->assertSame(323, $payload['selected_count']);
+        $this->assertSame(2786, $payload['final_public_accounted_count']);
+        $this->assertSame(0, $payload['final_public_shortfall']);
+        $this->assertSame($canonical, $payload['canonical_rollout_slugs']);
+        $this->assertSame([], $payload['blockers']);
+    }
+
+    public function test_invalid_2786_public_owner_plan_does_not_count_cn_proxy_partition(): void
+    {
+        $baseline = $this->slugs('current', 800);
+        $canonical = $this->slugs('canonical', 323);
+        $cnProxy = $this->prefixedSlugs('cn-policy', 1663, 'cn-');
+        $invalidPlan = [
+            ...$this->cnProxyPublicOwnerPlan(1663),
+            'public_route_allowed' => true,
+        ];
+
+        $payload = $this->select(
+            baseline: $baseline,
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy],
+            currentTotal: 800,
+            targetTotal: 2786,
+            cnProxyPublicOwnerPlan: $invalidPlan,
+        );
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(0, $payload['public_owner_delta_slug_count']);
+        $this->assertFalse($payload['cn_proxy_public_owner_plan']['ready']);
+        $this->assertContains('public_route_allowed', $payload['cn_proxy_public_owner_plan']['failed_requirements']);
+        $this->assertContains('cn_proxy_public_owner_plan_invalid', array_column($payload['blockers'], 'reason'));
+    }
+
     public function test_preserves_deterministic_source_order(): void
     {
         $baseline = $this->slugs('current', 80);
@@ -272,6 +356,7 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
         int $currentTotal,
         int $targetTotal,
         ?array $occupationExistingSlugs = null,
+        ?array $cnProxyPublicOwnerPlan = null,
     ): array {
         return (new CareerProgressiveReadinessSelector)->select(
             sourcePlan: $this->sourcePlan($sourceSlugs),
@@ -281,6 +366,7 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
             targetPublicTotal: $targetTotal,
             locales: ['en', 'zh'],
             occupationExistingSlugs: $occupationExistingSlugs,
+            cnProxyPublicOwnerPlan: $cnProxyPublicOwnerPlan,
         )->toArray();
     }
 
@@ -357,6 +443,44 @@ final class CareerProgressiveReadinessSelectionTest extends TestCase
         }
 
         return $slugs;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function prefixedSlugs(string $name, int $count, string $prefix): array
+    {
+        return array_map(
+            static fn (string $slug): string => $prefix.$slug,
+            $this->slugs($name, $count),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function cnProxyPublicOwnerPlan(int $count): array
+    {
+        return [
+            'schema_version' => 'career_2786_cn_proxy_public_owner_plan.v1',
+            'status' => 'validated',
+            'dry_run' => true,
+            'did_write' => false,
+            'cn_proxy_rows' => $count,
+            'public_cn_proxy_page_rows' => $count,
+            'reviewed_trust_manifest_complete' => true,
+            'public_owner_plan_ready' => true,
+            'route_owner_enabled' => false,
+            'public_route_allowed' => false,
+            'public_pages_exposed' => 0,
+            'noindex_default' => true,
+            'indexable_CN_proxy_rows' => 0,
+            'sitemap_CN_urls' => 0,
+            'llms_CN_urls' => 0,
+            'llms_full_CN_urls' => 0,
+            'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
+            'blockers' => [],
+        ];
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6836,6 +6836,108 @@
         }
       ]
     },
+    "REPAIR-2786-FINAL-READINESS-PUBLIC-OWNER-PARTITION-AUTHORITY-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-2786-final-readiness-public-owner-partition-authority-1",
+      "title": "fix(api): account reviewed public owner partition in 2786 readiness",
+      "name": "Account reviewed CN proxy public-owner partition in final 2786 readiness",
+      "status": "in_progress",
+      "depends_on": [
+        "2786-CN-PROXY-PUBLIC-OWNER-PLAN-1"
+      ],
+      "scope_type": "final_2786_public_owner_partition_authority_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php",
+        "backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no candidate prep dry-run",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no production DB mutation",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web",
+        "do not mark CN proxy rows as canonical rollout candidates",
+        "do not enable CN proxy indexability, sitemap, llms, llms-full, or public route exposure",
+        "do not weaken software-developers manual-hold rejection or final live acceptance"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-2786-FINAL-READINESS-PUBLIC-OWNER-PARTITION-AUTHORITY-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "2786 CN proxy public-owner plan was generated and reviewed before this PR; this PR consumes that read-only evidence in readiness/partition accounting."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to final 2786 readiness/partition command and domain logic, focused Career tests, audit docs, and authorized train metadata."
+        },
+        "local_validation": {
+          "status": "pass_with_external_mbti_sidecar",
+          "evidence": [
+            "php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi: pass (19 tests, 98 assertions)",
+            "php artisan test --filter=Career2786PublicResolutionPartition --no-ansi: pass (6 tests, 59 assertions)",
+            "php artisan test tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php --no-ansi: pass (7 tests, 44 assertions)",
+            "php artisan test tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php --no-ansi: pass (4 tests, 35 assertions)",
+            "php artisan test --filter=CareerProgressive --no-ansi: pass (37 tests, 171 assertions)",
+            "php artisan test --filter=Career80TotalLiveAcceptance --no-ansi: pass (11 tests, 49 assertions)",
+            "php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi: pass (27 tests, 138 assertions)",
+            "php artisan test --filter=CareerRuntimeCandidate --no-ansi: pass (8 tests, 40 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-2786-public-owner-partition.sqlite php artisan migrate --force --no-ansi: pass",
+            "ruby YAML.load_file docs/codex/pr-train.yaml: pass",
+            "python3 -m json.tool docs/codex/pr-train-state.json: pass",
+            "vendor/bin/pint --test: pass",
+            "git diff --check: pass",
+            "Local read-only smoke against /tmp 2786 artifacts: readiness status=blocked, selected_count=322, canonical_delta_slug_count=323, public_owner_delta_slug_count=1663, final_public_accounted_count=2785, final_public_shortfall=1, blocker=insufficient_final_public_partition_authority, writes_database=false.",
+            "Local read-only partition smoke against /tmp 2786 artifacts: status=pass, cn_proxy_policy_asset_count=1663, cn_proxy_public_owner_plan_count=1663, cn_proxy_policy_asset_unresolved_count=0, software_manual_hold_count=1, next_required_actions exclude CN_PROXY_AUTHORITY_POLICY_DECISION_1.",
+            "bash backend/scripts/ci_verify_mbti.sh: external blocker in BigFive pack publish/rollback compiled-directory checks; scoped Career tests pass and current PR does not modify BigFive pack publish/rollback code."
+          ]
+        },
+        "github_pr": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "2786-READINESS-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "sidecar_id": "SIDECAR-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-20260516-PUBLIC-OWNER-PARTITION-AUTHORITY",
+          "title": "Local MBTI CI BigFive pack publish and rollback compiled-directory assertions fail outside final 2786 readiness scope",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_slugs": [],
+          "affected_locales": [],
+          "evidence": [
+            "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
+            "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
+            "Current PR changes only Career final 2786 readiness/partition accounting logic, focused Career tests, audit docs, and authorized train metadata."
+          ],
+          "severity": "medium",
+          "next_goal": "SCAN-BIG5-PACK-PUBLISH-ROLLBACK-COMPILED-DIR-LOCAL-CI",
+          "may_continue_train": true
+        }
+      ]
+    },
     "PR-CMS-FIX-MASTER": {
       "repo": "fap-api",
       "branch": "codex/pr-cms-fix-master-semantic-content-gate",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -707,6 +707,49 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-2786-FINAL-READINESS-PUBLIC-OWNER-PARTITION-AUTHORITY-1
+    repo: fap-api
+    depends_on:
+      - 2786-CN-PROXY-PUBLIC-OWNER-PLAN-1
+    branch: codex/repair-2786-final-readiness-public-owner-partition-authority-1
+    title: "fix(api): account reviewed public owner partition in 2786 readiness"
+    name: "Account reviewed CN proxy public-owner partition in final 2786 readiness"
+    scope:
+      - Extend final 2786 readiness and public-resolution partition commands to consume reviewed CN proxy public-owner plan evidence.
+      - Count reviewed noindex CN proxy public-owner rows only toward final 2786 public accounting.
+      - Keep CN proxy rows excluded from canonical rollout selection, candidate prep, sitemap, llms, and llms-full eligibility.
+      - Preserve software-developers manual-hold and final live acceptance strictness.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php
+      - backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run candidate prep dry-run or apply.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Mark CN proxy rows as canonical rollout candidates.
+      - Enable CN proxy indexability, sitemap, llms, llms-full, or public route exposure.
+      - Weaken software-developers manual-hold rejection or final live acceptance.
+    validation:
+      - php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi
+      - php artisan test --filter=Career2786PublicResolutionPartition --no-ansi
+      - php artisan test tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php --no-ansi
+      - php artisan test tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- Adds final 2786 readiness/partition authority for reviewed CN proxy public-owner plan evidence.
- Counts reviewed noindex CN proxy public-owner rows only toward final 2786 public accounting.
- Keeps CN proxy rows excluded from canonical rollout selection, candidate prep, sitemap, llms, and llms-full eligibility.
- Preserves software-developers manual-hold and final live acceptance strictness.

## Non-goals
- No DB mutation.
- No candidate prep dry-run/apply.
- No rollout dry-run/apply.
- No deploy, rollback, quarantine, backfill, frontend action, or 2786 expansion execution.

## Validation
- `php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi` pass (19 tests, 98 assertions)
- `php artisan test --filter=Career2786PublicResolutionPartition --no-ansi` pass (6 tests, 59 assertions)
- `php artisan test tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php --no-ansi` pass (7 tests, 44 assertions)
- `php artisan test tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php --no-ansi` pass (4 tests, 35 assertions)
- `php artisan test --filter=CareerProgressive --no-ansi` pass (37 tests, 171 assertions)
- `php artisan test --filter=Career80TotalLiveAcceptance --no-ansi` pass (11 tests, 49 assertions)
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi` pass (27 tests, 138 assertions)
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi` pass (8 tests, 40 assertions)
- `php artisan route:list --no-ansi` pass
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-2786-public-owner-partition.sqlite php artisan migrate --force --no-ansi` pass
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'` pass
- `python3 -m json.tool docs/codex/pr-train-state.json` pass
- `vendor/bin/pint --test` pass
- `git diff --check` pass

## Local smoke
- Read-only 2786 readiness with `/tmp/career_2786_cn_proxy_public_owner_plan.json`: `status=blocked`, `canonical_delta_slug_count=323`, `public_owner_delta_slug_count=1663`, `selected_count=322`, `final_public_accounted_count=2785`, `final_public_shortfall=1`, blocker `insufficient_final_public_partition_authority`, `writes_database=false`.
- Read-only 2786 partition with the same plan: `status=pass`, `cn_proxy_policy_asset_count=1663`, `cn_proxy_public_owner_plan_count=1663`, `cn_proxy_policy_asset_unresolved_count=0`, `software_manual_hold_count=1`; next actions no longer include `CN_PROXY_AUTHORITY_POLICY_DECISION_1`.

## External sidecar
- `bash backend/scripts/ci_verify_mbti.sh` still fails outside this PR scope in `Tests\\Feature\\Content\\PacksPublishBig5Test` and `Tests\\Feature\\Content\\PacksRollbackBig5Test` at compiled-directory assertions. This PR does not modify BigFive pack publish/rollback code.

## Next step
- Rerun `2786-READINESS-1`; expected remaining blocker is the single `software-developers` manual-hold shortfall.
