### PR TITLE
fix(api): account software manual hold in 2786 readiness

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
+++ b/backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
@@ -21,6 +21,7 @@ final class CareerPlanCanonical2786PublicResolutionPartition extends Command
         {--locales=en,zh : Comma-separated locales}
         {--entity-context= : Optional entity context JSON; if supplied, rows without occupation_exists=true are partitioned for remediation}
         {--cn-proxy-public-owner-plan= : Optional reviewed CN proxy public-owner plan JSON for final 2786 partition accounting}
+        {--software-manual-hold-decision= : Optional reviewed software-developers manual-hold decision JSON for final 2786 partition accounting}
         {--strict : Fail on source-plan validation issues}
         {--json : Emit JSON output}
         {--output= : Optional output path for final 2786 partition JSON}';
@@ -47,11 +48,18 @@ final class CareerPlanCanonical2786PublicResolutionPartition extends Command
             $closeout = $this->readJson($closeoutPath, 'closeout');
             $entityContextPath = $this->pathOption('entity-context');
             $cnProxyPublicOwnerPlanPath = $this->pathOption('cn-proxy-public-owner-plan');
+            $softwareManualHoldDecisionPath = $this->pathOption('software-manual-hold-decision');
             $cnProxyPublicOwnerPlan = $cnProxyPublicOwnerPlanPath === null
                 ? null
                 : [
                     ...$this->readJson($cnProxyPublicOwnerPlanPath, 'cn_proxy_public_owner_plan'),
                     'source_path' => $cnProxyPublicOwnerPlanPath,
+                ];
+            $softwareManualHoldDecision = $softwareManualHoldDecisionPath === null
+                ? null
+                : [
+                    ...$this->readJson($softwareManualHoldDecisionPath, 'software_manual_hold_decision'),
+                    'source_path' => $softwareManualHoldDecisionPath,
                 ];
             $payload = app(Career2786PublicResolutionPartitionPlanner::class)->partition(
                 sourcePlan: $sourcePlan,
@@ -62,6 +70,7 @@ final class CareerPlanCanonical2786PublicResolutionPartition extends Command
                 locales: $this->localesOption(),
                 occupationExistingSlugs: $entityContextPath === null ? null : $this->readOccupationExistingSlugs($entityContextPath),
                 cnProxyPublicOwnerPlan: $cnProxyPublicOwnerPlan,
+                softwareManualHoldDecision: $softwareManualHoldDecision,
             )->toArray();
 
             $payload['source_plan']['validation_issue_count'] = count($sourcePlanValidation->issues);

--- a/backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php
@@ -21,6 +21,7 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
         {--locales=en,zh : Comma-separated locales}
         {--entity-context= : Optional production-derived entity context JSON; if supplied, selected delta slugs must have occupation_exists=true}
         {--cn-proxy-public-owner-plan= : Optional reviewed CN proxy public-owner plan JSON for final 2786 partition accounting}
+        {--software-manual-hold-decision= : Optional reviewed software-developers manual-hold decision JSON for final 2786 partition accounting}
         {--exclude-slugs= : Optional newline, comma, or JSON slug artifact to exclude}
         {--strict : Fail on source-plan validation issues}
         {--json : Emit JSON output}
@@ -47,11 +48,18 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
             $excludePath = $this->pathOption('exclude-slugs');
             $entityContextPath = $this->pathOption('entity-context');
             $cnProxyPublicOwnerPlanPath = $this->pathOption('cn-proxy-public-owner-plan');
+            $softwareManualHoldDecisionPath = $this->pathOption('software-manual-hold-decision');
             $cnProxyPublicOwnerPlan = $cnProxyPublicOwnerPlanPath === null
                 ? null
                 : [
                     ...$this->readJson($cnProxyPublicOwnerPlanPath, 'cn_proxy_public_owner_plan'),
                     'source_path' => $cnProxyPublicOwnerPlanPath,
+                ];
+            $softwareManualHoldDecision = $softwareManualHoldDecisionPath === null
+                ? null
+                : [
+                    ...$this->readJson($softwareManualHoldDecisionPath, 'software_manual_hold_decision'),
+                    'source_path' => $softwareManualHoldDecisionPath,
                 ];
             $payload = app(CareerProgressiveReadinessSelector::class)->select(
                 sourcePlan: $sourcePlan,
@@ -63,6 +71,7 @@ final class CareerPlanCanonicalProgressiveReadinessSelection extends Command
                 excludeSlugs: $excludePath === null ? [] : $this->readSlugList($excludePath, 'exclude_slug'),
                 occupationExistingSlugs: $entityContextPath === null ? null : $this->readOccupationExistingSlugs($entityContextPath),
                 cnProxyPublicOwnerPlan: $cnProxyPublicOwnerPlan,
+                softwareManualHoldDecision: $softwareManualHoldDecision,
                 strict: (bool) $this->option('strict'),
             )->toArray();
 

--- a/backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionPlanner.php
+++ b/backend/app/Domain/Career/Audit/Career2786PublicResolutionPartitionPlanner.php
@@ -26,6 +26,7 @@ final class Career2786PublicResolutionPartitionPlanner
         array $locales = ['en', 'zh'],
         ?array $occupationExistingSlugs = null,
         ?array $cnProxyPublicOwnerPlan = null,
+        ?array $softwareManualHoldDecision = null,
     ): Career2786PublicResolutionPartitionResult {
         $locales = $this->normalizedStringList($locales, 'locale');
         $baselineSlugs = $this->normalizedSlugList($currentPublicSlugs, 'baseline_slug');
@@ -36,6 +37,7 @@ final class Career2786PublicResolutionPartitionPlanner
         $occupationExistingSet = $occupationExistingSlugs === null ? [] : array_fill_keys($occupationExistingSlugs, true);
         $requiresOccupationExists = $occupationExistingSlugs !== null;
         $cnProxyPublicOwnerAuthority = $this->cnProxyPublicOwnerAuthority($cnProxyPublicOwnerPlan, $targetPublicTotal);
+        $softwareManualHoldAuthority = $this->softwareManualHoldAuthority($softwareManualHoldDecision, $targetPublicTotal);
         $seenSourceSlugs = [];
         $duplicateSourceSlugs = [];
         $sourceSlugMissingCount = 0;
@@ -103,6 +105,9 @@ final class Career2786PublicResolutionPartitionPlanner
         foreach ($cnProxyPublicOwnerAuthority['issues'] as $issue) {
             $issues[] = $issue;
         }
+        foreach ($softwareManualHoldAuthority['issues'] as $issue) {
+            $issues[] = $issue;
+        }
         $partitionCounts = [];
         foreach ($partitions as $partition => $slugs) {
             $partitionCounts[$partition] = count($slugs);
@@ -117,7 +122,9 @@ final class Career2786PublicResolutionPartitionPlanner
         $softwareManualHoldCount = $partitionCounts['software_manual_hold'];
         $cnProxyPublicOwnerCount = min((int) $cnProxyPublicOwnerAuthority['public_owner_count'], $cnProxyCount);
         $cnProxyPolicyUnresolvedCount = max(0, $cnProxyCount - $cnProxyPublicOwnerCount);
-        $finalPublicAccountedTotal = count($baselineSlugs) + $canonicalCandidateCount + $cnProxyPublicOwnerCount;
+        $softwareManualHoldDecisionCount = min((int) $softwareManualHoldAuthority['governed_non_public_count'], $softwareManualHoldCount);
+        $softwareManualHoldUnresolvedCount = max(0, $softwareManualHoldCount - $softwareManualHoldDecisionCount);
+        $finalPublicAccountedTotal = count($baselineSlugs) + $canonicalCandidateCount + $cnProxyPublicOwnerCount + $softwareManualHoldDecisionCount;
         $finalPublicShortfall = max(0, $targetPublicTotal - $finalPublicAccountedTotal);
         $finalPublicCanReachTarget = $finalPublicShortfall === 0;
         $readinessPass = $issues === [] && $finalPublicCanReachTarget;
@@ -153,9 +160,12 @@ final class Career2786PublicResolutionPartitionPlanner
             'cn_proxy_public_owner_plan_count' => $cnProxyPublicOwnerCount,
             'cn_proxy_policy_asset_unresolved_count' => $cnProxyPolicyUnresolvedCount,
             'software_manual_hold_count' => $softwareManualHoldCount,
-            'policy_partition_required' => $cnProxyPolicyUnresolvedCount > 0 || $softwareManualHoldCount > 0,
+            'software_manual_hold_decision_count' => $softwareManualHoldDecisionCount,
+            'software_manual_hold_unresolved_count' => $softwareManualHoldUnresolvedCount,
+            'policy_partition_required' => $cnProxyPolicyUnresolvedCount > 0 || $softwareManualHoldUnresolvedCount > 0,
             'entity_remediation_required' => $occupationMissingCount > 0,
             'cn_proxy_public_owner_plan' => $cnProxyPublicOwnerAuthority['summary'],
+            'software_manual_hold_decision' => $softwareManualHoldAuthority['summary'],
             'partitions' => $partitions,
             'rows' => $rows,
             'source_plan' => [
@@ -177,7 +187,7 @@ final class Career2786PublicResolutionPartitionPlanner
                 finalPublicCanReachTarget: $finalPublicCanReachTarget,
                 occupationMissingCount: $occupationMissingCount,
                 cnProxyUnresolvedCount: $cnProxyPolicyUnresolvedCount,
-                softwareManualHoldCount: $softwareManualHoldCount,
+                softwareManualHoldUnresolvedCount: $softwareManualHoldUnresolvedCount,
             ),
             'next_required_action' => $readinessPass
                 ? '2786_RUNTIME_CANDIDATE_PREP_PLAN'
@@ -440,13 +450,109 @@ final class Career2786PublicResolutionPartitionPlanner
     }
 
     /**
+     * @return array{ready: bool, governed_non_public_count: int, issues: list<CareerProgressiveReadinessSelectionIssue>, summary: array<string, mixed>}
+     */
+    private function softwareManualHoldAuthority(?array $decision, int $targetPublicTotal): array
+    {
+        $summary = [
+            'provided' => $decision !== null,
+            'ready' => false,
+            'governed_non_public_count' => 0,
+            'source_path' => $decision['source_path'] ?? null,
+            'decision' => $decision['decision'] ?? null,
+            'governed_non_public_partition' => $decision['governed_non_public_partition'] ?? null,
+        ];
+
+        if ($decision === null) {
+            return [
+                'ready' => false,
+                'governed_non_public_count' => 0,
+                'issues' => [],
+                'summary' => $summary,
+            ];
+        }
+
+        if ($targetPublicTotal !== self::TARGET_PUBLIC_TOTAL) {
+            $issue = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'software_manual_hold_decision_target_scope_invalid',
+                message: 'Software manual-hold decision evidence is valid only for target_public_total=2786.',
+                severity: 'high',
+                evidence: ['target_public_total' => $targetPublicTotal],
+            );
+
+            return [
+                'ready' => false,
+                'governed_non_public_count' => 0,
+                'issues' => [$issue],
+                'summary' => $summary,
+            ];
+        }
+
+        $count = (int) ($decision['governed_non_public_count'] ?? 0);
+        $required = [
+            'schema_version' => ($decision['schema_version'] ?? null) === 'career_2786_software_manual_hold_final_policy_decision.v1',
+            'status' => ($decision['status'] ?? null) === 'decided',
+            'slug' => ($decision['slug'] ?? null) === 'software-developers',
+            'decision' => ($decision['decision'] ?? null) === 'resolve_as_governed_non_public_manual_hold',
+            'accepted_for_final_resolution_accounting' => ($decision['accepted_for_final_resolution_accounting'] ?? null) === true,
+            'accepted_as_canonical_public_rollout_candidate' => ($decision['accepted_as_canonical_public_rollout_candidate'] ?? null) === false,
+            'accepted_as_public_nonindex_reference' => ($decision['accepted_as_public_nonindex_reference'] ?? null) === false,
+            'canonical_rollout_allowed' => ($decision['canonical_rollout_allowed'] ?? null) === false,
+            'candidate_prep_allowed' => ($decision['candidate_prep_allowed'] ?? null) === false,
+            'rollout_apply_allowed' => ($decision['rollout_apply_allowed'] ?? null) === false,
+            'public_route_allowed' => ($decision['public_route_allowed'] ?? null) === false,
+            'sitemap_allowed' => ($decision['sitemap_allowed'] ?? null) === false,
+            'llms_allowed' => ($decision['llms_allowed'] ?? null) === false,
+            'llms_full_allowed' => ($decision['llms_full_allowed'] ?? null) === false,
+            'governed_non_public_partition' => ($decision['governed_non_public_partition'] ?? null) === 'software_manual_hold',
+            'governed_non_public_count' => $count === 1,
+            'writes_database' => ($decision['writes_database'] ?? null) === false,
+            'blockers_not_resolved_empty' => ($decision['blockers_not_resolved_by_this_decision'] ?? []) === [],
+        ];
+        $failed = array_keys(array_filter($required, static fn (bool $passed): bool => ! $passed));
+        $summary = [
+            ...$summary,
+            'ready' => $failed === [],
+            'governed_non_public_count' => $failed === [] ? $count : 0,
+            'declared_governed_non_public_count' => $count,
+            'failed_requirements' => $failed,
+        ];
+
+        if ($failed === []) {
+            return [
+                'ready' => true,
+                'governed_non_public_count' => $count,
+                'issues' => [],
+                'summary' => $summary,
+            ];
+        }
+
+        $issue = new CareerProgressiveReadinessSelectionIssue(
+            reason: 'software_manual_hold_decision_invalid',
+            message: 'Software manual-hold decision cannot be used for final 2786 partition accounting.',
+            severity: 'blocker_for_publication',
+            evidence: [
+                'failed_requirements' => $failed,
+                'declared_governed_non_public_count' => $count,
+            ],
+        );
+
+        return [
+            'ready' => false,
+            'governed_non_public_count' => 0,
+            'issues' => [$issue],
+            'summary' => $summary,
+        ];
+    }
+
+    /**
      * @return list<string>
      */
     private function nextRequiredActions(
         bool $finalPublicCanReachTarget,
         int $occupationMissingCount,
         int $cnProxyUnresolvedCount,
-        int $softwareManualHoldCount,
+        int $softwareManualHoldUnresolvedCount,
     ): array {
         $actions = [];
         if (! $finalPublicCanReachTarget) {
@@ -458,7 +564,7 @@ final class Career2786PublicResolutionPartitionPlanner
         if ($cnProxyUnresolvedCount > 0) {
             $actions[] = 'CN_PROXY_AUTHORITY_POLICY_DECISION_1';
         }
-        if ($softwareManualHoldCount > 0) {
+        if ($softwareManualHoldUnresolvedCount > 0) {
             $actions[] = 'SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1';
         }
         $actions[] = '2786_READINESS_RERUN_AFTER_PARTITION_DECISIONS';

--- a/backend/app/Domain/Career/Audit/CareerProgressiveReadinessSelector.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveReadinessSelector.php
@@ -26,6 +26,7 @@ final class CareerProgressiveReadinessSelector
         array $excludeSlugs = [],
         ?array $occupationExistingSlugs = null,
         ?array $cnProxyPublicOwnerPlan = null,
+        ?array $softwareManualHoldDecision = null,
         bool $strict = false,
     ): CareerProgressiveReadinessSelectionResult {
         $locales = $this->normalizedStringList($locales, 'locale');
@@ -44,10 +45,17 @@ final class CareerProgressiveReadinessSelector
         foreach ($cnProxyPublicOwnerAuthority['issues'] as $issue) {
             $issues[] = $issue;
         }
+        $softwareManualHoldAuthority = $this->softwareManualHoldAuthority($softwareManualHoldDecision, $targetPublicTotal);
+        foreach ($softwareManualHoldAuthority['issues'] as $issue) {
+            $issues[] = $issue;
+        }
         $publicOwnerDeltaCount = $cnProxyPublicOwnerAuthority['ready']
             ? min((int) $cnProxyPublicOwnerAuthority['public_owner_count'], $deltaNeeded)
             : 0;
-        $canonicalDeltaNeeded = max(0, $deltaNeeded - $publicOwnerDeltaCount);
+        $softwareManualHoldDeltaCount = $softwareManualHoldAuthority['ready']
+            ? min((int) $softwareManualHoldAuthority['governed_non_public_count'], max(0, $deltaNeeded - $publicOwnerDeltaCount))
+            : 0;
+        $canonicalDeltaNeeded = max(0, $deltaNeeded - $publicOwnerDeltaCount - $softwareManualHoldDeltaCount);
         $candidates = [];
         $selectedSlugs = [];
         $duplicateSourceSlugs = [];
@@ -138,20 +146,21 @@ final class CareerProgressiveReadinessSelector
         }
 
         if (count($selectedSlugs) < $canonicalDeltaNeeded) {
-            $finalPublicAccountedCount = $currentPublicTotal + count($selectedSlugs) + $publicOwnerDeltaCount;
-            $reason = $publicOwnerDeltaCount > 0
+            $finalPublicAccountedCount = $currentPublicTotal + count($selectedSlugs) + $publicOwnerDeltaCount + $softwareManualHoldDeltaCount;
+            $reason = $publicOwnerDeltaCount > 0 || $softwareManualHoldDeltaCount > 0
                 ? 'insufficient_final_public_partition_authority'
                 : 'insufficient_source_ready_delta_slugs';
             $issues[] = new CareerProgressiveReadinessSelectionIssue(
                 reason: $reason,
-                message: $publicOwnerDeltaCount > 0
-                    ? 'Final 2786 public accounting still has an unresolved partition shortfall after CN proxy public-owner evidence.'
+                message: $publicOwnerDeltaCount > 0 || $softwareManualHoldDeltaCount > 0
+                    ? 'Final 2786 public accounting still has an unresolved partition shortfall after policy partition evidence.'
                     : 'Fewer than the required progressive delta source-ready slugs are available.',
                 severity: 'blocker_for_publication',
                 evidence: [
                     'required_delta_slug_count' => $deltaNeeded,
                     'required_canonical_delta_slug_count' => $canonicalDeltaNeeded,
                     'public_owner_delta_slug_count' => $publicOwnerDeltaCount,
+                    'software_manual_hold_delta_slug_count' => $softwareManualHoldDeltaCount,
                     'selected_count' => count($selectedSlugs),
                     'final_public_accounted_count' => $finalPublicAccountedCount,
                     'final_public_shortfall' => max(0, $targetPublicTotal - $finalPublicAccountedCount),
@@ -169,11 +178,13 @@ final class CareerProgressiveReadinessSelector
         ksort($excludedByReason);
         $targetSlugs = [...$baselineSlugs, ...$selectedSlugs];
         $status = $issues === [] ? 'pass' : 'blocked';
-        $finalPublicAccountedCount = $currentPublicTotal + count($selectedSlugs) + $publicOwnerDeltaCount;
+        $finalPublicAccountedCount = $currentPublicTotal + count($selectedSlugs) + $publicOwnerDeltaCount + $softwareManualHoldDeltaCount;
         $finalPublicShortfall = max(0, $targetPublicTotal - $finalPublicAccountedCount);
-        $selectionStrategy = $publicOwnerDeltaCount > 0
-            ? 'progressive_source_ready_after_closeout_baseline_with_public_owner_partition'
-            : 'progressive_source_ready_after_closeout_baseline';
+        $selectionStrategy = $softwareManualHoldDeltaCount > 0
+            ? 'progressive_source_ready_after_closeout_baseline_with_policy_partitions'
+            : ($publicOwnerDeltaCount > 0
+                ? 'progressive_source_ready_after_closeout_baseline_with_public_owner_partition'
+                : 'progressive_source_ready_after_closeout_baseline');
 
         return new CareerProgressiveReadinessSelectionResult([
             'schema_version' => self::SCHEMA_VERSION,
@@ -189,6 +200,7 @@ final class CareerProgressiveReadinessSelector
             'delta_slug_count' => $deltaNeeded,
             'canonical_delta_slug_count' => $canonicalDeltaNeeded,
             'public_owner_delta_slug_count' => $publicOwnerDeltaCount,
+            'software_manual_hold_delta_slug_count' => $softwareManualHoldDeltaCount,
             'selected_count' => count($selectedSlugs),
             'candidate_count' => $selectableCandidateCount,
             'source_ready_count' => $sourceReadyCount,
@@ -197,6 +209,7 @@ final class CareerProgressiveReadinessSelector
             'expected_delta_locale_rows' => $deltaNeeded * count($locales),
             'expected_canonical_delta_locale_rows' => $canonicalDeltaNeeded * count($locales),
             'expected_public_owner_locale_rows' => $publicOwnerDeltaCount * count($locales),
+            'expected_software_manual_hold_locale_rows' => $softwareManualHoldDeltaCount * count($locales),
             'expected_total_locale_rows' => $targetPublicTotal * count($locales),
             'final_public_accounted_count' => $finalPublicAccountedCount,
             'final_public_shortfall' => $finalPublicShortfall,
@@ -229,6 +242,7 @@ final class CareerProgressiveReadinessSelector
                 'occupation_missing_excluded_count' => $occupationMissingExcludedCount,
             ],
             'cn_proxy_public_owner_plan' => $cnProxyPublicOwnerAuthority['summary'],
+            'software_manual_hold_decision' => $softwareManualHoldAuthority['summary'],
             'excluded' => [
                 'excluded_by_reason' => $excludedByReason,
                 'baseline_excluded_count' => count($baselineSlugs),
@@ -461,6 +475,102 @@ final class CareerProgressiveReadinessSelector
         return [
             'ready' => false,
             'public_owner_count' => 0,
+            'issues' => [$issue],
+            'summary' => $summary,
+        ];
+    }
+
+    /**
+     * @return array{ready: bool, governed_non_public_count: int, issues: list<CareerProgressiveReadinessSelectionIssue>, summary: array<string, mixed>}
+     */
+    private function softwareManualHoldAuthority(?array $decision, int $targetPublicTotal): array
+    {
+        $summary = [
+            'provided' => $decision !== null,
+            'ready' => false,
+            'governed_non_public_count' => 0,
+            'source_path' => $decision['source_path'] ?? null,
+            'decision' => $decision['decision'] ?? null,
+            'governed_non_public_partition' => $decision['governed_non_public_partition'] ?? null,
+        ];
+
+        if ($decision === null) {
+            return [
+                'ready' => false,
+                'governed_non_public_count' => 0,
+                'issues' => [],
+                'summary' => $summary,
+            ];
+        }
+
+        if ($targetPublicTotal !== 2786) {
+            $issue = new CareerProgressiveReadinessSelectionIssue(
+                reason: 'software_manual_hold_decision_target_scope_invalid',
+                message: 'Software manual-hold decision evidence is valid only for the final 2786 readiness target.',
+                severity: 'high',
+                evidence: ['target_public_total' => $targetPublicTotal],
+            );
+
+            return [
+                'ready' => false,
+                'governed_non_public_count' => 0,
+                'issues' => [$issue],
+                'summary' => $summary,
+            ];
+        }
+
+        $count = (int) ($decision['governed_non_public_count'] ?? 0);
+        $required = [
+            'schema_version' => ($decision['schema_version'] ?? null) === 'career_2786_software_manual_hold_final_policy_decision.v1',
+            'status' => ($decision['status'] ?? null) === 'decided',
+            'slug' => ($decision['slug'] ?? null) === 'software-developers',
+            'decision' => ($decision['decision'] ?? null) === 'resolve_as_governed_non_public_manual_hold',
+            'accepted_for_final_resolution_accounting' => ($decision['accepted_for_final_resolution_accounting'] ?? null) === true,
+            'accepted_as_canonical_public_rollout_candidate' => ($decision['accepted_as_canonical_public_rollout_candidate'] ?? null) === false,
+            'accepted_as_public_nonindex_reference' => ($decision['accepted_as_public_nonindex_reference'] ?? null) === false,
+            'canonical_rollout_allowed' => ($decision['canonical_rollout_allowed'] ?? null) === false,
+            'candidate_prep_allowed' => ($decision['candidate_prep_allowed'] ?? null) === false,
+            'rollout_apply_allowed' => ($decision['rollout_apply_allowed'] ?? null) === false,
+            'public_route_allowed' => ($decision['public_route_allowed'] ?? null) === false,
+            'sitemap_allowed' => ($decision['sitemap_allowed'] ?? null) === false,
+            'llms_allowed' => ($decision['llms_allowed'] ?? null) === false,
+            'llms_full_allowed' => ($decision['llms_full_allowed'] ?? null) === false,
+            'governed_non_public_partition' => ($decision['governed_non_public_partition'] ?? null) === 'software_manual_hold',
+            'governed_non_public_count' => $count === 1,
+            'writes_database' => ($decision['writes_database'] ?? null) === false,
+            'blockers_not_resolved_empty' => ($decision['blockers_not_resolved_by_this_decision'] ?? []) === [],
+        ];
+        $failed = array_keys(array_filter($required, static fn (bool $passed): bool => ! $passed));
+        $summary = [
+            ...$summary,
+            'ready' => $failed === [],
+            'governed_non_public_count' => $failed === [] ? $count : 0,
+            'declared_governed_non_public_count' => $count,
+            'failed_requirements' => $failed,
+        ];
+
+        if ($failed === []) {
+            return [
+                'ready' => true,
+                'governed_non_public_count' => $count,
+                'issues' => [],
+                'summary' => $summary,
+            ];
+        }
+
+        $issue = new CareerProgressiveReadinessSelectionIssue(
+            reason: 'software_manual_hold_decision_invalid',
+            message: 'Software manual-hold decision cannot be used for final 2786 partition accounting.',
+            severity: 'blocker_for_publication',
+            evidence: [
+                'failed_requirements' => $failed,
+                'declared_governed_non_public_count' => $count,
+            ],
+        );
+
+        return [
+            'ready' => false,
+            'governed_non_public_count' => 0,
             'issues' => [$issue],
             'summary' => $summary,
         ];

--- a/backend/docs/career/audits/2786_public_resolution_partition.md
+++ b/backend/docs/career/audits/2786_public_resolution_partition.md
@@ -13,6 +13,8 @@ The command does not treat every remaining source row as a canonical rollout can
 - `--locales=en,zh`
 - `--entity-context=` optional entity context with `occupation_exists=true` evidence.
 - `--cn-proxy-public-owner-plan=` optional reviewed CN proxy public-owner plan.
+- `--software-manual-hold-decision=` optional reviewed `software-developers`
+  manual-hold decision artifact.
 
 ## Partitions
 
@@ -52,6 +54,39 @@ If the plan resolves all CN proxy policy assets, the next actions no longer
 include `CN_PROXY_AUTHORITY_POLICY_DECISION_1`. Other partitions, such as
 `software_manual_hold`, remain independent blockers until they have their own
 authority decision.
+
+## Software Manual-Hold Authority
+
+The final 2786 partition can consume the
+`career_2786_software_manual_hold_final_policy_decision.v1` artifact for
+`software-developers`. This decision is accounting-only. It resolves the one-row
+manual-hold partition as governed non-public evidence for final 2786 resolution
+accounting only when all guards pass:
+
+- `status=decided`
+- `slug=software-developers`
+- `decision=resolve_as_governed_non_public_manual_hold`
+- final resolution accounting is explicitly accepted
+- canonical rollout, candidate prep, rollout apply, public route, sitemap,
+  llms, and llms-full are all disabled
+- public nonindex reference is not accepted
+- governed non-public partition is `software_manual_hold`
+- governed non-public count is exactly `1`
+- `writes_database=false`
+- no unresolved blockers remain in the decision artifact
+
+When accepted, the output includes:
+
+- `software_manual_hold_decision_count`
+- `software_manual_hold_unresolved_count`
+- `software_manual_hold_decision`
+- updated `final_public_accounted_total`
+- updated `final_public_shortfall`
+
+This authority does not publish `software-developers`, does not create a public
+route, and does not permit candidate preparation or canonical rollout for the
+slug. The rollout manifest gate and rollout executor must continue to reject
+`software-developers` if it appears in a delta manifest.
 
 ## Non-goals
 

--- a/backend/docs/career/audits/progressive_readiness_selection.md
+++ b/backend/docs/career/audits/progressive_readiness_selection.md
@@ -179,6 +179,31 @@ This authority is accounting-only for final readiness. It does not publish CN
 proxy rows, does not permit canonical rollout promotion for CN proxy rows, and
 does not weaken final live acceptance.
 
+## Final 2786 Software Manual-Hold Authority
+
+`--software-manual-hold-decision` is scoped to target `2786`. When supplied and
+valid, the selector:
+
+- keeps `software-developers` excluded from `selected_slugs`,
+  `delta_promotion_slugs`, and `canonical_rollout_slugs`;
+- records `software_manual_hold_delta_slug_count` and
+  `expected_software_manual_hold_locale_rows`;
+- reduces `canonical_delta_slug_count` to the remaining canonical rollout
+  shortfall after both CN proxy public-owner and software manual-hold
+  accounting; and
+- reports `final_public_accounted_count` / `final_public_shortfall`.
+
+The decision must be decided, read-only, write-free, scoped to
+`software-developers`, accepted only for final resolution accounting, and must
+keep canonical rollout, candidate prep, rollout apply, public route, sitemap,
+llms, and llms-full disabled. Invalid manual-hold evidence is reported as
+`software_manual_hold_decision_invalid` and is not counted toward the final
+target.
+
+This authority is accounting-only for final readiness. It does not publish
+`software-developers`, does not permit canonical rollout promotion for the slug,
+and does not weaken final live acceptance.
+
 ## Non-Goals
 
 - No DB mutation.

--- a/backend/tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php
@@ -103,6 +103,43 @@ final class CareerPlanCanonical2786PublicResolutionPartitionCommandTest extends 
         $this->assertFileExists($output);
     }
 
+    public function test_command_accounts_software_manual_hold_decision_without_unlocking_rollout_candidates(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->slugs('policy', 1663, 'cn-');
+        $software = ['software-developers'];
+        $baselinePath = $this->writeSlugs('baseline', $baseline);
+        $output = $this->tempPath('output');
+
+        $exitCode = Artisan::call('career:plan-canonical-2786-public-resolution-partition', [
+            '--source-plan' => $this->writeSourcePlan([...$baseline, ...$canonical, ...$cnProxy, ...$software]),
+            '--closeout' => $this->writeCloseout($baselinePath),
+            '--current-total' => '800',
+            '--target-total' => '2786',
+            '--locales' => 'en,zh',
+            '--entity-context' => $this->writeEntityContext([...$baseline, ...$canonical, ...$cnProxy, ...$software], []),
+            '--cn-proxy-public-owner-plan' => $this->writeCnProxyPublicOwnerPlan(1663),
+            '--software-manual-hold-decision' => $this->writeSoftwareManualHoldDecision(),
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['readiness_pass']);
+        $this->assertSame(322, $payload['canonical_rollout_candidate_count']);
+        $this->assertSame(1, $payload['software_manual_hold_count']);
+        $this->assertSame(1, $payload['software_manual_hold_decision_count']);
+        $this->assertSame(0, $payload['software_manual_hold_unresolved_count']);
+        $this->assertSame(2786, $payload['final_public_accounted_total']);
+        $this->assertSame(0, $payload['final_public_shortfall']);
+        $this->assertTrue($payload['software_manual_hold_decision']['ready']);
+        $this->assertNotContains('SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1', $payload['next_required_actions']);
+        $this->assertFileExists($output);
+    }
+
     public function test_missing_source_plan_blocks_without_mutation(): void
     {
         $baselinePath = $this->writeSlugs('baseline', $this->slugs('baseline', 800));
@@ -239,6 +276,30 @@ final class CareerPlanCanonical2786PublicResolutionPartitionCommandTest extends 
             'llms_full_CN_urls' => 0,
             'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
             'blockers' => [],
+        ]);
+    }
+
+    private function writeSoftwareManualHoldDecision(): string
+    {
+        return $this->writeJson('software-manual-hold-decision', [
+            'schema_version' => 'career_2786_software_manual_hold_final_policy_decision.v1',
+            'status' => 'decided',
+            'slug' => 'software-developers',
+            'decision' => 'resolve_as_governed_non_public_manual_hold',
+            'accepted_for_final_resolution_accounting' => true,
+            'accepted_as_canonical_public_rollout_candidate' => false,
+            'accepted_as_public_nonindex_reference' => false,
+            'canonical_rollout_allowed' => false,
+            'candidate_prep_allowed' => false,
+            'rollout_apply_allowed' => false,
+            'public_route_allowed' => false,
+            'sitemap_allowed' => false,
+            'llms_allowed' => false,
+            'llms_full_allowed' => false,
+            'governed_non_public_partition' => 'software_manual_hold',
+            'governed_non_public_count' => 1,
+            'writes_database' => false,
+            'blockers_not_resolved_by_this_decision' => [],
         ]);
     }
 

--- a/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php
@@ -138,6 +138,72 @@ final class CareerPlanCanonicalProgressiveReadinessSelectionCommandTest extends 
         $this->assertFileExists($output);
     }
 
+    public function test_final_2786_selection_uses_software_manual_hold_decision_for_partition_accounting_only(): void
+    {
+        $current = $this->slugs('current', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->prefixedSlugs('policy', 1663, 'cn-');
+        $currentSlugs = $this->writeSlugs('current', $current);
+        $output = $this->tempPath('output');
+
+        $exitCode = Artisan::call('career:plan-canonical-progressive-readiness-selection', [
+            '--source-plan' => $this->writeSourcePlan([...$current, ...$canonical, ...$cnProxy, 'software-developers']),
+            '--closeout' => $this->writeCloseout(800, $currentSlugs),
+            '--current-total' => '800',
+            '--target-total' => '2786',
+            '--locales' => 'en,zh',
+            '--cn-proxy-public-owner-plan' => $this->writeCnProxyPublicOwnerPlan(1663),
+            '--software-manual-hold-decision' => $this->writeSoftwareManualHoldDecision(),
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(1986, $payload['delta_slug_count']);
+        $this->assertSame(322, $payload['canonical_delta_slug_count']);
+        $this->assertSame(1663, $payload['public_owner_delta_slug_count']);
+        $this->assertSame(1, $payload['software_manual_hold_delta_slug_count']);
+        $this->assertSame(322, $payload['selected_count']);
+        $this->assertSame(2786, $payload['final_public_accounted_count']);
+        $this->assertSame(0, $payload['final_public_shortfall']);
+        $this->assertTrue($payload['software_manual_hold_decision']['ready']);
+        $this->assertNotContains('software-developers', $payload['selected_slugs']);
+        $this->assertNotContains('software-developers', $payload['canonical_rollout_slugs']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFalse($payload['rollout_allowed']);
+        $this->assertFileExists($output);
+    }
+
+    public function test_invalid_software_manual_hold_decision_blocks_final_2786_accounting(): void
+    {
+        $current = $this->slugs('current', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->prefixedSlugs('policy', 1663, 'cn-');
+        $currentSlugs = $this->writeSlugs('current', $current);
+
+        $exitCode = Artisan::call('career:plan-canonical-progressive-readiness-selection', [
+            '--source-plan' => $this->writeSourcePlan([...$current, ...$canonical, ...$cnProxy, 'software-developers']),
+            '--closeout' => $this->writeCloseout(800, $currentSlugs),
+            '--current-total' => '800',
+            '--target-total' => '2786',
+            '--locales' => 'en,zh',
+            '--cn-proxy-public-owner-plan' => $this->writeCnProxyPublicOwnerPlan(1663),
+            '--software-manual-hold-decision' => $this->writeSoftwareManualHoldDecision(['public_route_allowed' => true]),
+            '--json' => true,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(0, $payload['software_manual_hold_delta_slug_count']);
+        $this->assertFalse($payload['software_manual_hold_decision']['ready']);
+        $this->assertContains('public_route_allowed', $payload['software_manual_hold_decision']['failed_requirements']);
+        $this->assertContains('software_manual_hold_decision_invalid', array_column($payload['blockers'], 'reason'));
+    }
+
     public function test_entity_context_with_no_existing_occupations_blocks_without_mutation(): void
     {
         $current = $this->slugs('current', 80);
@@ -308,6 +374,36 @@ final class CareerPlanCanonicalProgressiveReadinessSelectionCommandTest extends 
             'llms_full_CN_urls' => 0,
             'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
             'blockers' => [],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function writeSoftwareManualHoldDecision(array $overrides = []): string
+    {
+        return $this->writeJson('software-manual-hold-decision', [
+            ...[
+                'schema_version' => 'career_2786_software_manual_hold_final_policy_decision.v1',
+                'status' => 'decided',
+                'slug' => 'software-developers',
+                'decision' => 'resolve_as_governed_non_public_manual_hold',
+                'accepted_for_final_resolution_accounting' => true,
+                'accepted_as_canonical_public_rollout_candidate' => false,
+                'accepted_as_public_nonindex_reference' => false,
+                'canonical_rollout_allowed' => false,
+                'candidate_prep_allowed' => false,
+                'rollout_apply_allowed' => false,
+                'public_route_allowed' => false,
+                'sitemap_allowed' => false,
+                'llms_allowed' => false,
+                'llms_full_allowed' => false,
+                'governed_non_public_partition' => 'software_manual_hold',
+                'governed_non_public_count' => 1,
+                'writes_database' => false,
+                'blockers_not_resolved_by_this_decision' => [],
+            ],
+            ...$overrides,
         ]);
     }
 

--- a/backend/tests/Unit/Domain/Career/Audit/Career2786PublicResolutionPartitionPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career2786PublicResolutionPartitionPlannerTest.php
@@ -104,6 +104,72 @@ final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
         $this->assertContains('DO_NOT_RUN_2786_CANONICAL_CANDIDATE_PREP', $payload['next_required_actions']);
     }
 
+    public function test_software_manual_hold_decision_accounts_for_final_partition_without_unlocking_rollout_candidate(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->slugs('policy', 1663, 'cn-');
+        $software = ['software-developers'];
+
+        $payload = $this->partition(
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+            baselineSlugs: $baseline,
+            occupationExistingSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+            cnProxyPublicOwnerPlan: $this->cnProxyPublicOwnerPlan(1663),
+            softwareManualHoldDecision: $this->softwareManualHoldDecision(),
+        );
+
+        $softwareRows = array_values(array_filter(
+            $payload['rows'],
+            static fn (array $row): bool => $row['slug'] === 'software-developers',
+        ));
+
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['readiness_pass']);
+        $this->assertSame(322, $payload['canonical_rollout_candidate_count']);
+        $this->assertSame(1, $payload['software_manual_hold_count']);
+        $this->assertSame(1, $payload['software_manual_hold_decision_count']);
+        $this->assertSame(0, $payload['software_manual_hold_unresolved_count']);
+        $this->assertSame(2786, $payload['final_public_accounted_total']);
+        $this->assertSame(0, $payload['final_public_shortfall']);
+        $this->assertTrue($payload['software_manual_hold_decision']['ready']);
+        $this->assertNotContains('SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1', $payload['next_required_actions']);
+        $this->assertNotContains('DO_NOT_RUN_2786_CANONICAL_CANDIDATE_PREP', $payload['next_required_actions']);
+        $this->assertCount(1, $softwareRows);
+        $this->assertFalse($softwareRows[0]['rollout_candidate']);
+        $this->assertFalse($softwareRows[0]['canonical_rollout_candidate']);
+        $this->assertFalse($softwareRows[0]['candidate_prep_allowed']);
+    }
+
+    public function test_invalid_software_manual_hold_decision_blocks_final_partition_accounting(): void
+    {
+        $baseline = $this->slugs('baseline', 800);
+        $canonical = $this->slugs('canonical', 322);
+        $cnProxy = $this->slugs('policy', 1663, 'cn-');
+        $software = ['software-developers'];
+        $invalidDecision = [
+            ...$this->softwareManualHoldDecision(),
+            'sitemap_allowed' => true,
+        ];
+
+        $payload = $this->partition(
+            sourceSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+            baselineSlugs: $baseline,
+            occupationExistingSlugs: [...$baseline, ...$canonical, ...$cnProxy, ...$software],
+            cnProxyPublicOwnerPlan: $this->cnProxyPublicOwnerPlan(1663),
+            softwareManualHoldDecision: $invalidDecision,
+        );
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertFalse($payload['readiness_pass']);
+        $this->assertSame(0, $payload['software_manual_hold_decision_count']);
+        $this->assertSame(1, $payload['software_manual_hold_unresolved_count']);
+        $this->assertFalse($payload['software_manual_hold_decision']['ready']);
+        $this->assertContains('sitemap_allowed', $payload['software_manual_hold_decision']['failed_requirements']);
+        $this->assertContains('software_manual_hold_decision_invalid', array_column($payload['blockers'], 'reason'));
+        $this->assertContains('SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1', $payload['next_required_actions']);
+    }
+
     public function test_reviewed_cn_proxy_public_owner_plan_allows_final_partition_readiness_when_accounting_is_complete(): void
     {
         $baseline = $this->slugs('baseline', 800);
@@ -176,6 +242,7 @@ final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
         array $baselineSlugs,
         array $occupationExistingSlugs,
         ?array $cnProxyPublicOwnerPlan = null,
+        ?array $softwareManualHoldDecision = null,
     ): array {
         return (new Career2786PublicResolutionPartitionPlanner)->partition(
             sourcePlan: new CareerPublicResolutionPlan(
@@ -196,6 +263,7 @@ final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
             locales: ['en', 'zh'],
             occupationExistingSlugs: $occupationExistingSlugs,
             cnProxyPublicOwnerPlan: $cnProxyPublicOwnerPlan,
+            softwareManualHoldDecision: $softwareManualHoldDecision,
         )->toArray();
     }
 
@@ -261,6 +329,33 @@ final class Career2786PublicResolutionPartitionPlannerTest extends TestCase
             'llms_full_CN_urls' => 0,
             'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
             'blockers' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function softwareManualHoldDecision(): array
+    {
+        return [
+            'schema_version' => 'career_2786_software_manual_hold_final_policy_decision.v1',
+            'status' => 'decided',
+            'slug' => 'software-developers',
+            'decision' => 'resolve_as_governed_non_public_manual_hold',
+            'accepted_for_final_resolution_accounting' => true,
+            'accepted_as_canonical_public_rollout_candidate' => false,
+            'accepted_as_public_nonindex_reference' => false,
+            'canonical_rollout_allowed' => false,
+            'candidate_prep_allowed' => false,
+            'rollout_apply_allowed' => false,
+            'public_route_allowed' => false,
+            'sitemap_allowed' => false,
+            'llms_allowed' => false,
+            'llms_full_allowed' => false,
+            'governed_non_public_partition' => 'software_manual_hold',
+            'governed_non_public_count' => 1,
+            'writes_database' => false,
+            'blockers_not_resolved_by_this_decision' => [],
         ];
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6938,6 +6938,91 @@
         }
       ]
     },
+    "REPAIR-2786-FINAL-READINESS-SOFTWARE-MANUAL-HOLD-AUTHORITY-1": {
+      "repo": "fap-api",
+      "branch": "fix/career-2786-final-readiness-software-manual-hold-authority-1",
+      "title": "fix(api): account software manual hold in 2786 readiness",
+      "name": "Account software-developers manual-hold decision in final 2786 readiness",
+      "status": "in_progress",
+      "depends_on": [
+        "SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1",
+        "REPAIR-2786-FINAL-READINESS-PUBLIC-OWNER-PARTITION-AUTHORITY-1"
+      ],
+      "scope_type": "final_2786_software_manual_hold_authority_only",
+      "allowed_paths": [
+        "backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php",
+        "backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php",
+        "backend/app/Domain/Career/Audit/**",
+        "backend/tests/Unit/Domain/Career/Audit/**",
+        "backend/tests/Feature/Console/**",
+        "backend/docs/career/audits/**",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ],
+      "non_goals": [
+        "no candidate prep dry-run",
+        "no candidate prep apply",
+        "no rollout dry-run",
+        "no rollout apply",
+        "no production DB mutation",
+        "no rollback",
+        "no quarantine",
+        "no deploy",
+        "no fap-web",
+        "do not mark software-developers as a canonical rollout candidate",
+        "do not enable software-developers public route, indexability, sitemap, llms, or llms-full exposure",
+        "do not weaken final live acceptance"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-2786-FINAL-READINESS-SOFTWARE-MANUAL-HOLD-AUTHORITY-1, then implementing the PR."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1 produced /tmp/career_2786_software_manual_hold_final_policy_decision.json and PR #1417 is present on origin/main."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to final 2786 readiness/partition command and domain logic, focused Career tests, audit docs, and authorized train metadata."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": [
+            "php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi: pass (19 tests, 98 assertions)",
+            "php artisan test --filter=Career2786PublicResolutionPartition --no-ansi: pass (8 tests, 82 assertions)",
+            "php artisan test tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php --no-ansi: pass (9 tests, 66 assertions)",
+            "php artisan test tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php --no-ansi: pass (5 tests, 47 assertions)",
+            "php artisan test --filter=CareerProgressive --no-ansi: pass (37 tests, 171 assertions)",
+            "php artisan test --filter=Career80TotalLiveAcceptance --no-ansi: pass (11 tests, 49 assertions)",
+            "php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi: pass (27 tests, 138 assertions)",
+            "php artisan test --filter=CareerRuntimeCandidate --no-ansi: pass (8 tests, 40 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-2786-software-manual-hold-authority.sqlite php artisan migrate --force --no-ansi: pass",
+            "ruby YAML.load_file docs/codex/pr-train.yaml: pass",
+            "python3 -m json.tool docs/codex/pr-train-state.json: pass",
+            "vendor/bin/pint --test: pass",
+            "git diff --check: pass",
+            "bash backend/scripts/ci_verify_mbti.sh: pass",
+            "Local read-only readiness smoke against /tmp 2786 artifacts: status=pass, selected_count=322, canonical_delta_slug_count=322, public_owner_delta_slug_count=1663, software_manual_hold_delta_slug_count=1, final_public_accounted_count=2786, final_public_shortfall=0, writes_database=false.",
+            "Local read-only partition smoke against /tmp 2786 artifacts: status=pass, canonical_rollout_candidate_count=322, cn_proxy_public_owner_plan_count=1663, software_manual_hold_decision_count=1, software_manual_hold_unresolved_count=0, final_public_accounted_total=2786, final_public_shortfall=0, candidate_prep_allowed=false."
+          ]
+        },
+        "github_pr": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "next_pr": "2786-READINESS-1",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": []
+    },
     "PR-CMS-FIX-MASTER": {
       "repo": "fap-api",
       "branch": "codex/pr-cms-fix-master-semantic-content-gate",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -750,6 +750,51 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-2786-FINAL-READINESS-SOFTWARE-MANUAL-HOLD-AUTHORITY-1
+    repo: fap-api
+    depends_on:
+      - SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1
+      - REPAIR-2786-FINAL-READINESS-PUBLIC-OWNER-PARTITION-AUTHORITY-1
+    branch: fix/career-2786-final-readiness-software-manual-hold-authority-1
+    title: "fix(api): account software manual hold in 2786 readiness"
+    name: "Account software-developers manual-hold decision in final 2786 readiness"
+    scope:
+      - Extend final 2786 readiness and public-resolution partition commands to consume reviewed software-developers manual-hold decision evidence.
+      - Count the accepted software manual-hold decision only toward final 2786 governed non-public accounting.
+      - Keep software-developers excluded from canonical rollout selection, candidate prep, rollout manifests, public routes, sitemap, llms, and llms-full eligibility.
+      - Preserve CN proxy public-owner authority, rollout executor rejection, and final live acceptance strictness.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerPlanCanonicalProgressiveReadinessSelection.php
+      - backend/app/Console/Commands/CareerPlanCanonical2786PublicResolutionPartition.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Unit/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Run 2786 readiness execution beyond read-only local smoke.
+      - Run candidate prep dry-run or apply.
+      - Run rollout dry-run.
+      - Run rollout apply.
+      - Run backfill, rollback, quarantine, or publication expansion.
+      - Query or mutate production DB.
+      - Touch fap-web or deploy.
+      - Mark software-developers as a canonical rollout candidate.
+      - Enable software-developers public route, indexability, sitemap, llms, or llms-full exposure.
+      - Weaken final live acceptance.
+    validation:
+      - php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi
+      - php artisan test --filter=Career2786PublicResolutionPartition --no-ansi
+      - php artisan test tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php --no-ansi
+      - php artisan test tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- Adds final 2786 readiness/partition support for the reviewed `software-developers` manual-hold decision artifact.
- Counts the decision only toward governed non-public final resolution accounting.
- Keeps `software-developers` out of canonical rollout selection, candidate prep, rollout manifests, public routes, sitemap, llms, and llms-full.
- Registers the authorized PR-train item and documents the accounting-only authority.

## Guardrails
- Read-only planner/command logic only.
- No DB mutation, candidate prep, rollout dry-run, rollout apply, deploy, rollback, quarantine, or fap-web change.
- Does not weaken final live acceptance or rollout executor rejection.

## Local validation
- `php artisan test --filter=CareerProgressiveReadinessSelection --no-ansi` passed.
- `php artisan test --filter=Career2786PublicResolutionPartition --no-ansi` passed.
- `php artisan test tests/Feature/Console/CareerPlanCanonicalProgressiveReadinessSelectionCommandTest.php --no-ansi` passed.
- `php artisan test tests/Feature/Console/CareerPlanCanonical2786PublicResolutionPartitionCommandTest.php --no-ansi` passed.
- `php artisan test --filter=CareerProgressive --no-ansi` passed.
- `php artisan test --filter=Career80TotalLiveAcceptance --no-ansi` passed.
- `php artisan test --filter=CareerAuditCanonicalEligibility --no-ansi` passed.
- `php artisan test --filter=CareerRuntimeCandidate --no-ansi` passed.
- `php artisan route:list --no-ansi` passed.
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-2786-software-manual-hold-authority.sqlite php artisan migrate --force --no-ansi` passed.
- `vendor/bin/pint --test` passed.
- `git diff --check` passed.
- `bash backend/scripts/ci_verify_mbti.sh` passed.

## Smoke evidence
- Readiness smoke with `/tmp/career_2786_software_manual_hold_final_policy_decision.json`: `status=pass`, `selected_count=322`, `public_owner_delta_slug_count=1663`, `software_manual_hold_delta_slug_count=1`, `final_public_accounted_count=2786`, `final_public_shortfall=0`, `writes_database=false`.
- Partition smoke: `status=pass`, `canonical_rollout_candidate_count=322`, `cn_proxy_public_owner_plan_count=1663`, `software_manual_hold_decision_count=1`, `software_manual_hold_unresolved_count=0`, `final_public_accounted_total=2786`, `candidate_prep_allowed=false`.

## Next step
- `2786-READINESS-1` rerun with `--software-manual-hold-decision=/tmp/career_2786_software_manual_hold_final_policy_decision.json`.
