### PR TITLE
fix(api): derive career directory from runtime projection

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
@@ -43,6 +43,23 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
             ?? null;
     }
 
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function publicDatasetItems(): array
+    {
+        return $this->visibleItems(static fn (array $item): bool => ($item['dataset_visible'] ?? false) === true);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function publicDetailItems(): array
+    {
+        return $this->visibleItems(static fn (array $item): bool => ($item['detail_route_enabled'] ?? false) === true
+            && ($item['release_gate_pass'] ?? false) === true);
+    }
+
     public function datasetVisible(string $slug): bool
     {
         return (bool) ($this->itemForSlug($slug)['dataset_visible'] ?? false);
@@ -103,6 +120,29 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
         $this->hydrate();
 
         return $this->itemsBySlug ?? [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function visibleItems(callable $filter): array
+    {
+        $items = [];
+
+        foreach ($this->itemsBySlug() as $item) {
+            if (! $filter($item)) {
+                continue;
+            }
+
+            $items[] = $item;
+        }
+
+        usort($items, static fn (array $left, array $right): int => strcmp(
+            strtolower((string) ($left['slug'] ?? '')),
+            strtolower((string) ($right['slug'] ?? '')),
+        ));
+
+        return $items;
     }
 
     private function hydrate(): void

--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php
@@ -11,6 +11,16 @@ interface CareerRuntimePublishProjectionVisibility
      */
     public function itemForSlug(string $slug, string $locale = 'en'): ?array;
 
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function publicDatasetItems(): array;
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function publicDetailItems(): array;
+
     public function datasetVisible(string $slug): bool;
 
     public function searchVisible(string $slug): bool;

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -134,6 +134,15 @@ final class CareerJobListBundleBuilder
             $items = $items->concat($directoryDraftItems)->values();
         }
 
+        $visibleSlugs = $items
+            ->map(static fn (CareerJobListItemBundle $item): string => (string) ($item->identity['canonical_slug'] ?? ''))
+            ->filter()
+            ->all();
+        $runtimeProjectionItems = $this->buildRuntimeProjectionCareerJobItems($visibleSlugs, $includeNonIndexable);
+        if ($runtimeProjectionItems !== []) {
+            $items = $items->concat($runtimeProjectionItems)->values();
+        }
+
         /** @var Collection<int, CareerJobListItemBundle> $items */
         $items = $items->sortBy(static fn (CareerJobListItemBundle $item): array => [
             strtolower((string) ($item->titles['canonical_en'] ?? '')),
@@ -192,6 +201,45 @@ final class CareerJobListBundleBuilder
                 && $this->runtimePublishProjection->datasetVisible((string) $occupation->canonical_slug))
             ->values()
             ->map(fn (Occupation $occupation): CareerJobListItemBundle => $this->buildDirectoryDraftCareerJobItem($occupation))
+            ->all();
+    }
+
+    /**
+     * @param  list<string>  $excludedSlugs
+     * @return list<CareerJobListItemBundle>
+     */
+    private function buildRuntimeProjectionCareerJobItems(array $excludedSlugs, bool $includeNonIndexable): array
+    {
+        $excluded = array_flip(array_filter($excludedSlugs));
+        $projectionItemsBySlug = [];
+
+        foreach ($this->runtimePublishProjection->publicDetailItems() as $item) {
+            $slug = trim((string) ($item['slug'] ?? ''));
+            if ($slug === '' || isset($excluded[$slug])) {
+                continue;
+            }
+
+            if (! $includeNonIndexable && ($item['robots_indexable'] ?? false) !== true) {
+                continue;
+            }
+
+            $projectionItemsBySlug[$slug] = $item;
+        }
+
+        if ($projectionItemsBySlug === []) {
+            return [];
+        }
+
+        return Occupation::query()
+            ->with('family:id,canonical_slug')
+            ->whereIn('canonical_slug', array_keys($projectionItemsBySlug))
+            ->orderBy('canonical_title_en')
+            ->orderBy('canonical_slug')
+            ->get()
+            ->map(fn (Occupation $occupation): CareerJobListItemBundle => $this->buildRuntimeProjectionCareerJobItem(
+                $occupation,
+                $projectionItemsBySlug[(string) $occupation->canonical_slug] ?? [],
+            ))
             ->all();
     }
 
@@ -404,6 +452,59 @@ final class CareerJobListBundleBuilder
     }
 
     /**
+     * @param  array<string, mixed>  $projectionItem
+     */
+    private function buildRuntimeProjectionCareerJobItem(Occupation $occupation, array $projectionItem): CareerJobListItemBundle
+    {
+        return new CareerJobListItemBundle(
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+                'entity_level' => $occupation->entity_level,
+                'family_uuid' => $occupation->family_id,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $occupation->canonical_title_zh,
+                'search_h1_zh' => $occupation->search_h1_zh,
+            ],
+            truthSummary: [
+                'truth_market' => $occupation->truth_market,
+            ],
+            trustSummary: [
+                'reviewer_status' => 'runtime_publish_projection',
+                'reviewed_at' => null,
+                'content_version' => 'runtime_publish_projection',
+                'data_version' => 'runtime_publish_projection',
+                'logic_version' => 'career.protocol.job_detail.runtime_projection.v1',
+                'editorial_patch_required' => false,
+                'editorial_patch_status' => null,
+                'allow_strong_claim' => true,
+                'allow_salary_comparison' => false,
+                'allow_ai_strategy' => false,
+                'reason_codes' => array_values(array_unique(array_filter(array_merge(
+                    ['runtime_publish_projection', 'career_job_index_runtime_projection_fallback'],
+                    is_array($projectionItem['reason_codes'] ?? null) ? $projectionItem['reason_codes'] : [],
+                ), static fn (mixed $reason): bool => is_scalar($reason) && trim((string) $reason) !== ''))),
+            ],
+            scoreSummary: [],
+            seoContract: $this->buildRuntimeProjectionSeoContract($occupation, $projectionItem),
+            provenanceMeta: [
+                'content_version' => 'runtime_publish_projection',
+                'data_version' => 'runtime_publish_projection',
+                'logic_version' => 'career.protocol.job_detail.runtime_projection.v1',
+                'compiler_version' => null,
+                'compiled_at' => null,
+                'truth_metric_id' => null,
+                'trust_manifest_id' => null,
+                'index_state_id' => null,
+                'compile_run_id' => null,
+                'import_run_id' => null,
+            ],
+        );
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function buildSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot): array
@@ -496,6 +597,48 @@ final class CareerJobListBundleBuilder
             'public_stub_kind' => self::PUBLIC_DIRECTORY_STUB_KIND,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? 'noindex,follow',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $projectionItem
+     * @return array<string, mixed>
+     */
+    private function buildRuntimeProjectionSeoContract(Occupation $occupation, array $projectionItem): array
+    {
+        $canonicalPath = is_string($projectionItem['canonical_path'] ?? null)
+            ? $projectionItem['canonical_path']
+            : '/career/jobs/'.(string) $occupation->canonical_slug;
+        $canonicalTarget = is_string($projectionItem['canonical_target'] ?? null)
+            ? $projectionItem['canonical_target']
+            : null;
+        $indexEligible = ($projectionItem['robots_indexable'] ?? false) === true;
+        $publicIndexState = $indexEligible ? IndexStateValue::INDEXABLE : IndexStateValue::NOINDEX;
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_job_list_item_runtime_projection_bundle',
+            'canonical_url' => $canonicalTarget ?: $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => $publicIndexState,
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalTarget,
+            'index_state' => $publicIndexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => array_values(array_unique(array_filter(array_merge(
+                ['runtime_publish_projection', 'career_job_index_runtime_projection_fallback'],
+                is_array($projectionItem['reason_codes'] ?? null) ? $projectionItem['reason_codes'] : [],
+            ), static fn (mixed $reason): bool => is_scalar($reason) && trim((string) $reason) !== ''))),
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
         ];
     }
 

--- a/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
@@ -19,7 +19,7 @@ final class CareerFullDatasetAuthorityBuilder
 {
     public const AUTHORITY_KIND = 'career_full_dataset_authority';
 
-    public const AUTHORITY_VERSION = 'career.dataset_authority.full_342_plus_directory_drafts.v1';
+    public const AUTHORITY_VERSION = 'career.dataset_authority.runtime_projection_plus_legacy_342.v2';
 
     public const DATASET_KEY = 'career_all_342_occupations_dataset';
 
@@ -65,6 +65,10 @@ final class CareerFullDatasetAuthorityBuilder
             static fn (mixed $row): bool => is_array($row)
         ));
         $strongIndexBySlug = $this->mapBySlug((array) ($strongIndex['members'] ?? []), 'canonical_slug');
+        $runtimeDatasetItemsBySlug = $this->mapRuntimeProjectionItemsBySlug(
+            $this->runtimePublishProjection->publicDatasetItems(),
+        );
+        $hasRuntimeDatasetAuthority = $runtimeDatasetItemsBySlug !== [];
 
         $batchContextBySlug = $this->buildBatchContextBySlug();
         $familyBySlug = $this->loadFamilyBySlug(array_map(
@@ -93,11 +97,12 @@ final class CareerFullDatasetAuthorityBuilder
             }
             $ledgerSlugs[$slug] = true;
 
-            if (! $this->runtimePublishProjection->datasetVisible($slug)) {
+            if ($hasRuntimeDatasetAuthority && ! $this->runtimePublishProjection->datasetVisible($slug)) {
                 $excludedCount++;
 
                 continue;
             }
+            unset($runtimeDatasetItemsBySlug[$slug]);
 
             $releaseCohort = $this->normalizeNullableString($ledgerMember['release_cohort'] ?? null);
             $publicIndexState = $this->normalizeNullableString($ledgerMember['public_index_state'] ?? null);
@@ -184,11 +189,12 @@ final class CareerFullDatasetAuthorityBuilder
         }
 
         foreach ($this->loadDirectoryDraftMembers(array_keys($ledgerSlugs)) as $directoryDraftMember) {
-            if (! $this->runtimePublishProjection->datasetVisible($directoryDraftMember->canonicalSlug)) {
+            if ($hasRuntimeDatasetAuthority && ! $this->runtimePublishProjection->datasetVisible($directoryDraftMember->canonicalSlug)) {
                 $excludedCount++;
 
                 continue;
             }
+            unset($runtimeDatasetItemsBySlug[$directoryDraftMember->canonicalSlug]);
 
             $releaseCohort = 'directory_draft_pending_detail';
             $publicIndexState = 'noindex';
@@ -204,6 +210,32 @@ final class CareerFullDatasetAuthorityBuilder
             $familyDistribution[$familySlug] = (int) ($familyDistribution[$familySlug] ?? 0) + 1;
             $publishTrackDistribution[$publishTrack] = (int) ($publishTrackDistribution[$publishTrack] ?? 0) + 1;
             $members[] = $directoryDraftMember;
+        }
+
+        foreach ($this->buildRuntimeProjectionMembers($runtimeDatasetItemsBySlug) as $runtimeMember) {
+            $releaseCohort = $runtimeMember->releaseCohort;
+            $publicIndexState = $runtimeMember->publicIndexState;
+            $strongIndexDecision = $runtimeMember->strongIndexDecision;
+            $familySlug = $runtimeMember->familySlug ?? '__unknown__';
+            $publishTrack = $runtimeMember->publishTrack ?? '__unknown__';
+
+            $includedCount++;
+            if ($releaseCohort !== null) {
+                $releaseCohortCounts[$releaseCohort] = (int) ($releaseCohortCounts[$releaseCohort] ?? 0) + 1;
+                $includedReleaseCohortCounts[$releaseCohort] = (int) ($includedReleaseCohortCounts[$releaseCohort] ?? 0) + 1;
+            }
+
+            if ($publicIndexState !== null) {
+                $publicIndexStateCounts[$publicIndexState] = (int) ($publicIndexStateCounts[$publicIndexState] ?? 0) + 1;
+            }
+
+            if ($strongIndexDecision !== null) {
+                $strongDecisionCounts[$strongIndexDecision] = (int) ($strongDecisionCounts[$strongIndexDecision] ?? 0) + 1;
+            }
+
+            $familyDistribution[$familySlug] = (int) ($familyDistribution[$familySlug] ?? 0) + 1;
+            $publishTrackDistribution[$publishTrack] = (int) ($publishTrackDistribution[$publishTrack] ?? 0) + 1;
+            $members[] = $runtimeMember;
         }
 
         usort($members, static fn (CareerFullDatasetMember $left, CareerFullDatasetMember $right): int => strcmp(
@@ -268,6 +300,63 @@ final class CareerFullDatasetAuthorityBuilder
     }
 
     /**
+     * @param  array<string, array<string, mixed>>  $runtimeDatasetItemsBySlug
+     * @return list<CareerFullDatasetMember>
+     */
+    private function buildRuntimeProjectionMembers(array $runtimeDatasetItemsBySlug): array
+    {
+        if ($runtimeDatasetItemsBySlug === []) {
+            return [];
+        }
+
+        $occupationsBySlug = $this->loadOccupationsBySlug(array_keys($runtimeDatasetItemsBySlug));
+        $members = [];
+
+        foreach ($runtimeDatasetItemsBySlug as $slug => $item) {
+            $occupation = $occupationsBySlug[$slug] ?? null;
+            if (! $occupation instanceof Occupation) {
+                continue;
+            }
+
+            $familySlug = $this->normalizeNullableString($occupation->family?->canonical_slug);
+            $robotsIndexable = ($item['robots_indexable'] ?? false) === true;
+            $releaseGatePass = ($item['release_gate_pass'] ?? false) === true;
+            $detailRouteEnabled = ($item['detail_route_enabled'] ?? false) === true;
+            $publicIndexState = $robotsIndexable ? 'indexable' : 'noindex';
+            $releaseCohort = $detailRouteEnabled && $releaseGatePass && $robotsIndexable
+                ? 'public_detail_indexable'
+                : 'public_detail_conservative';
+            $strongIndexDecision = $releaseGatePass && $robotsIndexable
+                ? 'strong_index_ready'
+                : 'runtime_publish_projection_visible';
+
+            $members[] = new CareerFullDatasetMember(
+                memberKind: 'career_tracked_occupation',
+                canonicalSlug: $slug,
+                canonicalTitleEn: $this->normalizeNullableString($occupation->canonical_title_en),
+                canonicalTitleZh: $this->normalizeNullableString($occupation->canonical_title_zh),
+                familySlug: $familySlug,
+                publishTrack: 'runtime_publish_projection',
+                batchOrigin: 'runtime_publish_projection',
+                releaseCohort: $releaseCohort,
+                publicIndexState: $publicIndexState,
+                strongIndexDecision: $strongIndexDecision,
+                includedInPublicDataset: true,
+                exclusionReasons: [],
+                publicFacets: [
+                    'release_cohort' => $releaseCohort,
+                    'public_index_state' => $publicIndexState,
+                    'strong_index_decision' => $strongIndexDecision,
+                    'family_slug' => $familySlug,
+                    'publish_track' => 'runtime_publish_projection',
+                ],
+            );
+        }
+
+        return $members;
+    }
+
+    /**
      * @param  list<string>  $excludedSlugs
      * @return list<CareerFullDatasetMember>
      */
@@ -315,6 +404,31 @@ final class CareerFullDatasetAuthorityBuilder
         return Occupation::query()
             ->where('canonical_slug', $slug)
             ->value('canonical_title_zh');
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, Occupation>
+     */
+    private function loadOccupationsBySlug(array $slugs): array
+    {
+        $normalizedSlugs = array_values(array_filter(array_unique(array_map(
+            static fn (string $slug): string => trim($slug),
+            $slugs,
+        )), static fn (string $slug): bool => $slug !== ''));
+
+        if ($normalizedSlugs === []) {
+            return [];
+        }
+
+        return Occupation::query()
+            ->with('family:id,canonical_slug')
+            ->whereIn('canonical_slug', $normalizedSlugs)
+            ->get()
+            ->mapWithKeys(static fn (Occupation $occupation): array => [
+                (string) $occupation->canonical_slug => $occupation,
+            ])
+            ->all();
     }
 
     /**
@@ -438,6 +552,28 @@ final class CareerFullDatasetAuthorityBuilder
 
             $mapped[$slug] = $row;
         }
+
+        return $mapped;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, array<string, mixed>>
+     */
+    private function mapRuntimeProjectionItemsBySlug(array $items): array
+    {
+        $mapped = [];
+
+        foreach ($items as $item) {
+            $slug = trim((string) ($item['slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $mapped[$slug] = $item;
+        }
+
+        ksort($mapped);
 
         return $mapped;
     }

--- a/backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+++ b/backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
@@ -13,9 +13,9 @@ use Illuminate\Support\Facades\Cache;
 
 final class PublicCareerAuthorityResponseCache
 {
-    public const DATASET_HUB_CACHE_KEY = 'career:public-authority:dataset-hub:v2';
+    public const DATASET_HUB_CACHE_KEY = 'career:public-authority:dataset-hub:v3';
 
-    public const DATASET_METHOD_CACHE_KEY = 'career:public-authority:dataset-method:v2';
+    public const DATASET_METHOD_CACHE_KEY = 'career:public-authority:dataset-method:v3';
 
     public const LAUNCH_GOVERNANCE_CLOSURE_CACHE_KEY = 'career:public-authority:launch-governance-closure:v1';
 

--- a/backend/tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php
+++ b/backend/tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php
@@ -47,6 +47,23 @@ final class CareerRuntimePublishProjectionVisibilityFixture implements CareerRun
             ?? null;
     }
 
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function publicDatasetItems(): array
+    {
+        return $this->visibleItems(static fn (array $item): bool => ($item['dataset_visible'] ?? true) === true);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function publicDetailItems(): array
+    {
+        return $this->visibleItems(static fn (array $item): bool => ($item['detail_route_enabled'] ?? true) === true
+            && ($item['release_gate_pass'] ?? true) === true);
+    }
+
     public function datasetVisible(string $slug): bool
     {
         return $this->datasetVisible[$this->normalizeSlug($slug)] ?? $this->defaultDatasetVisible;
@@ -75,6 +92,43 @@ final class CareerRuntimePublishProjectionVisibilityFixture implements CareerRun
     public function familyHubLive(string $slug): bool
     {
         return $this->familyHubLive[$this->normalizeSlug($slug)] ?? $this->defaultFamilyHubLive;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function visibleItems(callable $filter): array
+    {
+        $itemsBySlug = [];
+
+        foreach ($this->items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $slug = $this->normalizeSlug((string) ($item['slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $item += [
+                'slug' => $slug,
+                'dataset_visible' => $this->datasetVisible($slug),
+                'detail_route_enabled' => $this->detailRouteEnabled($slug),
+                'release_gate_pass' => $this->releaseGatePass($slug),
+                'robots_indexable' => $this->robotsIndexable($slug),
+            ];
+
+            $itemsBySlug[$slug] ??= $item;
+        }
+
+        $items = array_values(array_filter($itemsBySlug, $filter));
+        usort($items, static fn (array $left, array $right): int => strcmp(
+            (string) ($left['slug'] ?? ''),
+            (string) ($right['slug'] ?? ''),
+        ));
+
+        return $items;
     }
 
     private function normalizeSlug(string $slug): string

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -278,6 +278,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php',
+            'backend/app/Services/Career/PublicCareerAuthorityResponseCache.php',
             'backend/app/Services/SEO/SitemapGenerator.php',
             'backend/app/Services/SEO/SitemapCache.php',
         ];
@@ -1887,6 +1888,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php',
+            'backend/app/Services/Career/PublicCareerAuthorityResponseCache.php',
             'backend/app/Services/SEO/SitemapGenerator.php',
             'backend/app/Services/SEO/SitemapCache.php',
         ], true);

--- a/backend/tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php
@@ -36,7 +36,7 @@ final class CareerFullDatasetAuthorityBuilderTest extends TestCase
         $authority = app(CareerFullDatasetAuthorityBuilder::class)->build()->toArray();
 
         $this->assertSame('career_full_dataset_authority', $authority['authority_kind'] ?? null);
-        $this->assertSame('career.dataset_authority.full_342_plus_directory_drafts.v1', $authority['authority_version'] ?? null);
+        $this->assertSame('career.dataset_authority.runtime_projection_plus_legacy_342.v2', $authority['authority_version'] ?? null);
         $this->assertSame('career_all_342_occupations_dataset', $authority['dataset_key'] ?? null);
         $this->assertSame('career_all_342', $authority['dataset_scope'] ?? null);
         $this->assertSame('career_tracked_occupation', $authority['member_kind'] ?? null);
@@ -80,12 +80,60 @@ final class CareerFullDatasetAuthorityBuilderTest extends TestCase
         $this->assertSame('目录草稿职业', $draftMember['canonical_title_zh'] ?? null);
     }
 
+    public function test_it_adds_runtime_projection_public_occupations_missing_from_legacy_ledger(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $runtimeOccupation = $this->createRuntimeProjectionOccupation('runtime-public-specialist');
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(items: [
+                'runtime-public-specialist' => [
+                    'slug' => 'runtime-public-specialist',
+                    'dataset_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                ],
+            ]),
+        );
+
+        $authority = app(CareerFullDatasetAuthorityBuilder::class)->build()->toArray();
+        $members = collect((array) ($authority['members'] ?? []));
+        $runtimeMember = $members->firstWhere('canonical_slug', $runtimeOccupation->canonical_slug);
+
+        $this->assertSame(343, (int) ($authority['member_count'] ?? 0));
+        $this->assertSame(343, (int) data_get($authority, 'tracking_counts.tracked_total_occupations', 0));
+        $this->assertIsArray($runtimeMember);
+        $this->assertSame('public_detail_indexable', $runtimeMember['release_cohort'] ?? null);
+        $this->assertSame('indexable', $runtimeMember['public_index_state'] ?? null);
+        $this->assertSame('strong_index_ready', $runtimeMember['strong_index_decision'] ?? null);
+        $this->assertSame('runtime_publish_projection', $runtimeMember['publish_track'] ?? null);
+        $this->assertSame('Runtime Public Specialist', $runtimeMember['canonical_title_en'] ?? null);
+        $this->assertSame('运行时公开专家', $runtimeMember['canonical_title_zh'] ?? null);
+        $this->assertTrue((bool) ($runtimeMember['included_in_public_dataset'] ?? false));
+    }
+
     public function test_it_excludes_members_when_runtime_projection_marks_dataset_not_visible(): void
     {
         $this->app->instance(
             CareerRuntimePublishProjectionVisibility::class,
             new CareerRuntimePublishProjectionVisibilityFixture(datasetVisible: [
                 'data-scientists' => false,
+            ], items: [
+                'actors' => [
+                    'slug' => 'actors',
+                    'dataset_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                ],
+                'data-scientists' => [
+                    'slug' => 'data-scientists',
+                    'dataset_visible' => false,
+                    'detail_route_enabled' => false,
+                    'robots_indexable' => false,
+                    'release_gate_pass' => false,
+                ],
             ]),
         );
         $this->materializeCurrentFirstWaveFixture();
@@ -150,5 +198,26 @@ final class CareerFullDatasetAuthorityBuilderTest extends TestCase
         ]);
 
         return $occupation->fresh();
+    }
+
+    private function createRuntimeProjectionOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'runtime-public-family',
+            'title_en' => 'Runtime Public Family',
+            'title_zh' => '运行时公开职业族',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'occupation',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => 'Runtime Public Specialist',
+            'canonical_title_zh' => '运行时公开专家',
+            'search_h1_zh' => '运行时公开专家',
+        ]);
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
@@ -7,6 +7,8 @@ namespace Tests\Unit\Services\Career;
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
 use App\Services\Career\Bundles\CareerJobListBundleBuilder;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -106,6 +108,36 @@ final class CareerJobListBundleBuilderTest extends TestCase
         $items = app(CareerJobListBundleBuilder::class)->build(includeNonIndexable: true);
 
         $this->assertSame([], $items);
+    }
+
+    public function test_it_includes_runtime_projection_detail_jobs_missing_from_legacy_compile_sources(): void
+    {
+        $occupation = $this->createRuntimeProjectionOccupation('runtime-public-specialist');
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(items: [
+                'runtime-public-specialist' => [
+                    'slug' => 'runtime-public-specialist',
+                    'canonical_path' => '/career/jobs/runtime-public-specialist',
+                    'dataset_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                    'reason_codes' => ['validated_display_asset_backed_release'],
+                ],
+            ]),
+        );
+
+        $items = app(CareerJobListBundleBuilder::class)->build();
+        $payloads = array_map(static fn ($item): array => $item->toArray(), $items);
+
+        $this->assertCount(1, $payloads);
+        $this->assertSame($occupation->canonical_slug, data_get($payloads[0], 'identity.canonical_slug'));
+        $this->assertSame('Runtime Public Specialist', data_get($payloads[0], 'titles.canonical_en'));
+        $this->assertSame('运行时公开专家', data_get($payloads[0], 'titles.canonical_zh'));
+        $this->assertSame('indexable', data_get($payloads[0], 'seo_contract.index_state'));
+        $this->assertTrue((bool) data_get($payloads[0], 'seo_contract.index_eligible'));
+        $this->assertContains('runtime_publish_projection', data_get($payloads[0], 'seo_contract.reason_codes'));
     }
 
     public function test_it_can_include_current_non_indexable_job_when_explicitly_requested(): void
@@ -217,5 +249,26 @@ final class CareerJobListBundleBuilderTest extends TestCase
             'compileRun' => $compileRun,
             'snapshot' => $snapshot,
         ] + $chain;
+    }
+
+    private function createRuntimeProjectionOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'runtime-public-family',
+            'title_en' => 'Runtime Public Family',
+            'title_zh' => '运行时公开职业族',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'occupation',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => 'Runtime Public Specialist',
+            'canonical_title_zh' => '运行时公开专家',
+            'search_h1_zh' => '运行时公开专家',
+        ]);
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
@@ -67,6 +67,8 @@ final class CareerRuntimePublishProjectionLookupTest extends TestCase
         $this->assertTrue($lookup->searchVisible('actors'));
         $this->assertTrue($lookup->robotsIndexable('actors'));
         $this->assertTrue($lookup->releaseGatePass('actors'));
+        $this->assertSame(['actors'], array_column($lookup->publicDatasetItems(), 'slug'));
+        $this->assertSame(['actors'], array_column($lookup->publicDetailItems(), 'slug'));
         $this->assertFalse($lookup->detailRouteEnabled('software-developers'));
         $this->assertFalse($lookup->datasetVisible('software-developers'));
         $this->assertFalse($lookup->searchVisible('software-developers'));


### PR DESCRIPTION
## Summary

This fixes the career directory count regression where the public career surface could show only the legacy dataset population while many runtime-published career detail pages were already live.

Root cause: the API dataset hub and job list bundle still depended on legacy full342 / compiled / directory-draft sources, while the full publication pipeline publishes through the latest materialized runtime projection. Runtime-published slugs that were not in those legacy sources were live and indexable, but absent from the dataset hub and jobs directory payload.

## Changes

- Add enumerable runtime projection visibility methods for public dataset and detail-route items.
- Include runtime projection public occupations in `CareerFullDatasetAuthorityBuilder` when missing from legacy authority inputs.
- Include runtime projection public detail jobs in `CareerJobListBundleBuilder` when missing from compiled/docx/directory-draft sources.
- Bump public career authority cache keys to v3 so the old forever-cached 234-member dataset hub is not reused after deploy.
- Preserve read-only behavior and existing legacy fallback behavior for synthetic tests that do not provide enumerable runtime authority.

## Validation

- `php artisan test --filter=CareerDatasetPublicApiTest --no-ansi`
- `php artisan test --filter=CareerPublicDatasetContractBuilderTest --no-ansi`
- `php artisan test --filter=CareerRuntimePublishProjectionLookupTest --no-ansi`
- `php artisan test --filter=CareerFullDatasetAuthorityBuilderTest --no-ansi`
- `php artisan test --filter=CareerJobListBundleBuilderTest --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-directory-runtime-authority.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Production

No deploy, DB mutation, rollout, apply, rollback, quarantine, or fap-web change is performed by this PR.
