### PR TITLE
AUDIT-API-IQ-RESULT-SECRECY: fix(security): redact IQ answer keys and locked report payloads

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -24,6 +24,7 @@ use App\Services\Content\EnneagramPackLoader;
 use App\Services\Enneagram\EnneagramObservationStateService;
 use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Enneagram\EnneagramPublicProjectionService;
+use App\Services\Iq\IqResultPayloadRedactor;
 use App\Services\Mbti\MbtiActionJourneyContractService;
 use App\Services\Mbti\MbtiAdaptiveSelectionService;
 use App\Services\Mbti\MbtiIntraTypeProfileService;
@@ -273,6 +274,10 @@ class AttemptReadController extends Controller
         }
         if (! is_array($compatScoresPct)) {
             $compatScoresPct = [];
+        }
+        if (IqResultPayloadRedactor::isIqScale($responseCodes['scale_code_legacy'], $responseCodes['scale_code_v2'])) {
+            $payload = IqResultPayloadRedactor::redactAnswerKeys($payload);
+            $compatScores = IqResultPayloadRedactor::redactAnswerKeys($compatScores);
         }
 
         $hasBigFiveProjectionFullAccess = $scaleCode === 'BIG5_OCEAN'
@@ -2245,7 +2250,7 @@ class AttemptReadController extends Controller
             $this->resolveAnonId($request)
         );
         if (($payload['ok'] ?? false) === true) {
-            return $payload;
+            return $this->redactIqSubmissionPayload($payload, $attempt);
         }
 
         if (! $this->shouldUsePublicArtifactFallback($request, $attempt)) {
@@ -2265,7 +2270,29 @@ class AttemptReadController extends Controller
             $fallbackAnonId
         );
 
-        return ($fallbackPayload['ok'] ?? false) === true ? $fallbackPayload : $payload;
+        return ($fallbackPayload['ok'] ?? false) === true
+            ? $this->redactIqSubmissionPayload($fallbackPayload, $attempt)
+            : $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function redactIqSubmissionPayload(array $payload, Attempt $attempt): array
+    {
+        if (! IqResultPayloadRedactor::isIqScale(
+            (string) ($attempt->scale_code ?? ''),
+            (string) ($attempt->scale_code_v2 ?? '')
+        )) {
+            return $payload;
+        }
+
+        if (is_array($payload['result'] ?? null)) {
+            $payload['result'] = IqResultPayloadRedactor::redactAnswerKeys($payload['result']);
+        }
+
+        return $payload;
     }
 
     private function resolvePublicAttemptFromArtifacts(

--- a/backend/app/Services/Assessment/Drivers/IqTestDriver.php
+++ b/backend/app/Services/Assessment/Drivers/IqTestDriver.php
@@ -320,7 +320,6 @@ class IqTestDriver implements DriverInterface
      *   question_id:string,
      *   dimension:string,
      *   selected_code:string,
-     *   correct_answer:string,
      *   is_correct:bool,
      *   raw_points:float,
      *   awarded_points:float
@@ -346,7 +345,6 @@ class IqTestDriver implements DriverInterface
                 'question_id' => $questionId,
                 'dimension' => (string) ($definition['dimension'] ?? ''),
                 'selected_code' => $selectedCode,
-                'correct_answer' => (string) ($definition['correct_answer'] ?? ''),
                 'is_correct' => $isCorrect,
                 'raw_points' => $rawPoints,
                 'awarded_points' => $isCorrect ? $rawPoints : 0.0,
@@ -363,7 +361,6 @@ class IqTestDriver implements DriverInterface
      *   question_id:string,
      *   dimension:string,
      *   selected_code:string,
-     *   correct_answer:string,
      *   is_correct:bool,
      *   raw_points:float,
      *   awarded_points:float

--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -8,6 +8,7 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Assessment\AssessmentRunner;
 use App\Services\Experiments\ExperimentAssigner;
+use App\Services\Iq\IqResultPayloadRedactor;
 use App\Services\Observability\BigFiveTelemetry;
 use App\Services\Report\ReportGatekeeper;
 use App\Services\Scale\ScaleCodeResponseProjector;
@@ -289,6 +290,11 @@ class AttemptSubmitService
         $payload['scale_code_legacy'] = $responseCodes['scale_code_legacy'];
         $payload['scale_code_v2'] = $responseCodes['scale_code_v2'];
         $payload['scale_uid'] = $responseCodes['scale_uid'];
+
+        if (IqResultPayloadRedactor::isIqScale($responseCodes['scale_code_legacy'], $responseCodes['scale_code_v2'])) {
+            $payload = IqResultPayloadRedactor::redactAnswerKeys($payload);
+            $compatScores = IqResultPayloadRedactor::redactAnswerKeys($compatScores);
+        }
 
         return [
             'ok' => true,

--- a/backend/app/Services/Iq/IqResultPayloadRedactor.php
+++ b/backend/app/Services/Iq/IqResultPayloadRedactor.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Iq;
+
+final class IqResultPayloadRedactor
+{
+    private const IQ_SCALE_CODES = [
+        'IQ_RAVEN',
+        'IQ_INTELLIGENCE_QUOTIENT',
+    ];
+
+    private const ANSWER_KEY_FIELDS = [
+        'answer_key',
+        'answerKey',
+        'correct_answer',
+        'correctAnswer',
+    ];
+
+    public static function isIqScale(?string $scaleCode, ?string $scaleCodeV2 = null): bool
+    {
+        return in_array(strtoupper(trim((string) $scaleCode)), self::IQ_SCALE_CODES, true)
+            || in_array(strtoupper(trim((string) $scaleCodeV2)), self::IQ_SCALE_CODES, true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    public static function redactAnswerKeys(array $payload): array
+    {
+        return self::redactNode($payload);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function redactNode(array $payload): array
+    {
+        $redacted = [];
+
+        foreach ($payload as $key => $value) {
+            if (is_string($key) && in_array($key, self::ANSWER_KEY_FIELDS, true)) {
+                continue;
+            }
+
+            $redacted[$key] = is_array($value) ? self::redactNode($value) : $value;
+        }
+
+        return $redacted;
+    }
+}

--- a/backend/app/Services/Report/IqReportBuilder.php
+++ b/backend/app/Services/Report/IqReportBuilder.php
@@ -48,6 +48,15 @@ final class IqReportBuilder
         $reportAccessLevel = ReportAccess::normalizeReportAccessLevel((string) ($ctx['report_access_level'] ?? ReportAccess::REPORT_ACCESS_FULL));
         $normalizedVariant = ReportAccess::normalizeVariant($variant);
         $legacyScaleCode = strtoupper(trim((string) ($attempt->scale_code ?? $result->scale_code ?? 'IQ_RAVEN')));
+        if (! $this->allowsPaidReportPayload($normalizedVariant, $reportAccessLevel)) {
+            return $this->buildLockedReport(
+                $attempt,
+                $legacyScaleCode !== '' ? $legacyScaleCode : 'IQ_RAVEN',
+                $summary,
+                $reportAccessLevel,
+                $normalizedVariant
+            );
+        }
 
         return [
             'schema_version' => 'iq.report.v1',
@@ -90,6 +99,49 @@ final class IqReportBuilder
             ],
             'generated_at' => now()->toISOString(),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @return array<string,mixed>
+     */
+    private function buildLockedReport(
+        Attempt $attempt,
+        string $legacyScaleCode,
+        array $summary,
+        string $reportAccessLevel,
+        string $normalizedVariant
+    ): array {
+        return [
+            'schema_version' => 'iq.report.v1',
+            'scale_code' => self::CANONICAL_SCALE_CODE,
+            'scale_code_legacy' => $legacyScaleCode,
+            'attempt_id' => (string) ($attempt->id ?? ''),
+            'summary' => [
+                'raw_score' => null,
+                'iq_estimate' => null,
+                'percentile' => null,
+                'confidence_interval' => null,
+                'norms_status' => $this->stringOrNull($summary['norms_status'] ?? null),
+            ],
+            'access' => [
+                'report_access_level' => $reportAccessLevel,
+                'variant' => $normalizedVariant,
+            ],
+            'sections' => [],
+            '_meta' => [
+                'locked' => true,
+                'redacted' => true,
+                'redaction_policy' => 'iq.locked_report.v1',
+            ],
+            'generated_at' => now()->toISOString(),
+        ];
+    }
+
+    private function allowsPaidReportPayload(string $normalizedVariant, string $reportAccessLevel): bool
+    {
+        return $normalizedVariant === ReportAccess::VARIANT_FULL
+            && $reportAccessLevel === ReportAccess::REPORT_ACCESS_FULL;
     }
 
     /**

--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Attempts\AttemptSubmitService;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -63,7 +64,7 @@ final class IqReportContractTest extends TestCase
         ]);
     }
 
-    private function createScoredResult(string $attemptId): void
+    private function createScoredResult(string $attemptId): Result
     {
         $score = [
             'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
@@ -114,9 +115,24 @@ final class IqReportContractTest extends TestCase
                     'percent_correct' => 50.0,
                 ],
             ],
+            'answer_key' => [
+                'IQ001' => 'A',
+            ],
+            'items' => [
+                [
+                    'item_id' => 'FM-IQ-VSI-HS-L2-0001',
+                    'question_id' => 'IQ001',
+                    'dimension' => 'VSI',
+                    'selected_code' => 'B',
+                    'correct_answer' => 'A',
+                    'is_correct' => false,
+                    'raw_points' => 1.0,
+                    'awarded_points' => 0.0,
+                ],
+            ],
         ];
 
-        Result::create([
+        return Result::create([
             'id' => (string) Str::uuid(),
             'org_id' => 0,
             'attempt_id' => $attemptId,
@@ -124,7 +140,15 @@ final class IqReportContractTest extends TestCase
             'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT',
             'scale_version' => 'v0.3',
             'type_code' => '',
-            'scores_json' => [],
+            'scores_json' => [
+                'items' => [
+                    [
+                        'question_id' => 'IQ001',
+                        'selected_code' => 'B',
+                        'correct_answer' => 'A',
+                    ],
+                ],
+            ],
             'scores_pct' => [],
             'axis_states' => [],
             'content_package_version' => 'v0.3.0-demo',
@@ -168,15 +192,121 @@ final class IqReportContractTest extends TestCase
         $response->assertJsonPath('report.scale_code', 'IQ_INTELLIGENCE_QUOTIENT');
         $response->assertJsonPath('report.scale_code_legacy', 'IQ_RAVEN');
         $response->assertJsonPath('report.attempt_id', $attemptId);
-        $response->assertJsonPath('report.summary.raw_score', 21);
-        $response->assertJsonPath('report.dimensions.visual_spatial_insight.raw_score', 3);
-        $response->assertJsonPath('report.dimensions.visual_spatial_pattern_reasoning.percent_correct', 100);
-        $response->assertJsonPath('report.dimensions.numerical_pattern_reasoning.correct_count', 2);
-        $response->assertJsonPath('report.quality.level', 'A');
-        $response->assertJsonPath('report.stability.status', 'stable');
-        $response->assertJsonPath('report.iq_pro.pdf_payload.status', 'contract_defined_not_implemented');
+        $response->assertJsonPath('report.summary.raw_score', null);
+        $response->assertJsonPath('report.sections', []);
+        $response->assertJsonPath('report._meta.redacted', true);
         $response->assertJsonPath('report.access.report_access_level', 'free');
+        $response->assertJsonMissingPath('report.dimensions');
+        $response->assertJsonMissingPath('report.quality');
+        $response->assertJsonMissingPath('report.stability');
+        $response->assertJsonMissingPath('report.scoring');
+        $response->assertJsonMissingPath('report.iq_pro');
         $response->assertJsonMissingPath('report.profile');
         $response->assertJsonPath('upgrade_sku', null);
+    }
+
+    public function test_iq_result_endpoint_redacts_legacy_answer_keys_from_public_payload(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_iq_result_redaction';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createScoredResult($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(200);
+        $this->assertPayloadHasNoAnswerKeyFields($response->json());
+        $this->assertSame('B', data_get($response->json(), 'result.normed_json.items.0.selected_code'));
+        $this->assertFalse((bool) data_get($response->json(), 'result.normed_json.items.0.is_correct'));
+    }
+
+    public function test_iq_submit_payload_redacts_legacy_answer_keys_before_response_serialization(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_iq_submit_redaction';
+        $this->createAttempt($attemptId, $anonId);
+        $result = $this->createScoredResult($attemptId);
+        $attempt = Attempt::query()->where('id', $attemptId)->firstOrFail();
+
+        $payload = app(AttemptSubmitService::class)->buildSubmitPayload($attempt, $result, true);
+
+        $this->assertPayloadHasNoAnswerKeyFields($payload);
+        $this->assertSame('B', data_get($payload, 'result.normed_json.items.0.selected_code'));
+        $this->assertFalse((bool) data_get($payload, 'result.normed_json.items.0.is_correct'));
+    }
+
+    public function test_iq_submission_read_redacts_stored_submit_response_answer_keys(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_iq_submission_read_redaction';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+
+        DB::table('attempt_submissions')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => null,
+            'actor_anon_id' => $anonId,
+            'dedupe_key' => hash('sha256', $attemptId.':iq-submission-redaction'),
+            'mode' => 'async',
+            'state' => 'succeeded',
+            'error_code' => null,
+            'error_message' => null,
+            'request_payload_json' => json_encode(['attempt_id' => $attemptId], JSON_THROW_ON_ERROR),
+            'response_payload_json' => json_encode([
+                'ok' => true,
+                'attempt_id' => $attemptId,
+                'result' => [
+                    'normed_json' => [
+                        'items' => [
+                            [
+                                'question_id' => 'IQ001',
+                                'selected_code' => 'B',
+                                'correct_answer' => 'A',
+                            ],
+                        ],
+                    ],
+                    'answer_key' => ['IQ001' => 'A'],
+                ],
+            ], JSON_THROW_ON_ERROR),
+            'started_at' => now()->subMinute(),
+            'finished_at' => now()->subSeconds(10),
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subSeconds(5),
+        ]);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/submission");
+
+        $response->assertStatus(200);
+        $this->assertPayloadHasNoAnswerKeyFields($response->json());
+        $this->assertSame('B', data_get($response->json(), 'result.result.normed_json.items.0.selected_code'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertPayloadHasNoAnswerKeyFields(array $payload): void
+    {
+        foreach ($payload as $key => $value) {
+            $this->assertNotContains($key, ['answer_key', 'answerKey', 'correct_answer', 'correctAnswer']);
+
+            if (is_array($value)) {
+                $this->assertPayloadHasNoAnswerKeyFields($value);
+            }
+        }
     }
 }

--- a/backend/tests/Unit/Assessment/IqTestDriverTest.php
+++ b/backend/tests/Unit/Assessment/IqTestDriverTest.php
@@ -41,6 +41,8 @@ final class IqTestDriverTest extends TestCase
         $this->assertSame(100.0, data_get($result->axisScoresJson, 'scores_pct.VSI'));
         $this->assertSame(0.0, data_get($result->axisScoresJson, 'scores_pct.NPR'));
         $this->assertCount(3, data_get($result->normedJson, 'items', []));
+        $this->assertArrayNotHasKey('correct_answer', data_get($result->normedJson, 'items.0', []));
+        $this->assertStringNotContainsString('correct_answer', json_encode($result->toArray(), JSON_THROW_ON_ERROR));
     }
 
     public function test_missing_answer_key_returns_blocked_unscored_state(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -795,6 +795,38 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_result_secrecy_redaction_only(): void
+    {
+        $changed = [
+            'backend/app/Services/Attempts/AttemptSubmitService.php',
+            'backend/app/Services/Iq/IqResultPayloadRedactor.php',
+        ];
+        $allowedSubmitChangedLines = [
+            '+use App\\Services\\Iq\\IqResultPayloadRedactor;',
+            '+        if (IqResultPayloadRedactor::isIqScale($responseCodes[\'scale_code_legacy\'], $responseCodes[\'scale_code_v2\'])) {',
+            '+            $payload = IqResultPayloadRedactor::redactAnswerKeys($payload);',
+            '+            $compatScores = IqResultPayloadRedactor::redactAnswerKeys($compatScores);',
+            '+        }',
+            '+',
+        ];
+        $blockedSubmitChangedLines = [
+            '+        $payload[\'big5_result_page_v2\'] = [];',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            attemptSubmitServiceChangedLines: $allowedSubmitChangedLines,
+        ));
+        $this->assertSame(['backend/app/Services/Attempts/AttemptSubmitService.php'], $this->mbtiImpactingRuntimeChanges(
+            ['backend/app/Services/Attempts/AttemptSubmitService.php'],
+            '',
+            '',
+            attemptSubmitServiceChangedLines: $blockedSubmitChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_riasec_measurement_contract_compare_policy_changes(): void
     {
         $changed = [
@@ -1305,6 +1337,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ?array $scaleRegistrySeederChangedLines = null,
         ?array $articleControllerChangedLines = null,
         ?array $attributionControllerChangedLines = null,
+        ?array $attemptSubmitServiceChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -1371,6 +1404,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isFileImportIdempotencyHardeningFile($file)) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Services/Attempts/AttemptSubmitService.php'
+                && $this->attemptSubmitServiceDiffIsIqResultSecrecyRedactionOnly(
+                    $attemptSubmitServiceChangedLines ?? (
+                        $repoRoot !== '' && $baseRef !== ''
+                            ? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                            : []
+                    )
+                )
+            ) {
+                continue;
+            }
+
+            if ($this->isIqResultSecrecyRedactionFile($file)) {
                 continue;
             }
 
@@ -1742,6 +1792,26 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isIqScoringContractFoundationFile(string $file): bool
     {
         return $file === 'backend/app/Services/Assessment/Drivers/IqTestDriver.php';
+    }
+
+    private function isIqResultSecrecyRedactionFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Iq/IqResultPayloadRedactor.php';
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function attemptSubmitServiceDiffIsIqResultSecrecyRedactionOnly(array $changedLines): bool
+    {
+        return $changedLines === [
+            '+use App\\Services\\Iq\\IqResultPayloadRedactor;',
+            '+        if (IqResultPayloadRedactor::isIqScale($responseCodes[\'scale_code_legacy\'], $responseCodes[\'scale_code_v2\'])) {',
+            '+            $payload = IqResultPayloadRedactor::redactAnswerKeys($payload);',
+            '+            $compatScores = IqResultPayloadRedactor::redactAnswerKeys($compatScores);',
+            '+        }',
+            '+',
+        ];
     }
 
     private function isRiasecMeasurementContractComparePolicyFile(string $file): bool

--- a/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
@@ -120,11 +120,14 @@ final class IqReportBuilderTest extends TestCase
 
         $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', data_get($payload, 'scale_code'));
         $this->assertNull(data_get($payload, 'summary.raw_score'));
-        $this->assertSame('blocked_unscored', data_get($payload, 'scoring.status'));
-        $this->assertSame('ANSWER_KEY_MISSING', data_get($payload, 'scoring.reason_code'));
-        $this->assertSame('unstable', data_get($payload, 'stability.status'));
-        $this->assertSame(['PARTIAL_COMPLETION'], data_get($payload, 'quality.flags'));
-        $this->assertArrayHasKey('visual_spatial_insight', (array) data_get($payload, 'dimensions'));
         $this->assertSame('free', data_get($payload, 'access.report_access_level'));
+        $this->assertSame('free', data_get($payload, 'access.variant'));
+        $this->assertSame([], data_get($payload, 'sections'));
+        $this->assertTrue((bool) data_get($payload, '_meta.redacted'));
+        $this->assertNull(data_get($payload, 'scoring'));
+        $this->assertNull(data_get($payload, 'dimensions'));
+        $this->assertNull(data_get($payload, 'quality'));
+        $this->assertNull(data_get($payload, 'stability'));
+        $this->assertNull(data_get($payload, 'iq_pro'));
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T13:45:00+08:00",
+  "updated_at": "2026-05-16T14:55:11+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -7286,6 +7286,345 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": []
+    },
+    "AUDIT-API-IQ-RESULT-SECRECY": {
+      "repo": "fap-api",
+      "branch": "codex/audit-api-iq-result-secrecy",
+      "base": "main",
+      "global_sequence": 2,
+      "depends_on": [
+        "AUDIT-WEB-CMS-LINK-XSS:fap-web"
+      ],
+      "status": "committed",
+      "train_scope": "security_audit_remediation",
+      "risk_level": "high",
+      "title": "fix(security): redact IQ answer keys and locked report payloads",
+      "findings": [
+        "IQ result responses expose answer keys",
+        "Locked IQ reports expose non-free score sections"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding the 11 security audit train items to fap-web and fap-api pr-train manifest/state without starting implementation."
+        },
+        "scope_validation_policy": {
+          "status": "planned",
+          "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-WEB-CMS-LINK-XSS merged as fermatmind/fap-web#822 with merge commit 76ce4d0c81a90473ba39b2866755c12283feca29."
+        },
+        "branch_preflight": {
+          "status": "pass",
+          "evidence": "Created codex/audit-api-iq-result-secrecy from origin/main 99e89da6fca74c9c0360147aaf50ec18811a1e52; unrelated .playwright-mcp/ remains untracked and outside scope."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are limited to IQ result redaction, IQ report gating, submit/result response serialization, focused IQ tests, and authorized PR train metadata."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": [
+            "composer dump-autoload: pass (refreshed stale local autoload path before testing)",
+            "php artisan test tests/Unit/Assessment/IqTestDriverTest.php tests/Unit/Services/Report/IqReportBuilderTest.php tests/Feature/V0_3/IqReportContractTest.php --no-ansi: pass (7 tests, 428 assertions)",
+            "php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi: pass after submission-read redaction addition (4 tests, 404 assertions)",
+            "php artisan test --filter=Iq --no-ansi: pass (37 tests, 1042 assertions)",
+            "php artisan test --filter=AttemptSubmit --no-ansi: pass (8 tests, 88 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "vendor/bin/pint --test: pass (3272 files)",
+            "ruby YAML.load_file docs/codex/pr-train.yaml: pass",
+            "python3 -m json.tool docs/codex/pr-train-state.json: pass",
+            "git diff --check: pass",
+            "git diff --cached --check: pass"
+          ]
+        },
+        "commit": {
+          "status": "pass",
+          "evidence": "444c24162d83e9fc45ae8322fde6bbf4834b634b"
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": "444c24162d83e9fc45ae8322fde6bbf4834b634b",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-16T14:10:19+08:00",
+          "status": "planned",
+          "summary": "Initialized AUDIT-API-IQ-RESULT-SECRECY as a security audit remediation train item. Implementation has not started."
+        },
+        {
+          "at": "2026-05-16T14:46:59+08:00",
+          "status": "in_progress",
+          "summary": "Started implementation on codex/audit-api-iq-result-secrecy from latest origin/main after dependency merge verification."
+        },
+        {
+          "at": "2026-05-16T14:52:54+08:00",
+          "status": "local_checks_passed",
+          "summary": "Implemented IQ answer-key redaction and locked/free report gating; required local validation passed before commit."
+        },
+        {
+          "at": "2026-05-16T14:54:48+08:00",
+          "status": "local_checks_passed",
+          "summary": "Re-ran required local validation after adding IQ submission-read redaction for stored async submit payloads."
+        },
+        {
+          "at": "2026-05-16T14:55:11+08:00",
+          "status": "committed",
+          "summary": "Committed scoped remediation at 444c24162d83e9fc45ae8322fde6bbf4834b634b."
+        }
+      ]
+    },
+    "AUDIT-API-CMS-MEDIA-URL-GUARD": {
+      "repo": "fap-api",
+      "branch": "codex/audit-api-cms-media-url-guard",
+      "base": "main",
+      "global_sequence": 6,
+      "depends_on": [
+        "AUDIT-WEB-LLMS-FANOUT-BUDGET:fap-web"
+      ],
+      "status": "planned",
+      "train_scope": "security_audit_remediation",
+      "risk_level": "medium",
+      "title": "fix(security): enforce public media URL guard for CMS media and JSON-LD",
+      "findings": [
+        "CMS media CDN verification permits SSRF",
+        "JSON-LD image bypasses public media URL guard"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding the 11 security audit train items to fap-web and fap-api pr-train manifest/state without starting implementation."
+        },
+        "scope_validation_policy": {
+          "status": "planned",
+          "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-16T14:10:19+08:00",
+          "status": "planned",
+          "summary": "Initialized AUDIT-API-CMS-MEDIA-URL-GUARD as a security audit remediation train item. Implementation has not started."
+        }
+      ]
+    },
+    "AUDIT-API-CAREER-ROLLOUT-AUTHORITY": {
+      "repo": "fap-api",
+      "branch": "codex/audit-api-career-rollout-authority",
+      "base": "main",
+      "global_sequence": 7,
+      "depends_on": [
+        "AUDIT-API-CMS-MEDIA-URL-GUARD"
+      ],
+      "status": "planned",
+      "train_scope": "security_audit_remediation",
+      "risk_level": "medium",
+      "title": "fix(security): enforce career rollout authority gates",
+      "findings": [
+        "Explicit delta mode bypasses audit policy blockers",
+        "Progressive selection can promote unready career slugs",
+        "Unsigned rollout reports can publish career slugs",
+        "Career rollout slugs bypass review authority"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding the 11 security audit train items to fap-web and fap-api pr-train manifest/state without starting implementation."
+        },
+        "scope_validation_policy": {
+          "status": "planned",
+          "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-16T14:10:19+08:00",
+          "status": "planned",
+          "summary": "Initialized AUDIT-API-CAREER-ROLLOUT-AUTHORITY as a security audit remediation train item. Implementation has not started."
+        }
+      ]
+    },
+    "AUDIT-API-CAREER-ARTIFACT-READINESS": {
+      "repo": "fap-api",
+      "branch": "codex/audit-api-career-artifact-readiness",
+      "base": "main",
+      "global_sequence": 8,
+      "depends_on": [
+        "AUDIT-API-CAREER-ROLLOUT-AUTHORITY"
+      ],
+      "status": "planned",
+      "train_scope": "security_audit_remediation",
+      "risk_level": "medium",
+      "title": "fix(security): fail closed on career readiness artifacts",
+      "findings": [
+        "Career refresh planner fails open on artifacts",
+        "Index context artifacts can bypass index_eligible gate",
+        "Unsupported locale bypasses zh readiness gate"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding the 11 security audit train items to fap-web and fap-api pr-train manifest/state without starting implementation."
+        },
+        "scope_validation_policy": {
+          "status": "planned",
+          "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-16T14:10:19+08:00",
+          "status": "planned",
+          "summary": "Initialized AUDIT-API-CAREER-ARTIFACT-READINESS as a security audit remediation train item. Implementation has not started."
+        }
+      ]
+    },
+    "AUDIT-API-ARTICLE-PUBLISH-GATE": {
+      "repo": "fap-api",
+      "branch": "codex/audit-api-article-publish-gate",
+      "base": "main",
+      "global_sequence": 9,
+      "depends_on": [
+        "AUDIT-API-CAREER-ARTIFACT-READINESS"
+      ],
+      "status": "planned",
+      "train_scope": "security_audit_remediation",
+      "risk_level": "medium",
+      "title": "fix(security): require editorial approval for controlled article publish",
+      "findings": [
+        "Controlled article publish bypasses review gates"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding the 11 security audit train items to fap-web and fap-api pr-train manifest/state without starting implementation."
+        },
+        "scope_validation_policy": {
+          "status": "planned",
+          "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-16T14:10:19+08:00",
+          "status": "planned",
+          "summary": "Initialized AUDIT-API-ARTICLE-PUBLISH-GATE as a security audit remediation train item. Implementation has not started."
+        }
+      ]
+    },
+    "AUDIT-API-OPS-TENANT-SCOPING": {
+      "repo": "fap-api",
+      "branch": "codex/audit-api-ops-tenant-scoping",
+      "base": "main",
+      "global_sequence": 10,
+      "depends_on": [
+        "AUDIT-API-ARTICLE-PUBLISH-GATE"
+      ],
+      "status": "planned",
+      "train_scope": "security_audit_remediation",
+      "risk_level": "medium",
+      "title": "fix(security): scope ops release failure audits by org",
+      "findings": [
+        "Ops dashboard leaks cross-org release failure audits"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding the 11 security audit train items to fap-web and fap-api pr-train manifest/state without starting implementation."
+        },
+        "scope_validation_policy": {
+          "status": "planned",
+          "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-16T14:10:19+08:00",
+          "status": "planned",
+          "summary": "Initialized AUDIT-API-OPS-TENANT-SCOPING as a security audit remediation train item. Implementation has not started."
+        }
+      ]
+    },
+    "AUDIT-API-SAFE-TMP-ARTIFACTS": {
+      "repo": "fap-api",
+      "branch": "codex/audit-api-safe-tmp-artifacts",
+      "base": "main",
+      "global_sequence": 11,
+      "depends_on": [
+        "AUDIT-API-OPS-TENANT-SCOPING"
+      ],
+      "status": "planned",
+      "train_scope": "security_audit_remediation",
+      "risk_level": "medium",
+      "title": "fix(security): write temporary artifacts safely",
+      "findings": [
+        "Predictable /tmp artifact outputs allow symlink overwrite"
+      ],
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding the 11 security audit train items to fap-web and fap-api pr-train manifest/state without starting implementation."
+        },
+        "scope_validation_policy": {
+          "status": "planned",
+          "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-16T14:10:19+08:00",
+          "status": "planned",
+          "summary": "Initialized AUDIT-API-SAFE-TMP-ARTIFACTS as a security audit remediation train item. Implementation has not started."
+        }
+      ]
     }
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T14:55:11+08:00",
+  "updated_at": "2026-05-16T14:55:44+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -7342,12 +7342,12 @@
         },
         "commit": {
           "status": "pass",
-          "evidence": "444c24162d83e9fc45ae8322fde6bbf4834b634b"
+          "evidence": "5154b59e9306539a2bb1424bd367675267809acb"
         }
       },
       "failure_reason": null,
       "pr_url": null,
-      "commit_sha": "444c24162d83e9fc45ae8322fde6bbf4834b634b",
+      "commit_sha": "5154b59e9306539a2bb1424bd367675267809acb",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -7377,6 +7377,11 @@
           "at": "2026-05-16T14:55:11+08:00",
           "status": "committed",
           "summary": "Committed scoped remediation at 444c24162d83e9fc45ae8322fde6bbf4834b634b."
+        },
+        {
+          "at": "2026-05-16T14:55:44+08:00",
+          "status": "committed",
+          "summary": "Recorded implementation commit 5154b59e9306539a2bb1424bd367675267809acb."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T14:55:44+08:00",
+  "updated_at": "2026-05-16T14:56:23+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -7295,7 +7295,7 @@
       "depends_on": [
         "AUDIT-WEB-CMS-LINK-XSS:fap-web"
       ],
-      "status": "committed",
+      "status": "pr_open",
       "train_scope": "security_audit_remediation",
       "risk_level": "high",
       "title": "fix(security): redact IQ answer keys and locked report payloads",
@@ -7343,10 +7343,14 @@
         "commit": {
           "status": "pass",
           "evidence": "5154b59e9306539a2bb1424bd367675267809acb"
+        },
+        "github_pr_created": {
+          "status": "pass",
+          "evidence": "https://github.com/fermatmind/fap-api/pull/1422"
         }
       },
       "failure_reason": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1422",
       "commit_sha": "5154b59e9306539a2bb1424bd367675267809acb",
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -7382,6 +7386,11 @@
           "at": "2026-05-16T14:55:44+08:00",
           "status": "committed",
           "summary": "Recorded implementation commit 5154b59e9306539a2bb1424bd367675267809acb."
+        },
+        {
+          "at": "2026-05-16T14:56:23+08:00",
+          "status": "pr_open",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1422."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T15:06:30+08:00",
+  "updated_at": "2026-05-16T15:08:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -7295,7 +7295,7 @@
       "depends_on": [
         "AUDIT-WEB-CMS-LINK-XSS:fap-web"
       ],
-      "status": "ci_fix_local_checks_passed",
+      "status": "ci_fix_committed",
       "train_scope": "security_audit_remediation",
       "risk_level": "high",
       "title": "fix(security): redact IQ answer keys and locked report payloads",
@@ -7369,11 +7369,15 @@
             "git diff --check: pass",
             "bash backend/scripts/ci_verify_mbti.sh: pass"
           ]
+        },
+        "ci_fix_commit": {
+          "status": "pass",
+          "evidence": "3084b090bf76d9e7c293355852c56c2ec2809ac1 records the scoped BigFive runtime freeze classifier fix for IQ result secrecy redaction."
         }
       },
       "failure_reason": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1422",
-      "commit_sha": "5154b59e9306539a2bb1424bd367675267809acb",
+      "commit_sha": "3084b090bf76d9e7c293355852c56c2ec2809ac1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -7418,6 +7422,11 @@
           "at": "2026-05-16T15:06:30+08:00",
           "status": "github_checks_failed_scoped_fix_local_passed",
           "summary": "Inspected verify-mbti failures on PR #1422, added exact IQ result secrecy redaction allowance to the BigFive runtime freeze classifier, and re-ran required plus MBTI CI validation locally."
+        },
+        {
+          "at": "2026-05-16T15:08:00+08:00",
+          "status": "ci_fix_committed",
+          "summary": "Committed scoped GitHub CI fix at 3084b090bf76d9e7c293355852c56c2ec2809ac1."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T14:56:23+08:00",
+  "updated_at": "2026-05-16T15:06:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -7295,7 +7295,7 @@
       "depends_on": [
         "AUDIT-WEB-CMS-LINK-XSS:fap-web"
       ],
-      "status": "pr_open",
+      "status": "ci_fix_local_checks_passed",
       "train_scope": "security_audit_remediation",
       "risk_level": "high",
       "title": "fix(security): redact IQ answer keys and locked report payloads",
@@ -7347,6 +7347,28 @@
         "github_pr_created": {
           "status": "pass",
           "evidence": "https://github.com/fermatmind/fap-api/pull/1422"
+        },
+        "github_checks_initial": {
+          "status": "fail_current_pr_scoped_fix_applied",
+          "evidence": [
+            "GitHub PR #1422 failed verify-mbti-legacy and verify-mbti-v2 on Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff.",
+            "Failure listed current PR IQ secrecy files backend/app/Services/Attempts/AttemptSubmitService.php and backend/app/Services/Iq/IqResultPayloadRedactor.php as runtime-impacting until the BigFive freeze classifier had an exact IQ redaction-only allowance.",
+            "This was introduced by the current PR and fixed in scope by adding an exact diff allowlist and negative assertion; no BigFive runtime payload changes were allowed."
+          ]
+        },
+        "ci_fix_local_validation": {
+          "status": "pass",
+          "evidence": [
+            "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze --no-ansi: pass (67 tests, 72 assertions)",
+            "php artisan test --filter=Iq --no-ansi: pass (38 tests, 1044 assertions)",
+            "php artisan test --filter=AttemptSubmit --no-ansi: pass (8 tests, 88 assertions)",
+            "php artisan route:list --no-ansi: pass",
+            "vendor/bin/pint --test: pass (3272 files)",
+            "ruby YAML.load_file docs/codex/pr-train.yaml: pass",
+            "python3 -m json.tool docs/codex/pr-train-state.json: pass",
+            "git diff --check: pass",
+            "bash backend/scripts/ci_verify_mbti.sh: pass"
+          ]
         }
       },
       "failure_reason": null,
@@ -7391,6 +7413,11 @@
           "at": "2026-05-16T14:56:23+08:00",
           "status": "pr_open",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1422."
+        },
+        {
+          "at": "2026-05-16T15:06:30+08:00",
+          "status": "github_checks_failed_scoped_fix_local_passed",
+          "summary": "Inspected verify-mbti failures on PR #1422, added exact IQ result secrecy redaction allowance to the BigFive runtime freeze classifier, and re-ran required plus MBTI CI validation locally."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -3940,3 +3940,329 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+
+  - id: AUDIT-API-IQ-RESULT-SECRECY
+    repo: fap-api
+    depends_on:
+      - AUDIT-WEB-CMS-LINK-XSS:fap-web
+    branch: codex/audit-api-iq-result-secrecy
+    global_sequence: 2
+    title: "fix(security): redact IQ answer keys and locked report payloads"
+    name: "Redact IQ answer keys and locked report payloads"
+    findings:
+      - "IQ result responses expose answer keys"
+      - "Locked IQ reports expose non-free score sections"
+    scope:
+      - Remove answer-key fields from public IQ result serialization and submit responses.
+      - Preserve server-side IQ scoring correctness while redacting correct answers from persisted/public payloads where required.
+      - Enforce locked/free/pro IQ report access gates for score sections and narrative sections.
+      - Add regression tests proving answer keys and paid sections are not exposed publicly.
+    allowed_paths:
+      - backend/app/Services/Assessment/Drivers/IqTestDriver.php
+      - backend/app/Services/Attempts/**
+      - backend/app/Services/Reports/**
+      - backend/app/Services/Iq/**
+      - backend/app/Http/Controllers/API/**
+      - backend/app/Http/Resources/**
+      - backend/tests/Feature/**
+      - backend/tests/Unit/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change IQ scoring semantics or answer-key storage authority.
+      - Touch fap-web.
+      - Modify payment/order/report entitlement business policy beyond redaction/access enforcement.
+      - Run production DB mutation, deploy, rollback, unlock, or process termination.
+    validation:
+      - php artisan test --filter=Iq --no-ansi
+      - php artisan test --filter=AttemptSubmit --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by AUDIT-API-IQ-RESULT-SECRECY
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: AUDIT-API-CMS-MEDIA-URL-GUARD
+    repo: fap-api
+    depends_on:
+      - AUDIT-WEB-LLMS-FANOUT-BUDGET:fap-web
+    branch: codex/audit-api-cms-media-url-guard
+    global_sequence: 6
+    title: "fix(security): enforce public media URL guard for CMS media and JSON-LD"
+    name: "Enforce public media URL guard for CMS media and JSON-LD"
+    findings:
+      - "CMS media CDN verification permits SSRF"
+      - "JSON-LD image bypasses public media URL guard"
+    scope:
+      - Constrain CMS media CDN verification to approved public media/CDN origins.
+      - Reject localhost, private, link-local, non-http(s), and unapproved redirect targets.
+      - Apply the public media URL guard to JSON-LD image fields and public article media variants.
+      - Add regression tests for blocked and allowed media URLs.
+    allowed_paths:
+      - backend/app/Services/Cms/**
+      - backend/app/Services/Media/**
+      - backend/app/Support/**
+      - backend/app/Http/Resources/**
+      - backend/app/Http/Controllers/API/V0_5/Cms/**
+      - backend/tests/Feature/Cms/**
+      - backend/tests/Unit/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change article content or publish state.
+      - Touch fap-web.
+      - Run media sync against production.
+      - Run production DB mutation, deploy, rollback, unlock, or process termination.
+    validation:
+      - php artisan test --filter=Media --no-ansi
+      - php artisan test --filter=Article --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by AUDIT-API-CMS-MEDIA-URL-GUARD
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: AUDIT-API-CAREER-ROLLOUT-AUTHORITY
+    repo: fap-api
+    depends_on:
+      - AUDIT-API-CMS-MEDIA-URL-GUARD
+    branch: codex/audit-api-career-rollout-authority
+    global_sequence: 7
+    title: "fix(security): enforce career rollout authority gates"
+    name: "Enforce career rollout authority gates"
+    findings:
+      - "Explicit delta mode bypasses audit policy blockers"
+      - "Progressive selection can promote unready career slugs"
+      - "Unsigned rollout reports can publish career slugs"
+      - "Career rollout slugs bypass review authority"
+    scope:
+      - Require approved rollout/readiness authority for explicit delta slugs.
+      - Preserve hard blockers, audit policy blockers, and review/family handoff authority in progressive selection and rollout ledger paths.
+      - Reject unsigned, stale, or untrusted rollout reports for publication authority.
+      - Add regression tests proving unreviewed/unready slugs cannot be promoted.
+    allowed_paths:
+      - backend/app/Console/Commands/Career*
+      - backend/app/Domain/Career/**
+      - backend/app/Services/Career/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/**
+      - backend/tests/Unit/Services/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run rollout dry-run or apply.
+      - Run candidate preparation apply.
+      - Run backfill, rollback, quarantine, publication expansion, production DB mutation, or deploy.
+      - Touch fap-web.
+      - Weaken final live acceptance.
+    validation:
+      - php artisan test --filter=Career --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by AUDIT-API-CAREER-ROLLOUT-AUTHORITY
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: AUDIT-API-CAREER-ARTIFACT-READINESS
+    repo: fap-api
+    depends_on:
+      - AUDIT-API-CAREER-ROLLOUT-AUTHORITY
+    branch: codex/audit-api-career-artifact-readiness
+    global_sequence: 8
+    title: "fix(security): fail closed on career readiness artifacts"
+    name: "Fail closed on career readiness artifacts"
+    findings:
+      - "Career refresh planner fails open on artifacts"
+      - "Index context artifacts can bypass index_eligible gate"
+      - "Unsupported locale bypasses zh readiness gate"
+    scope:
+      - Require valid passed target/runtime/candidate artifacts before readiness pass.
+      - Treat missing or null index_eligible as not eligible for artifact-based index context.
+      - Normalize and validate locale before zh readiness gates are evaluated.
+      - Add regression tests for malformed, blocked, and missing readiness artifacts.
+    allowed_paths:
+      - backend/app/Console/Commands/Career*
+      - backend/app/Domain/Career/**
+      - backend/app/Http/Resources/Career/**
+      - backend/app/Services/Career/**
+      - backend/tests/Feature/Career/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/**
+      - backend/tests/Unit/Services/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run rollout dry-run or apply.
+      - Run candidate preparation apply.
+      - Run backfill, rollback, quarantine, publication expansion, production DB mutation, or deploy.
+      - Touch fap-web.
+      - Weaken final live acceptance.
+    validation:
+      - php artisan test --filter=Career --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by AUDIT-API-CAREER-ARTIFACT-READINESS
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: AUDIT-API-ARTICLE-PUBLISH-GATE
+    repo: fap-api
+    depends_on:
+      - AUDIT-API-CAREER-ARTIFACT-READINESS
+    branch: codex/audit-api-article-publish-gate
+    global_sequence: 9
+    title: "fix(security): require editorial approval for controlled article publish"
+    name: "Require editorial approval for controlled article publish"
+    findings:
+      - "Controlled article publish bypasses review gates"
+    scope:
+      - Require approved editorial review state before controlled article publication.
+      - Revalidate publish preflight atomically immediately before publish.
+      - Add regression tests proving unapproved, stale, archived, or already-published revisions cannot bypass review gates.
+    allowed_paths:
+      - backend/app/Console/Commands/*Article*
+      - backend/app/Models/Article*
+      - backend/app/Services/Cms/**
+      - backend/app/Domain/Cms/**
+      - backend/tests/Feature/Console/*Article*
+      - backend/tests/Feature/Cms/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change article body content.
+      - Publish, unpublish, import, or mutate production content.
+      - Touch attempts, results, reports, orders, payments, shares, scoring, or fap-web.
+      - Run production DB mutation, deploy, rollback, unlock, or process termination.
+    validation:
+      - php artisan test --filter=Article --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by AUDIT-API-ARTICLE-PUBLISH-GATE
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: AUDIT-API-OPS-TENANT-SCOPING
+    repo: fap-api
+    depends_on:
+      - AUDIT-API-ARTICLE-PUBLISH-GATE
+    branch: codex/audit-api-ops-tenant-scoping
+    global_sequence: 10
+    title: "fix(security): scope ops release failure audits by org"
+    name: "Scope ops release failure audits by org"
+    findings:
+      - "Ops dashboard leaks cross-org release failure audits"
+    scope:
+      - Constrain ops article publishing release-failure audit queries to the selected/current org context.
+      - Avoid unscoped AuditLog exposure unless explicitly safe and still tenant-filtered.
+      - Add regression tests proving cross-org audit rows are not visible.
+    allowed_paths:
+      - backend/app/Filament/Ops/Pages/ArticlePublishingOpsPage.php
+      - backend/app/Models/AuditLog.php
+      - backend/app/Services/Ops/**
+      - backend/tests/Feature/Ops/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change article publishing workflow semantics beyond tenant scoping.
+      - Touch fap-web.
+      - Run production DB mutation, deploy, rollback, unlock, or process termination.
+    validation:
+      - php artisan test tests/Feature/Ops/ArticlePublishingOpsPageTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by AUDIT-API-OPS-TENANT-SCOPING
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: AUDIT-API-SAFE-TMP-ARTIFACTS
+    repo: fap-api
+    depends_on:
+      - AUDIT-API-OPS-TENANT-SCOPING
+    branch: codex/audit-api-safe-tmp-artifacts
+    global_sequence: 11
+    title: "fix(security): write temporary artifacts safely"
+    name: "Write temporary artifacts safely"
+    findings:
+      - "Predictable /tmp artifact outputs allow symlink overwrite"
+    scope:
+      - Replace predictable /tmp artifact output paths with safe temporary file/directory creation.
+      - Prevent symlink overwrite and path traversal for generated artifact outputs.
+      - Add regression tests proving attacker-controlled symlinks cannot be overwritten.
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Domain/**/*
+      - backend/app/Support/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/**
+      - backend/docs/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change publication authority semantics.
+      - Touch fap-web.
+      - Run production DB mutation, deploy, rollback, unlock, or process termination.
+    validation:
+      - php artisan test --filter=Artifact --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by AUDIT-API-SAFE-TMP-ARTIFACTS
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Findings Addressed
- AUDIT-API-IQ-RESULT-SECRECY
- Public IQ result/submit surfaces must not emit answer-key fields.
- Locked/free IQ report payloads must not include paid score sections or IQ pro payload sections.

## What Changed
- Removed `correct_answer` from newly scored IQ result item payloads while preserving server-side scoring correctness.
- Added an IQ result payload redactor and applied it to submit payload construction, result reads, and stored async submission reads.
- Made IQ report composition fail closed for non-full access: free/locked variants expose only a redacted shell and omit score/pro sections.
- Added regression coverage for IQ driver output, public result reads, submit payload serialization, stored submission reads, and locked report gating.
- Added an exact Big Five runtime freeze classifier allowance for this IQ-only redaction diff, with a negative assertion proving unrelated shared runtime edits remain blocked.
- Added authorized fap-api security audit train entries and recorded this train item state.

## Why
IQ scoring can keep answer keys in server-side scoring specs, but public response payloads and locked report views should not disclose answer-key material or paid report sections.

## Validation Commands
- `composer dump-autoload`
- `php artisan test tests/Unit/Assessment/IqTestDriverTest.php tests/Unit/Services/Report/IqReportBuilderTest.php tests/Feature/V0_3/IqReportContractTest.php --no-ansi`
- `php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze --no-ansi`
- `php artisan test --filter=Iq --no-ansi`
- `php artisan test --filter=AttemptSubmit --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`
- `python3 -m json.tool docs/codex/pr-train-state.json`
- `git diff --check`
- `git diff --cached --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## GitHub Checks
- Initial `verify-mbti-legacy` and `verify-mbti-v2` failure was inspected and fixed inside current scope.
- Latest required checks passed on head `75ad2be9`: `hygiene`, `verify-mbti-legacy`, `verify-mbti-v2`.

## Sidecar Issues Recorded
None.

## Intentionally Deferred
- No IQ scoring semantics changes.
- No answer-key storage authority changes.
- No payment/order/report entitlement business-policy expansion beyond redaction/access enforcement.
- No production deploy, rollback, unlock, or process changes.

## Repository Rule Impact
No route, migration, middleware, or content-authority change. Backend remains the IQ scoring and report authority.
