### PR TITLE
AUDIT-API-CMS-MEDIA-URL-GUARD: fix(security): enforce public media URL guard for CMS media and JSON-LD

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -900,8 +900,10 @@ class ArticleController extends Controller
         $seoMeta['seo_title'] = $revision->seo_title;
         $seoMeta['seo_description'] = $revision->seo_description;
         $seoMeta['canonical_url'] = CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta['canonical_url'] ?? null);
-        if (array_key_exists('schema_json', $seoMeta)) {
-            $seoMeta['schema_json'] = CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json']);
+        if (is_array($seoMeta['schema_json'] ?? null)) {
+            $seoMeta['schema_json'] = PublicMediaUrlGuard::sanitizeJsonLdImageFields(
+                CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json'])
+            );
         }
 
         return $seoMeta;
@@ -1046,8 +1048,10 @@ class ArticleController extends Controller
         }
 
         $seoMeta['canonical_url'] = CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta['canonical_url'] ?? null);
-        if (array_key_exists('schema_json', $seoMeta)) {
-            $seoMeta['schema_json'] = CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json']);
+        if (is_array($seoMeta['schema_json'] ?? null)) {
+            $seoMeta['schema_json'] = PublicMediaUrlGuard::sanitizeJsonLdImageFields(
+                CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json'])
+            );
         }
 
         return $seoMeta;

--- a/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
@@ -321,8 +321,10 @@ final class LandingSurfaceController extends Controller
             $seoMeta['canonical_url'] = CanonicalFrontendUrl::normalizeAbsoluteUrl(
                 $seoMeta['canonical_url'] ?? null
             );
-            if (array_key_exists('schema_json', $seoMeta)) {
-                $seoMeta['schema_json'] = CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json']);
+            if (is_array($seoMeta['schema_json'] ?? null)) {
+                $seoMeta['schema_json'] = PublicMediaUrlGuard::sanitizeJsonLdImageFields(
+                    CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json'])
+                );
             }
         }
 

--- a/backend/app/Services/Cms/ArticleSeoService.php
+++ b/backend/app/Services/Cms/ArticleSeoService.php
@@ -9,6 +9,7 @@ use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
 use App\Services\Career\StructuredData\CareerArticleStructuredDataBuilder;
 use App\Support\CanonicalFrontendUrl;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -88,7 +89,9 @@ final class ArticleSeoService
         $description = $revision?->seo_description ?? $seo?->seo_description
             ?? Str::limit($this->normalizeWhitespace(strip_tags($descriptionSource)), 160);
         $canonical = $this->buildCanonicalUrl((string) $article->slug, $locale);
-        $image = $seo?->og_image_url ?? $this->resolveArticleImageUrl($article);
+        $image = PublicMediaUrlGuard::sanitizeNullableUrl(
+            $seo?->og_image_url ?? $this->resolveArticleImageUrl($article)
+        );
 
         return [
             'title' => $title,
@@ -131,7 +134,9 @@ final class ArticleSeoService
                 ?? Str::limit($this->normalizeWhitespace(strip_tags($descriptionSource)), 160),
             'url' => $canonical,
             'main_entity_of_page' => $canonical,
-            'image' => $seo?->og_image_url ?? $this->resolveArticleImageUrl($article),
+            'image' => PublicMediaUrlGuard::sanitizeNullableUrl(
+                $seo?->og_image_url ?? $this->resolveArticleImageUrl($article)
+            ),
             'date_published' => $revision?->published_at?->toAtomString() ?? $article->published_at?->toAtomString(),
             'date_modified' => $revision?->updated_at?->toAtomString() ?? $article->updated_at?->toAtomString(),
             'article_section' => $this->normalizeString($article->category?->name),
@@ -148,8 +153,10 @@ final class ArticleSeoService
             $jsonLd = array_replace_recursive($jsonLd, $seo->schema_json);
         }
 
-        return CanonicalFrontendUrl::normalizeNestedUrls(
-            $this->normalizeJsonLdUrls($jsonLd, $canonical, (string) $article->slug)
+        return PublicMediaUrlGuard::sanitizeJsonLdImageFields(
+            CanonicalFrontendUrl::normalizeNestedUrls(
+                $this->normalizeJsonLdUrls($jsonLd, $canonical, (string) $article->slug)
+            )
         );
     }
 

--- a/backend/app/Services/Cms/MediaAssetStorageSyncService.php
+++ b/backend/app/Services/Cms/MediaAssetStorageSyncService.php
@@ -152,7 +152,9 @@ final class MediaAssetStorageSyncService
         }
 
         try {
-            $response = Http::timeout($this->cdnVerifyTimeoutSeconds())->get($candidate);
+            $response = Http::timeout($this->cdnVerifyTimeoutSeconds())
+                ->withoutRedirecting()
+                ->get($candidate);
             $contentType = strtolower((string) $response->header('Content-Type', ''));
             if (! $response->successful() || ! str_starts_with($contentType, 'image/')) {
                 $failures[] = sprintf('%s returned %s %s', $candidate, (string) $response->status(), $contentType);

--- a/backend/app/Support/PublicMediaUrlGuard.php
+++ b/backend/app/Support/PublicMediaUrlGuard.php
@@ -11,6 +11,14 @@ final class PublicMediaUrlGuard
     /**
      * @var list<string>
      */
+    private const DEFAULT_ALLOWED_MEDIA_HOSTS = [
+        'api.fermatmind.com',
+        'assets.fermatmind.com',
+    ];
+
+    /**
+     * @var list<string>
+     */
     private const BLOCKED_MARKERS = [
         'myqcloud.com',
         '.qcloud.com',
@@ -21,6 +29,17 @@ final class PublicMediaUrlGuard
         'watermark',
     ];
 
+    /**
+     * @var list<string>
+     */
+    private const JSON_LD_MEDIA_KEYS = [
+        'contentUrl',
+        'image',
+        'logo',
+        'thumbnail',
+        'thumbnailUrl',
+    ];
+
     public static function sanitizeNullableUrl(mixed $url): ?string
     {
         $normalized = trim((string) $url);
@@ -29,7 +48,7 @@ final class PublicMediaUrlGuard
             return null;
         }
 
-        return self::isBlockedUrl($normalized) ? null : $normalized;
+        return self::isAllowedPublicMediaUrl($normalized) ? $normalized : null;
     }
 
     public static function canonicalAssetOrigin(): string
@@ -37,7 +56,7 @@ final class PublicMediaUrlGuard
         $origin = trim((string) config('fap.media.asset_origin', self::DEFAULT_ASSET_ORIGIN));
         $origin = rtrim($origin, '/');
 
-        if ($origin === '' || ! preg_match('/^https?:\/\//i', $origin)) {
+        if ($origin === '' || ! preg_match('/^https:\/\//i', $origin)) {
             return self::DEFAULT_ASSET_ORIGIN;
         }
 
@@ -60,7 +79,7 @@ final class PublicMediaUrlGuard
             return null;
         }
 
-        return self::canonicalAssetOrigin().$publicPath;
+        return self::sanitizeNullableUrl(self::canonicalAssetOrigin().$publicPath);
     }
 
     public static function canonicalMediaUrl(?string $disk, mixed $path, mixed $url): ?string
@@ -84,12 +103,16 @@ final class PublicMediaUrlGuard
             return null;
         }
 
-        foreach ($keys as $key) {
-            if (! array_key_exists($key, $payload)) {
+        foreach ($payload as $key => $value) {
+            if (in_array((string) $key, $keys, true)) {
+                $payload[$key] = self::sanitizeNullableUrl($value);
+
                 continue;
             }
 
-            $payload[$key] = self::sanitizeNullableUrl($payload[$key]);
+            if (is_array($value)) {
+                $payload[$key] = self::sanitizeArrayFields($value, $keys) ?? [];
+            }
         }
 
         return $payload;
@@ -112,6 +135,16 @@ final class PublicMediaUrlGuard
         return $meta;
     }
 
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public static function sanitizeJsonLdImageFields(array $payload): array
+    {
+        /** @var array<string, mixed> */
+        return self::sanitizeJsonLdNode($payload);
+    }
+
     public static function isBlockedUrl(?string $url): bool
     {
         $normalized = strtolower(trim((string) $url));
@@ -126,6 +159,40 @@ final class PublicMediaUrlGuard
         }
 
         return false;
+    }
+
+    public static function isAllowedPublicMediaUrl(?string $url): bool
+    {
+        $normalized = trim((string) $url);
+        if ($normalized === '' || self::isBlockedUrl($normalized)) {
+            return false;
+        }
+
+        $parts = parse_url($normalized);
+        if (! is_array($parts)) {
+            return false;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = self::normalizeHost((string) ($parts['host'] ?? ''));
+        if ($scheme !== 'https' || $host === '') {
+            return false;
+        }
+
+        if (array_key_exists('user', $parts) || array_key_exists('pass', $parts)) {
+            return false;
+        }
+
+        $port = (int) ($parts['port'] ?? 443);
+        if ($port !== 443) {
+            return false;
+        }
+
+        if (self::isPrivateOrLocalHost($host)) {
+            return false;
+        }
+
+        return in_array($host, self::allowedMediaHosts(), true);
     }
 
     private static function publicPathForDisk(?string $disk, string $path): string
@@ -147,5 +214,109 @@ final class PublicMediaUrlGuard
         }
 
         return '/'.ltrim($trimmed, '/');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function allowedMediaHosts(): array
+    {
+        $hosts = self::DEFAULT_ALLOWED_MEDIA_HOSTS;
+
+        foreach ([self::DEFAULT_ASSET_ORIGIN, self::canonicalAssetOrigin(), (string) config('app.url', '')] as $origin) {
+            $host = self::normalizeHost((string) parse_url($origin, PHP_URL_HOST));
+            if ($host !== '' && ! self::isPrivateOrLocalHost($host)) {
+                $hosts[] = $host;
+            }
+        }
+
+        return array_values(array_unique($hosts));
+    }
+
+    private static function normalizeHost(string $host): string
+    {
+        return strtolower(trim($host, "[] \t\n\r\0\x0B."));
+    }
+
+    private static function isPrivateOrLocalHost(string $host): bool
+    {
+        $normalized = self::normalizeHost($host);
+        if ($normalized === '' || $normalized === 'localhost' || str_ends_with($normalized, '.localhost')) {
+            return true;
+        }
+
+        if (filter_var($normalized, FILTER_VALIDATE_IP)) {
+            return filter_var(
+                $normalized,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            ) === false;
+        }
+
+        return false;
+    }
+
+    private static function isJsonLdImageObject(mixed $type): bool
+    {
+        $types = is_array($type) ? $type : [$type];
+
+        foreach ($types as $candidate) {
+            if (strcasecmp(trim((string) $candidate), 'ImageObject') === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function isJsonLdMediaKey(string $key): bool
+    {
+        return in_array($key, self::JSON_LD_MEDIA_KEYS, true);
+    }
+
+    private static function sanitizeJsonLdMediaValue(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return self::sanitizeNullableUrl($value);
+        }
+
+        if (! is_array($value)) {
+            return null;
+        }
+
+        if (array_is_list($value)) {
+            $sanitized = [];
+            foreach ($value as $item) {
+                $media = self::sanitizeJsonLdMediaValue($item);
+                if ($media !== null && $media !== []) {
+                    $sanitized[] = $media;
+                }
+            }
+
+            return $sanitized;
+        }
+
+        return self::sanitizeJsonLdNode($value);
+    }
+
+    private static function sanitizeJsonLdNode(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $isImageObject = self::isJsonLdImageObject($value['@type'] ?? null);
+        foreach ($value as $key => $nestedValue) {
+            $keyName = (string) $key;
+            if (self::isJsonLdMediaKey($keyName) || ($isImageObject && in_array($keyName, ['contentUrl', 'url'], true))) {
+                $value[$key] = self::sanitizeJsonLdMediaValue($nestedValue);
+
+                continue;
+            }
+
+            $value[$key] = self::sanitizeJsonLdNode($nestedValue);
+        }
+
+        return $value;
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -239,6 +239,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Models/MediaAsset.php',
             'backend/app/Models/MediaVariant.php',
             'backend/app/Services/Cms/MediaAssetStorageSyncService.php',
+            'backend/app/Support/PublicMediaUrlGuard.php',
             'backend/database/migrations/2026_05_16_000100_add_media_asset_sync_status.php',
         ];
 
@@ -1694,6 +1695,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Models/MediaAsset.php',
             'backend/app/Models/MediaVariant.php',
             'backend/app/Services/Cms/MediaAssetStorageSyncService.php',
+            'backend/app/Support/PublicMediaUrlGuard.php',
             'backend/database/migrations/2026_05_16_000100_add_media_asset_sync_status.php',
         ], true);
     }

--- a/backend/tests/Unit/Services/Cms/ArticleSeoServiceMediaGuardTest.php
+++ b/backend/tests/Unit/Services/Cms/ArticleSeoServiceMediaGuardTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Cms;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Services\Cms\ArticleSeoService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class ArticleSeoServiceMediaGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_generated_json_ld_sanitizes_image_fields_from_seo_schema_json(): void
+    {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'jsonld-media-guard',
+            'locale' => 'en',
+            'title' => 'JSON-LD media guard',
+            'excerpt' => 'Guard article media URLs.',
+            'content_md' => '# JSON-LD media guard',
+            'cover_image_url' => 'https://169.254.169.254/latest/meta-data',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 5, 16, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'JSON-LD media guard | FermatMind',
+            'seo_description' => 'Guard article media URLs.',
+            'canonical_url' => 'https://www.fermatmind.com/en/articles/jsonld-media-guard',
+            'og_title' => 'JSON-LD media guard',
+            'og_description' => 'Guard article media URLs.',
+            'og_image_url' => 'https://127.0.0.1/internal.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+            'schema_json' => [
+                '@type' => 'Article',
+                'url' => 'https://www.fermatmind.com/en/articles/jsonld-media-guard',
+                'image' => [
+                    'https://cdn.example.test/blocked.png',
+                    [
+                        '@type' => 'ImageObject',
+                        'url' => 'https://api.fermatmind.com/static/articles/cover.png',
+                    ],
+                ],
+            ],
+        ]);
+
+        $jsonLd = app(ArticleSeoService::class)->generateJsonLd($article);
+        $encoded = json_encode($jsonLd, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('https://fermatmind.com/en/articles/jsonld-media-guard', data_get($jsonLd, 'url'));
+        $this->assertSame('https://api.fermatmind.com/static/articles/cover.png', data_get($jsonLd, 'image.0.url'));
+        $this->assertStringNotContainsString('169.254.169.254', $encoded);
+        $this->assertStringNotContainsString('127.0.0.1', $encoded);
+        $this->assertStringNotContainsString('cdn.example.test', $encoded);
+    }
+}

--- a/backend/tests/Unit/Services/Cms/MediaAssetStorageSyncServiceTest.php
+++ b/backend/tests/Unit/Services/Cms/MediaAssetStorageSyncServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Cms;
+
+use App\Models\MediaAsset;
+use App\Services\Cms\MediaAssetStorageSyncService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+final class MediaAssetStorageSyncServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cdn_verification_rejects_private_media_urls_without_fetching_them(): void
+    {
+        Http::fake();
+        config(['fap.media.cdn_verify_enabled' => true]);
+
+        $asset = $this->assetWithUrl('https://169.254.169.254/latest/meta-data');
+
+        $verified = app(MediaAssetStorageSyncService::class)->verifyCdn($asset);
+
+        $this->assertSame(MediaAsset::CDN_FAILED, (string) $verified->cdn_status);
+        $this->assertStringContainsString('missing or blocked CDN URL', (string) $verified->last_error);
+        Http::assertNothingSent();
+    }
+
+    public function test_cdn_verification_fails_closed_on_redirect_responses(): void
+    {
+        Http::fake([
+            'assets.fermatmind.com/*' => Http::response('', 302, [
+                'Content-Type' => 'text/html',
+                'Location' => 'https://127.0.0.1/internal.png',
+            ]),
+        ]);
+        config(['fap.media.cdn_verify_enabled' => true]);
+
+        $asset = $this->assetWithUrl('https://assets.fermatmind.com/static/articles/cover.png');
+
+        $verified = app(MediaAssetStorageSyncService::class)->verifyCdn($asset);
+
+        $this->assertSame(MediaAsset::CDN_FAILED, (string) $verified->cdn_status);
+        $this->assertStringContainsString('returned 302 text/html', (string) $verified->last_error);
+    }
+
+    private function assetWithUrl(string $url): MediaAsset
+    {
+        return MediaAsset::query()->create([
+            'org_id' => 0,
+            'asset_key' => 'asset_'.md5($url),
+            'disk' => 'public_static',
+            'path' => 'static/articles/cover.png',
+            'url' => $url,
+            'mime_type' => 'image/png',
+            'width' => 1200,
+            'height' => 630,
+            'bytes' => 1234,
+            'alt' => 'cover',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'sync_status' => MediaAsset::SYNC_SYNCED,
+            'cdn_status' => MediaAsset::CDN_NOT_VERIFIED,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
+++ b/backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
@@ -5,40 +5,127 @@ declare(strict_types=1);
 namespace Tests\Unit\Support;
 
 use App\Support\PublicMediaUrlGuard;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 final class PublicMediaUrlGuardTest extends TestCase
 {
-    public function test_sanitize_nullable_url_blocks_tencent_markers_and_keeps_safe_urls(): void
+    public function test_sanitize_nullable_url_allows_only_explicit_public_media_origins(): void
     {
+        config([
+            'app.url' => 'https://api.staging.fermatmind.com',
+            'fap.media.asset_origin' => 'https://assets.fermatmind.com',
+        ]);
+
         $this->assertNull(
             PublicMediaUrlGuard::sanitizeNullableUrl('https://bucket.cos.ap-shanghai.myqcloud.com/path.png')
         );
         $this->assertNull(
             PublicMediaUrlGuard::sanitizeNullableUrl('https://example.test/image.png?ci-process=cover')
         );
-        $this->assertSame(
+
+        foreach ([
             '/images/local-cover.png',
-            PublicMediaUrlGuard::sanitizeNullableUrl('/images/local-cover.png')
-        );
-        $this->assertSame(
+            'javascript:alert(1)',
+            'data:image/png;base64,AAAA',
+            'ftp://assets.fermatmind.com/static/cover.png',
+            'http://assets.fermatmind.com/static/cover.png',
             'https://cdn.example.test/cover.png',
-            PublicMediaUrlGuard::sanitizeNullableUrl('https://cdn.example.test/cover.png')
+            'https://assets.fermatmind.com.evil.test/static/cover.png',
+            'https://127.0.0.1/static/cover.png',
+            'https://10.0.0.2/static/cover.png',
+            'https://172.16.0.2/static/cover.png',
+            'https://192.168.0.2/static/cover.png',
+            'https://169.254.169.254/latest/meta-data',
+            'https://localhost/static/cover.png',
+            'https://[::1]/static/cover.png',
+            'https://assets.fermatmind.com:8443/static/cover.png',
+            'https://user:pass@assets.fermatmind.com/static/cover.png',
+        ] as $blockedUrl) {
+            $this->assertNull(PublicMediaUrlGuard::sanitizeNullableUrl($blockedUrl), $blockedUrl);
+        }
+
+        foreach ([
+            'https://assets.fermatmind.com/static/share/mbti_wide_1200x630.png',
+            'https://api.fermatmind.com/static/social/wechat-qr.jpg',
+            'https://api.staging.fermatmind.com/static/articles/cover.png',
+        ] as $allowedUrl) {
+            $this->assertSame($allowedUrl, PublicMediaUrlGuard::sanitizeNullableUrl($allowedUrl), $allowedUrl);
+        }
+    }
+
+    public function test_public_media_url_for_path_canonicalizes_internal_paths_to_the_asset_origin(): void
+    {
+        config(['fap.media.asset_origin' => 'https://assets.fermatmind.com']);
+
+        $this->assertSame(
+            'https://assets.fermatmind.com/storage/media-library/cover.png',
+            PublicMediaUrlGuard::publicMediaUrlForPath('public', 'media-library/cover.png')
+        );
+
+        $this->assertSame(
+            'https://assets.fermatmind.com/static/share/mbti_wide_1200x630.png',
+            PublicMediaUrlGuard::publicMediaUrlForPath(null, '/static/share/mbti_wide_1200x630.png')
         );
     }
 
-    public function test_sanitize_array_fields_only_nulls_blocked_media_fields(): void
+    public function test_sanitize_array_fields_recursively_nulls_unsafe_media_fields(): void
     {
         $payload = PublicMediaUrlGuard::sanitizeArrayFields([
             'og_image_url' => 'https://bucket.cos.ap-shanghai.myqcloud.com/og.png',
-            'twitter_image_url' => 'https://cdn.example.test/twitter.png',
+            'twitter_image_url' => 'https://assets.fermatmind.com/static/twitter.png',
+            'variants' => [
+                'hero' => ['url' => 'https://127.0.0.1/internal.png'],
+                'card' => ['url' => 'https://api.fermatmind.com/static/card.png'],
+            ],
             'title' => 'SEO',
-        ], ['og_image_url', 'twitter_image_url']);
+        ], ['og_image_url', 'twitter_image_url', 'url']);
 
         $this->assertSame([
             'og_image_url' => null,
-            'twitter_image_url' => 'https://cdn.example.test/twitter.png',
+            'twitter_image_url' => 'https://assets.fermatmind.com/static/twitter.png',
+            'variants' => [
+                'hero' => ['url' => null],
+                'card' => ['url' => 'https://api.fermatmind.com/static/card.png'],
+            ],
             'title' => 'SEO',
         ], $payload);
+    }
+
+    public function test_sanitize_json_ld_image_fields_blocks_unsafe_image_urls_without_rewriting_canonical_urls(): void
+    {
+        $payload = PublicMediaUrlGuard::sanitizeJsonLdImageFields([
+            '@type' => 'Article',
+            'url' => 'https://fermatmind.com/en/articles/career-fit-guide',
+            'mainEntityOfPage' => 'https://fermatmind.com/en/articles/career-fit-guide#webpage',
+            'image' => [
+                'https://api.fermatmind.com/static/articles/cover.png',
+                'https://169.254.169.254/latest/meta-data',
+                [
+                    '@type' => 'ImageObject',
+                    'url' => 'https://cdn.example.test/blocked.png',
+                    'contentUrl' => 'https://assets.fermatmind.com/static/articles/content.png',
+                ],
+            ],
+            'publisher' => [
+                '@type' => 'Organization',
+                'logo' => [
+                    '@type' => 'ImageObject',
+                    'url' => 'https://localhost/logo.png',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('https://fermatmind.com/en/articles/career-fit-guide', $payload['url']);
+        $this->assertSame('https://fermatmind.com/en/articles/career-fit-guide#webpage', $payload['mainEntityOfPage']);
+        $this->assertSame('https://api.fermatmind.com/static/articles/cover.png', $payload['image'][0]);
+        $this->assertSame([
+            '@type' => 'ImageObject',
+            'url' => null,
+            'contentUrl' => 'https://assets.fermatmind.com/static/articles/content.png',
+        ], $payload['image'][1]);
+        $this->assertSame([
+            '@type' => 'ImageObject',
+            'url' => null,
+        ], $payload['publisher']['logo']);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T16:22:44+08:00",
+  "updated_at": "2026-05-16T16:27:24+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -1597,7 +1597,7 @@
       "branch": "fix/career-surface-readiness-audit8",
       "title": "feat(api): add career surface readiness audit",
       "name": "Career Surface Readiness Audit",
-      "status": "pr_open",
+      "status": "ci_fix_in_progress",
       "depends_on": [
         "AUDIT-7"
       ],
@@ -7516,6 +7516,15 @@
           "status": "pass",
           "command": "git diff --cached --check",
           "evidence": "No staged whitespace errors."
+        },
+        "github_checks_initial": {
+          "status": "fail_current_pr_scope",
+          "evidence": "verify-mbti-v2 and verify-mbti-legacy failed because BigFiveResultPageV2CoreBodyPreviewTest flagged backend/app/Support/PublicMediaUrlGuard.php in runtime path diff. This file is current PR scope and should be classified with CMS media pipeline hardening."
+        },
+        "ci_fix_validation": {
+          "status": "pass",
+          "command": "php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi",
+          "evidence": "79 tests passed after adding PublicMediaUrlGuard.php to the CMS media pipeline freeze classifier."
         }
       },
       "failure_reason": null,
@@ -7575,6 +7584,11 @@
           "at": "2026-05-16T16:22:44+08:00",
           "status": "pr_open",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1423."
+        },
+        {
+          "at": "2026-05-16T16:27:24+08:00",
+          "status": "ci_fix_in_progress",
+          "summary": "Initial GitHub verify-mbti checks failed on a current-scope freeze classifier gap for PublicMediaUrlGuard.php. Added the guard to CMS media pipeline allowance and verified BigFiveResultPageV2CoreBodyPreview locally."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T16:21:23+08:00",
+  "updated_at": "2026-05-16T16:21:45+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -4275,7 +4275,7 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": "ee64c2911f9023dbf07ef2dc73cfa6645407c227",
+      "commit_sha": "485949cd5b84b2b1836abefa2b639db8d724d64c",
       "pr_url": null,
       "checks": {
         "authorization": {
@@ -7569,7 +7569,7 @@
         {
           "at": "2026-05-16T16:21:23+08:00",
           "status": "committed",
-          "summary": "Committed scoped implementation as ee64c2911f9023dbf07ef2dc73cfa6645407c227."
+          "summary": "Committed scoped implementation as 485949cd5b84b2b1836abefa2b639db8d724d64c."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T16:21:45+08:00",
+  "updated_at": "2026-05-16T16:22:44+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -1876,7 +1876,7 @@
       "branch": "fix/career-expansion-manifest-train-audit11",
       "title": "feat(api): add career canonical expansion manifest train generator",
       "name": "Career Canonical Expansion Manifest Train Generator",
-      "status": "committed",
+      "status": "pr_open",
       "depends_on": [
         "AUDIT-10"
       ],
@@ -3574,7 +3574,7 @@
         "docs/codex/pr-train-state.json"
       ],
       "commit_sha": "bb01c378674b28857b98ddbdf3d657144ef3b83e",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1423",
       "checks": {},
       "failure_reason": null,
       "merged_at": null,
@@ -7570,6 +7570,11 @@
           "at": "2026-05-16T16:21:23+08:00",
           "status": "committed",
           "summary": "Committed scoped implementation as 485949cd5b84b2b1836abefa2b639db8d724d64c."
+        },
+        {
+          "at": "2026-05-16T16:22:44+08:00",
+          "status": "pr_open",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1423."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T15:08:00+08:00",
+  "updated_at": "2026-05-16T16:21:23+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -1876,7 +1876,7 @@
       "branch": "fix/career-expansion-manifest-train-audit11",
       "title": "feat(api): add career canonical expansion manifest train generator",
       "name": "Career Canonical Expansion Manifest Train Generator",
-      "status": "in_progress",
+      "status": "committed",
       "depends_on": [
         "AUDIT-10"
       ],
@@ -4275,7 +4275,7 @@
         "no 80 readiness run",
         "no deploy"
       ],
-      "commit_sha": null,
+      "commit_sha": "ee64c2911f9023dbf07ef2dc73cfa6645407c227",
       "pr_url": null,
       "checks": {
         "authorization": {
@@ -7438,7 +7438,7 @@
       "depends_on": [
         "AUDIT-WEB-LLMS-FANOUT-BUDGET:fap-web"
       ],
-      "status": "planned",
+      "status": "in_progress",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): enforce public media URL guard for CMS media and JSON-LD",
@@ -7454,6 +7454,68 @@
         "scope_validation_policy": {
           "status": "planned",
           "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "AUDIT-WEB-LLMS-FANOUT-BUDGET merged as fap-web#825 with merge commit 6bf3a89d58b793d086166eb0faa8b6ba620913e1."
+        },
+        "branch_preflight": {
+          "status": "pass",
+          "evidence": "Created codex/audit-api-cms-media-url-guard from fap-api origin/main at ce2e634c6c877f167c71b4c37637c9d3f0986694. Local main is checked out in another worktree, so this worktree started directly from origin/main after verifying HEAD == origin/main."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to CMS services/controllers, Support URL guard, Unit tests, and PR train state; unrelated untracked .playwright-mcp/ is not staged and remains isolated."
+        },
+        "targeted_security_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Support/PublicMediaUrlGuardTest.php tests/Unit/Services/Cms/MediaAssetStorageSyncServiceTest.php tests/Unit/Services/Cms/ArticleSeoServiceMediaGuardTest.php --no-ansi",
+          "evidence": "7 tests passed, covering public media allowlist rejection, private/local URL blocking, CDN verification fail-closed behavior, redirect fail-closed behavior, recursive media variant sanitization, and Article JSON-LD image sanitization."
+        },
+        "manifest_media_tests": {
+          "status": "external_sidecar_candidate",
+          "command": "php artisan test --filter=Media --no-ansi",
+          "evidence": "Current-scope guard tests, MediaAssetStorageSyncService tests, and V0_5 MediaLibraryOssSync tests passed. Existing backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest internal media write/upload assertions fail with 401 because those tests do not authenticate against the current CMS admin middleware. The failing file is outside the declared allowed_paths and is not modified by this PR."
+        },
+        "manifest_article_tests": {
+          "status": "external_sidecar_candidate",
+          "command": "php artisan test --filter=Article --no-ansi",
+          "evidence": "Current-scope ArticleSeoServiceMediaGuard test, ArticlePublicApi tests, ArticleSeoService tests, and ArticlePublishingRuntimeTruth tests passed. Existing Ops translation tests fail outside this PR scope: ArticleMachineTranslationProviderTest throws Source article is outside translation content scope, and ArticleTranslationContractTest misses English source in the ops locale list."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3274 files passed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check",
+          "evidence": "No whitespace errors."
+        },
+        "bigfive_freeze_classifier": {
+          "status": "pass",
+          "command": "php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi",
+          "evidence": "79 tests passed."
+        },
+        "skill_migration_check": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-skill.sqlite php artisan migrate --force",
+          "evidence": "SQLite migration completed successfully."
+        },
+        "mbti_ci_gate": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Completed successfully, including MBTI, Enneagram, Partner API, migration safety, auth guest, OpenAPI, order security, share flow, dependency security, and queue backlog gates."
+        },
+        "cached_diff_check": {
+          "status": "pass",
+          "command": "git diff --cached --check",
+          "evidence": "No staged whitespace errors."
         }
       },
       "failure_reason": null,
@@ -7462,12 +7524,52 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+        {
+          "id": "AUDIT-API-CMS-MEDIA-URL-GUARD-SIDECAR-01",
+          "title": "MediaLibraryPublicApiTest internal media write/upload fixtures need CMS admin authentication",
+          "scope_relation": "external_to_current_pr",
+          "evidence": "php artisan test --filter=Media --no-ansi fails three backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest assertions with 401 on /api/v0.5/internal/media-assets write/upload routes. Current PR does not change route auth or that test file, and focused media guard / OSS sync tests pass.",
+          "next_goal": "Repair or relocate legacy MediaLibraryPublicApiTest auth fixtures in a dedicated CMS media test hygiene PR."
+        },
+        {
+          "id": "AUDIT-API-CMS-MEDIA-URL-GUARD-SIDECAR-02",
+          "title": "Article Ops translation tests have pre-existing scope/list failures",
+          "scope_relation": "external_to_current_pr",
+          "evidence": "php artisan test --filter=Article --no-ansi fails ArticleMachineTranslationProviderTest with Source article is outside translation content scope and ArticleTranslationContractTest missing English source. Current PR only changes media URL guard and JSON-LD image sanitization paths.",
+          "next_goal": "Investigate Ops article translation scope/list fixtures in a dedicated article translation test hygiene PR."
+        }
+      ],
       "history": [
         {
           "at": "2026-05-16T14:10:19+08:00",
           "status": "planned",
           "summary": "Initialized AUDIT-API-CMS-MEDIA-URL-GUARD as a security audit remediation train item. Implementation has not started."
+        },
+        {
+          "at": "2026-05-16T16:08:14+08:00",
+          "status": "in_progress",
+          "summary": "Started implementation on codex/audit-api-cms-media-url-guard after dependency fap-web#825 merge verification."
+        },
+        {
+          "at": "2026-05-16T16:16:12+08:00",
+          "status": "local_validation_with_external_sidecars",
+          "summary": "Implemented scoped media URL guard hardening and JSON-LD image sanitization. Focused tests, route:list, Pint, diff check, and BigFive freeze classifier passed; broad manifest Media/Article filters have external pre-existing failures recorded as sidecar candidates pending GitHub required checks."
+        },
+        {
+          "at": "2026-05-16T16:20:22+08:00",
+          "status": "required_gates_passed_with_sidecar_candidates",
+          "summary": "Skill migration check and backend ci_verify_mbti.sh passed. Big Five compiled artifacts regenerated by the check were restored because they are verification outputs and outside PR scope."
+        },
+        {
+          "at": "2026-05-16T16:21:10+08:00",
+          "status": "staged",
+          "summary": "Path-limited staged scoped files only and git diff --cached --check passed."
+        },
+        {
+          "at": "2026-05-16T16:21:23+08:00",
+          "status": "committed",
+          "summary": "Committed scoped implementation as ee64c2911f9023dbf07ef2dc73cfa6645407c227."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -7438,7 +7438,7 @@
       "depends_on": [
         "AUDIT-WEB-LLMS-FANOUT-BUDGET:fap-web"
       ],
-      "status": "in_progress",
+      "status": "ready_to_merge",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): enforce public media URL guard for CMS media and JSON-LD",
@@ -7473,12 +7473,12 @@
           "evidence": "7 tests passed, covering public media allowlist rejection, private/local URL blocking, CDN verification fail-closed behavior, redirect fail-closed behavior, recursive media variant sanitization, and Article JSON-LD image sanitization."
         },
         "manifest_media_tests": {
-          "status": "external_sidecar_candidate",
+          "status": "external_sidecar_recorded",
           "command": "php artisan test --filter=Media --no-ansi",
           "evidence": "Current-scope guard tests, MediaAssetStorageSyncService tests, and V0_5 MediaLibraryOssSync tests passed. Existing backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest internal media write/upload assertions fail with 401 because those tests do not authenticate against the current CMS admin middleware. The failing file is outside the declared allowed_paths and is not modified by this PR."
         },
         "manifest_article_tests": {
-          "status": "external_sidecar_candidate",
+          "status": "external_sidecar_recorded",
           "command": "php artisan test --filter=Article --no-ansi",
           "evidence": "Current-scope ArticleSeoServiceMediaGuard test, ArticlePublicApi tests, ArticleSeoService tests, and ArticlePublishingRuntimeTruth tests passed. Existing Ops translation tests fail outside this PR scope: ArticleMachineTranslationProviderTest throws Source article is outside translation content scope, and ArticleTranslationContractTest misses English source in the ops locale list."
         },
@@ -7525,11 +7525,16 @@
           "status": "pass",
           "command": "php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi",
           "evidence": "79 tests passed after adding PublicMediaUrlGuard.php to the CMS media pipeline freeze classifier."
+        },
+        "github_checks_latest": {
+          "status": "pass",
+          "command": "gh pr checks 1423 --repo fermatmind/fap-api --watch --interval 20",
+          "evidence": "hygiene, verify-mbti-v2, and verify-mbti-legacy all passed for PR #1423 after the scoped freeze-classifier fix."
         }
       },
       "failure_reason": null,
-      "pr_url": null,
-      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1423",
+      "commit_sha": "4b3aa1a93817d3b54d292dfc9bb5b81c28b27f96",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -7589,6 +7594,11 @@
           "at": "2026-05-16T16:27:24+08:00",
           "status": "ci_fix_in_progress",
           "summary": "Initial GitHub verify-mbti checks failed on a current-scope freeze classifier gap for PublicMediaUrlGuard.php. Added the guard to CMS media pipeline allowance and verified BigFiveResultPageV2CoreBodyPreview locally."
+        },
+        {
+          "at": "2026-05-16T16:33:21+08:00",
+          "status": "ready_to_merge",
+          "summary": "GitHub required checks passed after the scoped CI fix. Broad Media/Article filter failures are recorded as external sidecar issues because they were not introduced by this PR, required GitHub checks are green, and scope validation is green."
         }
       ]
     },


### PR DESCRIPTION
## Findings addressed
- CMS media CDN verification permitted unsafe private/local/unapproved URL targets.
- Article/CMS JSON-LD image fields could bypass the public media URL guard.

## What changed
- Tightened `PublicMediaUrlGuard` to allow only explicit public media origins, require HTTPS, and reject private, loopback, link-local, credentialed, non-default-port, non-HTTP(S), and legacy blocked media URLs.
- Applied media URL sanitization recursively to article media variants and JSON-LD image-like fields, including `ImageObject.url` / `contentUrl`.
- Made CMS media CDN verification fail closed on redirects by disabling redirect following.
- Added focused unit coverage for URL allowlist/blocklist behavior, JSON-LD image sanitization, Article SEO JSON-LD output, and CDN verification fail-closed behavior.

## Why
This keeps CMS-provided media metadata from reintroducing private/internal fetch targets or unsafe image URLs into public article/media SEO surfaces.

## Validation commands
- `php artisan test tests/Unit/Support/PublicMediaUrlGuardTest.php tests/Unit/Services/Cms/MediaAssetStorageSyncServiceTest.php tests/Unit/Services/Cms/ArticleSeoServiceMediaGuardTest.php --no-ansi` PASS
- `php artisan route:list --no-ansi` PASS
- `vendor/bin/pint --test` PASS
- `git diff --check` PASS
- `git diff --cached --check` PASS
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-skill.sqlite php artisan migrate --force` PASS
- `bash backend/scripts/ci_verify_mbti.sh` PASS
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi` PASS

## Sidecar issues recorded
- `AUDIT-API-CMS-MEDIA-URL-GUARD-SIDECAR-01`: `php artisan test --filter=Media --no-ansi` has pre-existing `MediaLibraryPublicApiTest` internal media write/upload 401 failures because those fixtures do not authenticate against the current CMS admin middleware. The failing file is outside this PR's allowed paths.
- `AUDIT-API-CMS-MEDIA-URL-GUARD-SIDECAR-02`: `php artisan test --filter=Article --no-ansi` has pre-existing Ops translation scope/list failures outside this PR's media URL guard scope.

## Intentionally deferred
- No route auth, Ops translation, article content, publish state, production media sync, fap-web, deploy, rollback, unlock, or process-control changes.

## Repository rule impact
- CMS/backend remains authoritative for CMS media metadata. This PR only hardens backend validation/sanitization before public projection.
