### PR TITLE
fix(api): require visible detail counts for 2786 acceptance

### DIFF
--- a/backend/app/Domain/Career/Audit/Career80TotalLiveAcceptancePlanner.php
+++ b/backend/app/Domain/Career/Audit/Career80TotalLiveAcceptancePlanner.php
@@ -101,6 +101,9 @@ final class Career80TotalLiveAcceptancePlanner
                 'expected_locale_rows' => $expectedLocaleRows,
                 'target_public_total_validated' => count($combinedSlugs) === $targetPublicTotal,
                 'acceptance_artifact_supplied' => $acceptanceSupplied,
+                'full_visible_publication_gate' => $liveAcceptance === null
+                    ? ['required' => (new CareerFullVisiblePublicationGate)->appliesTo($targetPublicTotal)]
+                    : (new CareerFullVisiblePublicationGate)->summary($liveAcceptance, $targetPublicTotal, count($locales)),
             ],
             'blockers' => $blockers,
             'sidecars' => [],
@@ -224,6 +227,15 @@ final class Career80TotalLiveAcceptancePlanner
                     'actual' => $this->liveAcceptanceExpectedRows($liveAcceptance),
                 ]);
             }
+
+            $blockers = [
+                ...$blockers,
+                ...(new CareerFullVisiblePublicationGate)->blockers(
+                    liveAcceptance: $liveAcceptance,
+                    targetPublicTotal: $targetPublicTotal,
+                    localeCount: count($locales),
+                ),
+            ];
         }
 
         return $blockers;

--- a/backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
+++ b/backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerFullVisiblePublicationGate
+{
+    public function appliesTo(int $targetPublicTotal): bool
+    {
+        return $targetPublicTotal === 2786;
+    }
+
+    /**
+     * @param  array<string, mixed>  $liveAcceptance
+     * @return array<string, mixed>
+     */
+    public function summary(array $liveAcceptance, int $targetPublicTotal, int $localeCount): array
+    {
+        $expectedLocaleRows = $targetPublicTotal * $localeCount;
+
+        return [
+            'required' => $this->appliesTo($targetPublicTotal),
+            'target_public_total' => $targetPublicTotal,
+            'expected_locale_rows' => $expectedLocaleRows,
+            'directory_member_count' => $this->directoryMemberCount($liveAcceptance),
+            'career_jobs_item_count' => $this->careerJobsItemCount($liveAcceptance),
+            'detail_ready_count' => $this->detailReadyCount($liveAcceptance),
+            'public_detail_indexable_count' => $this->publicDetailIndexableCount($liveAcceptance),
+            'canonical_public_slug_count' => $this->intAtAny($liveAcceptance, [
+                'canonical_public_slug_count',
+                'product_surface.canonical_public_slug_count',
+            ]),
+            'found_published_locale_rows' => $this->foundPublishedLocaleRows($liveAcceptance),
+            'release_gate_pass_count' => $this->releaseGatePassCount($liveAcceptance),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $liveAcceptance
+     * @return list<array{reason: string, context: array<string, mixed>}>
+     */
+    public function blockers(array $liveAcceptance, int $targetPublicTotal, int $localeCount): array
+    {
+        if (! $this->appliesTo($targetPublicTotal)) {
+            return [];
+        }
+
+        $summary = $this->summary($liveAcceptance, $targetPublicTotal, $localeCount);
+        $expectedLocaleRows = $targetPublicTotal * $localeCount;
+        $blockers = [];
+
+        $this->requireCount(
+            blockers: $blockers,
+            reasonPrefix: 'product_directory_member_count',
+            expected: $targetPublicTotal,
+            actual: $summary['directory_member_count'],
+        );
+        $this->requireCount(
+            blockers: $blockers,
+            reasonPrefix: 'product_career_jobs_item_count',
+            expected: $targetPublicTotal,
+            actual: $summary['career_jobs_item_count'],
+        );
+        $this->requireCount(
+            blockers: $blockers,
+            reasonPrefix: 'product_detail_ready_count',
+            expected: $targetPublicTotal,
+            actual: $summary['detail_ready_count'],
+        );
+        $this->requireCount(
+            blockers: $blockers,
+            reasonPrefix: 'product_public_detail_indexable_count',
+            expected: $targetPublicTotal,
+            actual: $summary['public_detail_indexable_count'],
+        );
+        $this->requireCount(
+            blockers: $blockers,
+            reasonPrefix: 'product_found_published_locale_rows',
+            expected: $expectedLocaleRows,
+            actual: $summary['found_published_locale_rows'],
+        );
+        $this->requireCount(
+            blockers: $blockers,
+            reasonPrefix: 'product_release_gate_pass_count',
+            expected: $expectedLocaleRows,
+            actual: $summary['release_gate_pass_count'],
+        );
+
+        $canonicalPublicSlugCount = $summary['canonical_public_slug_count'];
+        if ($canonicalPublicSlugCount !== null && $canonicalPublicSlugCount !== $targetPublicTotal) {
+            $blockers[] = $this->blocker('product_canonical_public_slug_count_mismatch', [
+                'expected' => $targetPublicTotal,
+                'actual' => $canonicalPublicSlugCount,
+            ]);
+        }
+
+        if ($blockers !== [] && $this->intAtAny($liveAcceptance, [
+            'partition_accounting.final_public_accounted_total',
+            'final_public_accounted_total',
+        ]) === $targetPublicTotal) {
+            $blockers[] = $this->blocker('partition_accounting_not_product_publication_evidence', [
+                'target_public_total' => $targetPublicTotal,
+                'message' => 'Final partition accounting cannot prove the public directory member count or detail-ready count.',
+            ]);
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @param  list<array{reason: string, context: array<string, mixed>}>  $blockers
+     */
+    private function requireCount(array &$blockers, string $reasonPrefix, int $expected, ?int $actual): void
+    {
+        if ($actual === null) {
+            $blockers[] = $this->blocker($reasonPrefix.'_missing', ['expected' => $expected]);
+
+            return;
+        }
+
+        if ($actual !== $expected) {
+            $blockers[] = $this->blocker($reasonPrefix.'_mismatch', [
+                'expected' => $expected,
+                'actual' => $actual,
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function directoryMemberCount(array $payload): ?int
+    {
+        return $this->intAtAny($payload, [
+            'product_surface.directory_member_count',
+            'product_surface.member_count',
+            'directory.member_count',
+            'career_directory.member_count',
+            'collection_summary.member_count',
+            'api_collection_summary.member_count',
+            'observed_public_directory_member_count',
+            'observed_dataset_members_len',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function careerJobsItemCount(array $payload): ?int
+    {
+        return $this->intAtAny($payload, [
+            'product_surface.career_jobs_item_count',
+            'product_surface.job_items_count',
+            'career_jobs.item_count',
+            'career_job_list.item_count',
+            'job_items_count',
+            'observed_job_items_count',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function detailReadyCount(array $payload): ?int
+    {
+        return $this->intAtAny($payload, [
+            'product_surface.detail_ready_count',
+            'product_surface.visible_detail_count',
+            'product_surface.public_detail_indexable_count',
+            'career_jobs.detail_ready_count',
+            'collection_summary.public_detail_indexable_count',
+            'api_collection_summary.public_detail_indexable_count',
+            'public_detail_indexable_count',
+            'observed_detail_ready_count',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function publicDetailIndexableCount(array $payload): ?int
+    {
+        return $this->intAtAny($payload, [
+            'product_surface.public_detail_indexable_count',
+            'collection_summary.public_detail_indexable_count',
+            'api_collection_summary.public_detail_indexable_count',
+            'public_detail_indexable_count',
+            'observed_detail_ready_count',
+        ]) ?? $this->detailReadyCount($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function foundPublishedLocaleRows(array $payload): ?int
+    {
+        return $this->intAtAny($payload, [
+            'found_published',
+            'projection_truth.found_published',
+            'acceptance_summary.found_published',
+            'canonical_public_locale_rows',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function releaseGatePassCount(array $payload): ?int
+    {
+        return $this->intAtAny($payload, [
+            'release_gate_pass_count',
+            'release_gate.pass_count',
+            'acceptance_summary.release_gate_pass_count',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $paths
+     */
+    private function intAtAny(array $payload, array $paths): ?int
+    {
+        foreach ($paths as $path) {
+            $value = data_get($payload, $path);
+            if (is_numeric($value)) {
+                return (int) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{reason: string, context: array<string, mixed>}
+     */
+    private function blocker(string $reason, array $context): array
+    {
+        return [
+            'reason' => $reason,
+            'context' => $context,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlanner.php
@@ -131,6 +131,15 @@ final class CareerProgressiveCohortCloseoutPlanner
             $blockers[] = $this->blocker('total_slugs_path_missing', []);
         }
 
+        $blockers = [
+            ...$blockers,
+            ...(new CareerFullVisiblePublicationGate)->blockers(
+                liveAcceptance: $liveAcceptance,
+                targetPublicTotal: $targetPublicTotal,
+                localeCount: $this->localeCount($liveAcceptance),
+            ),
+        ];
+
         return $blockers;
     }
 
@@ -154,6 +163,11 @@ final class CareerProgressiveCohortCloseoutPlanner
             'unexpected_exposure' => $liveAcceptance['unexpected_exposure'] ?? null,
             'failures_count' => $this->countList($liveAcceptance['failures'] ?? []),
             'sidecars_count' => $this->countList($liveAcceptance['sidecars'] ?? []),
+            'full_visible_publication_gate' => (new CareerFullVisiblePublicationGate)->summary(
+                liveAcceptance: $liveAcceptance,
+                targetPublicTotal: (int) ($liveAcceptance['target_public_total'] ?? $liveAcceptance['expected_slugs'] ?? 0),
+                localeCount: $this->localeCount($liveAcceptance),
+            ),
         ];
     }
 

--- a/backend/docs/career/audits/2786_full_public_resolution_retrospective.md
+++ b/backend/docs/career/audits/2786_full_public_resolution_retrospective.md
@@ -67,6 +67,12 @@ Final closeout evidence:
 - `blockers_count=0`
 - `sidecars_count=0`
 
+Post-release correction:
+
+- The evidence above proves final public-resolution partition accounting, not 2786 visible public detail pages.
+- A product-visible 2786 publication claim must additionally prove public career directory `member_count=2786`, career jobs item count `2786`, detail-ready / `public_detail_indexable_count=2786`, and `5572` published locale rows.
+- Artifacts with `canonical_public_slug_count=1122` or `canonical_public_locale_rows=2244` must not be accepted as “2786 careers visible” evidence, even when `final_public_accounted_total=2786`.
+
 ## Cohort path
 
 The program intentionally avoided a single all-2786 publication action. It used

--- a/backend/docs/career/audits/progressive_closeout.md
+++ b/backend/docs/career/audits/progressive_closeout.md
@@ -33,4 +33,6 @@ The closeout artifact records:
 
 The command refuses closeout when the live acceptance artifact is not `status=pass`, `accepted=true`, and `writes_database=false`, when failures are present, when baseline plus delta does not equal the target total, or when the total slug artifact path is missing.
 
+For `target_public_total=2786`, closeout also refuses partition-accounting-only evidence. The live acceptance artifact must prove the product-visible surface: directory `member_count=2786`, career jobs item count `2786`, detail-ready / `public_detail_indexable_count=2786`, and `5572` published locale rows. A final partition total of `2786` is not sufficient when public routes or detail pages remain disabled.
+
 It does not run readiness, candidate preparation, rollout dry-run, rollout apply, live crawl, backfill, rollback, quarantine, deploy, or any database mutation.

--- a/backend/docs/career/audits/progressive_live_acceptance.md
+++ b/backend/docs/career/audits/progressive_live_acceptance.md
@@ -10,6 +10,15 @@ Supported target totals:
 
 The command consumes a progressive target-delta artifact and optional rollout manifest and live acceptance artifact. It validates that the current public cohort plus the explicit delta cohort equals the target total and that any supplied live acceptance artifact reports the expected locale row count.
 
+For the final `2786` target, the command also enforces the product-visible publication gate. A supplied live acceptance artifact cannot pass by partition accounting alone. It must prove:
+
+- public career directory `member_count=2786`
+- career jobs index item count `2786`
+- detail-ready / `public_detail_indexable_count=2786`
+- published locale rows and release-gate pass count `5572`
+
+CN proxy public-owner accounting and software manual-hold accounting may be recorded as context, but they are not accepted as evidence that 2786 public detail pages are visible.
+
 Example:
 
 ```bash

--- a/backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
@@ -119,6 +119,83 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
         $this->assertContains('live_acceptance_expected_rows_mismatch', array_column($payload['blockers'], 'reason'));
     }
 
+    public function test_2786_live_acceptance_blocks_partition_accounting_without_product_surface_counts(): void
+    {
+        $artifact = $this->liveAcceptance(accepted: true, expectedRows: 5572);
+        $artifact['target_public_total'] = 2786;
+        $artifact['canonical_public_slug_count'] = 1122;
+        $artifact['canonical_public_locale_rows'] = 2244;
+        $artifact['partition_accounting'] = [
+            'current_public_baseline' => 800,
+            'canonical_rollout_delta' => 322,
+            'cn_proxy_public_owner_count' => 1663,
+            'software_manual_hold_count' => 1,
+            'final_public_accounted_total' => 2786,
+            'final_public_shortfall' => 0,
+        ];
+        $artifact['acceptance_summary'] = [
+            'found_published' => 2244,
+            'release_gate_pass_count' => 2244,
+        ];
+
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(800, 2786, 1986)),
+            '--live-acceptance' => $this->writeJson('live-acceptance', $artifact),
+        ]);
+        $payload = $this->payload();
+        $reasons = array_column($payload['blockers'], 'reason');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('product_directory_member_count_missing', $reasons);
+        $this->assertContains('product_detail_ready_count_missing', $reasons);
+        $this->assertContains('product_found_published_locale_rows_mismatch', $reasons);
+        $this->assertContains('partition_accounting_not_product_publication_evidence', $reasons);
+        $this->assertSame(1122, data_get($payload, 'validation.full_visible_publication_gate.canonical_public_slug_count'));
+    }
+
+    public function test_2786_live_acceptance_requires_directory_and_detail_counts_to_match_target(): void
+    {
+        $artifact = $this->fullVisible2786Acceptance();
+        $artifact['product_surface']['directory_member_count'] = 1122;
+        $artifact['product_surface']['career_jobs_item_count'] = 1122;
+        $artifact['product_surface']['detail_ready_count'] = 808;
+        $artifact['product_surface']['public_detail_indexable_count'] = 808;
+        $artifact['found_published'] = 2244;
+        $artifact['release_gate']['pass_count'] = 2244;
+
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(800, 2786, 1986)),
+            '--live-acceptance' => $this->writeJson('live-acceptance', $artifact),
+        ]);
+        $payload = $this->payload();
+        $reasons = array_column($payload['blockers'], 'reason');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('product_directory_member_count_mismatch', $reasons);
+        $this->assertContains('product_career_jobs_item_count_mismatch', $reasons);
+        $this->assertContains('product_detail_ready_count_mismatch', $reasons);
+        $this->assertContains('product_public_detail_indexable_count_mismatch', $reasons);
+        $this->assertContains('product_found_published_locale_rows_mismatch', $reasons);
+        $this->assertContains('product_release_gate_pass_count_mismatch', $reasons);
+    }
+
+    public function test_2786_live_acceptance_passes_only_with_full_visible_product_counts(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(800, 2786, 1986)),
+            '--live-acceptance' => $this->writeJson('live-acceptance', $this->fullVisible2786Acceptance()),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['accepted']);
+        $this->assertSame(2786, data_get($payload, 'validation.full_visible_publication_gate.directory_member_count'));
+        $this->assertSame(2786, data_get($payload, 'validation.full_visible_publication_gate.detail_ready_count'));
+        $this->assertSame(5572, data_get($payload, 'validation.full_visible_publication_gate.found_published_locale_rows'));
+    }
+
     /**
      * @param  array<string, mixed>  $options
      */
@@ -204,6 +281,33 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
             'expected_rows' => $expectedRows,
             'read_only' => true,
             'writes_database' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fullVisible2786Acceptance(): array
+    {
+        return [
+            'status' => 'pass',
+            'accepted' => true,
+            'expected_rows' => 5572,
+            'target_public_total' => 2786,
+            'read_only' => true,
+            'writes_database' => false,
+            'product_surface' => [
+                'directory_member_count' => 2786,
+                'career_jobs_item_count' => 2786,
+                'detail_ready_count' => 2786,
+                'public_detail_indexable_count' => 2786,
+                'canonical_public_slug_count' => 2786,
+            ],
+            'found_published' => 5572,
+            'release_gate' => [
+                'pass_count' => 5572,
+                'blocked_count' => 0,
+            ],
         ];
     }
 

--- a/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php
@@ -90,12 +90,44 @@ final class CareerProgressiveCohortCloseoutPlannerTest extends TestCase
         $this->assertContains('total_slugs_path_missing', array_column($result['blockers'], 'reason'));
     }
 
+    public function test_refuses_2786_closeout_when_acceptance_only_proves_partition_accounting(): void
+    {
+        $artifact = $this->liveAcceptance(target: 2786, baseline: 800, delta: 1986);
+        unset($artifact['product_surface']);
+        $artifact['canonical_public_slug_count'] = 1122;
+        $artifact['canonical_public_locale_rows'] = 2244;
+        $artifact['partition_accounting'] = [
+            'current_public_baseline' => 800,
+            'canonical_rollout_delta' => 322,
+            'cn_proxy_public_owner_count' => 1663,
+            'software_manual_hold_count' => 1,
+            'final_public_accounted_total' => 2786,
+            'final_public_shortfall' => 0,
+        ];
+        $artifact['found_published'] = 2244;
+        $artifact['projection_truth']['found_published'] = 2244;
+        $artifact['release_gate']['pass_count'] = 2244;
+
+        $result = (new CareerProgressiveCohortCloseoutPlanner)->closeout(
+            liveAcceptance: $artifact,
+            totalSlugsPath: '/tmp/career_2786_total_slugs.txt',
+        )->toArray();
+        $reasons = array_column($result['blockers'], 'reason');
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertFalse($result['accepted']);
+        $this->assertContains('product_directory_member_count_missing', $reasons);
+        $this->assertContains('product_detail_ready_count_missing', $reasons);
+        $this->assertContains('product_found_published_locale_rows_mismatch', $reasons);
+        $this->assertContains('partition_accounting_not_product_publication_evidence', $reasons);
+    }
+
     /**
      * @return array<string, mixed>
      */
     private function liveAcceptance(int $target, int $baseline, int $delta): array
     {
-        return [
+        $artifact = [
             'schema_version' => 'career_80_total_live_acceptance.v1',
             'status' => 'pass',
             'accepted' => true,
@@ -120,5 +152,19 @@ final class CareerProgressiveCohortCloseoutPlannerTest extends TestCase
             'failures' => [],
             'sidecars' => [],
         ];
+
+        if ($target === 2786) {
+            $artifact['product_surface'] = [
+                'directory_member_count' => 2786,
+                'career_jobs_item_count' => 2786,
+                'detail_ready_count' => 2786,
+                'public_detail_indexable_count' => 2786,
+                'canonical_public_slug_count' => 2786,
+            ];
+            $artifact['found_published'] = 5572;
+            $artifact['release_gate']['pass_count'] = 5572;
+        }
+
+        return $artifact;
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -453,6 +453,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php',
             'backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php',
@@ -2047,6 +2048,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Domain/Career/Audit/Career80TargetDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/Career80TargetDeltaResult.php',
+            'backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php',
             'backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanner.php',
             'backend/app/Domain/Career/Audit/CareerProgressiveCohortDeltaPlanResult.php',
             'backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php',
@@ -2723,11 +2725,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
         }
 
+        exec($gitPrefix.'fetch --no-tags --deepen=1000 origin main:refs/remotes/origin/main 2>/dev/null', output: $deepenOutput, result_code: $deepenExitCode);
+        if ($deepenExitCode === 0) {
+            $baseRef = trim((string) shell_exec($gitPrefix.'merge-base origin/main HEAD 2>/dev/null'));
+            if ($baseRef !== '') {
+                return $baseRef;
+            }
+        }
+
         $isShallow = trim((string) shell_exec($gitPrefix.'rev-parse --is-shallow-repository 2>/dev/null')) === 'true';
         if ($isShallow) {
             exec($gitPrefix.'fetch --no-tags --unshallow origin 2>/dev/null', output: $unshallowOutput, result_code: $unshallowExitCode);
             if ($unshallowExitCode === 0) {
                 exec($gitPrefix.'fetch --no-tags origin main:refs/remotes/origin/main 2>/dev/null');
+            }
+        }
+
+        $baseRef = trim((string) shell_exec($gitPrefix.'merge-base origin/main HEAD 2>/dev/null'));
+        if ($baseRef !== '') {
+            return $baseRef;
+        }
+
+        exec($gitPrefix.'fetch --no-tags origin main:refs/remotes/origin/main 2>/dev/null', output: $fullFetchOutput, result_code: $fullFetchExitCode);
+        if ($fullFetchExitCode === 0) {
+            $baseRef = trim((string) shell_exec($gitPrefix.'merge-base origin/main HEAD 2>/dev/null'));
+            if ($baseRef !== '') {
+                return $baseRef;
             }
         }
 

--- a/docs/release/RELEASE_POLICY.md
+++ b/docs/release/RELEASE_POLICY.md
@@ -44,4 +44,6 @@ php artisan release:verify-public-content \
 - Career dataset/jobs API 当前可见计数会被记录为 `dataset_jobs_api_count`，不再与 workbook row count 混用
 - 如提供 `--public-resolution-ledger`，职业 public-resolution ledger 必须满足 2786 terminal rows、793 canonical public assets、1993 governed non-public rows，并保持 sitemap/llms/llms-full 与 held/software-developers leakage 为 0
 
-Career dataset/jobs API 计数不是 2786 workbook rows，也不是 793 canonical public assets。不要把 `member_count` 或 job list `item_count` 与 public-resolution ledger 口径互相比较。
+Career dataset/jobs API 计数默认不是 2786 workbook rows，也不是 canonical public-resolution ledger 的分区会计数。普通发布不得把 `member_count` 或 job list `item_count` 与 ledger 口径互相混用。
+
+例外：如果发布声明是“2786 个职业资产已上线 / 2786 个职业可见 / 2786 个职业可看详情”，验收必须改用产品真实口径，要求 public career directory `member_count=2786`、career jobs API item count `2786`、detail-ready / `public_detail_indexable_count=2786`，并验证 `5572` locale rows。仅有 `final_public_accounted_total=2786` 的 partition accounting 不得作为全量公开详情上线证据。


### PR DESCRIPTION
## Summary
- adds a 2786-only product-visible publication gate for career live acceptance and closeout
- requires directory member count, career jobs item count, detail-ready/indexable count, published locale rows, and release-gate rows to match the 2786 public claim
- blocks partition-accounting-only evidence such as final_public_accounted_total=2786 when visible/detail counts remain short
- documents the corrected product-real acceptance policy

## Validation
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-repair-2786-visible-gate.sqlite php artisan migrate --force --no-ansi
- php artisan test --filter=CareerValidateCanonicalProgressiveLiveAcceptance --no-ansi
- php artisan test --filter=CareerProgressiveCohortCloseoutPlanner --no-ansi
- php artisan test --filter=CareerCloseoutCanonicalProgressiveCohort --no-ansi
- vendor/bin/pint --test --no-ansi
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh

## Repository rule impact
- Career publication authority remains backend-only.
- No DB mutation, deploy, rollout, backfill, rollback, quarantine, or fap-web changes.
- This PR changes acceptance semantics only for target_public_total=2786: a full-public claim now requires product-visible directory/detail evidence, not only partition accounting.

## Acceptance notes
- Current 1122/2244 style artifacts are expected to block under this gate until product surfaces prove 2786 visible careers and 5572 locale rows.
