### PR TITLE
AUDIT-API-CAREER-ARTIFACT-READINESS: fix(security): fail closed on career readiness artifacts

### DIFF
--- a/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
+++ b/backend/app/Console/Commands/CareerAuditCanonicalEligibility.php
@@ -894,7 +894,7 @@ final class CareerAuditCanonicalEligibility extends Command
         if ($state === '' && $rawState === '') {
             $reasons[] = CareerIndexStateAuthorityIssue::INDEX_STATE_MISSING;
         }
-        if ($row->indexEligible === false) {
+        if ($row->indexEligible !== true) {
             $reasons[] = CareerIndexStateAuthorityIssue::INDEX_ELIGIBLE_FALSE;
         }
         if ($state === 'noindex' || $rawState === 'noindex') {

--- a/backend/app/Console/Commands/CareerExportCanonicalEligibilityDbContext.php
+++ b/backend/app/Console/Commands/CareerExportCanonicalEligibilityDbContext.php
@@ -399,7 +399,7 @@ final class CareerExportCanonicalEligibilityDbContext extends Command
                 'canonical_slug' => $slug,
                 'latest_index_state' => null,
                 'public_facing_state' => null,
-                'index_eligible' => null,
+                'index_eligible' => false,
                 'changed_at' => null,
                 'reason_codes' => [],
                 'evidence' => [
@@ -416,7 +416,7 @@ final class CareerExportCanonicalEligibilityDbContext extends Command
                 'canonical_slug' => $slug,
                 'latest_index_state' => null,
                 'public_facing_state' => null,
-                'index_eligible' => null,
+                'index_eligible' => false,
                 'changed_at' => null,
                 'reason_codes' => [],
                 'evidence' => [

--- a/backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Domain\Career\Audit\CareerRuntimeArtifactRefreshPlanner;
 use App\Domain\Career\Audit\CareerRuntimeCandidatePrepPlanner;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -98,17 +99,14 @@ final class CareerPlanCanonicalRuntimeCandidatePrep extends Command
     private function localesOption(): array
     {
         $raw = trim((string) ($this->option('locales') ?? 'en,zh'));
-        $locales = array_values(array_unique(array_filter(array_map(
-            static fn (string $locale): string => strtolower(trim($locale)),
-            explode(',', $raw)
-        ))));
-        sort($locales);
-
-        if ($locales === []) {
+        if ($raw === '') {
             throw new RuntimeException('locales_missing');
         }
 
-        return $locales;
+        return CareerRuntimeArtifactRefreshPlanner::normalizeLocaleList(
+            array_map(static fn (string $locale): string => trim($locale), explode(',', $raw)),
+            'locale'
+        );
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyClassifier.php
+++ b/backend/app/Domain/Career/Audit/Career2786ReadinessPolicyClassifier.php
@@ -14,10 +14,12 @@ final class Career2786ReadinessPolicyClassifier
         'occupation_missing',
         'entity_field_missing',
         'index_state_missing',
+        'index_eligible_false',
     ];
 
     private const APPROVAL_GATED_REASONS = [
         'index_state_missing',
+        'index_eligible_false',
         'occupation_missing',
         'entity_field_missing',
     ];

--- a/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactReader.php
+++ b/backend/app/Domain/Career/Audit/CareerIndexStateContextArtifactReader.php
@@ -95,23 +95,21 @@ final class CareerIndexStateContextArtifactReader
             }
             $seen[$slug] = true;
 
-            if (array_key_exists('index_eligible', $rowValue) && ! is_bool($rowValue['index_eligible']) && $rowValue['index_eligible'] !== null) {
+            if (! array_key_exists('index_eligible', $rowValue) || ! is_bool($rowValue['index_eligible'])) {
                 $issues[] = new CareerIndexStateContextArtifactIssue(
                     reason: CareerIndexStateContextArtifactIssue::REQUIRED_FIELD_MISSING,
-                    message: 'Index-state context row requires nullable boolean index_eligible.',
+                    message: 'Index-state context row requires boolean index_eligible.',
                     canonicalSlug: $slug,
                     field: 'index_eligible',
                     evidence: [['row_index' => $index, 'canonical_slug' => $slug]]
                 );
-
-                continue;
             }
 
             $rows[] = new CareerIndexStateContextArtifactRow(
                 canonicalSlug: $slug,
                 latestIndexState: self::optionalString($rowValue['latest_index_state'] ?? null),
                 publicFacingState: self::optionalString($rowValue['public_facing_state'] ?? null),
-                indexEligible: $rowValue['index_eligible'] ?? null,
+                indexEligible: is_bool($rowValue['index_eligible'] ?? null) ? $rowValue['index_eligible'] : null,
                 changedAt: self::optionalString($rowValue['changed_at'] ?? null),
                 reasonCodes: self::stringListOrEmpty($rowValue['reason_codes'] ?? []),
                 evidence: self::mapOrEmpty($rowValue['evidence'] ?? []),

--- a/backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php
@@ -8,6 +8,8 @@ final class CareerRuntimeArtifactRefreshPlanner
 {
     public const SCHEMA_VERSION = 'career_runtime_artifact_refresh_plan.v1';
 
+    public const CANONICAL_LOCALES = ['en', 'zh'];
+
     private const TARGET = 'career_80_delta';
 
     private const DELTA_SLUG_COUNT = 51;
@@ -19,6 +21,49 @@ final class CareerRuntimeArtifactRefreshPlanner
     private const LEDGER_OUTPUT = '/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json';
 
     private const SUMMARY_OUTPUT = '/tmp/career_80_delta_runtime_artifact_refresh_summary.json';
+
+    /**
+     * @param  list<mixed>  $values
+     * @return list<string>
+     */
+    public static function normalizeLocaleList(array $values, string $context): array
+    {
+        $locales = [];
+        foreach ($values as $index => $value) {
+            if (! is_scalar($value)) {
+                throw new \RuntimeException($context.'_invalid_at_'.$index);
+            }
+
+            $locale = self::normalizeLocale((string) $value);
+            if ($locale === null) {
+                $safe = preg_replace('/[^a-z0-9]+/', '_', strtolower(trim((string) $value))) ?: 'unknown';
+
+                throw new \RuntimeException($context.'_unsupported_'.$safe);
+            }
+
+            $locales[] = $locale;
+        }
+
+        $locales = array_values(array_unique($locales));
+        sort($locales);
+
+        if ($locales === []) {
+            throw new \RuntimeException($context.'_missing');
+        }
+
+        return $locales;
+    }
+
+    public static function normalizeLocale(string $value): ?string
+    {
+        $normalized = strtolower(str_replace('_', '-', trim($value)));
+
+        return match ($normalized) {
+            'en', 'en-us', 'en-gb' => 'en',
+            'zh', 'zh-cn', 'zh-hans', 'zh-hans-cn' => 'zh',
+            default => null,
+        };
+    }
 
     /**
      * @param  array<string, mixed>|null  $deltaPlan
@@ -47,7 +92,15 @@ final class CareerRuntimeArtifactRefreshPlanner
             $blockers[] = $this->blocker('candidate_prep_plan_missing', 'The runtime candidate preparation plan is required for runtime artifact refresh planning.', []);
         }
 
-        $deltaSlugCount = $this->deltaSlugCount($deltaPlan, $candidatePrepPlan);
+        $deltaValidation = $this->validateDeltaPlan($deltaPlan);
+        $candidatePlanValidation = $this->validateCandidatePrepPlan($candidatePrepPlan);
+        $deltaSlugCount = $candidatePlanValidation['delta_slug_count'] ?? $deltaValidation['delta_slug_count'] ?? 0;
+        $blockers = [
+            ...$blockers,
+            ...$deltaValidation['blockers'],
+            ...$candidatePlanValidation['blockers'],
+        ];
+
         if ($deltaSlugCount !== self::DELTA_SLUG_COUNT) {
             $blockers[] = $this->blocker('delta_slug_count_not_51', 'The runtime artifact refresh plan is scoped to exactly 51 delta slugs.', [
                 'delta_slug_count' => $deltaSlugCount,
@@ -56,18 +109,18 @@ final class CareerRuntimeArtifactRefreshPlanner
         }
 
         $phase = 'pre_apply';
+        $applyReady = false;
         if ($candidatePrepApply === null) {
             $blockers[] = $this->blocker('candidate_prep_apply_artifact_missing', 'A verified candidate preparation apply artifact is required before runtime artifacts can be refreshed.', []);
-        } elseif (($candidatePrepApply['write_verified'] ?? null) !== true) {
-            $phase = 'blocked';
-            $blockers[] = $this->blocker('candidate_prep_apply_not_verified', 'Candidate preparation apply artifact must have write_verified=true before refreshing runtime artifacts.', [
-                'write_verified' => $candidatePrepApply['write_verified'] ?? null,
-                'status' => $candidatePrepApply['status'] ?? null,
-            ]);
         } else {
-            $phase = 'post_apply_ready';
+            $applyValidation = $this->validateCandidatePrepApply($candidatePrepApply, $deltaSlugCount);
+            $blockers = [...$blockers, ...$applyValidation['blockers']];
+            $applyReady = $applyValidation['ready'];
         }
 
+        if ($candidatePrepApply !== null) {
+            $phase = $applyReady ? 'post_apply_ready' : 'blocked';
+        }
         $status = $blockers === [] ? 'planned' : 'blocked';
 
         return new CareerRuntimeArtifactRefreshResult([
@@ -91,28 +144,225 @@ final class CareerRuntimeArtifactRefreshPlanner
 
     /**
      * @param  array<string, mixed>|null  $deltaPlan
-     * @param  array<string, mixed>|null  $candidatePrepPlan
+     * @return array{delta_slug_count: int|null, blockers: list<array<string, mixed>>}
      */
-    private function deltaSlugCount(?array $deltaPlan, ?array $candidatePrepPlan): int
+    private function validateDeltaPlan(?array $deltaPlan): array
     {
-        $count = $candidatePrepPlan['delta_slug_count']
-            ?? $deltaPlan['delta_promotion_count']
-            ?? $deltaPlan['delta_slug_count']
-            ?? null;
-
-        if (is_numeric($count)) {
-            return (int) $count;
+        if ($deltaPlan === null) {
+            return ['delta_slug_count' => null, 'blockers' => []];
         }
 
-        $slugs = $candidatePrepPlan['slugs']
-            ?? $candidatePrepPlan['recommended_rollout_delta_slugs']
-            ?? $candidatePrepPlan['delta_promotion_slugs']
-            ?? $deltaPlan['recommended_rollout_delta_slugs']
-            ?? $deltaPlan['delta_promotion_slugs']
-            ?? $deltaPlan['slugs']
-            ?? null;
+        $blockers = [];
+        if (($deltaPlan['status'] ?? null) !== 'pass') {
+            $blockers[] = $this->blocker('target_delta_plan_not_pass', 'Target delta plan must have status=pass before runtime artifact refresh readiness can pass.', [
+                'status' => $deltaPlan['status'] ?? null,
+            ]);
+        }
 
-        return is_array($slugs) && array_is_list($slugs) ? count(array_unique($slugs)) : self::DELTA_SLUG_COUNT;
+        if (($deltaPlan['schema_version'] ?? null) !== 'career_80_target_delta.v1') {
+            $blockers[] = $this->blocker('target_delta_plan_schema_invalid', 'Target delta plan schema_version must be career_80_target_delta.v1 for this refresh target.', [
+                'schema_version' => $deltaPlan['schema_version'] ?? null,
+            ]);
+        }
+
+        $slugs = $this->slugList($deltaPlan, ['recommended_rollout_delta_slugs', 'delta_promotion_slugs', 'slugs']);
+        $declaredCount = $this->declaredCount($deltaPlan, ['delta_promotion_count', 'delta_slug_count']);
+        if ($declaredCount === null) {
+            $blockers[] = $this->blocker('target_delta_slug_count_missing', 'Target delta plan must declare an explicit delta slug count.', []);
+        }
+        if ($slugs === null) {
+            $blockers[] = $this->blocker('target_delta_slug_list_missing', 'Target delta plan must include an explicit delta slug list.', []);
+        }
+        if (is_array($slugs) && $declaredCount !== null && count($slugs) !== $declaredCount) {
+            $blockers[] = $this->blocker('target_delta_slug_count_mismatch', 'Target delta plan slug list count must match the declared delta slug count.', [
+                'declared' => $declaredCount,
+                'actual' => count($slugs),
+            ]);
+        }
+
+        return [
+            'delta_slug_count' => $declaredCount ?? (is_array($slugs) ? count($slugs) : null),
+            'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $candidatePrepPlan
+     * @return array{delta_slug_count: int|null, blockers: list<array<string, mixed>>}
+     */
+    private function validateCandidatePrepPlan(?array $candidatePrepPlan): array
+    {
+        if ($candidatePrepPlan === null) {
+            return ['delta_slug_count' => null, 'blockers' => []];
+        }
+
+        $blockers = [];
+        if (($candidatePrepPlan['status'] ?? null) !== 'planned') {
+            $blockers[] = $this->blocker('candidate_prep_plan_not_planned', 'Runtime candidate preparation plan must have status=planned before artifact refresh readiness can pass.', [
+                'status' => $candidatePrepPlan['status'] ?? null,
+            ]);
+        }
+
+        if (($candidatePrepPlan['schema_version'] ?? null) !== 'career_runtime_candidate_prep_plan.v1') {
+            $blockers[] = $this->blocker('candidate_prep_plan_schema_invalid', 'Runtime candidate preparation plan schema_version must be career_runtime_candidate_prep_plan.v1.', [
+                'schema_version' => $candidatePrepPlan['schema_version'] ?? null,
+            ]);
+        }
+
+        if (($candidatePrepPlan['target'] ?? null) !== self::TARGET) {
+            $blockers[] = $this->blocker('candidate_prep_plan_target_invalid', 'Runtime candidate preparation plan target must match the artifact refresh target.', [
+                'target' => $candidatePrepPlan['target'] ?? null,
+                'expected' => self::TARGET,
+            ]);
+        }
+
+        $deltaSlugCount = $this->declaredCount($candidatePrepPlan, ['delta_slug_count']);
+        if ($deltaSlugCount === null) {
+            $blockers[] = $this->blocker('candidate_prep_plan_delta_slug_count_missing', 'Runtime candidate preparation plan must declare delta_slug_count.', []);
+        }
+
+        $localeCount = $this->localeCount($candidatePrepPlan['locales'] ?? null, 'candidate_prep_plan_locale', $blockers);
+        $plannedRowsCount = $this->declaredCount($candidatePrepPlan, ['planned_candidate_rows_count', 'expected_delta_locale_rows', 'expected_locale_rows']);
+        if ($deltaSlugCount !== null && $plannedRowsCount !== null && $plannedRowsCount !== $deltaSlugCount * $localeCount) {
+            $blockers[] = $this->blocker('candidate_prep_plan_locale_row_count_mismatch', 'Runtime candidate preparation plan locale row count must match delta_slug_count times locale count.', [
+                'delta_slug_count' => $deltaSlugCount,
+                'locale_count' => $localeCount,
+                'declared_locale_rows' => $plannedRowsCount,
+            ]);
+        }
+
+        return ['delta_slug_count' => $deltaSlugCount, 'blockers' => $blockers];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidatePrepApply
+     * @return array{ready: bool, blockers: list<array<string, mixed>>}
+     */
+    private function validateCandidatePrepApply(array $candidatePrepApply, int $expectedSlugCount): array
+    {
+        $blockers = [];
+
+        if (($candidatePrepApply['write_verified'] ?? null) !== true) {
+            $blockers[] = $this->blocker('candidate_prep_apply_not_verified', 'Candidate preparation apply artifact must have write_verified=true before refreshing runtime artifacts.', [
+                'write_verified' => $candidatePrepApply['write_verified'] ?? null,
+                'status' => $candidatePrepApply['status'] ?? null,
+            ]);
+        }
+        if (($candidatePrepApply['status'] ?? null) !== 'applied') {
+            $blockers[] = $this->blocker('candidate_prep_apply_not_applied', 'Candidate preparation apply artifact must have status=applied before refreshing runtime artifacts.', [
+                'status' => $candidatePrepApply['status'] ?? null,
+            ]);
+        }
+        if (($candidatePrepApply['writes_database'] ?? null) !== true) {
+            $blockers[] = $this->blocker('candidate_prep_apply_write_not_confirmed', 'Candidate preparation apply artifact must confirm writes_database=true.', [
+                'writes_database' => $candidatePrepApply['writes_database'] ?? null,
+            ]);
+        }
+
+        $failures = $candidatePrepApply['failures'] ?? [];
+        if (! is_array($failures) || $failures !== []) {
+            $blockers[] = $this->blocker('candidate_prep_apply_failures_present', 'Candidate preparation apply artifact must not contain failures.', [
+                'failure_count' => is_array($failures) ? count($failures) : null,
+            ]);
+        }
+
+        $localeCount = $this->localeCount($candidatePrepApply['locales'] ?? null, 'candidate_prep_apply_locale', $blockers);
+        foreach (['slug_count', 'created_count', 'verified_count'] as $key) {
+            $count = $this->declaredCount($candidatePrepApply, [$key]);
+            if ($count === null || $count !== $expectedSlugCount) {
+                $blockers[] = $this->blocker('candidate_prep_apply_'.$key.'_mismatch', 'Candidate preparation apply artifact count must match the expected delta slug count.', [
+                    'field' => $key,
+                    'declared' => $count,
+                    'expected' => $expectedSlugCount,
+                ]);
+            }
+        }
+
+        $expectedLocaleRows = $this->declaredCount($candidatePrepApply, ['expected_locale_rows', 'expected_delta_locale_rows']);
+        if ($expectedLocaleRows !== null && $expectedLocaleRows !== $expectedSlugCount * $localeCount) {
+            $blockers[] = $this->blocker('candidate_prep_apply_locale_row_count_mismatch', 'Candidate preparation apply artifact expected locale rows must match slug count times locale count.', [
+                'expected_slug_count' => $expectedSlugCount,
+                'locale_count' => $localeCount,
+                'declared_locale_rows' => $expectedLocaleRows,
+            ]);
+        }
+
+        return ['ready' => $blockers === [], 'blockers' => $blockers];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @param  list<string>  $keys
+     */
+    private function declaredCount(array $artifact, array $keys): ?int
+    {
+        foreach ($keys as $key) {
+            $value = $artifact[$key] ?? null;
+            if (is_numeric($value) && (int) $value >= 0) {
+                return (int) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @param  list<string>  $keys
+     * @return list<string>|null
+     */
+    private function slugList(array $artifact, array $keys): ?array
+    {
+        foreach ($keys as $key) {
+            $value = $artifact[$key] ?? null;
+            if (! is_array($value) || ! array_is_list($value)) {
+                continue;
+            }
+
+            $slugs = [];
+            foreach ($value as $index => $slug) {
+                if (! is_string($slug) || trim($slug) === '') {
+                    return null;
+                }
+
+                $slugs[] = strtolower(trim($slug));
+            }
+
+            $unique = array_values(array_unique($slugs));
+            sort($unique);
+
+            return count($unique) === count($slugs) ? $unique : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $blockers
+     */
+    private function localeCount(mixed $locales, string $context, array &$blockers): int
+    {
+        if ($locales === null) {
+            return count(self::CANONICAL_LOCALES);
+        }
+
+        if (! is_array($locales) || ! array_is_list($locales)) {
+            $blockers[] = $this->blocker($context.'_invalid', 'Readiness artifact locales must be a list.', [
+                'locales' => $locales,
+            ]);
+
+            return count(self::CANONICAL_LOCALES);
+        }
+
+        try {
+            return count(self::normalizeLocaleList($locales, $context));
+        } catch (\RuntimeException $exception) {
+            $blockers[] = $this->blocker($exception->getMessage(), 'Readiness artifact locales must normalize to supported canonical locales.', [
+                'locales' => $locales,
+            ]);
+
+            return count(self::CANONICAL_LOCALES);
+        }
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php
@@ -202,22 +202,16 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
      */
     private function locales(array $candidatePrepApply): array
     {
-        $rawLocales = $candidatePrepApply['locales'] ?? self::DEFAULT_LOCALES;
-        if (! is_array($rawLocales) || ! array_is_list($rawLocales)) {
+        if (! array_key_exists('locales', $candidatePrepApply)) {
             return self::DEFAULT_LOCALES;
         }
 
-        $locales = [];
-        foreach ($rawLocales as $locale) {
-            if (is_string($locale) && trim($locale) !== '') {
-                $locales[] = trim($locale);
-            }
+        $rawLocales = $candidatePrepApply['locales'];
+        if (! is_array($rawLocales) || ! array_is_list($rawLocales)) {
+            throw new RuntimeException('candidate_prep_apply_locales_invalid');
         }
 
-        $locales = array_values(array_unique($locales));
-        sort($locales);
-
-        return $locales === [] ? self::DEFAULT_LOCALES : $locales;
+        return CareerRuntimeArtifactRefreshPlanner::normalizeLocaleList($rawLocales, 'candidate_prep_apply_locale');
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
@@ -27,7 +27,7 @@ final class CareerRuntimeCandidatePrepPlanner
         ?string $cohort = null,
     ): CareerRuntimeCandidatePrepResult {
         $deltaSlugs = $this->deltaSlugs($targetDeltaPlan);
-        $locales = $this->normalizedUniqueStrings($locales, 'locale');
+        $locales = CareerRuntimeArtifactRefreshPlanner::normalizeLocaleList($locales, 'locale');
         $artifactTargetPublicTotal = $this->artifactTargetPublicTotal($targetDeltaPlan);
         $currentPublicTotal = $this->artifactCurrentPublicTotal($targetDeltaPlan);
         $targetPublicTotal ??= $artifactTargetPublicTotal ?? 80;

--- a/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php
@@ -367,6 +367,26 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         $this->assertContains('index_context_slug_duplicate', data_get($payload, 'rows.0.index_status.reasons'));
     }
 
+    public function test_index_context_artifact_missing_index_eligible_blocks_index_layer(): void
+    {
+        $indexPath = $this->writeIndexContext([
+            ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed', 'public_facing_state' => 'indexed'],
+        ]);
+
+        Artisan::call('career:audit-canonical-eligibility', [
+            '--scope' => 'slugs',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--index-state-context' => $indexPath,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('blocked', data_get($payload, 'rows.0.index_status.status'));
+        $this->assertContains('index_context_required_field_missing', data_get($payload, 'rows.0.index_status.reasons'));
+        $this->assertContains('index_eligible_false', data_get($payload, 'rows.0.index_status.reasons'));
+    }
+
     public function test_surface_context_artifact_marks_context_supplied(): void
     {
         $surfacePath = $this->writeSurfaceContext([
@@ -497,7 +517,7 @@ final class CareerAuditCanonicalEligibilityCommandTest extends TestCase
         ]);
         $indexPath = $this->writeIndexContext([
             ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed', 'public_facing_state' => 'indexed', 'index_eligible' => true],
-            ['canonical_slug' => 'missing-index', 'latest_index_state' => null, 'public_facing_state' => null, 'index_eligible' => null, 'evidence' => ['occupation_missing' => false]],
+            ['canonical_slug' => 'missing-index', 'latest_index_state' => null, 'public_facing_state' => null, 'index_eligible' => false, 'evidence' => ['occupation_missing' => false]],
         ]);
         $surfacePath = $this->writeSurfaceContext([
             ['canonical_slug' => 'actuaries', 'locale' => 'en', 'api_canonical_path' => '/en/career/jobs/actuaries', 'api_indexable' => true, 'surface_verified' => false, 'issues' => ['surface_unverified']],

--- a/backend/tests/Feature/Console/CareerExportCanonicalEligibilityDbContextCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportCanonicalEligibilityDbContextCommandTest.php
@@ -95,6 +95,7 @@ final class CareerExportCanonicalEligibilityDbContextCommandTest extends TestCas
         $this->assertSame(['manual_review_passed'], $indexArtifact->rowsBySlug()['actuaries']->reasonCodes);
         $this->assertSame($latestIndexStateId, $indexArtifact->rowsBySlug()['actuaries']->evidence['index_state_id']);
         $this->assertNull($indexArtifact->rowsBySlug()['missing-career']->latestIndexState);
+        $this->assertFalse($indexArtifact->rowsBySlug()['missing-career']->indexEligible);
     }
 
     public function test_exported_artifacts_can_be_consumed_by_canonical_eligibility_audit(): void

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
@@ -59,6 +59,26 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
         $this->assertSame([], $payload['blockers']);
     }
 
+    public function test_malformed_candidate_prep_plan_blocks_refresh_readiness(): void
+    {
+        $exitCode = $this->callCommand([
+            '--delta-plan' => $this->writeJson('delta-plan', $this->deltaPlan()),
+            '--candidate-prep-plan' => $this->writeJson('prep-plan', [
+                'schema_version' => 'career_runtime_candidate_prep_plan.v1',
+                'status' => 'planned',
+                'target' => 'career_80_delta',
+                'delta_slug_count' => 51,
+                'planned_candidate_rows_count' => 51,
+            ]),
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApply(writeVerified: true)),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('candidate_prep_plan_locale_row_count_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
     public function test_unverified_candidate_prep_apply_blocks(): void
     {
         $exitCode = $this->callCommand([
@@ -71,6 +91,45 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
         $this->assertSame(0, $exitCode, Artisan::output());
         $this->assertSame('blocked', $payload['status']);
         $this->assertSame('candidate_prep_apply_not_verified', $payload['blockers'][0]['reason']);
+    }
+
+    public function test_candidate_aware_mode_normalizes_zh_cn_locale_alias(): void
+    {
+        $exitCode = $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', [
+                ...$this->candidatePrepApplyForSlugs(['delta-001']),
+                'locales' => ['en-US', 'zh-CN'],
+            ]),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(['en', 'zh'], $payload['locales']);
+        $this->assertSame(2, $payload['projection']['overlay_rows']);
+    }
+
+    public function test_candidate_aware_mode_blocks_unsupported_locale(): void
+    {
+        $exitCode = $this->callCommand([
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', [
+                ...$this->candidatePrepApplyForSlugs(['delta-001']),
+                'locales' => ['en', 'zh-TW'],
+            ]),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--expect-slug-count' => 1,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('candidate_prep_apply_locale_unsupported_zh_tw', $payload['blockers'][0]['reason']);
     }
 
     public function test_writes_output_file_without_executing_exports(): void
@@ -401,6 +460,8 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
             'status' => 'planned',
             'target' => 'career_80_delta',
             'delta_slug_count' => 51,
+            'locales' => ['en', 'zh'],
+            'expected_locale_rows' => 102,
             'planned_candidate_rows_count' => 102,
         ];
     }
@@ -414,8 +475,12 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
             'status' => $writeVerified ? 'applied' : 'blocked',
             'writes_database' => $writeVerified,
             'write_verified' => $writeVerified,
+            'slug_count' => $writeVerified ? 51 : 0,
+            'expected_locale_rows' => $writeVerified ? 102 : 0,
             'created_count' => $writeVerified ? 51 : 0,
             'verified_count' => $writeVerified ? 51 : 0,
+            'failures' => [],
+            'locales' => ['en', 'zh'],
         ];
     }
 

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php
@@ -115,6 +115,31 @@ final class CareerPlanCanonicalRuntimeCandidatePrepCommandTest extends TestCase
         $this->assertSame(2, $payload['planned_candidate_rows_count']);
     }
 
+    public function test_target_locale_aliases_are_normalized_before_planning(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeTargetDelta(['delta-001']),
+            '--locales' => 'en-US,zh-CN',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(['en', 'zh'], $payload['locales']);
+        $this->assertSame(2, $payload['expected_locale_rows']);
+    }
+
+    public function test_unsupported_target_locale_blocks_planning(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeTargetDelta(['delta-001']),
+            '--locales' => 'en,zh-TW',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('locale_unsupported_zh_tw', $payload['blockers'][0]['reason']);
+    }
+
     public function test_no_db_mutation_or_apply_is_exposed(): void
     {
         $exitCode = $this->callCommand([

--- a/backend/tests/Unit/Domain/Career/Audit/CareerEntityIndexContextArtifactReaderTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerEntityIndexContextArtifactReaderTest.php
@@ -98,6 +98,20 @@ final class CareerEntityIndexContextArtifactReaderTest extends TestCase
         $this->assertSame(['index_context_slug_duplicate' => 1], $artifact->byReason());
     }
 
+    public function test_index_context_reader_reports_missing_or_null_index_eligible(): void
+    {
+        $artifact = CareerIndexStateContextArtifactReader::fromPath($this->writeJson('index-missing-eligible', [
+            'rows' => [
+                ['canonical_slug' => 'actuaries', 'latest_index_state' => 'indexed'],
+                ['canonical_slug' => 'auditors', 'latest_index_state' => 'indexed', 'index_eligible' => null],
+            ],
+        ]));
+
+        $this->assertSame(['index_context_required_field_missing' => 2], $artifact->byReason());
+        $this->assertNull($artifact->rowsBySlug()['actuaries']->indexEligible);
+        $this->assertNull($artifact->rowsBySlug()['auditors']->indexEligible);
+    }
+
     /**
      * @param  array<string, mixed>  $payload
      */

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php
@@ -66,6 +66,48 @@ final class CareerRuntimeArtifactRefreshPlannerTest extends TestCase
         $this->assertSame('candidate_prep_apply_not_verified', $payload['blockers'][0]['reason']);
     }
 
+    public function test_blocks_malformed_target_and_candidate_artifacts(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            deltaPlan: [
+                'schema_version' => 'career_80_target_delta.v1',
+                'status' => 'blocked',
+            ],
+            candidatePrepPlan: [
+                'schema_version' => 'career_runtime_candidate_prep_plan.v1',
+                'status' => 'planned',
+                'target' => 'career_80_delta',
+                'delta_slug_count' => 51,
+                'planned_candidate_rows_count' => 102,
+            ],
+            candidatePrepApply: $this->candidatePrepApply(writeVerified: true),
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('target_delta_plan_not_pass', array_column($payload['blockers'], 'reason'));
+        $this->assertContains('target_delta_slug_count_missing', array_column($payload['blockers'], 'reason'));
+        $this->assertContains('target_delta_slug_list_missing', array_column($payload['blockers'], 'reason'));
+    }
+
+    public function test_blocks_apply_artifact_with_failures_or_mismatched_counts(): void
+    {
+        $apply = [
+            ...$this->candidatePrepApply(writeVerified: true),
+            'failures' => [['reason' => 'write_failed']],
+            'verified_count' => 50,
+        ];
+
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            deltaPlan: $this->deltaPlan(),
+            candidatePrepPlan: $this->candidatePrepPlan(),
+            candidatePrepApply: $apply,
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('candidate_prep_apply_failures_present', array_column($payload['blockers'], 'reason'));
+        $this->assertContains('candidate_prep_apply_verified_count_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
     public function test_marks_writes_database_false_and_commands_read_only(): void
     {
         $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
@@ -134,6 +176,8 @@ final class CareerRuntimeArtifactRefreshPlannerTest extends TestCase
             'status' => 'planned',
             'target' => 'career_80_delta',
             'delta_slug_count' => 51,
+            'locales' => ['en', 'zh'],
+            'expected_locale_rows' => 102,
             'planned_candidate_rows_count' => 102,
         ];
     }
@@ -147,8 +191,12 @@ final class CareerRuntimeArtifactRefreshPlannerTest extends TestCase
             'status' => $writeVerified ? 'applied' : 'blocked',
             'writes_database' => $writeVerified,
             'write_verified' => $writeVerified,
+            'slug_count' => $writeVerified ? 51 : 0,
+            'expected_locale_rows' => $writeVerified ? 102 : 0,
             'created_count' => $writeVerified ? 51 : 0,
             'verified_count' => $writeVerified ? 51 : 0,
+            'failures' => [],
+            'locales' => ['en', 'zh-CN'],
         ];
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T16:27:24+08:00",
+  "updated_at": "2026-05-16T17:33:21+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -7620,7 +7620,7 @@
       "depends_on": [
         "AUDIT-API-CMS-MEDIA-URL-GUARD"
       ],
-      "status": "pr_open",
+      "status": "merged",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): enforce career rollout authority gates",
@@ -7708,14 +7708,26 @@
           "status": "pass",
           "command": "gh run watch 25958079049 --repo fermatmind/fap-api --exit-status",
           "evidence": "GitHub CI passed for PR #1424 at head 78b080f600b15c1e09723491772b9beb84376390: hygiene, verify-mbti-legacy, and verify-mbti-v2 all completed successfully. Duplicate pull_request runs for the same head also reported success."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "GitHub CI run 25958186942 passed at head 96b13461f04c0c125e0c7b7788538af17017a9a7: hygiene, verify-mbti-legacy, and verify-mbti-v2 were green before squash merge."
+        },
+        "post_merge_cleanup": {
+          "status": "pass",
+          "evidence": "Confirmed PR #1424 merged, origin/main contains ca4e5576e4de9b55980553896c52137481d49d73, local main worktree fast-forwarded, remote branch deleted, local task branch deleted from the primary worktree."
+        },
+        "post_merge_revalidation": {
+          "status": "pass",
+          "evidence": "Post-merge validation passed: php artisan test tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php tests/Unit/Services/Career/CanonicalBatchPromotionExecutorServiceTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php --no-ansi; php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi; git diff --check."
         }
       },
       "failure_reason": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1424",
-      "commit_sha": "78b080f600b15c1e09723491772b9beb84376390",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "commit_sha": "ca4e5576e4de9b55980553896c52137481d49d73",
+      "merged_at": "2026-05-16T09:19:26Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "id": "AUDIT-API-CAREER-ROLLOUT-AUTHORITY-SIDECAR-01",
@@ -7762,6 +7774,11 @@
           "at": "2026-05-16T17:14:05+08:00",
           "status": "ready_to_merge",
           "summary": "GitHub required checks passed for PR #1424 at head 78b080f600b15c1e09723491772b9beb84376390. Broad Career filter and full Pint failures were recorded as external sidecar issues because they are outside current scope, required checks are green, and scope validation is green."
+        },
+        {
+          "at": "2026-05-16T17:33:21+08:00",
+          "status": "merged",
+          "summary": "Squash merged PR #1424 as ca4e5576e4de9b55980553896c52137481d49d73; remote/local task branches cleaned up and post-merge revalidation passed."
         }
       ]
     },
@@ -7773,7 +7790,7 @@
       "depends_on": [
         "AUDIT-API-CAREER-ROLLOUT-AUTHORITY"
       ],
-      "status": "planned",
+      "status": "local_validation_passed_with_external_sidecar_pending",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): fail closed on career readiness artifacts",
@@ -7790,6 +7807,38 @@
         "scope_validation_policy": {
           "status": "planned",
           "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "Depends on AUDIT-API-CAREER-ROLLOUT-AUTHORITY, which is merged in origin/main at ca4e5576e4de9b55980553896c52137481d49d73."
+        },
+        "branch": {
+          "status": "pass",
+          "evidence": "Created codex/audit-api-career-artifact-readiness from origin/main after PR #1424 merge."
+        },
+        "focused_tests": {
+          "status": "pass",
+          "evidence": "php artisan test tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php tests/Unit/Domain/Career/Audit/CareerEntityIndexContextArtifactReaderTest.php tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php --no-ansi passed: 70 tests, 316 assertions."
+        },
+        "db_context_regression": {
+          "status": "pass",
+          "evidence": "php artisan test tests/Feature/Console/CareerExportCanonicalEligibilityDbContextCommandTest.php tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php tests/Unit/Domain/Career/Audit/CareerEntityIndexContextArtifactReaderTest.php --no-ansi passed: 40 tests, 200 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "evidence": "php artisan route:list --no-ansi completed successfully and listed 197 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "evidence": "backend/vendor/bin/pint --test passed for 3276 files."
+        },
+        "broad_career_filter": {
+          "status": "external_fail_pending_sidecar",
+          "evidence": "php artisan test --filter=Career --no-ansi completed with 1255 passed and 50 failed. The remaining failures are in pre-existing first-wave/career public surface and attribution tests outside the AUDIT-API-CAREER-ARTIFACT-READINESS changed files. Current-scope Career artifact readiness tests pass; sidecar will be finalized only if GitHub required checks and scope validation are green."
+        },
+        "diff_check": {
+          "status": "pass",
+          "evidence": "git diff --check passed."
         }
       },
       "failure_reason": null,
@@ -7798,12 +7847,26 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+        {
+          "id": "AUDIT-API-CAREER-ARTIFACT-READINESS-SIDECAR-01",
+          "status": "pending_github_required_checks",
+          "title": "Broad Career test filter has pre-existing first-wave and public career surface failures.",
+          "scope_relation": "external_to_current_pr",
+          "evidence": "After current-scope fixes, php artisan test --filter=Career --no-ansi still reports 50 failures in first-wave launch/readiness/dataset/discoverability, career attribution, job list/search, display asset import, and release public content tests. The failures are not in the artifact readiness files changed by this PR.",
+          "may_continue_train_after_github_green": true
+        }
+      ],
       "history": [
         {
           "at": "2026-05-16T14:10:19+08:00",
           "status": "planned",
           "summary": "Initialized AUDIT-API-CAREER-ARTIFACT-READINESS as a security audit remediation train item. Implementation has not started."
+        },
+        {
+          "at": "2026-05-16T17:33:21+08:00",
+          "status": "local_validation_passed_with_external_sidecar_pending",
+          "summary": "Implemented AUDIT-API-CAREER-ARTIFACT-READINESS. Focused artifact readiness tests, db-context regression tests, route list, full Pint, and git diff --check passed. Broad Career filter still has external pre-existing failures pending sidecar finalization after GitHub required checks pass."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-16T17:33:21+08:00",
+  "updated_at": "2026-05-17T07:28:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -7790,7 +7790,7 @@
       "depends_on": [
         "AUDIT-API-CAREER-ROLLOUT-AUTHORITY"
       ],
-      "status": "local_validation_passed_with_external_sidecar_pending",
+      "status": "ready_to_merge",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): fail closed on career readiness artifacts",
@@ -7805,8 +7805,8 @@
           "evidence": "User explicitly authorized adding the 11 security audit train items to fap-web and fap-api pr-train manifest/state without starting implementation."
         },
         "scope_validation_policy": {
-          "status": "planned",
-          "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+          "status": "pass",
+          "evidence": "Changed files are confined to the AUDIT-API-CAREER-ARTIFACT-READINESS manifest scope. The only unrelated worktree entry is untracked .playwright-mcp/, which was not staged or touched."
         },
         "dependency": {
           "status": "pass",
@@ -7839,21 +7839,29 @@
         "diff_check": {
           "status": "pass",
           "evidence": "git diff --check passed."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "GitHub CI run 25975666613 passed hygiene, verify-mbti-legacy, and verify-mbti-v2 for head 88400b47568e64f25c21f985e34b736a20980a2b."
+        },
+        "bigfive_runtime_freeze": {
+          "status": "pass",
+          "evidence": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --no-ansi passed after folding locale policy into an existing career readiness planner file."
         }
       },
       "failure_reason": null,
-      "pr_url": null,
-      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1426",
+      "commit_sha": "88400b47568e64f25c21f985e34b736a20980a2b",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "sidecar_issues": [
         {
           "id": "AUDIT-API-CAREER-ARTIFACT-READINESS-SIDECAR-01",
-          "status": "pending_github_required_checks",
+          "status": "recorded_external_sidecar",
           "title": "Broad Career test filter has pre-existing first-wave and public career surface failures.",
           "scope_relation": "external_to_current_pr",
-          "evidence": "After current-scope fixes, php artisan test --filter=Career --no-ansi still reports 50 failures in first-wave launch/readiness/dataset/discoverability, career attribution, job list/search, display asset import, and release public content tests. The failures are not in the artifact readiness files changed by this PR.",
+          "evidence": "After current-scope fixes, php artisan test --filter=Career --no-ansi still reports 50 failures in first-wave launch/readiness/dataset/discoverability, career attribution, job list/search, display asset import, and release public content tests. The failures are not in the artifact readiness files changed by this PR. GitHub required checks and scope validation are green, so this external blocker is recorded as a sidecar and does not stop the train.",
           "may_continue_train_after_github_green": true
         }
       ],
@@ -7867,6 +7875,11 @@
           "at": "2026-05-16T17:33:21+08:00",
           "status": "local_validation_passed_with_external_sidecar_pending",
           "summary": "Implemented AUDIT-API-CAREER-ARTIFACT-READINESS. Focused artifact readiness tests, db-context regression tests, route list, full Pint, and git diff --check passed. Broad Career filter still has external pre-existing failures pending sidecar finalization after GitHub required checks pass."
+        },
+        {
+          "at": "2026-05-17T07:28:30+08:00",
+          "status": "ready_to_merge",
+          "summary": "PR #1426 is open with scoped diff, local validation passed, GitHub required checks passed on run 25975666613, and the broad Career filter blocker is recorded as an external sidecar."
         }
       ]
     },


### PR DESCRIPTION
## Findings addressed
- AUDIT-API-CAREER-ARTIFACT-READINESS: readiness artifacts now fail closed instead of accepting malformed, incomplete, or unsupported-locale runtime artifacts.

## What changed
- Added a canonical readiness artifact locale policy for career audit/runtime artifact generation and validation.
- Hardened runtime artifact refresh planning so target delta, candidate prep plan, and candidate apply artifacts require explicit valid pass/applied signals before readiness can pass.
- Hardened index context artifact parsing so missing/null/non-boolean `index_eligible` is treated as ineligible and blocks artifact-based readiness.
- Updated career eligibility/export tests and readiness planner tests to prove malformed, blocked, missing, and unsupported-locale artifacts fail closed.
- Updated the PR train ledger for this audit item and the previous merged train item cleanup/revalidation.

## Why
Readiness promotion must not infer success from absent or malformed artifact fields. The artifact path now requires explicit positive evidence before allowing readiness to pass.

## Validation commands
- `php -l` on changed PHP source files
- `php artisan test tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php tests/Unit/Domain/Career/Audit/CareerEntityIndexContextArtifactReaderTest.php tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php --no-ansi`
- `php artisan test tests/Feature/Console/CareerExportCanonicalEligibilityDbContextCommandTest.php tests/Feature/Console/CareerAuditCanonicalEligibilityCommandTest.php tests/Unit/Domain/Career/Audit/CareerEntityIndexContextArtifactReaderTest.php --no-ansi`
- `php artisan route:list --no-ansi`
- `backend/vendor/bin/pint --test`
- `git diff --check`

## Sidecar issues recorded
- `AUDIT-API-CAREER-ARTIFACT-READINESS-SIDECAR-01`: broad `php artisan test --filter=Career --no-ansi` still has external first-wave/public surface/attribution failures not introduced by this PR. Evidence captured in the train state; this remains external pending GitHub required checks and scope validation.

## Intentionally deferred items
- No deploy, rollback, rollout apply, backfill, unlock, or process management was run.
- Existing broad Career suite failures outside this scope are deferred to sidecar handling.

## Repository rule impact
- Backend remains the authority for career readiness and artifacts.
- No frontend content authority, CMS authority, SEO enumeration, deploy readiness, or public content ownership rule changes are introduced.