### PR TITLE
AUDIT-API-ARTICLE-PUBLISH-GATE: fix(security): require editorial approval for controlled article publish

### DIFF
--- a/backend/app/Console/Commands/ArticlePublishControlled.php
+++ b/backend/app/Console/Commands/ArticlePublishControlled.php
@@ -75,10 +75,22 @@ final class ArticlePublishControlled extends Command
         if ($errors === [] && ! $dryRun) {
             $publishedIds = [];
             foreach ($plans as $plan) {
-                $publishedIds[] = $this->publishPlannedArticle($plan, $publisher, $auditLogger, $expectedConfirmation, $makeIndexable);
+                try {
+                    $publishedIds[] = $this->publishPlannedArticle($plan, $publisher, $auditLogger, $expectedConfirmation, $makeIndexable);
+                } catch (RuntimeException $exception) {
+                    $errors[] = $this->issue(
+                        'publish',
+                        'publish_preflight_failed',
+                        $exception->getMessage(),
+                        ['article_id' => (int) ($plan['article_id'] ?? 0)]
+                    );
+                    break;
+                }
             }
 
             $summary['published_article_ids'] = $publishedIds;
+            $summary['errors'] = $errors;
+            $summary['ok'] = $errors === [];
         }
 
         $this->emitSummary($summary);
@@ -145,11 +157,12 @@ final class ArticlePublishControlled extends Command
      * @param  list<int>  $acknowledgedWarnings
      * @return array<string,mixed>
      */
-    private function preflightArticle(int $articleId, array $acknowledgedWarnings, bool $makeIndexable): array
+    private function preflightArticle(int $articleId, array $acknowledgedWarnings, bool $makeIndexable, bool $lockForUpdate = false): array
     {
         $article = Article::query()
             ->withoutGlobalScopes()
             ->with(['workingRevision', 'seoMeta', 'category', 'tags'])
+            ->when($lockForUpdate, static fn ($query) => $query->lockForUpdate())
             ->find($articleId);
 
         if (! $article instanceof Article) {
@@ -160,10 +173,21 @@ final class ArticlePublishControlled extends Command
             ];
         }
 
+        if ($lockForUpdate && $article->working_revision_id !== null) {
+            $revision = ArticleTranslationRevision::query()
+                ->withoutGlobalScopes()
+                ->whereKey((int) $article->working_revision_id)
+                ->lockForUpdate()
+                ->first();
+
+            $article->setRelation('workingRevision', $revision);
+        }
+
         $import = ArticleEditorialPackageImport::query()
             ->withoutGlobalScopes()
             ->where('article_id', $articleId)
             ->latest('id')
+            ->when($lockForUpdate, static fn ($query) => $query->lockForUpdate())
             ->first();
 
         $seoMeta = $article->seoMeta instanceof ArticleSeoMeta ? $article->seoMeta : null;
@@ -186,6 +210,17 @@ final class ArticlePublishControlled extends Command
             $errors[] = $this->issue('article', 'already_published', 'Article is already published.');
         }
 
+        if ((string) $article->lifecycle_state !== '' && in_array((string) $article->lifecycle_state, [
+            Article::LIFECYCLE_ARCHIVED,
+            Article::LIFECYCLE_SOFT_DELETED,
+        ], true)) {
+            $errors[] = $this->issue('article.lifecycle_state', 'article_lifecycle_not_publishable', 'Archived or soft-deleted articles cannot be controlled-published.');
+        }
+
+        if (method_exists($article, 'trashed') && $article->trashed()) {
+            $errors[] = $this->issue('article.deleted_at', 'article_soft_deleted', 'Soft-deleted articles cannot be controlled-published.');
+        }
+
         if (! in_array((string) $article->status, ['draft', 'review_pending'], true)) {
             $errors[] = $this->issue('article.status', 'invalid_status', 'Controlled publish only accepts draft or review_pending articles.');
         }
@@ -202,6 +237,18 @@ final class ArticlePublishControlled extends Command
             ArticleTranslationRevision::STATUS_PUBLISHED,
         ], true)) {
             $errors[] = $this->issue('working_revision.revision_status', 'invalid_revision_status', 'Working revision status is not publishable.');
+        } elseif ((string) $revision->revision_status !== ArticleTranslationRevision::STATUS_APPROVED) {
+            $errors[] = $this->issue('working_revision.revision_status', 'revision_not_editorially_approved', 'Working revision must be editorially approved before controlled publish.');
+        }
+
+        if ($revision instanceof ArticleTranslationRevision && (string) $revision->revision_status === ArticleTranslationRevision::STATUS_APPROVED) {
+            if ((int) ($revision->reviewed_by ?? 0) <= 0 || $revision->reviewed_at === null) {
+                $errors[] = $this->issue('working_revision.review', 'revision_review_missing', 'Approved working revision must include review actor and timestamp.');
+            }
+
+            if ($revision->approved_at === null) {
+                $errors[] = $this->issue('working_revision.approved_at', 'revision_approval_missing', 'Approved working revision must include approval timestamp.');
+            }
         }
 
         if (! $import instanceof ArticleEditorialPackageImport) {
@@ -298,6 +345,7 @@ final class ArticlePublishControlled extends Command
             'import_id' => $import?->id,
             'import_status' => $import?->status,
             'claim_status' => $claimStatus,
+            'claim_warning_acknowledged' => in_array($articleId, $acknowledgedWarnings, true),
             'claim_matches_count' => count($claimMatches),
             'body_hash' => $bodyHash,
             'references_count' => (int) ($import?->references_count ?? 0),
@@ -323,7 +371,19 @@ final class ArticlePublishControlled extends Command
     ): int {
         $articleId = (int) $plan['article_id'];
 
-        DB::transaction(function () use ($articleId, $makeIndexable): void {
+        $article = DB::transaction(function () use ($articleId, $plan, $publisher, $makeIndexable): Article {
+            $acknowledgedWarnings = ((bool) ($plan['claim_warning_acknowledged'] ?? false)) ? [$articleId] : [];
+            $revalidatedPlan = $this->preflightArticle($articleId, $acknowledgedWarnings, $makeIndexable, lockForUpdate: true);
+
+            if (($revalidatedPlan['errors'] ?? []) !== []) {
+                $codes = collect((array) $revalidatedPlan['errors'])
+                    ->map(static fn (mixed $error): string => is_array($error) ? (string) ($error['code'] ?? '') : '')
+                    ->filter()
+                    ->implode(',');
+
+                throw new RuntimeException('controlled publish preflight failed before publish: '.$codes);
+            }
+
             $article = Article::query()
                 ->withoutGlobalScopes()
                 ->with('workingRevision')
@@ -334,11 +394,6 @@ final class ArticlePublishControlled extends Command
             if (! $article instanceof Article || ! $article->workingRevision instanceof ArticleTranslationRevision) {
                 throw new RuntimeException('planned article disappeared before publish.');
             }
-
-            $article->workingRevision->forceFill([
-                'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
-                'approved_at' => $article->workingRevision->approved_at ?? now(),
-            ])->save();
 
             if ($makeIndexable) {
                 $article->forceFill(['is_indexable' => true])->save();
@@ -351,9 +406,9 @@ final class ArticlePublishControlled extends Command
                         'is_indexable' => true,
                     ]);
             }
-        });
 
-        $article = $publisher->publishArticle($articleId, 'controlled_codex_publish');
+            return $publisher->publishArticle($articleId, 'controlled_codex_publish');
+        });
 
         $auditLogger->log(
             Request::create('/ops/articles/publish-controlled', 'POST'),

--- a/backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php
+++ b/backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Console;
 
+use App\Console\Commands\ArticlePublishControlled;
 use App\Models\Article;
 use App\Models\ArticleCategory;
 use App\Models\ArticleEditorialPackageImport;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTag;
 use App\Models\ArticleTranslationRevision;
+use App\Services\Audit\AuditLogger;
+use App\Services\Cms\ArticlePublishService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+use ReflectionMethod;
+use RuntimeException;
 use Tests\TestCase;
 
 final class ArticlePublishControlledCommandTest extends TestCase
@@ -145,31 +150,164 @@ final class ArticlePublishControlledCommandTest extends TestCase
         $this->assertNull($article->published_revision_id);
     }
 
+    public function test_controlled_publish_rejects_unapproved_working_revision_without_self_approving(): void
+    {
+        $article = $this->createControlledDraft([
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'reviewed_by' => 7,
+            'reviewed_at' => now()->subMinutes(5),
+            'approved_at' => null,
+        ]);
+        $confirmation = "I explicitly approve Codex to publish article id {$article->id} after preflight passes.";
+
+        $this->artisan('articles:publish-controlled', [
+            '--article' => [(string) $article->id],
+            '--confirm' => $confirmation,
+            '--make-indexable' => true,
+        ])
+            ->expectsOutputToContain('ok=0')
+            ->expectsOutputToContain('revision_not_editorially_approved')
+            ->assertExitCode(1);
+
+        $article->refresh();
+        $this->assertSame('draft', (string) $article->status);
+        $this->assertNull($article->published_revision_id);
+        $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, (string) $article->workingRevision?->revision_status);
+        $this->assertNull($article->workingRevision?->approved_at);
+    }
+
+    public function test_controlled_publish_rejects_approved_revision_without_review_metadata(): void
+    {
+        $article = $this->createControlledDraft([
+            'reviewed_by' => null,
+            'reviewed_at' => null,
+            'approved_at' => null,
+        ]);
+        $confirmation = "I explicitly approve Codex to publish article id {$article->id} after preflight passes.";
+
+        $this->artisan('articles:publish-controlled', [
+            '--article' => [(string) $article->id],
+            '--confirm' => $confirmation,
+            '--make-indexable' => true,
+        ])
+            ->expectsOutputToContain('ok=0')
+            ->expectsOutputToContain('revision_review_missing')
+            ->expectsOutputToContain('revision_approval_missing')
+            ->assertExitCode(1);
+
+        $article->refresh();
+        $this->assertSame('draft', (string) $article->status);
+        $this->assertNull($article->published_revision_id);
+    }
+
+    public function test_controlled_publish_rejects_stale_and_already_published_revisions(): void
+    {
+        foreach ([ArticleTranslationRevision::STATUS_STALE, ArticleTranslationRevision::STATUS_PUBLISHED] as $status) {
+            $article = $this->createControlledDraft([
+                'slug' => 'controlled-publish-'.$status,
+                'revision_status' => $status,
+                'published_at' => $status === ArticleTranslationRevision::STATUS_PUBLISHED ? now()->subMinute() : null,
+            ]);
+            $confirmation = "I explicitly approve Codex to publish article id {$article->id} after preflight passes.";
+
+            $this->artisan('articles:publish-controlled', [
+                '--article' => [(string) $article->id],
+                '--confirm' => $confirmation,
+                '--make-indexable' => true,
+            ])
+                ->expectsOutputToContain('ok=0')
+                ->expectsOutputToContain('invalid_revision_status')
+                ->assertExitCode(1);
+
+            $article->refresh();
+            $this->assertSame('draft', (string) $article->status);
+            $this->assertNull($article->published_revision_id);
+        }
+    }
+
+    public function test_controlled_publish_rejects_archived_articles(): void
+    {
+        $article = $this->createControlledDraft([
+            'lifecycle_state' => Article::LIFECYCLE_ARCHIVED,
+        ]);
+        $confirmation = "I explicitly approve Codex to publish article id {$article->id} after preflight passes.";
+
+        $this->artisan('articles:publish-controlled', [
+            '--article' => [(string) $article->id],
+            '--confirm' => $confirmation,
+            '--make-indexable' => true,
+        ])
+            ->expectsOutputToContain('ok=0')
+            ->expectsOutputToContain('article_lifecycle_not_publishable')
+            ->assertExitCode(1);
+
+        $article->refresh();
+        $this->assertSame('draft', (string) $article->status);
+        $this->assertNull($article->published_revision_id);
+    }
+
+    public function test_controlled_publish_revalidates_review_gate_inside_transaction_before_publishing(): void
+    {
+        $article = $this->createControlledDraft(['slug' => 'controlled-publish-revalidate']);
+        $command = app(ArticlePublishControlled::class);
+        $preflight = new ReflectionMethod($command, 'preflightArticle');
+        $publish = new ReflectionMethod($command, 'publishPlannedArticle');
+
+        $plan = $preflight->invoke($command, (int) $article->id, [], true);
+        $this->assertIsArray($plan);
+        $this->assertTrue((bool) $plan['ok']);
+
+        ArticleTranslationRevision::query()
+            ->withoutGlobalScopes()
+            ->whereKey((int) $article->working_revision_id)
+            ->update(['revision_status' => ArticleTranslationRevision::STATUS_STALE]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('invalid_revision_status');
+
+        try {
+            $publish->invoke(
+                $command,
+                $plan,
+                app(ArticlePublishService::class),
+                app(AuditLogger::class),
+                "I explicitly approve Codex to publish article id {$article->id} after preflight passes.",
+                true
+            );
+        } finally {
+            $article->refresh();
+            $this->assertSame('draft', (string) $article->status);
+            $this->assertNull($article->published_revision_id);
+            $this->assertSame(ArticleTranslationRevision::STATUS_STALE, (string) $article->workingRevision?->revision_status);
+        }
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */
     private function createControlledDraft(array $overrides = []): Article
     {
-        $category = ArticleCategory::query()->withoutGlobalScopes()->create([
-            'org_id' => 0,
-            'slug' => 'career-development',
-            'name' => '职业发展',
-            'is_active' => true,
-        ]);
-        $tag = ArticleTag::query()->withoutGlobalScopes()->create([
-            'org_id' => 0,
-            'slug' => 'riasec',
-            'name' => 'RIASEC',
-            'is_active' => true,
-        ]);
+        $category = ArticleCategory::query()->withoutGlobalScopes()->firstOrCreate(
+            ['org_id' => 0, 'slug' => 'career-development'],
+            ['name' => '职业发展', 'is_active' => true]
+        );
+        $tag = ArticleTag::query()->withoutGlobalScopes()->firstOrCreate(
+            ['org_id' => 0, 'slug' => 'riasec'],
+            ['name' => 'RIASEC', 'is_active' => true]
+        );
         $body = "# Controlled Publish Draft\n\n## 执行摘要\n\n正文。\n\n## FAQ\n\n### Q\n\nA.";
         $bodyHash = hash('sha256', preg_replace("/\r\n?/", "\n", trim($body)));
         $locale = (string) ($overrides['locale'] ?? 'zh-CN');
+        $slug = (string) ($overrides['slug'] ?? 'controlled-publish-draft');
+        $revisionStatus = (string) ($overrides['revision_status'] ?? ArticleTranslationRevision::STATUS_APPROVED);
+        $reviewedBy = array_key_exists('reviewed_by', $overrides) ? $overrides['reviewed_by'] : 7;
+        $reviewedAt = array_key_exists('reviewed_at', $overrides) ? $overrides['reviewed_at'] : now()->subMinutes(10);
+        $approvedAt = array_key_exists('approved_at', $overrides) ? $overrides['approved_at'] : now()->subMinutes(5);
 
         $article = Article::query()->withoutGlobalScopes()->create([
             'org_id' => 0,
             'category_id' => (int) $category->id,
-            'slug' => 'controlled-publish-draft',
+            'slug' => $slug,
             'locale' => $locale,
             'title' => 'Controlled Publish Draft',
             'excerpt' => 'Controlled excerpt',
@@ -178,7 +316,8 @@ final class ArticlePublishControlledCommandTest extends TestCase
             'cover_image_alt' => 'Controlled cover alt',
             'cover_image_width' => 1200,
             'cover_image_height' => 675,
-            'status' => 'draft',
+            'status' => (string) ($overrides['status'] ?? 'draft'),
+            'lifecycle_state' => $overrides['lifecycle_state'] ?? Article::LIFECYCLE_ACTIVE,
             'is_public' => false,
             'is_indexable' => false,
         ]);
@@ -192,12 +331,16 @@ final class ArticlePublishControlledCommandTest extends TestCase
             'locale' => $locale,
             'source_locale' => $locale,
             'revision_number' => 1,
-            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'revision_status' => $revisionStatus,
             'title' => 'Controlled Publish Draft',
             'excerpt' => 'Controlled excerpt',
             'content_md' => $body,
             'seo_title' => 'Controlled SEO Title',
             'seo_description' => 'Controlled SEO description',
+            'reviewed_by' => $reviewedBy,
+            'reviewed_at' => $reviewedAt,
+            'approved_at' => $approvedAt,
+            'published_at' => $overrides['published_at'] ?? null,
         ]);
         $article->forceFill(['working_revision_id' => (int) $revision->id])->save();
 
@@ -233,7 +376,7 @@ final class ArticlePublishControlledCommandTest extends TestCase
         ArticleEditorialPackageImport::query()->withoutGlobalScopes()->create([
             'org_id' => 0,
             'article_id' => (int) $article->id,
-            'slug' => (string) $article->slug,
+            'slug' => $slug,
             'locale' => $locale,
             'title' => 'Controlled Publish Draft',
             'content_track' => 'evergreen_knowledge',
@@ -253,14 +396,20 @@ final class ArticlePublishControlledCommandTest extends TestCase
         return $article->fresh(['workingRevision', 'publishedRevision', 'seoMeta', 'category', 'tags']) ?? $article;
     }
 
-    private function fakeContentReleaseEndpoint(): void
+    private function fakeContentReleaseEndpoint(?callable $onRequest = null): void
     {
         config()->set('ops.content_release_observability.cache_invalidation_urls', [
             'https://cache.example.test/api/content-release/revalidate',
         ]);
         config()->set('ops.content_release_observability.cache_invalidation_secret', 'release-secret');
         Http::fake([
-            'https://cache.example.test/*' => Http::response(['ok' => true], 200),
+            'https://cache.example.test/*' => function ($request) use ($onRequest) {
+                if ($onRequest !== null) {
+                    $onRequest($request);
+                }
+
+                return Http::response(['ok' => true], 200);
+            },
         ]);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2026,7 +2026,7 @@
       "branch": "fix/career-batch-live-acceptance-v2-audit12",
       "title": "feat(api): add career batch live acceptance v2",
       "name": "Career Batch Live Acceptance V2",
-      "status": "committed",
+      "status": "open",
       "depends_on": [
         "AUDIT-11"
       ],
@@ -7954,8 +7954,8 @@
         }
       },
       "failure_reason": null,
-      "pr_url": null,
-      "commit_sha": "7409b42500ad2419a5d0e157e00f5b04fb23d535",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1427",
+      "commit_sha": "6b69b7d85c038ad9b9cbf80b00a4317c42042748",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -7988,6 +7988,11 @@
           "at": "2026-05-17T07:42:01+08:00",
           "status": "committed",
           "summary": "Committed scoped AUDIT-API-ARTICLE-PUBLISH-GATE changes locally as 7409b42500ad2419a5d0e157e00f5b04fb23d535."
+        },
+        {
+          "at": "2026-05-17T07:42:01+08:00",
+          "status": "open",
+          "summary": "Pushed codex/audit-api-article-publish-gate and opened PR #1427 at https://github.com/fermatmind/fap-api/pull/1427."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T07:28:30+08:00",
+  "updated_at": "2026-05-17T07:42:01+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2026,7 +2026,7 @@
       "branch": "fix/career-batch-live-acceptance-v2-audit12",
       "title": "feat(api): add career batch live acceptance v2",
       "name": "Career Batch Live Acceptance V2",
-      "status": "in_progress",
+      "status": "committed",
       "depends_on": [
         "AUDIT-11"
       ],
@@ -7790,7 +7790,7 @@
       "depends_on": [
         "AUDIT-API-CAREER-ROLLOUT-AUTHORITY"
       ],
-      "status": "ready_to_merge",
+      "status": "merged",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): fail closed on career readiness artifacts",
@@ -7847,14 +7847,18 @@
         "bigfive_runtime_freeze": {
           "status": "pass",
           "evidence": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --no-ansi passed after folding locale policy into an existing career readiness planner file."
+        },
+        "post_merge_revalidation": {
+          "status": "pass",
+          "evidence": "After syncing main to origin/main db336b6dca6ac77683393dc50602c3928e8dfa50, targeted artifact readiness tests passed with 77 tests / 362 assertions; php artisan route:list --no-ansi passed; git diff --check passed."
         }
       },
       "failure_reason": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1426",
-      "commit_sha": "88400b47568e64f25c21f985e34b736a20980a2b",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "commit_sha": "db336b6dca6ac77683393dc50602c3928e8dfa50",
+      "merged_at": "2026-05-16T23:33:27Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "id": "AUDIT-API-CAREER-ARTIFACT-READINESS-SIDECAR-01",
@@ -7880,6 +7884,11 @@
           "at": "2026-05-17T07:28:30+08:00",
           "status": "ready_to_merge",
           "summary": "PR #1426 is open with scoped diff, local validation passed, GitHub required checks passed on run 25975666613, and the broad Career filter blocker is recorded as an external sidecar."
+        },
+        {
+          "at": "2026-05-17T07:35:30+08:00",
+          "status": "merged",
+          "summary": "Squash merged PR #1426 as db336b6dca6ac77683393dc50602c3928e8dfa50; origin/main contains the merge commit, remote/local task branches were cleaned up, and post-merge revalidation passed."
         }
       ]
     },
@@ -7891,7 +7900,7 @@
       "depends_on": [
         "AUDIT-API-CAREER-ARTIFACT-READINESS"
       ],
-      "status": "planned",
+      "status": "in_progress",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): require editorial approval for controlled article publish",
@@ -7906,20 +7915,79 @@
         "scope_validation_policy": {
           "status": "planned",
           "evidence": "External blockers may be recorded as sidecar only when not introduced by the current PR, GitHub required checks are green, and scoped validation is green."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "Depends on AUDIT-API-CAREER-ARTIFACT-READINESS, which is merged in origin/main at db336b6dca6ac77683393dc50602c3928e8dfa50."
+        },
+        "branch": {
+          "status": "pass",
+          "evidence": "Created codex/audit-api-article-publish-gate from latest origin/main after PR #1426 merge."
+        },
+        "implementation": {
+          "status": "pass",
+          "evidence": "Controlled article publish now requires an approved working revision with review actor/timestamp and approval timestamp, rejects stale/published/archived publish inputs, removes publish-time self-approval, and re-runs locked preflight inside the publish transaction before mutation."
+        },
+        "focused_article_publish_tests": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan test tests/Feature/Console/ArticlePublishControlledCommandTest.php --no-ansi passed: 8 tests / 66 assertions."
+        },
+        "manifest_article_filter": {
+          "status": "external_sidecar",
+          "evidence": "cd backend && php artisan test --filter=Article --no-ansi failed with 3 failures outside this PR scope: CareerDatasetPublicApiTest member_count 1 vs 342, ArticleMachineTranslationProviderTest source article outside translation content scope, and ArticleTranslationContractTest missing English source in ops list. The same command on origin/main db336b6dca6ac77683393dc50602c3928e8dfa50 also fails with those three failures plus the older ArticlePublishControlled tests fixed by this PR."
+        },
+        "route_list": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan route:list --no-ansi passed and listed 197 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "evidence": "cd backend && vendor/bin/pint --test passed for 3276 files."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to backend/app/Console/Commands/ArticlePublishControlled.php, backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php, and docs/codex/pr-train-state.json, all within the approved PR scope."
+        },
+        "diff_check": {
+          "status": "pass",
+          "evidence": "git diff --check passed."
         }
       },
       "failure_reason": null,
       "pr_url": null,
-      "commit_sha": null,
+      "commit_sha": "e72d598afecbd6b472dd6f299c9ae2d153c9afa1",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+        {
+          "id": "AUDIT-API-ARTICLE-PUBLISH-GATE-SIDECAR-01",
+          "title": "Existing broad Article filter failures outside controlled publish gate scope",
+          "status": "open",
+          "evidence": "On this branch, php artisan test --filter=Article --no-ansi fails in CareerDatasetPublicApiTest, ArticleMachineTranslationProviderTest, and ArticleTranslationContractTest. On origin/main db336b6dca6ac77683393dc50602c3928e8dfa50 the same three failures are already present, so they are not introduced by this PR.",
+          "recorded_at": "2026-05-17T07:42:01+08:00"
+        }
+      ],
       "history": [
         {
           "at": "2026-05-16T14:10:19+08:00",
           "status": "planned",
           "summary": "Initialized AUDIT-API-ARTICLE-PUBLISH-GATE as a security audit remediation train item. Implementation has not started."
+        },
+        {
+          "at": "2026-05-17T07:35:30+08:00",
+          "status": "in_progress",
+          "summary": "Started AUDIT-API-ARTICLE-PUBLISH-GATE from latest origin/main after dependency merge and cleanup."
+        },
+        {
+          "at": "2026-05-17T07:42:01+08:00",
+          "status": "local_validated_with_sidecar",
+          "summary": "Implemented controlled publish review gates and transaction revalidation. Focused tests, route list, Pint, scope validation, and diff check passed; broad Article filter failures were confirmed on origin/main and recorded as sidecar."
+        },
+        {
+          "at": "2026-05-17T07:42:01+08:00",
+          "status": "committed",
+          "summary": "Committed scoped AUDIT-API-ARTICLE-PUBLISH-GATE changes locally as e72d598afecbd6b472dd6f299c9ae2d153c9afa1."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2113,7 +2113,7 @@
       "branch": "fix/career-2786-full-audit-report-audit13",
       "title": "feat(api): add career 2786 full audit artifact report",
       "name": "Career 2786 Full Audit Artifact Report",
-      "status": "in_progress",
+      "status": "committed",
       "depends_on": [
         "AUDIT-12"
       ],
@@ -7955,7 +7955,7 @@
       },
       "failure_reason": null,
       "pr_url": null,
-      "commit_sha": "e72d598afecbd6b472dd6f299c9ae2d153c9afa1",
+      "commit_sha": "7409b42500ad2419a5d0e157e00f5b04fb23d535",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -7987,7 +7987,7 @@
         {
           "at": "2026-05-17T07:42:01+08:00",
           "status": "committed",
-          "summary": "Committed scoped AUDIT-API-ARTICLE-PUBLISH-GATE changes locally as e72d598afecbd6b472dd6f299c9ae2d153c9afa1."
+          "summary": "Committed scoped AUDIT-API-ARTICLE-PUBLISH-GATE changes locally as 7409b42500ad2419a5d0e157e00f5b04fb23d535."
         }
       ]
     },


### PR DESCRIPTION
## Findings addressed
- Controlled article publish could promote an unapproved working revision by self-approving it during publish.
- Controlled publish did not re-run the editorial gate under lock immediately before mutation.

## What changed
- Require the working article translation revision to be `approved` before controlled publish.
- Require approved revisions to carry review actor, review timestamp, and approval timestamp.
- Reject stale, archived, already-published revisions and archived/soft-deleted articles during controlled preflight.
- Remove publish-time self-approval from `articles:publish-controlled`.
- Re-run locked preflight inside the publish transaction before making the article indexable and publishing it.
- Add regression tests for unapproved revisions, missing review metadata, stale/published revisions, archived articles, and transaction-time revalidation.
- Update the PR train ledger for PR #1426 merge cleanup and this audit item.

## Why
Controlled publish must be a release gate for already-reviewed editorial content, not an approval mechanism. The command now fails closed unless editorial approval is already present and still valid at publish time.

## Validation commands
- `php -l backend/app/Console/Commands/ArticlePublishControlled.php`
- `php -l backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php`
- `cd backend && php artisan test tests/Feature/Console/ArticlePublishControlledCommandTest.php --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `git diff --check`
- `git diff --cached --check`

## Sidecar issues recorded
- `AUDIT-API-ARTICLE-PUBLISH-GATE-SIDECAR-01`: `cd backend && php artisan test --filter=Article --no-ansi` still has existing failures outside this PR scope. The same broad-filter failures are present on `origin/main` for `CareerDatasetPublicApiTest`, `ArticleMachineTranslationProviderTest`, and `ArticleTranslationContractTest`; this PR's focused controlled publish tests pass.

## Intentionally deferred items
- No production content publish/unpublish/import actions.
- No changes to generic CMS article body content, attempts, results, reports, orders, payments, shares, scoring, frontend code, deployment, rollback, unlock, or process management.
