### PR TITLE
fix(api): align career 2786 product claim authority

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
+++ b/backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
@@ -33,6 +33,7 @@ final class CareerFullVisiblePublicationGate
             ]),
             'found_published_locale_rows' => $this->foundPublishedLocaleRows($liveAcceptance),
             'release_gate_pass_count' => $this->releaseGatePassCount($liveAcceptance),
+            'product_claim' => $this->productClaim($liveAcceptance, $targetPublicTotal, $expectedLocaleRows),
         ];
     }
 
@@ -213,6 +214,58 @@ final class CareerFullVisiblePublicationGate
             'release_gate.pass_count',
             'acceptance_summary.release_gate_pass_count',
         ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function productClaim(array $payload, int $targetPublicTotal, int $expectedLocaleRows): array
+    {
+        $directoryMemberCount = $this->directoryMemberCount($payload);
+        $careerJobsItemCount = $this->careerJobsItemCount($payload);
+        $detailReadyCount = $this->detailReadyCount($payload);
+        $publicDetailIndexableCount = $this->publicDetailIndexableCount($payload);
+        $foundPublishedLocaleRows = $this->foundPublishedLocaleRows($payload);
+        $releaseGatePassCount = $this->releaseGatePassCount($payload);
+        $partitionAccountingTotal = $this->intAtAny($payload, [
+            'partition_accounting.final_public_accounted_total',
+            'final_public_accounted_total',
+        ]);
+        $visibleDetailClaimAllowed = $this->appliesTo($targetPublicTotal)
+            && $directoryMemberCount === $targetPublicTotal
+            && $careerJobsItemCount === $targetPublicTotal
+            && $detailReadyCount === $targetPublicTotal
+            && $publicDetailIndexableCount === $targetPublicTotal
+            && $foundPublishedLocaleRows === $expectedLocaleRows
+            && $releaseGatePassCount === $expectedLocaleRows;
+
+        return [
+            'claim_policy_version' => 'career_product_visible_claim.v1',
+            'target_public_total' => $targetPublicTotal,
+            'expected_locale_rows' => $expectedLocaleRows,
+            'visible_detail_claim_allowed' => $visibleDetailClaimAllowed,
+            'partition_accounting_claim_allowed' => $partitionAccountingTotal === $targetPublicTotal,
+            'safe_claim_scope' => $visibleDetailClaimAllowed
+                ? 'product_visible_detail_publication'
+                : ($partitionAccountingTotal === $targetPublicTotal
+                    ? 'partition_accounted_not_visible_detail'
+                    : 'insufficient_product_evidence'),
+            'claimable_counts' => [
+                'directory_member_count' => $directoryMemberCount,
+                'career_jobs_item_count' => $careerJobsItemCount,
+                'detail_ready_count' => $detailReadyCount,
+                'public_detail_indexable_count' => $publicDetailIndexableCount,
+                'found_published_locale_rows' => $foundPublishedLocaleRows,
+                'release_gate_pass_count' => $releaseGatePassCount,
+                'partition_accounting_total' => $partitionAccountingTotal,
+            ],
+            'blocked_claims' => $visibleDetailClaimAllowed ? [] : [
+                '2786_visible_directory_members',
+                '2786_visible_detail_pages',
+                '2786_detail_indexable_pages',
+            ],
+        ];
     }
 
     /**

--- a/backend/docs/career/audits/2786_full_public_resolution_retrospective.md
+++ b/backend/docs/career/audits/2786_full_public_resolution_retrospective.md
@@ -72,6 +72,7 @@ Post-release correction:
 - The evidence above proves final public-resolution partition accounting, not 2786 visible public detail pages.
 - A product-visible 2786 publication claim must additionally prove public career directory `member_count=2786`, career jobs item count `2786`, detail-ready / `public_detail_indexable_count=2786`, and `5572` published locale rows.
 - Artifacts with `canonical_public_slug_count=1122` or `canonical_public_locale_rows=2244` must not be accepted as “2786 careers visible” evidence, even when `final_public_accounted_total=2786`.
+- New acceptance artifacts expose `full_visible_publication_gate.product_claim`. Product-facing copy must use its `safe_claim_scope` and `claimable_counts`. When the scope is `partition_accounted_not_visible_detail`, the safe claim is that 2786 assets are accounted/resolved, not that 2786 career detail pages are visible.
 
 ## Cohort path
 

--- a/backend/docs/career/audits/product_visible_claim_authority.md
+++ b/backend/docs/career/audits/product_visible_claim_authority.md
@@ -1,0 +1,57 @@
+# Product-visible Career claim authority
+
+Career public-resolution accounting and product-visible publication are separate claims.
+
+For the final `2786` Career program, partition accounting may prove that every source row has a governed resolution. It does not prove that every source row is visible in the public career directory or has a viewable detail page.
+
+## Claim scopes
+
+`partition_accounted_not_visible_detail` means:
+
+- the 2786 source set has been accounted for through canonical rollout, CN proxy public-owner, manual-hold, or another governed partition;
+- the artifact may describe assets as accounted or resolved;
+- it must not describe the product as having 2786 visible directory entries, 2786 viewable detail pages, or 2786 detail-indexable pages.
+
+`product_visible_detail_publication` means:
+
+- public career directory `member_count` equals the target total;
+- career jobs index item count equals the target total;
+- detail-ready and `public_detail_indexable_count` equal the target total;
+- published locale rows and release-gate pass rows equal `target_public_total * locale_count`.
+
+Only `product_visible_detail_publication` may support a product claim that 2786 occupations are visible with detail pages.
+
+## Runtime artifact field
+
+`CareerFullVisiblePublicationGate` emits:
+
+```json
+{
+  "product_claim": {
+    "claim_policy_version": "career_product_visible_claim.v1",
+    "visible_detail_claim_allowed": false,
+    "partition_accounting_claim_allowed": true,
+    "safe_claim_scope": "partition_accounted_not_visible_detail",
+    "claimable_counts": {
+      "directory_member_count": 1122,
+      "career_jobs_item_count": 1122,
+      "detail_ready_count": 808,
+      "public_detail_indexable_count": 808,
+      "found_published_locale_rows": 2244,
+      "release_gate_pass_count": 2244,
+      "partition_accounting_total": 2786
+    },
+    "blocked_claims": [
+      "2786_visible_directory_members",
+      "2786_visible_detail_pages",
+      "2786_detail_indexable_pages"
+    ]
+  }
+}
+```
+
+Downstream closeout, release notes, and product copy should use `safe_claim_scope` and `claimable_counts` rather than inferring visible publication from `final_public_accounted_total`.
+
+## Non-goals
+
+This policy does not publish missing pages, generate occupation content, alter CN proxy policy, weaken software manual-hold policy, deploy, mutate production data, or move Career publication authority into fap-web.

--- a/backend/docs/career/audits/progressive_closeout.md
+++ b/backend/docs/career/audits/progressive_closeout.md
@@ -35,4 +35,6 @@ The command refuses closeout when the live acceptance artifact is not `status=pa
 
 For `target_public_total=2786`, closeout also refuses partition-accounting-only evidence. The live acceptance artifact must prove the product-visible surface: directory `member_count=2786`, career jobs item count `2786`, detail-ready / `public_detail_indexable_count=2786`, and `5572` published locale rows. A final partition total of `2786` is not sufficient when public routes or detail pages remain disabled.
 
+Closeout records carry the visible publication gate summary under `acceptance_summary.full_visible_publication_gate.product_claim`. Operators must not translate `final_public_accounted_total=2786` into a product-visible claim unless `visible_detail_claim_allowed=true` and `safe_claim_scope=product_visible_detail_publication`.
+
 It does not run readiness, candidate preparation, rollout dry-run, rollout apply, live crawl, backfill, rollback, quarantine, deploy, or any database mutation.

--- a/backend/docs/career/audits/progressive_live_acceptance.md
+++ b/backend/docs/career/audits/progressive_live_acceptance.md
@@ -19,6 +19,11 @@ For the final `2786` target, the command also enforces the product-visible publi
 
 CN proxy public-owner accounting and software manual-hold accounting may be recorded as context, but they are not accepted as evidence that 2786 public detail pages are visible.
 
+The final visible gate also emits `product_claim`. Downstream product copy and release notes must use `product_claim.safe_claim_scope` and `product_claim.claimable_counts`:
+
+- `product_visible_detail_publication` allows a visible/detail page claim for the target total.
+- `partition_accounted_not_visible_detail` allows only an accounted/resolved source-set claim. It explicitly blocks claims such as `2786_visible_directory_members`, `2786_visible_detail_pages`, and `2786_detail_indexable_pages`.
+
 Example:
 
 ```bash

--- a/backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
@@ -152,6 +152,13 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
         $this->assertContains('product_found_published_locale_rows_mismatch', $reasons);
         $this->assertContains('partition_accounting_not_product_publication_evidence', $reasons);
         $this->assertSame(1122, data_get($payload, 'validation.full_visible_publication_gate.canonical_public_slug_count'));
+        $this->assertFalse(data_get($payload, 'validation.full_visible_publication_gate.product_claim.visible_detail_claim_allowed'));
+        $this->assertTrue(data_get($payload, 'validation.full_visible_publication_gate.product_claim.partition_accounting_claim_allowed'));
+        $this->assertSame('partition_accounted_not_visible_detail', data_get($payload, 'validation.full_visible_publication_gate.product_claim.safe_claim_scope'));
+        $this->assertContains(
+            '2786_visible_detail_pages',
+            data_get($payload, 'validation.full_visible_publication_gate.product_claim.blocked_claims'),
+        );
     }
 
     public function test_2786_live_acceptance_requires_directory_and_detail_counts_to_match_target(): void
@@ -178,6 +185,9 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
         $this->assertContains('product_public_detail_indexable_count_mismatch', $reasons);
         $this->assertContains('product_found_published_locale_rows_mismatch', $reasons);
         $this->assertContains('product_release_gate_pass_count_mismatch', $reasons);
+        $this->assertFalse(data_get($payload, 'validation.full_visible_publication_gate.product_claim.visible_detail_claim_allowed'));
+        $this->assertSame(1122, data_get($payload, 'validation.full_visible_publication_gate.product_claim.claimable_counts.directory_member_count'));
+        $this->assertSame(808, data_get($payload, 'validation.full_visible_publication_gate.product_claim.claimable_counts.detail_ready_count'));
     }
 
     public function test_2786_live_acceptance_passes_only_with_full_visible_product_counts(): void
@@ -194,6 +204,9 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
         $this->assertSame(2786, data_get($payload, 'validation.full_visible_publication_gate.directory_member_count'));
         $this->assertSame(2786, data_get($payload, 'validation.full_visible_publication_gate.detail_ready_count'));
         $this->assertSame(5572, data_get($payload, 'validation.full_visible_publication_gate.found_published_locale_rows'));
+        $this->assertTrue(data_get($payload, 'validation.full_visible_publication_gate.product_claim.visible_detail_claim_allowed'));
+        $this->assertSame('product_visible_detail_publication', data_get($payload, 'validation.full_visible_publication_gate.product_claim.safe_claim_scope'));
+        $this->assertSame([], data_get($payload, 'validation.full_visible_publication_gate.product_claim.blocked_claims'));
     }
 
     /**

--- a/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php
@@ -62,6 +62,8 @@ final class CareerProgressiveCohortCloseoutPlannerTest extends TestCase
         $this->assertSame(2786, $result['target_public_total']);
         $this->assertSame(5572, $result['expected_locale_rows']);
         $this->assertSame('CAREER_2786_FINAL_CLOSEOUT_COMPLETE', $result['next_required_action']);
+        $this->assertTrue(data_get($result, 'acceptance_summary.full_visible_publication_gate.product_claim.visible_detail_claim_allowed'));
+        $this->assertSame('product_visible_detail_publication', data_get($result, 'acceptance_summary.full_visible_publication_gate.product_claim.safe_claim_scope'));
     }
 
     public function test_refuses_closeout_when_acceptance_failed(): void
@@ -120,6 +122,9 @@ final class CareerProgressiveCohortCloseoutPlannerTest extends TestCase
         $this->assertContains('product_detail_ready_count_missing', $reasons);
         $this->assertContains('product_found_published_locale_rows_mismatch', $reasons);
         $this->assertContains('partition_accounting_not_product_publication_evidence', $reasons);
+        $this->assertFalse(data_get($result, 'acceptance_summary.full_visible_publication_gate.product_claim.visible_detail_claim_allowed'));
+        $this->assertTrue(data_get($result, 'acceptance_summary.full_visible_publication_gate.product_claim.partition_accounting_claim_allowed'));
+        $this->assertSame('partition_accounted_not_visible_detail', data_get($result, 'acceptance_summary.full_visible_publication_gate.product_claim.safe_claim_scope'));
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T08:16:00+08:00",
+  "updated_at": "2026-05-17T08:28:18+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -8205,6 +8205,44 @@
           "summary": "Inspected PR #1429 verify-mbti-legacy failure, fixed the Big Five runtime freeze classifier for the safe tmp artifact helper, and validated the focused freeze suite, helper tests, route list, Pint, and diff check locally."
         }
       ]
+    },
+    "REPAIR-PRODUCT-CLAIM-2786-PARTITION-AWARE-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-product-claim-2786-partition-aware-1",
+      "base": "main",
+      "depends_on": [
+        "REPAIR-2786-FINAL-READINESS-SOFTWARE-MANUAL-HOLD-AUTHORITY-1"
+      ],
+      "status": "in_progress",
+      "train_scope": "career_product_claim_authority",
+      "risk_level": "medium",
+      "title": "fix(api): align career 2786 product claim authority",
+      "name": "Align Career 2786 product claim with visible publication truth",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-PRODUCT-CLAIM-2786-PARTITION-AWARE-1, then implementing the PR."
+        },
+        "scope": {
+          "status": "planned",
+          "evidence": "Scope is limited to backend Career visible claim authority, focused tests/docs, and authorized train metadata. No fap-web, deploy, DB mutation, rollout, or content generation is allowed."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-17T08:28:18+08:00",
+          "status": "in_progress",
+          "summary": "Registered authorized product-visible claim authority PR and started implementation from clean origin/main worktree."
+        }
+      ],
+      "next_pr": "PRODUCT_POLICY_DECISION_OR_VISIBLE_GAP_REMEDIATION"
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -846,6 +846,40 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: REPAIR-PRODUCT-CLAIM-2786-PARTITION-AWARE-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-2786-FINAL-READINESS-SOFTWARE-MANUAL-HOLD-AUTHORITY-1
+    branch: codex/repair-product-claim-2786-partition-aware-1
+    title: "fix(api): align career 2786 product claim authority"
+    name: "Align Career 2786 product claim with visible publication truth"
+    scope:
+      - Add backend claim authority to distinguish partition-accounted 2786 evidence from product-visible 2786 detail publication evidence.
+      - Emit safe claim scope and claimable counts from the final visible publication gate.
+      - Document that 2786 visible/detail claims require product-visible member, job, detail-ready, and locale-row counts.
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
+      - backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
+      - backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish missing career pages.
+      - Generate occupation content.
+      - Mutate production data.
+      - Deploy, backfill, rollout, rollback, or quarantine.
+      - Touch fap-web or move Career authority to frontend fallback data.
+    validation:
+      - php artisan test --filter=CareerValidateCanonicalProgressiveLiveAcceptance --no-ansi
+      - php artisan test --filter=CareerProgressiveCohortCloseoutPlanner --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- Adds backend product-visible claim authority to the Career full visible publication gate.
- Distinguishes partition-accounted 2786 evidence from product-visible directory/detail publication evidence.
- Emits claimable counts, safe claim scope, and blocked visible/detail claims in validation summaries.
- Documents the claim policy and updates progressive live acceptance / closeout docs.
- Registers REPAIR-PRODUCT-CLAIM-2786-PARTITION-AWARE-1 in the PR train manifest and state ledger.

## Scope
- Backend Career audit authority only.
- No fap-web changes.
- No content generation, deploy, rollout, backfill, rollback, quarantine, or production DB mutation.

## Tests
- `php -l app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php`
- `php artisan test --filter=CareerValidateCanonicalProgressiveLiveAcceptance --no-ansi`
- `php artisan test --filter=CareerProgressiveCohortCloseoutPlanner --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-product-claim.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`
- `git diff --cached --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Repository Rule Impact
- Career publication claims remain backend-authoritative.
- 2786 product-visible claims now require product-visible member, job, detail-ready, public-detail-indexable, locale-row, and release-gate evidence.
- Partition accounting can still be represented, but cannot be mistaken for product-visible 2786 detail publication.