### PR TITLE
fix(api): add guarded CN proxy noindex public-owner surface

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerCnProxyPublicOwnerController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerCnProxyPublicOwnerController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Services\Career\Bundles\CareerCnProxyPublicOwnerSurfaceBuilder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class CareerCnProxyPublicOwnerController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerCnProxyPublicOwnerSurfaceBuilder $surfaceBuilder,
+    ) {}
+
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $publicLocale = is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN';
+        $surface = $this->surfaceBuilder->buildBySlug($slug, $publicLocale);
+
+        if ($surface === null) {
+            return $this->notFoundResponse('career CN proxy public-owner surface unavailable.');
+        }
+
+        return response()->json($surface);
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\API\V0_5\Career;
 use App\Http\Controllers\Concerns\RespondsWithNotFound;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Career\CareerJobDetailResource;
+use App\Services\Career\Bundles\CareerCnProxyPublicOwnerSurfaceBuilder;
 use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -17,6 +18,7 @@ final class CareerJobDetailController extends Controller
 
     public function __construct(
         private readonly CareerJobDetailBundleBuilder $bundleBuilder,
+        private readonly CareerCnProxyPublicOwnerSurfaceBuilder $cnProxySurfaceBuilder,
     ) {}
 
     public function show(Request $request, string $slug): JsonResponse|CareerJobDetailResource
@@ -25,6 +27,11 @@ final class CareerJobDetailController extends Controller
         $bundle = $this->bundleBuilder->buildBySlug($slug, $publicLocale);
 
         if ($bundle === null) {
+            $cnProxySurface = $this->cnProxySurfaceBuilder->buildBySlug($slug, $publicLocale);
+            if ($cnProxySurface !== null) {
+                return response()->json($cnProxySurface);
+            }
+
             return $this->notFoundResponse('career job detail bundle unavailable.');
         }
 

--- a/backend/app/Services/Career/Bundles/CareerCnProxyPublicOwnerSurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerCnProxyPublicOwnerSurfaceBuilder.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+final class CareerCnProxyPublicOwnerSurfaceBuilder
+{
+    private const PLAN_DEFAULT_PATH = '/tmp/career_2786_cn_proxy_public_owner_plan.json';
+
+    private const MANIFEST_DEFAULT_PATH = '/tmp/career_2786_cn_proxy_trust_manifest_reviewed_validator_normalized.json';
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $plan = null;
+
+    /**
+     * @var array<string, array<string, mixed>>|null
+     */
+    private ?array $claimsBySlug = null;
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function buildBySlug(string $slug, string $locale = 'zh-CN'): ?array
+    {
+        $normalizedSlug = strtolower(trim($slug));
+        if ($normalizedSlug === '' || ! str_starts_with($normalizedSlug, 'cn-')) {
+            return null;
+        }
+
+        $plan = $this->loadPlan();
+        if (! $this->planAllowsNoindexSurface($plan)) {
+            return null;
+        }
+
+        $claim = $this->claimsBySlug($plan)[$normalizedSlug] ?? null;
+        if (! is_array($claim) || ! $this->claimAllowsNoindexSurface($claim)) {
+            return null;
+        }
+
+        return $this->surfacePayload($normalizedSlug, $locale, $claim, $plan);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadPlan(): array
+    {
+        if ($this->plan !== null) {
+            return $this->plan;
+        }
+
+        $path = $this->configuredPath('cn_proxy_public_owner_plan_path', self::PLAN_DEFAULT_PATH);
+        if ($path === null || ! is_file($path)) {
+            return $this->plan = [];
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return $this->plan = is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @return array<string, array<string, mixed>>
+     */
+    private function claimsBySlug(array $plan): array
+    {
+        if ($this->claimsBySlug !== null) {
+            return $this->claimsBySlug;
+        }
+
+        $path = $this->configuredPath('cn_proxy_trust_manifest_path', null)
+            ?? $this->stringValue($plan['manifest_path'] ?? null)
+            ?? self::MANIFEST_DEFAULT_PATH;
+        if (! is_file($path)) {
+            return $this->claimsBySlug = [];
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            return $this->claimsBySlug = [];
+        }
+
+        $rows = $decoded['claims'] ?? $decoded['rows'] ?? [];
+        if (! is_array($rows)) {
+            return $this->claimsBySlug = [];
+        }
+
+        $claims = [];
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = strtolower(trim((string) ($row['slug'] ?? $row['source_slug'] ?? '')));
+            if ($slug !== '') {
+                $claims[$slug] = $row;
+            }
+        }
+
+        return $this->claimsBySlug = $claims;
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     */
+    private function planAllowsNoindexSurface(array $plan): bool
+    {
+        return ($plan['status'] ?? null) === 'validated'
+            && ($plan['public_owner_plan_ready'] ?? null) === true
+            && ($plan['reviewed_trust_manifest_complete'] ?? null) === true
+            && (int) ($plan['public_cn_proxy_page_rows'] ?? 0) > 0
+            && (int) ($plan['indexable_CN_proxy_rows'] ?? 0) === 0
+            && (int) ($plan['sitemap_CN_urls'] ?? 0) === 0
+            && (int) ($plan['llms_CN_urls'] ?? 0) === 0
+            && (int) ($plan['llms_full_CN_urls'] ?? 0) === 0
+            && (int) ($plan['occupations_delta'] ?? 0) === 0
+            && (int) ($plan['occupation_crosswalks_delta'] ?? 0) === 0
+            && (int) ($plan['career_job_display_assets_delta'] ?? 0) === 0
+            && ($plan['CN_proxy_can_masquerade_as_US_canonical_job'] ?? true) === false
+            && ($plan['US_canonical_job_schema_returned'] ?? true) === false
+            && ($plan['noindex_default'] ?? null) === true
+            && ($plan['blockers'] ?? []) === [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $claim
+     */
+    private function claimAllowsNoindexSurface(array $claim): bool
+    {
+        return ($claim['public_resolution_type'] ?? null) === 'public_cn_proxy_page'
+            && ($claim['review_decision'] ?? null) === 'approve_noindex_public_cn_proxy_page'
+            && $this->stringValue($claim['reviewer'] ?? null) !== null
+            && $this->stringValue($claim['reviewed_at'] ?? null) !== null
+            && $this->stringValue($claim['boundary_disclaimer'] ?? null) !== null
+            && $this->stringValue($claim['rollback_condition'] ?? null) !== null
+            && ($claim['indexability'] ?? null) === 'noindex'
+            && ! $this->truthy($claim['public_eligible'] ?? false)
+            && ! $this->truthy($claim['sitemap_eligible'] ?? false)
+            && ! $this->truthy($claim['llms_eligible'] ?? false)
+            && ! $this->truthy($claim['llms_full_eligible'] ?? false)
+            && is_array($claim['evidence_refs'] ?? null)
+            && $claim['evidence_refs'] !== [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $claim
+     * @param  array<string, mixed>  $plan
+     * @return array<string, mixed>
+     */
+    private function surfacePayload(string $slug, string $locale, array $claim, array $plan): array
+    {
+        $evidence = is_array($claim['evidence_refs'] ?? null) ? $claim['evidence_refs'] : [];
+        $source = is_array($evidence[0] ?? null) ? $evidence[0] : [];
+        $titleZh = $this->stringValue($source['title_zh'] ?? null) ?? $slug;
+        $titleEn = $this->stringValue($source['title_en'] ?? null) ?? $slug;
+
+        return [
+            'bundle_kind' => 'career_cn_proxy_public_owner',
+            'bundle_version' => 'career.protocol.cn_proxy_public_owner.v1',
+            'identity' => [
+                'canonical_slug' => $slug,
+                'source_slug' => $slug,
+                'public_resolution_type' => 'public_cn_proxy_page',
+                'entity_level' => 'cn_proxy_public_owner',
+            ],
+            'titles' => [
+                'canonical_en' => $titleEn,
+                'canonical_zh' => $titleZh,
+                'search_h1_zh' => $titleZh,
+            ],
+            'locale_policy' => [
+                'requested_locale' => $locale,
+                'truth_market' => 'CN',
+                'display_market' => 'CN',
+                'truth_notice_required' => true,
+            ],
+            'public_owner_policy' => [
+                'route_owner_enabled' => true,
+                'canonical_job_detail' => false,
+                'public_url_allowed' => true,
+                'indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+                'us_canonical_job_schema_returned' => false,
+                'boundary_disclaimer_required' => true,
+                'trust_manifest_required' => true,
+                'claim_policy' => 'reviewed_noindex_public_cn_proxy_page',
+            ],
+            'boundary_notice' => [
+                'text' => (string) $claim['boundary_disclaimer'],
+                'schema_policy' => $this->stringValue($claim['schema_policy'] ?? null),
+                'rollback_condition' => (string) $claim['rollback_condition'],
+            ],
+            'trust_manifest' => [
+                'reviewer_status' => $this->stringValue($claim['review_status'] ?? null) ?? 'human_reviewed',
+                'reviewer' => (string) $claim['reviewer'],
+                'reviewed_at' => (string) $claim['reviewed_at'],
+                'review_decision' => (string) $claim['review_decision'],
+                'evidence_strength' => $this->stringValue($claim['evidence_strength'] ?? null),
+                'last_validated_at' => $this->stringValue($claim['last_validated_at'] ?? null),
+            ],
+            'evidence_refs' => $evidence,
+            'seo_contract' => [
+                'canonical_path' => '/career/cn-proxy/'.$slug,
+                'canonical_target' => null,
+                'index_state' => 'noindex',
+                'index_eligible' => false,
+                'robots_policy' => 'noindex,follow',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+                'surface_type' => 'career_cn_proxy_public_owner',
+                'reason_codes' => [
+                    'cn_proxy_public_owner',
+                    'noindex_required',
+                    'not_us_canonical_job',
+                    'not_sitemap_or_llms_eligible',
+                ],
+            ],
+            'structured_data' => [
+                'occupation' => [],
+                'breadcrumb_list' => [],
+            ],
+            'provenance_meta' => [
+                'plan_status' => $this->stringValue($plan['status'] ?? null),
+                'guarded_public_owner_state' => $this->stringValue($plan['guarded_public_owner_state'] ?? null),
+                'claim_id' => $this->stringValue($claim['claim_id'] ?? null),
+                'row_number' => is_numeric($claim['row_number'] ?? null) ? (int) $claim['row_number'] : null,
+            ],
+        ];
+    }
+
+    private function configuredPath(string $key, ?string $default): ?string
+    {
+        $value = config('fap.career.'.$key);
+
+        return $this->stringValue($value) ?? $default;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function truthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value !== 0;
+        }
+
+        return in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes'], true);
+    }
+}

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -54,6 +54,14 @@ return [
     'career' => [
         'public_resolution_plan_path' => env('CAREER_PUBLIC_RESOLUTION_PLAN_PATH', null),
         'duplicate_identity_scan_path' => env('CAREER_DUPLICATE_IDENTITY_SCAN_PATH', null),
+        'cn_proxy_public_owner_plan_path' => env(
+            'CAREER_CN_PROXY_PUBLIC_OWNER_PLAN_PATH',
+            '/tmp/career_2786_cn_proxy_public_owner_plan.json',
+        ),
+        'cn_proxy_trust_manifest_path' => env(
+            'CAREER_CN_PROXY_TRUST_MANIFEST_PATH',
+            '/tmp/career_2786_cn_proxy_trust_manifest_reviewed_validator_normalized.json',
+        ),
     ],
 
     'media' => [

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2553,6 +2553,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/cn-proxy/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_career_cn_proxy_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerCnProxyPublicOwnerController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/datasets/occupations": {
             "get": {
                 "operationId": "get_api_v0_5_career_datasets_occupations",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Career\CareerAliasResolutionController;
 use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
+use App\Http\Controllers\API\V0_5\Career\CareerCnProxyPublicOwnerController;
 use App\Http\Controllers\API\V0_5\Career\CareerDatasetHubController;
 use App\Http\Controllers\API\V0_5\Career\CareerDatasetMethodController;
 use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
@@ -471,6 +472,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/first-wave/rollout-queue', [CareerFirstWaveRolloutQueueController::class, 'show']);
     Route::get('/career/first-wave/readiness', [CareerFirstWaveReadinessController::class, 'show']);
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
+    Route::get('/career/cn-proxy/{slug}', [CareerCnProxyPublicOwnerController::class, 'show']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);
     Route::get('/career/jobs/{slug}/explainability', [CareerJobExplainabilityController::class, 'show']);
     Route::get('/career/recommendations/mbti', [CareerRecommendationIndexController::class, 'index']);

--- a/backend/tests/Feature/Career/CareerCnProxyPublicOwnerApiTest.php
+++ b/backend/tests/Feature/Career/CareerCnProxyPublicOwnerApiTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerCnProxyPublicOwnerApiTest extends TestCase
+{
+    public function test_it_exposes_reviewed_cn_proxy_public_owner_surface_as_noindex_noncanonical_page(): void
+    {
+        [$planPath, $manifestPath] = $this->writeReviewedPublicOwnerArtifacts();
+        config()->set('fap.career.cn_proxy_public_owner_plan_path', $planPath);
+        config()->set('fap.career.cn_proxy_trust_manifest_path', $manifestPath);
+
+        $this->getJson('/api/v0.5/career/cn-proxy/cn-1-01-00-01?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_cn_proxy_public_owner')
+            ->assertJsonPath('identity.canonical_slug', 'cn-1-01-00-01')
+            ->assertJsonPath('identity.public_resolution_type', 'public_cn_proxy_page')
+            ->assertJsonPath('public_owner_policy.route_owner_enabled', true)
+            ->assertJsonPath('public_owner_policy.canonical_job_detail', false)
+            ->assertJsonPath('public_owner_policy.indexable', false)
+            ->assertJsonPath('public_owner_policy.sitemap_eligible', false)
+            ->assertJsonPath('public_owner_policy.llms_eligible', false)
+            ->assertJsonPath('public_owner_policy.llms_full_eligible', false)
+            ->assertJsonPath('public_owner_policy.us_canonical_job_schema_returned', false)
+            ->assertJsonPath('seo_contract.canonical_path', '/career/cn-proxy/cn-1-01-00-01')
+            ->assertJsonPath('seo_contract.index_eligible', false)
+            ->assertJsonPath('seo_contract.robots_policy', 'noindex,follow')
+            ->assertJsonPath('structured_data.occupation', [])
+            ->assertJsonPath('trust_manifest.review_decision', 'approve_noindex_public_cn_proxy_page');
+    }
+
+    public function test_existing_job_detail_api_falls_back_to_cn_proxy_surface_without_canonical_job_schema(): void
+    {
+        [$planPath, $manifestPath] = $this->writeReviewedPublicOwnerArtifacts();
+        config()->set('fap.career.cn_proxy_public_owner_plan_path', $planPath);
+        config()->set('fap.career.cn_proxy_trust_manifest_path', $manifestPath);
+
+        $this->getJson('/api/v0.5/career/jobs/cn-1-01-00-01?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_cn_proxy_public_owner')
+            ->assertJsonPath('identity.canonical_slug', 'cn-1-01-00-01')
+            ->assertJsonPath('seo_contract.robots_policy', 'noindex,follow')
+            ->assertJsonPath('public_owner_policy.canonical_job_detail', false)
+            ->assertJsonPath('structured_data.occupation', []);
+    }
+
+    public function test_it_fails_closed_when_reviewed_manifest_is_missing(): void
+    {
+        [$planPath] = $this->writeReviewedPublicOwnerArtifacts(writeManifest: false);
+        config()->set('fap.career.cn_proxy_public_owner_plan_path', $planPath);
+        config()->set('fap.career.cn_proxy_trust_manifest_path', storage_path('framework/testing/missing-cn-proxy-manifest.json'));
+
+        $this->getJson('/api/v0.5/career/cn-proxy/cn-1-01-00-01')
+            ->assertNotFound();
+    }
+
+    public function test_it_rejects_manifest_that_attempts_indexable_cn_proxy_publication(): void
+    {
+        [$planPath, $manifestPath] = $this->writeReviewedPublicOwnerArtifacts(indexable: true);
+        config()->set('fap.career.cn_proxy_public_owner_plan_path', $planPath);
+        config()->set('fap.career.cn_proxy_trust_manifest_path', $manifestPath);
+
+        $this->getJson('/api/v0.5/career/cn-proxy/cn-1-01-00-01')
+            ->assertNotFound();
+    }
+
+    /**
+     * @return array{0: string, 1?: string}
+     */
+    private function writeReviewedPublicOwnerArtifacts(bool $writeManifest = true, bool $indexable = false): array
+    {
+        $dir = storage_path('framework/testing/cn-proxy-public-owner');
+        File::ensureDirectoryExists($dir);
+
+        $manifestPath = $dir.'/reviewed-manifest.json';
+        $planPath = $dir.'/public-owner-plan.json';
+
+        if ($writeManifest) {
+            File::put($manifestPath, (string) json_encode([
+                'schema_version' => 'career_2786_cn_proxy_trust_manifest_draft.v1',
+                'status' => 'reviewed_noindex_non_indexable',
+                'claims' => [
+                    [
+                        'claim_id' => 'career-2786-cn-proxy-cn-1-01-00-01',
+                        'row_number' => 183,
+                        'slug' => 'cn-1-01-00-01',
+                        'source_slug' => 'cn-1-01-00-01',
+                        'public_resolution_type' => 'public_cn_proxy_page',
+                        'public_eligible' => false,
+                        'claim_text' => 'CN proxy occupation boundary claim for 中国共产党机关负责人.',
+                        'claim_locale' => 'zh-CN,en',
+                        'source_authority_model' => 'career_2786_public_resolution_plan_d23b_cn_proxy_scope',
+                        'evidence_refs' => [
+                            [
+                                'artifact' => '/tmp/career_2786_public_resolution_partition_after_occupation_apply.json',
+                                'source_row_number' => 183,
+                                'source_code' => '11-1011.00',
+                                'title_en' => 'Chinese Communist Party Agency Managers',
+                                'title_zh' => '中国共产党机关负责人',
+                            ],
+                        ],
+                        'evidence_strength' => 'source_plan_scope_with_reviewed_proxy_mapping',
+                        'reviewer' => 'reviewer',
+                        'reviewed_at' => '2026-05-15T21:30:56Z',
+                        'review_status' => 'human_reviewed',
+                        'schema_policy' => 'public_cn_proxy_page_noindex_non_sitemap_non_llms_until_release_gate',
+                        'indexability' => $indexable ? 'indexable' : 'noindex',
+                        'sitemap_eligible' => false,
+                        'llms_eligible' => false,
+                        'llms_full_eligible' => false,
+                        'boundary_disclaimer' => 'This CN occupation proxy page describes a China-source occupation boundary and is not a US canonical job page.',
+                        'rollback_condition' => 'Remove or keep blocked if reviewer approval, source authority evidence, disclaimer, noindex policy, or release gate validation fails.',
+                        'last_validated_at' => '2026-05-15T21:25:03Z',
+                        'review_decision' => 'approve_noindex_public_cn_proxy_page',
+                        'review_notes' => 'human review confirmed; preserve noindex/non-sitemap/non-llms policy',
+                    ],
+                ],
+            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+        } else {
+            File::delete($manifestPath);
+        }
+
+        File::put($planPath, (string) json_encode([
+            'status' => 'validated',
+            'command' => 'career:validate-cn-proxy-public-owner',
+            'dry_run' => true,
+            'did_write' => false,
+            'manifest_path' => $manifestPath,
+            'cn_proxy_rows' => 1663,
+            'reviewed_trust_manifest_rows' => 1663,
+            'reviewed_trust_manifest_complete' => true,
+            'public_owner_plan_ready' => true,
+            'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
+            'public_cn_proxy_page_rows' => 1663,
+            'indexable_CN_proxy_rows' => 0,
+            'sitemap_CN_urls' => 0,
+            'llms_CN_urls' => 0,
+            'llms_full_CN_urls' => 0,
+            'display_asset_delta' => 0,
+            'career_job_display_assets_delta' => 0,
+            'occupations_delta' => 0,
+            'occupation_crosswalks_delta' => 0,
+            'CN_proxy_can_masquerade_as_US_canonical_job' => false,
+            'US_canonical_job_schema_returned' => false,
+            'noindex_default' => true,
+            'blockers' => [],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+
+        return $writeManifest ? [$planPath, $manifestPath] : [$planPath];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1015,6 +1015,27 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_cn_proxy_public_owner_surface_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerCnProxyPublicOwnerController.php',
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php',
+            'backend/app/Services/Career/Bundles/CareerCnProxyPublicOwnerSurfaceBuilder.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerCnProxyPublicOwnerController;',
+            "+    Route::get('/career/cn-proxy/{slug}', [CareerCnProxyPublicOwnerController::class, 'show']);",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_asset_backed_bundle_changes(): void
     {
         $changed = [
@@ -1522,6 +1543,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
             if (
                 $file === 'backend/routes/api.php'
+                && $this->routeDiffIsCareerCnProxyPublicOwnerSurfaceOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCareerPublicDistributionOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
@@ -1951,8 +1979,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php',
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerCnProxyPublicOwnerController.php',
             'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php',
             'backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerCnProxyPublicOwnerSurfaceBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php',
             'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
@@ -2483,6 +2513,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticlePublishControlled\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsCareerCnProxyPublicOwnerSurfaceOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (preg_match('/CareerCnProxyPublicOwnerController|\\/career\\/cn-proxy\\/\\{slug\\}/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T08:28:18+08:00",
+  "updated_at": "2026-05-17T09:56:25+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -8243,6 +8243,71 @@
         }
       ],
       "next_pr": "PRODUCT_POLICY_DECISION_OR_VISIBLE_GAP_REMEDIATION"
+    },
+    "REPAIR-CN-PROXY-NOINDEX-PUBLIC-OWNER-SURFACE-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-cn-proxy-noindex-public-owner-surface-1",
+      "status": "local_validated",
+      "title": "fix(api): add guarded CN proxy noindex public-owner surface",
+      "checks": {
+        "train_registration_authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-CN-PROXY-NOINDEX-PUBLIC-OWNER-SURFACE-1."
+        },
+        "scope": {
+          "status": "planned",
+          "evidence": "Backend-only guarded CN proxy noindex public-owner surface; no DB mutation, deploy, rollout, sitemap, llms, canonical job publication, or fap-web action."
+        },
+        "openapi_snapshot_scope": {
+          "status": "planned",
+          "evidence": "New public API route requires backend/docs/contracts/openapi.snapshot.json update; no runtime semantics beyond route contract snapshot."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to career API route/controller/service/config/tests, OpenAPI snapshot, and authorized PR train metadata."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=CareerCnProxyPublicOwnerApi --no-ansi",
+          "evidence": "4 tests passed, 24 assertions."
+        },
+        "cn_proxy_validator_regression": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi",
+          "evidence": "5 tests passed, 79 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan route:list --no-ansi",
+          "evidence": "api/v0.5/career/cn-proxy/{slug} is registered; route:list exits 0."
+        },
+        "sqlite_migrate_pretend": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-ansi --force",
+          "evidence": "Migration SQL generation completed successfully; no production DB used."
+        },
+        "openapi_snapshot": {
+          "status": "pass",
+          "command": "bash scripts/export_openapi.sh --check",
+          "evidence": "Snapshot updated for the new route and check reports up-to-date."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3281 files passed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full CI master chain exited 0 after OpenAPI snapshot update."
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null
     }
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T09:56:25+08:00",
+  "updated_at": "2026-05-17T09:57:18+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -8247,7 +8247,7 @@
     "REPAIR-CN-PROXY-NOINDEX-PUBLIC-OWNER-SURFACE-1": {
       "repo": "fap-api",
       "branch": "codex/repair-cn-proxy-noindex-public-owner-surface-1",
-      "status": "local_validated",
+      "status": "pr_open",
       "title": "fix(api): add guarded CN proxy noindex public-owner surface",
       "checks": {
         "train_registration_authorization": {
@@ -8304,10 +8304,16 @@
           "status": "pass",
           "command": "bash backend/scripts/ci_verify_mbti.sh",
           "evidence": "Full CI master chain exited 0 after OpenAPI snapshot update."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR opened as https://github.com/fermatmind/fap-api/pull/1431; GitHub checks pending at PR creation."
         }
       },
       "sidecar_issues": [],
-      "failure_reason": null
+      "failure_reason": null,
+      "commit_sha": "39c079a34babf048df02f39bdd9fdda78dc07d9e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1431"
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -4301,3 +4301,44 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+
+  - id: REPAIR-CN-PROXY-NOINDEX-PUBLIC-OWNER-SURFACE-1
+    repo: fap-api
+    branch: codex/repair-cn-proxy-noindex-public-owner-surface-1
+    title: "fix(api): add guarded CN proxy noindex public-owner surface"
+    name: "Add guarded CN proxy noindex public-owner surface"
+    findings:
+      - "Reviewed CN proxy public-owner rows have policy evidence but no guarded backend route owner surface."
+      - "CN proxy rows must remain noindex and noncanonical while exposing a controlled owner-facing public surface."
+    scope:
+      - Add a backend-owned CN proxy public-owner API surface for reviewed public_cn_proxy_page claims.
+      - Fail closed unless the reviewed trust manifest and public-owner plan prove noindex, noncanonical, non-sitemap, and non-llms policy.
+      - Preserve canonical career job rollout, dataset, search, sitemap, and llms exclusion for CN proxy rows.
+      - Add regression coverage for direct CN proxy route, career job detail fallback, missing manifest, and indexability rejection.
+    allowed_paths:
+      - backend/routes/api.php
+      - backend/config/fap.php
+      - backend/app/Http/Controllers/API/V0_5/Career/**
+      - backend/app/Services/Career/Bundles/**
+      - backend/tests/Feature/Career/**
+      - backend/docs/contracts/openapi.snapshot.json
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Publish CN proxy rows as public_canonical_job.
+      - Mark CN proxy rows indexable.
+      - Add CN proxy URLs to sitemap, llms, or llms-full.
+      - Mutate DB, deploy, rollout, backfill, rollback, quarantine, or touch fap-web.
+    validation:
+      - php artisan test --filter=CareerCnProxyPublicOwnerApi --no-ansi
+      - php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi
+      - php artisan route:list --no-ansi
+      - bash scripts/export_openapi.sh --check
+      - vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds a guarded backend CN proxy public-owner surface at `GET /api/v0.5/career/cn-proxy/{slug}`.
- Allows `/api/v0.5/career/jobs/{slug}` to fail over to the CN proxy owner surface only for reviewed `cn-*` proxy slugs.
- Fails closed unless the public-owner plan and reviewed trust manifest prove noindex, noncanonical, non-sitemap, and non-llms policy.
- Updates the OpenAPI snapshot and PR train ledger for `REPAIR-CN-PROXY-NOINDEX-PUBLIC-OWNER-SURFACE-1`.

## Non-goals
- No DB mutation.
- No deploy.
- No rollout/apply/backfill/rollback/quarantine.
- No fap-web changes.
- No canonical job publication for CN proxy rows.
- No sitemap, llms, llms-full, or indexable exposure for CN proxy rows.

## Tests
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=CareerCnProxyPublicOwnerApi --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `bash scripts/export_openapi.sh --check`
- `vendor/bin/pint --test`
- `git diff --check && git diff --cached --check`
- `bash backend/scripts/ci_verify_mbti.sh`
