### PR TITLE
fix(api): promote display-backed directory draft jobs in list authority

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -10,7 +10,9 @@ use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\DTO\Career\CareerJobListItemBundle;
 use App\Models\CareerCompileRun;
 use App\Models\CareerJob;
+use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
 use App\Models\RecommendationSnapshot;
 use App\Models\Scopes\TenantScope;
 use App\Services\PublicSurface\SeoSurfaceContractService;
@@ -24,6 +26,20 @@ final class CareerJobListBundleBuilder
 
     private const PUBLIC_DIRECTORY_STUB_KIND = 'public_directory_stub';
 
+    private const DISPLAY_SURFACE_VERSION = 'display.surface.v1';
+
+    private const DISPLAY_ASSET_VERSION = 'v4.2';
+
+    private const DISPLAY_ASSET_TYPE = 'career_job_public_display';
+
+    private const DISPLAY_READY_STATUS = 'ready_for_pilot';
+
+    private const DISPLAY_COMPONENT_ORDER_COUNT = 24;
+
+    private const DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS = [
+        'software-developers',
+    ];
+
     private const MAX_PUBLIC_COMPILED_ROWS = 3200;
 
     private const MAX_PUBLIC_DOCX_ROWS = 3200;
@@ -33,6 +49,7 @@ final class CareerJobListBundleBuilder
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerRuntimePublishProjectionVisibility $runtimePublishProjection,
+        private readonly CareerJobDisplaySurfaceBuilder $displaySurfaceBuilder,
     ) {}
 
     /**
@@ -424,6 +441,10 @@ final class CareerJobListBundleBuilder
 
     private function buildDirectoryDraftCareerJobItem(Occupation $occupation): CareerJobListItemBundle
     {
+        if ($this->directoryDraftHasDisplayAssetBackedDetail($occupation)) {
+            return $this->buildDisplayAssetBackedDirectoryDraftCareerJobItem($occupation);
+        }
+
         return new CareerJobListItemBundle(
             identity: [
                 'canonical_slug' => $occupation->canonical_slug,
@@ -448,6 +469,53 @@ final class CareerJobListBundleBuilder
             scoreSummary: [],
             seoContract: $this->buildDirectoryDraftSeoContract($occupation, 'career_job_list_item_bundle'),
             provenanceMeta: [],
+        );
+    }
+
+    private function buildDisplayAssetBackedDirectoryDraftCareerJobItem(Occupation $occupation): CareerJobListItemBundle
+    {
+        return new CareerJobListItemBundle(
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+                'entity_level' => $occupation->entity_level,
+                'family_uuid' => $occupation->family_id,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $occupation->canonical_title_zh,
+                'search_h1_zh' => $occupation->search_h1_zh,
+            ],
+            truthSummary: [
+                'truth_market' => $occupation->truth_market,
+            ],
+            trustSummary: [
+                'reviewer_status' => 'pilot_display_asset',
+                'reviewed_at' => null,
+                'content_version' => 'display_asset_backed_v4_2',
+                'data_version' => 'career_job_display_assets.v4.2',
+                'logic_version' => 'career.protocol.job_list.display_asset_backed.v1',
+                'editorial_patch_required' => false,
+                'editorial_patch_status' => null,
+                'allow_strong_claim' => false,
+                'allow_salary_comparison' => false,
+                'allow_ai_strategy' => false,
+                'reason_codes' => ['validated_display_asset_backed_release', 'runtime_publish_projection'],
+            ],
+            scoreSummary: [],
+            seoContract: $this->buildDisplayAssetBackedDirectoryDraftSeoContract($occupation),
+            provenanceMeta: [
+                'content_version' => 'display_asset_backed_v4_2',
+                'data_version' => 'career_job_display_assets.v4.2',
+                'logic_version' => 'career.protocol.job_list.display_asset_backed.v1',
+                'compiler_version' => null,
+                'compiled_at' => null,
+                'truth_metric_id' => null,
+                'trust_manifest_id' => null,
+                'index_state_id' => null,
+                'compile_run_id' => null,
+                'import_run_id' => null,
+            ],
         );
     }
 
@@ -601,6 +669,41 @@ final class CareerJobListBundleBuilder
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    private function buildDisplayAssetBackedDirectoryDraftSeoContract(Occupation $occupation): array
+    {
+        $canonicalPath = '/career/jobs/'.(string) $occupation->canonical_slug;
+        $indexEligible = $this->runtimeProjectionVisibilityAllowsIndexing((string) $occupation->canonical_slug);
+        $indexState = $indexEligible ? IndexStateValue::INDEXABLE : IndexStateValue::TRUST_LIMITED;
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_job_list_item_display_asset_backed_bundle',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => $indexState,
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalPath,
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => $indexEligible
+                ? ['validated_display_asset_backed_release', 'runtime_publish_projection']
+                : ['display_asset_backed_pilot_noindex'],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
      * @param  array<string, mixed>  $projectionItem
      * @return array<string, mixed>
      */
@@ -666,5 +769,92 @@ final class CareerJobListBundleBuilder
     {
         return is_string(data_get($job->seoMeta?->jsonld_overrides_json, 'source_docx'))
             && data_get($job->market_demand_json, 'source_refs.0.url') !== null;
+    }
+
+    private function directoryDraftHasDisplayAssetBackedDetail(Occupation $occupation): bool
+    {
+        $slug = strtolower(trim((string) $occupation->canonical_slug));
+        if ($slug === '' || in_array($slug, self::DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS, true)) {
+            return false;
+        }
+
+        if (! $this->runtimeProjectionVisibilityAllowsIndexing($slug)) {
+            return false;
+        }
+
+        if (! $this->hasDisplayAssetBackedAuthority($occupation)) {
+            return false;
+        }
+
+        if (! $this->validDisplayAssetBackedAsset($occupation, $slug) instanceof CareerJobDisplayAsset) {
+            return false;
+        }
+
+        return $this->displaySurfaceBuilder->buildForOccupation($occupation, 'en') !== null;
+    }
+
+    private function runtimeProjectionVisibilityAllowsIndexing(string $slug): bool
+    {
+        return $this->runtimePublishProjection->detailRouteEnabled($slug)
+            && $this->runtimePublishProjection->robotsIndexable($slug)
+            && $this->runtimePublishProjection->releaseGatePass($slug);
+    }
+
+    private function hasDisplayAssetBackedAuthority(Occupation $occupation): bool
+    {
+        $occupation->loadMissing('crosswalks');
+
+        $requiredSystems = ['us_soc', 'onet_soc_2019'];
+        foreach ($requiredSystems as $sourceSystem) {
+            $rows = $occupation->crosswalks
+                ->filter(static fn (OccupationCrosswalk $crosswalk): bool => strtolower((string) $crosswalk->source_system) === $sourceSystem)
+                ->values();
+
+            if ($rows->count() !== 1) {
+                return false;
+            }
+
+            $sourceCode = trim((string) $rows->first()?->source_code);
+            if ($sourceCode === '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function validDisplayAssetBackedAsset(Occupation $occupation, string $subjectSlug): ?CareerJobDisplayAsset
+    {
+        $assets = CareerJobDisplayAsset::query()
+            ->where('occupation_id', $occupation->id)
+            ->where('canonical_slug', $subjectSlug)
+            ->where('surface_version', self::DISPLAY_SURFACE_VERSION)
+            ->where('asset_version', self::DISPLAY_ASSET_VERSION)
+            ->where('template_version', self::DISPLAY_ASSET_VERSION)
+            ->where('status', self::DISPLAY_READY_STATUS)
+            ->where('asset_type', self::DISPLAY_ASSET_TYPE)
+            ->get();
+
+        if ($assets->count() !== 1) {
+            return null;
+        }
+
+        $asset = $assets->first();
+        if (! $asset instanceof CareerJobDisplayAsset) {
+            return null;
+        }
+
+        $componentOrder = is_array($asset->component_order_json) ? array_values($asset->component_order_json) : [];
+        if (count($componentOrder) !== self::DISPLAY_COMPONENT_ORDER_COUNT) {
+            return null;
+        }
+
+        $pages = is_array($asset->page_payload_json) ? $asset->page_payload_json : [];
+        $localizedPages = is_array($pages['page'] ?? null) ? $pages['page'] : $pages;
+        if (! is_array($localizedPages['zh'] ?? null) || ! is_array($localizedPages['en'] ?? null)) {
+            return null;
+        }
+
+        return $asset;
     }
 }

--- a/backend/docs/career/audits/directory_detail_pending_display_asset_authority.md
+++ b/backend/docs/career/audits/directory_detail_pending_display_asset_authority.md
@@ -1,0 +1,28 @@
+# Directory Detail Pending Display Asset Authority
+
+## Purpose
+
+The career jobs list must not keep a directory draft occupation as a public directory stub when the backend can already serve a validated display-asset-backed detail bundle for that same slug.
+
+This authority separates two states:
+
+- Directory draft without validated detail evidence remains a noindex `public_directory_stub`.
+- Directory draft with a valid display asset, runtime projection indexability, and release gate pass is listed as a detail-ready career item.
+
+## Required evidence
+
+A directory draft item can be upgraded from `detail_page_unavailable` only when all checks pass:
+
+- The runtime projection enables the detail route.
+- The runtime projection marks the slug robots-indexable.
+- The runtime projection release gate passes.
+- The slug is not an explicit manual hold such as `software-developers`.
+- The occupation has exactly one `us_soc` and exactly one `onet_soc_2019` crosswalk row with non-empty source codes.
+- Exactly one ready `career_job_public_display` asset exists for the occupation and canonical slug.
+- The display asset is `display.surface.v1` / `v4.2`, has 24 ordered components, and has both `zh` and `en` page payloads.
+- The display surface builder accepts the public page contract without forbidden public keys or product schema leakage.
+
+## Non-goals
+
+This change does not publish new rows, mutate production data, weaken rollout gates, or turn CN proxy / manual-hold rows into canonical jobs. It only makes the list surface use the same validated display-asset authority that the detail route already enforces.
+

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
 use App\Models\OccupationCrosswalk;
@@ -13,11 +15,49 @@ use App\Models\OccupationFamily;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerJobListApiTest extends TestCase
 {
     use RefreshDatabase;
+
+    private const DISPLAY_COMPONENT_ORDER = [
+        'breadcrumb',
+        'hero',
+        'fermat_decision_card',
+        'primary_cta',
+        'career_snapshot_primary_locale',
+        'career_snapshot_secondary_locale',
+        'fit_decision_checklist',
+        'riasec_fit_block',
+        'personality_fit_block',
+        'definition_block',
+        'responsibilities_block',
+        'work_context_block',
+        'market_signal_card',
+        'adjacent_career_comparison_table',
+        'ai_impact_table',
+        'career_risk_cards',
+        'contract_project_risk_block',
+        'next_steps_block',
+        'faq_block',
+        'related_next_pages',
+        'source_card',
+        'methodology_note',
+        'trust_footer',
+        'schema_anchor',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture,
+        );
+    }
 
     public function test_it_returns_a_resource_backed_lightweight_job_index(): void
     {
@@ -115,6 +155,92 @@ final class CareerJobListApiTest extends TestCase
         $this->getJson('/api/v0.5/career/jobs/cn-digital-compliance-specialist')
             ->assertStatus(404)
             ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_directory_draft_with_valid_display_asset_is_listed_as_detail_ready(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                detailRouteEnabled: ['acupuncturists' => true],
+                robotsIndexable: ['acupuncturists' => true],
+                releaseGatePass: ['acupuncturists' => true],
+            ),
+        );
+
+        $occupation = $this->createDirectoryDraftOccupation([
+            'canonical_slug' => 'acupuncturists',
+            'canonical_title_en' => 'Acupuncturists',
+            'canonical_title_zh' => '针灸师',
+            'search_h1_zh' => '针灸师',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+        ]);
+        $this->addDisplayAssetBackedCrosswalks($occupation, '29-1291', '29-1291.00');
+        $this->createDisplayAsset($occupation->refresh());
+
+        $response = $this->getJson('/api/v0.5/career/jobs')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'acupuncturists')
+            ->assertJsonPath('items.0.identity.entity_level', 'dataset_candidate')
+            ->assertJsonPath('items.0.trust_summary.reviewer_status', 'pilot_display_asset')
+            ->assertJsonPath('items.0.trust_summary.logic_version', 'career.protocol.job_list.display_asset_backed.v1')
+            ->assertJsonPath('items.0.trust_summary.reason_codes.0', 'validated_display_asset_backed_release')
+            ->assertJsonPath('items.0.trust_summary.reason_codes.1', 'runtime_publish_projection')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', true)
+            ->assertJsonPath('items.0.seo_contract.index_state', 'indexable')
+            ->assertJsonPath('items.0.seo_contract.reason_codes.0', 'validated_display_asset_backed_release')
+            ->assertJsonPath('items.0.seo_contract.reason_codes.1', 'runtime_publish_projection')
+            ->assertJsonPath('items.0.seo_contract.robots_policy', 'index,follow')
+            ->assertJsonMissingPath('items.0.trust_summary.public_stub_kind')
+            ->assertJsonMissingPath('items.0.trust_summary.status')
+            ->assertJsonMissingPath('items.0.trust_summary.availability')
+            ->assertJsonMissingPath('items.0.seo_contract.public_stub_kind')
+            ->assertJsonMissingPath('items.0.governance')
+            ->assertJsonMissingPath('items.0.readiness');
+
+        $encoded = json_encode($response->json(), JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('release_gate', $encoded);
+        $this->assertStringNotContainsString('tracking_json', $encoded);
+        $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
+
+        $this->getJson('/api/v0.5/career/jobs/acupuncturists?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'acupuncturists')
+            ->assertJsonPath('seo_contract.index_eligible', true)
+            ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1');
+    }
+
+    public function test_directory_draft_display_asset_remains_stub_when_runtime_projection_rejects_indexing(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                detailRouteEnabled: ['business-intelligence-analysts' => true],
+                robotsIndexable: ['business-intelligence-analysts' => false],
+                releaseGatePass: ['business-intelligence-analysts' => true],
+            ),
+        );
+
+        $occupation = $this->createDirectoryDraftOccupation([
+            'canonical_slug' => 'business-intelligence-analysts',
+            'canonical_title_en' => 'Business Intelligence Analysts',
+            'canonical_title_zh' => '商业智能分析师',
+            'search_h1_zh' => '商业智能分析师',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+        ]);
+        $this->addDisplayAssetBackedCrosswalks($occupation, '15-2051', '15-2051.01');
+        $this->createDisplayAsset($occupation->refresh());
+
+        $this->getJson('/api/v0.5/career/jobs')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'business-intelligence-analysts')
+            ->assertJsonPath('items.0.trust_summary.public_stub_kind', 'public_directory_stub')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('items.0.seo_contract.reason_codes.0', 'detail_page_unavailable');
     }
 
     /**
@@ -217,5 +343,102 @@ final class CareerJobListApiTest extends TestCase
         ]);
 
         return $occupation->fresh();
+    }
+
+    private function addDisplayAssetBackedCrosswalks(Occupation $occupation, string $socCode, string $onetCode): void
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'display_asset_crosswalks',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'display-asset-crosswalks-'.$occupation->canonical_slug,
+            'scope_mode' => 'display_asset_backed_directory_draft',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'us_soc',
+            'source_code' => $socCode,
+            'source_title' => (string) $occupation->canonical_title_en,
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1,
+            'import_run_id' => $importRun->id,
+            'row_fingerprint' => hash('sha256', 'display-asset-us-soc-'.$occupation->canonical_slug),
+        ]);
+
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'onet_soc_2019',
+            'source_code' => $onetCode,
+            'source_title' => (string) $occupation->canonical_title_en,
+            'mapping_type' => 'directory_candidate',
+            'confidence_score' => 0.5,
+            'import_run_id' => $importRun->id,
+            'row_fingerprint' => hash('sha256', 'display-asset-onet-'.$occupation->canonical_slug),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createDisplayAsset(Occupation $occupation, array $overrides = []): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create(array_replace([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => self::DISPLAY_COMPONENT_ORDER,
+            'page_payload_json' => [
+                'zh' => [
+                    'hero' => ['title' => (string) $occupation->canonical_title_zh],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'BLS official wage evidence',
+                        'body' => 'Official wage signal from BLS.',
+                    ],
+                    'ai_impact_table' => [
+                        'score_normalized' => '82',
+                        'label' => 'medium',
+                        'source' => 'FermatMind central score',
+                    ],
+                ],
+                'en' => [
+                    'hero' => ['title' => (string) $occupation->canonical_title_en],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'BLS official wage evidence',
+                        'body' => 'Official wage signal from BLS.',
+                    ],
+                    'ai_impact_table' => [
+                        'score_normalized' => '82',
+                        'label' => 'medium',
+                        'source' => 'FermatMind central score',
+                    ],
+                ],
+            ],
+            'sources_json' => [
+                'primary' => [
+                    ['label' => 'BLS Occupational Outlook Handbook', 'url' => 'https://example.test/bls'],
+                ],
+            ],
+            'structured_data_json' => [
+                '@type' => 'Occupation',
+                'name' => (string) $occupation->canonical_title_en,
+                'raw_ai_exposure_score' => 8.2,
+            ],
+            'implementation_contract_json' => [
+                'structured_data_policy' => 'visible_content_only',
+                'tracking_json' => ['do_not_show' => true],
+            ],
+            'metadata_json' => [
+                'validator_version' => 'career_asset_import_validator_v0.1',
+            ],
+        ], $overrides));
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T09:57:18+08:00",
+  "updated_at": "2026-05-17T11:05:12+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2496,7 +2496,7 @@
       "branch": "fix/career-audit-entity-index-context-consumer",
       "title": "fix(api): add career audit entity index context inputs",
       "name": "Add entity and index context artifact inputs for 2786 audit",
-      "status": "in_progress",
+      "status": "local_validation_passed",
       "depends_on": [
         "REPAIR-RUN-CTX-1"
       ],
@@ -8314,6 +8314,88 @@
       "failure_reason": null,
       "commit_sha": "39c079a34babf048df02f39bdd9fdda78dc07d9e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1431"
+    },
+    "REPAIR-DIRECTORY-DETAIL-PENDING-314-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-directory-detail-pending-314-1",
+      "base": "main",
+      "depends_on": [
+        "REPAIR-CN-PROXY-NOINDEX-PUBLIC-OWNER-SURFACE-1"
+      ],
+      "status": "in_progress",
+      "train_scope": "career_directory_detail_pending_authority",
+      "risk_level": "medium",
+      "title": "fix(api): promote display-backed directory draft jobs in list authority",
+      "name": "Repair directory pending detail list authority for display-asset-backed Career jobs",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-DIRECTORY-DETAIL-PENDING-314-1, then implementing the PR."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are confined to backend Career jobs list detail readiness authority, focused tests/docs, docs, and authorized train metadata. No fap-web, deploy, DB mutation, rollout, apply, or content generation was performed."
+        },
+        "career_job_list_api": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Career/CareerJobListApiTest.php --no-ansi",
+          "evidence": "5 tests passed, 94 assertions."
+        },
+        "career_job_display_surface_api": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi",
+          "evidence": "14 tests passed, 786 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-directory-detail-pending-314.sqlite php artisan migrate --force --no-ansi",
+          "evidence": "SQLite migration completed successfully in local testing database."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobListBundleBuilder.php tests/Feature/Career/CareerJobListApiTest.php",
+          "evidence": "Style check passed after formatting scoped files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "Whitespace checks passed."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full CI master chain exited 0."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR not opened yet at local validation checkpoint."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-17T10:54:07+08:00",
+          "status": "in_progress",
+          "summary": "Registered authorized directory detail pending repair PR and started implementation from clean origin/main worktree."
+        },
+        {
+          "at": "2026-05-17T11:05:12+08:00",
+          "status": "local_validation_passed",
+          "summary": "Implemented display-asset-backed directory draft list authority and passed focused Career tests, route list, sqlite migrate, scoped Pint, diff checks, and full MBTI CI chain."
+        }
+      ],
+      "next_pr": "SCAN-2786-VISIBLE-DETAIL-GAP-AFTER-DIRECTORY-DETAIL-REPAIR-1"
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -4342,3 +4342,42 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+
+  - id: REPAIR-DIRECTORY-DETAIL-PENDING-314-1
+    repo: fap-api
+    branch: codex/repair-directory-detail-pending-314-1
+    title: "fix(api): promote display-backed directory draft jobs in list authority"
+    name: "Repair directory pending detail list authority for display-asset-backed Career jobs"
+    findings:
+      - "Post-CN-proxy visible gap scan found directory-draft occupations whose detail endpoints already return validated display-asset-backed bundles while the jobs list still marks them as detail_page_unavailable stubs."
+      - "The product-visible count must be driven by backend detail readiness, not stale directory stub semantics."
+    scope:
+      - Make the Career jobs list upgrade directory_draft occupations to detail-ready list items only when display asset, runtime projection, and release gate evidence match the detail route authority.
+      - Preserve noindex public directory stubs for directory drafts without valid display assets or runtime projection indexability.
+      - Preserve explicit manual holds such as software-developers.
+      - Add regression coverage for display-backed directory draft list readiness and projection rejection.
+    allowed_paths:
+      - backend/app/Services/Career/Bundles/**
+      - backend/tests/Feature/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Mutate DB or generate production content.
+      - Run rollout, apply, backfill, rollback, quarantine, or deploy.
+      - Change CN proxy public-owner noindex policy.
+      - Force-enable software-developers or any manual-hold slug.
+      - Touch fap-web.
+    validation:
+      - php artisan test tests/Feature/Career/CareerJobListApiTest.php --no-ansi
+      - php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
+      - vendor/bin/pint --test app/Services/Career/Bundles/CareerJobListBundleBuilder.php tests/Feature/Career/CareerJobListApiTest.php
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Promote directory-draft Career jobs from `public_directory_stub` to detail-ready list items only when validated display-asset evidence, SOC/O*NET authority, runtime projection indexability, and release gate pass all agree.
- Preserve noindex stub behavior for missing display evidence or runtime projection rejection, and keep `software-developers` manual hold closed.
- Register `REPAIR-DIRECTORY-DETAIL-PENDING-314-1` in the PR train metadata and document the authority boundary.

## Tests
- `php artisan test tests/Feature/Career/CareerJobListApiTest.php --no-ansi`
- `php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobListBundleBuilder.php tests/Feature/Career/CareerJobListApiTest.php`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-directory-detail-pending-314.sqlite php artisan migrate --force --no-ansi`
- `git diff --check && git diff --cached --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Non-goals
- No DB mutation, rollout, apply, deploy, backfill, rollback, quarantine, content generation, CN proxy policy weakening, or fap-web change.

## Next
- After merge and backend deploy, run `SCAN-2786-VISIBLE-DETAIL-GAP-AFTER-DIRECTORY-DETAIL-REPAIR-1` to measure product-visible detail count again.