### PR TITLE
fix(api): align directory list with runtime detail authority

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -445,6 +445,11 @@ final class CareerJobListBundleBuilder
             return $this->buildDisplayAssetBackedDirectoryDraftCareerJobItem($occupation);
         }
 
+        $runtimeProjectionItem = $this->runtimePublishedDirectoryDraftProjectionItem($occupation);
+        if ($runtimeProjectionItem !== null) {
+            return $this->buildRuntimeProjectionCareerJobItem($occupation, $runtimeProjectionItem);
+        }
+
         return new CareerJobListItemBundle(
             identity: [
                 'canonical_slug' => $occupation->canonical_slug,
@@ -798,6 +803,51 @@ final class CareerJobListBundleBuilder
         return $this->runtimePublishProjection->detailRouteEnabled($slug)
             && $this->runtimePublishProjection->robotsIndexable($slug)
             && $this->runtimePublishProjection->releaseGatePass($slug);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function runtimePublishedDirectoryDraftProjectionItem(Occupation $occupation): ?array
+    {
+        $slug = strtolower(trim((string) $occupation->canonical_slug));
+        if ($slug === '' || in_array($slug, self::DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS, true)) {
+            return null;
+        }
+
+        $item = $this->runtimePublishProjection->itemForSlug($slug, 'en');
+        if (! is_array($item)) {
+            return null;
+        }
+
+        $state = (string) (
+            $item['runtime_publish_state']
+            ?? $item['runtime_state']
+            ?? $item['projection_state']
+            ?? $item['state']
+            ?? ''
+        );
+
+        if ($state !== 'published') {
+            return null;
+        }
+
+        if (($item['detail_route_enabled'] ?? false) !== true
+            || ($item['robots_indexable'] ?? false) !== true
+            || ($item['release_gate_pass'] ?? false) !== true) {
+            return null;
+        }
+
+        return array_merge($item, [
+            'slug' => $slug,
+            'canonical_path' => is_string($item['canonical_path'] ?? null)
+                ? $item['canonical_path']
+                : '/career/jobs/'.$slug,
+            'reason_codes' => array_values(array_unique(array_filter(array_merge(
+                ['runtime_publish_projection', 'runtime_published_navigation_shell'],
+                is_array($item['reason_codes'] ?? null) ? $item['reason_codes'] : [],
+            ), static fn (mixed $reason): bool => is_scalar($reason) && trim((string) $reason) !== ''))),
+        ]);
     }
 
     private function hasDisplayAssetBackedAuthority(Occupation $occupation): bool

--- a/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
@@ -45,6 +45,13 @@ final class CareerFullDatasetAuthorityBuilder
 
     private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
 
+    /**
+     * @var list<string>
+     */
+    private const DIRECTORY_DRAFT_MANUAL_HOLD_SLUGS = [
+        'software-developers',
+    ];
+
     public function __construct(
         private readonly CareerFullReleaseLedgerService $fullReleaseLedgerService,
         private readonly CareerStrongIndexEligibilityService $strongIndexEligibilityService,
@@ -196,15 +203,27 @@ final class CareerFullDatasetAuthorityBuilder
             }
             unset($runtimeDatasetItemsBySlug[$directoryDraftMember->canonicalSlug]);
 
-            $releaseCohort = 'directory_draft_pending_detail';
-            $publicIndexState = 'noindex';
-            $strongIndexDecision = 'directory_draft_detail_pending';
+            $releaseCohort = $directoryDraftMember->releaseCohort ?? 'directory_draft_pending_detail';
+            $publicIndexState = $directoryDraftMember->publicIndexState ?? 'noindex';
+            $strongIndexDecision = $directoryDraftMember->strongIndexDecision ?? 'directory_draft_detail_pending';
             $familySlug = $directoryDraftMember->familySlug ?? '__unknown__';
             $publishTrack = $directoryDraftMember->publishTrack ?? 'directory_draft';
 
-            $includedCount++;
-            $releaseCohortCounts[$releaseCohort] = (int) ($releaseCohortCounts[$releaseCohort] ?? 0) + 1;
-            $includedReleaseCohortCounts[$releaseCohort] = (int) ($includedReleaseCohortCounts[$releaseCohort] ?? 0) + 1;
+            if ($directoryDraftMember->includedInPublicDataset) {
+                $includedCount++;
+            } else {
+                $excludedCount++;
+            }
+
+            if ($releaseCohort !== null) {
+                $releaseCohortCounts[$releaseCohort] = (int) ($releaseCohortCounts[$releaseCohort] ?? 0) + 1;
+                if ($directoryDraftMember->includedInPublicDataset) {
+                    $includedReleaseCohortCounts[$releaseCohort] = (int) ($includedReleaseCohortCounts[$releaseCohort] ?? 0) + 1;
+                } else {
+                    $excludedReleaseCohortCounts[$releaseCohort] = (int) ($excludedReleaseCohortCounts[$releaseCohort] ?? 0) + 1;
+                }
+            }
+
             $publicIndexStateCounts[$publicIndexState] = (int) ($publicIndexStateCounts[$publicIndexState] ?? 0) + 1;
             $strongDecisionCounts[$strongIndexDecision] = (int) ($strongDecisionCounts[$strongIndexDecision] ?? 0) + 1;
             $familyDistribution[$familySlug] = (int) ($familyDistribution[$familySlug] ?? 0) + 1;
@@ -372,6 +391,19 @@ final class CareerFullDatasetAuthorityBuilder
             ->filter(fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
             ->map(function (Occupation $occupation): CareerFullDatasetMember {
                 $familySlug = $occupation->family?->canonical_slug;
+                $runtimeProjectionItem = $this->runtimePublishedDirectoryDraftProjectionItem((string) $occupation->canonical_slug);
+                $releaseCohort = $runtimeProjectionItem !== null
+                    ? 'public_detail_indexable'
+                    : 'directory_draft_pending_detail';
+                $publicIndexState = $runtimeProjectionItem !== null ? 'indexable' : 'noindex';
+                $strongIndexDecision = $runtimeProjectionItem !== null
+                    ? 'strong_index_ready'
+                    : 'directory_draft_detail_pending';
+                $publishTrack = $runtimeProjectionItem !== null ? 'runtime_publish_projection' : 'directory_draft';
+                $batchOrigin = $runtimeProjectionItem !== null
+                    ? 'runtime_publish_projection'
+                    : 'china_us_occupation_directories_2026';
+                $exclusionReasons = $runtimeProjectionItem !== null ? [] : ['detail_page_unavailable'];
 
                 return new CareerFullDatasetMember(
                     memberKind: 'career_tracked_occupation',
@@ -379,19 +411,19 @@ final class CareerFullDatasetAuthorityBuilder
                     canonicalTitleEn: $this->normalizeNullableString($occupation->canonical_title_en),
                     canonicalTitleZh: $this->normalizeNullableString($occupation->canonical_title_zh),
                     familySlug: $this->normalizeNullableString($familySlug),
-                    publishTrack: 'directory_draft',
-                    batchOrigin: 'china_us_occupation_directories_2026',
-                    releaseCohort: 'directory_draft_pending_detail',
-                    publicIndexState: 'noindex',
-                    strongIndexDecision: 'directory_draft_detail_pending',
+                    publishTrack: $publishTrack,
+                    batchOrigin: $batchOrigin,
+                    releaseCohort: $releaseCohort,
+                    publicIndexState: $publicIndexState,
+                    strongIndexDecision: $strongIndexDecision,
                     includedInPublicDataset: true,
-                    exclusionReasons: ['detail_page_unavailable'],
+                    exclusionReasons: $exclusionReasons,
                     publicFacets: [
-                        'release_cohort' => 'directory_draft_pending_detail',
-                        'public_index_state' => 'noindex',
-                        'strong_index_decision' => 'directory_draft_detail_pending',
+                        'release_cohort' => $releaseCohort,
+                        'public_index_state' => $publicIndexState,
+                        'strong_index_decision' => $strongIndexDecision,
                         'family_slug' => $this->normalizeNullableString($familySlug),
-                        'publish_track' => 'directory_draft',
+                        'publish_track' => $publishTrack,
                     ],
                 );
             })
@@ -429,6 +461,42 @@ final class CareerFullDatasetAuthorityBuilder
                 (string) $occupation->canonical_slug => $occupation,
             ])
             ->all();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function runtimePublishedDirectoryDraftProjectionItem(string $slug): ?array
+    {
+        $normalizedSlug = strtolower(trim($slug));
+        if ($normalizedSlug === '' || in_array($normalizedSlug, self::DIRECTORY_DRAFT_MANUAL_HOLD_SLUGS, true)) {
+            return null;
+        }
+
+        $item = $this->runtimePublishProjection->itemForSlug($normalizedSlug, 'en');
+        if (! is_array($item)) {
+            return null;
+        }
+
+        $state = (string) (
+            $item['runtime_publish_state']
+            ?? $item['runtime_state']
+            ?? $item['projection_state']
+            ?? $item['state']
+            ?? ''
+        );
+
+        if ($state !== 'published') {
+            return null;
+        }
+
+        if (($item['detail_route_enabled'] ?? false) !== true
+            || ($item['robots_indexable'] ?? false) !== true
+            || ($item['release_gate_pass'] ?? false) !== true) {
+            return null;
+        }
+
+        return $item;
     }
 
     /**

--- a/backend/docs/career/audits/directory_list_detail_api_authority.md
+++ b/backend/docs/career/audits/directory_list_detail_api_authority.md
@@ -1,0 +1,52 @@
+# Career Directory List Detail API Authority
+
+## Purpose
+
+The Career jobs list must not keep a `directory_draft` occupation as a public directory stub when the backend runtime publish projection already proves that the canonical detail route is published, route-enabled, robots-indexable, and release-gate passing.
+
+This authority closes the gap where detail API responses were viewable while `/api/v0.5/career/jobs` still counted the same slugs as `detail_page_unavailable`.
+
+## Authority Order
+
+For `directory_draft` occupations, list authority is evaluated in this order:
+
+1. Display-asset-backed detail authority.
+2. Runtime-published detail shell authority.
+3. Public directory stub fallback.
+
+Runtime-published detail shell authority requires an explicit runtime projection item for the slug with:
+
+- `runtime_publish_state`, `runtime_state`, `projection_state`, or `state` equal to `published`.
+- `detail_route_enabled=true`.
+- `robots_indexable=true`.
+- `release_gate_pass=true`.
+
+Default visibility booleans are not enough. The projection item must exist so synthetic/default fixture behavior cannot accidentally promote draft rows.
+
+## Dataset Summary
+
+The full dataset authority uses the same runtime-published detail shell rule for `directory_draft` members.
+
+Rows that pass are counted as:
+
+- `release_cohort=public_detail_indexable`
+- `public_index_state=indexable`
+- `strong_index_decision=strong_index_ready`
+- `publish_track=runtime_publish_projection`
+
+Rows that do not pass remain:
+
+- `release_cohort=directory_draft_pending_detail`
+- `public_index_state=noindex`
+- `strong_index_decision=directory_draft_detail_pending`
+- `exclusion_reasons=["detail_page_unavailable"]`
+
+## Non-Goals
+
+- No DB mutation.
+- No rollout or apply.
+- No deploy.
+- No content generation.
+- No CN proxy policy change.
+- No manual-hold publication.
+- No fap-web change.

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -212,6 +212,89 @@ final class CareerJobListApiTest extends TestCase
             ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1');
     }
 
+    public function test_directory_draft_with_runtime_published_detail_shell_is_listed_as_detail_ready(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(items: [
+                'agricultural-workers-all-other' => [
+                    'slug' => 'agricultural-workers-all-other',
+                    'runtime_publish_state' => 'published',
+                    'dataset_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                    'canonical_path' => '/career/jobs/agricultural-workers-all-other',
+                    'reason_codes' => ['runtime_published_navigation_shell'],
+                ],
+            ]),
+        );
+
+        $this->createDirectoryDraftOccupation([
+            'canonical_slug' => 'agricultural-workers-all-other',
+            'canonical_title_en' => 'Agricultural Workers, All Other',
+            'canonical_title_zh' => '其他农业工人',
+            'search_h1_zh' => '其他农业工人',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/jobs')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'agricultural-workers-all-other')
+            ->assertJsonPath('items.0.identity.entity_level', 'dataset_candidate')
+            ->assertJsonPath('items.0.trust_summary.reviewer_status', 'runtime_publish_projection')
+            ->assertJsonPath('items.0.trust_summary.logic_version', 'career.protocol.job_detail.runtime_projection.v1')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', true)
+            ->assertJsonPath('items.0.seo_contract.index_state', 'indexable')
+            ->assertJsonPath('items.0.seo_contract.robots_policy', 'index,follow')
+            ->assertJsonMissingPath('items.0.trust_summary.public_stub_kind')
+            ->assertJsonMissingPath('items.0.trust_summary.status')
+            ->assertJsonMissingPath('items.0.trust_summary.availability')
+            ->assertJsonMissingPath('items.0.seo_contract.public_stub_kind');
+
+        $this->assertContains('runtime_publish_projection', $response->json('items.0.trust_summary.reason_codes'));
+        $this->assertContains('runtime_published_navigation_shell', $response->json('items.0.trust_summary.reason_codes'));
+        $this->assertContains('runtime_publish_projection', $response->json('items.0.seo_contract.reason_codes'));
+        $this->assertContains('runtime_published_navigation_shell', $response->json('items.0.seo_contract.reason_codes'));
+    }
+
+    public function test_directory_draft_runtime_projection_requires_published_state_before_list_upgrade(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(items: [
+                'water-resource-specialists' => [
+                    'slug' => 'water-resource-specialists',
+                    'runtime_publish_state' => 'candidate',
+                    'dataset_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                    'canonical_path' => '/career/jobs/water-resource-specialists',
+                ],
+            ]),
+        );
+
+        $this->createDirectoryDraftOccupation([
+            'canonical_slug' => 'water-resource-specialists',
+            'canonical_title_en' => 'Water Resource Specialists',
+            'canonical_title_zh' => '水资源专家',
+            'search_h1_zh' => '水资源专家',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'water-resource-specialists')
+            ->assertJsonPath('items.0.trust_summary.public_stub_kind', 'public_directory_stub')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('items.0.seo_contract.reason_codes.0', 'detail_page_unavailable');
+    }
+
     public function test_directory_draft_display_asset_remains_stub_when_runtime_projection_rejects_indexing(): void
     {
         $this->app->instance(

--- a/backend/tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php
@@ -80,6 +80,46 @@ final class CareerFullDatasetAuthorityBuilderTest extends TestCase
         $this->assertSame('目录草稿职业', $draftMember['canonical_title_zh'] ?? null);
     }
 
+    public function test_directory_draft_with_runtime_published_shell_updates_dataset_summary_counts(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $draft = $this->createDirectoryDraftOccupation();
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(items: [
+                $draft->canonical_slug => [
+                    'slug' => $draft->canonical_slug,
+                    'runtime_publish_state' => 'published',
+                    'dataset_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                ],
+            ]),
+        );
+
+        $authority = app(CareerFullDatasetAuthorityBuilder::class)->build()->toArray();
+        $members = collect((array) ($authority['members'] ?? []));
+        $draftMember = $members->firstWhere('canonical_slug', $draft->canonical_slug);
+
+        $this->assertSame(343, (int) ($authority['member_count'] ?? 0));
+        $this->assertIsArray($draftMember);
+        $this->assertSame('public_detail_indexable', $draftMember['release_cohort'] ?? null);
+        $this->assertSame('indexable', $draftMember['public_index_state'] ?? null);
+        $this->assertSame('strong_index_ready', $draftMember['strong_index_decision'] ?? null);
+        $this->assertSame('runtime_publish_projection', $draftMember['publish_track'] ?? null);
+        $this->assertSame('runtime_publish_projection', $draftMember['batch_origin'] ?? null);
+        $this->assertSame([], $draftMember['exclusion_reasons'] ?? null);
+        $this->assertSame('public_detail_indexable', data_get($draftMember, 'public_facets.release_cohort'));
+        $this->assertSame('runtime_publish_projection', data_get($draftMember, 'public_facets.publish_track'));
+        $this->assertGreaterThanOrEqual(1, (int) data_get($authority, 'summary.release_cohort_counts.public_detail_indexable', 0));
+        $this->assertGreaterThanOrEqual(1, (int) data_get($authority, 'summary.public_index_state_counts.indexable', 0));
+        $this->assertSame(
+            0,
+            (int) data_get($authority, 'summary.release_cohort_counts.directory_draft_pending_detail', 0)
+        );
+    }
+
     public function test_it_adds_runtime_projection_public_occupations_missing_from_legacy_ledger(): void
     {
         $this->materializeCurrentFirstWaveFixture();

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -8396,6 +8396,93 @@
         }
       ],
       "next_pr": "SCAN-2786-VISIBLE-DETAIL-GAP-AFTER-DIRECTORY-DETAIL-REPAIR-1"
+    },
+    "REPAIR-DIRECTORY-LIST-DETAIL-API-AUTHORITY-75-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-directory-list-detail-api-authority-75-1",
+      "base": "main",
+      "depends_on": [
+        "REPAIR-DIRECTORY-DETAIL-PENDING-314-1"
+      ],
+      "status": "in_progress",
+      "train_scope": "career_directory_list_detail_api_authority",
+      "risk_level": "medium",
+      "title": "fix(api): align directory list with runtime detail authority",
+      "name": "Repair remaining Career directory list detail API authority gap",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-DIRECTORY-LIST-DETAIL-API-AUTHORITY-75-1, then implementing the PR."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Career jobs list/detail API authority, dataset authority, focused tests/docs, and authorized train metadata. No fap-web, deploy, DB mutation, rollout, apply, or content generation was performed."
+        },
+        "career_job_list_api": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Career/CareerJobListApiTest.php --no-ansi",
+          "evidence": "7 tests completed with 117 assertions; PHPUnit reported warnings from existing fixture file reads but no failures."
+        },
+        "career_full_dataset_authority_builder": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php --no-ansi",
+          "evidence": "5 tests completed with 363 assertions; PHPUnit reported warnings from existing fixture file reads but no failures."
+        },
+        "career_job_display_surface_api": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi",
+          "evidence": "14 tests passed, 786 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-directory-list-detail-api-authority-75.sqlite php artisan migrate --force --no-ansi",
+          "evidence": "SQLite migration completed successfully in local testing database."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobListBundleBuilder.php app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php tests/Feature/Career/CareerJobListApiTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php",
+          "evidence": "Scoped Pint check passed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "Whitespace checks passed."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full CI master chain exited 0."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR not opened yet."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-17T16:20:00+08:00",
+          "status": "in_progress",
+          "summary": "Registered authorized directory list detail API authority PR and started implementation from clean origin/main worktree."
+        },
+        {
+          "at": "2026-05-17T16:45:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Implemented runtime-published detail shell authority for directory draft list and dataset rows, then passed focused Career tests, route list, sqlite migrate, scoped Pint, diff checks, and full MBTI CI chain."
+        }
+      ],
+      "next_pr": "SCAN-2786-VISIBLE-DETAIL-GAP-AFTER-DIRECTORY-LIST-DETAIL-API-AUTHORITY-75-1"
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -4381,3 +4381,44 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+
+  - id: REPAIR-DIRECTORY-LIST-DETAIL-API-AUTHORITY-75-1
+    repo: fap-api
+    branch: codex/repair-directory-list-detail-api-authority-75-1
+    title: "fix(api): align directory list with runtime detail authority"
+    name: "Repair remaining Career directory list detail API authority gap"
+    findings:
+      - "After REPAIR-DIRECTORY-DETAIL-PENDING-314-1 was deployed, the visible gap scan still found 75 jobs-list rows marked noindex/public_directory_stub while their detail APIs returned indexable runtime-published display surfaces."
+      - "The jobs list and dataset summary must consume explicit runtime-published detail shell authority before falling back to directory_draft stub semantics."
+    scope:
+      - Promote directory_draft jobs-list rows when an explicit runtime projection item proves published detail route, robots indexability, and release gate pass.
+      - Align full dataset authority member and summary counts for those runtime-published directory draft rows.
+      - Preserve stub/noindex behavior when runtime projection item is missing, not published, not indexable, or release-gate blocked.
+      - Preserve software manual-hold and CN proxy policy.
+    allowed_paths:
+      - backend/app/Services/Career/Bundles/**
+      - backend/app/Services/Career/Dataset/**
+      - backend/tests/Feature/Career/**
+      - backend/tests/Unit/Services/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Mutate DB or generate production content.
+      - Run rollout, apply, backfill, rollback, quarantine, or deploy.
+      - Change CN proxy public-owner noindex policy.
+      - Force-enable software-developers or any manual-hold slug.
+      - Touch fap-web.
+    validation:
+      - php artisan test tests/Feature/Career/CareerJobListApiTest.php --no-ansi
+      - php artisan test tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-directory-list-detail-api-authority-75.sqlite php artisan migrate --force --no-ansi
+      - vendor/bin/pint --test app/Services/Career/Bundles/CareerJobListBundleBuilder.php app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php tests/Feature/Career/CareerJobListApiTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Summary
- Adds runtime-published detail shell authority for `directory_draft` Career jobs list rows.
- Aligns full dataset authority counts so runtime-published directory draft rows count as `public_detail_indexable` instead of `directory_draft_pending_detail`.
- Preserves stub/noindex behavior when the explicit runtime projection item is missing, non-published, non-indexable, or release-gate blocked.
- Registers `REPAIR-DIRECTORY-LIST-DETAIL-API-AUTHORITY-75-1` in the PR train metadata.

## Scope
- Backend Career jobs list and dataset authority only.
- No DB mutation, rollout, apply, deploy, content generation, CN proxy policy change, software manual-hold publication, or fap-web change.

## Tests
- `php artisan test tests/Feature/Career/CareerJobListApiTest.php --no-ansi` (passes; PHPUnit reports existing fixture file-read warnings)
- `php artisan test tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php --no-ansi` (passes; PHPUnit reports existing fixture file-read warnings)
- `php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-directory-list-detail-api-authority-75.sqlite php artisan migrate --force --no-ansi`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobListBundleBuilder.php app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php tests/Feature/Career/CareerJobListApiTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php`
- `git diff --check && git diff --cached --check`
- `bash backend/scripts/ci_verify_mbti.sh`
