### PR TITLE
feat(seo-intel): add disabled collector skeleton

### DIFF
--- a/backend/app/Console/Commands/SeoIntelCollectCommand.php
+++ b/backend/app/Console/Commands/SeoIntelCollectCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\SeoIntelCollectorManager;
+use Illuminate\Console\Command;
+
+final class SeoIntelCollectCommand extends Command
+{
+    protected $signature = 'seo-intel:collect
+        {--collector=noop : Collector name to run}
+        {--dry-run : Force dry-run mode}
+        {--no-write : Prevent writes even when future collectors are enabled}
+        {--json : Output safe machine-readable JSON}';
+
+    protected $description = 'Run a disabled-by-default Search Intelligence collector skeleton.';
+
+    public function handle(SeoIntelCollectorManager $manager): int
+    {
+        $dryRun = $this->option('dry-run') || (bool) config('seo_intel.dry_run_default', true);
+        $collector = (string) $this->option('collector');
+
+        $result = $manager->collect($collector, [
+            'dry_run' => $dryRun,
+            'no_write' => (bool) $this->option('no-write'),
+        ]);
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($result->toArray(), JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line('collector='.$result->collector);
+            $this->line('status='.$result->status);
+            $this->line('dry_run='.($result->dryRun ? '1' : '0'));
+            $this->line('writes_attempted='.($result->writesAttempted ? '1' : '0'));
+            $this->line('writes_committed='.($result->writesCommitted ? '1' : '0'));
+            $this->line('external_calls_attempted='.($result->externalCallsAttempted ? '1' : '0'));
+        }
+
+        return $result->status === 'blocked' ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/backend/app/Services/SeoIntel/Collectors/NoopSeoIntelCollector.php
+++ b/backend/app/Services/SeoIntel/Collectors/NoopSeoIntelCollector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\Collectors;
+
+use App\Services\SeoIntel\SeoIntelCollector;
+use App\Services\SeoIntel\SeoIntelCollectorResult;
+
+final class NoopSeoIntelCollector implements SeoIntelCollector
+{
+    public function name(): string
+    {
+        return 'noop';
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function collect(array $options = []): SeoIntelCollectorResult
+    {
+        return new SeoIntelCollectorResult(
+            collector: $this->name(),
+            status: 'success',
+            dryRun: (bool) ($options['dry_run'] ?? true),
+            writesAttempted: false,
+            writesCommitted: false,
+            externalCallsAttempted: false,
+            itemsSeen: 0,
+            issues: [],
+            metadata: [
+                'skeleton_only' => true,
+                'production_data_reads' => false,
+                'node2_local_laravel_data_source' => false,
+            ],
+        );
+    }
+}

--- a/backend/app/Services/SeoIntel/SeoIntelCollector.php
+++ b/backend/app/Services/SeoIntel/SeoIntelCollector.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+interface SeoIntelCollector
+{
+    public function name(): string;
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function collect(array $options = []): SeoIntelCollectorResult;
+}

--- a/backend/app/Services/SeoIntel/SeoIntelCollectorManager.php
+++ b/backend/app/Services/SeoIntel/SeoIntelCollectorManager.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use App\Services\SeoIntel\Collectors\NoopSeoIntelCollector;
+
+final class SeoIntelCollectorManager
+{
+    /**
+     * @return list<string>
+     */
+    public function allowedCollectors(): array
+    {
+        $allowed = config('seo_intel.allowed_collectors', ['noop']);
+
+        if (! is_array($allowed)) {
+            return ['noop'];
+        }
+
+        return array_values(array_filter(
+            array_map(static fn (mixed $collector): string => (string) $collector, $allowed),
+            static fn (string $collector): bool => $collector !== ''
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function collect(?string $collector = null, array $options = []): SeoIntelCollectorResult
+    {
+        $collectorName = $collector ?: (string) config('seo_intel.default_collector', 'noop');
+        $dryRun = array_key_exists('dry_run', $options)
+            ? (bool) $options['dry_run']
+            : (bool) config('seo_intel.dry_run_default', true);
+
+        if (! in_array($collectorName, $this->allowedCollectors(), true)) {
+            return $this->blocked($collectorName, $dryRun, 'unknown_collector');
+        }
+
+        if (! $this->externalApiCallsAllowed()) {
+            $options['allow_external_api_calls'] = false;
+        }
+
+        $collectorsEnabled = (bool) config('seo_intel.collectors_enabled', false);
+        $noopDryRunAllowed = $collectorName === 'noop' && $dryRun;
+
+        if (! $collectorsEnabled && ! $noopDryRunAllowed) {
+            return $this->blocked($collectorName, $dryRun, 'collectors_disabled');
+        }
+
+        if (! $this->writesAllowed($dryRun, (bool) ($options['no_write'] ?? false))) {
+            $options['writes_allowed'] = false;
+        }
+
+        return $this->resolve($collectorName)->collect($options + ['dry_run' => $dryRun]);
+    }
+
+    private function resolve(string $collector): SeoIntelCollector
+    {
+        if ($collector === 'noop') {
+            return new NoopSeoIntelCollector;
+        }
+
+        return new NoopSeoIntelCollector;
+    }
+
+    private function writesAllowed(bool $dryRun, bool $noWrite): bool
+    {
+        return ! $dryRun
+            && ! $noWrite
+            && (bool) config('seo_intel.enabled', false)
+            && (bool) config('seo_intel.write_enabled', false);
+    }
+
+    private function externalApiCallsAllowed(): bool
+    {
+        return (bool) config('seo_intel.allow_external_api_calls', false);
+    }
+
+    private function blocked(string $collector, bool $dryRun, string $reason): SeoIntelCollectorResult
+    {
+        return new SeoIntelCollectorResult(
+            collector: $collector,
+            status: 'blocked',
+            dryRun: $dryRun,
+            writesAttempted: false,
+            writesCommitted: false,
+            externalCallsAttempted: false,
+            itemsSeen: 0,
+            issues: [$reason],
+            metadata: [
+                'collectors_enabled' => (bool) config('seo_intel.collectors_enabled', false),
+                'write_enabled' => (bool) config('seo_intel.write_enabled', false),
+                'external_api_calls_allowed' => $this->externalApiCallsAllowed(),
+            ],
+        );
+    }
+}

--- a/backend/app/Services/SeoIntel/SeoIntelCollectorResult.php
+++ b/backend/app/Services/SeoIntel/SeoIntelCollectorResult.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+final class SeoIntelCollectorResult
+{
+    /**
+     * @param  list<string>  $issues
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __construct(
+        public readonly string $collector,
+        public readonly string $status,
+        public readonly bool $dryRun,
+        public readonly bool $writesAttempted,
+        public readonly bool $writesCommitted,
+        public readonly bool $externalCallsAttempted,
+        public readonly int $itemsSeen = 0,
+        public readonly array $issues = [],
+        public readonly array $metadata = [],
+    ) {}
+
+    /**
+     * @return array{
+     *     collector: string,
+     *     status: string,
+     *     dry_run: bool,
+     *     writes_attempted: bool,
+     *     writes_committed: bool,
+     *     external_calls_attempted: bool,
+     *     items_seen: int,
+     *     issues: list<string>,
+     *     metadata: array<string, mixed>
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'collector' => $this->collector,
+            'status' => $this->status,
+            'dry_run' => $this->dryRun,
+            'writes_attempted' => $this->writesAttempted,
+            'writes_committed' => $this->writesCommitted,
+            'external_calls_attempted' => $this->externalCallsAttempted,
+            'items_seen' => $this->itemsSeen,
+            'issues' => $this->issues,
+            'metadata' => $this->metadata,
+        ];
+    }
+}

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -5,6 +5,13 @@ return [
     'connection' => env('SEO_INTEL_DB_CONNECTION', 'seo_intel'),
     'write_enabled' => env('SEO_INTEL_WRITE_ENABLED', false),
     'collectors_enabled' => env('SEO_INTEL_COLLECTORS_ENABLED', false),
+    'dry_run_default' => env('SEO_INTEL_DRY_RUN_DEFAULT', true),
+    'allow_external_api_calls' => false,
+    'allowed_collectors' => [
+        'noop',
+    ],
+    'default_collector' => 'noop',
+    'collector_timeout_seconds' => env('SEO_INTEL_COLLECTOR_TIMEOUT_SECONDS', 30),
     'allow_pii_detail' => false,
     'allow_raw_order_no' => false,
     'allow_raw_attempt_id' => false,

--- a/backend/docs/seo/generated/seo-intel-collector-skeleton.v1.json
+++ b/backend/docs/seo/generated/seo-intel-collector-skeleton.v1.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "source_documents": [
+    "SEO-DASH-00B",
+    "SEO-DASH-01A",
+    "SEO-DASH-TRAIN-00",
+    "BACKEND-RUNTIME-02D"
+  ],
+  "repo": "fap-api",
+  "collectors_enabled_by_default": false,
+  "write_enabled_by_default": false,
+  "dry_run_default": true,
+  "external_api_calls_allowed": false,
+  "scheduler_enabled": false,
+  "queue_worker_enabled": false,
+  "collectors": [
+    "noop"
+  ],
+  "real_collectors_implemented": [],
+  "db_writes_in_noop": false,
+  "production_data_reads_in_noop": false,
+  "node2_local_laravel_data_source": false,
+  "gsc_connected": false,
+  "baidu_connected": false,
+  "indexnow_connected": false,
+  "metabase_deployed": false,
+  "pii_output_forbidden": [
+    "email",
+    "order_no",
+    "attempt_id",
+    "payment_id",
+    "cookie",
+    "token"
+  ],
+  "forbidden_actions": [
+    "production_migration",
+    "production_deploy",
+    "scheduler_activation",
+    "queue_worker_activation",
+    "external_api_call",
+    "node2_local_laravel_read",
+    "live_data_write"
+  ],
+  "next_task": "SEO-DASH-02A"
+}

--- a/backend/docs/seo/seo-intel-collector-skeleton.md
+++ b/backend/docs/seo/seo-intel-collector-skeleton.md
@@ -1,0 +1,77 @@
+# SEO-DASH-01B seo_intel Collector Skeleton
+
+## Purpose
+
+This document records the SEO-DASH-01B Search Intelligence collector skeleton. It adds the service and command shape needed for later collectors, but it does not enable production collection.
+
+## Non-Activation Boundary
+
+- No production collector is enabled.
+- No scheduler job is enabled.
+- No queue worker is created.
+- No external API is connected.
+- No GSC, Baidu, IndexNow, Metabase, or crawler-log integration is implemented.
+- No database writes are committed by default.
+- No collector reads Node2 local Laravel, Node2 local DB, or Node2 local queue.
+- No fap-web runtime, sitemap, llms, payment, order, report, email, recommendation, or scoring behavior is changed.
+
+## Runtime Shape
+
+The collector boundary consists of:
+
+- `SeoIntelCollector`: interface for future collectors.
+- `SeoIntelCollectorResult`: safe result object for command and tests.
+- `SeoIntelCollectorManager`: resolver and guard layer.
+- `NoopSeoIntelCollector`: dry-run-only skeleton collector.
+- `seo-intel:collect`: Artisan command for explicit manual invocation.
+
+The only collector implemented in this PR is `noop`. It performs no production data reads, no DB writes, and no external calls.
+
+## Default Config
+
+The `seo_intel` config remains disabled by default:
+
+- `enabled = false`
+- `write_enabled = false`
+- `collectors_enabled = false`
+- `dry_run_default = true`
+- `allow_external_api_calls = false`
+- `allowed_collectors = [noop]`
+- `default_collector = noop`
+
+`noop` may be invoked as a dry-run command so that the command contract can be tested without enabling collection.
+
+## Command Boundary
+
+Safe dry-run command:
+
+```bash
+php artisan seo-intel:collect --collector=noop --dry-run --json
+```
+
+The command output is safe JSON and must not include email, raw order identifiers, raw attempt identifiers, payment identifiers, cookies, tokens, or secrets.
+
+Unknown collectors are rejected by the manager. Non-dry-run collector execution remains blocked while collectors are disabled.
+
+## Deferred Collectors
+
+The following are explicitly deferred:
+
+- URL Truth Inventory collector
+- drift collector
+- crawler log collector
+- funnel attribution collector
+- revenue daily builder
+- GSC collector
+- Baidu collector
+- IndexNow collector
+- Metabase dashboard deployment
+- CMS issue queue producer
+
+## Source Authority
+
+Future collectors must use the accepted backend authority source from BACKEND-RUNTIME-02D. Node2 is an API edge gateway only; Node2 local Laravel, local DB, php84, fap-mysql, and local queue are not Search Intelligence data sources.
+
+## Next Task
+
+The next implementation task is `SEO-DASH-02A`: URL Truth Inventory after the disabled collector skeleton is accepted.

--- a/backend/tests/Feature/SeoIntel/SeoIntelCollectorSkeletonTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelCollectorSkeletonTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\SeoIntelCollectorManager;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelCollectorSkeletonTest extends TestCase
+{
+    #[Test]
+    public function collector_config_remains_disabled_by_default(): void
+    {
+        $this->assertFalse((bool) config('seo_intel.enabled'));
+        $this->assertFalse((bool) config('seo_intel.write_enabled'));
+        $this->assertFalse((bool) config('seo_intel.collectors_enabled'));
+        $this->assertTrue((bool) config('seo_intel.dry_run_default'));
+        $this->assertFalse((bool) config('seo_intel.allow_external_api_calls'));
+        $this->assertSame(['noop'], config('seo_intel.allowed_collectors'));
+        $this->assertSame('noop', config('seo_intel.default_collector'));
+    }
+
+    #[Test]
+    public function manager_rejects_unknown_collectors_without_writes_or_external_calls(): void
+    {
+        $result = (new SeoIntelCollectorManager)->collect('gsc', ['dry_run' => true]);
+
+        $this->assertSame('gsc', $result->collector);
+        $this->assertSame('blocked', $result->status);
+        $this->assertTrue($result->dryRun);
+        $this->assertFalse($result->writesAttempted);
+        $this->assertFalse($result->writesCommitted);
+        $this->assertFalse($result->externalCallsAttempted);
+        $this->assertContains('unknown_collector', $result->issues);
+    }
+
+    #[Test]
+    public function noop_collector_returns_dry_run_success_without_writes_or_external_calls(): void
+    {
+        $result = (new SeoIntelCollectorManager)->collect('noop', ['dry_run' => true]);
+
+        $this->assertSame('noop', $result->collector);
+        $this->assertSame('success', $result->status);
+        $this->assertTrue($result->dryRun);
+        $this->assertFalse($result->writesAttempted);
+        $this->assertFalse($result->writesCommitted);
+        $this->assertFalse($result->externalCallsAttempted);
+        $this->assertSame(0, $result->itemsSeen);
+        $this->assertFalse((bool) ($result->metadata['production_data_reads'] ?? true));
+        $this->assertFalse((bool) ($result->metadata['node2_local_laravel_data_source'] ?? true));
+    }
+
+    #[Test]
+    public function noop_command_outputs_safe_json_without_sensitive_identifiers(): void
+    {
+        $exitCode = Artisan::call('seo-intel:collect', [
+            '--collector' => 'noop',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $output = trim(Artisan::output());
+        $decoded = json_decode($output, true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertIsArray($decoded);
+        $this->assertSame('noop', $decoded['collector'] ?? null);
+        $this->assertSame('success', $decoded['status'] ?? null);
+        $this->assertTrue((bool) ($decoded['dry_run'] ?? false));
+        $this->assertFalse((bool) ($decoded['writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($decoded['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($decoded['external_calls_attempted'] ?? true));
+
+        foreach (['email', 'order_no', 'attempt_id', 'payment_id', 'cookie', 'token'] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $output);
+        }
+    }
+
+    #[Test]
+    public function collector_skeleton_does_not_add_scheduler_activation(): void
+    {
+        $bootstrap = (string) file_get_contents(base_path('bootstrap/app.php'));
+
+        $this->assertStringNotContainsString('seo-intel:collect', $bootstrap);
+        $this->assertStringNotContainsString('SeoIntelCollectCommand', $bootstrap);
+    }
+
+    #[Test]
+    public function generated_artifact_locks_disabled_skeleton_boundary(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(1, $artifact['version'] ?? null);
+        $this->assertContains('SEO-DASH-01A', $artifact['source_documents'] ?? []);
+        $this->assertContains('BACKEND-RUNTIME-02D', $artifact['source_documents'] ?? []);
+        $this->assertFalse((bool) ($artifact['collectors_enabled_by_default'] ?? true));
+        $this->assertFalse((bool) ($artifact['write_enabled_by_default'] ?? true));
+        $this->assertTrue((bool) ($artifact['dry_run_default'] ?? false));
+        $this->assertFalse((bool) ($artifact['external_api_calls_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['scheduler_enabled'] ?? true));
+        $this->assertFalse((bool) ($artifact['queue_worker_enabled'] ?? true));
+        $this->assertSame(['noop'], $artifact['collectors'] ?? []);
+        $this->assertSame([], $artifact['real_collectors_implemented'] ?? ['unexpected']);
+        $this->assertFalse((bool) ($artifact['db_writes_in_noop'] ?? true));
+        $this->assertFalse((bool) ($artifact['production_data_reads_in_noop'] ?? true));
+        $this->assertFalse((bool) ($artifact['node2_local_laravel_data_source'] ?? true));
+        $this->assertFalse((bool) ($artifact['gsc_connected'] ?? true));
+        $this->assertFalse((bool) ($artifact['baidu_connected'] ?? true));
+        $this->assertFalse((bool) ($artifact['indexnow_connected'] ?? true));
+        $this->assertFalse((bool) ($artifact['metabase_deployed'] ?? true));
+        $this->assertSame('SEO-DASH-02A', $artifact['next_task'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-intel-collector-skeleton.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelLogicalDbFoundationTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelLogicalDbFoundationTest.php
@@ -178,15 +178,8 @@ final class SeoIntelLogicalDbFoundationTest extends TestCase
     }
 
     #[Test]
-    public function this_pr_does_not_create_collector_commands_or_scheduler_activation(): void
+    public function logical_db_foundation_artifact_does_not_create_collector_or_scheduler_activation(): void
     {
-        $this->assertSame([], glob(base_path('app/Console/Commands/*SeoIntel*.php')) ?: []);
-        $this->assertSame([], glob(base_path('app/Console/Commands/*SearchIntelligence*.php')) ?: []);
-
-        $kernelSource = (string) file_get_contents(base_path('app/Console/Kernel.php'));
-        $this->assertStringNotContainsString('SeoIntel', $kernelSource);
-        $this->assertStringNotContainsString('SearchIntelligence', $kernelSource);
-
         $artifact = $this->artifact();
         $this->assertFalse((bool) ($artifact['collector_command_created'] ?? true));
         $this->assertFalse((bool) ($artifact['scheduler_activation_created'] ?? true));

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -295,6 +295,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_intel_disabled_collector_skeleton_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoIntelCollectCommand.php',
+            'backend/app/Services/SeoIntel/Collectors/NoopSeoIntelCollector.php',
+            'backend/app/Services/SeoIntel/SeoIntelCollector.php',
+            'backend/app/Services/SeoIntel/SeoIntelCollectorManager.php',
+            'backend/app/Services/SeoIntel/SeoIntelCollectorResult.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_public_distribution_owner_changes(): void
     {
         $changed = [
@@ -1443,6 +1456,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoIntelDisabledCollectorSkeletonFile($file)) {
+                continue;
+            }
+
             if ($this->isControlledArticlePublishSopFile($file)) {
                 continue;
             }
@@ -1824,6 +1841,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/database/migrations/2026_05_17_000100_create_seo_urls_table.php',
             'backend/database/migrations/2026_05_17_000200_create_seo_url_entities_table.php',
             'backend/database/migrations/2026_05_17_000300_create_seo_internal_traffic_rules_table.php',
+        ], true);
+    }
+
+    private function isSeoIntelDisabledCollectorSkeletonFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoIntelCollectCommand.php',
+            'backend/app/Services/SeoIntel/Collectors/NoopSeoIntelCollector.php',
+            'backend/app/Services/SeoIntel/SeoIntelCollector.php',
+            'backend/app/Services/SeoIntel/SeoIntelCollectorManager.php',
+            'backend/app/Services/SeoIntel/SeoIntelCollectorResult.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T11:34:42+08:00",
+  "updated_at": "2026-05-17T12:45:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -8405,7 +8405,7 @@
         "SEO-DASH-00B",
         "BACKEND-RUNTIME-02D"
       ],
-      "status": "in_progress",
+      "status": "merged_reconciled",
       "train_scope": "search_intelligence_logical_db_foundation",
       "risk_level": "high_schema_foundation",
       "title": "feat(seo-intel): add logical DB foundation",
@@ -8469,8 +8469,8 @@
           "status": "false"
         },
         "github_required_checks": {
-          "status": "pending_after_ci_fix_push",
-          "evidence": "PR https://github.com/fermatmind/fap-api/pull/1433 failed verify-mbti-v2 and verify-mbti-legacy. The current CI fix updates the BigFiveResultPageV2CoreBodyPreviewTest runtime freeze classifier to ignore the three SEO-DASH-01A schema-only migration files; local CI fix validation passed and the branch is pending push/re-run."
+          "status": "pass",
+          "evidence": "GitHub PR #1433 merged with hygiene, verify-mbti-v2, and verify-mbti-legacy passing."
         },
         "ci_fix_bigfive_freeze_classifier": {
           "status": "pass",
@@ -8502,10 +8502,10 @@
       },
       "failure_reason": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1433",
-      "commit_sha": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "commit_sha": "235547ab160d66acbae07619d14f654e2bc019ce",
+      "merged_at": "2026-05-17T04:05:13Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "Local default MySQL credentials block php artisan migrate --pretend",
@@ -8567,9 +8567,15 @@
           "at": "2026-05-17T11:58:00+08:00",
           "status": "ci_fix_local_checks_passed_pending_github_rerun",
           "summary": "Amended SEO-DASH-01A commit with the CI classifier fix and recorded the local validation pass. Branch is ready to push for GitHub check rerun."
+        },
+        {
+          "at": "2026-05-17T12:17:54+08:00",
+          "status": "merged_reconciled",
+          "summary": "Reconciled SEO-DASH-01A after PR #1433 was merged; origin/main contains merge commit afddee88d046dc8aed7da7b6426b3a9be0aa00e1 and the task branch was cleaned up."
         }
       ],
-      "next_pr": "SEO-DASH-01B"
+      "next_pr": "SEO-DASH-01B",
+      "merge_commit_sha": "afddee88d046dc8aed7da7b6426b3a9be0aa00e1"
     },
     "REPAIR-DIRECTORY-LIST-DETAIL-API-AUTHORITY-75-1": {
       "repo": "fap-api",
@@ -8662,6 +8668,145 @@
         }
       ],
       "next_pr": "SCAN-2786-VISIBLE-DETAIL-GAP-AFTER-DIRECTORY-LIST-DETAIL-API-AUTHORITY-75-1"
+    },
+    "SEO-DASH-01B": {
+      "repo": "fap-api",
+      "branch": "codex/seo-dash-01b-collector-skeleton-disabled",
+      "base": "main",
+      "depends_on": [
+        "SEO-DASH-01A"
+      ],
+      "status": "sync_conflict_resolved_pending_github_rerun",
+      "train_scope": "search_intelligence_collector_skeleton_disabled",
+      "risk_level": "medium_disabled_skeleton",
+      "title": "feat(seo-intel): add disabled collector skeleton",
+      "name": "collector skeleton disabled by default",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly provided SEO-DASH-01B with branch, title, allowed files, validation commands, and permission to update fap-api PR train metadata."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-DASH-01A is merged into origin/main at merge commit afddee88d046dc8aed7da7b6426b3a9be0aa00e1."
+        },
+        "production_deploy_allowed": {
+          "status": "false"
+        },
+        "production_migration_execution_allowed": {
+          "status": "false"
+        },
+        "external_api_credentials_required": {
+          "status": "false"
+        },
+        "scheduler_activation": {
+          "status": "false"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to allowed seo_intel config, services, safe Artisan command, focused SeoIntel tests, Big Five runtime freeze classifier test update, docs/generated artifact, and root docs/codex PR train metadata. No migrations, scheduler activation, queue worker, external API connector, deploy/env, payment/order/report/email/recommendation/scoring, sitemap, or llms behavior files were changed."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=SeoIntel",
+          "evidence": "14 tests passed, 163 assertions."
+        },
+        "noop_command_json": {
+          "status": "pass",
+          "command": "php artisan seo-intel:collect --collector=noop --dry-run --json",
+          "evidence": "Command returned success JSON with dry_run=true, writes_attempted=false, writes_committed=false, external_calls_attempted=false."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test config/seo_intel.php app/Services/SeoIntel/SeoIntelCollector.php app/Services/SeoIntel/SeoIntelCollectorResult.php app/Services/SeoIntel/SeoIntelCollectorManager.php app/Services/SeoIntel/Collectors/NoopSeoIntelCollector.php app/Console/Commands/SeoIntelCollectCommand.php tests/Feature/SeoIntel/SeoIntelCollectorSkeletonTest.php tests/Feature/SeoIntel/SeoIntelLogicalDbFoundationTest.php"
+        },
+        "json": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -m json.tool backend/docs/seo/generated/seo-intel-collector-skeleton.v1.json >/dev/null"
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "github_required_checks": {
+          "status": "pending_rerun",
+          "evidence": "GitHub checks previously passed on c68f6732711518519b334634d953165c78522c6a, but mergeStateStatus was DIRTY after main advanced. Checks will rerun after the rebase push."
+        },
+        "ci_fix_bigfive_freeze_classifier": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze_classifier --no-ansi",
+          "evidence": "71 tests passed, 76 assertions."
+        },
+        "ci_fix_seo_intel_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=SeoIntel --no-ansi",
+          "evidence": "14 tests passed, 163 assertions."
+        },
+        "ci_fix_mbti_full": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full local MBTI CI completed with exit code 0 after the runtime freeze classifier fix."
+        },
+        "ci_fix_pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php config/seo_intel.php app/Services/SeoIntel/SeoIntelCollector.php app/Services/SeoIntel/SeoIntelCollectorResult.php app/Services/SeoIntel/SeoIntelCollectorManager.php app/Services/SeoIntel/Collectors/NoopSeoIntelCollector.php app/Console/Commands/SeoIntelCollectCommand.php tests/Feature/SeoIntel/SeoIntelCollectorSkeletonTest.php tests/Feature/SeoIntel/SeoIntelLogicalDbFoundationTest.php"
+        },
+        "branch_sync": {
+          "status": "pass",
+          "evidence": "Rebased PR branch onto origin/main after PR #1434 advanced main; resolved PR-train state conflict by preserving the main repair entry and retaining SEO-DASH-01A/SEO-DASH-01B state."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1435",
+      "commit_sha": "pending_post_rebase_push",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "Big Five runtime freeze classifier blocks SEO-DASH-01B skeleton files",
+          "repo": "fap-api",
+          "affected_command_or_check": "GitHub CI verify-mbti-v2 and verify-mbti-legacy",
+          "evidence": "BigFiveResultPageV2CoreBodyPreviewTest failed asserting no runtime path changes; changed paths were the SEO-DASH-01B disabled collector command and service skeleton files.",
+          "why_external_to_current_pr": "The classifier must explicitly recognize the current PR disabled collector skeleton files as non-MBTI/Big-Five runtime changes.",
+          "owner": "current_pr",
+          "follow_up_recommendation": "Resolved in current CI fix by adding a narrow classifier allowlist for the SEO-DASH-01B disabled collector skeleton files and rerunning the local MBTI CI gate.",
+          "resolved_by_current_ci_fix": true
+        }
+      ],
+      "history": [
+        {
+          "at": "2026-05-17T12:17:54+08:00",
+          "status": "in_progress",
+          "summary": "Registered authorized SEO-DASH-01B and started disabled-by-default collector skeleton from origin/main."
+        },
+        {
+          "at": "2026-05-17T12:19:47+08:00",
+          "status": "local_validation_passed",
+          "summary": "Implemented disabled collector skeleton. SeoIntel tests, noop dry-run JSON command, route list, scoped Pint, JSON validation, and git diff check passed."
+        },
+        {
+          "at": "2026-05-17T12:22:20+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened GitHub PR https://github.com/fermatmind/fap-api/pull/1435 for human review; auto-merge is intentionally disabled because this PR introduces collector skeleton code."
+        },
+        {
+          "at": "2026-05-17T12:31:00+08:00",
+          "status": "ci_fix_local_checks_passed",
+          "summary": "GitHub verify-mbti-v2 and verify-mbti-legacy failed on the Big Five runtime freeze classifier. Added a narrow classifier allowlist and regression test for SEO-DASH-01B disabled collector skeleton files. Targeted classifier tests, SeoIntel tests, scoped Pint, git diff check, and full local backend/scripts/ci_verify_mbti.sh passed."
+        },
+        {
+          "at": "2026-05-17T12:45:00+08:00",
+          "status": "sync_conflict_resolved_pending_github_rerun",
+          "summary": "Rebased SEO-DASH-01B onto latest origin/main after PR #1434 advanced main; preserved the repair PR ledger entry and retained the current SEO-DASH-01B scope."
+        }
+      ],
+      "next_pr": "SEO-DASH-02A"
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -93,6 +93,58 @@ prs:
     production_db_creation: human_confirm_required
     external_api_credentials_required: false
     next_task: SEO-DASH-01B
+
+  - id: SEO-DASH-01B
+    repo: fap-api
+    depends_on:
+      - SEO-DASH-01A
+    branch: codex/seo-dash-01b-collector-skeleton-disabled
+    title: "feat(seo-intel): add disabled collector skeleton"
+    name: "collector skeleton disabled by default"
+    findings:
+      - "SEO-DASH-01A merged the disabled-by-default seo_intel logical DB foundation."
+      - "BACKEND-RUNTIME-02D accepted Node2 as API edge gateway and Node3/fap-api-prod as backend authority candidate."
+      - "SEO Collector must not read Node2 local Laravel."
+    scope:
+      - Add collector interface, result object, manager, and noop collector.
+      - Add a safe Artisan command for explicit dry-run invocation.
+      - Keep collectors, writes, scheduler, queue workers, and external API calls disabled by default.
+      - Add docs/generated artifact and focused SeoIntel tests for no writes, no external calls, and no scheduler activation.
+    allowed_paths:
+      - backend/config/seo_intel.php
+      - backend/app/Services/SeoIntel/**
+      - backend/app/Console/Commands/SeoIntelCollectCommand.php
+      - backend/tests/**/SeoIntel*Test.php
+      - backend/tests/Feature/SeoIntel/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/seo/seo-intel-collector-skeleton.md
+      - backend/docs/seo/generated/seo-intel-collector-skeleton.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production migrations.
+      - Create production seo_intel DB.
+      - Deploy, SSH, edit env, or touch Node2/Node3.
+      - Connect GSC, Baidu, IndexNow, or deploy Metabase.
+      - Enable scheduler jobs or create queue workers.
+      - Write live data or call external APIs.
+      - Change payment, order, report, email, recommendation, scoring, sitemap, or llms behavior.
+      - Modify fap-web runtime or use fap-api/fap-web as production frontend runtime.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan seo-intel:collect --collector=noop --dry-run --json
+      - cd backend && php artisan route:list --no-ansi
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false
+    next_task: SEO-DASH-02A
   - id: PR-MEDIA-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed

- Adds a disabled-by-default Search Intelligence collector skeleton.
- Adds `SeoIntelCollector`, `SeoIntelCollectorResult`, `SeoIntelCollectorManager`, and a `NoopSeoIntelCollector`.
- Adds a safe manual Artisan command: `seo-intel:collect --collector=noop --dry-run --json`.
- Extends `seo_intel` config with dry-run, allowed collector, timeout, and external API guard fields while keeping collectors and writes disabled by default.
- Adds the SEO-DASH-01B docs/generated artifact and focused SeoIntel tests.
- Registers SEO-DASH-01B in the fap-api PR train metadata and reconciles SEO-DASH-01A as merged.

## Why

SEO-DASH-01A established the logical `seo_intel` foundation. This PR creates only the disabled skeleton needed for future collectors, without production activation, scheduler activation, queue workers, external API calls, live data writes, or Node2 local Laravel reads.

## Validation commands

- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan seo-intel:collect --collector=noop --dry-run --json`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test config/seo_intel.php app/Services/SeoIntel/SeoIntelCollector.php app/Services/SeoIntel/SeoIntelCollectorResult.php app/Services/SeoIntel/SeoIntelCollectorManager.php app/Services/SeoIntel/Collectors/NoopSeoIntelCollector.php app/Console/Commands/SeoIntelCollectCommand.php tests/Feature/SeoIntel/SeoIntelCollectorSkeletonTest.php tests/Feature/SeoIntel/SeoIntelLogicalDbFoundationTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -m json.tool backend/docs/seo/generated/seo-intel-collector-skeleton.v1.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred

- Production `seo_intel` DB creation and production migration execution.
- Real URL/drift/funnel/search-channel collectors.
- GSC, Baidu, IndexNow, crawler-log, and Metabase integrations.
- Scheduler jobs and queue workers.
- Live data writes or external API calls.

## Repository rule impact

No content authority, CMS publishing, sitemap/llms, payment/order/report/email/recommendation/scoring, fap-web runtime, or deploy behavior changes. Node2 local Laravel remains explicitly excluded as a Search Intelligence data source.

## Human review required

Do not auto-merge. This PR introduces collector skeleton code and should stop for human review after checks are green.
