### PR TITLE
fix(api): add CN proxy visible detail policy authority

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCnProxyVisibleDetailPolicyAuthority.php
+++ b/backend/app/Console/Commands/CareerPlanCnProxyVisibleDetailPolicyAuthority.php
@@ -1,0 +1,510 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerPlanCnProxyVisibleDetailPolicyAuthority extends Command
+{
+    private const EXPECTED_TARGET_TOTAL = 2786;
+
+    private const EXPECTED_CN_PROXY_ROWS = 1663;
+
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_VISIBLE_DETAIL_PRECONDITIONS = [
+        'explicit_product_policy_decision_for_cn_proxy_visible_detail',
+        'cn_first_authority_source_evidence',
+        'cn_visible_detail_schema_policy',
+        'cn_display_asset_pipeline',
+        'cn_directory_inclusion_gate',
+        'cn_visible_live_acceptance',
+    ];
+
+    protected $signature = 'career:plan-cn-proxy-visible-detail-policy-authority
+        {--scope= : CN proxy scope or slug matrix JSON artifact}
+        {--public-owner-plan= : Reviewed noindex CN proxy public-owner plan JSON artifact}
+        {--visible-gap= : Product visible gap or CN proxy policy scan summary JSON artifact}
+        {--decision= : Optional explicit product policy decision JSON artifact}
+        {--target-total=2786 : Target product visible detail total}
+        {--json : Emit JSON output}
+        {--output= : Optional JSON output artifact path}';
+
+    protected $description = 'Plan CN proxy visible-detail publication policy authority without mutating production state.';
+
+    public function handle(): int
+    {
+        try {
+            $scopePath = $this->requiredPath('scope');
+            $publicOwnerPlanPath = $this->requiredPath('public-owner-plan');
+            $visibleGapPath = $this->requiredPath('visible-gap');
+            $decisionPath = $this->optionalPath('decision');
+            $targetTotal = (int) $this->option('target-total');
+
+            $scopePayload = $this->readJson($scopePath, 'CN proxy scope');
+            $publicOwnerPlan = $this->readJson($publicOwnerPlanPath, 'CN proxy public-owner plan');
+            $visibleGap = $this->readJson($visibleGapPath, 'visible gap summary');
+            $decision = $decisionPath === null ? [] : $this->readJson($decisionPath, 'product policy decision');
+
+            $cnProxyRows = $this->cnProxyRowCount($scopePayload);
+            $ownerSummary = $this->publicOwnerSummary($publicOwnerPlan);
+            $surfaceSummary = $this->surfaceSummary($visibleGap);
+            $decisionSummary = $this->decisionSummary($decision);
+            $blockers = $this->blockers($targetTotal, $cnProxyRows, $ownerSummary, $surfaceSummary, $decisionSummary);
+            $visibleDetailRequested = (bool) $decisionSummary['visible_detail_publication_requested'];
+            $partitionAwareSelected = (bool) $decisionSummary['partition_aware_claim_selected'];
+
+            $status = $blockers === [] ? 'pass' : 'blocked';
+            $visibleDetailPublicationAllowed = $status === 'pass' && $visibleDetailRequested;
+
+            $payload = [
+                'schema_version' => 'career_cn_proxy_visible_detail_policy_authority.v1',
+                'status' => $status,
+                'command' => 'career:plan-cn-proxy-visible-detail-policy-authority',
+                'read_only' => true,
+                'writes_database' => false,
+                'apply_allowed' => false,
+                'rollout_allowed' => false,
+                'candidate_prep_allowed' => false,
+                'deploy_required' => false,
+                'target_total' => $targetTotal,
+                'expected_cn_proxy_rows' => self::EXPECTED_CN_PROXY_ROWS,
+                'cn_proxy_rows' => $cnProxyRows,
+                'scope_path' => $scopePath,
+                'public_owner_plan_path' => $publicOwnerPlanPath,
+                'visible_gap_path' => $visibleGapPath,
+                'decision_path' => $decisionPath,
+                'reviewed_noindex_public_owner' => $ownerSummary,
+                'current_product_surface' => $surfaceSummary,
+                'product_policy_decision' => $decisionSummary,
+                'required_visible_detail_preconditions' => self::REQUIRED_VISIBLE_DETAIL_PRECONDITIONS,
+                'visible_detail_publication_requested' => $visibleDetailRequested,
+                'partition_aware_claim_selected' => $partitionAwareSelected,
+                'visible_detail_publication_allowed' => $visibleDetailPublicationAllowed,
+                'safe_claim_scope' => $visibleDetailPublicationAllowed
+                    ? 'product_visible_detail_publication'
+                    : ($partitionAwareSelected ? 'partition_accounted_not_visible_detail' : 'insufficient_product_policy_authority'),
+                'blocked_claims' => $visibleDetailPublicationAllowed ? [] : [
+                    '2786_visible_directory_members',
+                    '2786_visible_detail_pages',
+                    '2786_detail_indexable_pages',
+                ],
+                'blockers' => $blockers,
+                'next_required_action' => $this->nextRequiredAction($blockers, $visibleDetailRequested, $partitionAwareSelected),
+            ];
+
+            $this->writeOutputArtifact($payload);
+            $this->emitPayload($payload);
+
+            return $status === 'pass' ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $throwable) {
+            $payload = [
+                'schema_version' => 'career_cn_proxy_visible_detail_policy_authority.v1',
+                'status' => 'failed',
+                'command' => 'career:plan-cn-proxy-visible-detail-policy-authority',
+                'read_only' => true,
+                'writes_database' => false,
+                'apply_allowed' => false,
+                'rollout_allowed' => false,
+                'candidate_prep_allowed' => false,
+                'message' => $throwable->getMessage(),
+                'blockers' => [
+                    [
+                        'reason' => 'command_or_artifact_error',
+                        'context' => [
+                            'message' => $throwable->getMessage(),
+                        ],
+                    ],
+                ],
+                'next_required_action' => 'REPAIR_COMMAND_OR_ARTIFACT_INPUT',
+            ];
+
+            $this->writeOutputArtifact($payload);
+            $this->emitPayload($payload, error: true);
+
+            return self::FAILURE;
+        }
+    }
+
+    private function requiredPath(string $option): string
+    {
+        $path = trim((string) $this->option($option));
+        if ($path === '') {
+            throw new \RuntimeException($option.' artifact path is required');
+        }
+        if (! is_file($path)) {
+            throw new \RuntimeException($option.' artifact not found: '.$path);
+        }
+
+        return $path;
+    }
+
+    private function optionalPath(string $option): ?string
+    {
+        $value = $this->option($option);
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        $path = trim((string) $value);
+        if (! is_file($path)) {
+            throw new \RuntimeException($option.' artifact not found: '.$path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path, string $label): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException($label.' artifact is not valid JSON: '.$path);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function cnProxyRowCount(array $payload): int
+    {
+        $rows = data_get($payload, 'rows');
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'cn_proxy_scope.rows');
+        }
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'slug_matrix');
+        }
+
+        if (is_array($rows)) {
+            $count = 0;
+            foreach ($rows as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+                $partition = (string) ($row['partition'] ?? $row['public_resolution_type'] ?? $row['recommended_resolution'] ?? '');
+                $slug = (string) ($row['slug'] ?? $row['source_slug'] ?? '');
+                if (str_contains($partition, 'cn_proxy') || str_starts_with($slug, 'cn-') || str_starts_with($slug, 'cn-proxy-')) {
+                    $count++;
+                }
+            }
+
+            return $count > 0 ? $count : count($rows);
+        }
+
+        foreach ([
+            'cn_proxy_rows',
+            'current_counts.cn_proxy_noindex_public_owner',
+            'visible_counts_after_1434.cn_proxy_public_owner_partition',
+            'count',
+        ] as $path) {
+            $value = data_get($payload, $path);
+            if (is_numeric($value)) {
+                return (int) $value;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function publicOwnerSummary(array $payload): array
+    {
+        $planReady = $this->boolAtAny($payload, [
+            'public_owner_plan_ready',
+            'summary.public_owner_plan_ready',
+        ]);
+        $reviewComplete = $this->boolAtAny($payload, [
+            'reviewed_trust_manifest_complete',
+            'reviewed_manifest_complete',
+            'summary.reviewed_trust_manifest_complete',
+        ]);
+
+        $rows = $this->intAtAny($payload, [
+            'public_cn_proxy_page_rows',
+            'cn_proxy_rows',
+            'summary.cn_proxy_rows',
+            'reviewed_manifest_claims',
+        ]);
+        $noindexDefault = $this->boolAtAny($payload, [
+            'noindex_default',
+            'summary.noindex_default',
+        ]);
+
+        return [
+            'plan_ready' => $planReady,
+            'reviewed_trust_manifest_complete' => $reviewComplete,
+            'public_cn_proxy_page_rows' => $rows,
+            'noindex_default' => $noindexDefault,
+            'indexable_cn_proxy_rows' => $this->intAtAny($payload, ['indexable_CN_proxy_rows', 'indexable_cn_proxy_rows']) ?? 0,
+            'sitemap_cn_urls' => $this->intAtAny($payload, ['sitemap_CN_urls', 'sitemap_cn_urls']) ?? 0,
+            'llms_cn_urls' => $this->intAtAny($payload, ['llms_CN_urls', 'llms_cn_urls']) ?? 0,
+            'llms_full_cn_urls' => $this->intAtAny($payload, ['llms_full_CN_urls', 'llms_full_cn_urls']) ?? 0,
+            'display_asset_delta' => $this->intAtAny($payload, ['display_asset_delta', 'career_job_display_assets_delta']) ?? 0,
+            'occupations_delta' => $this->intAtAny($payload, ['occupations_delta']) ?? 0,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function surfaceSummary(array $payload): array
+    {
+        return [
+            'source_assets' => $this->intAtAny($payload, [
+                'current_counts.source_assets',
+                'visible_counts_after_1434.all_source_slugs',
+                'visible_counts.source_assets',
+                'source_assets',
+            ]),
+            'visible_detail_indexable' => $this->intAtAny($payload, [
+                'current_counts.visible_detail_indexable',
+                'visible_counts_after_1434.backend_public_detail_indexable_count',
+                'visible_counts.backend_public_detail_indexable_count',
+                'detail_indexable_pages',
+            ]),
+            'cn_proxy_noindex_public_owner' => $this->intAtAny($payload, [
+                'current_counts.cn_proxy_noindex_public_owner',
+                'visible_counts_after_1434.cn_proxy_public_owner_partition',
+                'visible_counts.cn_proxy_public_owner_partition',
+                'cn_proxy_rows',
+            ]),
+            'software_manual_hold' => $this->intAtAny($payload, [
+                'current_counts.software_manual_hold',
+                'visible_counts_after_1434.software_manual_hold',
+                'visible_counts.software_manual_hold',
+            ]),
+            'gap_to_visible_detail' => $this->intAtAny($payload, [
+                'current_counts.gap_to_2786_visible_detail',
+                'visible_counts_after_1434.detail_indexable_gap_to_2786',
+                'visible_counts.detail_indexable_gap_to_2786',
+                'gap_to_2786_visible_detail',
+            ]),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function decisionSummary(array $payload): array
+    {
+        $decisionId = $this->nullableString(data_get($payload, 'decision_id'))
+            ?? $this->nullableString(data_get($payload, 'decision'))
+            ?? $this->nullableString(data_get($payload, 'selected_decision'))
+            ?? $this->nullableString(data_get($payload, 'recommended_decision'));
+
+        return [
+            'decision_id' => $decisionId,
+            'decision_artifact_present' => $payload !== [],
+            'visible_detail_publication_requested' => $decisionId === 'PURSUE_CN_PROXY_VISIBLE_DETAIL_PUBLICATION',
+            'partition_aware_claim_selected' => $decisionId === 'KEEP_PARTITION_AWARE_PRODUCT_CLAIM',
+            'human_review_required' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $owner
+     * @param  array<string, mixed>  $surface
+     * @param  array<string, mixed>  $decision
+     * @return list<array{reason: string, context: array<string, mixed>}>
+     */
+    private function blockers(int $targetTotal, int $cnProxyRows, array $owner, array $surface, array $decision): array
+    {
+        $blockers = [];
+
+        if ($targetTotal !== self::EXPECTED_TARGET_TOTAL) {
+            $blockers[] = $this->blocker('target_total_mismatch', [
+                'expected' => self::EXPECTED_TARGET_TOTAL,
+                'actual' => $targetTotal,
+            ]);
+        }
+
+        if ($cnProxyRows !== self::EXPECTED_CN_PROXY_ROWS) {
+            $blockers[] = $this->blocker('cn_proxy_row_count_mismatch', [
+                'expected' => self::EXPECTED_CN_PROXY_ROWS,
+                'actual' => $cnProxyRows,
+            ]);
+        }
+
+        if (($owner['plan_ready'] ?? false) !== true || ($owner['reviewed_trust_manifest_complete'] ?? false) !== true) {
+            $blockers[] = $this->blocker('reviewed_noindex_public_owner_plan_not_ready', $owner);
+        }
+
+        foreach ([
+            'indexable_cn_proxy_rows',
+            'sitemap_cn_urls',
+            'llms_cn_urls',
+            'llms_full_cn_urls',
+            'display_asset_delta',
+            'occupations_delta',
+        ] as $field) {
+            if ((int) ($owner[$field] ?? 0) !== 0) {
+                $blockers[] = $this->blocker('reviewed_noindex_public_owner_plan_unsafe_'.$field, [
+                    'actual' => (int) ($owner[$field] ?? 0),
+                ]);
+            }
+        }
+
+        if (($surface['source_assets'] ?? null) !== self::EXPECTED_TARGET_TOTAL) {
+            $blockers[] = $this->blocker('source_asset_count_mismatch', [
+                'expected' => self::EXPECTED_TARGET_TOTAL,
+                'actual' => $surface['source_assets'] ?? null,
+            ]);
+        }
+
+        if (($surface['cn_proxy_noindex_public_owner'] ?? null) !== self::EXPECTED_CN_PROXY_ROWS) {
+            $blockers[] = $this->blocker('cn_proxy_surface_count_mismatch', [
+                'expected' => self::EXPECTED_CN_PROXY_ROWS,
+                'actual' => $surface['cn_proxy_noindex_public_owner'] ?? null,
+            ]);
+        }
+
+        if (($decision['decision_artifact_present'] ?? false) !== true) {
+            $blockers[] = $this->blocker('product_policy_decision_missing', [
+                'required_decisions' => [
+                    'KEEP_PARTITION_AWARE_PRODUCT_CLAIM',
+                    'PURSUE_CN_PROXY_VISIBLE_DETAIL_PUBLICATION',
+                ],
+            ]);
+
+            return $blockers;
+        }
+
+        if (($decision['partition_aware_claim_selected'] ?? false) === true) {
+            return $blockers;
+        }
+
+        if (($decision['visible_detail_publication_requested'] ?? false) !== true) {
+            $blockers[] = $this->blocker('unsupported_product_policy_decision', [
+                'decision_id' => $decision['decision_id'] ?? null,
+            ]);
+
+            return $blockers;
+        }
+
+        foreach (array_slice(self::REQUIRED_VISIBLE_DETAIL_PRECONDITIONS, 1) as $precondition) {
+            $blockers[] = $this->blocker($precondition.'_missing', [
+                'message' => 'Reviewed noindex CN proxy public-owner evidence does not authorize indexable visible detail publication.',
+            ]);
+        }
+
+        return $blockers;
+    }
+
+    private function nextRequiredAction(array $blockers, bool $visibleDetailRequested, bool $partitionAwareSelected): string
+    {
+        if ($blockers === [] && $partitionAwareSelected) {
+            return 'KEEP_PARTITION_AWARE_PRODUCT_CLAIM';
+        }
+
+        if ($visibleDetailRequested) {
+            return 'REPAIR_CN_PROXY_CN_FIRST_DISPLAY_ASSET_PIPELINE_1';
+        }
+
+        return 'PRODUCT_POLICY_DECISION_CN_PROXY_VISIBLE_DETAIL_1';
+    }
+
+    /**
+     * @param  list<string>  $paths
+     */
+    private function intAtAny(array $payload, array $paths): ?int
+    {
+        foreach ($paths as $path) {
+            $value = data_get($payload, $path);
+            if (is_numeric($value)) {
+                return (int) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<string>  $paths
+     */
+    private function boolAtAny(array $payload, array $paths): ?bool
+    {
+        foreach ($paths as $path) {
+            $value = data_get($payload, $path);
+            if (is_bool($value)) {
+                return $value;
+            }
+            if (is_numeric($value)) {
+                return (bool) $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @return array{reason: string, context: array<string, mixed>}
+     */
+    private function blocker(string $reason, array $context): array
+    {
+        return [
+            'reason' => $reason,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeOutputArtifact(array $payload): void
+    {
+        $outputPath = $this->option('output');
+        if ($outputPath === null || trim((string) $outputPath) === '') {
+            return;
+        }
+
+        $path = trim((string) $outputPath);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function emitPayload(array $payload, bool $error = false): void
+    {
+        if ($this->option('json')) {
+            $this->line(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return;
+        }
+
+        $line = ($payload['status'] ?? 'unknown').': '.($payload['next_required_action'] ?? 'no_next_action');
+        if ($error) {
+            $this->error($line);
+
+            return;
+        }
+
+        $this->info($line);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -56,6 +56,7 @@ use App\Console\Commands\CareerPlanCanonicalProgressiveReadinessSelection;
 use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerPlanCanonicalRuntimeArtifactRefresh;
 use App\Console\Commands\CareerPlanCanonicalRuntimeCandidatePrep;
+use App\Console\Commands\CareerPlanCnProxyVisibleDetailPolicyAuthority;
 use App\Console\Commands\CareerPrepareCanonicalRuntimeCandidates;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRemediateCanonicalIndexState;
@@ -231,6 +232,7 @@ class Kernel extends ConsoleKernel
         CareerPlanCanonicalRolloutBatchTransition::class,
         CareerPlanCanonicalRuntimeArtifactRefresh::class,
         CareerPlanCanonicalRuntimeCandidatePrep::class,
+        CareerPlanCnProxyVisibleDetailPolicyAuthority::class,
         CareerPrepareCanonicalRuntimeCandidates::class,
         CareerReleaseGateNoindexCleanup::class,
         CareerRemediateCanonicalIndexState::class,

--- a/backend/docs/career/audits/cn_proxy_visible_detail_policy_authority.md
+++ b/backend/docs/career/audits/cn_proxy_visible_detail_policy_authority.md
@@ -1,0 +1,70 @@
+# CN Proxy Visible Detail Policy Authority
+
+This document defines the backend gate for any future attempt to count CN proxy rows as product-visible Career detail pages.
+
+## Current Authority
+
+The reviewed CN proxy public-owner train authorizes a noindex, noncanonical owner surface only. It does not authorize:
+
+- canonical Career job detail publication
+- indexable detail pages
+- sitemap URLs
+- llms or llms-full entries
+- generated display assets
+- occupation or crosswalk creation
+- inclusion in the product-visible 2786 detail-page claim
+
+The current product-safe claim remains partition aware unless the full visible-detail policy gate passes.
+
+## Command
+
+Use the read-only planner:
+
+```bash
+php artisan career:plan-cn-proxy-visible-detail-policy-authority \
+  --scope=/tmp/career_2786_cn_proxy_policy_scan_after_1434_slug_matrix.json \
+  --public-owner-plan=/tmp/career_2786_cn_proxy_public_owner_plan.json \
+  --visible-gap=/tmp/career_2786_cn_proxy_policy_scan_after_1434_summary.json \
+  --decision=/tmp/career_2786_product_policy_decision_cn_proxy_visible_detail.json \
+  --target-total=2786 \
+  --json \
+  --output=/tmp/career_2786_cn_proxy_visible_detail_policy_authority.json
+```
+
+The command never mutates the database and always reports:
+
+- `read_only=true`
+- `writes_database=false`
+- `apply_allowed=false`
+- `rollout_allowed=false`
+- `candidate_prep_allowed=false`
+
+## Decision Semantics
+
+`KEEP_PARTITION_AWARE_PRODUCT_CLAIM` means CN proxy rows stay in the reviewed noindex public-owner partition. The planner may pass, but `visible_detail_publication_allowed=false` and `safe_claim_scope=partition_accounted_not_visible_detail`.
+
+`PURSUE_CN_PROXY_VISIBLE_DETAIL_PUBLICATION` starts a separate visible-detail program. The planner must block until all CN-first publication prerequisites exist.
+
+## Required Visible-Detail Preconditions
+
+Visible detail publication for CN proxy rows requires all of:
+
+- explicit product policy decision for CN proxy visible detail
+- CN-first authority source evidence
+- CN visible detail schema policy
+- CN display asset pipeline
+- CN directory inclusion gate
+- CN visible live acceptance
+
+Reviewed noindex public-owner evidence alone must never satisfy these conditions.
+
+## Non-Goals
+
+This gate does not:
+
+- generate content
+- create occupations
+- run candidate prep
+- run rollout dry-run or rollout apply
+- change sitemap, llms, or frontend behavior
+- publish CN proxy rows as US canonical jobs

--- a/backend/tests/Feature/Console/CareerPlanCnProxyVisibleDetailPolicyAuthorityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCnProxyVisibleDetailPolicyAuthorityCommandTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerPlanCnProxyVisibleDetailPolicyAuthority;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerPlanCnProxyVisibleDetailPolicyAuthorityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(CareerPlanCnProxyVisibleDetailPolicyAuthority::class),
+        );
+    }
+
+    public function test_it_blocks_visible_detail_authority_without_explicit_product_decision(): void
+    {
+        $exitCode = Artisan::call('career:plan-cn-proxy-visible-detail-policy-authority', [
+            '--scope' => $this->writeCnProxyScopeFixture(),
+            '--public-owner-plan' => $this->writePublicOwnerPlanFixture(),
+            '--visible-gap' => $this->writeVisibleGapFixture(),
+            '--json' => true,
+        ]);
+
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFalse($payload['rollout_allowed']);
+        $this->assertFalse($payload['candidate_prep_allowed']);
+        $this->assertSame(1663, $payload['cn_proxy_rows']);
+        $this->assertFalse($payload['visible_detail_publication_allowed']);
+        $this->assertContains('product_policy_decision_missing', array_column($payload['blockers'], 'reason'));
+    }
+
+    public function test_it_accepts_conservative_partition_aware_decision_without_publication_apply(): void
+    {
+        $exitCode = Artisan::call('career:plan-cn-proxy-visible-detail-policy-authority', [
+            '--scope' => $this->writeCnProxyScopeFixture(),
+            '--public-owner-plan' => $this->writePublicOwnerPlanFixture(),
+            '--visible-gap' => $this->writeVisibleGapFixture(),
+            '--decision' => $this->writeDecisionFixture('KEEP_PARTITION_AWARE_PRODUCT_CLAIM'),
+            '--output' => storage_path('framework/testing/career-cn-proxy-visible-detail-policy-authority.json'),
+            '--json' => true,
+        ]);
+
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame('partition_accounted_not_visible_detail', $payload['safe_claim_scope']);
+        $this->assertTrue($payload['partition_aware_claim_selected']);
+        $this->assertFalse($payload['visible_detail_publication_requested']);
+        $this->assertFalse($payload['visible_detail_publication_allowed']);
+        $this->assertSame([], $payload['blockers']);
+        $this->assertSame('KEEP_PARTITION_AWARE_PRODUCT_CLAIM', $payload['next_required_action']);
+        $this->assertFileExists(storage_path('framework/testing/career-cn-proxy-visible-detail-policy-authority.json'));
+    }
+
+    public function test_it_blocks_visible_detail_decision_until_cn_first_authority_pipeline_exists(): void
+    {
+        $exitCode = Artisan::call('career:plan-cn-proxy-visible-detail-policy-authority', [
+            '--scope' => $this->writeCnProxyScopeFixture(),
+            '--public-owner-plan' => $this->writePublicOwnerPlanFixture(),
+            '--visible-gap' => $this->writeVisibleGapFixture(),
+            '--decision' => $this->writeDecisionFixture('PURSUE_CN_PROXY_VISIBLE_DETAIL_PUBLICATION'),
+            '--json' => true,
+        ]);
+
+        $payload = $this->payload();
+        $reasons = array_column($payload['blockers'], 'reason');
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertTrue($payload['visible_detail_publication_requested']);
+        $this->assertFalse($payload['visible_detail_publication_allowed']);
+        $this->assertSame('insufficient_product_policy_authority', $payload['safe_claim_scope']);
+        $this->assertContains('cn_first_authority_source_evidence_missing', $reasons);
+        $this->assertContains('cn_visible_detail_schema_policy_missing', $reasons);
+        $this->assertContains('cn_display_asset_pipeline_missing', $reasons);
+        $this->assertContains('cn_directory_inclusion_gate_missing', $reasons);
+        $this->assertContains('cn_visible_live_acceptance_missing', $reasons);
+        $this->assertSame('REPAIR_CN_PROXY_CN_FIRST_DISPLAY_ASSET_PIPELINE_1', $payload['next_required_action']);
+    }
+
+    public function test_it_rejects_noindex_public_owner_plan_that_attempts_indexable_cn_proxy_surface(): void
+    {
+        $exitCode = Artisan::call('career:plan-cn-proxy-visible-detail-policy-authority', [
+            '--scope' => $this->writeCnProxyScopeFixture(),
+            '--public-owner-plan' => $this->writePublicOwnerPlanFixture(indexableRows: 1),
+            '--visible-gap' => $this->writeVisibleGapFixture(),
+            '--decision' => $this->writeDecisionFixture('KEEP_PARTITION_AWARE_PRODUCT_CLAIM'),
+            '--json' => true,
+        ]);
+
+        $payload = $this->payload();
+        $reasons = array_column($payload['blockers'], 'reason');
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('reviewed_noindex_public_owner_plan_unsafe_indexable_cn_proxy_rows', $reasons);
+        $this->assertContains('reviewed_noindex_public_owner_plan_unsafe_sitemap_cn_urls', $reasons);
+        $this->assertContains('reviewed_noindex_public_owner_plan_unsafe_llms_cn_urls', $reasons);
+        $this->assertContains('reviewed_noindex_public_owner_plan_unsafe_llms_full_cn_urls', $reasons);
+        $this->assertFalse($payload['visible_detail_publication_allowed']);
+    }
+
+    public function test_it_rejects_cn_proxy_scope_count_mismatch(): void
+    {
+        $exitCode = Artisan::call('career:plan-cn-proxy-visible-detail-policy-authority', [
+            '--scope' => $this->writeCnProxyScopeFixture(count: 1662),
+            '--public-owner-plan' => $this->writePublicOwnerPlanFixture(),
+            '--visible-gap' => $this->writeVisibleGapFixture(),
+            '--decision' => $this->writeDecisionFixture('KEEP_PARTITION_AWARE_PRODUCT_CLAIM'),
+            '--json' => true,
+        ]);
+
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertContains('cn_proxy_row_count_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    private function writeCnProxyScopeFixture(int $count = 1663): string
+    {
+        $path = storage_path('framework/testing/career-cn-proxy-visible-detail-scope.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        $rows = [];
+        for ($index = 1; $index <= $count; $index++) {
+            $rows[] = [
+                'slug' => sprintf('cn-proxy-%04d', $index),
+                'partition' => 'cn_proxy_public_owner',
+            ];
+        }
+
+        File::put($path, json_encode([
+            'schema_version' => 'career_cn_proxy_scope.test.v1',
+            'rows' => $rows,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+
+    private function writePublicOwnerPlanFixture(int $indexableRows = 0): string
+    {
+        $path = storage_path('framework/testing/career-cn-proxy-visible-detail-public-owner-plan.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        File::put($path, json_encode([
+            'schema_version' => 'career_cn_proxy_public_owner_plan.test.v1',
+            'status' => 'pass',
+            'public_owner_plan_ready' => true,
+            'reviewed_trust_manifest_complete' => true,
+            'cn_proxy_rows' => 1663,
+            'public_cn_proxy_page_rows' => 1663,
+            'noindex_default' => true,
+            'indexable_CN_proxy_rows' => $indexableRows,
+            'sitemap_CN_urls' => $indexableRows,
+            'llms_CN_urls' => $indexableRows,
+            'llms_full_CN_urls' => $indexableRows,
+            'display_asset_delta' => 0,
+            'career_job_display_assets_delta' => 0,
+            'occupations_delta' => 0,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+
+    private function writeVisibleGapFixture(): string
+    {
+        $path = storage_path('framework/testing/career-cn-proxy-visible-detail-gap.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        File::put($path, json_encode([
+            'schema_version' => 'career_2786_cn_proxy_policy_scan_after_1434.summary.v1',
+            'visible_counts_after_1434' => [
+                'all_source_slugs' => 2786,
+                'backend_public_detail_indexable_count' => 1122,
+                'cn_proxy_public_owner_partition' => 1663,
+                'software_manual_hold' => 1,
+                'detail_indexable_gap_to_2786' => 1664,
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+
+    private function writeDecisionFixture(string $decisionId): string
+    {
+        $path = storage_path('framework/testing/career-cn-proxy-visible-detail-decision.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        File::put($path, json_encode([
+            'schema_version' => 'career_product_policy_decision.test.v1',
+            'decision_id' => $decisionId,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3188,7 +3188,7 @@
       "branch": "fix/career-entity-remediation-plan-1",
       "title": "fix(api): add career occupation entity remediation planning",
       "name": "Add career occupation entity remediation planning",
-      "status": "in_progress",
+      "status": "local_validation_passed",
       "depends_on": [
         "REPAIR-INDEX-1",
         "SCAN-3"
@@ -8668,6 +8668,95 @@
         }
       ],
       "next_pr": "SCAN-2786-VISIBLE-DETAIL-GAP-AFTER-DIRECTORY-LIST-DETAIL-API-AUTHORITY-75-1"
+    },
+    "REPAIR-CN-PROXY-VISIBLE-DETAIL-POLICY-AUTHORITY-1": {
+      "repo": "fap-api",
+      "branch": "codex/repair-cn-proxy-visible-detail-policy-authority-1",
+      "base": "main",
+      "status": "in_progress",
+      "train_scope": "cn_proxy_visible_detail_policy_authority",
+      "risk_level": "medium_publication_authority",
+      "title": "fix(api): add CN proxy visible detail policy authority",
+      "name": "Add CN proxy visible detail policy authority",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for REPAIR-CN-PROXY-VISIBLE-DETAIL-POLICY-AUTHORITY-1, then implementing the PR."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Changed files are confined to read-only CN proxy visible detail policy authority command, command registration, focused console tests/docs, and authorized train metadata. No DB mutation, deploy, rollout, candidate prep, backfill, rollback, quarantine, or fap-web change was performed."
+        },
+        "cn_proxy_visible_detail_policy_authority": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerPlanCnProxyVisibleDetailPolicyAuthority --no-ansi",
+          "evidence": "5 tests passed, 39 assertions."
+        },
+        "cn_proxy_public_owner_regression": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi",
+          "evidence": "5 tests passed, 79 assertions."
+        },
+        "command_registration": {
+          "status": "pass",
+          "command": "php backend/artisan list --no-ansi | grep career:plan-cn-proxy-visible-detail-policy-authority",
+          "evidence": "The new read-only policy authority planner is registered."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cn-proxy-visible-detail-policy-authority.sqlite php artisan migrate --force --no-ansi",
+          "evidence": "SQLite migration completed successfully in local testing database."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test app/Console/Commands/CareerPlanCnProxyVisibleDetailPolicyAuthority.php tests/Feature/Console/CareerPlanCnProxyVisibleDetailPolicyAuthorityCommandTest.php",
+          "evidence": "Scoped Pint check passed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check",
+          "evidence": "Whitespace check passed."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full CI master chain exited 0."
+        },
+        "production_deploy_allowed": {
+          "status": "false"
+        },
+        "production_mutation_allowed": {
+          "status": "false"
+        },
+        "fap_web_touched": {
+          "status": "false"
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-17T22:00:00+08:00",
+          "status": "in_progress",
+          "summary": "Registered authorized CN proxy visible detail policy authority PR and started implementation from clean origin/main worktree."
+        },
+        {
+          "at": "2026-05-17T22:35:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Added read-only CN proxy visible-detail policy authority planner, focused tests, docs, and train metadata. Focused Career tests, command registration, route list, SQLite migrate, scoped Pint, diff check, and full MBTI CI chain passed."
+        }
+      ],
+      "next_pr": "REPAIR-CN-PROXY-CN-FIRST-DISPLAY-ASSET-PIPELINE-1"
     },
     "SEO-DASH-01B": {
       "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -4448,6 +4448,45 @@ prs:
       github_checks_required: true
       squash: true
 
+  - id: REPAIR-CN-PROXY-VISIBLE-DETAIL-POLICY-AUTHORITY-1
+    repo: fap-api
+    branch: codex/repair-cn-proxy-visible-detail-policy-authority-1
+    title: "fix(api): add CN proxy visible detail policy authority"
+    name: "Add CN proxy visible detail policy authority"
+    findings:
+      - "Product-visible 2786 claims require an explicit distinction between reviewed noindex CN proxy owner records and indexable visible detail pages."
+      - "The existing reviewed CN proxy public-owner evidence must not be treated as authorization for canonical visible detail publication."
+    scope:
+      - Add a read-only backend policy authority planner for CN proxy visible-detail publication.
+      - Require an explicit product policy decision before any CN proxy visible-detail train can proceed.
+      - Block visible-detail publication when only reviewed noindex public-owner evidence exists.
+      - Preserve partition-aware product claim semantics when the conservative decision is selected.
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Console/Kernel.php
+      - backend/tests/Feature/Console/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Publish CN proxy rows as public_canonical_job.
+      - Mark CN proxy rows indexable.
+      - Add CN proxy URLs to sitemap, llms, or llms-full.
+      - Mutate DB, deploy, rollout, candidate prep, backfill, rollback, quarantine, or touch fap-web.
+    validation:
+      - php artisan test --filter=CareerPlanCnProxyVisibleDetailPolicyAuthority --no-ansi
+      - php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi
+      - php artisan route:list --no-ansi
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cn-proxy-visible-detail-policy-authority.sqlite php artisan migrate --force --no-ansi
+      - vendor/bin/pint --test app/Console/Commands/CareerPlanCnProxyVisibleDetailPolicyAuthority.php tests/Feature/Console/CareerPlanCnProxyVisibleDetailPolicyAuthorityCommandTest.php
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
   - id: REPAIR-DIRECTORY-DETAIL-PENDING-314-1
     repo: fap-api
     branch: codex/repair-directory-detail-pending-314-1


### PR DESCRIPTION
## Summary
- Adds a read-only `career:plan-cn-proxy-visible-detail-policy-authority` planner for CN proxy visible-detail publication authority.
- Separates reviewed noindex CN proxy public-owner evidence from product-visible/detail-page publication authorization.
- Blocks the visible-detail path until explicit CN-first authority, schema policy, display pipeline, directory gate, and live acceptance exist.
- Registers `REPAIR-CN-PROXY-VISIBLE-DETAIL-POLICY-AUTHORITY-1` in PR train metadata and documents the policy gate.

## Scope / non-goals
- Read-only policy authority only.
- No DB mutation, deploy, rollout, candidate prep, backfill, rollback, quarantine, or fap-web change.
- Does not publish CN proxy rows as canonical jobs, make them indexable, or add sitemap/llms URLs.

## Validation
- `php artisan test --filter=CareerPlanCnProxyVisibleDetailPolicyAuthority --no-ansi` passed: 5 tests, 39 assertions.
- `php artisan test --filter=CareerValidateCnProxyPublicOwner --no-ansi` passed: 5 tests, 79 assertions.
- `php artisan route:list --no-ansi` passed: 198 routes.
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cn-proxy-visible-detail-policy-authority.sqlite php artisan migrate --force --no-ansi` passed.
- `vendor/bin/pint --test app/Console/Commands/CareerPlanCnProxyVisibleDetailPolicyAuthority.php tests/Feature/Console/CareerPlanCnProxyVisibleDetailPolicyAuthorityCommandTest.php` passed.
- `git diff --check && git diff --cached --check` passed.
- `bash backend/scripts/ci_verify_mbti.sh` passed.

## Repository rule impact
- No route changes.
- No migration changes.
- No middleware changes.
- Console-only read-only authority planner; production deploy is needed only if this command must be available in production runtime.
