### PR TITLE
fix(ops): approve system article revisions from review

### DIFF
--- a/backend/app/Filament/Ops/Pages/EditorialReviewPage.php
+++ b/backend/app/Filament/Ops/Pages/EditorialReviewPage.php
@@ -12,8 +12,10 @@ use App\Filament\Ops\Support\EditorialReviewAudit;
 use App\Filament\Ops\Support\EditorialReviewChecklist;
 use App\Models\AdminUser;
 use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
+use App\Services\Cms\ArticleTranslationWorkflowService;
 use App\Support\OrgContext;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
@@ -161,6 +163,13 @@ class EditorialReviewPage extends Page
             throw new AuthorizationException(__('ops.custom_pages.common.errors.not_assigned_reviewer'));
         }
 
+        $workingRevision = $record instanceof Article ? $record->workingRevision : null;
+        if ($workingRevision instanceof ArticleTranslationRevision
+            && $workingRevision->revision_status === ArticleTranslationRevision::STATUS_HUMAN_REVIEW) {
+            app(ArticleTranslationWorkflowService::class)
+                ->approveEditorialWorkingRevision($record, $this->actorAdminId());
+        }
+
         EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, $type, $record);
 
         Notification::make()
@@ -236,6 +245,7 @@ class EditorialReviewPage extends Page
         $currentOrgIds = $this->currentOrgIds();
 
         $articles = Article::query()
+            ->withoutGlobalScopes()
             ->with('seoMeta')
             ->whereIn('org_id', $currentOrgIds)
             ->where('status', 'draft')
@@ -332,7 +342,7 @@ class EditorialReviewPage extends Page
     {
         $orgId = max(0, (int) app(OrgContext::class)->orgId());
 
-        return $orgId > 0 ? [$orgId] : [];
+        return $orgId > 0 ? [0, $orgId] : [];
     }
 
     /**
@@ -500,7 +510,7 @@ class EditorialReviewPage extends Page
         }
 
         return match ($type) {
-            'article' => Article::query()->whereIn('org_id', $this->currentOrgIds())->findOrFail($id),
+            'article' => Article::query()->withoutGlobalScopes()->whereIn('org_id', $this->currentOrgIds())->findOrFail($id),
             'guide' => CareerGuide::query()->withoutGlobalScopes()->where('org_id', 0)->findOrFail($id),
             'job' => CareerJob::query()->withoutGlobalScopes()->where('org_id', 0)->findOrFail($id),
             default => throw new AuthorizationException(__('ops.custom_pages.common.errors.unsupported_review_type')),

--- a/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+++ b/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
@@ -215,8 +215,18 @@ final class ArticleTranslationWorkflowService
 
     public function approveTranslation(Article $target): ArticleTranslationRevision
     {
-        return DB::transaction(function () use ($target): ArticleTranslationRevision {
-            $locked = $this->lockTarget($target);
+        return $this->approveHumanReviewRevision($target, null, true);
+    }
+
+    public function approveEditorialWorkingRevision(Article $target, ?int $adminUserId = null): ArticleTranslationRevision
+    {
+        return $this->approveHumanReviewRevision($target, $adminUserId, false);
+    }
+
+    private function approveHumanReviewRevision(Article $target, ?int $adminUserId, bool $markEditorialApproved): ArticleTranslationRevision
+    {
+        return DB::transaction(function () use ($target, $adminUserId, $markEditorialApproved): ArticleTranslationRevision {
+            $locked = $this->lockWorkingArticle($target);
             $revision = $this->workingRevisionOrFail($locked);
 
             if ($revision->revision_status !== ArticleTranslationRevision::STATUS_HUMAN_REVIEW) {
@@ -224,19 +234,36 @@ final class ArticleTranslationWorkflowService
                     'working revision is not human_review',
                 ]);
             }
-            $blockers = $this->preflight($locked)['blockers'];
+
+            $actorId = $adminUserId ?: $this->actorAdminId();
+            if ($actorId <= 0) {
+                throw new ArticleTranslationWorkflowException('Approval requires an authenticated admin actor.', [
+                    'approval actor missing',
+                ]);
+            }
+
+            $blockers = $locked->isSourceArticle()
+                ? $this->sourceEditorialApprovalBlockers($locked, $revision)
+                : $this->preflight($locked)['blockers'];
+
             if ($blockers !== []) {
                 throw new ArticleTranslationWorkflowException('Translation approval is blocked by preflight issues.', $blockers);
             }
 
+            $now = now();
             $revision->forceFill([
                 'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
-                'approved_at' => $revision->approved_at ?? now(),
+                'reviewed_by' => $revision->reviewed_by ?: $actorId,
+                'reviewed_at' => $revision->reviewed_at ?? $now,
+                'approved_at' => $revision->approved_at ?? $now,
             ])->save();
             $locked->forceFill([
                 'translation_status' => Article::TRANSLATION_STATUS_APPROVED,
             ])->saveQuietly();
-            $this->markEditorialApproved($locked);
+
+            if ($markEditorialApproved) {
+                $this->markEditorialApproved($locked);
+            }
 
             $this->log('article_translation_approved', $locked, [
                 'revision_id' => (int) $revision->id,
@@ -512,18 +539,25 @@ final class ArticleTranslationWorkflowService
 
     private function lockTarget(Article $target): Article
     {
-        /** @var Article $locked */
-        $locked = Article::query()
-            ->withoutGlobalScopes()
-            ->with(['workingRevision', 'publishedRevision', 'sourceCanonical.workingRevision', 'seoMeta'])
-            ->lockForUpdate()
-            ->findOrFail($target->id);
+        $locked = $this->lockWorkingArticle($target);
 
         if ($locked->isSourceArticle()) {
             throw new ArticleTranslationWorkflowException('This action requires a target translation article.', [
                 'target article is source',
             ]);
         }
+
+        return $locked;
+    }
+
+    private function lockWorkingArticle(Article $target): Article
+    {
+        /** @var Article $locked */
+        $locked = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['workingRevision', 'publishedRevision', 'sourceCanonical.workingRevision', 'seoMeta'])
+            ->lockForUpdate()
+            ->findOrFail($target->id);
 
         return $locked;
     }
@@ -577,6 +611,31 @@ final class ArticleTranslationWorkflowService
         }
 
         return array_values(array_unique($blockers));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sourceEditorialApprovalBlockers(Article $source, ArticleTranslationRevision $revision): array
+    {
+        $blockers = [];
+
+        if (! $source->isSourceArticle()) {
+            $blockers[] = 'source article linkage invalid';
+        }
+        if ((int) $source->org_id !== self::PUBLIC_EDITORIAL_ORG_ID) {
+            $blockers[] = 'source article org mismatch';
+        }
+
+        $source->loadMissing(['seoMeta']);
+        if ($source->seoMeta instanceof ArticleSeoMeta && (int) $source->seoMeta->org_id !== (int) $source->org_id) {
+            $blockers[] = 'source seo_meta org mismatch';
+        }
+
+        return array_values(array_unique(array_merge(
+            $blockers,
+            $this->revisionOwnershipBlockers($source, $revision, 'source working revision'),
+        )));
     }
 
     /**
@@ -657,9 +716,7 @@ final class ArticleTranslationWorkflowService
 
     private function markEditorialApproved(Article $target): void
     {
-        $guard = (string) config('admin.guard', 'admin');
-        $actor = auth($guard)->user();
-        $actorId = is_object($actor) && is_numeric(data_get($actor, 'id')) ? (int) data_get($actor, 'id') : null;
+        $actorId = $this->actorAdminId() ?: null;
 
         EditorialReview::withoutGlobalScopes()->updateOrCreate(
             [
@@ -674,6 +731,14 @@ final class ArticleTranslationWorkflowService
                 'last_transition_at' => now(),
             ],
         );
+    }
+
+    private function actorAdminId(): int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $actor = auth($guard)->user();
+
+        return is_object($actor) && is_numeric(data_get($actor, 'id')) ? (int) data_get($actor, 'id') : 0;
     }
 
     private function sourceHashFor(Article $source): string

--- a/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
+++ b/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
@@ -736,6 +736,116 @@ final class ContentCmsProductLayerTest extends TestCase
         $this->assertTrue($article->is_public);
     }
 
+    public function test_editorial_review_can_approve_public_system_article_working_revision(): void
+    {
+        $owner = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+
+        $session = $this->opsSession((int) $owner->id);
+        $selectedOrgId = (int) $session['ops_org_id'];
+
+        $article = $this->seedArticle([
+            'org_id' => 0,
+            'slug' => 'system-review-article',
+            'locale' => 'en',
+            'source_locale' => 'en',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'translation_group_id' => 'system-review-article-group',
+            'source_version_hash' => 'system-review-source-hash',
+            'title' => 'System Review Article',
+            'excerpt' => 'System review excerpt',
+            'content_md' => 'System review body',
+            'content_html' => '<p>System review body</p>',
+            'status' => 'draft',
+            'is_public' => false,
+            'published_at' => null,
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'System Review Article SEO Title',
+            'seo_description' => 'System Review Article SEO Description',
+            'canonical_url' => 'https://example.test/articles/system-review-article',
+            'og_title' => 'System Review Article OG Title',
+            'og_description' => 'System Review Article OG Description',
+            'og_image_url' => 'https://example.test/images/system-review-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => 'system-review-article-group',
+            'locale' => 'en',
+            'source_locale' => 'en',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'source_version_hash' => 'system-review-source-hash',
+            'translated_from_version_hash' => 'system-review-source-hash',
+            'title' => 'System Review Article',
+            'excerpt' => 'System review excerpt',
+            'content_md' => 'System review body',
+            'seo_title' => 'System Review Article SEO Title',
+            'seo_description' => 'System Review Article SEO Description',
+        ]);
+        $article->forceFill(['working_revision_id' => (int) $revision->id])->save();
+
+        $this->setOpsContext($selectedOrgId, $owner, '/ops/editorial-review');
+        $reviewSurface = Livewire::test(EditorialReviewPage::class)
+            ->assertOk();
+        $this->assertTrue(
+            collect($reviewSurface->get('reviewItems'))
+                ->contains(fn (array $item): bool => (int) $item['id'] === (int) $article->id
+                    && $item['type'] === 'article'
+                    && $item['title'] === 'System Review Article')
+        );
+
+        $reviewSurface
+            ->set('ownerAssignments.article_'.$article->id, (string) $owner->id)
+            ->call('assignOwnerItem', 'article', (int) $article->id);
+
+        $this->setOpsContext($selectedOrgId, $reviewer, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->set('reviewerAssignments.article_'.$article->id, (string) $reviewer->id)
+            ->call('assignReviewerItem', 'article', (int) $article->id);
+
+        $this->setOpsContext($selectedOrgId, $owner, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->call('submitItem', 'article', (int) $article->id);
+
+        $this->setOpsContext($selectedOrgId, $reviewer, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->call('approveItem', 'article', (int) $article->id);
+
+        $revision->refresh();
+        $article->refresh();
+
+        $this->assertSame(ArticleTranslationRevision::STATUS_APPROVED, (string) $revision->revision_status);
+        $this->assertSame((int) $reviewer->id, (int) $revision->reviewed_by);
+        $this->assertNotNull($revision->reviewed_at);
+        $this->assertNotNull($revision->approved_at);
+        $this->assertSame(Article::TRANSLATION_STATUS_APPROVED, (string) $article->translation_status);
+
+        $workflow = EditorialReview::withoutGlobalScopes()
+            ->where('content_type', 'article')
+            ->where('content_id', (int) $article->id)
+            ->first();
+
+        $this->assertNotNull($workflow);
+        $this->assertSame(EditorialReview::STATE_APPROVED, (string) $workflow->workflow_state);
+    }
+
     public function test_reassigning_reviewer_invalidates_existing_approval_until_resubmitted(): void
     {
         $owner = $this->createAdminWithPermissions([

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -685,6 +685,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_editorial_review_approval_changes(): void
+    {
+        $changed = [
+            'backend/app/Filament/Ops/Pages/EditorialReviewPage.php',
+            'backend/app/Services/Cms/ArticleTranslationWorkflowService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_controlled_article_publish_sop_changes(): void
     {
         $changed = [
@@ -1475,6 +1485,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleEditorialReviewApprovalFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleMultiTestGraphEdgeFile($file)) {
                 continue;
             }
@@ -1858,6 +1872,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Filament/Ops/Pages/ArticlePublishingOpsPage.php',
             'backend/app/Models/ArticleEditorialPackageImport.php',
             'backend/database/migrations/2026_05_14_000100_create_article_editorial_package_imports_table.php',
+        ], true);
+    }
+
+    private function isArticleEditorialReviewApprovalFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Filament/Ops/Pages/EditorialReviewPage.php',
+            'backend/app/Services/Cms/ArticleTranslationWorkflowService.php',
         ], true);
     }
 


### PR DESCRIPTION
## Summary
- include public system articles (`org_id=0`) in the Ops editorial review surface for selected ops orgs
- approve `human_review` article working revisions through the CMS workflow when editorial review is approved
- persist revision `reviewed_by`, `reviewed_at`, and `approved_at` so controlled article publish preflight can pass
- add coverage for approving a public system article working revision from Ops editorial review

## Why
Codex-assisted controlled article publish for article ids 35 and 36 was blocked because the system CMS articles were `org_id=0` and did not appear in the Ops editorial review queue. Their working revisions stayed in `human_review`, so `articles:publish-controlled` correctly failed with `revision_not_editorially_approved`.

## Validation
- `php -l backend/app/Filament/Ops/Pages/EditorialReviewPage.php`
- `php -l backend/app/Services/Cms/ArticleTranslationWorkflowService.php`
- `cd backend && php artisan test --filter=ContentCmsProductLayerTest`
- `cd backend && php artisan test --filter=ArticleTranslationOpsPageTest`
- `cd backend && ./vendor/bin/pint app/Services/Cms/ArticleTranslationWorkflowService.php app/Filament/Ops/Pages/EditorialReviewPage.php tests/Feature/Ops/ContentCmsProductLayerTest.php`
- `git diff --check`

## Intentionally deferred
- no production data mutation in this PR
- no deployment in this PR
- article ids 35 and 36 still need production Ops approval and controlled publish after this is merged/deployed

## Known unrelated issue
- `cd backend && php artisan test --filter=ArticleTranslationContractTest` currently fails on `article_locale_scoped_list_still_uses_current_ops_locale`; this test exercises ArticleResource locale list visibility, not the edited Ops review/working-revision approval path.

## Repository rule impact
This updates the backend-authoritative CMS publishing workflow for system article review. Public article content remains managed through backend CMS Article resources and controlled publish remains gated by `articles:publish-controlled`. No frontend content authority changes.