### PR TITLE
docs(seo-intel): add Metabase MVP dashboard spec

### DIFF
--- a/backend/docs/seo/generated/metabase-mvp-dashboard.v1.json
+++ b/backend/docs/seo/generated/metabase-mvp-dashboard.v1.json
@@ -1,0 +1,275 @@
+{
+  "version": 1,
+  "source_documents": [
+    "SEO-DASH-00B",
+    "SEO-DASH-01A",
+    "SEO-DASH-03B",
+    "SEO-DASH-04A",
+    "SEO-DASH-04B",
+    "CHINA-SEARCH-04",
+    "BACKEND-RUNTIME-02D"
+  ],
+  "metabase_deployed": false,
+  "production_connection_created": false,
+  "read_only_policy_required": true,
+  "allowed_data_source": "seo_intel",
+  "forbidden_data_sources": [
+    "business_db",
+    "cms_write_tables",
+    "node2_local_db",
+    "raw_orders",
+    "raw_payments",
+    "raw_email",
+    "raw_events_detail"
+  ],
+  "read_only_policy": {
+    "metabase_reads_seo_intel_only": true,
+    "read_only_db_user_required": true,
+    "metabase_can_write": false,
+    "business_db_connection_allowed": false,
+    "cms_write_tables_allowed": false,
+    "node2_local_db_allowed": false,
+    "raw_business_tables_allowed": false,
+    "raw_pii_allowed": false
+  },
+  "dashboards": [
+    {
+      "name": "URL Truth & Drift",
+      "cards": [
+        "URL count by page_entity_type",
+        "Indexability state",
+        "Drift issue counts",
+        "Sitemap/llms parity warnings",
+        "Private/noindex exposure warnings"
+      ]
+    },
+    {
+      "name": "Search Channel Health",
+      "cards": [
+        "GSC rows/clicks/impressions/CTR/position",
+        "Baidu push dry-run/submission status",
+        "IndexNow submission status",
+        "360/Sogou/Shenma verification/submission status",
+        "Source engine breakdown"
+      ]
+    },
+    {
+      "name": "Landing Attribution",
+      "cards": [
+        "Landing events",
+        "Funnel event counts",
+        "Source engine",
+        "Consent state",
+        "Traffic quality"
+      ]
+    },
+    {
+      "name": "Revenue / Cluster",
+      "cards": [
+        "Revenue cents",
+        "Orders count",
+        "Purchase count",
+        "AOV",
+        "RPV proxy",
+        "Purchase rate",
+        "Cluster",
+        "Page entity type"
+      ]
+    },
+    {
+      "name": "Crawler Health",
+      "cards": [
+        "Bot family",
+        "Source engine",
+        "Crawl count",
+        "Status code",
+        "Response time bucket",
+        "Private flow hits",
+        "Noindex hits"
+      ]
+    },
+    {
+      "name": "Internal / QA Filtering",
+      "cards": [
+        "Internal traffic counts",
+        "QA traffic counts",
+        "Bot traffic counts",
+        "Non-production counts",
+        "Excluded traffic counts",
+        "Traffic quality breakdown"
+      ]
+    }
+  ],
+  "sanitized_views": [
+    {
+      "name": "seo_v_url_truth_overview",
+      "source_tables": [
+        "seo_urls"
+      ],
+      "exposed_fields": [
+        "locale",
+        "page_entity_type",
+        "cluster",
+        "source_authority",
+        "indexability_state",
+        "lastmod_source",
+        "is_private_flow",
+        "url_count",
+        "first_seen_at",
+        "last_seen_at"
+      ],
+      "definition": "select locale, page_entity_type, cluster, source_authority, indexability_state, lastmod_source, is_private_flow, count(*) as url_count, min(first_seen_at) as first_seen_at, max(last_seen_at) as last_seen_at from seo_urls group by locale, page_entity_type, cluster, source_authority, indexability_state, lastmod_source, is_private_flow"
+    },
+    {
+      "name": "seo_v_search_channel_health",
+      "source_tables": [
+        "seo_gsc_daily",
+        "seo_baidu_push_logs",
+        "seo_indexnow_submissions",
+        "seo_search_engine_verification_statuses",
+        "seo_domestic_submission_logs",
+        "seo_domestic_index_samples"
+      ],
+      "exposed_fields": [
+        "report_date",
+        "source_engine",
+        "status",
+        "clicks",
+        "impressions",
+        "ctr_ppm",
+        "average_position_milli",
+        "submission_count",
+        "verification_count",
+        "index_sample_count"
+      ],
+      "definition": "planned union aggregate over search channel daily tables exposing report_date, source_engine, status counts, clicks, impressions, ctr_ppm, average_position_milli, submission_count, verification_count, and index_sample_count"
+    },
+    {
+      "name": "seo_v_landing_attribution_daily",
+      "source_tables": [
+        "seo_landing_attribution_daily",
+        "seo_event_funnel_daily",
+        "seo_consent_daily"
+      ],
+      "exposed_fields": [
+        "report_date",
+        "canonical_url_hash",
+        "locale",
+        "source_engine",
+        "source_route_family",
+        "source_slug",
+        "content_id",
+        "test_slug",
+        "cta_id",
+        "entrypoint",
+        "consent_state",
+        "traffic_quality",
+        "landing_event_count",
+        "start_attempt_count",
+        "submit_attempt_count",
+        "view_result_count",
+        "click_unlock_count",
+        "create_order_count",
+        "purchase_success_count"
+      ],
+      "definition": "select report_date, canonical_url_hash, locale, source_engine, source_route_family, source_slug, content_id, test_slug, cta_id, entrypoint, first_touch_count, last_touch_count, cta_touch_count, landing_event_count, start_attempt_count, submit_attempt_count, purchase_success_count from seo_landing_attribution_daily"
+    },
+    {
+      "name": "seo_v_revenue_cluster_daily",
+      "source_tables": [
+        "seo_revenue_daily",
+        "seo_cluster_daily"
+      ],
+      "exposed_fields": [
+        "report_date",
+        "canonical_url_hash",
+        "locale",
+        "page_entity_type",
+        "cluster",
+        "source_engine",
+        "orders_count",
+        "purchase_count",
+        "revenue_cents",
+        "currency",
+        "aov_cents",
+        "rpv_proxy_cents",
+        "purchase_rate_ppm"
+      ],
+      "definition": "select report_date, canonical_url_hash, locale, page_entity_type, cluster, source_engine, orders_count, purchase_count, revenue_cents, currency, aov_cents, rpv_proxy_cents, purchase_rate_ppm from seo_revenue_daily"
+    },
+    {
+      "name": "seo_v_crawler_health_daily",
+      "source_tables": [
+        "seo_crawler_logs_daily"
+      ],
+      "exposed_fields": [
+        "report_date",
+        "canonical_url_hash",
+        "path_hash",
+        "path_display_masked",
+        "locale",
+        "page_entity_type",
+        "source_engine",
+        "bot_family",
+        "method",
+        "status_code",
+        "response_time_bucket",
+        "crawl_count",
+        "robots_allowed",
+        "blocked_by_robots",
+        "private_flow_hit",
+        "noindex_hit"
+      ],
+      "definition": "select report_date, canonical_url_hash, path_hash, path_display_masked, locale, page_entity_type, source_engine, bot_family, method, status_code, response_time_bucket, crawl_count, robots_allowed, blocked_by_robots, private_flow_hit, noindex_hit from seo_crawler_logs_daily"
+    },
+    {
+      "name": "seo_v_internal_traffic_filtering",
+      "source_tables": [
+        "seo_internal_traffic_rules",
+        "seo_event_funnel_daily"
+      ],
+      "exposed_fields": [
+        "rule_type",
+        "match_kind",
+        "pattern_display_masked",
+        "environment",
+        "is_active",
+        "traffic_quality",
+        "event_count"
+      ],
+      "definition": "planned aggregate over seo_internal_traffic_rules and seo_event_funnel_daily exposing masked rules, environment, active state, traffic_quality, and event_count"
+    }
+  ],
+  "forbidden_fields": [
+    "email",
+    "raw_email",
+    "order_no",
+    "raw_order_no",
+    "attempt_id",
+    "raw_attempt_id",
+    "payment_id",
+    "provider_event_id",
+    "cookie",
+    "raw_cookie",
+    "raw_ip",
+    "ip_address",
+    "raw_user_agent",
+    "user_agent",
+    "raw_payload",
+    "payment_payload",
+    "provider_payload",
+    "token",
+    "api_key",
+    "secret"
+  ],
+  "purchase_truth_source": "backend_orders_payment_benefits_aggregates",
+  "ga4_purchase_truth": false,
+  "baidu_purchase_truth": false,
+  "search_channels_are_truth": false,
+  "crawler_logs_are_truth": false,
+  "metabase_credentials_added": false,
+  "production_db_user_created": false,
+  "scheduler_enabled": false,
+  "queue_worker_enabled": false,
+  "next_task": "SEO-DASH-06"
+}

--- a/backend/docs/seo/metabase-deployment-runbook.md
+++ b/backend/docs/seo/metabase-deployment-runbook.md
@@ -1,0 +1,59 @@
+# Metabase Deployment Runbook
+
+## Status
+
+No Metabase deployment happens in SEO-DASH-05.
+
+Production Metabase deployment requires explicit human approval after this PR is reviewed.
+
+## Required Preconditions
+
+- Production `seo_intel` DB exists.
+- Production migrations or view creation have separate human approval.
+- Read-only DB user exists for `seo_intel` only.
+- No business DB connection is configured.
+- No CMS write DB connection is configured.
+- No Node2 local DB connection is configured.
+- Dashboard owner is assigned.
+- Access control owner is assigned.
+- PII redaction review is complete.
+- Backup and restore plan is documented.
+
+## Connection Policy
+
+Metabase must connect only to sanitized `seo_intel` aggregate views or tables.
+
+Forbidden connections:
+
+- business DB
+- CMS write tables
+- Node2 local DB
+- raw orders
+- raw payments
+- raw email
+- raw event detail
+- raw crawler logs
+
+## Access Control
+
+- Use a read-only database user.
+- Disable write permissions.
+- Restrict admin access to named owners.
+- Review dashboard sharing before production use.
+- Review exported CSV permissions before enabling exports.
+
+## PII Review
+
+Before deployment, confirm dashboards do not expose raw email, raw order numbers, raw attempt IDs, provider event IDs, payment IDs, raw IPs, raw cookies, raw user agents, raw payloads, or payment payloads.
+
+## Stop Conditions
+
+Stop deployment if:
+
+- Metabase requires business DB access.
+- Metabase requires CMS write table access.
+- Metabase requires Node2 local DB access.
+- Any dashboard exposes raw PII or raw identifiers.
+- Read-only DB user is not available.
+- Production migration or view creation approval is missing.
+- Dashboard owner is not assigned.

--- a/backend/docs/seo/metabase-mvp-dashboard.md
+++ b/backend/docs/seo/metabase-mvp-dashboard.md
@@ -1,0 +1,116 @@
+# Metabase MVP Dashboard Specification
+
+## Purpose
+
+SEO-DASH-05 defines the Metabase MVP dashboard policy for FermatMind Search Intelligence.
+This PR does not deploy Metabase, add credentials, create a production connection, create production read-only users, or run production migrations.
+
+## Data Sources
+
+Metabase may read only sanitized `seo_intel` aggregate tables and views.
+
+Metabase must not connect to or query:
+
+- business DB
+- CMS write tables
+- Node2 local DB
+- raw orders
+- raw payments
+- raw email
+- raw event detail
+- raw crawler logs
+
+Purchase truth comes from backend orders, payments, and benefits aggregates. GA4, Baidu, GSC, IndexNow, domestic search adapters, and crawler logs are not purchase truth.
+
+Search channels are feedback or adapter signals only. They are not alternate SEO truth. Crawler hits do not grant indexability.
+
+## Read-Only Policy
+
+- Metabase must use a read-only DB user.
+- The connection must be scoped to `seo_intel`.
+- Metabase must not write.
+- Metabase must not query CMS write tables or business DB tables.
+- Metabase must not query Node2 local Laravel, DB, queue, php84, or fap-mysql.
+- Metabase must not expose raw email, raw order numbers, raw attempt IDs, provider event IDs, payment IDs, raw IPs, cookies, raw user agents, raw payloads, or payment payloads.
+
+## MVP Dashboards
+
+### URL Truth & Drift
+
+- URL count by `page_entity_type`
+- `indexability_state`
+- drift issue counts
+- sitemap/llms parity warnings
+- private/noindex exposure warnings
+
+### Search Channel Health
+
+- GSC rows, clicks, impressions, CTR, and position
+- Baidu push dry-run/submission status
+- IndexNow submission status
+- 360/Sogou/Shenma verification and submission status
+- `source_engine` breakdown
+
+### Landing Attribution
+
+- `landing_event_count`
+- `start_attempt_count`
+- `submit_attempt_count`
+- `view_result_count`
+- `click_unlock_count`
+- `create_order_count`
+- `purchase_success_count`
+- `source_engine`
+- `consent_state`
+- `traffic_quality`
+
+### Revenue / Cluster
+
+- `revenue_cents`
+- `orders_count`
+- `purchase_count`
+- AOV
+- RPV proxy
+- purchase rate
+- `cluster`
+- `page_entity_type`
+
+### Crawler Health
+
+- `bot_family`
+- `source_engine`
+- `crawl_count`
+- `status_code`
+- `response_time_bucket`
+- private flow hits
+- noindex hits
+
+### Internal / QA Filtering
+
+- internal, QA, bot, and non-production counts
+- excluded traffic counts
+- `traffic_quality` breakdown
+
+## Sanitized Views
+
+This PR defines view contracts only in `backend/docs/seo/generated/metabase-mvp-dashboard.v1.json`.
+It does not create SQL views in production.
+
+Planned sanitized views:
+
+- `seo_v_url_truth_overview`
+- `seo_v_search_channel_health`
+- `seo_v_landing_attribution_daily`
+- `seo_v_revenue_cluster_daily`
+- `seo_v_crawler_health_daily`
+- `seo_v_internal_traffic_filtering`
+
+The views expose aggregate counts, hashes, masked display fields, dates, statuses, source engines, clusters, and page/entity categories only.
+
+## Semantic Boundaries
+
+Dashboard names and metrics must not imply that RIASEC, Big Five, Career Decision, or AI career planning are full recommender runtimes. Use neutral metric labels such as `career_support_view`, `career_direction_page_view`, `riasec_result_view`, `workstyle_content_view`, and `interest_signal_page_view`.
+
+## Next Task
+
+Next task: SEO-DASH-06.

--- a/backend/tests/Feature/SeoIntel/SeoIntelMetabaseMvpDashboardTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelMetabaseMvpDashboardTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelMetabaseMvpDashboardTest extends TestCase
+{
+    #[Test]
+    public function generated_artifact_locks_metabase_policy_and_next_task(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(1, $artifact['version'] ?? null);
+        $this->assertContains('SEO-DASH-00B', $artifact['source_documents'] ?? []);
+        $this->assertContains('CHINA-SEARCH-04', $artifact['source_documents'] ?? []);
+        $this->assertFalse((bool) ($artifact['metabase_deployed'] ?? true));
+        $this->assertFalse((bool) ($artifact['production_connection_created'] ?? true));
+        $this->assertTrue((bool) ($artifact['read_only_policy_required'] ?? false));
+        $this->assertSame('seo_intel', $artifact['allowed_data_source'] ?? null);
+        $this->assertContains('business_db', $artifact['forbidden_data_sources'] ?? []);
+        $this->assertContains('cms_write_tables', $artifact['forbidden_data_sources'] ?? []);
+        $this->assertContains('node2_local_db', $artifact['forbidden_data_sources'] ?? []);
+        $this->assertSame('backend_orders_payment_benefits_aggregates', $artifact['purchase_truth_source'] ?? null);
+        $this->assertFalse((bool) ($artifact['ga4_purchase_truth'] ?? true));
+        $this->assertFalse((bool) ($artifact['baidu_purchase_truth'] ?? true));
+        $this->assertFalse((bool) ($artifact['search_channels_are_truth'] ?? true));
+        $this->assertFalse((bool) ($artifact['crawler_logs_are_truth'] ?? true));
+        $this->assertFalse((bool) ($artifact['metabase_credentials_added'] ?? true));
+        $this->assertFalse((bool) ($artifact['production_db_user_created'] ?? true));
+        $this->assertFalse((bool) ($artifact['scheduler_enabled'] ?? true));
+        $this->assertFalse((bool) ($artifact['queue_worker_enabled'] ?? true));
+        $this->assertSame('SEO-DASH-06', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function dashboards_include_all_mvp_groups(): void
+    {
+        $names = array_column($this->artifact()['dashboards'] ?? [], 'name');
+
+        foreach ([
+            'URL Truth & Drift',
+            'Search Channel Health',
+            'Landing Attribution',
+            'Revenue / Cluster',
+            'Crawler Health',
+            'Internal / QA Filtering',
+        ] as $dashboard) {
+            $this->assertContains($dashboard, $names);
+        }
+    }
+
+    #[Test]
+    public function sanitized_views_do_not_expose_forbidden_fields_or_sources(): void
+    {
+        $artifact = $this->artifact();
+        $views = $artifact['sanitized_views'] ?? [];
+
+        $this->assertCount(6, $views);
+        $this->assertSame([
+            'seo_v_url_truth_overview',
+            'seo_v_search_channel_health',
+            'seo_v_landing_attribution_daily',
+            'seo_v_revenue_cluster_daily',
+            'seo_v_crawler_health_daily',
+            'seo_v_internal_traffic_filtering',
+        ], array_column($views, 'name'));
+
+        foreach ($views as $view) {
+            $encodedView = strtolower(json_encode($view, JSON_THROW_ON_ERROR));
+
+            foreach ($this->forbiddenTermsForViewDefinitions() as $term) {
+                $this->assertStringNotContainsString($term, $encodedView, ($view['name'] ?? 'view').' must not expose '.$term);
+            }
+
+            foreach (['business_db', 'cms_write_tables', 'node2_local_db', 'orders', 'payments', 'email_events'] as $source) {
+                $this->assertNotContains($source, $view['source_tables'] ?? [], ($view['name'] ?? 'view').' must not source '.$source);
+            }
+        }
+    }
+
+    #[Test]
+    public function docs_and_artifact_forbid_raw_pii_and_metabase_deployment(): void
+    {
+        $dashboardDoc = (string) file_get_contents(base_path('docs/seo/metabase-mvp-dashboard.md'));
+        $runbook = (string) file_get_contents(base_path('docs/seo/metabase-deployment-runbook.md'));
+        $artifactJson = (string) file_get_contents(base_path('docs/seo/generated/metabase-mvp-dashboard.v1.json'));
+        $combined = strtolower($dashboardDoc."\n".$runbook."\n".$artifactJson);
+
+        foreach ([
+            'metabase_deployed": false',
+            'production_connection_created": false',
+            'read-only db user',
+            'metabase must not expose raw email',
+            'raw order',
+            'raw attempt',
+            'provider event',
+            'raw ip',
+            'raw cookies',
+            'no metabase deployment happens',
+        ] as $requiredBoundary) {
+            $this->assertStringContainsString($requiredBoundary, $combined);
+        }
+    }
+
+    #[Test]
+    public function no_deployment_credentials_or_scheduler_activation_are_introduced(): void
+    {
+        $bootstrap = (string) file_get_contents(base_path('bootstrap/app.php'));
+        $config = (string) file_get_contents(config_path('seo_intel.php'));
+        $artifact = json_encode($this->artifact(), JSON_THROW_ON_ERROR);
+
+        $this->assertStringNotContainsString('metabase', strtolower($bootstrap));
+        $this->assertStringNotContainsString('METABASE_', $config);
+        $this->assertStringNotContainsString('metabase_password', strtolower($artifact));
+        $this->assertStringNotContainsString('metabase_secret', strtolower($artifact));
+        $this->assertStringNotContainsString('seo-intel:collect', $bootstrap);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/metabase-mvp-dashboard.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenTermsForViewDefinitions(): array
+    {
+        return [
+            'email',
+            'order_no',
+            'raw_order_no',
+            'attempt_id',
+            'raw_attempt_id',
+            'payment_id',
+            'provider_event_id',
+            'cookie',
+            'raw_cookie',
+            'raw_ip',
+            'ip_address',
+            'raw_user_agent',
+            'user_agent',
+            'raw_payload',
+            'payment_payload',
+            'provider_payload',
+            'token',
+            'api_key',
+            'secret',
+        ];
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T12:10:00Z",
+  "updated_at": "2026-05-17T12:47:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -2113,7 +2113,7 @@
       "branch": "fix/career-2786-full-audit-report-audit13",
       "title": "feat(api): add career 2786 full audit artifact report",
       "name": "Career 2786 Full Audit Artifact Report",
-      "status": "committed",
+      "status": "pr_open",
       "depends_on": [
         "AUDIT-12"
       ],
@@ -3188,7 +3188,7 @@
       "branch": "fix/career-entity-remediation-plan-1",
       "title": "fix(api): add career occupation entity remediation planning",
       "name": "Add career occupation entity remediation planning",
-      "status": "local_validation_passed",
+      "status": "committed",
       "depends_on": [
         "REPAIR-INDEX-1",
         "SCAN-3"
@@ -4247,7 +4247,7 @@
       "branch": "fix/career-surface-context-export-producer",
       "title": "fix(api): add career surface context export producer",
       "name": "Add read-only Career 2786 surface context artifact producer",
-      "status": "in_progress",
+      "status": "local_validation_passed",
       "depends_on": [
         "RUN-1D",
         "REPAIR-80-CANDIDATE-1"
@@ -4303,7 +4303,7 @@
       "branch": "fix/career-index-entity-policy-readiness-2",
       "title": "fix(api): classify career readiness policy blockers",
       "name": "Defer broad surface verification and classify index/entity/policy readiness",
-      "status": "in_progress",
+      "status": "github_checks_passed",
       "depends_on": [
         "RUN-1E",
         "CTX-SURFACE-EXPORT-1"
@@ -4388,7 +4388,7 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
+      "commit_sha": "bb315e305714183e7c0130deacfbcf9159c95bd1",
       "pr_url": null,
       "checks": {
         "authorization": {
@@ -9630,7 +9630,7 @@
       "depends_on": [
         "CHINA-SEARCH-03"
       ],
-      "status": "pr_open",
+      "status": "merged",
       "train_scope": "chinese_crawler_log_collector_foundation",
       "risk_level": "medium_disabled_crawler_log_schema",
       "title": "feat(seo-intel): add Chinese crawler log collector foundation",
@@ -9689,14 +9689,17 @@
           "status": "pass",
           "command": "git diff --check && git diff --cached --check"
         },
-        "github": "pending"
+        "github": {
+          "status": "pass",
+          "evidence": "GitHub required checks passed for PR #1445 and mergeStateStatus was CLEAN before squash merge."
+        }
       },
       "failure_reason": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1445",
-      "commit_sha": "6370c74273a96ca8e639bd140c8bb139abe7d5af",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "commit_sha": "f78b71f8e8ffa60133a2c3f3b7e4aee91495a5f1",
+      "merged_at": "2026-05-17T12:07:10Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "history": [
         {
@@ -9718,9 +9721,119 @@
           "at": "2026-05-17T12:10:00Z",
           "status": "pr_open",
           "summary": "Opened PR #1445 for CHINA-SEARCH-04; GitHub checks pending."
+        },
+        {
+          "at": "2026-05-17T12:07:10Z",
+          "status": "merged",
+          "summary": "PR #1445 merged; origin/main contains merge commit f78b71f8e8ffa60133a2c3f3b7e4aee91495a5f1 and local/remote branch cleanup completed."
         }
       ],
       "next_pr": "SEO-DASH-05"
+    },
+    "SEO-DASH-05": {
+      "repo": "fap-api",
+      "branch": "codex/seo-dash-05-metabase-mvp-dashboard",
+      "base": "main",
+      "depends_on": [
+        "CHINA-SEARCH-04"
+      ],
+      "status": "in_progress",
+      "train_scope": "metabase_mvp_dashboard_policy_sanitized_views",
+      "risk_level": "low_docs_contract_no_deploy",
+      "title": "docs(seo-intel): add Metabase MVP dashboard spec",
+      "name": "Metabase MVP dashboard spec and sanitized views",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly provided SEO-DASH-05 with branch, title, allowed files, validation commands, and permission to update fap-api PR train metadata."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "CHINA-SEARCH-04 merged in fap-api PR #1445 and origin/main contains merge commit f78b71f8e8ffa60133a2c3f3b7e4aee91495a5f1."
+        },
+        "production_deploy_allowed": {
+          "status": "false"
+        },
+        "production_migration_execution_allowed": {
+          "status": "false"
+        },
+        "metabase_deployment": {
+          "status": "human_confirm_required"
+        },
+        "read_only_db_user": {
+          "status": "human_confirm_required"
+        },
+        "scheduler_activation": {
+          "status": "false"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Metabase MVP dashboard docs, deployment runbook, generated artifact, static SeoIntel contract test, and docs/codex PR train metadata. No fap-web runtime, payment/order/report/email/recommendation/scoring, deploy/env, scheduler, queue, production DB connection, Metabase credentials/deployment, sitemap, llms, OpenResty/Nginx/CDN/cloud, or Node2/Node3 runtime files changed."
+        },
+        "seo_intel_metabase_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=SeoIntelMetabaseMvpDashboard",
+          "evidence": "5 tests passed with 201 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=SeoIntel",
+          "evidence": "75 tests passed with 1441 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "Full Pint check passed across 3353 files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "github": {
+          "status": "pass",
+          "evidence": "PR #1446 CI passed: hygiene, verify-mbti-legacy, and verify-mbti-v2 completed successfully; mergeStateStatus=CLEAN."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1446",
+      "commit_sha": "7680be80d65e36f7fc4fa50764a930f1f2dcf077",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-17T12:20:00Z",
+          "status": "in_progress",
+          "summary": "Registered authorized SEO-DASH-05 and started Metabase MVP dashboard policy, sanitized view definitions, runbook, artifact, and static tests from origin/main."
+        },
+        {
+          "at": "2026-05-17T12:28:00Z",
+          "status": "local_validation_passed",
+          "summary": "Implemented Metabase MVP dashboard policy, sanitized view definitions as generated artifact contracts, deployment runbook, and static SeoIntel tests. SeoIntel tests, route list, Pint, JSON/YAML validation, and diff checks passed."
+        },
+        {
+          "at": "2026-05-17T12:31:00Z",
+          "status": "committed",
+          "summary": "Committed SEO-DASH-05 local changes at 06b91f6424752ebfbde56cebe577cd307e7f568e."
+        },
+        {
+          "at": "2026-05-17T12:35:00Z",
+          "status": "pr_open",
+          "summary": "Opened PR #1446 for SEO-DASH-05; GitHub checks pending."
+        },
+        {
+          "at": "2026-05-17T12:47:00Z",
+          "status": "github_checks_passed",
+          "summary": "GitHub checks passed for PR #1446 and mergeStateStatus is CLEAN. PR remains open for human review; not merged."
+        }
+      ],
+      "next_pr": "SEO-DASH-06"
     }
   },
   "SEO-DASH-04B": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -537,6 +537,55 @@ prs:
     production_log_access: human_confirm_required
     scheduler_activation: false
     next_task: SEO-DASH-05
+  - id: SEO-DASH-05
+    repo: fap-api
+    depends_on:
+      - CHINA-SEARCH-04
+    branch: codex/seo-dash-05-metabase-mvp-dashboard
+    title: "docs(seo-intel): add Metabase MVP dashboard spec"
+    name: "Metabase MVP dashboard spec and sanitized views"
+    findings:
+      - "CHINA-SEARCH-04 merged Chinese crawler log collector foundation."
+      - "Metabase may read only sanitized seo_intel aggregates and must not query business, CMS write, Node2 local, or raw detail data sources."
+      - "Purchase truth remains backend orders/payment/benefits aggregates; search channels and crawler logs are not truth sources."
+    scope:
+      - Define Metabase read-only policy and MVP dashboard groups.
+      - Define sanitized view contracts over seo_intel aggregates in generated artifact without deploying Metabase or creating production connections.
+      - Add deployment runbook, generated artifact, and static SeoIntel contract tests proving no PII/raw identifiers, credentials, scheduler, or deployment activation.
+      - Keep production DB, Metabase deployment, env, scheduler, queue, external APIs, runtime behavior, sitemap/llms, and fap-web unchanged.
+    allowed_paths:
+      - backend/database/migrations/*seo_intel_views*
+      - backend/app/Services/SeoIntel/**
+      - backend/tests/**/SeoIntel*Test.php
+      - backend/docs/seo/metabase-mvp-dashboard.md
+      - backend/docs/seo/generated/metabase-mvp-dashboard.v1.json
+      - backend/docs/seo/metabase-deployment-runbook.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy Metabase, add Metabase credentials, edit env, connect production DB, create production read-only users, or create production seo_intel DB.
+      - Run production migrations, enable scheduler jobs, create queue workers, SSH, or touch Node2/Node3.
+      - Query business DB, CMS write tables, raw orders, raw payments, raw email, raw event detail, or Node2 local DB.
+      - Store or expose raw emails, order numbers, attempt ids, payment ids, provider event ids, cookies, raw IPs, raw user agents, tokens, secrets, raw payloads, or payment payloads.
+      - Use GA4/Baidu/GSC/search channels/crawler logs as purchase truth or alternate SEO truth.
+      - Change payment, order, report, email, recommendation, scoring, sitemap, or llms behavior.
+      - Modify fap-web runtime or use fap-api/fap-web as production frontend runtime.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    metabase_deployment: human_confirm_required
+    read_only_db_user: human_confirm_required
+    scheduler_activation: false
+    next_task: SEO-DASH-06
   - id: PR-MEDIA-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
Adds Metabase MVP dashboard specification and sanitized read-only policy for FermatMind Search Intelligence. Defines allowed seo_intel-only data access, forbidden raw business/PII data sources, MVP dashboard groups, sanitized view definitions or planned views, deployment runbook, generated artifact, and tests. Does not deploy Metabase, add credentials, connect production DB, change runtime behavior, or expose PII.

Validation commands:
- `cd backend && php artisan test --filter=SeoIntelMetabaseMvpDashboard`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/generated/metabase-mvp-dashboard.v1.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"`
- `git diff --check && git diff --cached --check`

Intentionally deferred:
- Metabase deployment and credentials.
- Production seo_intel DB creation or migrations.
- Production read-only DB user creation.
- Scheduler, queue worker, collector activation, and production DB connection.
- Runtime behavior, sitemap/llms, payment/order/report/email/recommendation/scoring changes.
