### PR TITLE
fix(cms-media): enforce public article media origin and variant readiness

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -17,6 +17,7 @@ use App\Models\Article;
 use App\Models\ArticleTranslationRevision;
 use App\Models\MediaAsset;
 use App\Services\Cms\ArticleTranslationRevisionWorkspace;
+use App\Services\Cms\MediaVariantGenerator;
 use App\Support\PublicMediaUrlGuard;
 use Filament\Forms;
 use Filament\Forms\Components\BelongsToManyMultiSelect;
@@ -152,6 +153,18 @@ class ArticleResource extends Resource
                                     ->afterStateUpdated(function (mixed $state, Forms\Set $set): void {
                                         $asset = self::resolveMediaAsset($state);
                                         if (! $asset instanceof MediaAsset) {
+                                            return;
+                                        }
+
+                                        if (! self::isArticleCoverReady($asset)) {
+                                            self::clearArticleCoverFields($set);
+
+                                            Notification::make()
+                                                ->title('Cover media is not publish-ready')
+                                                ->body(implode('; ', self::articleCoverReadinessFailures($asset)))
+                                                ->danger()
+                                                ->send();
+
                                             return;
                                         }
 
@@ -680,7 +693,16 @@ class ArticleResource extends Resource
 
         return MediaAsset::query()
             ->withoutGlobalScopes()
+            ->with('variants')
             ->publishedPublic()
+            ->where('cdn_status', MediaAsset::CDN_VERIFIED)
+            ->tap(function (Builder $query): void {
+                foreach (MediaVariantGenerator::variantKeys() as $variantKey) {
+                    $query->whereHas('variants', fn (Builder $variantQuery): Builder => $variantQuery
+                        ->where('variant_key', $variantKey)
+                        ->where('cdn_status', MediaAsset::CDN_VERIFIED));
+                }
+            })
             ->when($search !== '', fn (Builder $query) => $query
                 ->where(function (Builder $nested) use ($search): void {
                     $nested->where('asset_key', 'like', '%'.$search.'%')
@@ -689,6 +711,7 @@ class ArticleResource extends Resource
             ->orderByDesc('updated_at')
             ->limit(50)
             ->get()
+            ->filter(fn (MediaAsset $asset): bool => self::isArticleCoverReady($asset))
             ->mapWithKeys(fn (MediaAsset $asset): array => [
                 (int) $asset->id => self::mediaAssetOptionLabel($asset),
             ])
@@ -733,6 +756,16 @@ class ArticleResource extends Resource
     private static function articleCoverPayload(MediaAsset $asset): array
     {
         $asset->loadMissing('variants');
+        if (! self::isArticleCoverReady($asset)) {
+            return [
+                'cover_image_url' => null,
+                'cover_image_alt' => $asset->alt,
+                'cover_image_width' => null,
+                'cover_image_height' => null,
+                'cover_image_variants' => [],
+            ];
+        }
+
         $variants = [];
 
         foreach ($asset->variants as $variant) {
@@ -765,6 +798,69 @@ class ArticleResource extends Resource
             'cover_image_height' => $asset->height,
             'cover_image_variants' => $variants,
         ];
+    }
+
+    private static function clearArticleCoverFields(Forms\Set $set): void
+    {
+        $set('cover_image_url', null);
+        $set('cover_image_alt', null);
+        $set('cover_image_width', null);
+        $set('cover_image_height', null);
+        $set('cover_image_variants', []);
+    }
+
+    private static function isArticleCoverReady(MediaAsset $asset): bool
+    {
+        return self::articleCoverReadinessFailures($asset) === [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function articleCoverReadinessFailures(MediaAsset $asset): array
+    {
+        $asset->loadMissing('variants');
+        $failures = [];
+
+        if ((string) $asset->status !== MediaAsset::STATUS_PUBLISHED || ! (bool) $asset->is_public) {
+            $failures[] = 'asset is not published and public';
+        }
+
+        if ((string) $asset->cdn_status !== MediaAsset::CDN_VERIFIED) {
+            $failures[] = 'asset CDN is not verified';
+        }
+
+        if (PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $asset->path, $asset->url) === null) {
+            $failures[] = 'asset URL is not public-safe';
+        }
+
+        $variants = $asset->variants->keyBy(fn ($variant): string => trim((string) $variant->variant_key));
+        foreach (MediaVariantGenerator::variantKeys() as $variantKey) {
+            $variant = $variants->get($variantKey);
+            if (! $variant) {
+                $failures[] = "missing {$variantKey} variant";
+
+                continue;
+            }
+
+            if ((string) $variant->cdn_status !== MediaAsset::CDN_VERIFIED) {
+                $failures[] = "{$variantKey} variant CDN is not verified";
+            }
+
+            if (PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $variant->path, $variant->url) === null) {
+                $failures[] = "{$variantKey} variant URL is not public-safe";
+            }
+
+            if ((int) $variant->width <= 0 || (int) $variant->height <= 0) {
+                $failures[] = "{$variantKey} variant dimensions are missing";
+            }
+
+            if (! str_starts_with(strtolower((string) $variant->mime_type), 'image/')) {
+                $failures[] = "{$variantKey} variant MIME type is not an image";
+            }
+        }
+
+        return array_values(array_unique($failures));
     }
 
     public static function releaseRecord(Article $record, string $source = 'resource_table'): void

--- a/backend/app/Support/PublicMediaUrlGuard.php
+++ b/backend/app/Support/PublicMediaUrlGuard.php
@@ -84,6 +84,10 @@ final class PublicMediaUrlGuard
 
     public static function canonicalMediaUrl(?string $disk, mixed $path, mixed $url): ?string
     {
+        if (self::isPrivateOrOpsDisk($disk)) {
+            return null;
+        }
+
         $fromPath = self::publicMediaUrlForPath($disk, $path);
         if ($fromPath !== null) {
             return $fromPath;
@@ -202,11 +206,16 @@ final class PublicMediaUrlGuard
             return '';
         }
 
+        $normalizedDisk = strtolower(trim((string) $disk));
+        if (self::isPrivateOrOpsDisk($disk)) {
+            return '';
+        }
+
         if (str_starts_with($trimmed, '/')) {
             return $trimmed;
         }
 
-        if (trim((string) $disk) === 'public') {
+        if (in_array($normalizedDisk, ['public', 'public_static'], true)) {
             $prefix = trim((string) config('fap.media.public_storage_prefix', '/storage'));
             $prefix = $prefix === '' ? '/storage' : '/'.trim($prefix, '/');
 
@@ -236,6 +245,11 @@ final class PublicMediaUrlGuard
     private static function normalizeHost(string $host): string
     {
         return strtolower(trim($host, "[] \t\n\r\0\x0B."));
+    }
+
+    private static function isPrivateOrOpsDisk(?string $disk): bool
+    {
+        return in_array(strtolower(trim((string) $disk)), ['local', 'private', 'ops'], true);
     }
 
     private static function isPrivateOrLocalHost(string $host): bool

--- a/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
+++ b/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
@@ -4,11 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\Feature\MediaLibrary;
 
+use App\Filament\Ops\Resources\ArticleResource;
+use App\Models\AdminUser;
 use App\Models\MediaAsset;
 use App\Models\MediaVariant;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Services\Cms\MediaVariantGenerator;
+use App\Support\Rbac\PermissionNames;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use ReflectionMethod;
 use Tests\TestCase;
 
 final class MediaLibraryPublicApiTest extends TestCase
@@ -46,7 +54,7 @@ final class MediaLibraryPublicApiTest extends TestCase
             ->assertJsonPath('asset.url', 'https://assets.fermatmind.com/static/share/mbti_cover_source.png')
             ->assertJsonPath('asset.variants.0.variant_key', 'card');
 
-        $this->putJson('/api/v0.5/internal/media-assets/share.mbti.default', [
+        $this->actingAsContentWriter()->putJson('/api/v0.5/internal/media-assets/share.mbti.default', [
             'path' => '/static/share/mbti_wide_1200x630.png',
             'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/static/share/mbti_wide_1200x630.png',
             'mime_type' => 'image/jpeg',
@@ -108,7 +116,7 @@ final class MediaLibraryPublicApiTest extends TestCase
     {
         Storage::fake('public');
 
-        $this->post('/api/v0.5/internal/media-assets/articles.hero/upload', [
+        $this->actingAsContentWriter()->post('/api/v0.5/internal/media-assets/articles.hero/upload', [
             'file' => UploadedFile::fake()->image('source.jpg', 1800, 1200),
             'alt' => 'Article hero image',
             'caption' => 'Generated through Media Library.',
@@ -151,9 +159,44 @@ final class MediaLibraryPublicApiTest extends TestCase
         }
     }
 
+    public function test_article_cover_binding_requires_verified_public_standard_variants(): void
+    {
+        $ready = $this->createReadyArticleCoverAsset('articles.ready-cover');
+
+        $payload = $this->articleCoverPayload($ready);
+        $this->assertSame(
+            'https://assets.fermatmind.com/storage/media-library/variants/articles-ready-cover/hero_1600x900.jpg',
+            $payload['cover_image_url']
+        );
+        $expectedVariantKeys = MediaVariantGenerator::variantKeys();
+        $actualVariantKeys = array_keys($payload['cover_image_variants']);
+        sort($expectedVariantKeys);
+        sort($actualVariantKeys);
+        $this->assertSame($expectedVariantKeys, $actualVariantKeys);
+
+        $options = $this->mediaAssetOptions('ready-cover');
+        $this->assertArrayHasKey((int) $ready->id, $options);
+
+        $missingVariant = $this->createReadyArticleCoverAsset('articles.missing-variant');
+        $missingVariant->variants()->where('variant_key', 'og')->delete();
+        $missingVariant = $missingVariant->fresh('variants') ?? $missingVariant;
+
+        $this->assertNull($this->articleCoverPayload($missingVariant)['cover_image_url']);
+        $this->assertArrayNotHasKey((int) $missingVariant->id, $this->mediaAssetOptions('missing-variant'));
+
+        $unsafeDisk = $this->createReadyArticleCoverAsset('articles.ops-only-cover');
+        $unsafeDisk->forceFill([
+            'disk' => 'local',
+            'path' => 'ops-only/internal-cover.jpg',
+        ])->save();
+
+        $this->assertNull($this->articleCoverPayload($unsafeDisk)['cover_image_url']);
+        $this->assertArrayNotHasKey((int) $unsafeDisk->id, $this->mediaAssetOptions('ops-only-cover'));
+    }
+
     public function test_media_library_filters_legacy_url_when_no_path_can_be_canonicalized(): void
     {
-        $this->putJson('/api/v0.5/internal/media-assets/articles.legacy', [
+        $this->actingAsContentWriter()->putJson('/api/v0.5/internal/media-assets/articles.legacy', [
             'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/article.jpg',
             'alt' => 'Legacy article image',
             'status' => 'published',
@@ -230,5 +273,107 @@ final class MediaLibraryPublicApiTest extends TestCase
             ->expectsOutputToContain('legacy_url_count=0')
             ->expectsOutputToContain('no legacy media URLs found')
             ->assertExitCode(0);
+    }
+
+    private function createReadyArticleCoverAsset(string $assetKey): MediaAsset
+    {
+        $directory = str_replace('.', '-', $assetKey);
+
+        $asset = MediaAsset::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'asset_key' => $assetKey,
+            'disk' => 'public',
+            'path' => 'media-library/sources/'.$directory.'/source.jpg',
+            'url' => 'https://assets.fermatmind.com/storage/media-library/sources/'.$directory.'/source.jpg',
+            'mime_type' => 'image/jpeg',
+            'width' => 1600,
+            'height' => 900,
+            'bytes' => 1000,
+            'alt' => 'Ready article cover',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'sync_status' => MediaAsset::SYNC_SYNCED,
+            'cdn_status' => MediaAsset::CDN_VERIFIED,
+            'payload_json' => [],
+        ]);
+
+        foreach (MediaVariantGenerator::DEFAULT_VARIANTS as $variantKey => $spec) {
+            $asset->variants()->create([
+                'variant_key' => $variantKey,
+                'path' => sprintf(
+                    'media-library/variants/%s/%s_%sx%s.jpg',
+                    $directory,
+                    $variantKey,
+                    (string) $spec['width'],
+                    (string) $spec['height']
+                ),
+                'url' => sprintf(
+                    'https://assets.fermatmind.com/storage/media-library/variants/%s/%s_%sx%s.jpg',
+                    $directory,
+                    $variantKey,
+                    (string) $spec['width'],
+                    (string) $spec['height']
+                ),
+                'mime_type' => 'image/jpeg',
+                'width' => (int) $spec['width'],
+                'height' => (int) $spec['height'],
+                'bytes' => 1000,
+                'sync_status' => MediaAsset::SYNC_SYNCED,
+                'cdn_status' => MediaAsset::CDN_VERIFIED,
+                'payload_json' => [],
+            ]);
+        }
+
+        return $asset->fresh('variants') ?? $asset;
+    }
+
+    /**
+     * @return array{cover_image_url: ?string, cover_image_alt: ?string, cover_image_width: ?int, cover_image_height: ?int, cover_image_variants: array<string, array<string, mixed>>}
+     */
+    private function articleCoverPayload(MediaAsset $asset): array
+    {
+        $method = new ReflectionMethod(ArticleResource::class, 'articleCoverPayload');
+        $method->setAccessible(true);
+
+        /** @var array{cover_image_url: ?string, cover_image_alt: ?string, cover_image_width: ?int, cover_image_height: ?int, cover_image_variants: array<string, array<string, mixed>>} */
+        return $method->invoke(null, $asset);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function mediaAssetOptions(string $search): array
+    {
+        $method = new ReflectionMethod(ArticleResource::class, 'mediaAssetOptions');
+        $method->setAccessible(true);
+
+        /** @var array<int, string> */
+        return $method->invoke(null, $search);
+    }
+
+    private function actingAsContentWriter(): self
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        $permission = Permission::query()->firstOrCreate(
+            ['name' => PermissionNames::ADMIN_CONTENT_WRITE],
+            ['description' => null]
+        );
+        $role->permissions()->syncWithoutDetaching([$permission->id]);
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $this
+            ->withSession(['ops_org_id' => 0])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'));
     }
 }

--- a/backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
+++ b/backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
@@ -68,6 +68,18 @@ final class PublicMediaUrlGuardTest extends TestCase
         );
     }
 
+    public function test_public_media_url_for_path_rejects_private_or_ops_only_disks(): void
+    {
+        config(['fap.media.asset_origin' => 'https://assets.fermatmind.com']);
+
+        foreach (['local', 'private', 'ops'] as $disk) {
+            $this->assertNull(
+                PublicMediaUrlGuard::publicMediaUrlForPath($disk, 'articles/internal-cover.png'),
+                $disk
+            );
+        }
+    }
+
     public function test_sanitize_array_fields_recursively_nulls_unsafe_media_fields(): void
     {
         $payload = PublicMediaUrlGuard::sanitizeArrayFields([

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T12:47:00Z",
+  "updated_at": "2026-05-17T13:48:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -4360,7 +4360,7 @@
       "branch": "fix/career-index-state-minimum-remediation-gate",
       "title": "fix(api): add guarded career index state remediation command",
       "name": "Add guarded explicit-slug index_state remediation dry-run/apply planning",
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "depends_on": [
         "RUN-1F",
         "REPAIR-INDEX-ENTITY-POLICY-2"
@@ -9834,6 +9834,82 @@
         }
       ],
       "next_pr": "SEO-DASH-06"
+    },
+    "PUBLISH-API-MEDIA-ORIGIN-READYNESS": {
+      "repo": "fap-api",
+      "branch": "codex/publish-api-media-origin-readyness",
+      "base": "main",
+      "depends_on": [],
+      "status": "in_progress",
+      "train_scope": "publishing_reliability",
+      "risk_level": "medium",
+      "title": "fix(cms-media): enforce public article media origin and variant readiness",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly requested sequential execution of PUBLISH-API-MEDIA-ORIGIN-READYNESS, PUBLISH-WEB-CONTENT-CACHE-PURGE, and PUBLISH-API-ARTICLE-COVER-SMOKE."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PUBLISH-API-MEDIA-ORIGIN-READYNESS has no manifest dependencies."
+        },
+        "implementation": {
+          "status": "pass",
+          "evidence": "Article cover media readiness guard and focused regression tests implemented."
+        },
+        "public_media_url_guard": {
+          "status": "pass",
+          "command": "php artisan test --filter=PublicMediaUrlGuard --no-ansi",
+          "evidence": "5 tests passed with PHP 8.5 file_get_contents warnings only."
+        },
+        "media_library": {
+          "status": "pass",
+          "command": "php artisan test --filter=MediaLibrary --no-ansi",
+          "evidence": "10 tests passed with PHP 8.5 file_get_contents warnings only."
+        },
+        "article_resource": {
+          "status": "pass",
+          "command": "php artisan test --filter=ArticleResource --no-ansi",
+          "evidence": "No matching tests found; ArticleResource behavior is covered by MediaLibraryPublicApiTest reflection regression."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test app/Support/PublicMediaUrlGuard.php app/Filament/Ops/Resources/ArticleResource.php tests/Unit/Support/PublicMediaUrlGuardTest.php tests/Feature/MediaLibrary",
+          "evidence": "Pint passed across 4 files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to ArticleResource, PublicMediaUrlGuard, MediaLibrary/PublicMediaUrlGuard tests, and docs/codex PR train metadata. No public content, production media assets, deploy, rollback, unlock, process, DB mutation, or fap-web files changed."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-17T13:35:00Z",
+          "status": "in_progress",
+          "summary": "Started publishing reliability train item for CMS media origin and article cover variant readiness from origin/main; no production mutation, deploy, or media upload performed."
+        },
+        {
+          "at": "2026-05-17T13:48:00Z",
+          "status": "local_checks_passed",
+          "summary": "Implemented fail-closed article cover media readiness and verified focused PublicMediaUrlGuard, MediaLibrary, route list, Pint, YAML/JSON, and diff checks."
+        }
+      ]
     }
   },
   "SEO-DASH-04B": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T13:48:00Z",
+  "updated_at": "2026-05-17T13:52:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -4360,7 +4360,7 @@
       "branch": "fix/career-index-state-minimum-remediation-gate",
       "title": "fix(api): add guarded career index state remediation command",
       "name": "Add guarded explicit-slug index_state remediation dry-run/apply planning",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "RUN-1F",
         "REPAIR-INDEX-ENTITY-POLICY-2"
@@ -8174,8 +8174,8 @@
         }
       },
       "failure_reason": null,
-      "pr_url": null,
-      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1448",
+      "commit_sha": "517fcbc99a178665844bd80c1220477406013fa3",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -9908,6 +9908,11 @@
           "at": "2026-05-17T13:48:00Z",
           "status": "local_checks_passed",
           "summary": "Implemented fail-closed article cover media readiness and verified focused PublicMediaUrlGuard, MediaLibrary, route list, Pint, YAML/JSON, and diff checks."
+        },
+        {
+          "at": "2026-05-17T13:52:00Z",
+          "status": "pr_open",
+          "summary": "Opened PR #1448 for PUBLISH-API-MEDIA-ORIGIN-READYNESS after scoped local validation passed."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5007,3 +5007,55 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+
+  - id: PUBLISH-API-MEDIA-ORIGIN-READYNESS
+    repo: fap-api
+    branch: codex/publish-api-media-origin-readyness
+    base: main
+    depends_on: []
+    title: "fix(cms-media): enforce public article media origin and variant readiness"
+    name: "Enforce public article media origin and variant readiness"
+    train_scope: publishing_reliability
+    risk_level: medium
+    findings:
+      - "Article cover uploads can produce CMS URLs that are not accepted by the frontend media allowlist."
+      - "Missing or unreachable media variants can make article list cards fall back to placeholders after publish."
+    scope:
+      - Enforce public, frontend-allowlisted article cover media origins in backend CMS media guards.
+      - Require article cover readiness for hero, card, og, thumbnail, and preload variants before cover binding is considered publish-ready.
+      - Fail closed when selected media assets are ops-only, CDN-unverified, missing variants, or rejected by PublicMediaUrlGuard.
+      - Add tests for allowed media origins, rejected private/ops-only media URLs, and article cover variant readiness.
+    allowed_paths:
+      - backend/app/Support/PublicMediaUrlGuard.php
+      - backend/app/Services/Cms/MediaVariantGenerator.php
+      - backend/app/Services/Cms/MediaAssetStorageSyncService.php
+      - backend/app/Filament/Ops/Resources/ArticleResource.php
+      - backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
+      - backend/tests/Unit/Services/Cms/**
+      - backend/tests/Feature/MediaLibrary/**
+      - backend/tests/Feature/Ops/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+    do_not:
+      - Change public article content or publish/unpublish articles.
+      - Touch fap-web.
+      - Run production DB mutation, media migration, deploy, rollback, unlock, or process termination.
+      - Upload or replace live media assets.
+    validation:
+      - php artisan test --filter=PublicMediaUrlGuard --no-ansi
+      - php artisan test --filter=MediaLibrary --no-ansi
+      - php artisan test --filter=ArticleResource --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test app/Support/PublicMediaUrlGuard.php app/Services/Cms/MediaVariantGenerator.php app/Services/Cms/MediaAssetStorageSyncService.php app/Filament/Ops/Resources/ArticleResource.php tests/Unit/Support/PublicMediaUrlGuardTest.php tests/Feature/MediaLibrary tests/Feature/Ops
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by PUBLISH-API-MEDIA-ORIGIN-READYNESS
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## Findings addressed
- Article cover media could be bound from a CMS asset even when the selected media was not fully public-ready.
- Missing or unverified cover variants could leave article list/detail consumers with stale placeholders or partial image metadata.

## What changed
- Reject private/ops-only media disks in `PublicMediaUrlGuard` so local/private disk paths cannot be canonicalized into public article media URLs.
- Make ArticleResource cover binding fail closed unless the asset is published, public, CDN verified, and has verified `hero`, `card`, `thumbnail`, `og`, and `preload` image variants.
- Filter the CMS media cover selector to only show assets that pass the same readiness checks.
- Added regression coverage for private disk rejection, missing cover variants, and ready media selection.

## Why
Article cover updates should not produce ops-only, private, unverified, or incomplete media URLs in public article payloads. The backend CMS remains the authority for article cover metadata, but it now refuses incomplete media readiness at the binding boundary.

## Validation commands
- `php artisan test --filter=PublicMediaUrlGuard --no-ansi` passed, with PHP 8.5 `file_get_contents` warnings only.
- `php artisan test --filter=MediaLibrary --no-ansi` passed, with PHP 8.5 `file_get_contents` warnings only.
- `php artisan test --filter=ArticleResource --no-ansi` returned no matching tests; ArticleResource behavior is covered by `MediaLibraryPublicApiTest` reflection regression.
- `php artisan route:list --no-ansi` passed, 198 routes.
- `vendor/bin/pint --test app/Support/PublicMediaUrlGuard.php app/Filament/Ops/Resources/ArticleResource.php tests/Unit/Support/PublicMediaUrlGuardTest.php tests/Feature/MediaLibrary` passed.
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"` passed.
- `jq empty docs/codex/pr-train-state.json` passed.
- `git diff --check && git diff --cached --check` passed.

## Sidecar issues recorded
- None.

## Intentionally deferred
- Web article list/detail proxy cache purge remains deferred to `PUBLISH-WEB-CONTENT-CACHE-PURGE`.
- Operator publish smoke for cover propagation remains deferred to `PUBLISH-API-ARTICLE-COVER-SMOKE`.
- No production media uploads, DB mutations, deploys, rollback, unlock, or process commands were run.

## Repository rule impact
This tightens backend CMS/media authority for article cover images. Public editorial content remains backend CMS-authoritative; frontend does not receive fallback content or media ownership.
