### PR TITLE
[codex] guard content release runtime storage

### DIFF
--- a/backend/scripts/release_pack.sh
+++ b/backend/scripts/release_pack.sh
@@ -70,6 +70,7 @@ rm -rf "${STAGING_DIR}/.git" \
        "${STAGING_DIR}/backend/artifacts" \
        "${STAGING_DIR}/backend/storage/app/private/reports" \
        "${STAGING_DIR}/backend/storage/app/private/artifacts" \
+       "${STAGING_DIR}/backend/storage/app/private/content_releases" \
        "${STAGING_DIR}/backend/storage/app/private/packs_v2" \
        "${STAGING_DIR}/backend/storage/app/private/packs_v2_materialized" \
        "${STAGING_DIR}/backend/storage/app/content_packs_v2" \
@@ -90,6 +91,7 @@ find "${STAGING_DIR}" -type d -name 'artifacts' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type f -name '*.sqlite*' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/reports' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/artifacts' -print >> "$HITS_FILE"
+find "${STAGING_DIR}" -type d -path '*/storage/app/private/content_releases' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/packs_v2' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/packs_v2_materialized' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/content_packs_v2' -print >> "$HITS_FILE"

--- a/backend/tests/Feature/ReleasePackScriptContractTest.php
+++ b/backend/tests/Feature/ReleasePackScriptContractTest.php
@@ -25,4 +25,53 @@ final class ReleasePackScriptContractTest extends TestCase
             $script
         );
     }
+
+    public function test_release_hygiene_guards_cover_content_releases_runtime_tree(): void
+    {
+        $repoRoot = dirname(base_path());
+        $releasePackPath = $repoRoot.'/scripts/release_pack.sh';
+        $backendReleasePackPath = base_path('scripts/release_pack.sh');
+        $releaseHygienePath = $repoRoot.'/scripts/release_hygiene_gate.sh';
+        $sourceZipVerifyPath = $repoRoot.'/scripts/release/verify_source_zip_clean.sh';
+        $artifactCleanPath = $repoRoot.'/scripts/security/assert_artifact_clean.sh';
+
+        foreach ([$releasePackPath, $backendReleasePackPath, $releaseHygienePath, $sourceZipVerifyPath, $artifactCleanPath] as $path) {
+            $this->assertFileExists($path);
+        }
+
+        $releasePack = (string) file_get_contents($releasePackPath);
+        $backendReleasePack = (string) file_get_contents($backendReleasePackPath);
+        $releaseHygiene = (string) file_get_contents($releaseHygienePath);
+        $sourceZipVerify = (string) file_get_contents($sourceZipVerifyPath);
+        $artifactClean = (string) file_get_contents($artifactCleanPath);
+
+        $this->assertStringContainsString(
+            'backend/scripts/release_pack.sh',
+            $releasePack
+        );
+        $this->assertStringContainsString(
+            '"${STAGING_DIR}/backend/storage/app/private/content_releases"',
+            $backendReleasePack
+        );
+        $this->assertStringContainsString(
+            "find \"\${STAGING_DIR}\" -type d -path '*/storage/app/private/content_releases' -print >> \"\$HITS_FILE\"",
+            $backendReleasePack
+        );
+        $this->assertStringContainsString(
+            '"${TARGET}/backend/storage/app/private/content_releases"',
+            $releaseHygiene
+        );
+        $this->assertStringContainsString(
+            '^fap-api/backend/storage/app/private/content_releases/',
+            $sourceZipVerify
+        );
+        $this->assertStringContainsString(
+            '^backend/storage/app/private/content_releases/',
+            $artifactClean
+        );
+        $this->assertStringContainsString(
+            'check_only_gitkeep_files "backend/storage/app/private/content_releases"',
+            $artifactClean
+        );
+    }
 }

--- a/docs/SECURITY_SOURCE_EXPORT.md
+++ b/docs/SECURITY_SOURCE_EXPORT.md
@@ -6,7 +6,7 @@
 
 ## Forbidden
 - Do not use `zip -r` on workspace root.
-- Do not deliver packages that include `.git`, `.env`, `vendor`, `node_modules`, runtime `storage`, logs, sqlite, or artifacts.
+- Do not deliver packages that include `.git`, `.env`, `vendor`, `node_modules`, runtime `storage`, logs, sqlite, artifacts, or `backend/storage/app/private/content_releases`.
 
 ## Delivery artifact
 - Only `dist/fap-api-source.zip` is allowed for external source delivery.

--- a/docs/release/RELEASE_POLICY.md
+++ b/docs/release/RELEASE_POLICY.md
@@ -17,7 +17,7 @@
 1. `.env/.env.*`（排除 `.env.example`）：敏感信息泄露风险。
 2. `.git`：源码历史泄露与体积污染。
 3. `vendor`/`node_modules`：体积污染与不可控供应链复制。
-4. `backend/storage/logs`、`backend/artifacts`、`backend/storage/app/private/reports`、`backend/storage/app/archives`：运行时污染物，不可审计交付。
+4. `backend/storage/logs`、`backend/artifacts`、`backend/storage/app/private/reports`、`backend/storage/app/private/artifacts`、`backend/storage/app/private/content_releases`、`backend/storage/app/archives`：运行时污染物，不可审计交付。
 5. `*.sqlite*`：环境数据泄露风险。
 6. `__MACOSX`、`.DS_Store`：非业务污染物。
 

--- a/scripts/release/verify_source_zip_clean.sh
+++ b/scripts/release/verify_source_zip_clean.sh
@@ -17,7 +17,7 @@ LIST="$(unzip -Z1 "$ZIP")"
 LIST_FILTERED="$(echo "$LIST" | grep -vE '^(fap-api/backend/\.env\.example|fap-api/\.env\.example)$' || true)"
 
 # 1) 路径黑名单（命中直接失败）
-PATTERN_PATH='(^fap-api/\.git/|^fap-api/backend/\.env($|[./])|^fap-api/\.env($|[./])|^fap-api/backend/vendor/|^fap-api/vendor/|^fap-api/node_modules/|^fap-api/backend/node_modules/|^fap-api/backend/artifacts/|^fap-api/backend/database/.*\.sqlite$|^fap-api/backend/storage/logs/|^fap-api/backend/storage/framework/|^fap-api/backend/storage/app/private/reports/|^fap-api/backend/storage/app/private/artifacts/|^fap-api/backend/storage/app/private/packs_v2/|^fap-api/backend/storage/app/private/prune_plans/|^fap-api/backend/storage/app/archives/)'
+PATTERN_PATH='(^fap-api/\.git/|^fap-api/backend/\.env($|[./])|^fap-api/\.env($|[./])|^fap-api/backend/vendor/|^fap-api/vendor/|^fap-api/node_modules/|^fap-api/backend/node_modules/|^fap-api/backend/artifacts/|^fap-api/backend/database/.*\.sqlite$|^fap-api/backend/storage/logs/|^fap-api/backend/storage/framework/|^fap-api/backend/storage/app/private/reports/|^fap-api/backend/storage/app/private/artifacts/|^fap-api/backend/storage/app/private/content_releases/|^fap-api/backend/storage/app/private/packs_v2/|^fap-api/backend/storage/app/private/prune_plans/|^fap-api/backend/storage/app/archives/)'
 HITS_PATH="$(echo "$LIST_FILTERED" | grep -E "$PATTERN_PATH" || true)"
 [ -z "$HITS_PATH" ] || { echo "[verify][FAIL] forbidden paths found:"; echo "$HITS_PATH"; exit 1; }
 

--- a/scripts/release_hygiene_gate.sh
+++ b/scripts/release_hygiene_gate.sh
@@ -92,6 +92,7 @@ for p in \
   "${TARGET}/backend/artifacts" \
   "${TARGET}/backend/storage/app/private/reports" \
   "${TARGET}/backend/storage/app/private/artifacts" \
+  "${TARGET}/backend/storage/app/private/content_releases" \
   "${TARGET}/backend/storage/app/private/packs_v2" \
   "${TARGET}/backend/storage/app/private/packs_v2_materialized" \
   "${TARGET}/backend/storage/app/content_packs_v2" \

--- a/scripts/security/assert_artifact_clean.sh
+++ b/scripts/security/assert_artifact_clean.sh
@@ -100,6 +100,14 @@ check_repo_mode() {
     done <<< "$hits"
   fi
 
+  hits="$(contains_path '^backend/storage/app/private/content_releases/' "$tracked" | grep -Ev '/\.gitkeep$' || true)"
+  if [[ -n "$hits" ]]; then
+    while IFS= read -r f; do
+      [[ -n "$f" ]] || continue
+      fail "forbidden tracked runtime artifact: $f ; fix: keep only .gitkeep in backend/storage/app/private/content_releases."
+    done <<< "$hits"
+  fi
+
   hits="$(contains_path '^backend/storage/app/private/packs_v2/' "$tracked" | grep -Ev '/\.gitkeep$' || true)"
   if [[ -n "$hits" ]]; then
     while IFS= read -r f; do
@@ -176,6 +184,7 @@ check_artifact_mode() {
   check_only_gitkeep_files "backend/storage/framework"
   check_only_gitkeep_files "backend/storage/app/private/reports"
   check_only_gitkeep_files "backend/storage/app/private/artifacts"
+  check_only_gitkeep_files "backend/storage/app/private/content_releases"
   check_only_gitkeep_files "backend/storage/app/private/packs_v2"
   check_only_gitkeep_files "backend/storage/app/private/prune_plans"
   check_only_gitkeep_files "backend/storage/app/archives"


### PR DESCRIPTION
## Summary

Add an explicit release hygiene guard for `backend/storage/app/private/content_releases` so local Laravel runtime content release trees cannot enter source zips, release packages, or artifact-clean delivery checks.

## Issue / impact

The local runtime storage scan found `backend/storage/app/private/content_releases` can grow very large with generated `source_pack`, `previous_pack`, and `current_pack` release roots. These are runtime artifacts, not source. If a package is built from a polluted workspace, the tree can bloat delivery artifacts and leak non-auditable runtime state.

## Root cause

Existing ignore rules covered `content_releases`, but release/package hygiene scripts did not explicitly blacklist the path everywhere source zips and delivery artifacts are checked.

## Fix

- Add `backend/storage/app/private/content_releases` to release package cleanup and hard-gate checks.
- Add the same path to release hygiene and source zip forbidden path checks.
- Add repo/artifact mode checks in `assert_artifact_clean.sh`.
- Extend the release pack script contract test to assert the guard is present across all relevant scripts.
- Update source export and release policy docs to name the runtime tree explicitly.

## Scope guard

This PR only changes release hygiene / source zip verification / security artifact clean scripts, the corresponding contract test, and release documentation. It does not change storage retention behavior, content release publish/rollback/rehydrate code, migrations, routes, controllers, or services.

## Validation

- Fake dirty artifact tree containing `backend/storage/app/private/content_releases/dummy/source_pack/compiled/questions.compiled.json`: expected fail.
- Fake clean artifact tree: pass.
- Fake dirty source zip containing the same runtime path: expected fail.
- Fake clean source zip: pass.
- `cd backend && php artisan test --filter=ReleasePackScriptContractTest`: pass, 2 tests / 15 assertions.
- `cd backend && php artisan route:list --no-ansi`: pass, 198 routes.
- `git diff --check`: pass for the scoped files.
- `bash backend/scripts/ci_verify_mbti.sh`: pass on retry.

Note: the first `ci_verify_mbti.sh` attempt hit a transient `FileNotFoundException` for `2026_05_17_001700_create_seo_issue_queue_table.php` during `AuthGuestRouteWiringTest`; the file existed in `HEAD`, the single test passed immediately when rerun, and the full MBTI CI chain passed on retry.

## Local generated files not included

Running the MBTI CI regenerated BigFive compiled artifacts under `backend/content_packs/BIG5_OCEAN/v1/compiled`. Those files are intentionally not staged and are not part of this PR.
