### PR TITLE
docs(seo-intel): add production DB migration runbook

### DIFF
--- a/backend/docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json
+++ b/backend/docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json
@@ -1,0 +1,186 @@
+{
+  "version": 1,
+  "source_documents": [
+    "SEO-DASH-PROD-00",
+    "SEO-DASH-00B",
+    "SEO-DASH-01A",
+    "SEO-DASH-06",
+    "BACKEND-RUNTIME-02D"
+  ],
+  "production_db_created_in_this_pr": false,
+  "production_migration_executed_in_this_pr": false,
+  "production_env_edited_in_this_pr": false,
+  "deployment_executed_in_this_pr": false,
+  "collectors_enabled_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "metabase_deployed_in_this_pr": false,
+  "external_search_api_connected_in_this_pr": false,
+  "allowed_db_locations": [
+    "managed_mysql_rds_dedicated_analytics",
+    "approved_managed_mysql_separate_database_or_schema",
+    "private_analytics_database_reachable_from_approved_backend_ops_networks"
+  ],
+  "forbidden_db_locations": [
+    "node2_local_db",
+    "node2_local_laravel",
+    "node2_php84_fap_mysql",
+    "business_db_raw_tables",
+    "cms_write_tables"
+  ],
+  "required_users": [
+    {
+      "name": "seo_intel_writer",
+      "purpose": "runtime writer for approved seo_intel tables only",
+      "permissions": [
+        "insert_approved_seo_intel_tables",
+        "update_approved_seo_intel_tables"
+      ],
+      "forbidden_permissions": [
+        "business_db_read",
+        "business_db_write",
+        "node2_local_db_access",
+        "raw_payment_detail_access",
+        "raw_email_detail_access",
+        "ddl"
+      ]
+    },
+    {
+      "name": "seo_intel_metabase_readonly",
+      "purpose": "Metabase read-only user for sanitized seo_intel aggregates",
+      "permissions": [
+        "select_sanitized_seo_intel_tables_or_views"
+      ],
+      "forbidden_permissions": [
+        "insert",
+        "update",
+        "delete",
+        "alter",
+        "drop",
+        "create",
+        "business_db_read",
+        "cms_write_table_read",
+        "node2_local_db_access",
+        "raw_detail_table_read"
+      ]
+    },
+    {
+      "name": "migration_operator",
+      "purpose": "human-controlled migration-time DDL identity",
+      "permissions": [
+        "ddl_for_approved_seo_intel_migrations_during_change_window"
+      ],
+      "forbidden_permissions": [
+        "collector_runtime_use",
+        "scheduler_runtime_use",
+        "metabase_connection_use"
+      ]
+    }
+  ],
+  "permission_policy": {
+    "writer_can_access_business_tables": false,
+    "writer_can_access_node2_local_db": false,
+    "metabase_can_write": false,
+    "metabase_can_read_business_db_raw_tables": false,
+    "metabase_can_read_cms_write_tables": false,
+    "metabase_can_read_node2_local_db": false,
+    "migration_operator_used_for_collector_runtime": false,
+    "seo_intel_is_cms_source_of_truth": false
+  },
+  "migration_preflight_checklist": [
+    "production_seo_intel_db_created",
+    "seo_intel_writer_confirmed",
+    "seo_intel_metabase_readonly_confirmed",
+    "migration_operator_confirmed",
+    "backup_confirmed",
+    "restore_procedure_known",
+    "restore_test_or_rehearsal_available_before_write_enablement",
+    "change_window_approved",
+    "current_code_sha_confirmed",
+    "migration_list_reviewed",
+    "target_database_confirmed_as_seo_intel",
+    "pii_guard_reviewed",
+    "env_keys_prepared_but_not_printed",
+    "pretend_migration_output_reviewed",
+    "rollback_forward_fix_owner_assigned",
+    "required_github_checks_green",
+    "no_deploy_or_incident_in_progress"
+  ],
+  "command_templates": [
+    "php artisan migrate --database=seo_intel --pretend --no-ansi",
+    "php artisan migrate --database=seo_intel --no-ansi",
+    "php artisan migrate:status --database=seo_intel --no-ansi"
+  ],
+  "backup_restore_policy": {
+    "migrations_are_forward_only": true,
+    "rollback_methods": [
+      "verified_backup_restore",
+      "human_reviewed_forward_fix_migration"
+    ],
+    "restore_test_required_before_write_enablement": true,
+    "on_failure_keep_write_enabled_false": true,
+    "on_failure_keep_collectors_enabled_false": true,
+    "on_failure_keep_scheduler_disabled": true
+  },
+  "post_migration_validation": [
+    "expected_tables_exist",
+    "forbidden_columns_absent",
+    "row_counts_zero_or_expected",
+    "writer_can_write_only_approved_seo_intel_tables",
+    "writer_cannot_read_or_write_business_tables",
+    "metabase_readonly_can_select_only_approved_sanitized_tables_or_views",
+    "metabase_readonly_cannot_write_or_ddl",
+    "metabase_cannot_read_forbidden_data_sources",
+    "collector_dry_run_no_write_smoke_passes",
+    "route_list_unaffected",
+    "production_scheduler_not_enabled",
+    "collector_writes_not_enabled_until_later_step"
+  ],
+  "no_go_conditions": [
+    "missing_production_db_confirmation",
+    "missing_db_user_confirmation",
+    "missing_backup",
+    "missing_restore_plan",
+    "missing_restore_owner",
+    "node2_local_db_selected",
+    "business_db_raw_tables_exposed_to_metabase",
+    "cms_write_tables_exposed_to_metabase",
+    "pii_columns_found",
+    "env_values_would_be_printed",
+    "production_deploy_ongoing",
+    "incident_response_active",
+    "required_checks_red",
+    "migration_target_ambiguous",
+    "rollback_forward_fix_owner_missing"
+  ],
+  "pii_forbidden_fields": [
+    "email",
+    "order_no",
+    "raw_order_no",
+    "attempt_id",
+    "raw_attempt_id",
+    "payment_id",
+    "provider_event_id",
+    "cookie",
+    "raw_cookie",
+    "raw_ip",
+    "ip_address",
+    "raw_user_agent",
+    "user_agent",
+    "raw_payload",
+    "payment_payload",
+    "provider_payload",
+    "token",
+    "api_key",
+    "secret"
+  ],
+  "human_confirmation_required": [
+    "production_db_location",
+    "seo_intel_writer",
+    "seo_intel_metabase_readonly",
+    "migration_operator",
+    "backup_restore",
+    "change_window",
+    "rollback_forward_fix_owner"
+  ],
+  "next_task": "SEO-DASH-PROD-01B"
+}

--- a/backend/docs/seo/production-seo-intel-db-migration-runbook.md
+++ b/backend/docs/seo/production-seo-intel-db-migration-runbook.md
@@ -1,0 +1,170 @@
+# Production seo_intel DB Migration Runbook
+
+## A. Purpose
+
+This is a production activation runbook only.
+
+This PR does not create a production database, create database users, run production migrations, edit environment values, deploy, enable collectors, enable schedulers, connect external search APIs, deploy Metabase, or read production logs.
+
+It does not create database users.
+
+It does not run production migrations.
+
+## B. Current Readiness Status
+
+The SEO Intelligence MVP foundation is complete. Production activation remains blocked until a production `seo_intel` database, database users, backup/restore plan, migration approval, and ownership checklist are confirmed.
+
+Metabase, GSC, Baidu, IndexNow, domestic search adapters, crawler log access, collector writes, scheduler activation, and CMS issue summary exposure remain blocked until separate human-approved activation steps.
+
+## C. Production DB Placement Policy
+
+`seo_intel` must be logically isolated from the business database and operational CMS write tables.
+
+Allowed placement options:
+
+- A managed MySQL/RDS instance dedicated to analytics or reporting.
+- A separate database/schema on an approved managed MySQL/RDS cluster.
+- A private analytics database reachable only from approved backend/ops networks.
+
+Forbidden placement options:
+
+- Node2 local DB.
+- Node2 local Laravel, php84, fap-mysql, or local queue runtime.
+- Raw business database tables as the analytics surface.
+- CMS write tables as the analytics surface.
+
+`seo_intel` is an observation and aggregation store. It is not CMS source of truth, business truth, payment truth, or content publishing authority.
+
+## D. Required Users
+
+`seo_intel_writer`
+
+- Runtime writer for approved `seo_intel` tables only.
+- May insert/update approved aggregate and issue queue tables after write activation.
+- Must not read or write business tables.
+- Must not access raw payment, email, order, attempt, cookie, or raw IP detail.
+
+`seo_intel_metabase_readonly`
+
+- Metabase read-only user.
+- SELECT only on approved sanitized aggregate tables or views.
+- No write, DDL, migration, business DB, CMS write table, raw event, raw order, raw payment, raw email, raw crawler log, or Node2 local DB access.
+
+`migration_operator`
+
+- Human-controlled migration-time identity.
+- DDL permission only for approved `seo_intel` migrations during an approved change window.
+- Must not be used by collectors, scheduler jobs, Metabase, or runtime application traffic.
+
+## E. Permission Policy
+
+- Writer cannot read or write business tables.
+- Writer cannot access Node2 local DB.
+- Writer cannot access raw business, order, payment, email, cookie, or raw IP detail outside approved business systems.
+- Metabase cannot write.
+- Metabase cannot read raw business DB tables.
+- Metabase cannot read CMS write tables.
+- Metabase cannot read Node2 local DB.
+- Metabase cannot access raw email, raw order numbers, raw attempt IDs, payment IDs, provider event IDs, cookies, raw IPs, raw user agents, raw payloads, or payment payloads.
+- `migration_operator` is not used for collector runtime.
+- No `seo_intel` user may become content publishing authority.
+
+## F. Migration Preflight Checklist
+
+All items must be confirmed before any production migration:
+
+- Production `seo_intel` database exists.
+- `seo_intel_writer` exists with least-privilege runtime permissions.
+- `seo_intel_metabase_readonly` exists with SELECT-only permissions.
+- `migration_operator` is human-controlled and approved for the change window.
+- Backup is confirmed.
+- Restore procedure is known and assigned.
+- Restore test or restore rehearsal evidence is available before write enablement.
+- Maintenance/change window is approved.
+- Current production code SHA is confirmed.
+- Migration list is reviewed.
+- Migration target is confirmed as `seo_intel`, not business DB and not Node2 local DB.
+- PII guard is reviewed.
+- Environment keys are prepared but not printed.
+- `--pretend` migration output is reviewed.
+- Rollback/forward-fix owner is assigned.
+- Required GitHub checks for the release SHA are green.
+- No deploy or production incident is in progress.
+
+## G. Migration Command Templates
+
+These are templates only. Do not paste secrets into commands, shell history, tickets, logs, PR bodies, or chat.
+
+```bash
+php artisan migrate --database=seo_intel --pretend --no-ansi
+```
+
+```bash
+php artisan migrate --database=seo_intel --no-ansi
+```
+
+```bash
+php artisan migrate:status --database=seo_intel --no-ansi
+```
+
+Use the approved production execution channel and masked environment configuration. Do not run these commands from this PR.
+
+## H. Backup / Restore / Rollback
+
+`seo_intel` migrations are forward-only. Rollback is either:
+
+- restore from a verified backup, or
+- apply a human-reviewed forward-fix migration.
+
+Restore must be tested before collector write enablement. If migration fails, keep or set:
+
+- `SEO_INTEL_WRITE_ENABLED=false`
+- `SEO_INTEL_COLLECTORS_ENABLED=false`
+- scheduler disabled
+- Metabase disconnected or read-only connection blocked
+
+Failed migrations must not be repaired with ad hoc production edits. Use a reviewed forward-fix PR or restore plan.
+
+## I. Post-Migration Validation
+
+After approved migration execution:
+
+- Confirm expected `seo_intel` tables exist.
+- Confirm forbidden PII columns are absent.
+- Confirm row counts are zero or expected for newly migrated tables.
+- Confirm `seo_intel_writer` can write only approved `seo_intel` tables.
+- Confirm `seo_intel_writer` cannot read/write business tables.
+- Confirm `seo_intel_metabase_readonly` can SELECT only approved sanitized tables/views.
+- Confirm `seo_intel_metabase_readonly` cannot INSERT, UPDATE, DELETE, ALTER, DROP, or CREATE.
+- Confirm Metabase cannot write.
+- Confirm Metabase cannot read business DB, CMS write tables, Node2 local DB, raw orders, raw payments, raw email, raw events, or raw crawler logs.
+- Run collector dry-run/no-write smoke.
+- Confirm `php artisan route:list --no-ansi` is unaffected.
+- Confirm no production scheduler is enabled.
+- Confirm no collector writes are enabled until a later approved step.
+
+## J. No-Go Conditions
+
+Stop before production migration if any condition is true:
+
+- Production DB is not confirmed.
+- Required DB users are not confirmed.
+- Backup is missing.
+- Restore plan is missing.
+- Restore owner is missing.
+- Node2 local DB is selected.
+- Business DB raw tables are exposed to Metabase.
+- CMS write tables are exposed to Metabase.
+- PII columns are found.
+- Env values would be printed or copied into logs.
+- Production deploy is ongoing.
+- Incident response is active.
+- Required checks are red.
+- Migration target is ambiguous.
+- Rollback/forward-fix owner is not assigned.
+
+## K. Next Task
+
+Next task: `SEO-DASH-PROD-01B` for human-approved production DB/user/migration execution.
+
+If production DB and migrations are complete under human approval, the next activation step may proceed to `SEO-DASH-PROD-02` collector dry-run smoke.

--- a/backend/tests/Feature/SeoIntel/SeoIntelProductionActivationRunbookTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelProductionActivationRunbookTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelProductionActivationRunbookTest extends TestCase
+{
+    #[Test]
+    public function generated_artifact_locks_non_execution_boundary(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(1, $artifact['version'] ?? null);
+        $this->assertContains('SEO-DASH-PROD-00', $artifact['source_documents'] ?? []);
+        $this->assertContains('SEO-DASH-06', $artifact['source_documents'] ?? []);
+        $this->assertFalse((bool) ($artifact['production_db_created_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['production_migration_executed_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['production_env_edited_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['deployment_executed_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['collectors_enabled_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['scheduler_enabled_in_this_pr'] ?? true));
+        $this->assertSame('SEO-DASH-PROD-01B', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function db_placement_and_user_permissions_are_constrained(): void
+    {
+        $artifact = $this->artifact();
+        $userNames = array_column($artifact['required_users'] ?? [], 'name');
+
+        $this->assertContains('node2_local_db', $artifact['forbidden_db_locations'] ?? []);
+        $this->assertContains('business_db_raw_tables', $artifact['forbidden_db_locations'] ?? []);
+        $this->assertContains('seo_intel_writer', $userNames);
+        $this->assertContains('seo_intel_metabase_readonly', $userNames);
+        $this->assertContains('migration_operator', $userNames);
+        $this->assertFalse((bool) ($artifact['permission_policy']['metabase_can_write'] ?? true));
+        $this->assertFalse((bool) ($artifact['permission_policy']['metabase_can_read_business_db_raw_tables'] ?? true));
+        $this->assertFalse((bool) ($artifact['permission_policy']['metabase_can_read_node2_local_db'] ?? true));
+        $this->assertFalse((bool) ($artifact['permission_policy']['migration_operator_used_for_collector_runtime'] ?? true));
+    }
+
+    #[Test]
+    public function no_go_conditions_include_required_blocks(): void
+    {
+        $conditions = $this->artifact()['no_go_conditions'] ?? [];
+
+        foreach ([
+            'missing_backup',
+            'missing_db_user_confirmation',
+            'node2_local_db_selected',
+            'business_db_raw_tables_exposed_to_metabase',
+            'required_checks_red',
+        ] as $condition) {
+            $this->assertContains($condition, $conditions);
+        }
+    }
+
+    #[Test]
+    public function command_templates_are_placeholders_without_secrets(): void
+    {
+        $commands = $this->artifact()['command_templates'] ?? [];
+
+        $this->assertContains('php artisan migrate --database=seo_intel --pretend --no-ansi', $commands);
+        $this->assertContains('php artisan migrate --database=seo_intel --no-ansi', $commands);
+        $this->assertContains('php artisan migrate:status --database=seo_intel --no-ansi', $commands);
+
+        $encoded = strtolower(json_encode($commands, JSON_THROW_ON_ERROR));
+
+        foreach ([
+            'password=',
+            'token=',
+            'secret=',
+            'api_key=',
+            'mysql://',
+            'seo_intel_db_password',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded);
+        }
+    }
+
+    #[Test]
+    public function pii_forbidden_fields_cover_required_sensitive_values(): void
+    {
+        $fields = $this->artifact()['pii_forbidden_fields'] ?? [];
+
+        foreach ([
+            'email',
+            'order_no',
+            'attempt_id',
+            'payment_id',
+            'provider_event_id',
+            'cookie',
+            'raw_ip',
+        ] as $field) {
+            $this->assertContains($field, $fields);
+        }
+    }
+
+    #[Test]
+    public function runbook_states_no_production_execution_and_required_human_checks(): void
+    {
+        $runbook = strtolower((string) file_get_contents(base_path('docs/seo/production-seo-intel-db-migration-runbook.md')));
+
+        foreach ([
+            'this is a production activation runbook only',
+            'does not create a production database',
+            'does not create database users',
+            'does not run production migrations',
+            'node2 local db',
+            'seo_intel_writer',
+            'seo_intel_metabase_readonly',
+            'migration_operator',
+            'backup is confirmed',
+            'restore procedure is known',
+            'forward-fix',
+            'seo-dash-prod-01b',
+        ] as $required) {
+            $this->assertStringContainsString($required, $runbook);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T13:26:42Z",
+  "updated_at": "2026-05-17T14:08:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -152,7 +152,7 @@
     "backend-email-gated-report-read": {
       "repo": "fap-api",
       "branch": "codex/backend-email-gated-report-read",
-      "status": "github_checks_passed",
+      "status": "merged",
       "depends_on": [
         "backend-email-result-lookup"
       ],
@@ -4441,7 +4441,7 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
+      "commit_sha": "0bc77e5ebcbd2ebb81789dfb9e25f1ecc1ea855b",
       "pr_url": null,
       "checks": {
         "authorization": {
@@ -9914,15 +9914,15 @@
         },
         "github": {
           "status": "pass",
-          "evidence": "PR #1447 CI passed after current-scope freeze gate allowlist fix: hygiene, verify-mbti-legacy, and verify-mbti-v2 completed successfully before rebase; final rebased checks pending."
+          "evidence": "PR #1447 CI passed after current-scope freeze gate allowlist fix: hygiene, verify-mbti-legacy, and verify-mbti-v2 completed successfully; PR was squash merged."
         }
       },
       "failure_reason": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1447",
-      "commit_sha": "3eb6f16712f42b73f52d121e2a4b186ab14805d6",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "commit_sha": "8e2a7e5508c4644d6b4e7d44ef1beb16b9998b4d",
+      "merged_at": "2026-05-17T13:39:44Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "history": [
         {
@@ -9954,9 +9954,116 @@
           "at": "2026-05-17T13:26:42Z",
           "status": "rebased",
           "summary": "Rebased SEO-DASH-06 onto latest origin/main after PR #1447 became dirty due to a newer publishing reliability merge."
+        },
+        {
+          "at": "2026-05-17T13:39:44Z",
+          "status": "merged",
+          "summary": "PR #1447 merged; origin/main contains merge commit 8e2a7e5508c4644d6b4e7d44ef1beb16b9998b4d and local/remote branch cleanup completed."
         }
       ],
-      "next_pr": "SEO-DASH-MVP-COMPLETE"
+      "next_pr": "SEO-DASH-PROD-01A"
+    },
+    "SEO-DASH-PROD-01A": {
+      "repo": "fap-api",
+      "branch": "codex/seo-dash-prod-01a-seo-intel-db-migration-runbook",
+      "base": "main",
+      "depends_on": [
+        "SEO-DASH-PROD-00"
+      ],
+      "status": "in_progress",
+      "train_scope": "production_seo_intel_db_user_migration_runbook",
+      "risk_level": "low_docs_contract_no_execution",
+      "title": "docs(seo-intel): add production DB migration runbook",
+      "name": "production seo_intel DB user migration runbook",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly provided SEO-DASH-PROD-01A with branch, title, allowed files, validation commands, and permission to update fap-api PR train metadata."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-DASH-PROD-00 was a completed read-only readiness scan. It identified SEO-DASH-PROD-01A as the immediate next task."
+        },
+        "production_deploy_allowed": {
+          "status": "false"
+        },
+        "production_migration_execution_allowed": {
+          "status": "false"
+        },
+        "production_db_creation": {
+          "status": "false"
+        },
+        "db_user_creation": {
+          "status": "false"
+        },
+        "human_confirmation_required": {
+          "status": "required",
+          "items": [
+            "production_db_location",
+            "seo_intel_writer",
+            "seo_intel_metabase_readonly",
+            "migration_operator",
+            "backup_restore",
+            "change_window"
+          ]
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to production seo_intel DB migration runbook docs, generated artifact, focused SeoIntel runbook test, and docs/codex PR train metadata. No config, migrations, app runtime, env, deploy, payment/order/report/email/recommendation/scoring, sitemap/llms, cloud/DNS/CDN/OpenResty/Nginx, production credential, or fap-web runtime files changed."
+        },
+        "runbook_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=SeoIntelProductionActivationRunbook",
+          "evidence": "6 tests passed with 62 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "Full Pint check passed across 3361 files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "github": {
+          "status": "pending"
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "type": "local_main_diverged_patch_equivalent",
+          "summary": "Local main contained patch-equivalent release hygiene commit 91baf921 while origin/main contained squash commit ddcce8a1. This PR branch was created from origin/main without rewriting local main."
+        }
+      ],
+      "history": [
+        {
+          "at": "2026-05-17T14:08:00Z",
+          "status": "in_progress",
+          "summary": "Registered authorized SEO-DASH-PROD-01A and started production seo_intel DB/user/migration runbook from origin/main. No production execution performed."
+        },
+        {
+          "at": "2026-05-17T14:16:00Z",
+          "status": "local_validation_passed",
+          "summary": "Added production seo_intel DB/user/migration runbook, generated artifact, focused contract test, and train metadata. Runbook test, route list, Pint, JSON/YAML validation, and diff checks passed."
+        },
+        {
+          "at": "2026-05-17T14:18:00Z",
+          "status": "committed",
+          "summary": "Committed SEO-DASH-PROD-01A local changes at 0bc77e5ebcbd2ebb81789dfb9e25f1ecc1ea855b."
+        }
+      ],
+      "next_pr": "SEO-DASH-PROD-01B"
     },
     "PUBLISH-API-MEDIA-ORIGIN-READYNESS": {
       "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -641,6 +641,58 @@ prs:
     pseo_generation: false
     scheduler_activation: false
     next_task: SEO-DASH-MVP-COMPLETE
+
+  - id: SEO-DASH-PROD-01A
+    repo: fap-api
+    depends_on:
+      - SEO-DASH-PROD-00
+    branch: codex/seo-dash-prod-01a-seo-intel-db-migration-runbook
+    title: "docs(seo-intel): add production DB migration runbook"
+    name: "production seo_intel DB user migration runbook"
+    findings:
+      - "SEO-DASH-PROD-00 concluded the SEO-DASH MVP foundation is complete but production activation is blocked."
+      - "Production seo_intel DB existence, DB host/location, writer user, Metabase read-only user, backup/restore, and migration runbook are not confirmed."
+      - "This PR is a runbook/contract step only and must not execute production changes."
+    scope:
+      - Add production seo_intel DB placement policy, required users, least-privilege permissions, migration preflight, command templates, backup/restore, forward-fix rollback, post-migration validation, and no-go conditions.
+      - Add generated contract artifact proving no production DB, user, migration, env, deploy, collector, scheduler, Metabase, external API, or log access changes happen in this PR.
+      - Add focused SeoIntel contract test for the production activation runbook.
+      - Update docs/codex PR train metadata for SEO-DASH-PROD-01A.
+    allowed_paths:
+      - backend/docs/seo/production-seo-intel-db-migration-runbook.md
+      - backend/docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelProductionActivationRunbookTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create production database or DB users.
+      - Run production migrations, connect to production DB, edit env, deploy, SSH, or touch Node2/Node3.
+      - Enable collectors, scheduler jobs, queue workers, Metabase, GSC, Baidu, IndexNow, domestic search adapters, or production log reads.
+      - Change runtime code, backend behavior, payment, order, report, email, recommendation, scoring, sitemap, or llms behavior.
+      - Modify fap-web runtime or use fap-api/fap-web as production frontend runtime.
+      - Store or expose secrets, emails, order numbers, attempt ids, payment ids, provider event ids, cookies, raw IPs, tokens, or keys.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelProductionActivationRunbook
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    production_db_creation: false
+    human_confirmation_required:
+      - production_db_location
+      - seo_intel_writer
+      - seo_intel_metabase_readonly
+      - migration_operator
+      - backup_restore
+      - change_window
+    scheduler_activation: false
+    next_task: SEO-DASH-PROD-01B
   - id: PR-MEDIA-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## Summary
- Adds the production seo_intel DB/user/migration activation runbook for SEO-DASH-PROD-01A.
- Defines allowed/forbidden DB placement, required users, least-privilege policy, migration preflight, command templates without secrets, backup/restore and forward-fix rollback policy, post-migration validation, no-go conditions, and human confirmation checklist.
- Adds generated contract artifact and focused SeoIntel contract test.
- Updates PR train metadata and reconciles SEO-DASH-06 as merged.

## Why
SEO-DASH-PROD-00 found the MVP foundation complete but production activation blocked until DB/user/migration ownership and runbook requirements are locked.

## Validation
- `cd backend && php artisan test --filter=SeoIntelProductionActivationRunbook` - passed, 6 tests / 62 assertions
- `cd backend && php artisan route:list --no-ansi` - passed, 198 routes
- `cd backend && vendor/bin/pint --test` - passed, 3361 files
- `python3 -m json.tool backend/docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json` - passed
- `python3 -m json.tool docs/codex/pr-train-state.json` - passed
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Deferred / Not Done
- No production DB creation.
- No DB user creation.
- No production migration execution.
- No env edits, deploy, SSH, production DB connection, collector activation, scheduler activation, Metabase deployment, external API connection, or production log read.
- No runtime code, payment/order/report/email/recommendation/scoring, sitemap, or llms behavior changes.

## Repository Rule Impact
Docs/contract only. Does not change content authority, CMS publishing, sitemap/llms enumeration, runtime behavior, production deploy readiness, or frontend/backend authority boundaries.