### PR TITLE
chore(security): add docs shell safety guard

### DIFF
--- a/backend/tests/Feature/ReleasePackScriptContractTest.php
+++ b/backend/tests/Feature/ReleasePackScriptContractTest.php
@@ -74,4 +74,105 @@ final class ReleasePackScriptContractTest extends TestCase
             $artifactClean
         );
     }
+
+    public function test_docs_shell_safety_guard_is_wired_into_artifact_clean_check(): void
+    {
+        $repoRoot = dirname(base_path());
+        $guardPath = $repoRoot.'/scripts/security/assert_docs_shell_safety.sh';
+        $artifactCleanPath = $repoRoot.'/scripts/security/assert_artifact_clean.sh';
+
+        $this->assertFileExists($guardPath);
+        $this->assertFileExists($artifactCleanPath);
+
+        $artifactClean = (string) file_get_contents($artifactCleanPath);
+
+        $this->assertStringContainsString(
+            'bash "${SCRIPT_DIR}/assert_docs_shell_safety.sh" --target "$TARGET"',
+            $artifactClean
+        );
+    }
+
+    public function test_docs_shell_safety_guard_allows_quoted_heredoc(): void
+    {
+        [$exitCode, $output] = $this->runDocsShellSafetyGuard(
+            "```bash\n".
+            "cat > /tmp/ledger.md <<'EOF'\n".
+            "Markdown with code fences and variables is written as text.\n".
+            "EOF\n".
+            "```\n"
+        );
+
+        $this->assertSame(0, $exitCode, $output);
+    }
+
+    public function test_docs_shell_safety_guard_rejects_unquoted_heredoc(): void
+    {
+        [$exitCode, $output] = $this->runDocsShellSafetyGuard(
+            "```bash\n".
+            "cat > /tmp/ledger.md <<EOF\n".
+            "Markdown with backticks can be expanded by the shell.\n".
+            "EOF\n".
+            "```\n"
+        );
+
+        $this->assertNotSame(0, $exitCode, $output);
+        $this->assertStringContainsString('unquoted_heredoc_eof', $output);
+    }
+
+    public function test_docs_shell_safety_guard_rejects_content_releases_tree_delete_example(): void
+    {
+        [$exitCode, $output] = $this->runDocsShellSafetyGuard(
+            "```bash\n".
+            "rm -rf backend/storage/app/private/content_releases\n".
+            "```\n"
+        );
+
+        $this->assertNotSame(0, $exitCode, $output);
+        $this->assertStringContainsString('content_releases_whole_tree_delete_example', $output);
+    }
+
+    public function test_docs_shell_safety_guard_rejects_release_pack_bulk_delete_examples(): void
+    {
+        [$exitCode, $output] = $this->runDocsShellSafetyGuard(
+            "```bash\n".
+            "rm -rf backend/storage/app/private/content_releases/*/source_pack\n".
+            "rm -rf backend/storage/app/private/content_releases/backups/*/previous_pack\n".
+            "```\n"
+        );
+
+        $this->assertNotSame(0, $exitCode, $output);
+        $this->assertStringContainsString('release_pack_bulk_delete_example', $output);
+    }
+
+    public function test_docs_shell_safety_guard_allows_plain_explanatory_text(): void
+    {
+        [$exitCode, $output] = $this->runDocsShellSafetyGuard(
+            "The content release runtime tree must be audited before cleanup.\n".
+            "source_pack and previous_pack require manifest-aware review.\n".
+            "Use quoted heredocs for ledgers that contain Markdown examples.\n"
+        );
+
+        $this->assertSame(0, $exitCode, $output);
+    }
+
+    /**
+     * @return array{0:int,1:string}
+     */
+    private function runDocsShellSafetyGuard(string $markdown): array
+    {
+        $repoRoot = dirname(base_path());
+        $target = sys_get_temp_dir().'/fap-docs-shell-safety-'.bin2hex(random_bytes(8));
+        $docsDir = $target.'/docs';
+
+        mkdir($docsDir, 0777, true);
+        file_put_contents($docsDir.'/example.md', $markdown);
+
+        $command = 'bash '.escapeshellarg($repoRoot.'/scripts/security/assert_docs_shell_safety.sh')
+            .' --target '.escapeshellarg($target).' 2>&1';
+
+        $lines = [];
+        exec($command, $lines, $exitCode);
+
+        return [$exitCode, implode("\n", $lines)];
+    }
 }

--- a/docs/04-ops/storage-local-retention-sop.md
+++ b/docs/04-ops/storage-local-retention-sop.md
@@ -210,6 +210,22 @@ Markdown text can safely include code fences, variables, backticks, and command 
 EOF
 ```
 
-Do not use an unquoted `<<EOF` heredoc for that content. Unquoted heredocs allow shell expansion, so Markdown code fences and backticks can be interpreted by the shell instead of being written as text.
+Do not use an unquoted heredoc with an EOF delimiter for that content. Unquoted heredocs allow shell expansion, so Markdown code fences and backticks can be interpreted by the shell instead of being written as text.
 
 Do not include directly executable whole-tree deletion examples in operational ledgers or cleanup notes.
+
+## Docs shell safety guard
+
+The repository includes `scripts/security/assert_docs_shell_safety.sh` to catch repeatable documentation hazards before they enter release hygiene or artifact-clean checks.
+
+The guard fails docs that contain:
+
+```text
+unquoted heredoc examples that use EOF as the delimiter
+directly executable backend/storage/app/private/content_releases whole-tree delete examples
+directly executable source_pack or previous_pack bulk delete examples
+```
+
+Quoted heredoc delimiters such as `<<'EOF'`, `<<"EOF"`, and `<<-'EOF'` remain allowed.
+
+This guard is documentation safety only. It must not delete files, move files, run `storage:prune`, write prune plans, mutate the database, or change retention behavior.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T15:42:17Z",
+  "updated_at": "2026-05-17T16:09:09Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -10337,6 +10337,102 @@
           "at": "2026-05-17T15:42:17Z",
           "status": "ci_failure_fixed_locally",
           "summary": "Fixed GitHub CI failure by teaching the BigFive runtime freeze classifier that the read-only StorageReleaseRootsAudit command is allowed in this scoped PR; reran focused test, StorageReleaseRootsAuditTest, route:list, ci_verify_mbti, and diff checks successfully."
+        }
+      ]
+    },
+    "DOCS-SHELL-SAFETY-GUARD": {
+      "repo": "fap-api",
+      "branch": "codex/docs-shell-safety-guard",
+      "base": "main",
+      "depends_on": [],
+      "status": "committed",
+      "train_scope": "storage_runtime_hygiene",
+      "risk_level": "low",
+      "title": "chore(security): add docs shell safety guard",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding docs/codex/pr-train.yaml and docs/codex/pr-train-state.json entries for docs-shell-safety-guard."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "No manifest dependencies declared for DOCS-SHELL-SAFETY-GUARD."
+        },
+        "safety_boundary": {
+          "status": "pass",
+          "evidence": "Scope excludes cleanup, prune, delete, move, DB mutation, retention behavior changes, and publish/rollback/rehydrate/quarantine business logic changes."
+        },
+        "implementation": {
+          "status": "pass",
+          "evidence": "Added read-only docs shell safety guard, wired it through assert_artifact_clean.sh, covered quoted/unquoted heredoc and destructive docs examples in ReleasePackScriptContractTest, and documented guard purpose in the storage local retention SOP."
+        },
+        "docs_shell_safety_guard": {
+          "status": "pass",
+          "command": "bash scripts/security/assert_docs_shell_safety.sh",
+          "evidence": "Docs shell safety check passed for repository docs."
+        },
+        "artifact_clean_integration": {
+          "status": "pass",
+          "command": "bash scripts/security/assert_artifact_clean.sh",
+          "evidence": "Security artifact clean check invoked docs shell safety guard and passed in repo mode."
+        },
+        "release_pack_contract_test": {
+          "status": "pass",
+          "command": "php artisan test --filter=ReleasePackScriptContractTest --no-ansi",
+          "evidence": "8 tests passed with 26 assertions, including quoted heredoc pass, unquoted heredoc fail, content_releases delete example fail, source_pack/previous_pack bulk delete example fail, and explanatory text pass."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "ci_verify_mbti": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "MBTI CI master chain completed successfully; generated BIG5_OCEAN compiled tracked artifacts were restored to HEAD because they are outside this PR scope."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "Whitespace checks passed before and after ci_verify_mbti."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to docs shell safety guard, artifact clean integration, ReleasePackScriptContractTest, storage local retention SOP, and docs/codex train metadata. No cleanup, prune, delete, move, DB mutation, retention behavior, or publish/rollback/rehydrate/quarantine business logic changed."
+        },
+        "standalone_migrate": {
+          "status": "not_run",
+          "command": "php artisan migrate",
+          "evidence": "Not run because this PR has no migration or schema changes; ci_verify_mbti used its isolated sqlite harness."
+        },
+        "curl_health": {
+          "status": "not_run",
+          "command": "curl -i http://127.0.0.1:8000/api/health",
+          "evidence": "Not run because no persistent local server check was part of this docs/scripts safety guard PR."
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": "c1e8063a",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-17T16:01:58Z",
+          "status": "in_progress",
+          "summary": "Started DOCS-SHELL-SAFETY-GUARD after explicit manifest/state authorization; no cleanup, prune, delete, move, DB mutation, or retention behavior change performed."
+        },
+        {
+          "at": "2026-05-17T16:08:20Z",
+          "status": "local_checks_passed",
+          "summary": "Implemented docs shell safety guard and completed guard, artifact clean integration, ReleasePackScriptContractTest, route:list, ci_verify_mbti, and diff checks; no cleanup, prune, delete, move, DB mutation, or retention behavior change performed."
+        },
+        {
+          "at": "2026-05-17T16:09:09Z",
+          "status": "committed",
+          "summary": "Committed DOCS-SHELL-SAFETY-GUARD scoped changes at c1e8063a."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T16:09:09Z",
+  "updated_at": "2026-05-17T16:10:03Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -10345,7 +10345,7 @@
       "branch": "codex/docs-shell-safety-guard",
       "base": "main",
       "depends_on": [],
-      "status": "committed",
+      "status": "pr_open",
       "train_scope": "storage_runtime_hygiene",
       "risk_level": "low",
       "title": "chore(security): add docs shell safety guard",
@@ -10412,8 +10412,8 @@
         }
       },
       "failure_reason": null,
-      "pr_url": null,
-      "commit_sha": "c1e8063a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1455",
+      "commit_sha": "32fb9a3a",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -10433,6 +10433,11 @@
           "at": "2026-05-17T16:09:09Z",
           "status": "committed",
           "summary": "Committed DOCS-SHELL-SAFETY-GUARD scoped changes at c1e8063a."
+        },
+        {
+          "at": "2026-05-17T16:10:03Z",
+          "status": "pr_open",
+          "summary": "Opened GitHub PR #1455 for DOCS-SHELL-SAFETY-GUARD after scoped local validation passed."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5256,3 +5256,45 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+
+  - id: DOCS-SHELL-SAFETY-GUARD
+    repo: fap-api
+    branch: codex/docs-shell-safety-guard
+    base: main
+    depends_on: []
+    title: "chore(security): add docs shell safety guard"
+    name: "Add docs shell safety guard"
+    train_scope: storage_runtime_hygiene
+    risk_level: low
+    findings:
+      - "A local runtime storage incident was caused by writing Markdown ledger content through an unquoted heredoc, allowing shell expansion to execute command examples."
+      - "Docs and release hygiene need a lightweight guard against unquoted heredoc examples and directly executable destructive content_releases cleanup examples."
+    scope:
+      - Add scripts/security/assert_docs_shell_safety.sh as a read-only docs scanner.
+      - Reject unquoted <<EOF and <<-EOF heredoc examples in docs Markdown.
+      - Reject directly executable content_releases whole-tree delete examples and source_pack/previous_pack bulk delete examples in docs.
+      - Wire the guard through security artifact clean checks.
+      - Add focused ReleasePackScriptContractTest coverage and SOP documentation.
+    allowed_paths:
+      - scripts/security/assert_docs_shell_safety.sh
+      - scripts/security/assert_artifact_clean.sh
+      - backend/tests/Feature/ReleasePackScriptContractTest.php
+      - docs/04-ops/storage-local-retention-sop.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Delete files, move files, create quarantine directories, run storage:prune, or write prune plans.
+      - Add cleanup executors or destructive cleanup commands.
+      - Mutate DB or change retention behavior.
+      - Change publish, rollback, rehydrate, or quarantine business logic.
+      - Use unquoted heredocs for Markdown or command-example writing.
+    validation:
+      - bash scripts/security/assert_docs_shell_safety.sh
+      - php artisan test --filter=ReleasePackScriptContractTest --no-ansi
+      - php artisan route:list --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true

--- a/scripts/security/assert_artifact_clean.sh
+++ b/scripts/security/assert_artifact_clean.sh
@@ -240,6 +240,8 @@ if [[ "$MODE" != "repo" && "$MODE" != "artifact" ]]; then
 fi
 
 TARGET="$(cd "$TARGET" && pwd)"
+bash "${SCRIPT_DIR}/assert_docs_shell_safety.sh" --target "$TARGET"
+
 if [[ "$MODE" == "repo" ]]; then
   check_repo_mode
 else

--- a/scripts/security/assert_docs_shell_safety.sh
+++ b/scripts/security/assert_docs_shell_safety.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TARGET="$REPO_DIR"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  assert_docs_shell_safety.sh [--target <repo-or-artifact-root>]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      TARGET="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[SEC-DOCS-SHELL][FAIL] unknown arg: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET" || ! -d "$TARGET" ]]; then
+  echo "[SEC-DOCS-SHELL][FAIL] target_not_found: ${TARGET}" >&2
+  exit 2
+fi
+
+TARGET="$(cd "$TARGET" && pwd)"
+DOCS_DIR="${TARGET}/docs"
+fail_count=0
+
+fail() {
+  local file="$1"
+  local line="$2"
+  local reason="$3"
+  echo "[SEC-DOCS-SHELL][FAIL] reason=${reason} path=${file}:${line}" >&2
+  fail_count=$((fail_count + 1))
+}
+
+rel() {
+  local p="$1"
+  p="${p#${TARGET}/}"
+  echo "$p"
+}
+
+check_line() {
+  local file="$1"
+  local line_no="$2"
+  local line="$3"
+  local printable
+  printable="$(rel "$file")"
+
+  if [[ "$line" =~ (^|[^\<])\<\<-?EOF([^A-Za-z0-9_]|$) ]]; then
+    fail "$printable" "$line_no" "unquoted_heredoc_eof"
+  fi
+
+  if [[ "$line" =~ (^|[[:space:];|&])(sudo[[:space:]]+)?rm[[:space:]]+-[^[:space:]]*r[^[:space:]]*[[:space:]]+.*backend/storage/app/private/content_releases(/|[[:space:]]|$) ]]; then
+    fail "$printable" "$line_no" "content_releases_whole_tree_delete_example"
+  fi
+
+  if [[ "$line" =~ (^|[[:space:];|&])find[[:space:]]+.*backend/storage/app/private/content_releases.*[[:space:]]-delete([[:space:]]|$) ]]; then
+    fail "$printable" "$line_no" "content_releases_find_delete_example"
+  fi
+
+  if [[ "$line" =~ (^|[[:space:];|&])(sudo[[:space:]]+)?rm[[:space:]]+-[^[:space:]]*r[^[:space:]]*[[:space:]]+.*(source_pack|previous_pack)(/|[[:space:]]|$) ]]; then
+    fail "$printable" "$line_no" "release_pack_bulk_delete_example"
+  fi
+
+  if [[ "$line" =~ (^|[[:space:];|&])find[[:space:]]+.*(-name[[:space:]]+)?(source_pack|previous_pack).*(-delete|-exec[[:space:]]+(sudo[[:space:]]+)?rm)([[:space:]]|$) ]]; then
+    fail "$printable" "$line_no" "release_pack_find_delete_example"
+  fi
+}
+
+if [[ ! -d "$DOCS_DIR" ]]; then
+  echo "[SEC-DOCS-SHELL] docs shell safety check PASS (target=$TARGET docs=missing)"
+  exit 0
+fi
+
+while IFS= read -r -d '' file; do
+  line_no=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_no=$((line_no + 1))
+    check_line "$file" "$line_no" "$line"
+  done < "$file"
+done < <(find "$DOCS_DIR" -type f -name '*.md' -print0)
+
+if [[ "$fail_count" -gt 0 ]]; then
+  echo "[SEC-DOCS-SHELL] docs shell safety check failed with ${fail_count} issue(s)." >&2
+  exit 1
+fi
+
+echo "[SEC-DOCS-SHELL] docs shell safety check PASS (target=$TARGET)"


### PR DESCRIPTION
## Summary
- Add `scripts/security/assert_docs_shell_safety.sh` as a read-only docs Markdown safety scanner.
- Wire the guard into `scripts/security/assert_artifact_clean.sh` so release/security hygiene catches unsafe docs examples.
- Add `ReleasePackScriptContractTest` coverage for quoted heredoc pass, unquoted heredoc fail, content_releases tree delete example fail, source_pack/previous_pack bulk delete example fail, and plain explanatory text pass.
- Document the guard purpose in `docs/04-ops/storage-local-retention-sop.md`.

## Validation
- `bash scripts/security/assert_docs_shell_safety.sh`
- `bash scripts/security/assert_artifact_clean.sh`
- `cd backend && php artisan test --filter=ReleasePackScriptContractTest --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check && git diff --cached --check`

## Safety boundary
- No cleanup, prune, delete, move, DB mutation, or retention behavior change.
- No publish / rollback / rehydrate / quarantine business logic change.
- No cleanup executor added.

## Notes
- `php artisan migrate` was not run because this PR has no schema changes; `ci_verify_mbti.sh` used its isolated sqlite harness.
- `curl` health check was not run because no persistent local server check is required for this docs/scripts guard.