### PR TITLE
fix(career): harden taxonomy exporter limit semantics

### DIFF
--- a/backend/app/Console/Commands/CareerExportPublicTrustTaxonomy.php
+++ b/backend/app/Console/Commands/CareerExportPublicTrustTaxonomy.php
@@ -35,6 +35,7 @@ final class CareerExportPublicTrustTaxonomy extends Command
                 'status' => 'materialized',
                 'artifact' => $path,
                 'exportStatus' => $taxonomy['exportStatus'] ?? 'unknown',
+                'exportScope' => $taxonomy['exportScope'] ?? [],
                 'counts' => $taxonomy['counts'] ?? [],
             ];
 

--- a/backend/app/Domain/Career/Publish/CareerPublicTrustTaxonomyExporter.php
+++ b/backend/app/Domain/Career/Publish/CareerPublicTrustTaxonomyExporter.php
@@ -21,10 +21,18 @@ final class CareerPublicTrustTaxonomyExporter
      */
     public function build(?int $limit = null): array
     {
+        $limit = $limit !== null && $limit > 0 ? $limit : null;
         $schema = $this->schemaAvailability();
         $occupations = $schema['tables']['occupations']['exists']
             ? $this->occupationRows($limit)
             : collect();
+        $limitedOccupationIds = $limit !== null
+            ? $occupations
+                ->map(static fn (object $occupation): string => (string) ($occupation->id ?? ''))
+                ->filter(static fn (string $id): bool => $id !== '')
+                ->values()
+                ->all()
+            : null;
         $displayAssetsBySlug = $schema['tables']['career_job_display_assets']['exists']
             ? $this->displayAssetsBySlug()
             : [];
@@ -32,7 +40,7 @@ final class CareerPublicTrustTaxonomyExporter
             ? $this->latestIndexStatesByOccupation()
             : [];
         $aliases = $schema['tables']['occupation_aliases']['exists']
-            ? $this->aliasRows()
+            ? $this->aliasRows($limitedOccupationIds)
             : collect();
         $aliasesByOccupation = $aliases
             ->filter(static fn (object $alias): bool => isset($alias->occupation_id) && (string) $alias->occupation_id !== '')
@@ -84,6 +92,7 @@ final class CareerPublicTrustTaxonomyExporter
             'recommendationExpansionAllowed' => false,
             'profileMemoryExpansionAllowed' => false,
             'exportStatus' => $this->exportStatus($schema),
+            'exportScope' => $this->exportScope($limit),
             'schema' => $schema,
             'counts' => $this->counts($items, $occupations, $aliases),
             'classificationBuckets' => $this->classificationBuckets($items),
@@ -159,6 +168,7 @@ final class CareerPublicTrustTaxonomyExporter
                 'metadata_json',
                 'updated_at',
             ])
+            ->orderByRaw("case when status in ('blocked', 'draft', 'archived') then 1 else 0 end asc")
             ->orderByDesc('updated_at')
             ->get();
 
@@ -207,9 +217,13 @@ final class CareerPublicTrustTaxonomyExporter
     /**
      * @return Collection<int, object>
      */
-    private function aliasRows(): Collection
+    /**
+     * @param  list<string>|null  $limitedOccupationIds
+     * @return Collection<int, object>
+     */
+    private function aliasRows(?array $limitedOccupationIds): Collection
     {
-        return DB::table('occupation_aliases')
+        $query = DB::table('occupation_aliases')
             ->leftJoin('occupations', 'occupation_aliases.occupation_id', '=', 'occupations.id')
             ->select([
                 'occupation_aliases.id',
@@ -225,8 +239,17 @@ final class CareerPublicTrustTaxonomyExporter
                 'occupation_aliases.confidence_score',
                 'occupations.canonical_slug as target_canonical_slug',
             ])
-            ->orderBy('occupation_aliases.normalized')
-            ->get();
+            ->orderBy('occupation_aliases.normalized');
+
+        if ($limitedOccupationIds !== null) {
+            if ($limitedOccupationIds === []) {
+                return collect();
+            }
+
+            $query->whereIn('occupation_aliases.occupation_id', $limitedOccupationIds);
+        }
+
+        return $query->get();
     }
 
     /**
@@ -459,6 +482,29 @@ final class CareerPublicTrustTaxonomyExporter
         }
 
         return 'complete';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exportScope(?int $limit): array
+    {
+        $limited = $limit !== null;
+
+        return [
+            'mode' => $limited ? 'limited' : 'full',
+            'limitApplied' => $limit,
+            'limitedExport' => $limited,
+            'suitableForFullCountReconciliation' => ! $limited,
+            'occupationSelectionStrategy' => $limited
+                ? 'ordered_by_canonical_slug_limited_occupation_rows'
+                : 'all_backend_occupation_rows_ordered_by_canonical_slug',
+            'aliasSelectionStrategy' => $limited
+                ? 'related_to_limited_occupation_rows_only'
+                : 'all_backend_alias_rows',
+            'displayAssetSelectionStrategy' => 'prefer_non_blocked_non_draft_non_archived_asset_then_latest_updated_at_per_canonical_slug',
+            'savedCareerUserDataPolicy' => 'schema_and_boundary_policy_only_no_user_rows',
+        ];
     }
 
     private function noindexReason(bool $hasDisplayAsset, ?object $indexState): string

--- a/backend/tests/Feature/Console/CareerExportPublicTrustTaxonomyCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportPublicTrustTaxonomyCommandTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerExportPublicTrustTaxonomyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_limited_export_bounds_aliases_and_marks_reconciliation_unsuitable(): void
+    {
+        $familyId = (string) Str::uuid();
+        $alphaId = $this->insertOccupation($familyId, 'alpha-career');
+        $betaId = $this->insertOccupation($familyId, 'beta-career');
+        $this->insertAlias($alphaId, $familyId, 'alpha career', 'alpha-career');
+        $this->insertAlias($alphaId, $familyId, 'alpha role', 'alpha-role');
+        $this->insertAlias($betaId, $familyId, 'beta career', 'beta-career');
+        $this->insertIndexState($alphaId, true);
+        $this->insertIndexState($betaId, true);
+        $this->insertDisplayAsset($alphaId, 'alpha-career', 'draft-v2', 'draft', '2026-05-18 02:00:00');
+        $this->insertDisplayAsset($alphaId, 'alpha-career', 'public-v1', 'ready_for_pilot', '2026-05-18 01:00:00');
+        $this->insertDisplayAsset($betaId, 'beta-career', 'public-v1', 'ready_for_pilot', '2026-05-18 01:00:00');
+
+        $output = storage_path('framework/testing/career-taxonomy-limit1.json');
+        File::delete($output);
+
+        $exitCode = Artisan::call('career:export-public-trust-taxonomy', [
+            '--output' => $output,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $commandPayload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+        $artifact = json_decode((string) File::get($output), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('limited', $artifact['exportScope']['mode']);
+        $this->assertTrue((bool) $artifact['exportScope']['limitedExport']);
+        $this->assertFalse((bool) $artifact['exportScope']['suitableForFullCountReconciliation']);
+        $this->assertSame('related_to_limited_occupation_rows_only', $artifact['exportScope']['aliasSelectionStrategy']);
+        $this->assertSame($artifact['exportScope'], $commandPayload['exportScope']);
+        $this->assertSame(1, (int) $artifact['counts']['backendOccupationRows']);
+        $this->assertSame(2, (int) $artifact['counts']['backendAliasRows']);
+        $this->assertSame(2, (int) $artifact['counts']['aliasOnlyAssets']);
+        $this->assertNotContains('beta-career', $artifact['classificationBuckets']['aliasOnlyAssets']);
+
+        $canonicalAlpha = $this->firstItemBySlug($artifact['items'], 'alpha-career');
+        $this->assertSame('ready_for_pilot', $canonicalAlpha['routeEvidence']['display_asset_status']);
+        $this->assertSame('public-v1', $canonicalAlpha['routeEvidence']['asset_version']);
+        $this->assertTrue((bool) $canonicalAlpha['publicRouteAvailable']);
+    }
+
+    private function insertOccupation(string $familyId, string $slug): string
+    {
+        if (! DB::table('occupation_families')->where('id', $familyId)->exists()) {
+            DB::table('occupation_families')->insert([
+                'id' => $familyId,
+                'canonical_slug' => 'engineering',
+                'title_en' => 'Engineering',
+                'title_zh' => '工程',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $id = (string) Str::uuid();
+        DB::table('occupations')->insert([
+            'id' => $id,
+            'family_id' => $familyId,
+            'parent_id' => null,
+            'canonical_slug' => $slug,
+            'entity_level' => 'occupation',
+            'truth_market' => 'US',
+            'display_market' => 'global',
+            'crosswalk_mode' => 'canonical',
+            'canonical_title_en' => Str::title(str_replace('-', ' ', $slug)),
+            'canonical_title_zh' => $slug,
+            'search_h1_zh' => $slug,
+            'trust_inheritance_scope' => json_encode(['status' => 'approved'], JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $id;
+    }
+
+    private function insertAlias(string $occupationId, string $familyId, string $alias, string $normalized): void
+    {
+        DB::table('occupation_aliases')->insert([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => $occupationId,
+            'family_id' => $familyId,
+            'alias' => $alias,
+            'normalized' => $normalized,
+            'lang' => 'en',
+            'register' => 'alias',
+            'intent_scope' => 'career',
+            'target_kind' => 'occupation',
+            'precision_score' => 0.9,
+            'confidence_score' => 0.9,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertIndexState(string $occupationId, bool $eligible): void
+    {
+        DB::table('index_states')->insert([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => $occupationId,
+            'index_state' => $eligible ? 'indexable' : 'noindex',
+            'index_eligible' => $eligible,
+            'canonical_path' => '/career/jobs/example',
+            'canonical_target' => null,
+            'reason_codes' => json_encode(['test_fixture'], JSON_THROW_ON_ERROR),
+            'changed_at' => '2026-05-18 00:00:00',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertDisplayAsset(string $occupationId, string $slug, string $version, string $status, string $updatedAt): void
+    {
+        DB::table('career_job_display_assets')->insert([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => $occupationId,
+            'canonical_slug' => $slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => $version,
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => $status,
+            'component_order_json' => json_encode([], JSON_THROW_ON_ERROR),
+            'page_payload_json' => json_encode(['faq' => []], JSON_THROW_ON_ERROR),
+            'seo_payload_json' => json_encode(['title' => $slug], JSON_THROW_ON_ERROR),
+            'sources_json' => json_encode(['sources' => []], JSON_THROW_ON_ERROR),
+            'structured_data_json' => json_encode(['@type' => 'BreadcrumbList'], JSON_THROW_ON_ERROR),
+            'implementation_contract_json' => json_encode([], JSON_THROW_ON_ERROR),
+            'metadata_json' => json_encode([], JSON_THROW_ON_ERROR),
+            'created_at' => $updatedAt,
+            'updated_at' => $updatedAt,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function firstItemBySlug(array $items, string $slug): array
+    {
+        foreach ($items as $item) {
+            if (($item['slug'] ?? null) === $slug) {
+                return $item;
+            }
+        }
+
+        $this->fail("Item {$slug} not found.");
+    }
+}


### PR DESCRIPTION
## Summary
- Bound `career:export-public-trust-taxonomy --limit` alias rows to aliases related to limited occupation rows.
- Add `exportScope` metadata so limited exports are explicitly unsuitable for full count reconciliation.
- Prefer non-blocked/non-draft/non-archived display assets before latest updated display assets when selecting public truth.
- Add a focused feature test for limited export semantics and display asset selection.

## Runtime Impact
- No public route, recommendation, freemium, profile, checkout, or scoring change.
- Export command semantics only.

## Validation
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-fu3c.sqlite php artisan migrate --force --no-ansi`
- `php artisan test --filter=CareerExportPublicTrustTaxonomyCommandTest --no-ansi`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`
- `git diff --cached --check`