### PR TITLE
fix(seo-intel): isolate seo_intel migrations

### DIFF
--- a/backend/database/migrations/seo_intel/2026_05_17_000100_create_seo_urls_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000100_create_seo_urls_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_urls')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_000200_create_seo_url_entities_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000200_create_seo_url_entities_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_url_entities')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_000300_create_seo_internal_traffic_rules_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000300_create_seo_internal_traffic_rules_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_internal_traffic_rules')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_000400_create_seo_event_funnel_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000400_create_seo_event_funnel_daily_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_event_funnel_daily')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_000500_create_seo_landing_attribution_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000500_create_seo_landing_attribution_daily_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_landing_attribution_daily')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_000600_create_seo_revenue_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000600_create_seo_revenue_daily_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_revenue_daily')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_000700_create_seo_cluster_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000700_create_seo_cluster_daily_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_cluster_daily')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_000800_create_seo_consent_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000800_create_seo_consent_daily_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_consent_daily')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_000900_create_seo_gsc_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_000900_create_seo_gsc_daily_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_gsc_daily')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_001000_create_seo_baidu_push_logs_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_001000_create_seo_baidu_push_logs_table.php
@@ -6,18 +6,21 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
-        if (Schema::hasTable('seo_indexnow_submissions')) {
+        if (Schema::hasTable('seo_baidu_push_logs')) {
             return;
         }
 
-        Schema::create('seo_indexnow_submissions', function (Blueprint $table): void {
+        Schema::create('seo_baidu_push_logs', function (Blueprint $table): void {
             $table->id();
             $table->char('canonical_url_hash', 64);
             $table->text('canonical_url')->nullable();
-            $table->string('source_engine', 64)->default('bing_indexnow');
-            $table->string('submission_type', 64)->default('url_updated');
+            $table->string('locale', 16)->nullable();
+            $table->string('source_engine', 64)->default('baidu');
+            $table->string('submission_type', 64)->default('push');
             $table->string('submission_status', 64)->default('dry_run');
             $table->integer('response_code')->nullable();
             $table->char('response_body_hash', 64)->nullable();
@@ -27,10 +30,10 @@ return new class extends Migration
             $table->json('metadata_json')->nullable();
             $table->timestamps();
 
-            $table->index('canonical_url_hash', 'seo_indexnow_submissions_url_hash_idx');
-            $table->index('source_engine', 'seo_indexnow_submissions_source_engine_idx');
-            $table->index('submission_status', 'seo_indexnow_submissions_status_idx');
-            $table->index('submitted_at', 'seo_indexnow_submissions_submitted_at_idx');
+            $table->index('canonical_url_hash', 'seo_baidu_push_logs_url_hash_idx');
+            $table->index('source_engine', 'seo_baidu_push_logs_source_engine_idx');
+            $table->index('submission_status', 'seo_baidu_push_logs_status_idx');
+            $table->index('submitted_at', 'seo_baidu_push_logs_submitted_at_idx');
         });
     }
 

--- a/backend/database/migrations/seo_intel/2026_05_17_001100_create_seo_baidu_landing_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_001100_create_seo_baidu_landing_daily_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_baidu_landing_daily')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_001200_create_seo_indexnow_submissions_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_001200_create_seo_indexnow_submissions_table.php
@@ -6,19 +6,20 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
-        if (Schema::hasTable('seo_baidu_push_logs')) {
+        if (Schema::hasTable('seo_indexnow_submissions')) {
             return;
         }
 
-        Schema::create('seo_baidu_push_logs', function (Blueprint $table): void {
+        Schema::create('seo_indexnow_submissions', function (Blueprint $table): void {
             $table->id();
             $table->char('canonical_url_hash', 64);
             $table->text('canonical_url')->nullable();
-            $table->string('locale', 16)->nullable();
-            $table->string('source_engine', 64)->default('baidu');
-            $table->string('submission_type', 64)->default('push');
+            $table->string('source_engine', 64)->default('bing_indexnow');
+            $table->string('submission_type', 64)->default('url_updated');
             $table->string('submission_status', 64)->default('dry_run');
             $table->integer('response_code')->nullable();
             $table->char('response_body_hash', 64)->nullable();
@@ -28,10 +29,10 @@ return new class extends Migration
             $table->json('metadata_json')->nullable();
             $table->timestamps();
 
-            $table->index('canonical_url_hash', 'seo_baidu_push_logs_url_hash_idx');
-            $table->index('source_engine', 'seo_baidu_push_logs_source_engine_idx');
-            $table->index('submission_status', 'seo_baidu_push_logs_status_idx');
-            $table->index('submitted_at', 'seo_baidu_push_logs_submitted_at_idx');
+            $table->index('canonical_url_hash', 'seo_indexnow_submissions_url_hash_idx');
+            $table->index('source_engine', 'seo_indexnow_submissions_source_engine_idx');
+            $table->index('submission_status', 'seo_indexnow_submissions_status_idx');
+            $table->index('submitted_at', 'seo_indexnow_submissions_submitted_at_idx');
         });
     }
 

--- a/backend/database/migrations/seo_intel/2026_05_17_001300_create_seo_search_engine_verification_statuses_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_001300_create_seo_search_engine_verification_statuses_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_search_engine_verification_statuses')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_001400_create_seo_domestic_submission_logs_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_001400_create_seo_domestic_submission_logs_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_domestic_submission_logs')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_001500_create_seo_domestic_index_samples_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_001500_create_seo_domestic_index_samples_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_domestic_index_samples')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_001600_create_seo_crawler_logs_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_001600_create_seo_crawler_logs_daily_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_crawler_logs_daily')) {

--- a/backend/database/migrations/seo_intel/2026_05_17_001700_create_seo_issue_queue_table.php
+++ b/backend/database/migrations/seo_intel/2026_05_17_001700_create_seo_issue_queue_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    protected $connection = 'seo_intel';
+
     public function up(): void
     {
         if (Schema::hasTable('seo_issue_queue')) {

--- a/backend/docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json
+++ b/backend/docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json
@@ -15,6 +15,12 @@
   "scheduler_enabled_in_this_pr": false,
   "metabase_deployed_in_this_pr": false,
   "external_search_api_connected_in_this_pr": false,
+  "migration_path": "database/migrations/seo_intel",
+  "default_migration_path_allowed_for_seo_intel": false,
+  "bare_database_migration_command_allowed": false,
+  "required_pretend_command": "php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --pretend --no-ansi --force",
+  "required_actual_migration_command": "php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --no-ansi --force",
+  "required_status_command": "php artisan migrate:status --database=seo_intel --path=database/migrations/seo_intel --no-ansi",
   "allowed_db_locations": [
     "managed_mysql_rds_dedicated_analytics",
     "approved_managed_mysql_separate_database_or_schema",
@@ -106,9 +112,9 @@
     "no_deploy_or_incident_in_progress"
   ],
   "command_templates": [
-    "php artisan migrate --database=seo_intel --pretend --no-ansi",
-    "php artisan migrate --database=seo_intel --no-ansi",
-    "php artisan migrate:status --database=seo_intel --no-ansi"
+    "php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --pretend --no-ansi --force",
+    "php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --no-ansi --force",
+    "php artisan migrate:status --database=seo_intel --path=database/migrations/seo_intel --no-ansi"
   ],
   "backup_restore_policy": {
     "migrations_are_forward_only": true,
@@ -182,5 +188,5 @@
     "change_window",
     "rollback_forward_fix_owner"
   ],
-  "next_task": "SEO-DASH-PROD-01B"
+  "next_task": "SEO-DASH-PROD-01B-STAGE1-RETRY"
 }

--- a/backend/docs/seo/production-seo-intel-db-migration-runbook.md
+++ b/backend/docs/seo/production-seo-intel-db-migration-runbook.md
@@ -95,19 +95,25 @@ All items must be confirmed before any production migration:
 
 These are templates only. Do not paste secrets into commands, shell history, tickets, logs, PR bodies, or chat.
 
+Production `seo_intel` migration commands must always include the dedicated migration path. Never run
+`php artisan migrate --database=seo_intel` without `--path=database/migrations/seo_intel`; the default Laravel
+migration directory contains normal app and CMS migrations that must not run against the `seo_intel` schema.
+
 ```bash
-php artisan migrate --database=seo_intel --pretend --no-ansi
+php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --pretend --no-ansi --force
 ```
 
 ```bash
-php artisan migrate --database=seo_intel --no-ansi
+php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --no-ansi --force
 ```
 
 ```bash
-php artisan migrate:status --database=seo_intel --no-ansi
+php artisan migrate:status --database=seo_intel --path=database/migrations/seo_intel --no-ansi
 ```
 
 Use the approved production execution channel and masked environment configuration. Do not run these commands from this PR.
+The migration target is `seo_intel` only; default business migrations must not run against `seo_intel`.
+Default business migrations must not run against seo_intel.
 
 ## H. Backup / Restore / Rollback
 
@@ -165,6 +171,6 @@ Stop before production migration if any condition is true:
 
 ## K. Next Task
 
-Next task: `SEO-DASH-PROD-01B` for human-approved production DB/user/migration execution.
+Next task: `SEO-DASH-PROD-01B-STAGE1-RETRY` for a human-approved production migration Stage 1 retry using the isolated `seo_intel` migration path.
 
 If production DB and migrations are complete under human approval, the next activation step may proceed to `SEO-DASH-PROD-02` collector dry-run smoke.

--- a/backend/tests/Feature/SeoIntel/SeoIntelAttributionRevenueBuildersTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelAttributionRevenueBuildersTest.php
@@ -74,11 +74,11 @@ final class SeoIntelAttributionRevenueBuildersTest extends TestCase
             'raw_cookie',
         ];
         $paths = [
-            ...glob(base_path('database/migrations/*seo_event_funnel_daily*')),
-            ...glob(base_path('database/migrations/*seo_landing_attribution_daily*')),
-            ...glob(base_path('database/migrations/*seo_revenue_daily*')),
-            ...glob(base_path('database/migrations/*seo_cluster_daily*')),
-            ...glob(base_path('database/migrations/*seo_consent_daily*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_event_funnel_daily*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_landing_attribution_daily*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_revenue_daily*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_cluster_daily*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_consent_daily*')),
         ];
 
         $this->assertCount(5, $paths);

--- a/backend/tests/Feature/SeoIntel/SeoIntelBaiduIndexNowCollectorsTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelBaiduIndexNowCollectorsTest.php
@@ -31,9 +31,9 @@ final class SeoIntelBaiduIndexNowCollectorsTest extends TestCase
     public function search_channel_migrations_do_not_include_forbidden_columns(): void
     {
         $paths = [
-            ...glob(base_path('database/migrations/*seo_baidu_push_logs*')),
-            ...glob(base_path('database/migrations/*seo_baidu_landing_daily*')),
-            ...glob(base_path('database/migrations/*seo_indexnow_submissions*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_baidu_push_logs*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_baidu_landing_daily*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_indexnow_submissions*')),
         ];
 
         $this->assertCount(3, $paths);

--- a/backend/tests/Feature/SeoIntel/SeoIntelChineseCrawlerLogCollectorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelChineseCrawlerLogCollectorTest.php
@@ -32,7 +32,7 @@ final class SeoIntelChineseCrawlerLogCollectorTest extends TestCase
     #[Test]
     public function crawler_log_daily_migration_does_not_include_forbidden_columns(): void
     {
-        $paths = glob(base_path('database/migrations/*seo_crawler_logs_daily*'));
+        $paths = glob(base_path('database/migrations/seo_intel/*seo_crawler_logs_daily*'));
 
         $this->assertCount(1, $paths);
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelCmsIssueQueueSummaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelCmsIssueQueueSummaryTest.php
@@ -33,7 +33,7 @@ final class SeoIntelCmsIssueQueueSummaryTest extends TestCase
     #[Test]
     public function issue_queue_migration_does_not_include_forbidden_columns(): void
     {
-        $paths = glob(base_path('database/migrations/*seo_issue_queue*'));
+        $paths = glob(base_path('database/migrations/seo_intel/*seo_issue_queue*'));
 
         $this->assertCount(1, $paths);
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelDomesticSearchAdapterContractsTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelDomesticSearchAdapterContractsTest.php
@@ -33,9 +33,9 @@ final class SeoIntelDomesticSearchAdapterContractsTest extends TestCase
     public function domestic_search_migrations_do_not_include_forbidden_columns(): void
     {
         $paths = [
-            ...glob(base_path('database/migrations/*seo_search_engine_verification_statuses*')),
-            ...glob(base_path('database/migrations/*seo_domestic_submission_logs*')),
-            ...glob(base_path('database/migrations/*seo_domestic_index_samples*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_search_engine_verification_statuses*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_domestic_submission_logs*')),
+            ...glob(base_path('database/migrations/seo_intel/*seo_domestic_index_samples*')),
         ];
 
         $this->assertCount(3, $paths);

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php
@@ -42,7 +42,7 @@ final class SeoIntelGscCollectorTest extends TestCase
     #[Test]
     public function gsc_daily_migration_does_not_include_forbidden_columns(): void
     {
-        $paths = glob(base_path('database/migrations/*seo_gsc_daily*'));
+        $paths = glob(base_path('database/migrations/seo_intel/*seo_gsc_daily*'));
 
         $this->assertCount(1, $paths);
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelLogicalDbFoundationTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelLogicalDbFoundationTest.php
@@ -148,7 +148,7 @@ final class SeoIntelLogicalDbFoundationTest extends TestCase
     public function internal_traffic_rules_store_only_masked_or_hashed_patterns(): void
     {
         $source = (string) file_get_contents(base_path(
-            'database/migrations/2026_05_17_000300_create_seo_internal_traffic_rules_table.php'
+            'database/migrations/seo_intel/2026_05_17_000300_create_seo_internal_traffic_rules_table.php'
         ));
 
         $this->assertStringContainsString("char('pattern_hash', 64)", $source);
@@ -207,9 +207,9 @@ final class SeoIntelLogicalDbFoundationTest extends TestCase
     private function seoIntelMigrationSources(): array
     {
         $files = [
-            base_path('database/migrations/2026_05_17_000100_create_seo_urls_table.php'),
-            base_path('database/migrations/2026_05_17_000200_create_seo_url_entities_table.php'),
-            base_path('database/migrations/2026_05_17_000300_create_seo_internal_traffic_rules_table.php'),
+            base_path('database/migrations/seo_intel/2026_05_17_000100_create_seo_urls_table.php'),
+            base_path('database/migrations/seo_intel/2026_05_17_000200_create_seo_url_entities_table.php'),
+            base_path('database/migrations/seo_intel/2026_05_17_000300_create_seo_internal_traffic_rules_table.php'),
         ];
 
         $sources = [];

--- a/backend/tests/Feature/SeoIntel/SeoIntelMigrationIsolationTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelMigrationIsolationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelMigrationIsolationTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private const SEO_INTEL_MIGRATIONS = [
+        '2026_05_17_000100_create_seo_urls_table.php',
+        '2026_05_17_000200_create_seo_url_entities_table.php',
+        '2026_05_17_000300_create_seo_internal_traffic_rules_table.php',
+        '2026_05_17_000400_create_seo_event_funnel_daily_table.php',
+        '2026_05_17_000500_create_seo_landing_attribution_daily_table.php',
+        '2026_05_17_000600_create_seo_revenue_daily_table.php',
+        '2026_05_17_000700_create_seo_cluster_daily_table.php',
+        '2026_05_17_000800_create_seo_consent_daily_table.php',
+        '2026_05_17_000900_create_seo_gsc_daily_table.php',
+        '2026_05_17_001000_create_seo_baidu_push_logs_table.php',
+        '2026_05_17_001100_create_seo_baidu_landing_daily_table.php',
+        '2026_05_17_001200_create_seo_indexnow_submissions_table.php',
+        '2026_05_17_001300_create_seo_search_engine_verification_statuses_table.php',
+        '2026_05_17_001400_create_seo_domestic_submission_logs_table.php',
+        '2026_05_17_001500_create_seo_domestic_index_samples_table.php',
+        '2026_05_17_001600_create_seo_crawler_logs_daily_table.php',
+        '2026_05_17_001700_create_seo_issue_queue_table.php',
+    ];
+
+    #[Test]
+    public function default_migration_path_no_longer_contains_seo_intel_analytics_migrations(): void
+    {
+        foreach (self::SEO_INTEL_MIGRATIONS as $migration) {
+            $this->assertFileDoesNotExist(base_path("database/migrations/{$migration}"));
+        }
+
+        $defaultCreateSeoMigrations = glob(base_path('database/migrations/*create_seo_*'));
+
+        $this->assertSame([], $defaultCreateSeoMigrations ?: []);
+    }
+
+    #[Test]
+    public function dedicated_seo_intel_migration_path_contains_all_expected_migrations(): void
+    {
+        foreach (self::SEO_INTEL_MIGRATIONS as $migration) {
+            $this->assertFileExists(base_path("database/migrations/seo_intel/{$migration}"));
+        }
+    }
+
+    #[Test]
+    public function every_seo_intel_migration_is_explicitly_scoped_to_seo_intel_connection(): void
+    {
+        foreach (self::SEO_INTEL_MIGRATIONS as $migration) {
+            $contents = (string) file_get_contents(base_path("database/migrations/seo_intel/{$migration}"));
+
+            $this->assertStringContainsString("protected \$connection = 'seo_intel';", $contents, $migration);
+        }
+    }
+
+    #[Test]
+    public function non_seo_intel_cms_seo_migrations_remain_in_default_path(): void
+    {
+        foreach ([
+            '2026_02_15_160000_add_i18n_seo_content_fields_to_scales_registry.php',
+            '2026_03_05_154121_create_article_seo_meta_table.php',
+            '2026_03_08_000120_create_personality_profile_seo_meta_table.php',
+            '2026_03_08_000230_create_topic_profile_seo_meta_table.php',
+            '2026_03_08_000320_create_career_job_seo_meta_table.php',
+            '2026_03_15_000110_create_career_guide_seo_meta_table.php',
+        ] as $migration) {
+            $this->assertFileExists(base_path("database/migrations/{$migration}"));
+        }
+    }
+
+    #[Test]
+    public function runbook_artifact_forbids_bare_database_migration_command(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertFalse((bool) ($artifact['production_migration_executed_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['collectors_enabled_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['scheduler_enabled_in_this_pr'] ?? true));
+        $this->assertSame('database/migrations/seo_intel', $artifact['migration_path'] ?? null);
+        $this->assertFalse((bool) ($artifact['default_migration_path_allowed_for_seo_intel'] ?? true));
+        $this->assertFalse((bool) ($artifact['bare_database_migration_command_allowed'] ?? true));
+        $this->assertStringContainsString('--path=database/migrations/seo_intel', $artifact['required_pretend_command'] ?? '');
+        $this->assertStringContainsString('--path=database/migrations/seo_intel', $artifact['required_actual_migration_command'] ?? '');
+        $this->assertSame('SEO-DASH-PROD-01B-STAGE1-RETRY', $artifact['next_task'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelProductionActivationRunbookTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelProductionActivationRunbookTest.php
@@ -23,7 +23,7 @@ final class SeoIntelProductionActivationRunbookTest extends TestCase
         $this->assertFalse((bool) ($artifact['deployment_executed_in_this_pr'] ?? true));
         $this->assertFalse((bool) ($artifact['collectors_enabled_in_this_pr'] ?? true));
         $this->assertFalse((bool) ($artifact['scheduler_enabled_in_this_pr'] ?? true));
-        $this->assertSame('SEO-DASH-PROD-01B', $artifact['next_task'] ?? null);
+        $this->assertSame('SEO-DASH-PROD-01B-STAGE1-RETRY', $artifact['next_task'] ?? null);
     }
 
     #[Test]
@@ -62,11 +62,26 @@ final class SeoIntelProductionActivationRunbookTest extends TestCase
     #[Test]
     public function command_templates_are_placeholders_without_secrets(): void
     {
-        $commands = $this->artifact()['command_templates'] ?? [];
+        $artifact = $this->artifact();
+        $commands = $artifact['command_templates'] ?? [];
 
-        $this->assertContains('php artisan migrate --database=seo_intel --pretend --no-ansi', $commands);
-        $this->assertContains('php artisan migrate --database=seo_intel --no-ansi', $commands);
-        $this->assertContains('php artisan migrate:status --database=seo_intel --no-ansi', $commands);
+        $this->assertSame('database/migrations/seo_intel', $artifact['migration_path'] ?? null);
+        $this->assertFalse((bool) ($artifact['default_migration_path_allowed_for_seo_intel'] ?? true));
+        $this->assertFalse((bool) ($artifact['bare_database_migration_command_allowed'] ?? true));
+        $this->assertContains(
+            'php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --pretend --no-ansi --force',
+            $commands
+        );
+        $this->assertContains(
+            'php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --no-ansi --force',
+            $commands
+        );
+        $this->assertContains(
+            'php artisan migrate:status --database=seo_intel --path=database/migrations/seo_intel --no-ansi',
+            $commands
+        );
+        $this->assertNotContains('php artisan migrate --database=seo_intel --pretend --no-ansi', $commands);
+        $this->assertNotContains('php artisan migrate --database=seo_intel --no-ansi', $commands);
 
         $encoded = strtolower(json_encode($commands, JSON_THROW_ON_ERROR));
 
@@ -117,7 +132,10 @@ final class SeoIntelProductionActivationRunbookTest extends TestCase
             'backup is confirmed',
             'restore procedure is known',
             'forward-fix',
-            'seo-dash-prod-01b',
+            '--path=database/migrations/seo_intel',
+            'never run',
+            'default business migrations must not run against seo_intel',
+            'seo-dash-prod-01b-stage1-retry',
         ] as $required) {
             $this->assertStringContainsString($required, $runbook);
         }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -438,6 +438,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_intel_migration_isolation_files(): void
+    {
+        $changed = [
+            'backend/database/migrations/seo_intel/2026_05_17_000100_create_seo_urls_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000200_create_seo_url_entities_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001700_create_seo_issue_queue_table.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_public_distribution_owner_changes(): void
     {
         $changed = [
@@ -1655,6 +1666,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoIntelMigrationIsolationFile($file)) {
+                continue;
+            }
+
             if ($this->isControlledArticlePublishSopFile($file)) {
                 continue;
             }
@@ -2170,6 +2185,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/SeoIntel/SeoIssueSanitizer.php',
             'backend/app/Services/SeoIntel/SeoIssueSummaryService.php',
             'backend/database/migrations/2026_05_17_001700_create_seo_issue_queue_table.php',
+        ], true);
+    }
+
+    private function isSeoIntelMigrationIsolationFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/database/migrations/seo_intel/2026_05_17_000100_create_seo_urls_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000200_create_seo_url_entities_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000300_create_seo_internal_traffic_rules_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000400_create_seo_event_funnel_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000500_create_seo_landing_attribution_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000600_create_seo_revenue_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000700_create_seo_cluster_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000800_create_seo_consent_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_000900_create_seo_gsc_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001000_create_seo_baidu_push_logs_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001100_create_seo_baidu_landing_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001200_create_seo_indexnow_submissions_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001300_create_seo_search_engine_verification_statuses_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001400_create_seo_domestic_submission_logs_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001500_create_seo_domestic_index_samples_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001600_create_seo_crawler_logs_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_05_17_001700_create_seo_issue_queue_table.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -10130,6 +10130,11 @@
           "status": "not_run",
           "evidence": "Skipped because local execution lacks a safe seo_intel test connection; no production or cloud DB command was run."
         },
+        "bigfive_runtime_freeze": {
+          "status": "pass",
+          "command": "php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest",
+          "evidence": "Added narrow allowlist for the dedicated seo_intel migration isolation directory; 95 tests passed with 442 assertions."
+        },
         "github": {
           "status": "pending"
         }
@@ -10161,6 +10166,11 @@
           "at": "2026-05-18T02:21:53Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Pushed branch codex/seo-dash-prod-01c-seo-intel-migration-isolation and opened https://github.com/fermatmind/fap-api/pull/1458. GitHub checks pending; no production execution performed."
+        },
+        {
+          "at": "2026-05-18T02:28:13Z",
+          "status": "github_checks_fix_validated_locally",
+          "summary": "GitHub MBTI checks failed because the runtime freeze classifier did not recognize backend/database/migrations/seo_intel paths. Added a narrow migration-isolation allowlist and validated BigFiveResultPageV2CoreBodyPreviewTest, SeoIntel tests, route list, Pint, and diff checks locally."
         }
       ],
       "next_pr": "SEO-DASH-PROD-01B-STAGE1-RETRY"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4669,7 +4669,7 @@
       "branch": "codex/repair-80-candidate-runtime-pool-1",
       "title": "feat(api): add career 80 runtime candidate pool planner",
       "name": "Add read-only Career 80 runtime candidate pool planner",
-      "status": "in_progress",
+      "status": "committed",
       "depends_on": [
         "80-READINESS-3"
       ],
@@ -5128,7 +5128,7 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
+      "commit_sha": "45c51de1c2181987339f671e1d6a21abc05373aa",
       "pr_url": null,
       "checks": {
         "authorization": {
@@ -10064,6 +10064,101 @@
         }
       ],
       "next_pr": "SEO-DASH-PROD-01B"
+    },
+    "SEO-DASH-PROD-01C": {
+      "repo": "fap-api",
+      "branch": "codex/seo-dash-prod-01c-seo-intel-migration-isolation",
+      "base": "main",
+      "depends_on": [
+        "SEO-DASH-PROD-01B-STAGE1-BLOCKED"
+      ],
+      "status": "in_progress",
+      "train_scope": "seo_intel_migration_isolation",
+      "risk_level": "medium_migration_scope_no_production_execution",
+      "title": "fix(seo-intel): isolate seo_intel migrations",
+      "name": "seo_intel migration isolation",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly provided SEO-DASH-PROD-01C with branch, title, allowed files, validation commands, and permission to update fap-api PR train metadata."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-DASH-PROD-01B Stage 1 pretend migration was blocked because bare php artisan migrate --database=seo_intel would use the global migration directory."
+        },
+        "production_deploy_allowed": {
+          "status": "false"
+        },
+        "production_migration_execution_allowed": {
+          "status": "false"
+        },
+        "production_db_creation": {
+          "status": "false"
+        },
+        "env_edit_allowed": {
+          "status": "false"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to seo_intel migration relocation, production migration runbook docs/generated artifact, focused SeoIntel tests, and docs/codex PR train metadata. No runtime app code, env, deploy, collector activation, scheduler activation, cloud files, payment/order/report/email/recommendation/scoring, sitemap, llms, or fap-web files changed."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=SeoIntel",
+          "evidence": "94 tests passed with 1748 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "Full Pint check passed across 3369 files."
+        },
+        "json_validation": {
+          "status": "pass",
+          "command": "php -r json_decode(...)",
+          "evidence": "Generated runbook artifact and docs/codex PR train state JSON decoded successfully."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "optional_local_pretend": {
+          "status": "not_run",
+          "evidence": "Skipped because local execution lacks a safe seo_intel test connection; no production or cloud DB command was run."
+        },
+        "github": {
+          "status": "pending"
+        }
+      },
+      "failure_reason": null,
+      "pr_url": null,
+      "commit_sha": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-18T02:04:59Z",
+          "status": "in_progress",
+          "summary": "Registered authorized SEO-DASH-PROD-01C and started migration isolation from origin/main. No production execution performed."
+        },
+        {
+          "at": "2026-05-18T02:15:34Z",
+          "status": "local_validation_passed",
+          "summary": "Moved seo_intel analytics migrations into database/migrations/seo_intel, added explicit seo_intel connection scoping, updated runbook/artifact commands, and passed SeoIntel tests, route list, Pint, JSON validation, and diff checks."
+        },
+        {
+          "at": "2026-05-18T02:15:34Z",
+          "status": "committed",
+          "summary": "Committed SEO-DASH-PROD-01C local changes at 45c51de1c2181987339f671e1d6a21abc05373aa."
+        }
+      ],
+      "next_pr": "SEO-DASH-PROD-01B-STAGE1-RETRY"
     },
     "PUBLISH-API-MEDIA-ORIGIN-READYNESS": {
       "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5098,7 +5098,7 @@
       "branch": "fix/career-runtime-candidate-artifact-refresh-2",
       "title": "fix(api): add candidate-aware runtime artifact refresh",
       "name": "Add candidate-aware runtime artifact refresh after verified candidate prep apply",
-      "status": "in_progress",
+      "status": "pr_opened_github_checks_pending",
       "depends_on": [
         "RUNTIME-CANDIDATE-PREP-APPLY-1",
         "REPAIR-RUNTIME-ARTIFACT-REFRESH-1"
@@ -8738,8 +8738,8 @@
         }
       },
       "failure_reason": null,
-      "pr_url": null,
-      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1458",
+      "commit_sha": "4be636472402e50b5fb6124882fb696ed374b4e7",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -10156,6 +10156,11 @@
           "at": "2026-05-18T02:15:34Z",
           "status": "committed",
           "summary": "Committed SEO-DASH-PROD-01C local changes at 45c51de1c2181987339f671e1d6a21abc05373aa."
+        },
+        {
+          "at": "2026-05-18T02:21:53Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Pushed branch codex/seo-dash-prod-01c-seo-intel-migration-isolation and opened https://github.com/fermatmind/fap-api/pull/1458. GitHub checks pending; no production execution performed."
         }
       ],
       "next_pr": "SEO-DASH-PROD-01B-STAGE1-RETRY"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5240,7 +5240,7 @@
       "repo": "fap-api",
       "branch": "fix/career-candidate-aware-audit-policy-1",
       "title": "fix(api): accept candidate-aware runtime states for delta planning",
-      "status": "in_progress",
+      "status": "github_checks_passed_human_review_pending",
       "depends_on": [
         "REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2"
       ],
@@ -10031,12 +10031,13 @@
           "command": "git diff --check && git diff --cached --check"
         },
         "github": {
-          "status": "pending"
+          "status": "pass",
+          "evidence": "GitHub CI checks passed after the scoped BigFive runtime-freeze allowlist fix: hygiene, verify-mbti-legacy, and verify-mbti-v2."
         }
       },
       "failure_reason": null,
-      "pr_url": null,
-      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1458",
+      "commit_sha": "947f7936873a1cf38a20cea0f4a78ac8eabee6cb",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -10171,6 +10172,11 @@
           "at": "2026-05-18T02:28:13Z",
           "status": "github_checks_fix_validated_locally",
           "summary": "GitHub MBTI checks failed because the runtime freeze classifier did not recognize backend/database/migrations/seo_intel paths. Added a narrow migration-isolation allowlist and validated BigFiveResultPageV2CoreBodyPreviewTest, SeoIntel tests, route list, Pint, and diff checks locally."
+        },
+        {
+          "at": "2026-05-18T02:34:40Z",
+          "status": "github_checks_passed_human_review_pending",
+          "summary": "GitHub checks passed for PR #1458 after the scoped runtime-freeze allowlist fix. PR remains unmerged for human review."
         }
       ],
       "next_pr": "SEO-DASH-PROD-01B-STAGE1-RETRY"

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -693,6 +693,56 @@ prs:
       - change_window
     scheduler_activation: false
     next_task: SEO-DASH-PROD-01B
+
+  - id: SEO-DASH-PROD-01C
+    repo: fap-api
+    depends_on:
+      - SEO-DASH-PROD-01B-STAGE1-BLOCKED
+    branch: codex/seo-dash-prod-01c-seo-intel-migration-isolation
+    title: "fix(seo-intel): isolate seo_intel migrations"
+    name: "seo_intel migration isolation"
+    findings:
+      - "SEO-DASH-PROD-01B Stage 1 pretend was blocked because php artisan migrate --database=seo_intel uses the global Laravel migration directory."
+      - "The default migration directory contains unrelated CMS/app migrations that must not run against the seo_intel schema."
+      - "Production seo_intel migration must use a dedicated migration path and explicit seo_intel connection scoping."
+    scope:
+      - Move seo_intel analytics migrations into backend/database/migrations/seo_intel.
+      - Add explicit seo_intel connection scoping to every seo_intel migration.
+      - Update production runbook and generated artifact to require --path=database/migrations/seo_intel and forbid bare php artisan migrate --database=seo_intel.
+      - Add focused SeoIntel tests proving migration path isolation.
+      - Update docs/codex PR train metadata for SEO-DASH-PROD-01C.
+    allowed_paths:
+      - backend/database/migrations/seo_intel/**
+      - backend/database/migrations/*seo_*
+      - backend/docs/seo/production-seo-intel-db-migration-runbook.md
+      - backend/docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json
+      - backend/tests/Feature/SeoIntel/*Migration*Test.php
+      - backend/tests/Feature/SeoIntel/SeoIntelProductionActivationRunbookTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production migrations, deploy, SSH, edit env, or touch Aliyun/Tencent RDS.
+      - Enable collectors, scheduler jobs, queue workers, Metabase, GSC, Baidu, IndexNow, or production log reads.
+      - Change runtime code, backend behavior, payment, order, report, email, recommendation, scoring, sitemap, or llms behavior.
+      - Modify fap-web runtime or use fap-api/fap-web as production frontend runtime.
+      - Store or expose secrets, emails, order numbers, attempt ids, payment ids, provider event ids, cookies, raw IPs, tokens, or keys.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    production_db_creation: false
+    env_edit_allowed: false
+    scheduler_activation: false
+    next_task: SEO-DASH-PROD-01B-STAGE1-RETRY
   - id: PR-MEDIA-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Moved seo_intel analytics migrations into `backend/database/migrations/seo_intel`.
- Added explicit `protected $connection = 'seo_intel';` scoping to every seo_intel migration.
- Updated the production DB migration runbook and generated artifact to require `--path=database/migrations/seo_intel` and forbid bare `php artisan migrate --database=seo_intel`.
- Added migration isolation tests and updated existing SeoIntel migration-path contract tests.
- Added PR train metadata for `SEO-DASH-PROD-01C`.

## Why
`php artisan migrate --database=seo_intel` would use Laravel's default migration directory and could create unrelated app/CMS tables in the fresh seo_intel database. The production migration must target only the isolated seo_intel schema migrations.

## Validation
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `git diff --check && git diff --cached --check`
- `php -r 'json_decode(file_get_contents("backend/docs/seo/generated/production-seo-intel-db-migration-runbook.v1.json"), true, 512, JSON_THROW_ON_ERROR); json_decode(file_get_contents("docs/codex/pr-train-state.json"), true, 512, JSON_THROW_ON_ERROR); echo "json ok\n";'`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'`

## Intentionally deferred
- No production migration was run.
- No deployment, env edit, cloud command, collector activation, scheduler activation, Metabase deployment, or external API connection was performed.
- Production Stage 1 pretend retry remains deferred to `SEO-DASH-PROD-01B-STAGE1-RETRY` after human review.