### PR TITLE
docs(ops): align healthz probe runbooks

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -370,6 +370,10 @@ bash backend/scripts/ci_verify_mbti.sh
 ```
 
 通过标准：
+- healthz canonical probe path is `/api/healthz`
+- `/healthz` is a public alias, but production healthz remains allowlist-only
+- do not require arbitrary public-origin `/healthz` or `/api/healthz` to return `200`
+- deploy smoke may use localhost or another internal/allowlisted source for healthz verification
 - 路由与迁移命令成功。
 - 健康检查接口可达，且 `/api/v0.3/auth/guest` 合约通过。
 - MBTI CI 验收链路通过。

--- a/docs/04-ops/observability.md
+++ b/docs/04-ops/observability.md
@@ -1,7 +1,16 @@
 # PR8 Observability & Alerts
 
 ## Healthz Endpoint
-- Path: `GET /api/v0.3/healthz`
+- Canonical probe path: `GET /api/healthz`
+- Public alias: `GET /healthz`
+- Access policy:
+  - production healthz is allowlist-only
+  - requests from non-allowlisted public IPs may return `404` by design
+  - do not treat arbitrary public `curl` returning `404` as a deploy failure by itself
+- Verification modes:
+  - allowlisted external probe to `/api/healthz` or `/healthz`
+  - internal/local probe from the app host
+  - `php artisan ops:healthz-snapshot` for controlled runtime verification
 - 期望：
   - `.ok == true`
   - `.deps.db.ok == true`
@@ -25,7 +34,7 @@
 - Healthz `.deps.cache_dirs.ok==false`：P2
 
 ### Latency (API)
-- `/api/v0.3/healthz` p95 > 300ms 持续 5 分钟：P2
+- `/api/healthz` p95 > 300ms 持续 5 分钟：P2
 - `/api/v0.3/scales/MBTI/questions` p95 > 800ms 持续 5 分钟：P2
 
 ### Errors

--- a/docs/04-ops/rollback-runbook.md
+++ b/docs/04-ops/rollback-runbook.md
@@ -121,7 +121,7 @@ php artisan migrate --force
 php artisan migrate:status --no-ansi
 ```
 
-## 5) 回滚后 Smoke（必须包含 v0.3 boot 与 /healthz）
+## 5) 回滚后 Smoke（必须包含 v0.3 boot 与 allowlisted/internal healthz）
 
 ```bash
 set -euo pipefail
@@ -129,8 +129,17 @@ BASE_URL="https://<domain>"
 
 curl -fsS "${BASE_URL}/api/v0.3/boot" | grep -q '"ok":true' && echo "v0.3 boot OK"
 
-curl -fsS "${BASE_URL}/healthz" | grep -q '"ok":true' && echo "healthz OK" \
-  || curl -fsS "${BASE_URL}/api/healthz" | grep -q '"ok":true' && echo "api/healthz OK"
+# Healthz is allowlist-only in production.
+# Do not require arbitrary public-origin /healthz or /api/healthz to return 200.
+# Success criteria:
+# 1) an allowlisted probe to /api/healthz or /healthz returns .ok==true, or
+# 2) an internal/local verification path confirms healthz.
+
+curl -fsS "${BASE_URL}/api/healthz" | grep -q '"ok":true' && echo "api/healthz OK (allowlisted)" \
+  || curl -fsS "${BASE_URL}/healthz" | grep -q '"ok":true' && echo "healthz OK (allowlisted)"
+
+cd /var/www/fap-api/current/backend
+php artisan ops:healthz-snapshot
 ```
 
 ## 6) 常见故障排障


### PR DESCRIPTION
## What changed
- align healthz documentation to use `/api/healthz` as the canonical probe path
- document `/healthz` as a public alias with the same allowlist-only production policy
- update rollback and deploy runbooks to stop treating arbitrary public-origin `200` as a success requirement
- document allowlisted or internal healthz verification paths instead

## Why
- production confirmed that healthz routes exist after `#1459`, but non-allowlisted public requests return `404` by design
- the problem was documentation and runbook drift, not a missing route after deploy

## Validation
- `cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check`

## Intentionally deferred
- no runtime policy change
- no `healthz.allowed_ips` change
- no `HealthzAccessControl` logic change
