### PR TITLE
fix(ops): deprecate public healthz alias

### DIFF
--- a/01-api-design/MBTI-v0.3-endpoints.md
+++ b/01-api-design/MBTI-v0.3-endpoints.md
@@ -16,6 +16,7 @@ This file is a contract mirror of current runtime routes. It does not define fut
 
 ## Auth Labels
 - `Auth: Public` no token required.
+- `Auth: AllowlistOnly` no token required, but production access is restricted by trusted source IP policy.
 - `Auth: Sanctum` requires Laravel Sanctum session/token.
 - `Auth: AdminAuth` requires admin guard or `X-FAP-Admin-Token` path.
 - `Auth: FmTokenAuth` requires FM token middleware.
@@ -28,7 +29,7 @@ This file is a contract mirror of current runtime routes. It does not define fut
 ### Base (`2`)
 | Method | Path | Auth | Feature |
 |---|---|---|---|
-| `GET|HEAD` | `/api/healthz` | `Public` | `-` |
+| `GET|HEAD` | `/api/healthz` | `AllowlistOnly` | `-` |
 | `GET|HEAD` | `/api/user` | `Sanctum` | `-` |
 
 ### v0.3 (`82`)

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -371,8 +371,8 @@ bash backend/scripts/ci_verify_mbti.sh
 
 通过标准：
 - healthz canonical probe path is `/api/healthz`
-- `/healthz` is a public alias, but production healthz remains allowlist-only
-- do not require arbitrary public-origin `/healthz` or `/api/healthz` to return `200`
+- production healthz remains allowlist-only
+- do not require arbitrary public-origin `/api/healthz` to return `200`
 - deploy smoke may use localhost or another internal/allowlisted source for healthz verification
 - 路由与迁移命令成功。
 - 健康检查接口可达，且 `/api/v0.3/auth/guest` 合约通过。

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,8 +1,6 @@
 <?php
 
-use App\Http\Controllers\HealthzController;
 use App\Http\Controllers\SitemapController;
-use App\Http\Middleware\HealthzAccessControl;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -34,19 +32,6 @@ Route::get('/sitemap.xml', [SitemapController::class, 'index'])
         \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
         \App\Http\Middleware\VerifyCsrfToken::class,
     ]);
-
-Route::middleware([HealthzAccessControl::class, 'throttle:api_public'])
-    ->get('/healthz', [HealthzController::class, 'show'])
-    ->withoutMiddleware([
-        \Illuminate\Cookie\Middleware\EncryptCookies::class,
-        \App\Http\Middleware\EncryptCookies::class,
-        \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-        \Illuminate\Session\Middleware\StartSession::class,
-        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-        \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
-        \App\Http\Middleware\VerifyCsrfToken::class,
-    ])
-    ->name('healthz.public');
 
 if (config('admin.panel_enabled')) {
     Route::permanentRedirect('/admin', '/ops');

--- a/backend/tests/Feature/HealthzExposureTest.php
+++ b/backend/tests/Feature/HealthzExposureTest.php
@@ -16,13 +16,9 @@ class HealthzExposureTest extends TestCase
         $this->withServerVariables($server)
             ->getJson('/api/healthz')
             ->assertStatus(404);
-
-        $this->withServerVariables($server)
-            ->get('/healthz')
-            ->assertStatus(404);
     }
 
-    public function test_allowlist_ip_gets_minimal_healthz_payload(): void
+    public function test_allowlist_ip_gets_minimal_healthz_payload_only_on_canonical_api_route(): void
     {
         $this->forceEnvironment('production');
         config([
@@ -43,11 +39,9 @@ class HealthzExposureTest extends TestCase
         $response->assertJsonMissingPath('message');
         $this->assertSame(['ok', 'service', 'version', 'time'], array_keys($response->json()));
 
-        $rootResponse = $this->withServerVariables(['REMOTE_ADDR' => '127.0.0.1'])
-            ->get('/healthz');
-
-        $rootResponse->assertStatus(200);
-        $rootResponse->assertExactJson($response->json());
+        $this->withServerVariables(['REMOTE_ADDR' => '127.0.0.1'])
+            ->get('/healthz')
+            ->assertStatus(404);
     }
 
     private function forceEnvironment(string $env): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -198,7 +198,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
-    public function test_runtime_freeze_classifier_ignores_public_healthz_alias_route_change(): void
+    public function test_runtime_freeze_classifier_ignores_public_healthz_alias_route_addition(): void
     {
         $changed = [
             'backend/routes/web.php',
@@ -218,6 +218,31 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             '+        \\App\\Http\\Middleware\\VerifyCsrfToken::class,',
             '+    ])',
             '+    ->name(\'healthz.public\');',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', webRouteChangedLines: $webRouteChangedLines));
+    }
+
+    public function test_runtime_freeze_classifier_ignores_public_healthz_alias_route_removal(): void
+    {
+        $changed = [
+            'backend/routes/web.php',
+        ];
+        $webRouteChangedLines = [
+            '-use App\\Http\\Controllers\\HealthzController;',
+            '-use App\\Http\\Middleware\\HealthzAccessControl;',
+            '-Route::middleware([HealthzAccessControl::class, \'throttle:api_public\'])',
+            '-    ->get(\'/healthz\', [HealthzController::class, \'show\'])',
+            '-    ->withoutMiddleware([',
+            '-        \\Illuminate\\Cookie\\Middleware\\EncryptCookies::class,',
+            '-        \\App\\Http\\Middleware\\EncryptCookies::class,',
+            '-        \\Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::class,',
+            '-        \\Illuminate\\Session\\Middleware\\StartSession::class,',
+            '-        \\Illuminate\\View\\Middleware\\ShareErrorsFromSession::class,',
+            '-        \\Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::class,',
+            '-        \\App\\Http\\Middleware\\VerifyCsrfToken::class,',
+            '-    ])',
+            '-    ->name(\'healthz.public\');',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', webRouteChangedLines: $webRouteChangedLines));
@@ -3046,15 +3071,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         }
 
         foreach ($changedLines as $line) {
-            if (str_starts_with($line, '-')) {
-                return false;
-            }
-
-            if (preg_match('/^\+\s*[\\[\\]{}(),;]*\s*$/u', $line) === 1) {
+            if (preg_match('/^[+-]\s*[\\[\\]{}(),;]*\s*$/u', $line) === 1) {
                 continue;
             }
 
-            if (preg_match('/HealthzController|HealthzAccessControl|throttle:api_public|\\/healthz|healthz\\.public|withoutMiddleware|EncryptCookies|AddQueuedCookiesToResponse|StartSession|ShareErrorsFromSession|VerifyCsrfToken/u', $line) !== 1) {
+            if (preg_match('/^[+-].*(HealthzController|HealthzAccessControl|throttle:api_public|\\/healthz|healthz\\.public|withoutMiddleware|EncryptCookies|AddQueuedCookiesToResponse|StartSession|ShareErrorsFromSession|VerifyCsrfToken)/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/04-ops/observability.md
+++ b/docs/04-ops/observability.md
@@ -2,13 +2,12 @@
 
 ## Healthz Endpoint
 - Canonical probe path: `GET /api/healthz`
-- Public alias: `GET /healthz`
 - Access policy:
   - production healthz is allowlist-only
   - requests from non-allowlisted public IPs may return `404` by design
   - do not treat arbitrary public `curl` returning `404` as a deploy failure by itself
 - Verification modes:
-  - allowlisted external probe to `/api/healthz` or `/healthz`
+  - allowlisted external probe to `/api/healthz`
   - internal/local probe from the app host
   - `php artisan ops:healthz-snapshot` for controlled runtime verification
 - 期望：

--- a/docs/04-ops/rollback-runbook.md
+++ b/docs/04-ops/rollback-runbook.md
@@ -130,13 +130,12 @@ BASE_URL="https://<domain>"
 curl -fsS "${BASE_URL}/api/v0.3/boot" | grep -q '"ok":true' && echo "v0.3 boot OK"
 
 # Healthz is allowlist-only in production.
-# Do not require arbitrary public-origin /healthz or /api/healthz to return 200.
+# Do not require arbitrary public-origin /api/healthz to return 200.
 # Success criteria:
-# 1) an allowlisted probe to /api/healthz or /healthz returns .ok==true, or
+# 1) an allowlisted probe to /api/healthz returns .ok==true, or
 # 2) an internal/local verification path confirms healthz.
 
-curl -fsS "${BASE_URL}/api/healthz" | grep -q '"ok":true' && echo "api/healthz OK (allowlisted)" \
-  || curl -fsS "${BASE_URL}/healthz" | grep -q '"ok":true' && echo "healthz OK (allowlisted)"
+curl -fsS "${BASE_URL}/api/healthz" | grep -q '"ok":true' && echo "api/healthz OK (allowlisted)"
 
 cd /var/www/fap-api/current/backend
 php artisan ops:healthz-snapshot

--- a/docs/04-ops/runbook-triage.md
+++ b/docs/04-ops/runbook-triage.md
@@ -2,7 +2,7 @@
 
 ## Healthz red -> triage flow
 
-1) Check `/api/v0.3/healthz` response and identify which deps are red.
+1) Check `/api/healthz` response from an allowlisted or internal source and identify which deps are red.
 2) Validate infra/service connectivity (db/redis/queue/cache/content_source).
 3) Check deploy history (`v_deploy_events`) for recent changes.
 4) If needed, rollback or hotfix. Re-run healthz snapshot to confirm.


### PR DESCRIPTION
## What changed
- removed the top-level `/healthz` Laravel alias
- kept `/api/healthz` as the only canonical health probe path
- updated healthz exposure test to assert canonical-only behavior
- aligned deploy and ops docs with allowlist-only `/api/healthz` verification
- corrected the API contract mirror to mark `/api/healthz` as `AllowlistOnly` rather than unrestricted public

## Why
- production proved that `/api/healthz` is the stable internal/allowlisted probe path
- `/healthz` created long-term operational ambiguity because code, docs, and ingress behavior diverged
- the stable direction is to keep the access policy on `/api/healthz` and remove the unused alias instead of widening the public surface

## Validation
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/HealthzExposureTest.php --no-ansi`
- `git -C /Users/rainie/Desktop/GitHub/fap-api diff --check`

## Intentionally deferred
- no change to `HealthzAccessControl` or `HEALTHZ_ALLOWED_IPS` policy
- no change to nginx / ingress policy beyond documenting the canonical probe path
- no attempt to make arbitrary public-origin healthz return `200`