### PR TITLE
docs(seo-intel): add controlled write enablement plan

### DIFF
--- a/backend/docs/seo/controlled-write-enablement-plan.md
+++ b/backend/docs/seo/controlled-write-enablement-plan.md
@@ -1,0 +1,172 @@
+# SEO Intelligence Controlled Write Enablement Plan
+
+## A. Purpose
+
+This plan governs the first production writes into `seo_intel`.
+
+This PR does not enable writes. It does not enable scheduler execution. It does not deploy Metabase. It does not connect live external APIs, submit URLs to search engines, read production crawler logs, edit production environment files, or change runtime behavior.
+
+## B. Current Readiness State
+
+- Production `seo_intel` schema exists.
+- SEO-DASH-PROD-01B ran the isolated production migration successfully.
+- SEO-DASH-PROD-02 production collector dry-run smoke passed.
+- Production writes remain disabled.
+- Scheduler remains disabled.
+- Live external APIs remain disabled.
+- Metabase remains undeployed.
+
+## C. Write Enablement Principles
+
+- Write enablement is manual, explicit, and reversible.
+- No scheduler may be enabled until repeated manual write smokes pass.
+- No external API collector write may run before credentials and live API readiness are explicitly approved.
+- No production crawler log collector write may run before production log access is explicitly approved.
+- No Node2 local Laravel or Node2 local DB may be used as a data source.
+- No business DB raw tables may be used as a Metabase source.
+- No PII or raw detail values may be stored in `seo_intel` detail fields.
+- The migration operator identity is not a runtime collector identity.
+
+## D. Collector Write Tiers
+
+### Tier 0: Dry-run Only / Always Safe
+
+- `noop`
+- Any collector invoked with both `--dry-run` and `--no-write`
+
+### Tier 1: First Controlled Write Candidates
+
+- `url_truth_inventory`
+- `issue_queue_foundation` only if it writes sanitized fixture or governance-safe issue rows; otherwise it remains dry-run only.
+- `attribution_revenue_foundation` only if it reads existing safe backend events/orders through an approved aggregate builder and does not expose raw identifiers.
+
+### Tier 2: Later Controlled Write After Tier 1 Success
+
+- `drift_foundation`
+- `crawler_log_foundation` with fixture-only or non-production sample input only
+- `chinese_crawler_log_foundation` with fixture-only input only
+
+### Tier 3: Blocked Until External / Live Credentials Approved
+
+- `gsc_foundation`
+- `baidu_foundation`
+- `indexnow_foundation`
+- `so360_foundation`
+- `sogou_foundation`
+- `shenma_foundation`
+
+### Tier 4: Blocked Until Production Log-read Approval
+
+- Any production crawler log read
+- Any CDN, OpenResty, or Nginx production log ingestion
+
+## E. First Canary Recommendation
+
+The recommended first actual write canary is `url_truth_inventory`.
+
+The canary must be:
+
+1. One manual run only.
+2. No scheduler.
+3. No external API.
+4. No production crawler logs.
+5. Verified only against `seo_urls` and `seo_url_entities`.
+6. Checked for no forbidden PII columns or values.
+7. Checked for canonical URL, locale, and page entity type shape.
+8. Checked so no private flow URLs are accepted as indexable.
+
+If `url_truth_inventory` cannot produce a bounded, reviewable, nonzero canary write from approved backend authority inputs, actual write execution is blocked until bounded canary write support is added.
+
+Current implementation note: the backend authority URL truth source is still fixture-driven/skeleton in current source, so SEO-DASH-PROD-03B must confirm bounded canary support before any production write.
+
+## F. Required Env Posture for Actual Write Canary
+
+Use a temporary migration/runtime shell or explicit one-time command env only:
+
+```bash
+SEO_INTEL_ENABLED=true
+SEO_INTEL_COLLECTORS_ENABLED=true
+SEO_INTEL_WRITE_ENABLED=true
+SEO_INTEL_DRY_RUN_DEFAULT=false
+SEO_INTEL_GSC_ENABLED=false
+SEO_INTEL_BAIDU_ENABLED=false
+SEO_INTEL_INDEXNOW_ENABLED=false
+SEO_INTEL_SO360_ENABLED=false
+SEO_INTEL_SOGOU_ENABLED=false
+SEO_INTEL_SHENMA_ENABLED=false
+SEO_INTEL_CHINESE_CRAWLER_LOGS_ENABLED=false
+```
+
+Do not edit production service env permanently. Do not start queue workers or scheduler. Do not enable live external API flags. Do not enable production log-read flags.
+
+## G. Actual Write Command Template
+
+Use placeholders only and run from the verified migration/runtime host:
+
+```bash
+SEO_INTEL_ENABLED=true \
+SEO_INTEL_COLLECTORS_ENABLED=true \
+SEO_INTEL_WRITE_ENABLED=true \
+SEO_INTEL_DRY_RUN_DEFAULT=false \
+SEO_INTEL_GSC_ENABLED=false \
+SEO_INTEL_BAIDU_ENABLED=false \
+SEO_INTEL_INDEXNOW_ENABLED=false \
+SEO_INTEL_SO360_ENABLED=false \
+SEO_INTEL_SOGOU_ENABLED=false \
+SEO_INTEL_SHENMA_ENABLED=false \
+SEO_INTEL_CHINESE_CRAWLER_LOGS_ENABLED=false \
+php artisan seo-intel:collect --collector=url_truth_inventory --json
+```
+
+The current collector command has explicit safety flags for dry-run prevention of writes: `--dry-run` and `--no-write`. The actual write canary must omit those dry-run/no-write flags only after human approval and only with the temporary env posture above.
+
+Forbidden commands:
+
+- Collector command without an explicit collector name.
+- Any all-collectors wildcard or loop.
+- Scheduler-triggered collector execution.
+- Live GSC, Baidu, IndexNow, 360, Sogou, or Shenma collectors.
+- Production crawler log collectors.
+
+## H. Verification After Canary
+
+After the canary, verify:
+
+- Row counts before and after.
+- Only `seo_urls` and `seo_url_entities` changed for the first canary.
+- No business DB tables changed.
+- No forbidden PII values appear in any `seo_intel` table.
+- No raw email, order number, attempt id, payment id, provider event id, cookie, raw IP, raw user agent, token, secret, raw payload, payment payload, or provider payload is present.
+- No external API calls occurred.
+- No URL submissions occurred.
+- No production crawler logs were read.
+- No scheduler state changed.
+- No Metabase deployment or connection was created.
+
+## I. Rollback / Disable Procedure
+
+- Immediately set `SEO_INTEL_WRITE_ENABLED=false`.
+- Keep scheduler disabled.
+- Do not rollback schema.
+- If canary rows are wrong, mark or ignore them, or perform a forward-cleanup with separate human approval.
+- Do not run destructive delete, truncate, rollback, or refresh commands without separate approval.
+- A restore/forward-fix owner is required before write canary approval.
+
+## J. Human Approval Gates
+
+Explicit human approval is required before:
+
+- First write canary.
+- Enabling any additional collector.
+- Enabling scheduler.
+- Enabling live external APIs.
+- Enabling production crawler log read.
+- Deploying Metabase.
+
+## K. Next Task
+
+Next task: `SEO-DASH-PROD-03B`.
+
+If bounded `url_truth_inventory` canary support is confirmed, the task is `SEO-DASH-PROD-03B｜url_truth_inventory controlled write canary`.
+
+If bounded canary support is missing or the current source still emits no approved candidates, the task is `SEO-DASH-PROD-03B｜add bounded canary write support`.

--- a/backend/docs/seo/generated/controlled-write-enablement-plan.v1.json
+++ b/backend/docs/seo/generated/controlled-write-enablement-plan.v1.json
@@ -1,0 +1,142 @@
+{
+  "version": "controlled-write-enablement-plan.v1",
+  "source_documents": [
+    "SEO-DASH-PROD-01B",
+    "SEO-DASH-PROD-02",
+    "SEO-DASH-00B",
+    "BACKEND-RUNTIME-02D"
+  ],
+  "production_schema_ready": true,
+  "collector_dry_run_passed": true,
+  "write_enabled_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "metabase_deployed_in_this_pr": false,
+  "live_external_api_enabled_in_this_pr": false,
+  "production_crawler_log_read_enabled_in_this_pr": false,
+  "first_canary_collector": "url_truth_inventory",
+  "first_canary_status": "blocked_until_bounded_canary_support_confirmed",
+  "collector_tiers": {
+    "tier_0_dry_run_only_always_safe": [
+      "noop",
+      "all_collectors_with_dry_run_and_no_write"
+    ],
+    "tier_1_first_controlled_write_candidates": [
+      "url_truth_inventory",
+      "issue_queue_foundation_if_sanitized_fixture_or_governance_safe_only",
+      "attribution_revenue_foundation_if_approved_aggregate_builder_only"
+    ],
+    "tier_2_later_after_tier_1_success": [
+      "drift_foundation",
+      "crawler_log_foundation_fixture_or_non_production_sample_only",
+      "chinese_crawler_log_foundation_fixture_only"
+    ],
+    "tier_3_blocked_until_external_live_credentials_approved": [
+      "gsc_foundation",
+      "baidu_foundation",
+      "indexnow_foundation",
+      "so360_foundation",
+      "sogou_foundation",
+      "shenma_foundation"
+    ],
+    "tier_4_blocked_until_production_log_read_approval": [
+      "production_crawler_log_read",
+      "cdn_openresty_nginx_production_log_ingestion"
+    ]
+  },
+  "blocked_collectors": [
+    "gsc_foundation",
+    "baidu_foundation",
+    "indexnow_foundation",
+    "so360_foundation",
+    "sogou_foundation",
+    "shenma_foundation",
+    "production_crawler_log_read",
+    "cdn_openresty_nginx_production_log_ingestion"
+  ],
+  "required_env_posture": {
+    "temporary_command_session_only": true,
+    "permanent_production_env_edit_allowed": false,
+    "SEO_INTEL_ENABLED": "true",
+    "SEO_INTEL_COLLECTORS_ENABLED": "true",
+    "SEO_INTEL_WRITE_ENABLED": "true_only_for_approved_one_time_command_session",
+    "SEO_INTEL_DRY_RUN_DEFAULT": "false_only_for_approved_one_time_command_session",
+    "SEO_INTEL_GSC_ENABLED": "false",
+    "SEO_INTEL_BAIDU_ENABLED": "false",
+    "SEO_INTEL_INDEXNOW_ENABLED": "false",
+    "SEO_INTEL_SO360_ENABLED": "false",
+    "SEO_INTEL_SOGOU_ENABLED": "false",
+    "SEO_INTEL_SHENMA_ENABLED": "false",
+    "SEO_INTEL_CHINESE_CRAWLER_LOGS_ENABLED": "false",
+    "scheduler_enabled": false
+  },
+  "actual_write_command_template": "SEO_INTEL_ENABLED=true SEO_INTEL_COLLECTORS_ENABLED=true SEO_INTEL_WRITE_ENABLED=true SEO_INTEL_DRY_RUN_DEFAULT=false php artisan seo-intel:collect --collector=url_truth_inventory --json",
+  "forbidden_commands": [
+    "collector_without_explicit_collector_name",
+    "all_collectors_wildcard",
+    "scheduler_triggered_collector",
+    "live_gsc_baidu_indexnow_domestic_search_collectors",
+    "production_crawler_log_collectors"
+  ],
+  "forbidden_fields": [
+    "email",
+    "raw_email",
+    "order_no",
+    "raw_order_no",
+    "attempt_id",
+    "raw_attempt_id",
+    "payment_id",
+    "provider_event_id",
+    "cookie",
+    "raw_cookie",
+    "raw_ip",
+    "raw_user_agent",
+    "raw_payload",
+    "payment_payload",
+    "provider_payload",
+    "token",
+    "api_key",
+    "secret"
+  ],
+  "forbidden_sources": [
+    "node2_local_db",
+    "business_db_raw_tables",
+    "raw_orders",
+    "raw_payments",
+    "raw_email",
+    "raw_events_detail"
+  ],
+  "validation_requirements": [
+    "row_counts_before_after",
+    "only_expected_tables_changed",
+    "no_business_db_tables_changed",
+    "no_forbidden_pii_columns_or_values",
+    "no_raw_email_order_no_attempt_id_payment_id_provider_event_id_cookie_raw_ip",
+    "no_external_api_calls",
+    "no_url_submissions",
+    "no_scheduler_state_change",
+    "no_metabase_deployment",
+    "canonical_url_locale_page_entity_type_shape_valid",
+    "private_flow_urls_not_indexable"
+  ],
+  "rollback_policy": {
+    "first_action": "set_SEO_INTEL_WRITE_ENABLED_false",
+    "scheduler_remains_disabled": true,
+    "schema_rollback_allowed": false,
+    "wrong_canary_rows_policy": "mark_ignore_or_forward_cleanup_with_separate_human_approval",
+    "destructive_delete_requires_separate_approval": true,
+    "restore_or_forward_fix_owner_required": true
+  },
+  "human_approval_gates": [
+    "first_write_canary",
+    "additional_collector_enablement",
+    "scheduler_enablement",
+    "live_external_api_enablement",
+    "production_crawler_log_read_enablement",
+    "metabase_deployment"
+  ],
+  "production_write_execution": false,
+  "scheduler_activation": false,
+  "external_api_live_activation": false,
+  "metabase_deployment": false,
+  "next_task": "SEO-DASH-PROD-03B"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelControlledWriteEnablementPlanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelControlledWriteEnablementPlanTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelControlledWriteEnablementPlanTest extends TestCase
+{
+    #[Test]
+    public function generated_artifact_locks_no_write_activation_boundary(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('controlled-write-enablement-plan.v1', $artifact['version'] ?? null);
+        $this->assertContains('SEO-DASH-PROD-01B', $artifact['source_documents'] ?? []);
+        $this->assertContains('SEO-DASH-PROD-02', $artifact['source_documents'] ?? []);
+        $this->assertTrue((bool) ($artifact['production_schema_ready'] ?? false));
+        $this->assertTrue((bool) ($artifact['collector_dry_run_passed'] ?? false));
+        $this->assertFalse((bool) ($artifact['write_enabled_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['scheduler_enabled_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['metabase_deployed_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['live_external_api_enabled_in_this_pr'] ?? true));
+    }
+
+    #[Test]
+    public function first_canary_is_url_truth_and_external_collectors_are_not_first_canary(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('url_truth_inventory', $artifact['first_canary_collector'] ?? null);
+
+        foreach ([
+            'gsc_foundation',
+            'baidu_foundation',
+            'indexnow_foundation',
+            'so360_foundation',
+            'sogou_foundation',
+            'shenma_foundation',
+        ] as $collector) {
+            $this->assertNotSame($collector, $artifact['first_canary_collector'] ?? null);
+            $this->assertContains($collector, $artifact['blocked_collectors'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function production_logs_node2_and_business_raw_sources_remain_blocked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertContains('production_crawler_log_read', $artifact['blocked_collectors'] ?? []);
+        $this->assertContains('cdn_openresty_nginx_production_log_ingestion', $artifact['blocked_collectors'] ?? []);
+        $this->assertContains('node2_local_db', $artifact['forbidden_sources'] ?? []);
+        $this->assertContains('business_db_raw_tables', $artifact['forbidden_sources'] ?? []);
+    }
+
+    #[Test]
+    public function pii_forbidden_fields_cover_required_sensitive_values(): void
+    {
+        $fields = $this->artifact()['forbidden_fields'] ?? [];
+
+        foreach ([
+            'email',
+            'order_no',
+            'attempt_id',
+            'payment_id',
+            'provider_event_id',
+            'cookie',
+            'raw_ip',
+        ] as $field) {
+            $this->assertContains($field, $fields);
+        }
+    }
+
+    #[Test]
+    public function rollback_policy_requires_disabling_write_flag(): void
+    {
+        $policy = $this->artifact()['rollback_policy'] ?? [];
+
+        $this->assertSame('set_SEO_INTEL_WRITE_ENABLED_false', $policy['first_action'] ?? null);
+        $this->assertTrue((bool) ($policy['scheduler_remains_disabled'] ?? false));
+        $this->assertFalse((bool) ($policy['schema_rollback_allowed'] ?? true));
+        $this->assertTrue((bool) ($policy['restore_or_forward_fix_owner_required'] ?? false));
+    }
+
+    #[Test]
+    public function next_task_is_prod_03b(): void
+    {
+        $this->assertSame('SEO-DASH-PROD-03B', $this->artifact()['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function docs_forbid_automatic_scheduler_enablement(): void
+    {
+        $plan = strtolower((string) file_get_contents(base_path('docs/seo/controlled-write-enablement-plan.md')));
+
+        foreach ([
+            'this pr does not enable writes',
+            'it does not enable scheduler execution',
+            'no scheduler may be enabled until repeated manual write smokes pass',
+            'do not start queue workers or scheduler',
+            'scheduler-triggered collector execution',
+            'explicit human approval is required before',
+            'enabling scheduler',
+        ] as $required) {
+            $this->assertStringContainsString($required, $plan);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/controlled-write-enablement-plan.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-17T16:10:03Z",
+  "updated_at": "2026-05-18T12:01:20Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -10556,6 +10556,116 @@
           "summary": "Opened GitHub PR #1455 for DOCS-SHELL-SAFETY-GUARD after scoped local validation passed."
         }
       ]
+    },
+    "SEO-DASH-PROD-03A": {
+      "repo": "fap-api",
+      "branch": "codex/seo-dash-prod-03a-controlled-write-enablement-plan",
+      "base": "main",
+      "depends_on": [
+        "SEO-DASH-PROD-02"
+      ],
+      "status": "pr_opened_github_checks_pending",
+      "train_scope": "controlled_write_enablement_plan",
+      "risk_level": "low_docs_contract_no_execution",
+      "title": "docs(seo-intel): add controlled write enablement plan",
+      "name": "controlled write enablement plan",
+      "checks": {
+        "authorization": {
+          "status": "pass",
+          "evidence": "User explicitly provided SEO-DASH-PROD-03A with branch, title, allowed files, validation commands, and permission to update fap-api PR train metadata."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-DASH-PROD-02 production collector dry-run smoke passed: 13 collectors ran with --dry-run --no-write --json, writes_committed=false, external_calls_attempted=false, production_log_read_attempted=false, no URL submissions, and no collector-created rows."
+        },
+        "production_write_execution": {
+          "status": "false"
+        },
+        "scheduler_activation": {
+          "status": "false"
+        },
+        "external_api_live_activation": {
+          "status": "false"
+        },
+        "metabase_deployment": {
+          "status": "false"
+        },
+        "production_deploy_allowed": {
+          "status": "false"
+        },
+        "production_migration_execution_allowed": {
+          "status": "false"
+        },
+        "production_crawler_log_read_allowed": {
+          "status": "false"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to controlled write enablement docs, generated artifact, focused SeoIntel test, and docs/codex PR train metadata. No runtime code, config, migrations, env, deploy, scheduler, Metabase, external API, production crawler log, payment/order/report/email/recommendation/scoring, sitemap/llms, cloud, credential, or fap-web files changed."
+        },
+        "controlled_write_plan_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=SeoIntelControlledWriteEnablementPlan",
+          "evidence": "7 tests passed with 57 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=SeoIntel",
+          "evidence": "101 tests passed with 1805 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "Full Pint check passed across 3370 files."
+        },
+        "json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/controlled-write-enablement-plan.v1.json >/dev/null",
+          "evidence": "Generated controlled write enablement artifact decoded successfully."
+        },
+        "yaml_validation": {
+          "status": "pass",
+          "command": "python3 - <<'PY' ... yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())",
+          "evidence": "PR train manifest decoded successfully after installing user-level PyYAML required by the validation command. No repository files were changed by the dependency install."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "github": {
+          "status": "pending"
+        }
+      },
+      "failure_reason": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1463",
+      "commit_sha": "5c71805cc0d79f3400da3150010c111ccf9d7939",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-18T11:57:22Z",
+          "status": "in_progress",
+          "summary": "Registered authorized SEO-DASH-PROD-03A and started controlled write enablement plan from origin/main. No production write enablement, scheduler, Metabase, external API, production log read, env edit, deploy, or migration performed."
+        },
+        {
+          "at": "2026-05-18T11:59:55Z",
+          "status": "local_validation_passed",
+          "summary": "Added controlled write enablement plan, generated artifact, focused contract test, and train metadata. Focused test, SeoIntel tests, route list, Pint, JSON/YAML validation, and diff checks passed. No production write enablement or runtime behavior change performed."
+        },
+        {
+          "at": "2026-05-18T12:01:20Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Pushed branch codex/seo-dash-prod-03a-controlled-write-enablement-plan and opened https://github.com/fermatmind/fap-api/pull/1463. GitHub checks pending. No production write enablement or runtime behavior change performed."
+        }
+      ],
+      "next_pr": "SEO-DASH-PROD-03B"
     }
   },
   "SEO-DASH-04B": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -743,6 +743,61 @@ prs:
     env_edit_allowed: false
     scheduler_activation: false
     next_task: SEO-DASH-PROD-01B-STAGE1-RETRY
+
+  - id: SEO-DASH-PROD-03A
+    repo: fap-api
+    depends_on:
+      - SEO-DASH-PROD-02
+    branch: codex/seo-dash-prod-03a-controlled-write-enablement-plan
+    title: "docs(seo-intel): add controlled write enablement plan"
+    name: "controlled write enablement plan"
+    findings:
+      - "SEO-DASH-PROD-01B actual migration completed successfully and created the production seo_intel schema."
+      - "SEO-DASH-PROD-02 production collector dry-run smoke passed for 13 collectors with --dry-run --no-write --json."
+      - "Production writes, scheduler, Metabase, live external APIs, and production crawler log reads remain disabled."
+    scope:
+      - Add a controlled production write enablement plan for SEO Intelligence.
+      - Define collector write tiers, first canary recommendation, required temporary env posture, verification requirements, rollback policy, and human approval gates.
+      - Add a generated contract artifact proving this PR does not enable writes, scheduler, Metabase, live external APIs, production crawler logs, or runtime behavior.
+      - Add a focused SeoIntel contract test for the controlled write enablement plan.
+      - Update docs/codex PR train metadata for SEO-DASH-PROD-03A.
+    allowed_paths:
+      - backend/docs/seo/controlled-write-enablement-plan.md
+      - backend/docs/seo/generated/controlled-write-enablement-plan.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelControlledWriteEnablementPlanTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Enable collector writes, scheduler jobs, queue workers, Metabase, GSC, Baidu, IndexNow, domestic search adapters, or production log reads.
+      - Run production collector write commands, migrations, deploys, SSH commands, env edits, external API calls, or URL submissions.
+      - Touch Tencent rds-fap-prod, Node2 local DB, business DB migrations, or default DB migrations.
+      - Change runtime code, backend behavior, config, migrations, payment, order, report, email, recommendation, scoring, sitemap, or llms behavior.
+      - Modify fap-web runtime or use fap-api/fap-web as production frontend runtime.
+      - Store or expose secrets, DB hosts, passwords, tokens, emails, order numbers, attempt ids, payment ids, provider event ids, cookies, or raw IPs.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelControlledWriteEnablementPlan
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/controlled-write-enablement-plan.v1.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    production_crawler_log_read_allowed: false
+    next_task: SEO-DASH-PROD-03B
   - id: PR-MEDIA-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
Adds a controlled production write enablement plan for FermatMind SEO Intelligence. Defines collector write tiers, first canary recommendation, required env posture, verification requirements, rollback policy, human approval gates, generated artifact, and tests.

What changed:
- Added `backend/docs/seo/controlled-write-enablement-plan.md`.
- Added generated contract artifact at `backend/docs/seo/generated/controlled-write-enablement-plan.v1.json`.
- Added `SeoIntelControlledWriteEnablementPlanTest` coverage.
- Registered `SEO-DASH-PROD-03A` in PR train manifest/state.

Why:
- SEO-DASH-PROD-01B completed the production `seo_intel` migration.
- SEO-DASH-PROD-02 dry-run smoke passed for all collectors.
- The next safe step is a documented, test-locked manual write enablement plan, not actual write activation.

Validation:
- `cd backend && php artisan test --filter=SeoIntelControlledWriteEnablementPlan`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/controlled-write-enablement-plan.v1.json >/dev/null`
- `python3 - <<'PY'`
  `import yaml, pathlib`
  `yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())`
  `PY`
- `git diff --check`
- `git diff --cached --check`

Intentionally deferred:
- No collector writes enabled.
- No scheduler enabled.
- No Metabase deployment.
- No live external APIs connected.
- No production crawler logs read.
- No production env edits, deploys, migrations, or runtime behavior changes.
- No GTM/Baidu Ads/Search submission work.

This PR does not enable writes, scheduler, Metabase, external APIs, production crawler logs, or any runtime behavior.
