### PR TITLE
docs(seo-intel): add URL Truth MVP dashboard spec

### DIFF
--- a/backend/docs/seo/generated/url-truth-mvp-dashboard-spec.v1.json
+++ b/backend/docs/seo/generated/url-truth-mvp-dashboard-spec.v1.json
@@ -1,0 +1,214 @@
+{
+  "version": "url-truth-mvp-dashboard-spec.v1",
+  "source_documents": [
+    "SEO-DASH-PROD-03B-R2",
+    "SEO-DASH-PROD-03C",
+    "SEO-DASH-PROD-03D-R2",
+    "SEO-DASH-PROD-04A",
+    "SEO-DASH-PROD-04B"
+  ],
+  "task": "SEO-DASH-PROD-04B",
+  "purpose": "Define the URL Truth MVP dashboard and sanitized view plan for current seo_intel canary state.",
+  "current_production_state": {
+    "seo_urls": 7,
+    "seo_url_entities": 7,
+    "seo_issue_queue": 5,
+    "seo_gsc_daily": 0,
+    "seo_baidu_push_logs": 0,
+    "seo_indexnow_submissions": 0,
+    "seo_domestic_submission_logs": 0,
+    "seo_crawler_logs_daily": 0,
+    "seo_event_funnel_daily": 0,
+    "seo_revenue_daily": 0,
+    "seo_cluster_daily": 0,
+    "seo_consent_daily": 0
+  },
+  "safe_source_authorities": [
+    "backend_public_surface",
+    "scale_catalog"
+  ],
+  "dashboard_groups": [
+    {
+      "name": "URL Truth Overview",
+      "cards": [
+        "total_url_count",
+        "total_url_entity_mapping_count",
+        "count_by_page_entity_type",
+        "count_by_locale",
+        "count_by_indexability_state",
+        "count_by_source_authority",
+        "first_seen_last_seen_range"
+      ]
+    },
+    {
+      "name": "Issue Queue Overview",
+      "cards": [
+        "issue_count_by_issue_type",
+        "issue_count_by_severity",
+        "issue_count_by_status",
+        "issue_count_by_source_table_family",
+        "newest_issue_observation_timestamp"
+      ]
+    },
+    {
+      "name": "Safety Checks",
+      "cards": [
+        "forbidden_source_authority_count",
+        "private_flow_count",
+        "private_flow_indexable_count",
+        "unsupported_page_entity_type_count",
+        "missing_url_entity_mapping_count",
+        "missing_or_unknown_indexability_state_count",
+        "missing_lastmod_for_indexable_url_count"
+      ]
+    },
+    {
+      "name": "Collector Empty States",
+      "cards": [
+        "seo_gsc_daily_rows",
+        "seo_baidu_push_log_rows",
+        "seo_indexnow_submission_rows",
+        "seo_domestic_submission_rows",
+        "seo_crawler_log_daily_rows",
+        "seo_event_funnel_rows",
+        "seo_revenue_rows",
+        "seo_cluster_rows",
+        "seo_consent_rows"
+      ]
+    }
+  ],
+  "sanitized_views": [
+    {
+      "name": "seo_v_url_truth_mvp_overview",
+      "source_tables": [
+        "seo_urls",
+        "seo_url_entities"
+      ],
+      "exposed_fields": [
+        "locale",
+        "page_entity_type",
+        "indexability_state",
+        "source_authority",
+        "url_count",
+        "entity_mapping_count",
+        "first_seen_at",
+        "last_seen_at"
+      ]
+    },
+    {
+      "name": "seo_v_url_truth_authority_distribution",
+      "source_tables": [
+        "seo_urls"
+      ],
+      "exposed_fields": [
+        "source_authority",
+        "page_entity_type",
+        "url_count"
+      ]
+    },
+    {
+      "name": "seo_v_url_truth_indexability_distribution",
+      "source_tables": [
+        "seo_urls"
+      ],
+      "exposed_fields": [
+        "indexability_state",
+        "page_entity_type",
+        "locale",
+        "url_count"
+      ]
+    },
+    {
+      "name": "seo_v_url_truth_private_flow_safety",
+      "source_tables": [
+        "seo_urls"
+      ],
+      "exposed_fields": [
+        "page_entity_type",
+        "indexability_state",
+        "private_flow_count",
+        "private_flow_indexable_count"
+      ]
+    },
+    {
+      "name": "seo_v_issue_queue_mvp_overview",
+      "source_tables": [
+        "seo_issue_queue"
+      ],
+      "exposed_fields": [
+        "issue_type",
+        "severity",
+        "status",
+        "source_table_family",
+        "issue_count",
+        "newest_observed_at"
+      ]
+    },
+    {
+      "name": "seo_v_collector_empty_state_status",
+      "source_tables": [
+        "seo_gsc_daily",
+        "seo_baidu_push_logs",
+        "seo_indexnow_submissions",
+        "seo_domestic_submission_logs",
+        "seo_crawler_logs_daily",
+        "seo_event_funnel_daily",
+        "seo_revenue_daily",
+        "seo_cluster_daily",
+        "seo_consent_daily"
+      ],
+      "exposed_fields": [
+        "collector_table",
+        "row_count",
+        "write_canary_status"
+      ]
+    }
+  ],
+  "forbidden_sources": [
+    "business_db",
+    "cms_write_tables",
+    "node2_local_db",
+    "node2_local_laravel",
+    "frontend_fallback",
+    "static_sitemap_fallback",
+    "static_llms_fallback",
+    "gsc_live",
+    "baidu_live",
+    "indexnow_live",
+    "production_crawler_logs"
+  ],
+  "forbidden_fields": [
+    "email",
+    "raw_email",
+    "order_no",
+    "raw_order_no",
+    "attempt_id",
+    "raw_attempt_id",
+    "payment_id",
+    "provider_event_id",
+    "cookie",
+    "raw_cookie",
+    "raw_ip",
+    "raw_user_agent",
+    "raw_payload",
+    "payment_payload",
+    "provider_payload",
+    "token",
+    "api_key",
+    "secret"
+  ],
+  "metabase_deployed_in_this_pr": false,
+  "metabase_connection_created_in_this_pr": false,
+  "business_db_views_created_in_this_pr": false,
+  "sql_views_created_in_this_pr": false,
+  "credentials_added_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "production_write_execution": false,
+  "scheduler_enabled_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "production_crawler_log_read": false,
+  "research_publish_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "next_task": "PR-RESEARCH-00"
+}

--- a/backend/docs/seo/url-truth-mvp-dashboard-spec.md
+++ b/backend/docs/seo/url-truth-mvp-dashboard-spec.md
@@ -1,0 +1,147 @@
+# URL Truth MVP Dashboard Spec and Sanitized Views Plan
+
+## Purpose
+
+SEO-DASH-PROD-04B defines the first dashboard and sanitized view plan for the post-03D `seo_intel` state.
+This is a docs, generated-contract, and test PR only. It does not deploy Metabase, create SQL views, add credentials, edit environment files, run collector writes, enable scheduler, or connect external search APIs.
+
+## Current Safe Data State
+
+The MVP dashboard starts from the controlled canary state:
+
+- `seo_urls`: 7 rows
+- `seo_url_entities`: 7 rows
+- `seo_issue_queue`: 5 rows
+- all other checked collector tables: 0 rows
+
+Observed safe source authorities are:
+
+- `backend_public_surface`
+- `scale_catalog`
+
+The dashboard must show empty-state panels for collectors that have not passed a production write canary. Empty-state panels must not imply missing production data is a failure.
+
+## Dashboard Groups
+
+### URL Truth Overview
+
+Purpose: confirm the current backend-authoritative URL Truth inventory.
+
+Required cards:
+
+- total URL count
+- total URL/entity mapping count
+- count by `page_entity_type`
+- count by `locale`
+- count by `indexability_state`
+- count by `source_authority`
+- latest `first_seen_at` and `last_seen_at` ranges
+
+The source authority distribution must make backend-approved authorities visible and must keep frontend, static, and Node2 sources out of the truth model.
+
+### Issue Queue Overview
+
+Purpose: inspect sanitized drift and URL Truth observations created by controlled canaries.
+
+Required cards:
+
+- issue count by `issue_type`
+- issue count by `severity`
+- issue count by `status`
+- issue count by source table family
+- newest issue observation timestamp
+
+Issue cards must not expose raw evidence, raw URLs with query strings, raw payloads, raw identifiers, or raw PII.
+
+### Safety Checks
+
+Purpose: keep authority, privacy, and indexability boundaries visible.
+
+Required cards:
+
+- forbidden source authority count
+- private-flow count
+- private-flow indexable count
+- unsupported page entity type count
+- missing URL/entity mapping count
+- missing or unknown indexability state count
+- missing lastmod for indexable URL count
+
+### Collector Empty States
+
+Purpose: make not-yet-enabled collectors visible without pretending they have data.
+
+Required cards:
+
+- GSC daily rows
+- Baidu push rows
+- IndexNow submission rows
+- domestic submission rows
+- crawler daily rows
+- event funnel rows
+- revenue rows
+- cluster rows
+- consent rows
+
+All of these cards should display zero/empty until the relevant collector passes a controlled write canary or an approved read-only dashboard operation creates a sanitized view.
+
+## Sanitized View Plan
+
+This PR defines view contracts only. It does not create SQL views.
+
+Planned sanitized views:
+
+- `seo_v_url_truth_mvp_overview`
+- `seo_v_url_truth_authority_distribution`
+- `seo_v_url_truth_indexability_distribution`
+- `seo_v_url_truth_private_flow_safety`
+- `seo_v_issue_queue_mvp_overview`
+- `seo_v_collector_empty_state_status`
+
+Views may source only from `seo_intel` tables and must expose aggregate counts, dates, safe enums, status values, page entity types, locale, source authority, and sanitized issue types.
+
+Views must not source from:
+
+- business DB
+- CMS write tables
+- Node2 local DB
+- Node2 local Laravel runtime
+- frontend fallback
+- static sitemap fallback
+- static `llms.txt` fallback
+- live search APIs
+- production crawler logs
+
+Views must not expose:
+
+- raw email
+- raw order number
+- raw attempt ID
+- payment ID
+- provider event ID
+- cookie
+- raw IP
+- raw user agent
+- raw payload, payment payload, or provider payload
+- token, API key, or secret
+
+## Dashboard Access Boundary
+
+The dashboard is intended for a future Metabase connection that reads only `seo_intel` through the SEO-DASH-PROD-04A read-only boundary.
+No business DB connection, CMS write table connection, Node2 local source, or production crawler log source is allowed.
+
+## Stop Conditions
+
+Stop implementation or production planning if any of these occur:
+
+- a sanitized view requires a business DB source
+- a sanitized view exposes raw PII or raw evidence
+- a dashboard needs raw order, payment, event, email, user, report, or attempt data
+- frontend fallback, static sitemap fallback, or static `llms.txt` fallback becomes dashboard truth
+- private-flow pages appear as indexable
+- Metabase deployment or credentials are introduced in this PR
+- scheduler, collector writes, external search APIs, URL submission, or production crawler log reads are triggered
+
+## Next Task
+
+Next task: PR-RESEARCH-00.

--- a/backend/tests/Feature/SeoIntel/SeoIntelUrlTruthMvpDashboardSpecTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelUrlTruthMvpDashboardSpecTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelUrlTruthMvpDashboardSpecTest extends TestCase
+{
+    #[Test]
+    public function artifact_locks_current_url_truth_and_issue_queue_state(): void
+    {
+        $artifact = $this->artifact();
+        $state = $artifact['current_production_state'] ?? [];
+
+        $this->assertSame('url-truth-mvp-dashboard-spec.v1', $artifact['version'] ?? null);
+        $this->assertContains('SEO-DASH-PROD-04A', $artifact['source_documents'] ?? []);
+        $this->assertSame(7, $state['seo_urls'] ?? null);
+        $this->assertSame(7, $state['seo_url_entities'] ?? null);
+        $this->assertSame(5, $state['seo_issue_queue'] ?? null);
+
+        foreach ([
+            'seo_gsc_daily',
+            'seo_baidu_push_logs',
+            'seo_indexnow_submissions',
+            'seo_domestic_submission_logs',
+            'seo_crawler_logs_daily',
+            'seo_event_funnel_daily',
+            'seo_revenue_daily',
+            'seo_cluster_daily',
+            'seo_consent_daily',
+        ] as $emptyTable) {
+            $this->assertSame(0, $state[$emptyTable] ?? null, $emptyTable.' remains empty until a scoped canary passes');
+        }
+    }
+
+    #[Test]
+    public function dashboard_groups_cover_url_truth_issue_queue_safety_and_empty_states(): void
+    {
+        $groups = $this->artifact()['dashboard_groups'] ?? [];
+        $names = array_column($groups, 'name');
+
+        foreach ([
+            'URL Truth Overview',
+            'Issue Queue Overview',
+            'Safety Checks',
+            'Collector Empty States',
+        ] as $name) {
+            $this->assertContains($name, $names);
+        }
+
+        $encoded = json_encode($groups, JSON_THROW_ON_ERROR);
+
+        foreach ([
+            'count_by_page_entity_type',
+            'count_by_locale',
+            'count_by_indexability_state',
+            'count_by_source_authority',
+            'issue_count_by_issue_type',
+            'forbidden_source_authority_count',
+            'private_flow_count',
+            'private_flow_indexable_count',
+            'missing_lastmod_for_indexable_url_count',
+            'seo_gsc_daily_rows',
+        ] as $card) {
+            $this->assertStringContainsString($card, $encoded);
+        }
+    }
+
+    #[Test]
+    public function sanitized_views_use_only_seo_intel_tables_and_safe_fields(): void
+    {
+        $views = $this->artifact()['sanitized_views'] ?? [];
+
+        $this->assertSame([
+            'seo_v_url_truth_mvp_overview',
+            'seo_v_url_truth_authority_distribution',
+            'seo_v_url_truth_indexability_distribution',
+            'seo_v_url_truth_private_flow_safety',
+            'seo_v_issue_queue_mvp_overview',
+            'seo_v_collector_empty_state_status',
+        ], array_column($views, 'name'));
+
+        foreach ($views as $view) {
+            foreach ($view['source_tables'] ?? [] as $sourceTable) {
+                $this->assertStringStartsWith('seo_', $sourceTable);
+                $this->assertNotContains($sourceTable, [
+                    'seo_orders',
+                    'seo_payments',
+                    'seo_users',
+                ]);
+            }
+
+            $encoded = strtolower(json_encode($view, JSON_THROW_ON_ERROR));
+
+            foreach ($this->forbiddenFields() as $field) {
+                $this->assertStringNotContainsString($field, $encoded, ($view['name'] ?? 'view').' must not expose '.$field);
+            }
+        }
+    }
+
+    #[Test]
+    public function source_authority_and_activation_boundaries_remain_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame([
+            'backend_public_surface',
+            'scale_catalog',
+        ], $artifact['safe_source_authorities'] ?? []);
+
+        foreach ([
+            'business_db',
+            'cms_write_tables',
+            'node2_local_db',
+            'frontend_fallback',
+            'static_sitemap_fallback',
+            'static_llms_fallback',
+            'production_crawler_logs',
+        ] as $source) {
+            $this->assertContains($source, $artifact['forbidden_sources'] ?? []);
+        }
+
+        foreach ([
+            'metabase_deployed_in_this_pr',
+            'metabase_connection_created_in_this_pr',
+            'business_db_views_created_in_this_pr',
+            'sql_views_created_in_this_pr',
+            'credentials_added_in_this_pr',
+            'env_edit_in_this_pr',
+            'production_write_execution',
+            'scheduler_enabled_in_this_pr',
+            'external_api_live_activation',
+            'url_submission_performed',
+            'production_crawler_log_read',
+            'research_publish_in_this_pr',
+            'pseo_generation_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_state_sanitized_views_only_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/url-truth-mvp-dashboard-spec.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/url-truth-mvp-dashboard-spec.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'sanitized view plan',
+            'this pr defines view contracts only',
+            'it does not create sql views',
+            'does not deploy metabase',
+            'no business db connection',
+            'source authority distribution',
+            'private-flow count',
+            'forbidden source authority count',
+            'next task: pr-research-00',
+            '"next_task": "pr-research-00"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/url-truth-mvp-dashboard-spec.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenFields(): array
+    {
+        return [
+            'email',
+            'raw_email',
+            'order_no',
+            'raw_order_no',
+            'attempt_id',
+            'raw_attempt_id',
+            'payment_id',
+            'provider_event_id',
+            'cookie',
+            'raw_cookie',
+            'raw_ip',
+            'raw_user_agent',
+            'raw_payload',
+            'payment_payload',
+            'provider_payload',
+            'token',
+            'api_key',
+            'secret',
+        ];
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T01:43:32Z",
+  "updated_at": "2026-05-19T01:44:44Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11003,8 +11003,8 @@
     },
     "SEO-DASH-PROD-04B": {
       "repo": "fap-api",
-      "status": "local_validation_passed",
-      "state": "local_validation_passed",
+      "status": "pr_opened_github_checks_pending",
+      "state": "open",
       "title": "URL Truth MVP dashboard spec and sanitized views plan",
       "depends_on": [
         "SEO-DASH-PROD-04A"
@@ -11075,6 +11075,10 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github": {
+          "status": "pending",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1469"
         }
       },
       "sidecar_issues": [],
@@ -11093,10 +11097,17 @@
           "at": "2026-05-19T01:43:32Z",
           "status": "local_validation_passed",
           "summary": "Added URL Truth MVP dashboard spec, generated contract artifact, and focused SeoIntel test. Focused test, SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and git diff check passed. No production operation performed."
+        },
+        {
+          "at": "2026-05-19T01:44:44Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1469 for SEO-DASH-PROD-04B. GitHub checks pending. No production operation performed."
         }
       ],
       "branch": "codex/seo-dash-prod-04b-url-truth-mvp-dashboard-spec",
-      "base": "main"
+      "base": "main",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1469",
+      "commit_sha": "b7890990"
     },
     "PR-RESEARCH-00": {
       "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T01:32:37Z",
+  "updated_at": "2026-05-19T01:43:32Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -10893,8 +10893,8 @@
     },
     "SEO-DASH-PROD-04A": {
       "repo": "fap-api",
-      "status": "pr_opened_github_checks_pending",
-      "state": "open",
+      "status": "merged",
+      "state": "merged",
       "title": "Metabase read-only connection plan",
       "depends_on": [
         "SEO-DASH-PROD-03D-R2"
@@ -10959,8 +10959,7 @@
           "command": "git diff --check"
         },
         "github": {
-          "status": "pending",
-          "pr_url": "https://github.com/fermatmind/fap-api/pull/1468"
+          "status": "passed"
         }
       },
       "sidecar_issues": [],
@@ -10984,17 +10983,28 @@
           "at": "2026-05-19T01:32:37Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1468 for SEO-DASH-PROD-04A. GitHub checks pending. No production operation performed."
+        },
+        {
+          "at": "2026-05-19T01:41:52Z",
+          "status": "merged",
+          "summary": "Reconciled SEO-DASH-PROD-04A as merged via PR #1468 with merge commit 50f249144792a3db8d954bd91676e547a2e448ca. Remote branch absent and local main synced."
         }
       ],
       "branch": "codex/seo-dash-prod-04a-metabase-read-only-plan",
       "base": "main",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1468",
-      "commit_sha": "8c29a356"
+      "commit_sha": "8c29a356",
+      "final_status": "completed",
+      "merge_commit_sha": "50f249144792a3db8d954bd91676e547a2e448ca",
+      "merge_observed": true,
+      "merged_at": "2026-05-19T01:41:52Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "SEO-DASH-PROD-04B": {
       "repo": "fap-api",
-      "status": "planned",
-      "state": "planned",
+      "status": "local_validation_passed",
+      "state": "local_validation_passed",
       "title": "URL Truth MVP dashboard spec and sanitized views plan",
       "depends_on": [
         "SEO-DASH-PROD-04A"
@@ -11017,6 +11027,54 @@
         "registration": {
           "status": "planned",
           "evidence": "Registered by SEO-TRAIN-POST03D-PR-TRAIN-01 metadata reconciliation PR; no runtime code or production operation executed."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-DASH-PROD-04A merged as PR #1468 and main contains merge commit 50f249144792a3db8d954bd91676e547a2e448ca."
+        },
+        "scope": {
+          "status": "in_progress",
+          "evidence": "Implementing only URL Truth MVP dashboard spec doc, generated artifact, focused SeoIntel test, and PR train state metadata. No runtime code or production operation executed."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to URL Truth MVP dashboard spec doc, generated artifact, focused SeoIntel test, and docs/codex PR train state metadata. No runtime code, migrations, env, deploy, scheduler, collector writes, Metabase deployment, external APIs, crawler log reads, fap-web files, sitemap/llms behavior, research publish, pSEO, production operations, or database changes were performed."
+        },
+        "url_truth_mvp_dashboard_spec_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelUrlTruthMvpDashboardSpec",
+          "evidence": "5 tests passed with 206 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "evidence": "120 tests passed with 2204 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "Pint completed successfully; 3374 files checked."
+        },
+        "json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/url-truth-mvp-dashboard-spec.v1.json >/dev/null"
+        },
+        "yaml_validation": {
+          "status": "pass",
+          "command": "python3 - <<'PY' ... yaml.safe_load(docs/codex/pr-train.yaml)"
+        },
+        "state_json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
         }
       },
       "sidecar_issues": [],
@@ -11025,8 +11083,20 @@
           "at": "2026-05-19T01:02:33Z",
           "status": "planned",
           "summary": "Registered planned non-production PR train task SEO-DASH-PROD-04B: URL Truth MVP dashboard spec and sanitized views plan. Safety flags disable writes, scheduler, Metabase deployment, external APIs, crawler log reads, env edits, research publishing, and pSEO generation."
+        },
+        {
+          "at": "2026-05-19T01:41:52Z",
+          "status": "in_progress",
+          "summary": "Started SEO-DASH-PROD-04B URL Truth MVP dashboard spec on scoped branch. Scope excludes runtime code, migrations, env, deploy, collector writes, scheduler, Metabase deployment, external APIs, crawler log reads, research publish, pSEO, and production operations."
+        },
+        {
+          "at": "2026-05-19T01:43:32Z",
+          "status": "local_validation_passed",
+          "summary": "Added URL Truth MVP dashboard spec, generated contract artifact, and focused SeoIntel test. Focused test, SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and git diff check passed. No production operation performed."
         }
-      ]
+      ],
+      "branch": "codex/seo-dash-prod-04b-url-truth-mvp-dashboard-spec",
+      "base": "main"
     },
     "PR-RESEARCH-00": {
       "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Added the SEO-DASH-PROD-04B URL Truth MVP dashboard and sanitized views plan.
- Added a generated contract artifact for URL Truth overview, issue queue overview, safety checks, collector empty states, and sanitized view boundaries.
- Added focused SeoIntel tests and updated PR train state, including reconciliation of merged SEO-DASH-PROD-04A.

## Why
This defines the first non-production dashboard/read-model contract for the current safe `seo_intel` state after URL Truth and bounded drift issue canaries, without deploying Metabase or creating SQL views.

## Validation
- `cd backend && php artisan test --filter=SeoIntelUrlTruthMvpDashboardSpec`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/url-truth-mvp-dashboard-spec.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(docs/codex/pr-train.yaml)`
- `git diff --check`
- `git diff --cached --check`

## Intentionally not done
- No actual Metabase deployment or connection creation.
- No SQL views or business DB views created.
- No credentials or env edits.
- No production collector writes, scheduler, external API calls, URL submissions, production crawler log reads, migrations, RDS, DNS, CDN, or whitelist changes.
- No Research runtime, Research publish, pSEO, sitemap, or llms behavior change.
