### PR TITLE
docs(seo-intel): add crawler log readiness contract

### DIFF
--- a/backend/docs/seo/crawler-log-readiness-contract.md
+++ b/backend/docs/seo/crawler-log-readiness-contract.md
@@ -1,0 +1,93 @@
+# Crawler Log Readiness Contract
+
+## Purpose
+
+CRAWLER-LOG-00 defines the source approval, sanitization, and ingestion readiness boundary for future crawler log intelligence.
+This PR does not read production crawler logs, change CDN/Nginx/OpenResty configuration, add credentials, edit environment files, enable scheduler, run collector writes, deploy services, or modify runtime behavior.
+
+## Source Decision Boundary
+
+Future crawler log work must explicitly approve one source family before any read occurs:
+
+- CDN access logs
+- Nginx access logs
+- OpenResty access logs
+
+The approved source must document owner, path or export mechanism, retention, masking posture, access control, and rollback owner.
+Until that approval exists, production crawler log reads remain blocked.
+
+## Sanitization Rules
+
+Crawler log ingestion may store aggregate-only rows after sanitization.
+
+Allowed stored fields:
+
+- report date
+- bot family
+- source engine
+- route family
+- locale
+- page entity type
+- status code bucket
+- response time bucket
+- crawl count
+- private-flow count
+- noindex count
+
+Forbidden stored fields:
+
+- raw IP
+- cookie or raw cookie
+- raw user agent
+- full raw URL with query string
+- raw payload
+- token, API key, or secret
+- raw email, order number, attempt ID, payment ID, or provider event ID
+
+Raw user agent strings may be used transiently for classification only and must not be stored.
+Raw IPs must not be stored; if a future classifier needs network-level grouping it must use an approved irreversible hash or aggregate bucket.
+
+## Bot Classifier Scope
+
+Allowed bot families:
+
+- googlebot
+- bingbot
+- baiduspider
+- bytespider
+- sogou
+- so360
+- shenma
+- yandex
+- other_bot
+- unknown
+
+Chinese crawler labels must remain classifier labels only. They must not trigger URL submissions, alternate page generation, or search-channel actions.
+
+## Approval Gates
+
+Before a future production crawler-log read or ingestion:
+
+- source owner approves source path/export
+- security owner approves masking and access control
+- backend owner approves sanitized schema
+- SEO Intelligence owner approves report-only purpose
+- production operation receives explicit human approval
+- dry-run output confirms no raw IP, cookie, raw user agent, query string, raw payload, or PII
+- scheduler remains disabled unless separately approved later
+
+## Stop Conditions
+
+Stop immediately if:
+
+- production crawler logs are read in a docs/spec PR
+- raw IP, cookie, raw user agent, or raw URL query strings are stored
+- CDN/Nginx/OpenResty config is changed
+- scheduler or queue workers are enabled
+- crawler observations trigger URL submissions
+- crawler logs become URL Truth authority
+- Node2 local DB or business raw tables are used
+
+## Next Task
+
+Next task: CLAIM-LINT-00.

--- a/backend/docs/seo/generated/crawler-log-readiness-contract.v1.json
+++ b/backend/docs/seo/generated/crawler-log-readiness-contract.v1.json
@@ -1,0 +1,88 @@
+{
+  "version": "crawler-log-readiness-contract.v1",
+  "source_documents": [
+    "SEO-DASH-PROD-04B",
+    "SEARCH-CHANNEL-QUEUE-00",
+    "CRAWLER-LOG-00",
+    "CHINA-SEARCH-04"
+  ],
+  "task": "CRAWLER-LOG-00",
+  "candidate_source_families": [
+    "cdn_access_logs",
+    "nginx_access_logs",
+    "openresty_access_logs"
+  ],
+  "source_approval_required_fields": [
+    "owner",
+    "path_or_export_mechanism",
+    "retention",
+    "masking_posture",
+    "access_control",
+    "rollback_owner"
+  ],
+  "allowed_stored_fields": [
+    "report_date",
+    "bot_family",
+    "source_engine",
+    "route_family",
+    "locale",
+    "page_entity_type",
+    "status_code_bucket",
+    "response_time_bucket",
+    "crawl_count",
+    "private_flow_count",
+    "noindex_count"
+  ],
+  "forbidden_stored_fields": [
+    "raw_ip",
+    "cookie",
+    "raw_cookie",
+    "raw_user_agent",
+    "full_raw_url_with_query_string",
+    "raw_payload",
+    "token",
+    "api_key",
+    "secret",
+    "raw_email",
+    "order_no",
+    "attempt_id",
+    "payment_id",
+    "provider_event_id"
+  ],
+  "allowed_bot_families": [
+    "googlebot",
+    "bingbot",
+    "baiduspider",
+    "bytespider",
+    "sogou",
+    "so360",
+    "shenma",
+    "yandex",
+    "other_bot",
+    "unknown"
+  ],
+  "approval_gates": [
+    "source_owner_approval",
+    "security_owner_masking_approval",
+    "backend_owner_schema_approval",
+    "seo_intelligence_owner_report_only_approval",
+    "explicit_human_production_operation_approval",
+    "dry_run_no_raw_fields_confirmation",
+    "scheduler_remains_disabled"
+  ],
+  "production_log_read_in_this_pr": false,
+  "cdn_config_changed_in_this_pr": false,
+  "nginx_config_changed_in_this_pr": false,
+  "openresty_config_changed_in_this_pr": false,
+  "collector_write_executed_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "env_edit_in_this_pr": false,
+  "metabase_deployed_in_this_pr": false,
+  "raw_user_agent_storage_allowed": false,
+  "raw_ip_storage_allowed": false,
+  "cookie_storage_allowed": false,
+  "crawler_logs_as_url_truth_allowed": false,
+  "next_task": "CLAIM-LINT-00"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogReadinessContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogReadinessContractTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelCrawlerLogReadinessContractTest extends TestCase
+{
+    #[Test]
+    public function artifact_requires_source_approval_before_any_log_read(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('crawler-log-readiness-contract.v1', $artifact['version'] ?? null);
+        $this->assertContains('SEARCH-CHANNEL-QUEUE-00', $artifact['source_documents'] ?? []);
+
+        foreach (['cdn_access_logs', 'nginx_access_logs', 'openresty_access_logs'] as $source) {
+            $this->assertContains($source, $artifact['candidate_source_families'] ?? []);
+        }
+
+        foreach ([
+            'owner',
+            'path_or_export_mechanism',
+            'retention',
+            'masking_posture',
+            'access_control',
+            'rollback_owner',
+        ] as $field) {
+            $this->assertContains($field, $artifact['source_approval_required_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function storage_contract_is_aggregate_only_and_forbids_raw_fields(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'report_date',
+            'bot_family',
+            'source_engine',
+            'route_family',
+            'locale',
+            'page_entity_type',
+            'status_code_bucket',
+            'response_time_bucket',
+            'crawl_count',
+            'private_flow_count',
+            'noindex_count',
+        ] as $field) {
+            $this->assertContains($field, $artifact['allowed_stored_fields'] ?? []);
+        }
+
+        foreach ([
+            'raw_ip',
+            'cookie',
+            'raw_cookie',
+            'raw_user_agent',
+            'full_raw_url_with_query_string',
+            'raw_payload',
+            'token',
+            'api_key',
+            'secret',
+            'raw_email',
+            'order_no',
+            'attempt_id',
+            'payment_id',
+            'provider_event_id',
+        ] as $field) {
+            $this->assertContains($field, $artifact['forbidden_stored_fields'] ?? []);
+            $this->assertNotContains($field, $artifact['allowed_stored_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function bot_classifier_includes_chinese_crawlers_without_search_actions(): void
+    {
+        $families = $this->artifact()['allowed_bot_families'] ?? [];
+
+        foreach ([
+            'googlebot',
+            'bingbot',
+            'baiduspider',
+            'bytespider',
+            'sogou',
+            'so360',
+            'shenma',
+            'yandex',
+            'other_bot',
+            'unknown',
+        ] as $family) {
+            $this->assertContains($family, $families);
+        }
+    }
+
+    #[Test]
+    public function production_reads_config_changes_scheduler_and_raw_storage_remain_blocked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'production_log_read_in_this_pr',
+            'cdn_config_changed_in_this_pr',
+            'nginx_config_changed_in_this_pr',
+            'openresty_config_changed_in_this_pr',
+            'collector_write_executed_in_this_pr',
+            'scheduler_enabled_in_this_pr',
+            'external_api_live_activation',
+            'url_submission_performed',
+            'env_edit_in_this_pr',
+            'metabase_deployed_in_this_pr',
+            'raw_user_agent_storage_allowed',
+            'raw_ip_storage_allowed',
+            'cookie_storage_allowed',
+            'crawler_logs_as_url_truth_allowed',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_production_log_read_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/crawler-log-readiness-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/crawler-log-readiness-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'does not read production crawler logs',
+            'cdn access logs',
+            'nginx access logs',
+            'openresty access logs',
+            'aggregate-only rows',
+            'raw user agent strings may be used transiently',
+            'must not trigger url submissions',
+            'scheduler remains disabled',
+            'next task: claim-lint-00',
+            '"next_task": "claim-lint-00"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/crawler-log-readiness-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T02:16:34Z",
+  "updated_at": "2026-05-19T02:17:23Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11357,8 +11357,8 @@
     },
     "CRAWLER-LOG-00": {
       "repo": "fap-api",
-      "status": "local_validation_passed",
-      "state": "local_validation_passed",
+      "status": "pr_opened_github_checks_pending",
+      "state": "open",
       "title": "Crawler log readiness contract",
       "depends_on": [
         "SEO-DASH-PROD-04B"
@@ -11429,6 +11429,10 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github": {
+          "status": "pending",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1472"
         }
       },
       "sidecar_issues": [],
@@ -11447,10 +11451,17 @@
           "at": "2026-05-19T02:16:34Z",
           "status": "local_validation_passed",
           "summary": "Added crawler log readiness contract, generated artifact, and focused SeoIntel test. Focused test, SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and git diff check passed. No production log read, config change, scheduler, collector write, or production operation performed."
+        },
+        {
+          "at": "2026-05-19T02:17:23Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1472 for CRAWLER-LOG-00. GitHub checks pending. No production operation performed."
         }
       ],
       "branch": "codex/crawler-log-00-readiness-contract",
-      "base": "main"
+      "base": "main",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1472",
+      "commit_sha": "56a56f73"
     },
     "CLAIM-LINT-00": {
       "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T02:07:21Z",
+  "updated_at": "2026-05-19T02:16:34Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11239,8 +11239,8 @@
     },
     "SEARCH-CHANNEL-QUEUE-00": {
       "repo": "fap-api",
-      "status": "pr_opened_github_checks_pending",
-      "state": "open",
+      "status": "merged",
+      "state": "merged",
       "title": "Search Channel Queue design contract",
       "depends_on": [
         "SEO-DASH-PROD-04B"
@@ -11313,8 +11313,7 @@
           "command": "git diff --check"
         },
         "github": {
-          "status": "pending",
-          "pr_url": "https://github.com/fermatmind/fap-api/pull/1471"
+          "status": "passed"
         }
       },
       "sidecar_issues": [],
@@ -11338,17 +11337,28 @@
           "at": "2026-05-19T02:07:21Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1471 for SEARCH-CHANNEL-QUEUE-00. GitHub checks pending. No production operation performed."
+        },
+        {
+          "at": "2026-05-19T02:15:27Z",
+          "status": "merged",
+          "summary": "Reconciled SEARCH-CHANNEL-QUEUE-00 as merged via PR #1471. Remote branch absent and local main synced."
         }
       ],
       "branch": "codex/search-channel-queue-00-design-contract",
       "base": "main",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1471",
-      "commit_sha": "35c15972"
+      "commit_sha": "35c15972",
+      "final_status": "completed",
+      "merge_commit_sha": "e155f826",
+      "merge_observed": true,
+      "merged_at": "2026-05-19T02:15:27Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "CRAWLER-LOG-00": {
       "repo": "fap-api",
-      "status": "planned",
-      "state": "planned",
+      "status": "local_validation_passed",
+      "state": "local_validation_passed",
       "title": "Crawler log readiness contract",
       "depends_on": [
         "SEO-DASH-PROD-04B"
@@ -11371,6 +11381,54 @@
         "registration": {
           "status": "planned",
           "evidence": "Registered by SEO-TRAIN-POST03D-PR-TRAIN-01 metadata reconciliation PR; no runtime code or production operation executed."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-DASH-PROD-04B merged as PR #1469; SEARCH-CHANNEL-QUEUE-00 also merged as PR #1471."
+        },
+        "scope": {
+          "status": "in_progress",
+          "evidence": "Implementing only crawler log readiness contract doc, generated artifact, focused SeoIntel test, and PR train state metadata. No production log read, CDN/Nginx/OpenResty change, raw storage, scheduler, env edit, deploy, collector write, or production operation executed."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to crawler log readiness contract doc, generated artifact, focused SeoIntel test, and docs/codex PR train state metadata. No production log read, CDN/Nginx/OpenResty config change, raw storage, scheduler, env edit, deploy, collector write, or production operation was performed."
+        },
+        "crawler_log_readiness_contract_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelCrawlerLogReadinessContract",
+          "evidence": "5 tests passed with 92 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "evidence": "136 tests passed with 2485 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "Pint completed successfully; 3377 files checked."
+        },
+        "json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/crawler-log-readiness-contract.v1.json >/dev/null"
+        },
+        "state_json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        },
+        "yaml_validation": {
+          "status": "pass",
+          "command": "python3 - <<'PY' ... yaml.safe_load(docs/codex/pr-train.yaml)"
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
         }
       },
       "sidecar_issues": [],
@@ -11379,8 +11437,20 @@
           "at": "2026-05-19T01:02:33Z",
           "status": "planned",
           "summary": "Registered planned non-production PR train task CRAWLER-LOG-00: Crawler log readiness contract. Safety flags disable writes, scheduler, Metabase deployment, external APIs, crawler log reads, env edits, research publishing, and pSEO generation."
+        },
+        {
+          "at": "2026-05-19T02:15:27Z",
+          "status": "in_progress",
+          "summary": "Started CRAWLER-LOG-00 on scoped branch. Scope excludes production log reads, CDN/Nginx/OpenResty config changes, raw IP/cookie/user-agent storage, scheduler, env edits, deploys, collector writes, and production operations."
+        },
+        {
+          "at": "2026-05-19T02:16:34Z",
+          "status": "local_validation_passed",
+          "summary": "Added crawler log readiness contract, generated artifact, and focused SeoIntel test. Focused test, SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and git diff check passed. No production log read, config change, scheduler, collector write, or production operation performed."
         }
-      ]
+      ],
+      "branch": "codex/crawler-log-00-readiness-contract",
+      "base": "main"
     },
     "CLAIM-LINT-00": {
       "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Added CRAWLER-LOG-00 crawler log readiness contract.
- Added generated artifact covering source approval, aggregate-only storage, bot classifier families, approval gates, and no-read/no-config-change boundaries.
- Added focused SeoIntel tests and updated PR train state, including reconciliation of merged SEARCH-CHANNEL-QUEUE-00.

## Why
This defines crawler log readiness before any production log read, CDN/Nginx/OpenResty config change, scheduler, or ingestion work.

## Validation
- `cd backend && php artisan test --filter=SeoIntelCrawlerLogReadinessContract`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/crawler-log-readiness-contract.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(docs/codex/pr-train.yaml)`
- `git diff --check`
- `git diff --cached --check`

## Intentionally not done
- No production crawler log reads.
- No CDN/Nginx/OpenResty config changes.
- No raw IP/cookie/user-agent storage.
- No scheduler, collector writes, deploys, env edits, external API calls, URL submissions, migrations, RDS, DNS, CDN, or whitelist changes.
