### PR TITLE
docs(seo-intel): add Chinese claim boundary linter contract

### DIFF
--- a/backend/docs/seo/chinese-claim-boundary-linter.md
+++ b/backend/docs/seo/chinese-claim-boundary-linter.md
@@ -1,0 +1,78 @@
+# Chinese Claim Boundary Linter Contract
+
+## Purpose
+
+CLAIM-LINT-00 defines a Chinese SEO claim boundary contract for future content, Research Asset, and Search Channel review.
+This PR is docs/spec/test only. It does not activate runtime linting, change frontend copy, publish content, alter sitemap or `llms.txt`, run collector writes, enable scheduler, or deploy services.
+
+## Forbidden Claim Classes
+
+Chinese copy must be blocked or escalated for review when it implies:
+
+- 诊断
+- 确诊
+- 治疗
+- 治愈
+- 真实智商
+- 权威认证
+- 精准推荐
+- 最适合职业
+- 岗位胜任力
+- 招聘适配
+- 职业成功率
+- AI 职业规划
+- 心理疾病判断
+
+These phrases are especially risky when attached to RIASEC, Big Five, Career Decision, MBTI, or other self-assessment products.
+
+## Allowed Safer Wording
+
+Safer wording may be allowed when the page context remains non-diagnostic and non-deterministic:
+
+- 自评筛查
+- 非诊断
+- 结果仅供参考
+- 在线估测
+- 置信区间
+- 职业方向参考
+- 探索建议
+- 兴趣信号
+- 工作方式倾向
+- snapshot-based support
+
+Allowed wording must not be combined with guarantees, medical claims, hiring claims, exact IQ claims, or full career recommender claims.
+
+## Boundary Rules
+
+- RIASEC and Big Five career semantics remain shallow/partial assets.
+- Career Decision support must remain exploratory unless a separate approved runtime expands it.
+- Research Assets must include claim review before sitemap, `llms.txt`, or Search Channel Queue eligibility.
+- Draft, private, noindex, and claim-unsafe pages must not enter search submission queues.
+- Frontend runtime copy must not be changed by this PR.
+
+## Future Linter Behavior
+
+A future inactive linter may classify copy into:
+
+- `blocked_claim`
+- `needs_review`
+- `allowed_safer_wording`
+- `neutral`
+
+The linter should return matched phrase, class, severity, and suggested safer wording. It must not auto-publish, auto-edit CMS content, submit URLs, or mutate runtime copy.
+
+## Stop Conditions
+
+Stop if any implementation:
+
+- expands RIASEC, Big Five, or Career Decision claims into full recommendation claims
+- changes frontend runtime copy
+- changes publishing behavior
+- changes sitemap or `llms.txt`
+- enables runtime activation without approval
+- auto-publishes or auto-edits CMS content
+- triggers search submission
+
+## Next Task
+
+Next task: CONTENT-OPS-01.

--- a/backend/docs/seo/generated/chinese-claim-boundary-linter.v1.json
+++ b/backend/docs/seo/generated/chinese-claim-boundary-linter.v1.json
@@ -1,0 +1,74 @@
+{
+  "version": "chinese-claim-boundary-linter.v1",
+  "source_documents": [
+    "PR-RESEARCH-00",
+    "SEARCH-CHANNEL-QUEUE-00",
+    "CLAIM-LINT-00"
+  ],
+  "task": "CLAIM-LINT-00",
+  "forbidden_claim_classes": [
+    "诊断",
+    "确诊",
+    "治疗",
+    "治愈",
+    "真实智商",
+    "权威认证",
+    "精准推荐",
+    "最适合职业",
+    "岗位胜任力",
+    "招聘适配",
+    "职业成功率",
+    "AI 职业规划",
+    "心理疾病判断"
+  ],
+  "allowed_safer_wording": [
+    "自评筛查",
+    "非诊断",
+    "结果仅供参考",
+    "在线估测",
+    "置信区间",
+    "职业方向参考",
+    "探索建议",
+    "兴趣信号",
+    "工作方式倾向",
+    "snapshot-based support"
+  ],
+  "future_linter_classes": [
+    "blocked_claim",
+    "needs_review",
+    "allowed_safer_wording",
+    "neutral"
+  ],
+  "claim_boundaries": {
+    "riasec_full_recommendation_claims_allowed": false,
+    "big_five_full_recommendation_claims_allowed": false,
+    "career_decision_full_recommendation_claims_allowed": false,
+    "medical_diagnosis_claims_allowed": false,
+    "hiring_fit_claims_allowed": false,
+    "exact_iq_claims_allowed": false,
+    "guaranteed_career_outcome_claims_allowed": false
+  },
+  "blocked_page_eligibility_when_claim_unsafe": [
+    "sitemap",
+    "llms",
+    "search_channel_queue",
+    "baidu_push",
+    "indexnow",
+    "so360",
+    "sogou",
+    "shenma"
+  ],
+  "runtime_linter_activated_in_this_pr": false,
+  "frontend_runtime_copy_changed_in_this_pr": false,
+  "cms_content_mutated_in_this_pr": false,
+  "auto_publish_enabled_in_this_pr": false,
+  "sitemap_changed_in_this_pr": false,
+  "llms_changed_in_this_pr": false,
+  "url_submission_performed": false,
+  "production_write_execution": false,
+  "scheduler_enabled_in_this_pr": false,
+  "external_api_live_activation": false,
+  "env_edit_in_this_pr": false,
+  "metabase_deployed_in_this_pr": false,
+  "next_task": "CONTENT-OPS-01"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelChineseClaimBoundaryLinterTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelChineseClaimBoundaryLinterTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelChineseClaimBoundaryLinterTest extends TestCase
+{
+    #[Test]
+    public function artifact_locks_forbidden_chinese_claim_classes(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('chinese-claim-boundary-linter.v1', $artifact['version'] ?? null);
+        $this->assertContains('PR-RESEARCH-00', $artifact['source_documents'] ?? []);
+
+        foreach ([
+            '诊断',
+            '确诊',
+            '治疗',
+            '治愈',
+            '真实智商',
+            '权威认证',
+            '精准推荐',
+            '最适合职业',
+            '岗位胜任力',
+            '招聘适配',
+            '职业成功率',
+            'AI 职业规划',
+            '心理疾病判断',
+        ] as $claim) {
+            $this->assertContains($claim, $artifact['forbidden_claim_classes'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function artifact_lists_allowed_safer_wording_without_guarantees(): void
+    {
+        $wording = $this->artifact()['allowed_safer_wording'] ?? [];
+
+        foreach ([
+            '自评筛查',
+            '非诊断',
+            '结果仅供参考',
+            '在线估测',
+            '置信区间',
+            '职业方向参考',
+            '探索建议',
+            '兴趣信号',
+            '工作方式倾向',
+            'snapshot-based support',
+        ] as $phrase) {
+            $this->assertContains($phrase, $wording);
+        }
+    }
+
+    #[Test]
+    public function claim_boundaries_do_not_expand_career_or_medical_claims(): void
+    {
+        $boundaries = $this->artifact()['claim_boundaries'] ?? [];
+
+        foreach ([
+            'riasec_full_recommendation_claims_allowed',
+            'big_five_full_recommendation_claims_allowed',
+            'career_decision_full_recommendation_claims_allowed',
+            'medical_diagnosis_claims_allowed',
+            'hiring_fit_claims_allowed',
+            'exact_iq_claims_allowed',
+            'guaranteed_career_outcome_claims_allowed',
+        ] as $flag) {
+            $this->assertFalse((bool) ($boundaries[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function unsafe_claims_block_search_and_publish_surfaces(): void
+    {
+        $blocked = $this->artifact()['blocked_page_eligibility_when_claim_unsafe'] ?? [];
+
+        foreach ([
+            'sitemap',
+            'llms',
+            'search_channel_queue',
+            'baidu_push',
+            'indexnow',
+            'so360',
+            'sogou',
+            'shenma',
+        ] as $surface) {
+            $this->assertContains($surface, $blocked);
+        }
+    }
+
+    #[Test]
+    public function no_runtime_activation_or_content_mutation_happens_in_this_pr(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'runtime_linter_activated_in_this_pr',
+            'frontend_runtime_copy_changed_in_this_pr',
+            'cms_content_mutated_in_this_pr',
+            'auto_publish_enabled_in_this_pr',
+            'sitemap_changed_in_this_pr',
+            'llms_changed_in_this_pr',
+            'url_submission_performed',
+            'production_write_execution',
+            'scheduler_enabled_in_this_pr',
+            'external_api_live_activation',
+            'env_edit_in_this_pr',
+            'metabase_deployed_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_boundaries_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/chinese-claim-boundary-linter.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/chinese-claim-boundary-linter.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'docs/spec/test only',
+            'does not activate runtime linting',
+            '精准推荐',
+            '最适合职业',
+            '职业成功率',
+            '结果仅供参考',
+            '职业方向参考',
+            'riasec and big five career semantics remain shallow/partial assets',
+            'must not auto-publish',
+            'next task: content-ops-01',
+            '"next_task": "content-ops-01"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/chinese-claim-boundary-linter.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T02:17:23Z",
+  "updated_at": "2026-05-19T02:27:35Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11357,8 +11357,8 @@
     },
     "CRAWLER-LOG-00": {
       "repo": "fap-api",
-      "status": "pr_opened_github_checks_pending",
-      "state": "open",
+      "status": "merged",
+      "state": "merged",
       "title": "Crawler log readiness contract",
       "depends_on": [
         "SEO-DASH-PROD-04B"
@@ -11431,8 +11431,7 @@
           "command": "git diff --check"
         },
         "github": {
-          "status": "pending",
-          "pr_url": "https://github.com/fermatmind/fap-api/pull/1472"
+          "status": "passed"
         }
       },
       "sidecar_issues": [],
@@ -11456,17 +11455,28 @@
           "at": "2026-05-19T02:17:23Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1472 for CRAWLER-LOG-00. GitHub checks pending. No production operation performed."
+        },
+        {
+          "at": "2026-05-19T02:26:15Z",
+          "status": "merged",
+          "summary": "Reconciled CRAWLER-LOG-00 as merged via PR #1472. Remote branch absent and local main synced."
         }
       ],
       "branch": "codex/crawler-log-00-readiness-contract",
       "base": "main",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1472",
-      "commit_sha": "56a56f73"
+      "commit_sha": "56a56f73",
+      "final_status": "completed",
+      "merge_commit_sha": "4f619c18",
+      "merge_observed": true,
+      "merged_at": "2026-05-19T02:26:15Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "CLAIM-LINT-00": {
       "repo": "fap-api",
-      "status": "planned",
-      "state": "planned",
+      "status": "local_validation_passed",
+      "state": "local_validation_passed",
       "title": "Chinese claim boundary linter spec and tests",
       "depends_on": [
         "PR-RESEARCH-00"
@@ -11489,6 +11499,54 @@
         "registration": {
           "status": "planned",
           "evidence": "Registered by SEO-TRAIN-POST03D-PR-TRAIN-01 metadata reconciliation PR; no runtime code or production operation executed."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR-RESEARCH-00 merged as PR #1470. Main contains required dependency."
+        },
+        "scope": {
+          "status": "in_progress",
+          "evidence": "Implementing only Chinese claim boundary linter contract doc, generated artifact, focused SeoIntel test, and PR train state metadata. No runtime activation, service code, frontend copy, publish behavior, sitemap/llms change, or production operation executed."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Chinese claim boundary linter contract doc, generated artifact, focused SeoIntel test, and docs/codex PR train state metadata. No runtime activation, service code, frontend copy, publish behavior, sitemap/llms change, scheduler, collector write, external API, or production operation was performed."
+        },
+        "chinese_claim_boundary_linter_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelChineseClaimBoundaryLinter",
+          "evidence": "6 tests passed with 73 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "evidence": "142 tests passed with 2558 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "Pint completed successfully; 3378 files checked."
+        },
+        "json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/chinese-claim-boundary-linter.v1.json >/dev/null"
+        },
+        "state_json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        },
+        "yaml_validation": {
+          "status": "pass",
+          "command": "python3 - <<'PY' ... yaml.safe_load(docs/codex/pr-train.yaml)"
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
         }
       },
       "sidecar_issues": [],
@@ -11497,8 +11555,20 @@
           "at": "2026-05-19T01:02:33Z",
           "status": "planned",
           "summary": "Registered planned non-production PR train task CLAIM-LINT-00: Chinese claim boundary linter spec and tests. Safety flags disable writes, scheduler, Metabase deployment, external APIs, crawler log reads, env edits, research publishing, and pSEO generation."
+        },
+        {
+          "at": "2026-05-19T02:26:15Z",
+          "status": "in_progress",
+          "summary": "Started CLAIM-LINT-00 on scoped branch. Scope remains docs/spec/test only; no runtime activation, frontend copy change, publish behavior, sitemap/llms change, scheduler, external API, collector write, or production operation."
+        },
+        {
+          "at": "2026-05-19T02:27:35Z",
+          "status": "local_validation_passed",
+          "summary": "Added Chinese claim boundary linter contract, generated artifact, and focused SeoIntel test. Focused test, SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and git diff check passed. No runtime activation, content mutation, sitemap/llms change, or production operation performed."
         }
-      ]
+      ],
+      "branch": "codex/claim-lint-00-chinese-claim-boundary",
+      "base": "main"
     },
     "CONTENT-OPS-01": {
       "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T02:27:35Z",
+  "updated_at": "2026-05-19T02:28:20Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11475,8 +11475,8 @@
     },
     "CLAIM-LINT-00": {
       "repo": "fap-api",
-      "status": "local_validation_passed",
-      "state": "local_validation_passed",
+      "status": "pr_opened_github_checks_pending",
+      "state": "open",
       "title": "Chinese claim boundary linter spec and tests",
       "depends_on": [
         "PR-RESEARCH-00"
@@ -11547,6 +11547,10 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github": {
+          "status": "pending",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1473"
         }
       },
       "sidecar_issues": [],
@@ -11565,10 +11569,17 @@
           "at": "2026-05-19T02:27:35Z",
           "status": "local_validation_passed",
           "summary": "Added Chinese claim boundary linter contract, generated artifact, and focused SeoIntel test. Focused test, SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and git diff check passed. No runtime activation, content mutation, sitemap/llms change, or production operation performed."
+        },
+        {
+          "at": "2026-05-19T02:28:20Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1473 for CLAIM-LINT-00. GitHub checks pending. No production operation performed."
         }
       ],
       "branch": "codex/claim-lint-00-chinese-claim-boundary",
-      "base": "main"
+      "base": "main",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1473",
+      "commit_sha": "7e008bae"
     },
     "CONTENT-OPS-01": {
       "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Added CLAIM-LINT-00 Chinese claim boundary linter contract.
- Added generated artifact locking forbidden Chinese claim classes, safer wording, blocked search/publish surfaces, and no runtime activation.
- Added focused SeoIntel tests and updated PR train state, including reconciliation of merged CRAWLER-LOG-00.

## Why
This prevents Research, SEO, and content operations from expanding RIASEC, Big Five, Career Decision, or self-assessment copy into medical, hiring, exact-IQ, guaranteed-outcome, or full career recommendation claims.

## Validation
- `cd backend && php artisan test --filter=SeoIntelChineseClaimBoundaryLinter`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/chinese-claim-boundary-linter.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(docs/codex/pr-train.yaml)`
- `git diff --check`
- `git diff --cached --check`

## Intentionally not done
- No runtime linter activation or service code.
- No frontend runtime copy changes.
- No CMS content mutation, publishing behavior, sitemap, or llms changes.
- No URL submissions, scheduler, collector writes, external API calls, deploys, migrations, env edits, or production operations.
