### PR TITLE
docs(cms): add article operating workflow SOP

### DIFF
--- a/backend/docs/cms/article-operating-workflow-sop.md
+++ b/backend/docs/cms/article-operating-workflow-sop.md
@@ -1,0 +1,89 @@
+# CMS Article Operating Workflow SOP
+
+## Purpose
+
+CONTENT-OPS-01 defines the safe operating workflow for CMS-managed articles.
+This PR is a documentation, generated-artifact, and test PR only. It does not publish content, mutate CMS runtime state, change frontend runtime content, change sitemap or `llms.txt`, submit URLs, run collector writes, enable scheduler, deploy services, or edit environment files.
+
+## Workflow Stages
+
+### 1. Editorial Package
+
+The editor prepares an article package with:
+
+- title
+- slug proposal
+- locale
+- summary
+- body outline
+- SEO intent
+- claim boundary notes
+- internal link targets
+- media requirements
+- publication owner
+
+The package must not be treated as published content.
+
+### 2. CMS Draft
+
+The article is entered into CMS as draft only.
+
+Draft rules:
+
+- draft must not enter sitemap
+- draft must not enter `llms.txt`
+- draft must not enter Baidu push
+- draft must not enter IndexNow
+- draft must not enter 360, Sogou, or Shenma submission paths
+- draft must not be treated as URL Truth indexable
+
+### 3. Gate Checks
+
+Before publish, run gate checks for:
+
+- required CMS fields
+- canonical URL readiness
+- no private-flow links
+- claim boundary safety
+- internal link validity
+- media ownership and alt text
+- no raw PII or raw operational identifiers
+- no unsupported Research or pSEO page type assumptions
+- Search Channel Queue eligibility status
+
+### 4. Controlled Publish
+
+Publishing requires explicit owner approval in CMS.
+Publishing must not automatically trigger search submissions. Search Channel Queue eligibility is evaluated separately after URL Truth and claim checks.
+
+### 5. Post-publish Observation
+
+After controlled publish, SEO Intelligence may observe sanitized URL Truth and issue queue state.
+Observation does not mutate CMS content and does not auto-publish follow-up changes.
+
+## Claim Boundary
+
+Article copy must follow CLAIM-LINT-00 boundaries. It must not claim diagnosis, treatment, cure, exact IQ, guaranteed career outcomes, hiring fit, job competency, full career recommendation, or AI career planning authority.
+
+Allowed safer wording includes non-diagnostic, for-reference-only, online estimate, confidence interval, career direction reference, exploration suggestion, interest signal, and work style tendency framing.
+
+## Internal Link Checks
+
+Internal links must point to canonical, backend-authoritative, public pages.
+Links to drafts, private flows, checkout, payment, user reports, share flows, or noindex pages must be removed before publish.
+
+## Stop Conditions
+
+Stop the workflow if:
+
+- a draft enters sitemap, `llms.txt`, Baidu, IndexNow, 360, Sogou, or Shenma
+- a claim-unsafe article is approved for search submission
+- frontend local content becomes article authority
+- CMS runtime state is mutated by this PR
+- article publication is performed by this PR
+- raw PII or raw operational identifiers appear in content or metadata
+- scheduler, collector writes, external APIs, or URL submissions are triggered
+
+## Next Task
+
+Next task: none. This completes the registered 7-PR non-production post-03D train.

--- a/backend/docs/seo/generated/article-operating-workflow-sop.v1.json
+++ b/backend/docs/seo/generated/article-operating-workflow-sop.v1.json
@@ -1,0 +1,93 @@
+{
+  "version": "article-operating-workflow-sop.v1",
+  "source_documents": [
+    "SEARCH-CHANNEL-QUEUE-00",
+    "CLAIM-LINT-00",
+    "CONTENT-OPS-01"
+  ],
+  "task": "CONTENT-OPS-01",
+  "workflow_stages": [
+    "editorial_package",
+    "cms_draft",
+    "gate_checks",
+    "controlled_publish",
+    "post_publish_observation"
+  ],
+  "editorial_package_fields": [
+    "title",
+    "slug_proposal",
+    "locale",
+    "summary",
+    "body_outline",
+    "seo_intent",
+    "claim_boundary_notes",
+    "internal_link_targets",
+    "media_requirements",
+    "publication_owner"
+  ],
+  "draft_exclusions": [
+    "sitemap",
+    "llms",
+    "baidu_push",
+    "indexnow",
+    "so360",
+    "sogou",
+    "shenma",
+    "url_truth_indexable"
+  ],
+  "gate_checks": [
+    "required_cms_fields",
+    "canonical_url_readiness",
+    "no_private_flow_links",
+    "claim_boundary_safety",
+    "internal_link_validity",
+    "media_ownership_and_alt_text",
+    "no_raw_pii_or_raw_operational_identifiers",
+    "no_unsupported_research_or_pseo_page_type_assumptions",
+    "search_channel_queue_eligibility_status"
+  ],
+  "forbidden_claim_classes": [
+    "diagnosis",
+    "treatment",
+    "cure",
+    "exact_iq",
+    "guaranteed_career_outcome",
+    "hiring_fit",
+    "job_competency",
+    "full_career_recommendation",
+    "ai_career_planning_authority"
+  ],
+  "allowed_safer_wording": [
+    "non_diagnostic",
+    "for_reference_only",
+    "online_estimate",
+    "confidence_interval",
+    "career_direction_reference",
+    "exploration_suggestion",
+    "interest_signal",
+    "work_style_tendency"
+  ],
+  "forbidden_internal_link_targets": [
+    "draft",
+    "private_flow",
+    "checkout",
+    "payment",
+    "user_report",
+    "share_flow",
+    "noindex"
+  ],
+  "runtime_content_changed_in_this_pr": false,
+  "cms_runtime_mutation_in_this_pr": false,
+  "article_published_in_this_pr": false,
+  "sitemap_changed_in_this_pr": false,
+  "llms_changed_in_this_pr": false,
+  "url_submission_performed": false,
+  "production_write_execution": false,
+  "scheduler_enabled_in_this_pr": false,
+  "external_api_live_activation": false,
+  "collector_write_executed_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "metabase_deployed_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "next_task": null
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelArticleOperatingWorkflowSopTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelArticleOperatingWorkflowSopTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelArticleOperatingWorkflowSopTest extends TestCase
+{
+    #[Test]
+    public function artifact_defines_required_article_workflow_stages(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('article-operating-workflow-sop.v1', $artifact['version'] ?? null);
+        $this->assertContains('CLAIM-LINT-00', $artifact['source_documents'] ?? []);
+
+        $this->assertSame([
+            'editorial_package',
+            'cms_draft',
+            'gate_checks',
+            'controlled_publish',
+            'post_publish_observation',
+        ], $artifact['workflow_stages'] ?? []);
+    }
+
+    #[Test]
+    public function drafts_are_excluded_from_search_and_url_truth_indexability(): void
+    {
+        $exclusions = $this->artifact()['draft_exclusions'] ?? [];
+
+        foreach ([
+            'sitemap',
+            'llms',
+            'baidu_push',
+            'indexnow',
+            'so360',
+            'sogou',
+            'shenma',
+            'url_truth_indexable',
+        ] as $target) {
+            $this->assertContains($target, $exclusions);
+        }
+    }
+
+    #[Test]
+    public function gate_checks_cover_claims_links_media_pii_and_queue_eligibility(): void
+    {
+        $checks = $this->artifact()['gate_checks'] ?? [];
+
+        foreach ([
+            'required_cms_fields',
+            'canonical_url_readiness',
+            'no_private_flow_links',
+            'claim_boundary_safety',
+            'internal_link_validity',
+            'media_ownership_and_alt_text',
+            'no_raw_pii_or_raw_operational_identifiers',
+            'no_unsupported_research_or_pseo_page_type_assumptions',
+            'search_channel_queue_eligibility_status',
+        ] as $check) {
+            $this->assertContains($check, $checks);
+        }
+    }
+
+    #[Test]
+    public function forbidden_claims_and_internal_link_targets_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'diagnosis',
+            'treatment',
+            'cure',
+            'exact_iq',
+            'guaranteed_career_outcome',
+            'hiring_fit',
+            'job_competency',
+            'full_career_recommendation',
+            'ai_career_planning_authority',
+        ] as $claim) {
+            $this->assertContains($claim, $artifact['forbidden_claim_classes'] ?? []);
+        }
+
+        foreach ([
+            'draft',
+            'private_flow',
+            'checkout',
+            'payment',
+            'user_report',
+            'share_flow',
+            'noindex',
+        ] as $target) {
+            $this->assertContains($target, $artifact['forbidden_internal_link_targets'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function no_runtime_content_publish_or_production_activation_happens(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'runtime_content_changed_in_this_pr',
+            'cms_runtime_mutation_in_this_pr',
+            'article_published_in_this_pr',
+            'sitemap_changed_in_this_pr',
+            'llms_changed_in_this_pr',
+            'url_submission_performed',
+            'production_write_execution',
+            'scheduler_enabled_in_this_pr',
+            'external_api_live_activation',
+            'collector_write_executed_in_this_pr',
+            'env_edit_in_this_pr',
+            'metabase_deployed_in_this_pr',
+            'pseo_generation_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_publish_no_submission_and_train_completion(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/cms/article-operating-workflow-sop.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/article-operating-workflow-sop.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'does not publish content',
+            'draft must not enter sitemap',
+            'draft must not enter `llms.txt`',
+            'draft must not enter baidu push',
+            'controlled publish',
+            'publishing must not automatically trigger search submissions',
+            'no private-flow links',
+            'next task: none',
+            '"next_task": null',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/article-operating-workflow-sop.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T02:39:46Z",
+  "updated_at": "2026-05-19T02:40:46Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11593,8 +11593,8 @@
     },
     "CONTENT-OPS-01": {
       "repo": "fap-api",
-      "status": "local_validation_passed",
-      "state": "local_validation_passed",
+      "status": "pr_opened_github_checks_pending",
+      "state": "open",
       "title": "CMS article operating workflow SOP",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-00"
@@ -11665,6 +11665,10 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github": {
+          "status": "pending",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1474"
         }
       },
       "sidecar_issues": [],
@@ -11683,10 +11687,17 @@
           "at": "2026-05-19T02:39:46Z",
           "status": "local_validation_passed",
           "summary": "Added CMS article operating workflow SOP, generated artifact, and focused SeoIntel test. Focused test, SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and git diff check passed. No runtime content change, publish action, URL submission, CMS mutation, or production operation performed."
+        },
+        {
+          "at": "2026-05-19T02:40:46Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1474 for CONTENT-OPS-01. GitHub checks pending. No production operation performed."
         }
       ],
       "branch": "codex/content-ops-01-cms-article-operating-workflow",
-      "base": "main"
+      "base": "main",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1474",
+      "commit_sha": "3990f57e"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T02:28:20Z",
+  "updated_at": "2026-05-19T02:39:46Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11475,8 +11475,8 @@
     },
     "CLAIM-LINT-00": {
       "repo": "fap-api",
-      "status": "pr_opened_github_checks_pending",
-      "state": "open",
+      "status": "merged",
+      "state": "merged",
       "title": "Chinese claim boundary linter spec and tests",
       "depends_on": [
         "PR-RESEARCH-00"
@@ -11549,8 +11549,7 @@
           "command": "git diff --check"
         },
         "github": {
-          "status": "pending",
-          "pr_url": "https://github.com/fermatmind/fap-api/pull/1473"
+          "status": "passed"
         }
       },
       "sidecar_issues": [],
@@ -11574,17 +11573,28 @@
           "at": "2026-05-19T02:28:20Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1473 for CLAIM-LINT-00. GitHub checks pending. No production operation performed."
+        },
+        {
+          "at": "2026-05-19T02:37:09Z",
+          "status": "merged",
+          "summary": "Reconciled CLAIM-LINT-00 as merged via PR #1473. Remote branch absent and local main synced."
         }
       ],
       "branch": "codex/claim-lint-00-chinese-claim-boundary",
       "base": "main",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1473",
-      "commit_sha": "7e008bae"
+      "commit_sha": "7e008bae",
+      "final_status": "completed",
+      "merge_commit_sha": "fb831889",
+      "merge_observed": true,
+      "merged_at": "2026-05-19T02:37:09Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "CONTENT-OPS-01": {
       "repo": "fap-api",
-      "status": "planned",
-      "state": "planned",
+      "status": "local_validation_passed",
+      "state": "local_validation_passed",
       "title": "CMS article operating workflow SOP",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-00"
@@ -11607,6 +11617,54 @@
         "registration": {
           "status": "planned",
           "evidence": "Registered by SEO-TRAIN-POST03D-PR-TRAIN-01 metadata reconciliation PR; no runtime code or production operation executed."
+        },
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEARCH-CHANNEL-QUEUE-00 merged as PR #1471; CLAIM-LINT-00 also merged as PR #1473."
+        },
+        "scope": {
+          "status": "in_progress",
+          "evidence": "Implementing only CMS article operating workflow SOP doc, generated artifact, focused SeoIntel test, and PR train state metadata. No runtime content changes, publish action, sitemap/llms change, search submission, CMS runtime mutation, scheduler, env edit, deploy, collector write, or production operation executed."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to CMS article operating workflow SOP doc, generated artifact, focused SeoIntel test, and docs/codex PR train state metadata. No runtime content changes, publish action, sitemap/llms change, URL submission, CMS runtime mutation, scheduler, env edit, deploy, collector write, or production operation was performed."
+        },
+        "article_operating_workflow_sop_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelArticleOperatingWorkflowSop",
+          "evidence": "6 tests passed with 68 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "evidence": "148 tests passed with 2626 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 198 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "Pint completed successfully; 3379 files checked."
+        },
+        "json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/article-operating-workflow-sop.v1.json >/dev/null"
+        },
+        "state_json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        },
+        "yaml_validation": {
+          "status": "pass",
+          "command": "python3 - <<'PY' ... yaml.safe_load(docs/codex/pr-train.yaml)"
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
         }
       },
       "sidecar_issues": [],
@@ -11615,8 +11673,20 @@
           "at": "2026-05-19T01:02:33Z",
           "status": "planned",
           "summary": "Registered planned non-production PR train task CONTENT-OPS-01: CMS article operating workflow SOP. Safety flags disable writes, scheduler, Metabase deployment, external APIs, crawler log reads, env edits, research publishing, and pSEO generation."
+        },
+        {
+          "at": "2026-05-19T02:37:09Z",
+          "status": "in_progress",
+          "summary": "Started CONTENT-OPS-01 on scoped branch. Scope excludes runtime content changes, publishing, sitemap/llms behavior, URL submissions, CMS runtime mutation, scheduler, env edits, deploys, collector writes, and production operations."
+        },
+        {
+          "at": "2026-05-19T02:39:46Z",
+          "status": "local_validation_passed",
+          "summary": "Added CMS article operating workflow SOP, generated artifact, and focused SeoIntel test. Focused test, SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and git diff check passed. No runtime content change, publish action, URL submission, CMS mutation, or production operation performed."
         }
-      ]
+      ],
+      "branch": "codex/content-ops-01-cms-article-operating-workflow",
+      "base": "main"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {


### PR DESCRIPTION
## What changed
- Added CONTENT-OPS-01 CMS article operating workflow SOP.
- Added generated artifact covering Editorial Package, CMS Draft, Gate Checks, Controlled Publish, Search Channel Queue eligibility, claim boundaries, and draft exclusions.
- Added focused SeoIntel tests and updated PR train state, including reconciliation of merged CLAIM-LINT-00.

## Why
This defines article operating workflow boundaries before content operations proceed, keeping drafts out of sitemap/llms/search channels and keeping publish/search submission separate from this PR.

## Validation
- `cd backend && php artisan test --filter=SeoIntelArticleOperatingWorkflowSop`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/article-operating-workflow-sop.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(docs/codex/pr-train.yaml)`
- `git diff --check`
- `git diff --cached --check`

## Intentionally not done
- No runtime content changes.
- No article publishing or CMS runtime mutation.
- No sitemap or llms behavior changes.
- No URL submissions, scheduler, collector writes, external API calls, deploys, migrations, env edits, RDS, DNS, CDN, or whitelist changes.
