### PR TITLE
chore(ci): enable code scanning for fap-api

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "25 3 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (php)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: php
+          queries: security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: Code Scanning
 
 on:
   workflow_dispatch:
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze:
-    name: analyze (php)
+  semgrep:
+    name: semgrep sarif
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -28,11 +28,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          languages: php
-          queries: security-extended,security-and-quality
+          python-version: "3.12"
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+      - name: Install Semgrep
+        run: python -m pip install --upgrade semgrep
+
+      - name: Run Semgrep SARIF scan
+        run: |
+          semgrep scan \
+            --config p/php \
+            --config p/secrets \
+            --sarif \
+            --output semgrep.sarif \
+            --metrics=off || true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: semgrep.sarif

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -11897,7 +11897,15 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+      {
+        "title": "CodeQL PHP language unsupported by GitHub CodeQL action",
+        "introduced_by_current_pr": false,
+        "scope_impact": "The code scanning implementation uses Semgrep SARIF upload instead of CodeQL language analysis for PHP.",
+        "blocks_merge": false,
+        "evidence": "GitHub Actions log: Did not recognize the following languages: php."
+      }
+    ],
     "history": [
       {
         "at": "2026-05-19T03:37:17.996Z",
@@ -11918,6 +11926,11 @@
         "at": "2026-05-19T03:39:20.836Z",
         "status": "pr_open_github_checks_pending",
         "summary": "Opened PR #1476 for fap-api CodeQL code scanning enablement. GitHub checks pending."
+      },
+      {
+        "at": "2026-05-19T03:41:59.660Z",
+        "status": "github_checks_failed_scoped_fix",
+        "summary": "CodeQL does not support PHP in this runner. Replaced the workflow with Semgrep SARIF upload to produce GitHub code scanning analysis for fap-api without runtime changes."
       }
     ],
     "next_pr": "OPS-CI-CODESCAN-WEB-01"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -11873,5 +11873,48 @@
     },
     "failure_reason": null,
     "updated_at": "2026-05-17T10:36:34.999719Z"
+  },
+  "OPS-CI-CODESCAN-API-01": {
+    "status": "local_checks_passed",
+    "repo": "fap-api",
+    "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+    "branch": "codex/ops-ci-codescan-api-01",
+    "base": "main",
+    "title": "chore(ci): enable code scanning for fap-api",
+    "depends_on": [],
+    "commit_sha": "962be45f81044d1eec60088ef34235f8e020032e",
+    "pr_url": null,
+    "checks": {
+      "local": {
+        "yaml_validation": "passed",
+        "json_validation": "passed",
+        "git_diff_check": "passed",
+        "scope_validation": "passed"
+      },
+      "github": {}
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "history": [
+      {
+        "at": "2026-05-19T03:37:17.996Z",
+        "status": "in_progress",
+        "summary": "Started CodeQL code scanning enablement for fap-api. Scope is limited to CI workflow and PR train metadata; no runtime behavior changes."
+      },
+      {
+        "at": "2026-05-19T03:38:09.440Z",
+        "status": "local_checks_passed",
+        "summary": "Added fap-api CodeQL workflow and train metadata. YAML/JSON validation, git diff checks, and scope validation passed."
+      },
+      {
+        "at": "2026-05-19T03:38:21.593Z",
+        "status": "commit_created",
+        "summary": "Created local commit 962be45f81044d1eec60088ef34235f8e020032e."
+      }
+    ],
+    "next_pr": "OPS-CI-CODESCAN-WEB-01"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -11875,7 +11875,7 @@
     "updated_at": "2026-05-17T10:36:34.999719Z"
   },
   "OPS-CI-CODESCAN-API-01": {
-    "status": "local_checks_passed",
+    "status": "pr_open_github_checks_pending",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/ops-ci-codescan-api-01",
@@ -11883,7 +11883,7 @@
     "title": "chore(ci): enable code scanning for fap-api",
     "depends_on": [],
     "commit_sha": "962be45f81044d1eec60088ef34235f8e020032e",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1476",
     "checks": {
       "local": {
         "yaml_validation": "passed",
@@ -11913,6 +11913,11 @@
         "at": "2026-05-19T03:38:21.593Z",
         "status": "commit_created",
         "summary": "Created local commit 962be45f81044d1eec60088ef34235f8e020032e."
+      },
+      {
+        "at": "2026-05-19T03:39:20.836Z",
+        "status": "pr_open_github_checks_pending",
+        "summary": "Opened PR #1476 for fap-api CodeQL code scanning enablement. GitHub checks pending."
       }
     ],
     "next_pr": "OPS-CI-CODESCAN-WEB-01"

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5877,12 +5877,12 @@ prs:
     branch: codex/ops-ci-codescan-api-01
     base: main
     title: "chore(ci): enable code scanning for fap-api"
-    name: "Enable CodeQL code scanning for fap-api"
+    name: "Enable GitHub code scanning for fap-api"
     train_scope: ops_ci_codescan_api
     risk_level: L2
     type: ci/governance PR
     scope:
-      - Add GitHub CodeQL code scanning workflow for fap-api.
+      - Add GitHub code scanning workflow for fap-api using SARIF upload.
       - Produce analyzable GitHub code scanning results on pull requests and main.
       - Keep application runtime behavior unchanged.
     allowed_paths:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5870,3 +5870,41 @@ prs:
     human_review_required: true
     production_approval_required: false
     next_task: null
+
+  - id: OPS-CI-CODESCAN-API-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/ops-ci-codescan-api-01
+    base: main
+    title: "chore(ci): enable code scanning for fap-api"
+    name: "Enable CodeQL code scanning for fap-api"
+    train_scope: ops_ci_codescan_api
+    risk_level: L2
+    type: ci/governance PR
+    scope:
+      - Add GitHub CodeQL code scanning workflow for fap-api.
+      - Produce analyzable GitHub code scanning results on pull requests and main.
+      - Keep application runtime behavior unchanged.
+    allowed_paths:
+      - .github/workflows/codeql.yml
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change backend runtime behavior, routes, migrations, deploy scripts, or tests.
+      - Deploy production, unlock deploys, kill processes, or mutate servers.
+    validation:
+      - ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'
+      - ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: OPS-CI-CODESCAN-WEB-01


### PR DESCRIPTION
## What changed
- Added a GitHub code scanning workflow for fap-api using Semgrep SARIF upload.
- Registered `OPS-CI-CODESCAN-API-01` in the backend PR train manifest and state ledger.

## Why
- Deploy readiness currently cannot verify GitHub code scanning because the repository does not produce code scanning analysis.
- PHP is not supported by CodeQL in this runner, so this PR uses SARIF upload to create GitHub code scanning analysis for fap-api.

## Validation commands
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'`\n- `ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'`\n- `git diff --check`\n- `git diff --cached --check`\n\n## Intentionally deferred\n- No branch protection settings are changed in this PR.\n- No runtime code, deploy scripts, or production settings are changed.\n\n## Sidecar issues\n- CodeQL PHP language analysis is not available in the GitHub CodeQL action. The current PR uses Semgrep SARIF upload instead.\n- Existing deploy-readiness security gate used manual waiver before this PR because code scanning analysis did not exist. This PR enables future analysis generation but does not retroactively create historical analysis.\n\n## Repository rule impact\n- CI/governance only. No CMS authority, SEO/GEO enumeration, runtime behavior, or deploy readiness command behavior is changed.