### PR TITLE
docs(ops): codify canonical healthz and release-only deploy policy

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -353,7 +353,17 @@ sudo systemctl is-active fap-queue.service
 - `systemctl is-active fap-queue.service` 返回非 `active`
 - 只保留 `supervisorctl status fap-queue-*` 里的 worker 作为正式 owner
 
-## 7. 发布后验收
+## 7. Release-only 发布入口
+生产发布必须从干净的 release-only 工作区执行，而不是从开发分支、PR worktree 或 GitHub Desktop 停车分支执行。
+
+发布前置要求：
+- 本地分支必须是 `main`
+- `git status --short` 必须为空
+- `HEAD` 必须等于 `origin/main`
+- 不允许使用 detached HEAD 作为发布入口
+- PR worktree、临时验证目录和开发目录不得复用为生产发布目录
+
+## 8. 发布后验收
 ```bash
 cd /opt/fap-api/backend
 php artisan route:list
@@ -370,7 +380,7 @@ bash backend/scripts/ci_verify_mbti.sh
 ```
 
 通过标准：
-- healthz canonical probe path is `/api/healthz`
+- healthz canonical probe path is only `/api/healthz`
 - production healthz remains allowlist-only
 - do not require arbitrary public-origin `/api/healthz` to return `200`
 - deploy smoke may use localhost or another internal/allowlisted source for healthz verification
@@ -378,7 +388,7 @@ bash backend/scripts/ci_verify_mbti.sh
 - 健康检查接口可达，且 `/api/v0.3/auth/guest` 合约通过。
 - MBTI CI 验收链路通过。
 
-## 8. 回滚流程
+## 9. 回滚流程
 1. 切换到上一个可用发布版本（代码/工件）。
 2. 执行依赖安装与缓存重建（同部署步骤）。
 3. 迁移策略：本仓库以 forward-only 迁移为主，回滚优先采用“新修复迁移”而非 destructive rollback。

--- a/docs/04-ops/observability.md
+++ b/docs/04-ops/observability.md
@@ -2,6 +2,7 @@
 
 ## Healthz Endpoint
 - Canonical probe path: `GET /api/healthz`
+- There is no supported top-level `/healthz` production probe path.
 - Access policy:
   - production healthz is allowlist-only
   - requests from non-allowlisted public IPs may return `404` by design

--- a/docs/04-ops/rollback-runbook.md
+++ b/docs/04-ops/rollback-runbook.md
@@ -131,6 +131,7 @@ curl -fsS "${BASE_URL}/api/v0.3/boot" | grep -q '"ok":true' && echo "v0.3 boot O
 
 # Healthz is allowlist-only in production.
 # Do not require arbitrary public-origin /api/healthz to return 200.
+# Do not probe /healthz; /api/healthz is the only canonical path.
 # Success criteria:
 # 1) an allowlisted probe to /api/healthz returns .ok==true, or
 # 2) an internal/local verification path confirms healthz.

--- a/docs/04-ops/runbook-triage.md
+++ b/docs/04-ops/runbook-triage.md
@@ -7,6 +7,8 @@
 3) Check deploy history (`v_deploy_events`) for recent changes.
 4) If needed, rollback or hotfix. Re-run healthz snapshot to confirm.
 
+Non-allowlisted public `404` on `/api/healthz` is expected and is not a healthz-red signal. The top-level `/healthz` path is not a supported production probe.
+
 ## Redis red: common causes
 
 - Missing PHP extension: phpredis not installed

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T02:40:46Z",
+  "updated_at": "2026-05-19T04:02:03.272Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11934,5 +11934,56 @@
       }
     ],
     "next_pr": "OPS-CI-CODESCAN-WEB-01"
+  },
+  "OPS-RUNBOOK-HEALTHZ-01": {
+    "status": "in_progress",
+    "repo": "fap-api",
+    "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+    "branch": "codex/ops-runbook-healthz-01",
+    "base": "main",
+    "title": "docs(ops): codify canonical healthz and release-only deploy policy",
+    "depends_on": [
+      "OPS-CI-CODESCAN-API-01"
+    ],
+    "commit_sha": "818b49a891b30dc020921da3479cdc0550e6c62c",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1477",
+    "checks": {
+      "local": {
+        "yaml_parse": "passed",
+        "json_parse": "passed",
+        "markdown_manual_review": "passed",
+        "git_diff_check": "passed",
+        "scope_validation": "passed"
+      },
+      "github": {}
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "history": [
+      {
+        "at": "2026-05-19T04:00:51.285Z",
+        "status": "in_progress",
+        "summary": "Started docs-only healthz and release-only deploy policy PR."
+      },
+      {
+        "at": "2026-05-19T04:01:15.170Z",
+        "status": "local_checks_passed",
+        "summary": "YAML/JSON parse, markdown manual review, git diff --check, and allowed-path scope validation passed."
+      },
+      {
+        "at": "2026-05-19T04:01:25.129Z",
+        "status": "committed",
+        "summary": "Committed 818b49a891b30dc020921da3479cdc0550e6c62c."
+      },
+      {
+        "at": "2026-05-19T04:02:03.272Z",
+        "status": "pr_opened",
+        "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1477."
+      }
+    ],
+    "next_pr": "OPS-RELEASE-WORKFLOW-01"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5908,3 +5908,47 @@ prs:
     human_review_required: false
     production_approval_required: false
     next_task: OPS-CI-CODESCAN-WEB-01
+
+  - id: OPS-RUNBOOK-HEALTHZ-01
+    repo: fap-api
+    depends_on:
+      - OPS-CI-CODESCAN-API-01
+    branch: codex/ops-runbook-healthz-01
+    base: main
+    title: "docs(ops): codify canonical healthz and release-only deploy policy"
+    name: "Canonical healthz and release-only deploy policy"
+    train_scope: ops_runbook_healthz
+    risk_level: L2
+    type: docs/ops PR
+    scope:
+      - Codify /api/healthz as the only canonical backend health probe path.
+      - Codify allowlist-only and internal healthz verification.
+      - Codify release-only deployment workspace requirements.
+      - Align deploy, observability, rollback, and triage docs.
+      - Keep runtime behavior unchanged.
+    allowed_paths:
+      - README_DEPLOY.md
+      - docs/04-ops/observability.md
+      - docs/04-ops/rollback-runbook.md
+      - docs/04-ops/runbook-triage.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change backend runtime behavior, routes, healthz access control, deploy scripts, or server configuration.
+      - Deploy production, unlock deploys, kill processes, or mutate servers.
+    validation:
+      - ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'
+      - ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: OPS-RELEASE-WORKFLOW-01


### PR DESCRIPTION
## What changed
- Codifies `/api/healthz` as the only canonical backend health probe path.
- Documents that production healthz is allowlist-only and arbitrary public-origin `200` is not a deploy success requirement.
- Adds release-only deployment workspace requirements to prevent deploying from detached HEAD, PR worktrees, or desktop parking branches.
- Aligns deploy, observability, rollback, and triage docs around the same healthz policy.
- Adds PR train manifest/state records for `OPS-RUNBOOK-HEALTHZ-01`.

## Why
This removes ambiguity discovered during production readiness and deployment verification: public non-allowlisted healthz `404` is expected, while internal/allowlisted `/api/healthz` is the canonical smoke path.

## Validation commands
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'`
- `ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred items
- No runtime route, middleware, allowlist, deploy script, or server configuration changes.
- No production deployment.
- No backend or frontend code changes.

## Sidecar issues
- None.

## Repository rule impact
Docs/governance only. This reinforces release-only deployment discipline and backend-authoritative healthz verification without changing application behavior.
