### PR TITLE
docs(ops): codify release operator workflow and deploy incident governance

### DIFF
--- a/docs/04-ops/deploy-incident-runbook.md
+++ b/docs/04-ops/deploy-incident-runbook.md
@@ -1,0 +1,76 @@
+# Deploy Incident Runbook
+
+This runbook defines the decision tree for stuck or ambiguous deployment operations. It is read-only by default and does not authorize rollback, unlock, process killing, or server mutation.
+
+## First response rule
+
+When a deploy appears stuck, do not immediately rerun deployment. First determine whether the remote release actually completed, whether workers are healthy, and whether the local deploy process is only waiting on a stale worker step.
+
+## Read-only evidence to collect
+
+Collect evidence without mutating local or remote state:
+
+- local deploy command, release name, and target SHA
+- current backend symlink and `REVISION`
+- queue and supervisor status
+- PHP-FPM and nginx status when readable
+- Deployer lock status if readable
+- recent deploy task name where execution appears stuck
+- whether public smoke, internal smoke, or allowlisted smoke passes
+
+Do not print secrets, private key paths, real IP addresses, tokens, passwords, or private topology in incident notes.
+
+## Stuck deploy decision tree
+
+1. If the remote current symlink and `REVISION` match the intended release and backend smoke passes, classify as likely local deploy worker hang.
+2. If remote current symlink does not match the intended release, classify as deploy incomplete.
+3. If queue workers are not running or are on the wrong release, classify as worker convergence failure.
+4. If nginx or PHP-FPM is unhealthy, classify as web runtime failure.
+5. If healthz is checked from a non-allowlisted public source and returns `404`, do not classify as healthz failure. Recheck internally or from an allowlisted source.
+
+## Mutation approvals
+
+The following actions require separate explicit approval after read-only evidence is collected:
+
+- rollback
+- unlock
+- killing local or remote processes
+- restarting supervisor, queue workers, PHP-FPM, nginx, or PM2
+- rerunning production deploy
+- modifying server files or configuration
+
+Approval for one action does not imply approval for another.
+
+## Backend deploy incident classifications
+
+- `complete_and_verified`: intended release is active and smoke passed
+- `local_worker_hang`: remote release is active but local Deployer remains blocked
+- `deploy_incomplete`: current symlink or `REVISION` does not match intended release
+- `worker_convergence_failure`: queue or supervisor failed to converge
+- `web_runtime_failure`: PHP-FPM, nginx, or public smoke failed
+- `unknown`: evidence is insufficient or conflicting
+
+## Frontend deploy incident classifications
+
+- `complete_and_verified`: Node1 HEAD matches intended SHA, PM2 converged, public smoke passed
+- `pm2_convergence_failure`: PM2 process count or online status is wrong
+- `stale_process`: PM2 online but serving an older checkout or build
+- `build_or_asset_failure`: local chunk or public static asset smoke failed
+- `public_route_failure`: route smoke failed after PM2 convergence
+- `unknown`: evidence is insufficient or conflicting
+
+## Sidecar handling during incidents
+
+Do not block a completed and verified deploy on unrelated sidecar issues. Record them separately with owner, severity, and whether they require a follow-up PR or operational task.
+
+Sidecar issue record format:
+
+- summary
+- evidence
+- scope relation: current deploy / external / historical
+- production blocking: yes or no
+- recommended follow-up
+
+## Rollback recommendation boundary
+
+Recommend rollback only when the deployed release is active and introduces a production-impacting regression that cannot be mitigated safely within the current release. Missing arbitrary public-origin `/api/healthz` `200` is not by itself a rollback condition because production healthz is allowlist-only.

--- a/docs/04-ops/release-operator-workflow.md
+++ b/docs/04-ops/release-operator-workflow.md
@@ -1,0 +1,104 @@
+# Release Operator Workflow
+
+This runbook defines the production release operator workflow for FermatMind backend and frontend releases. It is a governance document only; it does not grant production write permission by itself.
+
+## Release-only workspace rule
+
+Production releases must run from a release-only checkout or worktree that is dedicated to deployment operations.
+
+Required state before any production deploy command:
+
+- the checkout is on `main`
+- `git status --short` is empty
+- `HEAD` equals `origin/main`
+- the deployment SHA has a merged PR record
+- required local readiness and read-only remote readiness have passed
+- the release operator has the exact deploy approval phrase for the resolved SHA
+
+Disallowed release entry points:
+
+- detached HEAD checkouts
+- GitHub Desktop parking branches
+- feature branches
+- PR worktrees
+- local development directories with unrelated files
+- any checkout that cannot prove `HEAD == origin/main`
+
+## Backend readiness governance
+
+Backend release readiness must resolve and record:
+
+- backend repo path and branch
+- backend SHA and latest merged PR
+- clean local main aligned with `origin/main`
+- required tools and environment variables present without printing secrets
+- Deployer availability
+- current backend remote symlink and `REVISION`
+- queue and supervisor status
+- PHP-FPM and nginx status when readable
+- deploy necessity and explicit approval phrase
+
+Backend deploy may proceed only after an explicit approval phrase naming the exact SHA and release name.
+
+## Frontend readiness governance
+
+Frontend release readiness must resolve and record:
+
+- frontend repo path and branch
+- frontend SHA and latest merged PR
+- clean local main aligned with `origin/main`
+- CMS API check status
+- frontend Node1 HEAD and PM2 status from read-only verification
+- public route smoke expectations
+- deploy necessity and explicit approval phrase
+
+Frontend deploy may proceed only after backend production smoke has passed unless the release is explicitly frontend-only and backend deploy is not necessary.
+
+## Release ordering
+
+Default production ordering:
+
+1. local readiness
+2. read-only remote readiness
+3. decide whether deploy is necessary
+4. backend explicit approval, if backend deploy is necessary
+5. backend deploy and backend smoke
+6. frontend explicit approval, if frontend deploy is necessary
+7. frontend deploy and frontend smoke
+8. release record
+
+Do not deploy a component just because local main changed. Deploy only when the remote runtime target is behind a runtime-impacting or explicitly approved SHA.
+
+## Healthz policy
+
+`/api/healthz` is the only canonical backend health probe path. Production healthz is allowlist-only. Public non-allowlisted requests returning `404` are not a deploy failure. Use internal or allowlisted probes for healthz verification.
+
+## Sidecar issue policy
+
+If a blocker is not introduced by the current PR or release and the current required checks are green, record it as a sidecar issue instead of stopping the train.
+
+Sidecar examples:
+
+- historical ledger noise
+- unrelated GitHub Actions platform noise
+- stale branch or worktree cleanup outside current scope
+- external repository configuration gaps
+- non-current-PR warnings
+
+Sidecar issues must include:
+
+- source of evidence
+- why it is outside current scope
+- risk level
+- owner or follow-up path
+- whether it blocks production deployment
+
+## Release record
+
+Every production release summary should record:
+
+- backend SHA, PR, release name, and smoke result
+- frontend SHA, PR, PM2 status, and smoke result
+- healthz verification source: internal or allowlisted
+- any sidecar issues
+- rollback recommendation, if any

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T04:02:03.272Z",
+  "updated_at": "2026-05-19T04:11:24.511Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11936,7 +11936,7 @@
     "next_pr": "OPS-CI-CODESCAN-WEB-01"
   },
   "OPS-RUNBOOK-HEALTHZ-01": {
-    "status": "in_progress",
+    "status": "merged",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/ops-runbook-healthz-01",
@@ -11955,12 +11955,18 @@
         "git_diff_check": "passed",
         "scope_validation": "passed"
       },
-      "github": {}
+      "github": {
+        "hygiene": "passed",
+        "semgrep_sarif": "passed",
+        "semgrep_oss": "passed",
+        "verify_mbti_legacy": "passed",
+        "verify_mbti_v2": "passed"
+      }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-19T04:08:06Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [],
     "history": [
       {
@@ -11982,8 +11988,65 @@
         "at": "2026-05-19T04:02:03.272Z",
         "status": "pr_opened",
         "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1477."
+      },
+      {
+        "at": "2026-05-19T04:10:16.588Z",
+        "status": "post_merge_cleanup_complete",
+        "summary": "PR #1477 merged at 29ec08275027a517993a7cea0fdc6c117bc85c87; origin/main synced; local and remote branches removed."
       }
     ],
-    "next_pr": "OPS-RELEASE-WORKFLOW-01"
+    "next_pr": "OPS-RELEASE-WORKFLOW-01",
+    "merge_commit": "29ec08275027a517993a7cea0fdc6c117bc85c87"
+  },
+  "OPS-RELEASE-WORKFLOW-01": {
+    "status": "in_progress",
+    "repo": "fap-api",
+    "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+    "branch": "codex/ops-release-workflow-01",
+    "base": "main",
+    "title": "docs(ops): codify release operator workflow and deploy incident governance",
+    "depends_on": [
+      "OPS-RUNBOOK-HEALTHZ-01"
+    ],
+    "commit_sha": "2084a3a5e9406a90508070a46814eec7c18fd087",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1478",
+    "checks": {
+      "local": {
+        "yaml_parse": "passed",
+        "json_parse": "passed",
+        "markdown_manual_review": "passed",
+        "git_diff_check": "passed",
+        "scope_validation": "passed"
+      },
+      "github": {}
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "history": [
+      {
+        "at": "2026-05-19T04:10:16.588Z",
+        "status": "in_progress",
+        "summary": "Started docs-only release operator workflow and deploy incident governance PR."
+      },
+      {
+        "at": "2026-05-19T04:10:40.653Z",
+        "status": "local_checks_passed",
+        "summary": "YAML/JSON parse, markdown manual review, git diff --check, and allowed-path scope validation passed."
+      },
+      {
+        "at": "2026-05-19T04:10:49.222Z",
+        "status": "committed",
+        "summary": "Committed 2084a3a5e9406a90508070a46814eec7c18fd087."
+      },
+      {
+        "at": "2026-05-19T04:11:24.511Z",
+        "status": "pr_opened",
+        "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1478."
+      }
+    ],
+    "next_pr": null
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5952,3 +5952,46 @@ prs:
     human_review_required: false
     production_approval_required: false
     next_task: OPS-RELEASE-WORKFLOW-01
+
+  - id: OPS-RELEASE-WORKFLOW-01
+    repo: fap-api
+    depends_on:
+      - OPS-RUNBOOK-HEALTHZ-01
+    branch: codex/ops-release-workflow-01
+    base: main
+    title: "docs(ops): codify release operator workflow and deploy incident governance"
+    name: "Release operator workflow and deploy incident governance"
+    train_scope: ops_release_workflow
+    risk_level: L2
+    type: docs/ops PR
+    scope:
+      - Define release-only clone and worktree conventions.
+      - Define backend and frontend readiness governance.
+      - Define stuck deploy and incident decision tree.
+      - Define sidecar issue handling for non-current-PR blockers.
+      - Keep runtime behavior unchanged.
+    allowed_paths:
+      - docs/04-ops/release-operator-workflow.md
+      - docs/04-ops/deploy-incident-runbook.md
+      - docs/04-ops/release-summary-2026-05-18-healthz-and-frontend-sync.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change backend runtime behavior, routes, middleware, deploy scripts, server configuration, or frontend code.
+      - Deploy production, unlock deploys, kill processes, rollback, or mutate servers.
+    validation:
+      - ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'
+      - ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: null


### PR DESCRIPTION
## What changed
- Adds release operator workflow documentation for release-only workspaces, backend/frontend readiness governance, deploy ordering, healthz policy, sidecar issue handling, and release records.
- Adds deploy incident runbook documentation for stuck deploy evidence collection, incident classification, mutation approval boundaries, and rollback recommendation boundaries.
- Adds PR train manifest/state records for `OPS-RELEASE-WORKFLOW-01`.
- Reconciles `OPS-RUNBOOK-HEALTHZ-01` as merged in the train ledger.

## Why
This codifies the operating model needed to prevent repeated deployment ambiguity around detached worktrees, stale local branches, healthz interpretation, stuck deploy handling, and non-current-PR blockers.

## Validation commands
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'`
- `ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred items
- No runtime code changes.
- No deploy script changes.
- No production deployment.
- No rollback, unlock, process kill, or server mutation.

## Sidecar issues
- None.

## Repository rule impact
Docs/governance only. This formalizes release operator rules, deploy incident boundaries, and sidecar issue policy without changing application behavior.
