### PR TITLE
docs(seo-intel): add SEO Dash MVP online summary

### DIFF
--- a/backend/docs/seo/generated/seo-dash-mvp-online-summary.v1.json
+++ b/backend/docs/seo/generated/seo-dash-mvp-online-summary.v1.json
@@ -1,0 +1,141 @@
+{
+  "version": "seo-dash-mvp-online-summary.v1",
+  "task": "SEO-DASH-MVP-ONLINE-SUMMARY",
+  "generated_at": "2026-05-19T13:20:25Z",
+  "source_documents": [
+    "SEO-DASH-PROD-04C-METABASE-READONLY-DATASOURCE-CONNECTION",
+    "SEO-DASH-PROD-04D",
+    "SEO-DASH-PROD-04E"
+  ],
+  "purpose": "Freeze the minimally online SEO Dash MVP state after private Metabase dashboard and access/export/sharing verification.",
+  "current_production_state": {
+    "seo_urls": 7,
+    "seo_url_entities": 7,
+    "seo_issue_queue": 5,
+    "other_checked_collector_tables": 0
+  },
+  "metabase_state": {
+    "host_model": "private_aliyun_ecs",
+    "public_ipv4_present": false,
+    "localhost_only": true,
+    "listen_host": "127.0.0.1",
+    "listen_port": 3000,
+    "boot_enabled": false,
+    "application_database": "metabase_app",
+    "application_database_engine": "postgresql",
+    "datasource_count": 1,
+    "datasource_name": "seo_intel",
+    "datasource_engine": "mysql",
+    "datasource_account": "seo_intel_metabase_readonly",
+    "read_verification_passed": true,
+    "write_deny_verification_passed": true
+  },
+  "dashboard": {
+    "name": "SEO Intelligence MVP \u2014 URL Truth & Issue Queue",
+    "created": true,
+    "verified_cards_count": 10,
+    "cards": [
+      "URL Truth total count",
+      "URL entity mapping total count",
+      "Issue Queue total count",
+      "URL Truth by page_entity_type",
+      "URL Truth by locale",
+      "URL Truth by source_authority",
+      "URL Truth by indexability_state",
+      "Issue Queue by issue_type",
+      "Private-flow / forbidden authority safety count",
+      "Recent issue rows, sanitized"
+    ],
+    "allowed_source_tables": [
+      "seo_urls",
+      "seo_url_entities",
+      "seo_issue_queue"
+    ],
+    "private_flow_or_forbidden_authority_count": 0
+  },
+  "access_export_sharing": {
+    "verification_passed": true,
+    "public_sharing_enabled": false,
+    "embedding_enabled": false,
+    "anonymous_links_present": false,
+    "public_dashboard_or_card_tokens_present": false,
+    "admin_user_count": 1,
+    "normal_operator_user_count": 0,
+    "api_key_count": 0,
+    "exports_performed": false,
+    "normal_operator_raw_sql_enabled": false,
+    "future_operator_onboarding_requires_permissions_plan": true
+  },
+  "not_yet_enabled": [
+    "scheduler",
+    "collector_writes",
+    "external_search_live",
+    "gsc_live",
+    "baidu_live",
+    "indexnow_live",
+    "url_submission",
+    "production_crawler_log_read",
+    "research_publish",
+    "pseo_generation",
+    "public_metabase_access",
+    "metabase_business_db_access"
+  ],
+  "forbidden_sources": [
+    "business_db",
+    "tencent_rds_fap_prod",
+    "node2_local_db",
+    "cms_write_tables",
+    "raw_orders",
+    "raw_payments",
+    "raw_events_detail",
+    "raw_email",
+    "raw_reports",
+    "raw_crawler_logs",
+    "provider_payloads",
+    "payment_payloads"
+  ],
+  "forbidden_fields": [
+    "password",
+    "token",
+    "cookie",
+    "email",
+    "raw_email",
+    "order_no",
+    "raw_order_no",
+    "attempt_id",
+    "raw_attempt_id",
+    "payment_id",
+    "raw_ip",
+    "raw_user_agent",
+    "raw_payload",
+    "provider_payload",
+    "payment_payload",
+    "secret",
+    "api_key"
+  ],
+  "next_phase": [
+    "Research MVP",
+    "Search Channel live readiness",
+    "crawler log readiness"
+  ],
+  "research_boundaries": {
+    "publish_allowed_in_this_train": false,
+    "sitemap_or_llms_inclusion_allowed_before_contract_gates": false,
+    "search_channel_queue_insertion_allowed_before_contract_gates": false,
+    "cms_draft_gate_required": true
+  },
+  "production_operations_performed_in_this_pr": false,
+  "metabase_operation_performed_in_this_pr": false,
+  "runtime_code_changed_in_this_pr": false,
+  "migration_changed_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "deploy_performed_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_performed_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "production_crawler_log_read": false,
+  "research_publish_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "next_task": "METABASE-OPS-ACCESS-RUNBOOK-00"
+}

--- a/backend/docs/seo/seo-dash-mvp-online-summary.md
+++ b/backend/docs/seo/seo-dash-mvp-online-summary.md
@@ -1,0 +1,96 @@
+# SEO Dash MVP Online Summary
+
+## Purpose
+
+SEO-DASH-MVP-ONLINE-SUMMARY freezes the first minimally online SEO Dash state after the Metabase localhost-only verification sequence.
+This is a documentation, generated-contract, and focused-test PR only. It does not deploy, edit environment files, operate Metabase, run collector writes, enable scheduler, call external search APIs, submit URLs, read production crawler logs, publish Research, or create pSEO.
+
+## Current Production SEO Dash State
+
+The current `seo_intel` production observation state is:
+
+- `seo_urls`: 7 rows
+- `seo_url_entities`: 7 rows
+- `seo_issue_queue`: 5 rows
+- all other checked collector tables: 0 rows
+
+Metabase is minimally online as a private observation layer:
+
+- hosted on the approved Aliyun private ECS host
+- listens only on `127.0.0.1:3000`
+- has no public IPv4 exposure
+- has boot enablement disabled
+- uses PostgreSQL `metabase_app` as the Metabase application database
+- has exactly one datasource: `seo_intel`
+- uses `seo_intel_metabase_readonly` for the datasource
+- has read verification passed for `seo_urls`, `seo_url_entities`, and `seo_issue_queue`
+- has write-deny verification passed for the readonly datasource user
+
+## Dashboard State
+
+The dashboard exists:
+
+`SEO Intelligence MVP — URL Truth & Issue Queue`
+
+The dashboard has 10 verified cards:
+
+- URL Truth total count
+- URL entity mapping total count
+- Issue Queue total count
+- URL Truth by `page_entity_type`
+- URL Truth by `locale`
+- URL Truth by `source_authority`
+- URL Truth by `indexability_state`
+- Issue Queue by `issue_type`
+- Private-flow / forbidden authority safety count
+- Recent issue rows, sanitized
+
+The dashboard cards may use only:
+
+- `seo_urls`
+- `seo_url_entities`
+- `seo_issue_queue`
+
+They must not use business DB tables, Tencent RDS, Node2 local DB, CMS write tables, raw orders, raw payments, raw events, raw email, raw crawler logs, provider payloads, payment payloads, raw IPs, cookies, user agents, or tokens.
+
+## Access, Export, and Sharing State
+
+SEO-DASH-PROD-04E verified the access/export/sharing policy:
+
+- public sharing is disabled
+- embedding is disabled where supported
+- no anonymous links exist
+- no public dashboard or card tokens exist
+- only the admin user exists
+- API key count is 0
+- no exports were performed
+- normal-user export and raw SQL policy is not materially active yet because no normal operator users exist
+- future operator onboarding requires a separate permissions plan
+
+## Not Yet Enabled
+
+The following remain intentionally not enabled:
+
+- scheduler
+- collector writes
+- live GSC integration
+- live Baidu integration
+- live IndexNow integration
+- URL submission
+- production crawler log reads
+- Research publish
+- pSEO generation
+- public Metabase access
+- business DB access from Metabase
+
+## Next Phase
+
+The next phase is:
+
+- Research MVP
+- Search Channel live readiness
+- crawler log readiness
+
+Research assets remain blocked from publish, sitemap, `llms.txt`, and Search Channel Queue until explicit backend/CMS, fap-web runtime, URL Truth, claim boundary, and Search Channel gates pass.
+
+Next task: `METABASE-OPS-ACCESS-RUNBOOK-00`

--- a/backend/tests/Feature/SeoIntel/SeoIntelDashMvpOnlineSummaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelDashMvpOnlineSummaryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelDashMvpOnlineSummaryTest extends TestCase
+{
+    #[Test]
+    public function artifact_locks_current_seo_dash_mvp_online_state(): void
+    {
+        $artifact = $this->artifact();
+        $state = $artifact['current_production_state'] ?? [];
+        $metabase = $artifact['metabase_state'] ?? [];
+
+        $this->assertSame('seo-dash-mvp-online-summary.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-DASH-MVP-ONLINE-SUMMARY', $artifact['task'] ?? null);
+        $this->assertSame(7, $state['seo_urls'] ?? null);
+        $this->assertSame(7, $state['seo_url_entities'] ?? null);
+        $this->assertSame(5, $state['seo_issue_queue'] ?? null);
+        $this->assertSame(0, $state['other_checked_collector_tables'] ?? null);
+
+        $this->assertTrue((bool) ($metabase['localhost_only'] ?? false));
+        $this->assertFalse((bool) ($metabase['public_ipv4_present'] ?? true));
+        $this->assertFalse((bool) ($metabase['boot_enabled'] ?? true));
+        $this->assertSame('metabase_app', $metabase['application_database'] ?? null);
+        $this->assertSame('seo_intel', $metabase['datasource_name'] ?? null);
+        $this->assertSame('seo_intel_metabase_readonly', $metabase['datasource_account'] ?? null);
+        $this->assertTrue((bool) ($metabase['read_verification_passed'] ?? false));
+        $this->assertTrue((bool) ($metabase['write_deny_verification_passed'] ?? false));
+    }
+
+    #[Test]
+    public function dashboard_cards_are_verified_and_limited_to_safe_seo_intel_tables(): void
+    {
+        $dashboard = $this->artifact()['dashboard'] ?? [];
+
+        $this->assertSame('SEO Intelligence MVP — URL Truth & Issue Queue', $dashboard['name'] ?? null);
+        $this->assertTrue((bool) ($dashboard['created'] ?? false));
+        $this->assertSame(10, $dashboard['verified_cards_count'] ?? null);
+        $this->assertSame(0, $dashboard['private_flow_or_forbidden_authority_count'] ?? null);
+
+        foreach ([
+            'URL Truth total count',
+            'URL entity mapping total count',
+            'Issue Queue total count',
+            'URL Truth by page_entity_type',
+            'URL Truth by locale',
+            'URL Truth by source_authority',
+            'URL Truth by indexability_state',
+            'Issue Queue by issue_type',
+            'Private-flow / forbidden authority safety count',
+            'Recent issue rows, sanitized',
+        ] as $card) {
+            $this->assertContains($card, $dashboard['cards'] ?? []);
+        }
+
+        $this->assertSame([
+            'seo_urls',
+            'seo_url_entities',
+            'seo_issue_queue',
+        ], $dashboard['allowed_source_tables'] ?? []);
+    }
+
+    #[Test]
+    public function access_export_and_sharing_policy_is_locked_down(): void
+    {
+        $policy = $this->artifact()['access_export_sharing'] ?? [];
+
+        $this->assertTrue((bool) ($policy['verification_passed'] ?? false));
+        $this->assertFalse((bool) ($policy['public_sharing_enabled'] ?? true));
+        $this->assertFalse((bool) ($policy['embedding_enabled'] ?? true));
+        $this->assertFalse((bool) ($policy['anonymous_links_present'] ?? true));
+        $this->assertFalse((bool) ($policy['public_dashboard_or_card_tokens_present'] ?? true));
+        $this->assertSame(1, $policy['admin_user_count'] ?? null);
+        $this->assertSame(0, $policy['normal_operator_user_count'] ?? null);
+        $this->assertSame(0, $policy['api_key_count'] ?? null);
+        $this->assertFalse((bool) ($policy['exports_performed'] ?? true));
+        $this->assertFalse((bool) ($policy['normal_operator_raw_sql_enabled'] ?? true));
+        $this->assertTrue((bool) ($policy['future_operator_onboarding_requires_permissions_plan'] ?? false));
+    }
+
+    #[Test]
+    public function forbidden_sources_fields_and_runtime_operations_remain_blocked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'scheduler',
+            'collector_writes',
+            'external_search_live',
+            'gsc_live',
+            'baidu_live',
+            'indexnow_live',
+            'url_submission',
+            'production_crawler_log_read',
+            'research_publish',
+            'pseo_generation',
+            'public_metabase_access',
+            'metabase_business_db_access',
+        ] as $blocked) {
+            $this->assertContains($blocked, $artifact['not_yet_enabled'] ?? []);
+        }
+
+        foreach ([
+            'business_db',
+            'tencent_rds_fap_prod',
+            'node2_local_db',
+            'cms_write_tables',
+            'raw_orders',
+            'raw_payments',
+            'raw_events_detail',
+            'raw_email',
+            'raw_reports',
+            'raw_crawler_logs',
+            'provider_payloads',
+            'payment_payloads',
+        ] as $source) {
+            $this->assertContains($source, $artifact['forbidden_sources'] ?? []);
+        }
+
+        foreach ($this->forbiddenFields() as $field) {
+            $this->assertContains($field, $artifact['forbidden_fields'] ?? []);
+        }
+
+        foreach ([
+            'production_operations_performed_in_this_pr',
+            'metabase_operation_performed_in_this_pr',
+            'runtime_code_changed_in_this_pr',
+            'migration_changed_in_this_pr',
+            'env_edit_in_this_pr',
+            'deploy_performed_in_this_pr',
+            'scheduler_enabled_in_this_pr',
+            'collector_write_performed_in_this_pr',
+            'external_api_live_activation',
+            'url_submission_performed',
+            'production_crawler_log_read',
+            'research_publish_in_this_pr',
+            'pseo_generation_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_summary_next_phase_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-dash-mvp-online-summary.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-dash-mvp-online-summary.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'seo dash mvp online summary',
+            'metabase is minimally online as a private observation layer',
+            'listens only on `127.0.0.1:3000`',
+            'datasource_account": "seo_intel_metabase_readonly"',
+            'dashboard has 10 verified cards',
+            'public sharing is disabled',
+            'embedding is disabled',
+            'not yet enabled',
+            'research mvp',
+            'search channel live readiness',
+            'crawler log readiness',
+            'research assets remain blocked from publish',
+            'next task: `metabase-ops-access-runbook-00`',
+            '"next_task": "metabase-ops-access-runbook-00"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-dash-mvp-online-summary.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenFields(): array
+    {
+        return [
+            'password',
+            'token',
+            'cookie',
+            'email',
+            'raw_email',
+            'order_no',
+            'raw_order_no',
+            'attempt_id',
+            'raw_attempt_id',
+            'payment_id',
+            'raw_ip',
+            'raw_user_agent',
+            'raw_payload',
+            'provider_payload',
+            'payment_payload',
+            'secret',
+            'api_key',
+        ];
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T13:34:00Z",
+  "updated_at": "2026-05-19T13:44:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11716,7 +11716,7 @@
       "local_cleanup_executed": true
     },
     "SEO-DASH-MVP-ONLINE-SUMMARY": {
-      "status": "pr_opened_github_checks_pending",
+      "status": "github_checks_passed",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/seo-dash-mvp-online-summary",
@@ -11725,7 +11725,7 @@
       "depends_on": [
         "CONTENT-OPS-01"
       ],
-      "commit_sha": "8df3f90b35cf311870d251f4f35dc886fcb8df56",
+      "commit_sha": "4bb71e548ff3729f52ebe4adcf030e44c2660c91",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1479",
       "checks": {
         "local": {
@@ -11738,7 +11738,14 @@
           "git_diff_check": "passed",
           "scope_validation": "passed"
         },
-        "github": {}
+        "github": {
+          "hygiene": "passed",
+          "semgrep_sarif": "passed",
+          "semgrep_oss": "passed",
+          "verify_mbti_legacy": "passed",
+          "verify_mbti_v2": "passed",
+          "mergeStateStatus": "CLEAN"
+        }
       },
       "failure_reason": null,
       "merged_at": null,
@@ -11773,6 +11780,11 @@
           "at": "2026-05-19T13:34:00Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1479. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-19T13:44:00Z",
+          "status": "github_checks_passed",
+          "summary": "GitHub checks passed for PR #1479: hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2. mergeStateStatus=CLEAN."
         }
       ],
       "next_pr": "METABASE-OPS-ACCESS-RUNBOOK-00"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T13:31:30Z",
+  "updated_at": "2026-05-19T13:34:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11716,7 +11716,7 @@
       "local_cleanup_executed": true
     },
     "SEO-DASH-MVP-ONLINE-SUMMARY": {
-      "status": "local_checks_passed",
+      "status": "pr_opened_github_checks_pending",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/seo-dash-mvp-online-summary",
@@ -11726,7 +11726,7 @@
         "CONTENT-OPS-01"
       ],
       "commit_sha": "8df3f90b35cf311870d251f4f35dc886fcb8df56",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1479",
       "checks": {
         "local": {
           "php_artisan_test_filter_seo_intel_dash_mvp_online_summary": "passed",
@@ -11768,6 +11768,11 @@
           "at": "2026-05-19T13:31:30Z",
           "status": "commit_created",
           "summary": "Created local commit 8df3f90b35cf311870d251f4f35dc886fcb8df56."
+        },
+        {
+          "at": "2026-05-19T13:34:00Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1479. GitHub checks pending."
         }
       ],
       "next_pr": "METABASE-OPS-ACCESS-RUNBOOK-00"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T04:11:24.511Z",
+  "updated_at": "2026-05-19T13:31:30Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11714,6 +11714,63 @@
       "merged_at": "2026-05-19T02:48:28Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true
+    },
+    "SEO-DASH-MVP-ONLINE-SUMMARY": {
+      "status": "local_checks_passed",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/seo-dash-mvp-online-summary",
+      "base": "main",
+      "title": "docs(seo-intel): add SEO Dash MVP online summary",
+      "depends_on": [
+        "CONTENT-OPS-01"
+      ],
+      "commit_sha": "8df3f90b35cf311870d251f4f35dc886fcb8df56",
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_dash_mvp_online_summary": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "OPS-RELEASE-WORKFLOW-01 ledger reconciliation",
+          "repo": "fap-api",
+          "introduced_by_current_pr": false,
+          "evidence": "GitHub reports PR #1478 merged and origin/main contains f04fe2048cab11f61fa18e1fbbde5023e5193bcf; state file still showed in_progress before this PR.",
+          "why_external_to_current_pr": "The stale OPS train item is not part of the SEO Dash MVP closeout train, but reconciling it removes an apparent pending PR conflict before starting this train."
+        }
+      ],
+      "history": [
+        {
+          "at": "2026-05-19T13:20:25Z",
+          "status": "in_progress",
+          "summary": "Started docs/generated/test-only SEO Dash MVP online summary PR. Scope excludes runtime code, migrations, env, deploy, collector writes, scheduler activation, Metabase operation, external APIs, URL submission, crawler log reads, Research publish, and pSEO."
+        },
+        {
+          "at": "2026-05-19T13:29:00Z",
+          "status": "local_checks_passed",
+          "summary": "Focused SeoIntelDashMvpOnlineSummary test, full SeoIntel test filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T13:31:30Z",
+          "status": "commit_created",
+          "summary": "Created local commit 8df3f90b35cf311870d251f4f35dc886fcb8df56."
+        }
+      ],
+      "next_pr": "METABASE-OPS-ACCESS-RUNBOOK-00"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5995,3 +5995,55 @@ prs:
     human_review_required: false
     production_approval_required: false
     next_task: null
+
+  - id: SEO-DASH-MVP-ONLINE-SUMMARY
+    repo: fap-api
+    depends_on:
+      - CONTENT-OPS-01
+    branch: codex/seo-dash-mvp-online-summary
+    base: main
+    title: "docs(seo-intel): add SEO Dash MVP online summary"
+    name: "SEO Dash MVP online summary"
+    train_scope: seo_dash_mvp_closeout_research_train
+    risk_level: low_docs_generated_tests_no_runtime_activation
+    type: docs/generated/test PR
+    scope:
+      - Freeze the current SEO Dash MVP online state in docs and a machine-readable artifact.
+      - Record current seo_intel counts, private Metabase localhost-only state, datasource boundary, dashboard verification, and access/export/sharing verification.
+      - Record scheduler, external search live, crawler log, Research publish, and pSEO as not enabled.
+      - Add a focused SeoIntel contract test.
+    allowed_paths:
+      - backend/docs/seo/seo-dash-mvp-online-summary.md
+      - backend/docs/seo/generated/seo-dash-mvp-online-summary.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelDashMvpOnlineSummaryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy, edit env files, run collector writes, enable scheduler, connect live search APIs, submit URLs, read production crawler logs, change RDS/DB/users/whitelist, expose Metabase publicly, publish Research content, or create pSEO.
+      - Change runtime code, backend services/controllers/routes, migrations, deploy scripts, sitemap behavior, llms behavior, or Metabase configuration.
+      - Connect Metabase to business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational tables.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelDashMvpOnlineSummary
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-dash-mvp-online-summary.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    metabase_operation: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: METABASE-OPS-ACCESS-RUNBOOK-00


### PR DESCRIPTION
## What changed
- Added `backend/docs/seo/seo-dash-mvp-online-summary.md` to freeze the minimally online SEO Dash MVP state.
- Added `backend/docs/seo/generated/seo-dash-mvp-online-summary.v1.json` as the machine-readable contract artifact.
- Added `SeoIntelDashMvpOnlineSummaryTest` to lock the Metabase, datasource, dashboard, sharing/export, and no-production-operation boundaries.
- Registered `SEO-DASH-MVP-ONLINE-SUMMARY` in the PR train manifest/state ledger.

## Why
SEO Dash MVP is minimally online in private localhost-only Metabase mode. This PR records that state before the Research MVP train continues.

## Validation
- `cd backend && php artisan test --filter=SeoIntelDashMvpOnlineSummary`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-dash-mvp-online-summary.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred / not changed
- No runtime code, migrations, env, deploy scripts, backend routes/controllers/services, scheduler, collector writes, external search API calls, URL submissions, crawler log reads, Metabase operation, Research publish, or pSEO generation.
- No Metabase public exposure, public links, business DB, Tencent RDS, or Node2 local DB connection.
- Next task remains `METABASE-OPS-ACCESS-RUNBOOK-00`.
