### PR TITLE
docs(seo-intel): add Metabase ops access runbook

### DIFF
--- a/backend/docs/seo/generated/metabase-ops-access-runbook.v1.json
+++ b/backend/docs/seo/generated/metabase-ops-access-runbook.v1.json
@@ -1,0 +1,160 @@
+{
+  "version": "metabase-ops-access-runbook.v1",
+  "task": "METABASE-OPS-ACCESS-RUNBOOK-00",
+  "generated_at": "2026-05-19T13:45:00Z",
+  "source_documents": [
+    "SEO-DASH-MVP-ONLINE-SUMMARY",
+    "SEO-DASH-PROD-04E"
+  ],
+  "purpose": "Define the operational access runbook for the private localhost-only SEO Dash Metabase instance.",
+  "access_model": {
+    "host_model": "approved_private_aliyun_ecs",
+    "localhost_only": true,
+    "listen_host": "127.0.0.1",
+    "listen_port": 3000,
+    "public_ipv4_allowed": false,
+    "public_security_group_ingress_allowed": false,
+    "public_dns_or_cdn_allowed": false,
+    "anonymous_links_allowed": false,
+    "public_sharing_allowed": false,
+    "public_embedding_allowed": false,
+    "safe_access_paths": [
+      "approved_console_session",
+      "workbench_local_forwarding",
+      "bastion_or_vpn_after_separate_approval"
+    ]
+  },
+  "service_policy": {
+    "service_name": "metabase",
+    "status_commands": [
+      "systemctl status metabase --no-pager",
+      "systemctl is-active metabase",
+      "systemctl is-enabled metabase",
+      "ss -lntp | grep ':3000' || true",
+      "curl -sS http://127.0.0.1:3000/api/health"
+    ],
+    "allowed_control_commands": [
+      "systemctl start metabase",
+      "systemctl stop metabase",
+      "systemctl restart metabase"
+    ],
+    "boot_enabled_policy": false,
+    "boot_policy_change_requires_separate_approval": true
+  },
+  "emergency_revoke": {
+    "triggers": [
+      "metabase_binds_0_0_0_0",
+      "ecs_public_ipv4_or_eip_present",
+      "public_security_group_ingress_present",
+      "public_sharing_enabled",
+      "embedding_enabled",
+      "unexpected_datasource_present",
+      "normal_operator_without_permissions_plan",
+      "business_or_raw_datasource_present"
+    ],
+    "steps": [
+      "systemctl stop metabase",
+      "systemctl disable metabase",
+      "confirm_no_public_or_port_3000_listener",
+      "remove_public_or_anonymous_links_if_safe",
+      "rotate_affected_admin_and_database_credentials_if_exposure_suspected",
+      "confirm_rds_public_endpoint_and_whitelist_remain_private"
+    ]
+  },
+  "password_rotation": {
+    "secrets_must_not_be_printed": true,
+    "metabase_admin_rotation_path": "localhost_only_admin_access",
+    "metabase_app_user_rotation_path": "approved_postgresql_rds_control_plane",
+    "seo_intel_metabase_readonly_rotation_path": "approved_mysql_rds_control_plane",
+    "forbidden_rotation_accounts": [
+      "seo_intel_writer",
+      "seo_intel_migrator",
+      "business_db_user",
+      "tencent_rds_user",
+      "node2_local_db_user"
+    ]
+  },
+  "export_policy": {
+    "exports_performed_in_this_pr": false,
+    "normal_operator_exports_allowed": false,
+    "owner_approval_required": true,
+    "allowed_export_scope": [
+      "sanitized_url_truth_aggregates",
+      "sanitized_issue_queue_summaries",
+      "safe_dashboard_screenshots_without_raw_pii"
+    ],
+    "forbidden_export_fields": [
+      "email",
+      "raw_email",
+      "order_no",
+      "raw_order_no",
+      "attempt_id",
+      "raw_attempt_id",
+      "payment_id",
+      "cookie",
+      "raw_ip",
+      "raw_user_agent",
+      "token",
+      "raw_payload",
+      "provider_payload",
+      "payment_payload",
+      "secret",
+      "api_key"
+    ]
+  },
+  "operator_onboarding": {
+    "blocked_until_permissions_plan": true,
+    "normal_operator_users_allowed_now": false,
+    "unrestricted_native_sql_allowed_for_normal_users": false,
+    "required_future_plan_items": [
+      "user_groups",
+      "collection_access",
+      "datasource_permissions",
+      "native_sql_policy",
+      "export_policy",
+      "emergency_revoke_owner",
+      "review_cadence"
+    ]
+  },
+  "datasource_boundary": {
+    "allowed_database": "seo_intel",
+    "allowed_datasource_user": "seo_intel_metabase_readonly",
+    "allowed_tables": [
+      "seo_urls",
+      "seo_url_entities",
+      "seo_issue_queue"
+    ],
+    "future_allowed_sources_require_approval": [
+      "sanitized_seo_intel_aggregate_tables",
+      "sanitized_seo_intel_aggregate_views"
+    ],
+    "forbidden_sources": [
+      "business_db",
+      "tencent_rds_fap_prod",
+      "node2_local_db",
+      "cms_write_tables",
+      "raw_orders",
+      "raw_payments",
+      "raw_events_detail",
+      "raw_email",
+      "raw_reports",
+      "raw_crawler_logs",
+      "provider_payloads",
+      "payment_payloads"
+    ]
+  },
+  "production_operations_performed_in_this_pr": false,
+  "metabase_operation_performed_in_this_pr": false,
+  "runtime_code_changed_in_this_pr": false,
+  "migration_changed_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "deploy_performed_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_performed_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "production_crawler_log_read": false,
+  "research_publish_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "next_task": "PR-RESEARCH-01"
+}

--- a/backend/docs/seo/metabase-ops-access-runbook.md
+++ b/backend/docs/seo/metabase-ops-access-runbook.md
@@ -1,0 +1,160 @@
+# Metabase Ops Access Runbook
+
+## Purpose
+
+METABASE-OPS-ACCESS-RUNBOOK-00 defines the operational access policy for the private SEO Dash Metabase instance.
+This is a documentation, generated-contract, and focused-test PR only. It does not operate Metabase, deploy, edit environment files, open public access, change DNS/CDN/OpenResty, modify RDS whitelist, connect databases, run collector writes, enable scheduler, or publish Research content.
+
+## Access Model
+
+Metabase remains a private operations tool:
+
+- host: approved Aliyun private ECS
+- public IPv4: none
+- Metabase bind address: `127.0.0.1`
+- Metabase port: `3000`
+- boot enablement: disabled
+- public sharing: disabled
+- anonymous links: disabled
+- public embedding: disabled
+- datasource boundary: `seo_intel` only
+- datasource account: `seo_intel_metabase_readonly`
+
+Owners must access Metabase through a safe private path such as an approved console session, Workbench-local forwarding, bastion, VPN, or another explicitly approved private ops channel. The runbook does not authorize public security-group ingress, public DNS exposure, CDN exposure, or anonymous/public share links.
+
+## Owner Access Procedure
+
+Before access:
+
+1. Confirm the target host is the approved Aliyun private Metabase ECS.
+2. Confirm the ECS has no public IPv4 or EIP.
+3. Confirm security group inbound rules have not been opened for public Metabase access.
+4. Confirm Metabase is still bound only to `127.0.0.1:3000`.
+5. Confirm the datasource count is exactly one and the datasource is `seo_intel`.
+
+Access must use a private owner-controlled path to `http://127.0.0.1:3000`.
+Do not create public dashboard links, public card links, anonymous links, public embeds, or a public reverse proxy as part of routine access.
+
+## Service Operations
+
+Allowed service inspection commands on the approved ECS:
+
+```bash
+systemctl status metabase --no-pager
+systemctl is-active metabase
+systemctl is-enabled metabase
+ss -lntp | grep ':3000' || true
+curl -sS http://127.0.0.1:3000/api/health
+```
+
+Allowed controlled service commands:
+
+```bash
+systemctl start metabase
+systemctl stop metabase
+systemctl restart metabase
+```
+
+Boot policy:
+
+```bash
+systemctl disable metabase
+```
+
+Metabase should remain boot-disabled until a separate production operations approval explicitly changes that policy.
+
+## Emergency Revoke
+
+Use emergency revoke if any of the following occurs:
+
+- Metabase binds to `0.0.0.0`
+- ECS public IPv4 or EIP appears
+- security group opens public inbound access
+- public sharing or embedding is enabled
+- an unexpected datasource appears
+- a normal operator user is added without a permissions plan
+- any business DB, Tencent RDS, Node2 local DB, CMS write table, or raw operational datasource appears
+
+Emergency revoke sequence:
+
+1. Stop Metabase: `systemctl stop metabase`
+2. Keep boot disabled: `systemctl disable metabase`
+3. Confirm `ss -lntp | grep ':3000' || true` shows no public listener.
+4. Remove any public/anonymous dashboard links or embeds through localhost admin access if Metabase remains safe to access.
+5. Rotate affected Metabase admin and database credentials if exposure is suspected.
+6. Reconfirm no RDS public endpoint or broad whitelist was introduced.
+
+Do not broaden whitelists or open public ports during revoke.
+
+## Password Rotation
+
+Password rotation must remain owner-controlled and must not expose secrets in docs, logs, PRs, screenshots, or command output.
+
+Rotation policy:
+
+- rotate Metabase admin credentials through localhost-only admin access
+- rotate `metabase_app_user` only through the approved PostgreSQL RDS control plane
+- rotate `seo_intel_metabase_readonly` only through the approved MySQL RDS control plane
+- update local secret storage on the private ECS without printing secret values
+- restart Metabase only after verifying it remains bound to `127.0.0.1:3000`
+
+Rotation must not use writer, migrator, business DB, Tencent RDS, Node2 local DB, or CMS write credentials.
+
+## Export Policy
+
+Exports are owner-controlled only.
+No exports may contain PII, raw evidence, raw payloads, order identifiers, payment identifiers, emails, cookies, raw IPs, user agents, tokens, provider payloads, or payment payloads.
+
+Allowed export scope is limited to:
+
+- sanitized aggregate URL Truth rows
+- sanitized Issue Queue summaries
+- safe dashboard screenshots with no raw PII
+
+Normal operator export remains blocked until a separate permissions and audit plan exists.
+
+## Operator Onboarding
+
+Operator onboarding is blocked until a separate permissions plan defines:
+
+- user groups
+- collection access
+- datasource permissions
+- native SQL policy
+- export policy
+- emergency revoke owner
+- review cadence
+
+Until then:
+
+- only the admin user should exist
+- no normal operators should be created
+- no unrestricted native SQL should be granted to normal users
+- no public sharing or anonymous access should be enabled
+
+## Datasource Boundary
+
+Metabase may read only:
+
+- `seo_intel`
+- `seo_urls`
+- `seo_url_entities`
+- `seo_issue_queue`
+- future sanitized `seo_intel` aggregate tables or views after explicit approval
+
+Metabase must not connect to:
+
+- business DB
+- Tencent `rds-fap-prod`
+- Node2 local DB
+- CMS write tables
+- raw orders
+- raw payments
+- raw events detail
+- raw email
+- raw reports
+- raw crawler logs
+- provider payloads
+- payment payloads
+
+Next task: `PR-RESEARCH-01`

--- a/backend/tests/Feature/SeoIntel/SeoIntelMetabaseOpsAccessRunbookTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelMetabaseOpsAccessRunbookTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelMetabaseOpsAccessRunbookTest extends TestCase
+{
+    #[Test]
+    public function artifact_locks_private_localhost_only_access_model(): void
+    {
+        $artifact = $this->artifact();
+        $access = $artifact['access_model'] ?? [];
+
+        $this->assertSame('metabase-ops-access-runbook.v1', $artifact['version'] ?? null);
+        $this->assertSame('METABASE-OPS-ACCESS-RUNBOOK-00', $artifact['task'] ?? null);
+        $this->assertTrue((bool) ($access['localhost_only'] ?? false));
+        $this->assertSame('127.0.0.1', $access['listen_host'] ?? null);
+        $this->assertSame(3000, $access['listen_port'] ?? null);
+        $this->assertFalse((bool) ($access['public_ipv4_allowed'] ?? true));
+        $this->assertFalse((bool) ($access['public_security_group_ingress_allowed'] ?? true));
+        $this->assertFalse((bool) ($access['public_dns_or_cdn_allowed'] ?? true));
+        $this->assertFalse((bool) ($access['anonymous_links_allowed'] ?? true));
+        $this->assertFalse((bool) ($access['public_sharing_allowed'] ?? true));
+        $this->assertFalse((bool) ($access['public_embedding_allowed'] ?? true));
+    }
+
+    #[Test]
+    public function service_policy_keeps_boot_disabled_and_documents_safe_commands(): void
+    {
+        $service = $this->artifact()['service_policy'] ?? [];
+
+        $this->assertSame('metabase', $service['service_name'] ?? null);
+        $this->assertFalse((bool) ($service['boot_enabled_policy'] ?? true));
+        $this->assertTrue((bool) ($service['boot_policy_change_requires_separate_approval'] ?? false));
+
+        foreach ([
+            'systemctl status metabase --no-pager',
+            'systemctl is-active metabase',
+            'systemctl is-enabled metabase',
+            "ss -lntp | grep ':3000' || true",
+            'curl -sS http://127.0.0.1:3000/api/health',
+        ] as $command) {
+            $this->assertContains($command, $service['status_commands'] ?? []);
+        }
+
+        foreach ([
+            'systemctl start metabase',
+            'systemctl stop metabase',
+            'systemctl restart metabase',
+        ] as $command) {
+            $this->assertContains($command, $service['allowed_control_commands'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function emergency_revoke_and_rotation_do_not_open_public_or_use_writer_credentials(): void
+    {
+        $artifact = $this->artifact();
+        $revoke = $artifact['emergency_revoke'] ?? [];
+        $rotation = $artifact['password_rotation'] ?? [];
+
+        foreach ([
+            'metabase_binds_0_0_0_0',
+            'ecs_public_ipv4_or_eip_present',
+            'public_security_group_ingress_present',
+            'public_sharing_enabled',
+            'embedding_enabled',
+            'unexpected_datasource_present',
+            'normal_operator_without_permissions_plan',
+            'business_or_raw_datasource_present',
+        ] as $trigger) {
+            $this->assertContains($trigger, $revoke['triggers'] ?? []);
+        }
+
+        foreach ([
+            'systemctl stop metabase',
+            'systemctl disable metabase',
+            'confirm_no_public_or_port_3000_listener',
+            'confirm_rds_public_endpoint_and_whitelist_remain_private',
+        ] as $step) {
+            $this->assertContains($step, $revoke['steps'] ?? []);
+        }
+
+        $this->assertTrue((bool) ($rotation['secrets_must_not_be_printed'] ?? false));
+
+        foreach ([
+            'seo_intel_writer',
+            'seo_intel_migrator',
+            'business_db_user',
+            'tencent_rds_user',
+            'node2_local_db_user',
+        ] as $account) {
+            $this->assertContains($account, $rotation['forbidden_rotation_accounts'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function export_and_operator_onboarding_policies_are_blocked_until_permissions_plan(): void
+    {
+        $artifact = $this->artifact();
+        $export = $artifact['export_policy'] ?? [];
+        $operator = $artifact['operator_onboarding'] ?? [];
+
+        $this->assertFalse((bool) ($export['exports_performed_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($export['normal_operator_exports_allowed'] ?? true));
+        $this->assertTrue((bool) ($export['owner_approval_required'] ?? false));
+
+        foreach ([
+            'sanitized_url_truth_aggregates',
+            'sanitized_issue_queue_summaries',
+            'safe_dashboard_screenshots_without_raw_pii',
+        ] as $scope) {
+            $this->assertContains($scope, $export['allowed_export_scope'] ?? []);
+        }
+
+        foreach ($this->forbiddenExportFields() as $field) {
+            $this->assertContains($field, $export['forbidden_export_fields'] ?? []);
+        }
+
+        $this->assertTrue((bool) ($operator['blocked_until_permissions_plan'] ?? false));
+        $this->assertFalse((bool) ($operator['normal_operator_users_allowed_now'] ?? true));
+        $this->assertFalse((bool) ($operator['unrestricted_native_sql_allowed_for_normal_users'] ?? true));
+    }
+
+    #[Test]
+    public function datasource_boundary_allows_only_seo_intel_and_forbids_business_raw_sources(): void
+    {
+        $boundary = $this->artifact()['datasource_boundary'] ?? [];
+
+        $this->assertSame('seo_intel', $boundary['allowed_database'] ?? null);
+        $this->assertSame('seo_intel_metabase_readonly', $boundary['allowed_datasource_user'] ?? null);
+        $this->assertSame([
+            'seo_urls',
+            'seo_url_entities',
+            'seo_issue_queue',
+        ], $boundary['allowed_tables'] ?? []);
+
+        foreach ([
+            'business_db',
+            'tencent_rds_fap_prod',
+            'node2_local_db',
+            'cms_write_tables',
+            'raw_orders',
+            'raw_payments',
+            'raw_events_detail',
+            'raw_email',
+            'raw_reports',
+            'raw_crawler_logs',
+            'provider_payloads',
+            'payment_payloads',
+        ] as $source) {
+            $this->assertContains($source, $boundary['forbidden_sources'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function no_runtime_production_or_research_publish_operation_is_authorized(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'production_operations_performed_in_this_pr',
+            'metabase_operation_performed_in_this_pr',
+            'runtime_code_changed_in_this_pr',
+            'migration_changed_in_this_pr',
+            'env_edit_in_this_pr',
+            'deploy_performed_in_this_pr',
+            'scheduler_enabled_in_this_pr',
+            'collector_write_performed_in_this_pr',
+            'external_api_live_activation',
+            'url_submission_performed',
+            'production_crawler_log_read',
+            'research_publish_in_this_pr',
+            'pseo_generation_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_private_access_export_policy_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/metabase-ops-access-runbook.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/metabase-ops-access-runbook.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'metabase ops access runbook',
+            'localhost-only',
+            'public sharing: disabled',
+            'anonymous links: disabled',
+            'boot enablement: disabled',
+            'emergency revoke',
+            'password rotation',
+            'exports are owner-controlled only',
+            'operator onboarding is blocked',
+            'metabase may read only',
+            'business db',
+            'node2 local db',
+            'next task: `pr-research-01`',
+            '"next_task": "pr-research-01"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/metabase-ops-access-runbook.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenExportFields(): array
+    {
+        return [
+            'email',
+            'raw_email',
+            'order_no',
+            'raw_order_no',
+            'attempt_id',
+            'raw_attempt_id',
+            'payment_id',
+            'cookie',
+            'raw_ip',
+            'raw_user_agent',
+            'token',
+            'raw_payload',
+            'provider_payload',
+            'payment_payload',
+            'secret',
+            'api_key',
+        ];
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T13:47:31Z",
+  "updated_at": "2026-05-19T13:54:02Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11796,7 +11796,7 @@
       "merge_commit": "e7c0814868304c448e1acfdd9ad52dc977ade5a4"
     },
     "METABASE-OPS-ACCESS-RUNBOOK-00": {
-      "status": "pr_opened_github_checks_pending",
+      "status": "github_checks_passed",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/metabase-ops-access-runbook-00",
@@ -11805,7 +11805,7 @@
       "depends_on": [
         "SEO-DASH-MVP-ONLINE-SUMMARY"
       ],
-      "commit_sha": "7ce8012d3fad29e80990fe91a37c56ba6c0c1bc0",
+      "commit_sha": "f7069764c74b5f64d6bb48704ad431263a143d7b",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1480",
       "checks": {
         "local": {
@@ -11817,6 +11817,14 @@
           "yaml_validation": "passed",
           "git_diff_check": "passed",
           "scope_validation": "passed"
+        },
+        "github": {
+          "hygiene": "passed",
+          "semgrep_sarif": "passed",
+          "semgrep_oss": "passed",
+          "verify_mbti_legacy": "passed",
+          "verify_mbti_v2": "passed",
+          "mergeStateStatus": "CLEAN"
         }
       },
       "failure_reason": null,
@@ -11844,6 +11852,11 @@
           "at": "2026-05-19T13:47:31Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1480. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-19T13:54:02Z",
+          "status": "github_checks_passed",
+          "summary": "GitHub checks passed for PR #1480: hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2. mergeStateStatus=CLEAN."
         }
       ],
       "next_pr": "PR-RESEARCH-01"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T13:44:00Z",
+  "updated_at": "2026-05-19T13:46:49Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11716,7 +11716,7 @@
       "local_cleanup_executed": true
     },
     "SEO-DASH-MVP-ONLINE-SUMMARY": {
-      "status": "github_checks_passed",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/seo-dash-mvp-online-summary",
@@ -11748,9 +11748,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-19T13:41:11Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "OPS-RELEASE-WORKFLOW-01 ledger reconciliation",
@@ -11785,9 +11785,63 @@
           "at": "2026-05-19T13:44:00Z",
           "status": "github_checks_passed",
           "summary": "GitHub checks passed for PR #1479: hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2. mergeStateStatus=CLEAN."
+        },
+        {
+          "at": "2026-05-19T13:45:00Z",
+          "status": "post_merge_cleanup_complete",
+          "summary": "PR #1479 merged at e7c0814868304c448e1acfdd9ad52dc977ade5a4; origin/main synced; remote branch deleted; local branch cleanup completed by gh merge checkout to main."
         }
       ],
-      "next_pr": "METABASE-OPS-ACCESS-RUNBOOK-00"
+      "next_pr": "METABASE-OPS-ACCESS-RUNBOOK-00",
+      "merge_commit": "e7c0814868304c448e1acfdd9ad52dc977ade5a4"
+    },
+    "METABASE-OPS-ACCESS-RUNBOOK-00": {
+      "status": "commit_created",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/metabase-ops-access-runbook-00",
+      "base": "main",
+      "title": "docs(seo-intel): add Metabase ops access runbook",
+      "depends_on": [
+        "SEO-DASH-MVP-ONLINE-SUMMARY"
+      ],
+      "commit_sha": "9e3be36f85170a962be719a73ab6b62294bf8cdc",
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_metabase_ops_access_runbook": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T13:45:00Z",
+          "status": "in_progress",
+          "summary": "Started docs/generated/test-only Metabase ops access runbook PR. Scope excludes runtime code, migrations, env, deploy, Metabase operation, public exposure, datasource changes, collector writes, scheduler activation, external APIs, URL submission, crawler log reads, Research publish, and pSEO."
+        },
+        {
+          "at": "2026-05-19T13:46:32Z",
+          "status": "local_checks_passed",
+          "summary": "Focused SeoIntelMetabaseOpsAccessRunbook test, full SeoIntel test filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T13:46:49Z",
+          "status": "commit_created",
+          "summary": "Created local commit 9e3be36f85170a962be719a73ab6b62294bf8cdc."
+        }
+      ],
+      "next_pr": "PR-RESEARCH-01"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T13:46:49Z",
+  "updated_at": "2026-05-19T13:47:31Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11796,7 +11796,7 @@
       "merge_commit": "e7c0814868304c448e1acfdd9ad52dc977ade5a4"
     },
     "METABASE-OPS-ACCESS-RUNBOOK-00": {
-      "status": "commit_created",
+      "status": "pr_opened_github_checks_pending",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/metabase-ops-access-runbook-00",
@@ -11805,8 +11805,8 @@
       "depends_on": [
         "SEO-DASH-MVP-ONLINE-SUMMARY"
       ],
-      "commit_sha": "9e3be36f85170a962be719a73ab6b62294bf8cdc",
-      "pr_url": null,
+      "commit_sha": "7ce8012d3fad29e80990fe91a37c56ba6c0c1bc0",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1480",
       "checks": {
         "local": {
           "php_artisan_test_filter_seo_intel_metabase_ops_access_runbook": "passed",
@@ -11839,6 +11839,11 @@
           "at": "2026-05-19T13:46:49Z",
           "status": "commit_created",
           "summary": "Created local commit 9e3be36f85170a962be719a73ab6b62294bf8cdc."
+        },
+        {
+          "at": "2026-05-19T13:47:31Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1480. GitHub checks pending."
         }
       ],
       "next_pr": "PR-RESEARCH-01"

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6047,3 +6047,54 @@ prs:
     human_review_required: false
     production_approval_required: false
     next_task: METABASE-OPS-ACCESS-RUNBOOK-00
+
+  - id: METABASE-OPS-ACCESS-RUNBOOK-00
+    repo: fap-api
+    depends_on:
+      - SEO-DASH-MVP-ONLINE-SUMMARY
+    branch: codex/metabase-ops-access-runbook-00
+    base: main
+    title: "docs(seo-intel): add Metabase ops access runbook"
+    name: "Metabase ops access runbook"
+    train_scope: seo_dash_mvp_closeout_research_train
+    risk_level: low_docs_generated_tests_no_runtime_activation
+    type: docs/generated/test PR
+    scope:
+      - Define localhost-only operational access for private Metabase.
+      - Document owner access, service start/stop/status, boot-disabled policy, emergency revoke, password rotation, export policy, and blocked operator onboarding.
+      - Add generated runbook artifact and focused SeoIntel contract test.
+    allowed_paths:
+      - backend/docs/seo/metabase-ops-access-runbook.md
+      - backend/docs/seo/generated/metabase-ops-access-runbook.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelMetabaseOpsAccessRunbookTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy, edit env files, run collector writes, enable scheduler, connect live search APIs, submit URLs, read production crawler logs, change RDS/DB/users/whitelist, expose Metabase publicly, publish Research content, or create pSEO.
+      - Operate Metabase, change service config, create users, create exports, create public links, open security groups, change DNS/CDN/OpenResty, or add datasources.
+      - Connect Metabase to business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational tables.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelMetabaseOpsAccessRunbook
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/metabase-ops-access-runbook.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    metabase_operation: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: PR-RESEARCH-01


### PR DESCRIPTION
## What changed
- Added the private Metabase operational access runbook for SEO Dash MVP operations.
- Added a generated JSON contract for the runbook policy surface.
- Added a focused SeoIntel feature test that validates the runbook and generated artifact.
- Updated the PR train manifest/state for `METABASE-OPS-ACCESS-RUNBOOK-00`.

## Why
The SEO Dash MVP is now online behind a private localhost-only Metabase instance. This PR freezes the operational access model before Research MVP work continues: no public exposure, boot disabled by default, owner-controlled access, emergency revoke, password rotation, export restrictions, and no business DB source.

## Validation
- `cd backend && php artisan test --filter=SeoIntelMetabaseOpsAccessRunbook`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/metabase-ops-access-runbook.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nPY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No Metabase operation or public exposure changes.
- No datasource, dashboard, scheduler, collector, search API, crawler log, Research publish, pSEO, env, deploy, runtime, or migration changes.
- Operator onboarding remains blocked until a separate permissions plan exists.
