### PR TITLE
feat(cms): add Research Asset backend MVP

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ResearchReportController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ResearchReportController.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Http\Controllers\Controller;
+use App\Models\ResearchReport;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+
+final class ResearchReportController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $query = ResearchReport::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $validated['org_id'])
+            ->where('locale', $validated['locale'])
+            ->publiclyReadable()
+            ->orderByDesc('published_at')
+            ->orderByDesc('id');
+
+        return response()->json([
+            'ok' => true,
+            'items' => $query->get()->map(fn (ResearchReport $report): array => $this->publicPayload($report))->values()->all(),
+            'page_entity_type' => ResearchReport::PAGE_ENTITY_TYPE,
+            'exposure_gate' => 'published_approved_public_indexable_only',
+        ]);
+    }
+
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $report = ResearchReport::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $validated['org_id'])
+            ->where('slug', $this->normalizeSlug($slug))
+            ->where('locale', $validated['locale'])
+            ->publiclyReadable()
+            ->first();
+
+        if (! $report instanceof ResearchReport) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'research report not found.',
+            ], 404);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'report' => $this->publicPayload($report),
+        ]);
+    }
+
+    public function internalIndex(Request $request): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $query = ResearchReport::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $validated['org_id'])
+            ->where('locale', $validated['locale'])
+            ->orderByDesc('updated_at')
+            ->orderByDesc('id');
+
+        return response()->json([
+            'ok' => true,
+            'items' => $query->get()->map(fn (ResearchReport $report): array => $this->internalPayload($report))->values()->all(),
+        ]);
+    }
+
+    public function internalShow(Request $request, string $slug): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $report = ResearchReport::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $validated['org_id'])
+            ->where('slug', $this->normalizeSlug($slug))
+            ->where('locale', $validated['locale'])
+            ->first();
+
+        if (! $report instanceof ResearchReport) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'research report not found.',
+            ], 404);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'report' => $this->internalPayload($report),
+        ]);
+    }
+
+    public function internalUpdate(Request $request, string $slug): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'title' => ['required', 'string', 'max:255'],
+            'executive_summary' => ['nullable', 'string', 'max:4000'],
+            'body_md' => ['nullable', 'string'],
+            'research_type' => ['required', Rule::in(ResearchReport::RESEARCH_TYPES)],
+            'methodology' => ['required', 'string', 'max:12000'],
+            'sample_disclaimer' => ['required', 'string', 'max:4000'],
+            'claim_boundary' => ['required', 'string', 'max:4000'],
+            'author_name' => ['nullable', 'string', 'max:128'],
+            'reviewer_name' => ['nullable', 'string', 'max:128'],
+            'references' => ['nullable', 'array'],
+            'references.*' => ['string', 'max:1000'],
+            'downloadable_asset_placeholder' => ['nullable', 'string', 'max:255'],
+            'locale' => ['required', 'string', Rule::in(['en', 'zh-CN'])],
+            'status' => ['required', Rule::in([
+                ResearchReport::STATUS_DRAFT,
+                ResearchReport::STATUS_PUBLISHED,
+                ResearchReport::STATUS_ARCHIVED,
+            ])],
+            'review_state' => ['required', Rule::in([
+                ResearchReport::REVIEW_DRAFT,
+                ResearchReport::REVIEW_RESEARCH,
+                ResearchReport::REVIEW_CLAIM,
+                ResearchReport::REVIEW_APPROVED,
+                ResearchReport::REVIEW_CHANGES_REQUESTED,
+            ])],
+            'is_public' => ['sometimes', 'boolean'],
+            'is_indexable' => ['sometimes', 'boolean'],
+            'last_reviewed_at' => ['nullable', 'date'],
+            'published_at' => ['nullable', 'date'],
+            'seo_title' => ['nullable', 'string', 'max:255'],
+            'seo_description' => ['nullable', 'string', 'max:2000'],
+            'canonical_path' => ['nullable', 'string', 'max:255'],
+            'org_id' => ['nullable', 'integer', 'min:0'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'VALIDATION_FAILED',
+                'errors' => $validator->errors()->toArray(),
+            ], 422);
+        }
+
+        $validated = $validator->validated();
+        $status = (string) $validated['status'];
+        $reviewState = (string) $validated['review_state'];
+        $isPublic = (bool) ($validated['is_public'] ?? false);
+        $isIndexable = (bool) ($validated['is_indexable'] ?? false);
+
+        if ($status === ResearchReport::STATUS_PUBLISHED && $reviewState !== ResearchReport::REVIEW_APPROVED) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'VALIDATION_FAILED',
+                'errors' => ['review_state' => ['published research reports must be approved.']],
+            ], 422);
+        }
+
+        if ($status !== ResearchReport::STATUS_PUBLISHED && ($isPublic || $isIndexable)) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'VALIDATION_FAILED',
+                'errors' => ['status' => ['draft or archived research reports cannot be public or indexable.']],
+            ], 422);
+        }
+
+        $orgId = (int) ($validated['org_id'] ?? 0);
+        $locale = (string) $validated['locale'];
+        $normalizedSlug = $this->normalizeSlug($slug);
+
+        $report = ResearchReport::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->where('slug', $normalizedSlug)
+            ->where('locale', $locale)
+            ->first() ?? new ResearchReport([
+                'org_id' => $orgId,
+                'slug' => $normalizedSlug,
+                'locale' => $locale,
+            ]);
+
+        $report->fill([
+            'title' => trim((string) $validated['title']),
+            'executive_summary' => $this->nullableString($validated['executive_summary'] ?? null),
+            'body_md' => $this->nullableString($validated['body_md'] ?? null),
+            'research_type' => (string) $validated['research_type'],
+            'methodology' => trim((string) $validated['methodology']),
+            'sample_disclaimer' => trim((string) $validated['sample_disclaimer']),
+            'claim_boundary' => trim((string) $validated['claim_boundary']),
+            'author_name' => $this->nullableString($validated['author_name'] ?? null),
+            'reviewer_name' => $this->nullableString($validated['reviewer_name'] ?? null),
+            'references' => array_values((array) ($validated['references'] ?? [])),
+            'downloadable_asset_placeholder' => $this->nullableString($validated['downloadable_asset_placeholder'] ?? null),
+            'status' => $status,
+            'review_state' => $reviewState,
+            'is_public' => $isPublic,
+            'is_indexable' => $isIndexable,
+            'last_reviewed_at' => $validated['last_reviewed_at'] ?? null,
+            'published_at' => $validated['published_at'] ?? null,
+            'seo_title' => $this->nullableString($validated['seo_title'] ?? null),
+            'seo_description' => $this->nullableString($validated['seo_description'] ?? null),
+            'canonical_path' => $this->nullableString($validated['canonical_path'] ?? null) ?? '/research/'.$normalizedSlug,
+        ]);
+        $report->save();
+
+        return response()->json([
+            'ok' => true,
+            'report' => $this->internalPayload($report),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>|JsonResponse
+     */
+    private function validateReadQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'locale' => ['nullable', 'string', Rule::in(['en', 'zh-CN'])],
+            'org_id' => ['nullable', 'integer', 'min:0'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'VALIDATION_FAILED',
+                'errors' => $validator->errors()->toArray(),
+            ], 422);
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'locale' => (string) ($validated['locale'] ?? 'en'),
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function publicPayload(ResearchReport $report): array
+    {
+        return [
+            'id' => (int) $report->id,
+            'slug' => (string) $report->slug,
+            'locale' => (string) $report->locale,
+            'page_entity_type' => ResearchReport::PAGE_ENTITY_TYPE,
+            'title' => (string) $report->title,
+            'executive_summary' => $report->executive_summary,
+            'body_md' => $report->body_md,
+            'research_type' => (string) $report->research_type,
+            'methodology' => $report->methodology,
+            'sample_disclaimer' => $report->sample_disclaimer,
+            'claim_boundary' => $report->claim_boundary,
+            'author_name' => $report->author_name,
+            'reviewer_name' => $report->reviewer_name,
+            'references' => $report->references ?? [],
+            'downloadable_asset_placeholder' => $report->downloadable_asset_placeholder,
+            'last_reviewed_at' => $report->last_reviewed_at?->toAtomString(),
+            'published_at' => $report->published_at?->toAtomString(),
+            'seo_title' => $report->seo_title,
+            'seo_description' => $report->seo_description,
+            'canonical_path' => $report->canonical_path,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function internalPayload(ResearchReport $report): array
+    {
+        return array_merge($this->publicPayload($report), [
+            'status' => (string) $report->status,
+            'review_state' => (string) $report->review_state,
+            'is_public' => (bool) $report->is_public,
+            'is_indexable' => (bool) $report->is_indexable,
+            'search_channel_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+        ]);
+    }
+
+    private function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $normalized = trim((string) ($value ?? ''));
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Models/ResearchReport.php
+++ b/backend/app/Models/ResearchReport.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+final class ResearchReport extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_PUBLISHED = 'published';
+
+    public const STATUS_ARCHIVED = 'archived';
+
+    public const REVIEW_DRAFT = 'draft';
+
+    public const REVIEW_RESEARCH = 'research_review';
+
+    public const REVIEW_CLAIM = 'claim_review';
+
+    public const REVIEW_APPROVED = 'approved';
+
+    public const REVIEW_CHANGES_REQUESTED = 'changes_requested';
+
+    public const PAGE_ENTITY_TYPE = 'research_report';
+
+    public const RESEARCH_TYPES = [
+        'salary_turnover',
+        'methodology',
+        'psychometric_research',
+        'market_research',
+        'other',
+    ];
+
+    protected $table = 'research_reports';
+
+    protected $fillable = [
+        'org_id',
+        'slug',
+        'locale',
+        'title',
+        'executive_summary',
+        'body_md',
+        'research_type',
+        'methodology',
+        'sample_disclaimer',
+        'claim_boundary',
+        'author_name',
+        'reviewer_name',
+        'references',
+        'downloadable_asset_placeholder',
+        'status',
+        'review_state',
+        'is_public',
+        'is_indexable',
+        'last_reviewed_at',
+        'published_at',
+        'seo_title',
+        'seo_description',
+        'canonical_path',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'references' => 'array',
+        'is_public' => 'boolean',
+        'is_indexable' => 'boolean',
+        'last_reviewed_at' => 'datetime',
+        'published_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  Builder<ResearchReport>  $query
+     * @return Builder<ResearchReport>
+     */
+    public function scopePubliclyReadable(Builder $query): Builder
+    {
+        return $query
+            ->where('status', self::STATUS_PUBLISHED)
+            ->where('review_state', self::REVIEW_APPROVED)
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->where(static function (Builder $publishedAtQuery): void {
+                $publishedAtQuery
+                    ->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
+}

--- a/backend/database/migrations/2026_05_19_000100_create_research_reports_table.php
+++ b/backend/database/migrations/2026_05_19_000100_create_research_reports_table.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('research_reports')) {
+            return;
+        }
+
+        Schema::create('research_reports', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('slug', 128);
+            $table->string('locale', 16)->default('en');
+            $table->string('title', 255);
+            $table->text('executive_summary')->nullable();
+            $table->longText('body_md')->nullable();
+            $table->string('research_type', 64);
+            $table->longText('methodology')->nullable();
+            $table->text('sample_disclaimer')->nullable();
+            $table->text('claim_boundary')->nullable();
+            $table->string('author_name', 128)->nullable();
+            $table->string('reviewer_name', 128)->nullable();
+            $table->json('references')->nullable();
+            $table->string('downloadable_asset_placeholder', 255)->nullable();
+            $table->string('status', 32)->default('draft');
+            $table->string('review_state', 64)->default('draft');
+            $table->boolean('is_public')->default(false);
+            $table->boolean('is_indexable')->default(false);
+            $table->dateTime('last_reviewed_at')->nullable();
+            $table->dateTime('published_at')->nullable();
+            $table->string('seo_title', 255)->nullable();
+            $table->text('seo_description')->nullable();
+            $table->string('canonical_path', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique(['org_id', 'slug', 'locale'], 'uq_research_reports_slug_locale');
+            $table->index(['org_id', 'locale', 'status', 'is_indexable'], 'idx_research_reports_public_read');
+            $table->index(['org_id', 'research_type', 'review_state'], 'idx_research_reports_review_scope');
+        });
+    }
+
+    public function down(): void
+    {
+        // Forward-only migration: destructive rollback is intentionally disabled.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -3557,6 +3557,76 @@
                 ]
             }
         },
+        "/api/v0.5/internal/research-reports": {
+            "get": {
+                "operationId": "get_api_v0_5_internal_research_reports",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ResearchReportController@internalIndex",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
+                ]
+            }
+        },
+        "/api/v0.5/internal/research-reports/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_internal_research_reports_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ResearchReportController@internalShow",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
+                ]
+            },
+            "put": {
+                "operationId": "put_api_v0_5_internal_research_reports_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ResearchReportController@internalUpdate",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
+                ]
+            }
+        },
         "/api/v0.5/internal/support-articles": {
             "get": {
                 "operationId": "get_api_v0_5_internal_support_articles",
@@ -3741,6 +3811,40 @@
                     }
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@seo",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/research": {
+            "get": {
+                "operationId": "get_api_v0_5_research",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ResearchReportController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/research/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_research_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ResearchReportController@show",
                 "x-laravel-middleware": [
                     "api"
                 ]

--- a/backend/docs/seo/generated/research-asset-backend-mvp.v1.json
+++ b/backend/docs/seo/generated/research-asset-backend-mvp.v1.json
@@ -1,0 +1,90 @@
+{
+  "version": "research-asset-backend-mvp.v1",
+  "task_id": "PR-RESEARCH-01",
+  "repo": "fap-api",
+  "artifact_type": "backend_cms_contract",
+  "entity": {
+    "model": "ResearchReport",
+    "table": "research_reports",
+    "page_entity_type": "research_report",
+    "public_route_family": "/research/{slug}",
+    "api_routes": {
+      "public_index": "/api/v0.5/research",
+      "public_show": "/api/v0.5/research/{slug}",
+      "internal_index": "/api/v0.5/internal/research-reports",
+      "internal_show": "/api/v0.5/internal/research-reports/{slug}",
+      "internal_update": "/api/v0.5/internal/research-reports/{slug}"
+    }
+  },
+  "required_metadata_fields": [
+    "research_type",
+    "methodology",
+    "sample_disclaimer",
+    "claim_boundary",
+    "author_name",
+    "reviewer_name",
+    "references",
+    "last_reviewed_at",
+    "downloadable_asset_placeholder"
+  ],
+  "draft_publish_gate": {
+    "public_read_requires": {
+      "status": "published",
+      "review_state": "approved",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "null_or_not_future"
+    },
+    "draft_or_archived_public_indexable_allowed": false,
+    "published_requires_approved_review": true
+  },
+  "public_api_boundary": {
+    "exposes_only_published_indexable_records": true,
+    "draft_returns_404": true,
+    "future_scheduled_returns_404": true,
+    "forbidden_sources": [
+      "business_db",
+      "tencent_rds_fap_prod",
+      "node2_local_db",
+      "cms_write_tables",
+      "raw_orders",
+      "raw_payments",
+      "raw_events_detail",
+      "raw_email",
+      "raw_reports",
+      "raw_crawler_logs",
+      "provider_payloads",
+      "payment_payloads",
+      "raw_ip_cookies_user_agents"
+    ]
+  },
+  "seo_search_boundary": {
+    "sitemap_eligible_in_this_pr": false,
+    "llms_eligible_in_this_pr": false,
+    "search_channel_queue_eligible_in_this_pr": false,
+    "url_truth_support_added_in_this_pr": false,
+    "dataset_schema_allowed_in_this_pr": false,
+    "research_publish_in_this_pr": false,
+    "pseo_in_this_pr": false
+  },
+  "claim_boundary": {
+    "diagnosis_treatment_or_cure_claims_allowed": false,
+    "hiring_fit_or_job_competency_claims_allowed": false,
+    "exact_iq_or_guaranteed_outcome_claims_allowed": false,
+    "career_recommendation_claim_expansion_allowed": false
+  },
+  "operations_not_performed": {
+    "deploy": false,
+    "production_env_edit": false,
+    "collector_write": false,
+    "scheduler_enabled": false,
+    "live_search_api_connected": false,
+    "url_submission": false,
+    "production_crawler_log_read": false,
+    "metabase_operation": false,
+    "rds_db_user_or_whitelist_change": false,
+    "research_content_import": false,
+    "research_publish": false
+  },
+  "next_task": "PR-RESEARCH-02"
+}

--- a/backend/docs/seo/research-asset-backend-mvp.md
+++ b/backend/docs/seo/research-asset-backend-mvp.md
@@ -1,0 +1,83 @@
+# Research Asset Backend MVP
+
+PR-RESEARCH-01 adds the backend/CMS authority foundation for Research Asset records. It does not import report content, publish Research, add sitemap entries, add `llms.txt` entries, enqueue Search Channel submissions, run collector writes, or change production infrastructure.
+
+## Authority Boundary
+
+Research Assets are backend/CMS authoritative. Frontend runtime may render only payloads returned by the Research public API. Frontend local files, hardcoded report copy, static JSON, sitemap fallback, and `llms.txt` fallback must not become Research truth.
+
+## Entity Contract
+
+Research records use:
+
+- model: `ResearchReport`
+- table: `research_reports`
+- public page entity type: `research_report`
+- public route family: `/research/{slug}`
+- CMS route family: `/api/v0.5/internal/research-reports/{slug}`
+- public API route family: `/api/v0.5/research/{slug}`
+
+Required metadata fields:
+
+- `research_type`
+- `methodology`
+- `sample_disclaimer`
+- `claim_boundary`
+- `author_name`
+- `reviewer_name`
+- `references`
+- `last_reviewed_at`
+- `downloadable_asset_placeholder`
+
+The initial allowed `research_type` values are:
+
+- `salary_turnover`
+- `methodology`
+- `psychometric_research`
+- `market_research`
+- `other`
+
+## Draft / Published Gate
+
+Public reads require all gates:
+
+- `status = published`
+- `review_state = approved`
+- `is_public = true`
+- `is_indexable = true`
+- `published_at` is null or not in the future
+
+Draft, archived, unapproved, private, noindex, and future-scheduled Research records return 404 from the public API. Internal CMS endpoints may read and update draft records behind CMS admin middleware.
+
+Draft or archived records cannot be marked public or indexable. Published records require the approved review state.
+
+## Public API Boundary
+
+The public API exposes only published/indexable Research records and safe Research metadata. It does not expose business DB data, user reports, orders, payments, attempts, emails, raw event detail, raw crawler logs, provider payloads, payment payloads, cookies, raw IPs, or private CMS write data.
+
+## SEO / Search Boundary
+
+This PR does not make Research eligible for sitemap, `llms.txt`, URL Truth, Search Channel Queue, Search Channel live submission, Dataset schema, or pSEO. Internal payloads explicitly keep:
+
+- `sitemap_eligible = false`
+- `llms_eligible = false`
+- `search_channel_eligible = false`
+
+Those gates must be defined by PR-RESEARCH-03 before any exposure change.
+
+## Claim Boundary
+
+Research copy must remain claim-safe. Research Assets must not claim diagnosis, treatment, cure, hiring fit, job competency, exact IQ, guaranteed salary, guaranteed turnover prediction, guaranteed career outcome, or AI career planning authority.
+
+RIASEC, Big Five, and career recommendation language remains bounded. This PR does not expand those claim surfaces.
+
+## What Was Not Done
+
+- No Research content imported.
+- No Research content published.
+- No sitemap behavior changed.
+- No `llms.txt` behavior changed.
+- No Search Channel Queue or live submission changed.
+- No Metabase operation performed.
+- No collector write or scheduler activation performed.
+- No production env, deploy, RDS, DB user, whitelist, DNS, CDN, or OpenResty change performed.

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -68,6 +68,7 @@ use App\Http\Controllers\API\V0_5\Cms\LandingSurfaceController;
 use App\Http\Controllers\API\V0_5\Cms\MediaLibraryController;
 use App\Http\Controllers\API\V0_5\Cms\PersonalityController;
 use App\Http\Controllers\API\V0_5\Cms\PersonalityDesktopCloneController;
+use App\Http\Controllers\API\V0_5\Cms\ResearchReportController;
 use App\Http\Controllers\API\V0_5\Cms\SupportArticleController;
 use App\Http\Controllers\API\V0_5\Cms\TopicController;
 use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkOverrideController;
@@ -492,6 +493,8 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);
+    Route::get('/research', [ResearchReportController::class, 'index']);
+    Route::get('/research/{slug}', [ResearchReportController::class, 'show']);
     Route::get('/support/articles', [SupportArticleController::class, 'index']);
     Route::get('/support/articles/{slug}', [SupportArticleController::class, 'show']);
     Route::get('/support/guides', [InterpretationGuideController::class, 'index']);
@@ -520,6 +523,8 @@ Route::prefix('v0.5')->group(function () {
         Route::get('/internal/content-pages', [ContentPageController::class, 'internalIndex']);
         Route::get('/internal/landing-surfaces', [LandingSurfaceController::class, 'internalIndex']);
         Route::get('/internal/media-assets', [MediaLibraryController::class, 'internalIndex']);
+        Route::get('/internal/research-reports', [ResearchReportController::class, 'internalIndex']);
+        Route::get('/internal/research-reports/{slug}', [ResearchReportController::class, 'internalShow']);
     });
 
     Route::middleware([
@@ -532,6 +537,7 @@ Route::prefix('v0.5')->group(function () {
         Route::put('/internal/landing-surfaces/{surfaceKey}', [LandingSurfaceController::class, 'internalUpdate']);
         Route::put('/internal/media-assets/{assetKey}', [MediaLibraryController::class, 'internalUpdate']);
         Route::post('/internal/media-assets/{assetKey}/upload', [MediaLibraryController::class, 'internalUpload']);
+        Route::put('/internal/research-reports/{slug}', [ResearchReportController::class, 'internalUpdate']);
     });
 
     Route::get('/landing-surfaces/{surfaceKey}', [LandingSurfaceController::class, 'show']);

--- a/backend/tests/Feature/Research/ResearchAssetBackendMvpTest.php
+++ b/backend/tests/Feature/Research/ResearchAssetBackendMvpTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Research;
+
+use App\Models\AdminUser;
+use App\Models\Permission;
+use App\Models\ResearchReport;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ResearchAssetBackendMvpTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_research_api_exposes_only_published_approved_public_indexable_records(): void
+    {
+        $visible = $this->createReport([
+            'slug' => 'mbti-salary-turnover',
+            'status' => ResearchReport::STATUS_PUBLISHED,
+            'review_state' => ResearchReport::REVIEW_APPROVED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 5, 18, 0, 0, 0, 'UTC'),
+        ]);
+
+        $this->createReport([
+            'slug' => 'draft-report',
+            'status' => ResearchReport::STATUS_DRAFT,
+            'review_state' => ResearchReport::REVIEW_RESEARCH,
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+
+        $this->createReport([
+            'slug' => 'noindex-report',
+            'status' => ResearchReport::STATUS_PUBLISHED,
+            'review_state' => ResearchReport::REVIEW_APPROVED,
+            'is_public' => true,
+            'is_indexable' => false,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/research?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('page_entity_type', 'research_report')
+            ->assertJsonPath('exposure_gate', 'published_approved_public_indexable_only')
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.slug', (string) $visible->slug)
+            ->assertJsonPath('items.0.page_entity_type', 'research_report')
+            ->assertJsonPath('items.0.research_type', 'salary_turnover')
+            ->assertJsonPath('items.0.methodology', 'Methods are documented before publish.')
+            ->assertJsonPath('items.0.sample_disclaimer', 'Aggregates only; no individual user data.')
+            ->assertJsonPath('items.0.claim_boundary', 'Descriptive research only; no hiring, diagnosis, or guaranteed outcome claims.');
+
+        $this->assertStringNotContainsString('draft-report', (string) $response->getContent());
+        $this->assertStringNotContainsString('noindex-report', (string) $response->getContent());
+
+        $this->getJson('/api/v0.5/research/draft-report?locale=en')->assertNotFound();
+        $this->getJson('/api/v0.5/research/noindex-report?locale=en')->assertNotFound();
+    }
+
+    public function test_public_research_detail_requires_publish_gate_and_returns_safe_metadata(): void
+    {
+        $this->createReport([
+            'slug' => 'mbti-salary-turnover',
+            'status' => ResearchReport::STATUS_PUBLISHED,
+            'review_state' => ResearchReport::REVIEW_APPROVED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'references' => ['Internal aggregate methodology memo'],
+            'last_reviewed_at' => Carbon::create(2026, 5, 18, 0, 0, 0, 'UTC'),
+            'published_at' => Carbon::create(2026, 5, 18, 1, 0, 0, 'UTC'),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/research/mbti-salary-turnover?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('report.slug', 'mbti-salary-turnover')
+            ->assertJsonPath('report.page_entity_type', 'research_report')
+            ->assertJsonPath('report.references.0', 'Internal aggregate methodology memo')
+            ->assertJsonPath('report.downloadable_asset_placeholder', 'asset pending')
+            ->assertJsonMissingPath('report.status')
+            ->assertJsonMissingPath('report.review_state')
+            ->assertJsonMissingPath('report.search_channel_eligible');
+    }
+
+    public function test_internal_cms_update_enforces_draft_publish_gate(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+
+        $this->withSession(['ops_org_id' => 0])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/internal/research-reports/draft-public-leak?locale=en', [
+                'title' => 'Draft public leak',
+                'executive_summary' => 'Should not become public.',
+                'body_md' => 'Draft body.',
+                'research_type' => 'salary_turnover',
+                'methodology' => 'Methods.',
+                'sample_disclaimer' => 'Aggregate-only sample disclaimer.',
+                'claim_boundary' => 'No diagnosis or hiring claims.',
+                'locale' => 'en',
+                'status' => 'draft',
+                'review_state' => 'research_review',
+                'is_public' => true,
+                'is_indexable' => true,
+            ])->assertStatus(422)
+            ->assertJsonPath('errors.status.0', 'draft or archived research reports cannot be public or indexable.');
+
+        $this->withSession(['ops_org_id' => 0])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/internal/research-reports/unapproved-publish?locale=en', [
+                'title' => 'Unapproved publish',
+                'executive_summary' => 'Should not publish.',
+                'body_md' => 'Body.',
+                'research_type' => 'salary_turnover',
+                'methodology' => 'Methods.',
+                'sample_disclaimer' => 'Aggregate-only sample disclaimer.',
+                'claim_boundary' => 'No diagnosis or hiring claims.',
+                'locale' => 'en',
+                'status' => 'published',
+                'review_state' => 'claim_review',
+                'is_public' => true,
+                'is_indexable' => true,
+            ])->assertStatus(422)
+            ->assertJsonPath('errors.review_state.0', 'published research reports must be approved.');
+
+        $response = $this->withSession(['ops_org_id' => 0])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/internal/research-reports/approved-research?locale=en', [
+                'title' => 'Approved research',
+                'executive_summary' => 'Summary.',
+                'body_md' => 'Body.',
+                'research_type' => 'salary_turnover',
+                'methodology' => 'Methods.',
+                'sample_disclaimer' => 'Aggregate-only sample disclaimer.',
+                'claim_boundary' => 'No diagnosis or hiring claims.',
+                'author_name' => 'Research Team',
+                'reviewer_name' => 'Claim Reviewer',
+                'references' => ['Reference A'],
+                'downloadable_asset_placeholder' => 'asset pending',
+                'locale' => 'en',
+                'status' => 'published',
+                'review_state' => 'approved',
+                'is_public' => true,
+                'is_indexable' => true,
+                'last_reviewed_at' => '2026-05-18T00:00:00Z',
+                'published_at' => '2026-05-18T01:00:00Z',
+                'seo_title' => 'Approved research',
+                'seo_description' => 'Research description.',
+                'canonical_path' => '/research/approved-research',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('report.slug', 'approved-research')
+            ->assertJsonPath('report.status', 'published')
+            ->assertJsonPath('report.review_state', 'approved')
+            ->assertJsonPath('report.sitemap_eligible', false)
+            ->assertJsonPath('report.llms_eligible', false)
+            ->assertJsonPath('report.search_channel_eligible', false);
+
+        $this->assertDatabaseHas('research_reports', [
+            'slug' => 'approved-research',
+            'status' => 'published',
+            'review_state' => 'approved',
+            'is_public' => true,
+            'is_indexable' => true,
+        ]);
+    }
+
+    public function test_research_artifact_records_no_publish_or_search_exposure_in_this_pr(): void
+    {
+        $artifact = json_decode((string) file_get_contents(base_path('docs/seo/generated/research-asset-backend-mvp.v1.json')), true);
+
+        $this->assertSame('research-asset-backend-mvp.v1', $artifact['version'] ?? null);
+        $this->assertSame('research_report', data_get($artifact, 'entity.page_entity_type'));
+        $this->assertSame('/api/v0.5/research/{slug}', data_get($artifact, 'entity.api_routes.public_show'));
+        $this->assertTrue((bool) data_get($artifact, 'draft_publish_gate.public_read_requires.is_public'));
+        $this->assertTrue((bool) data_get($artifact, 'draft_publish_gate.public_read_requires.is_indexable'));
+        $this->assertFalse((bool) data_get($artifact, 'seo_search_boundary.sitemap_eligible_in_this_pr'));
+        $this->assertFalse((bool) data_get($artifact, 'seo_search_boundary.llms_eligible_in_this_pr'));
+        $this->assertFalse((bool) data_get($artifact, 'seo_search_boundary.search_channel_queue_eligible_in_this_pr'));
+        $this->assertFalse((bool) data_get($artifact, 'seo_search_boundary.research_publish_in_this_pr'));
+        $this->assertFalse((bool) data_get($artifact, 'operations_not_performed.collector_write'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createReport(array $overrides = []): ResearchReport
+    {
+        return ResearchReport::query()->create(array_merge([
+            'org_id' => 0,
+            'slug' => 'research-report',
+            'locale' => 'en',
+            'title' => 'Research Report',
+            'executive_summary' => 'Executive summary.',
+            'body_md' => 'Body.',
+            'research_type' => 'salary_turnover',
+            'methodology' => 'Methods are documented before publish.',
+            'sample_disclaimer' => 'Aggregates only; no individual user data.',
+            'claim_boundary' => 'Descriptive research only; no hiring, diagnosis, or guaranteed outcome claims.',
+            'author_name' => 'Research Team',
+            'reviewer_name' => 'Claim Reviewer',
+            'references' => [],
+            'downloadable_asset_placeholder' => 'asset pending',
+            'status' => ResearchReport::STATUS_DRAFT,
+            'review_state' => ResearchReport::REVIEW_DRAFT,
+            'is_public' => false,
+            'is_indexable' => false,
+            'canonical_path' => '/research/research-report',
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<int,string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -805,6 +805,26 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_research_backend_mvp_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Cms/ResearchReportController.php',
+            'backend/app/Models/ResearchReport.php',
+            'backend/database/migrations/2026_05_19_000100_create_research_reports_table.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use App\Http\Controllers\API\V0_5\Cms\ResearchReportController;',
+            '+    Route::get(\'/research\', [ResearchReportController::class, \'index\']);',
+            '+    Route::get(\'/research/{slug}\', [ResearchReportController::class, \'show\']);',
+            '+        Route::get(\'/internal/research-reports\', [ResearchReportController::class, \'internalIndex\']);',
+            '+        Route::get(\'/internal/research-reports/{slug}\', [ResearchReportController::class, \'internalShow\']);',
+            '+        Route::put(\'/internal/research-reports/{slug}\', [ResearchReportController::class, \'internalUpdate\']);',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', routeChangedLines: $routeChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_publishing_runtime_truth_gate_changes(): void
     {
         $changed = [
@@ -1646,6 +1666,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isResearchBackendMvpFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php'
                 && $this->articleControllerDiffIsPublicArticleRecencyOrderingOnly(
@@ -1843,6 +1867,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/web.php'
                 && $this->routeDiffIsPublicHealthzAliasOnly($webRouteChangedLines ?? $this->webRouteChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsResearchBackendMvpOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -2078,6 +2109,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Cms/ArticlePublishService.php',
             'backend/app/Services/Cms/ArticleService.php',
             'backend/database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php',
+        ], true);
+    }
+
+    private function isResearchBackendMvpFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/Cms/ResearchReportController.php',
+            'backend/app/Models/ResearchReport.php',
+            'backend/database/migrations/2026_05_19_000100_create_research_reports_table.php',
         ], true);
     }
 
@@ -3014,6 +3054,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleCoverPropagationSmoke\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsResearchBackendMvpOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (preg_match('/ResearchReportController|\/research|\/internal\/research-reports/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T13:54:02Z",
+  "updated_at": "2026-05-19T14:09:09Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11796,7 +11796,7 @@
       "merge_commit": "e7c0814868304c448e1acfdd9ad52dc977ade5a4"
     },
     "METABASE-OPS-ACCESS-RUNBOOK-00": {
-      "status": "github_checks_passed",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/metabase-ops-access-runbook-00",
@@ -11805,7 +11805,7 @@
       "depends_on": [
         "SEO-DASH-MVP-ONLINE-SUMMARY"
       ],
-      "commit_sha": "f7069764c74b5f64d6bb48704ad431263a143d7b",
+      "commit_sha": "9be12b678bbfe40af75d5fd7e23d31f1aa31eb79",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1480",
       "checks": {
         "local": {
@@ -11828,8 +11828,8 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-19T14:00:03Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "sidecar_issues": [],
       "history": [
@@ -11857,9 +11857,63 @@
           "at": "2026-05-19T13:54:02Z",
           "status": "github_checks_passed",
           "summary": "GitHub checks passed for PR #1480: hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2. mergeStateStatus=CLEAN."
+        },
+        {
+          "at": "2026-05-19T14:05:25Z",
+          "status": "merged",
+          "summary": "Reconciled PR #1480 as merged with squash merge commit 9be12b678bbfe40af75d5fd7e23d31f1aa31eb79. Remote branch deleted; local cleanup pending script execution."
         }
       ],
       "next_pr": "PR-RESEARCH-01"
+    },
+    "PR-RESEARCH-01": {
+      "status": "commit_created",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/pr-research-01",
+      "base": "main",
+      "title": "feat(cms): add Research Asset backend MVP",
+      "depends_on": [
+        "METABASE-OPS-ACCESS-RUNBOOK-00"
+      ],
+      "commit_sha": "98d33ea1d601ba4a7446c9fce196dc37c101b53a",
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_research_asset_backend_mvp": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "php_artisan_migrate_pretend_sqlite_testing_path": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T14:05:25Z",
+          "status": "in_progress",
+          "summary": "Started Research backend/CMS MVP PR. Scope adds a ResearchReport backend/CMS authority foundation with draft/published gates and excludes Research publish, sitemap/llms/Search Channel exposure, frontend runtime exposure, collector writes, scheduler activation, external APIs, crawler log reads, env edits, deploy, and production operations."
+        },
+        {
+          "at": "2026-05-19T14:08:50Z",
+          "status": "local_checks_passed",
+          "summary": "Focused ResearchAssetBackendMvp test, full SeoIntel test filter, route list, sqlite testing migration pretend for the Research migration, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed. Default local MySQL migrate pretend was not used because the local root account rejected access; no production or external DB was touched."
+        },
+        {
+          "at": "2026-05-19T14:09:09Z",
+          "status": "commit_created",
+          "summary": "Created local commit 98d33ea1d601ba4a7446c9fce196dc37c101b53a."
+        }
+      ],
+      "next_pr": "PR-RESEARCH-02"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T14:14:16Z",
+  "updated_at": "2026-05-19T14:24:39Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11867,7 +11867,7 @@
       "next_pr": "PR-RESEARCH-01"
     },
     "PR-RESEARCH-01": {
-      "status": "github_checks_failed",
+      "status": "ci_fix_local_checks_passed",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/pr-research-01",
@@ -11888,7 +11888,8 @@
           "json_validation": "passed",
           "yaml_validation": "passed",
           "git_diff_check": "passed",
-          "scope_validation": "passed"
+          "scope_validation": "passed",
+          "bigfive_runtime_freeze_research_backend_mvp_allowlist": "passed"
         },
         "github": {
           "hygiene": "passed",
@@ -11899,7 +11900,7 @@
           "mergeStateStatus": "UNSTABLE"
         }
       },
-      "failure_reason": "GitHub verify-mbti-legacy and verify-mbti-v2 failed in Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff because PR-RESEARCH-01 intentionally changes backend/app ResearchReport files, backend/database Research migration, and backend/routes/api.php. Fix would require updating the Big Five runtime freeze classifier allowlist, which is outside the PR-RESEARCH-01 allowed files from the user prompt, so the train is stopped for explicit authorization.",
+      "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -11929,9 +11930,22 @@
           "at": "2026-05-19T14:14:16Z",
           "status": "github_checks_failed",
           "summary": "GitHub checks failed: verify-mbti-legacy and verify-mbti-v2. Failure is BigFive runtime freeze classifier detecting Research backend/CMS runtime files. No merge performed; train stopped before PR-RESEARCH-02."
+        },
+        {
+          "at": "2026-05-19T14:23:34Z",
+          "status": "ci_fix_in_progress",
+          "summary": "User authorized fixing PR #1481 CI. Updating the BigFive runtime freeze classifier with a narrow Research backend/CMS MVP allowlist and recording the test file in PR-RESEARCH-01 scope metadata."
+        },
+        {
+          "at": "2026-05-19T14:24:39Z",
+          "status": "ci_fix_local_checks_passed",
+          "summary": "Added a narrow Research backend/CMS MVP allowlist to the BigFive runtime freeze classifier. Focused BigFive runtime freeze test, ResearchAssetBackendMvp test, SeoIntel filter, route list, sqlite testing migrate --pretend, Pint, JSON/YAML validation, and git diff --check passed."
         }
       ],
-      "next_pr": "PR-RESEARCH-02"
+      "next_pr": "PR-RESEARCH-02",
+      "allowed_paths": [
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T14:09:47Z",
+  "updated_at": "2026-05-19T14:14:16Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11867,7 +11867,7 @@
       "next_pr": "PR-RESEARCH-01"
     },
     "PR-RESEARCH-01": {
-      "status": "pr_opened_github_checks_pending",
+      "status": "github_checks_failed",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/pr-research-01",
@@ -11876,7 +11876,7 @@
       "depends_on": [
         "METABASE-OPS-ACCESS-RUNBOOK-00"
       ],
-      "commit_sha": "2a6c675c45f467aa3ef5a039ae5dae40a8c8e6f4",
+      "commit_sha": "a0768d6bac3b94106b04dc22c667cd8cd6a3aabb",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1481",
       "checks": {
         "local": {
@@ -11889,9 +11889,17 @@
           "yaml_validation": "passed",
           "git_diff_check": "passed",
           "scope_validation": "passed"
+        },
+        "github": {
+          "hygiene": "passed",
+          "semgrep_sarif": "passed",
+          "semgrep_oss": "passed",
+          "verify_mbti_legacy": "failed",
+          "verify_mbti_v2": "failed",
+          "mergeStateStatus": "UNSTABLE"
         }
       },
-      "failure_reason": null,
+      "failure_reason": "GitHub verify-mbti-legacy and verify-mbti-v2 failed in Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff because PR-RESEARCH-01 intentionally changes backend/app ResearchReport files, backend/database Research migration, and backend/routes/api.php. Fix would require updating the Big Five runtime freeze classifier allowlist, which is outside the PR-RESEARCH-01 allowed files from the user prompt, so the train is stopped for explicit authorization.",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -11916,6 +11924,11 @@
           "at": "2026-05-19T14:09:47Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1481. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-19T14:14:16Z",
+          "status": "github_checks_failed",
+          "summary": "GitHub checks failed: verify-mbti-legacy and verify-mbti-v2. Failure is BigFive runtime freeze classifier detecting Research backend/CMS runtime files. No merge performed; train stopped before PR-RESEARCH-02."
         }
       ],
       "next_pr": "PR-RESEARCH-02"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T14:24:39Z",
+  "updated_at": "2026-05-19T14:31:45Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11889,14 +11889,16 @@
           "yaml_validation": "passed",
           "git_diff_check": "passed",
           "scope_validation": "passed",
-          "bigfive_runtime_freeze_research_backend_mvp_allowlist": "passed"
+          "bigfive_runtime_freeze_research_backend_mvp_allowlist": "passed",
+          "openapi_snapshot_check": "passed",
+          "openapi_diff_test": "passed"
         },
         "github": {
           "hygiene": "passed",
           "semgrep_sarif": "passed",
           "semgrep_oss": "passed",
-          "verify_mbti_legacy": "failed",
-          "verify_mbti_v2": "failed",
+          "verify_mbti_legacy": "failed_openapi_snapshot_drift",
+          "verify_mbti_v2": "failed_openapi_snapshot_drift",
           "mergeStateStatus": "UNSTABLE"
         }
       },
@@ -11940,11 +11942,22 @@
           "at": "2026-05-19T14:24:39Z",
           "status": "ci_fix_local_checks_passed",
           "summary": "Added a narrow Research backend/CMS MVP allowlist to the BigFive runtime freeze classifier. Focused BigFive runtime freeze test, ResearchAssetBackendMvp test, SeoIntel filter, route list, sqlite testing migrate --pretend, Pint, JSON/YAML validation, and git diff --check passed."
+        },
+        {
+          "at": "2026-05-19T14:31:05Z",
+          "status": "ci_fix_in_progress",
+          "summary": "GitHub verify-mbti jobs now fail on OpenAPI snapshot drift from the scoped Research API routes. Exported the route contract snapshot and added backend/docs/contracts/openapi.snapshot.json to the PR scope metadata."
+        },
+        {
+          "at": "2026-05-19T14:31:45Z",
+          "status": "ci_fix_local_checks_passed",
+          "summary": "Synced backend/docs/contracts/openapi.snapshot.json for the scoped Research routes. OpenApiDiffTest, export_openapi.sh --check, focused BigFive runtime freeze tests, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
         }
       ],
       "next_pr": "PR-RESEARCH-02",
       "allowed_paths": [
-        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "backend/docs/contracts/openapi.snapshot.json"
       ]
     }
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T14:09:09Z",
+  "updated_at": "2026-05-19T14:09:47Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11867,7 +11867,7 @@
       "next_pr": "PR-RESEARCH-01"
     },
     "PR-RESEARCH-01": {
-      "status": "commit_created",
+      "status": "pr_opened_github_checks_pending",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/pr-research-01",
@@ -11876,8 +11876,8 @@
       "depends_on": [
         "METABASE-OPS-ACCESS-RUNBOOK-00"
       ],
-      "commit_sha": "98d33ea1d601ba4a7446c9fce196dc37c101b53a",
-      "pr_url": null,
+      "commit_sha": "2a6c675c45f467aa3ef5a039ae5dae40a8c8e6f4",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1481",
       "checks": {
         "local": {
           "php_artisan_test_filter_research_asset_backend_mvp": "passed",
@@ -11911,6 +11911,11 @@
           "at": "2026-05-19T14:09:09Z",
           "status": "commit_created",
           "summary": "Created local commit 98d33ea1d601ba4a7446c9fce196dc37c101b53a."
+        },
+        {
+          "at": "2026-05-19T14:09:47Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1481. GitHub checks pending."
         }
       ],
       "next_pr": "PR-RESEARCH-02"

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6121,6 +6121,7 @@ prs:
       - backend/database/migrations/2026_05_19_000100_create_research_reports_table.php
       - backend/routes/api.php
       - backend/tests/Feature/Research/ResearchAssetBackendMvpTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - backend/docs/seo/research-asset-backend-mvp.md
       - backend/docs/seo/generated/research-asset-backend-mvp.v1.json
       - docs/codex/pr-train.yaml
@@ -6132,6 +6133,7 @@ prs:
       - Connect Metabase to business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational tables.
     validation:
       - cd backend && php artisan test --filter=ResearchAssetBackendMvp
+      - cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|research_backend_mvp' --no-ansi
       - cd backend && php artisan test --filter=SeoIntel
       - cd backend && php artisan route:list --no-ansi
       - cd backend && php artisan migrate --pretend

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6098,3 +6098,62 @@ prs:
     human_review_required: false
     production_approval_required: false
     next_task: PR-RESEARCH-01
+
+  - id: PR-RESEARCH-01
+    repo: fap-api
+    depends_on:
+      - METABASE-OPS-ACCESS-RUNBOOK-00
+    branch: codex/pr-research-01
+    base: main
+    title: "feat(cms): add Research Asset backend MVP"
+    name: "Research backend/CMS MVP"
+    train_scope: seo_dash_mvp_closeout_research_train
+    risk_level: backend_cms_foundation_no_publish_no_runtime_activation
+    type: backend/CMS code PR
+    scope:
+      - Add backend/CMS authority foundation for Research Asset records without importing or publishing content.
+      - Define the `research_report` page entity type contract and metadata fields for methodology, sample disclaimer, claim boundary, author/reviewer, references, last reviewed date, and downloadable asset placeholder.
+      - Gate public reads to published, approved, public, indexable Research records only.
+      - Keep Research blocked from sitemap, llms, Search Channel Queue, URL submission, Research publish, pSEO, collector writes, and scheduler activation.
+    allowed_paths:
+      - backend/app/Models/ResearchReport.php
+      - backend/app/Http/Controllers/API/V0_5/Cms/ResearchReportController.php
+      - backend/database/migrations/2026_05_19_000100_create_research_reports_table.php
+      - backend/routes/api.php
+      - backend/tests/Feature/Research/ResearchAssetBackendMvpTest.php
+      - backend/docs/seo/research-asset-backend-mvp.md
+      - backend/docs/seo/generated/research-asset-backend-mvp.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy, edit env files, run collector writes, enable scheduler, connect live search APIs, submit URLs, read production crawler logs, change RDS/DB/users/whitelist, expose Metabase publicly, publish Research content, or create pSEO.
+      - Change existing article behavior unless explicitly gated by Research-specific code.
+      - Add Research sitemap entries, llms entries, Search Channel Queue eligibility, Dataset schema, frontend runtime exposure, static fallback content, or report content imports.
+      - Connect Metabase to business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational tables.
+    validation:
+      - cd backend && php artisan test --filter=ResearchAssetBackendMvp
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && php artisan migrate --pretend
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/research-asset-backend-mvp.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    metabase_operation: false
+    research_publish: false
+    human_review_required: true
+    production_approval_required: false
+    next_task: PR-RESEARCH-02

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6122,6 +6122,7 @@ prs:
       - backend/routes/api.php
       - backend/tests/Feature/Research/ResearchAssetBackendMvpTest.php
       - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/contracts/openapi.snapshot.json
       - backend/docs/seo/research-asset-backend-mvp.md
       - backend/docs/seo/generated/research-asset-backend-mvp.v1.json
       - docs/codex/pr-train.yaml
@@ -6136,6 +6137,7 @@ prs:
       - cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|research_backend_mvp' --no-ansi
       - cd backend && php artisan test --filter=SeoIntel
       - cd backend && php artisan route:list --no-ansi
+      - cd backend && bash scripts/export_openapi.sh --check
       - cd backend && php artisan migrate --pretend
       - cd backend && vendor/bin/pint --test
       - python3 -m json.tool backend/docs/seo/generated/research-asset-backend-mvp.v1.json >/dev/null


### PR DESCRIPTION
## What changed
- Added a dedicated `ResearchReport` CMS model and `research_reports` migration for the `research_report` page entity type.
- Added public read APIs for published/approved/public/indexable Research records and internal CMS read/update APIs for draft workflow.
- Added required Research metadata: research type, methodology, sample disclaimer, claim boundary, author/reviewer, references, last reviewed date, and downloadable asset placeholder.
- Added Research backend MVP docs, generated JSON contract, focused feature tests, and PR train metadata.

## Why
Research Assets need a backend/CMS authority foundation before fap-web can render Research pages. This keeps Research behind explicit draft/published gates and blocks sitemap, `llms.txt`, Search Channel Queue, URL submission, Research publish, and pSEO until later contract PRs.

## Validation
- `cd backend && php artisan test --filter=ResearchAssetBackendMvp`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --path=database/migrations/2026_05_19_000100_create_research_reports_table.php`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/research-asset-backend-mvp.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nPY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No Research content import or publish.
- No sitemap, `llms.txt`, URL Truth, Search Channel Queue, Search Channel live submission, Dataset schema, pSEO, scheduler, collector write, crawler log read, env, deploy, Metabase, RDS/DB/user/whitelist, DNS/CDN/OpenResty, business DB, Tencent RDS, or Node2 changes.
- fap-web Research runtime remains deferred to `PR-RESEARCH-02`.
- Research SEO/GEO/Search Channel gates remain deferred to `PR-RESEARCH-03`.

## Repository rule impact
Research Asset is CMS/backend-authoritative. Frontend code must render backend Research payloads only and must not introduce local Research report copy or fallback truth.
