### PR TITLE
docs(research): add SEO GEO search channel contract

### DIFF
--- a/backend/docs/seo/generated/research-seo-geo-search-channel-contract.v1.json
+++ b/backend/docs/seo/generated/research-seo-geo-search-channel-contract.v1.json
@@ -1,0 +1,196 @@
+{
+  "version": "research-seo-geo-search-channel-contract.v1",
+  "task": "PR-RESEARCH-03",
+  "title": "Research SEO GEO Search Channel contract",
+  "source_documents": [
+    "PR-RESEARCH-00",
+    "PR-RESEARCH-01",
+    "PR-RESEARCH-02",
+    "SEARCH-CHANNEL-QUEUE-00",
+    "CLAIM-LINT-00",
+    "SEO-DASH-MVP-ONLINE-SUMMARY"
+  ],
+  "page_entity_type": "research_report",
+  "authority_model": {
+    "research_authority": "backend_cms",
+    "runtime_authority": "fap_web_backend_payload_only",
+    "observation_authority": "seo_intel_url_truth",
+    "metabase_role": "read_only_observation_dashboard",
+    "node2_role": "non_authority"
+  },
+  "allowed_authority_inputs": [
+    "backend_cms_research_asset",
+    "backend_public_research_payload",
+    "fap_web_backend_payload_runtime",
+    "seo_intel_url_truth_observation",
+    "future_sanitized_seo_intel_aggregate_views"
+  ],
+  "forbidden_authority_inputs": [
+    "frontend_fallback",
+    "static_sitemap_fallback",
+    "static_llms_fallback",
+    "node2_local_db",
+    "node2_local_laravel",
+    "business_db_raw_tables",
+    "metabase_business_db_connection",
+    "production_crawler_logs",
+    "raw_orders",
+    "raw_payments",
+    "raw_events",
+    "raw_reports",
+    "raw_email",
+    "provider_payloads",
+    "payment_payloads",
+    "cookies",
+    "raw_ips",
+    "user_agents"
+  ],
+  "sitemap_eligibility_gates": [
+    "backend_cms_source_exists",
+    "page_entity_type_research_report",
+    "status_published",
+    "review_state_approved",
+    "is_public_true",
+    "is_indexable_true",
+    "canonical_path_present",
+    "locale_explicit",
+    "fap_web_route_backend_payload_only",
+    "url_truth_supports_research_report",
+    "claim_boundary_review_passed",
+    "methodology_present",
+    "sample_disclaimer_present",
+    "references_present",
+    "author_present",
+    "reviewer_present",
+    "last_reviewed_at_present",
+    "no_private_flow",
+    "no_raw_pii",
+    "no_raw_evidence",
+    "no_user_specific_report_data",
+    "no_noindex_state"
+  ],
+  "llms_eligibility_gates": [
+    "sitemap_eligibility_passed",
+    "public_indexable_content",
+    "sanitized_summary",
+    "claim_boundary_preserved",
+    "methodology_visible",
+    "sample_disclaimer_visible",
+    "references_present",
+    "no_raw_evidence",
+    "no_private_payload",
+    "no_pii",
+    "no_order_payment_attempt_email_cookie_raw_ip_or_provider_payload",
+    "no_frontend_or_static_fallback_enumeration"
+  ],
+  "search_channel_queue_eligibility_gates": [
+    "sitemap_eligibility_passed",
+    "url_truth_supports_research_report",
+    "source_authority_backend_cms",
+    "indexability_explicit_indexable",
+    "claim_boundary_review_passed",
+    "search_channel_queue_accepts_research_report",
+    "later_channel_credentials_quota_owner_and_live_operation_approval"
+  ],
+  "url_truth_support": {
+    "page_entity_type": "research_report",
+    "source_authority": "backend_cms",
+    "safe_observed_tables": [
+      "seo_urls",
+      "seo_url_entities",
+      "seo_issue_queue"
+    ],
+    "required_states": [
+      "canonical_present",
+      "locale_explicit",
+      "indexability_explicit",
+      "private_flow_absent",
+      "forbidden_authority_absent"
+    ],
+    "forbidden_truth_sources": [
+      "frontend_fallback",
+      "static_sitemap_fallback",
+      "static_llms_fallback",
+      "live_search_response",
+      "node2_local_source",
+      "production_crawler_logs"
+    ]
+  },
+  "claim_boundary": {
+    "forbidden_claim_classes": [
+      "diagnosis",
+      "treatment",
+      "cure",
+      "hiring_fit",
+      "job_competency",
+      "exact_iq",
+      "guaranteed_salary",
+      "guaranteed_turnover_prediction",
+      "guaranteed_career_outcome",
+      "ai_career_planning_authority",
+      "full_career_recommendation"
+    ],
+    "required_safe_elements": [
+      "methodology",
+      "sample_disclaimer",
+      "references",
+      "author",
+      "reviewer",
+      "last_reviewed_at",
+      "claim_boundary"
+    ],
+    "expanded_claim_surfaces_blocked": [
+      "riasec_full_career_recommendation",
+      "big_five_full_career_recommendation",
+      "career_decision_full_recommendation"
+    ]
+  },
+  "dataset_schema_policy": {
+    "enabled_in_this_pr": false,
+    "blocked_until": [
+      "versioned_downloadable_asset",
+      "stable_public_file",
+      "checksum_or_immutable_version",
+      "license_or_usage_note",
+      "methodology_attached",
+      "sample_disclaimer_attached",
+      "no_raw_pii_or_private_evidence",
+      "dataset_ready_backend_contract"
+    ]
+  },
+  "excluded_states": [
+    "draft",
+    "archived",
+    "private",
+    "unapproved",
+    "noindex",
+    "future_scheduled",
+    "unsupported_page_type",
+    "claim_unsafe",
+    "missing_methodology",
+    "missing_references",
+    "private_flow",
+    "raw_pii_present",
+    "dataset_asset_not_versioned"
+  ],
+  "research_publish_in_this_pr": false,
+  "sitemap_changed_in_this_pr": false,
+  "llms_changed_in_this_pr": false,
+  "search_channel_queue_inserted_in_this_pr": false,
+  "url_submission_performed": false,
+  "external_api_live_activation": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_executed_in_this_pr": false,
+  "production_crawler_log_read": false,
+  "env_edit_in_this_pr": false,
+  "deployment_performed_in_this_pr": false,
+  "dataset_schema_enabled_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "frontend_fallback_authority_enabled": false,
+  "node2_source_used": false,
+  "metabase_operation_performed": false,
+  "business_db_connected": false,
+  "tencent_rds_connected": false,
+  "node2_db_connected": false,
+  "next_task": "RESEARCH-PUBLISH-READINESS-00"
+}

--- a/backend/docs/seo/research-seo-geo-search-channel-contract.md
+++ b/backend/docs/seo/research-seo-geo-search-channel-contract.md
@@ -1,0 +1,124 @@
+# Research SEO GEO Search Channel Contract
+
+## Purpose
+
+PR-RESEARCH-03 defines the gated SEO/GEO/Search Channel contract for Research Assets. It does not publish Research, change sitemap behavior, change `llms.txt` behavior, enqueue Search Channel records, submit URLs, enable live search APIs, run collector writes, enable scheduler, or create pSEO.
+
+## Authority Boundary
+
+Research pages use `page_entity_type = research_report`.
+
+Allowed authority inputs:
+
+- backend/CMS Research Asset records
+- backend public Research payloads returned only for published, approved, public, indexable records
+- fap-web Research runtime that renders backend payloads only
+- URL Truth observation in `seo_intel`
+- future sanitized aggregate tables or views derived from `seo_intel`
+
+Forbidden authority inputs:
+
+- frontend fallback content
+- static sitemap fallback
+- static `llms.txt` fallback
+- Node2 local DB
+- Node2 local Laravel
+- business DB raw tables
+- Metabase business DB connections
+- production crawler logs
+- raw orders, payments, events, reports, email, provider payloads, payment payloads, cookies, raw IPs, or user agents
+
+## Sitemap Eligibility Gate
+
+A Research URL may enter sitemap only after all gates pass:
+
+- backend CMS source exists
+- `page_entity_type = research_report`
+- status is published
+- review state is approved
+- record is public
+- record is indexable
+- canonical path is present
+- locale is explicit
+- fap-web route renders backend payload only
+- URL Truth supports and observes `research_report`
+- claim boundary review passed
+- methodology, sample disclaimer, references, author, reviewer, and last reviewed date are present
+- no private-flow, raw PII, raw evidence, user-specific report data, or noindex state is present
+
+Draft, archived, private, unapproved, noindex, future-scheduled, unsupported, and claim-unsafe Research records must remain excluded.
+
+## llms.txt Eligibility Gate
+
+Research may enter `llms.txt` only after the sitemap gate passes and a separate `llms.txt` inclusion review confirms:
+
+- the content is public and indexable
+- the summary is sanitized
+- claim boundaries are preserved
+- methodology and sample disclaimer are visible
+- references are present
+- no raw evidence, private payload, PII, order, payment, attempt, email, cookie, raw IP, or provider payload is exposed
+- frontend/static fallback is not used as enumeration truth
+
+## Search Channel Queue Eligibility Gate
+
+Research may enter Search Channel Queue only after:
+
+- sitemap eligibility passes
+- URL Truth supports `research_report`
+- source authority is backend/CMS
+- indexability is explicit and indexable
+- claim boundary review passed
+- the Search Channel Queue contract accepts `research_report`
+- channel credentials, quota, owner, and live-operation approval are completed in a later task
+
+This PR does not create queue records, submit URLs, connect GSC, connect Baidu, connect IndexNow, connect domestic adapters, or enable scheduler.
+
+## URL Truth Support
+
+URL Truth must treat Research as a backend-authoritative page type:
+
+- page entity type: `research_report`
+- source authority: backend CMS
+- safe observed tables: `seo_urls`, `seo_url_entities`, `seo_issue_queue`
+- required states: canonical present, locale explicit, indexability explicit, private-flow absent, forbidden authority absent
+
+Frontend fallback, sitemap fallback, `llms.txt` fallback, live search responses, Node2 local sources, and production crawler logs must not become URL Truth.
+
+## Claim Boundary
+
+Research must remain bounded to evidence-aware, non-diagnostic, reference-oriented language. It must not claim diagnosis, treatment, cure, hiring fit, job competency, exact IQ, guaranteed salary, guaranteed turnover prediction, guaranteed career outcome, or AI career planning authority.
+
+RIASEC, Big Five, and career recommendation surfaces must not expand into full career recommendation claims in this contract.
+
+## Dataset Schema Gate
+
+Dataset schema remains blocked unless a later contract confirms:
+
+- a versioned downloadable asset exists
+- the file is stable and public
+- checksum or immutable version is present
+- license or usage note is present
+- methodology and sample disclaimer are attached
+- no raw PII or private evidence is included
+- the backend contract explicitly marks the asset dataset-ready
+
+This PR does not enable Dataset schema.
+
+## What Was Not Done
+
+- No Research content published.
+- No sitemap behavior changed.
+- No `llms.txt` behavior changed.
+- No Search Channel Queue insertion performed.
+- No URL submitted to search engines.
+- No live GSC, Baidu, IndexNow, 360, Sogou, or Shenma API connected.
+- No scheduler or collector write enabled.
+- No production crawler logs read.
+- No Metabase operation performed.
+- No production env, deploy, RDS, DB user, whitelist, DNS, CDN, or OpenResty change performed.
+- No pSEO created.
+
+## Next Task
+
+Next task: `RESEARCH-PUBLISH-READINESS-00`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelResearchSeoGeoSearchChannelContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelResearchSeoGeoSearchChannelContractTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelResearchSeoGeoSearchChannelContractTest extends TestCase
+{
+    #[Test]
+    public function artifact_defines_research_report_authority_boundary(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('research-seo-geo-search-channel-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('PR-RESEARCH-03', $artifact['task'] ?? null);
+        $this->assertSame('research_report', $artifact['page_entity_type'] ?? null);
+        $this->assertSame('backend_cms', $artifact['authority_model']['research_authority'] ?? null);
+        $this->assertSame('fap_web_backend_payload_only', $artifact['authority_model']['runtime_authority'] ?? null);
+        $this->assertSame('seo_intel_url_truth', $artifact['authority_model']['observation_authority'] ?? null);
+
+        foreach ([
+            'frontend_fallback',
+            'static_sitemap_fallback',
+            'static_llms_fallback',
+            'node2_local_db',
+            'business_db_raw_tables',
+            'production_crawler_logs',
+        ] as $forbidden) {
+            $this->assertContains($forbidden, $artifact['forbidden_authority_inputs'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function sitemap_llms_and_search_channel_gates_are_explicit(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'backend_cms_source_exists',
+            'page_entity_type_research_report',
+            'status_published',
+            'review_state_approved',
+            'is_public_true',
+            'is_indexable_true',
+            'canonical_path_present',
+            'url_truth_supports_research_report',
+            'claim_boundary_review_passed',
+            'no_private_flow',
+            'no_raw_pii',
+        ] as $gate) {
+            $this->assertContains($gate, $artifact['sitemap_eligibility_gates'] ?? []);
+        }
+
+        foreach ([
+            'sitemap_eligibility_passed',
+            'sanitized_summary',
+            'claim_boundary_preserved',
+            'no_raw_evidence',
+            'no_private_payload',
+            'no_frontend_or_static_fallback_enumeration',
+        ] as $gate) {
+            $this->assertContains($gate, $artifact['llms_eligibility_gates'] ?? []);
+        }
+
+        foreach ([
+            'sitemap_eligibility_passed',
+            'url_truth_supports_research_report',
+            'source_authority_backend_cms',
+            'indexability_explicit_indexable',
+            'claim_boundary_review_passed',
+            'search_channel_queue_accepts_research_report',
+            'later_channel_credentials_quota_owner_and_live_operation_approval',
+        ] as $gate) {
+            $this->assertContains($gate, $artifact['search_channel_queue_eligibility_gates'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function url_truth_support_is_read_only_and_research_scoped(): void
+    {
+        $support = $this->artifact()['url_truth_support'] ?? [];
+
+        $this->assertSame('research_report', $support['page_entity_type'] ?? null);
+        $this->assertSame('backend_cms', $support['source_authority'] ?? null);
+
+        foreach (['seo_urls', 'seo_url_entities', 'seo_issue_queue'] as $table) {
+            $this->assertContains($table, $support['safe_observed_tables'] ?? []);
+        }
+
+        foreach ([
+            'canonical_present',
+            'locale_explicit',
+            'indexability_explicit',
+            'private_flow_absent',
+            'forbidden_authority_absent',
+        ] as $state) {
+            $this->assertContains($state, $support['required_states'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function claim_boundary_and_dataset_schema_remain_constrained(): void
+    {
+        $artifact = $this->artifact();
+        $claimBoundary = $artifact['claim_boundary'] ?? [];
+        $datasetPolicy = $artifact['dataset_schema_policy'] ?? [];
+
+        foreach ([
+            'diagnosis',
+            'treatment',
+            'cure',
+            'hiring_fit',
+            'job_competency',
+            'exact_iq',
+            'guaranteed_salary',
+            'guaranteed_turnover_prediction',
+            'guaranteed_career_outcome',
+            'ai_career_planning_authority',
+            'full_career_recommendation',
+        ] as $claim) {
+            $this->assertContains($claim, $claimBoundary['forbidden_claim_classes'] ?? []);
+        }
+
+        $this->assertFalse((bool) ($datasetPolicy['enabled_in_this_pr'] ?? true));
+
+        foreach ([
+            'versioned_downloadable_asset',
+            'stable_public_file',
+            'checksum_or_immutable_version',
+            'license_or_usage_note',
+            'dataset_ready_backend_contract',
+        ] as $gate) {
+            $this->assertContains($gate, $datasetPolicy['blocked_until'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function production_publish_and_exposure_flags_remain_false(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'research_publish_in_this_pr',
+            'sitemap_changed_in_this_pr',
+            'llms_changed_in_this_pr',
+            'search_channel_queue_inserted_in_this_pr',
+            'url_submission_performed',
+            'external_api_live_activation',
+            'scheduler_enabled_in_this_pr',
+            'collector_write_executed_in_this_pr',
+            'production_crawler_log_read',
+            'env_edit_in_this_pr',
+            'deployment_performed_in_this_pr',
+            'dataset_schema_enabled_in_this_pr',
+            'pseo_generation_in_this_pr',
+            'frontend_fallback_authority_enabled',
+            'node2_source_used',
+            'metabase_operation_performed',
+            'business_db_connected',
+            'tencent_rds_connected',
+            'node2_db_connected',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_publish_no_search_submission_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/research-seo-geo-search-channel-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/research-seo-geo-search-channel-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'page_entity_type = research_report',
+            'sitemap eligibility gate',
+            'llms.txt eligibility gate',
+            'search channel queue eligibility gate',
+            'dataset schema remains blocked',
+            'no research content published',
+            'no url submitted to search engines',
+            'next task: `research-publish-readiness-00`',
+            '"next_task": "research-publish-readiness-00"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/research-seo-geo-search-channel-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T15:16:05Z",
+  "updated_at": "2026-05-19T15:17:24Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11970,7 +11970,7 @@
       ]
     },
     "PR-RESEARCH-03": {
-      "status": "local_checks_passed",
+      "status": "pr_opened_github_checks_pending",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/pr-research-03",
@@ -11987,8 +11987,8 @@
           "status": "merged"
         }
       },
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "de16dbc701404f0d4297d789e906627bb439b2a7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1482",
       "checks": {
         "local": {
           "php_artisan_test_filter_seo_intel_research_seo_geo_search_channel_contract": "passed",
@@ -12001,7 +12001,10 @@
           "git_diff_cached_check": "passed",
           "scope_validation": "passed"
         },
-        "github": {}
+        "github": {
+          "status": "pending",
+          "mergeStateStatus": "UNSTABLE"
+        }
       },
       "failure_reason": null,
       "merged_at": null,
@@ -12018,6 +12021,11 @@
           "at": "2026-05-19T15:16:05Z",
           "status": "local_checks_passed",
           "summary": "Focused Research SEO/GEO/Search Channel contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff checks, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T15:17:24Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1482. GitHub checks pending."
         }
       ],
       "next_pr": "RESEARCH-PUBLISH-READINESS-00"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T14:31:45Z",
+  "updated_at": "2026-05-19T15:16:05Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11867,7 +11867,7 @@
       "next_pr": "PR-RESEARCH-01"
     },
     "PR-RESEARCH-01": {
-      "status": "ci_fix_local_checks_passed",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/pr-research-01",
@@ -11876,7 +11876,7 @@
       "depends_on": [
         "METABASE-OPS-ACCESS-RUNBOOK-00"
       ],
-      "commit_sha": "a0768d6bac3b94106b04dc22c667cd8cd6a3aabb",
+      "commit_sha": "1643b4d16acfcc6c8434037948afc337a4b47fd2",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1481",
       "checks": {
         "local": {
@@ -11897,15 +11897,19 @@
           "hygiene": "passed",
           "semgrep_sarif": "passed",
           "semgrep_oss": "passed",
-          "verify_mbti_legacy": "failed_openapi_snapshot_drift",
-          "verify_mbti_v2": "failed_openapi_snapshot_drift",
-          "mergeStateStatus": "UNSTABLE"
+          "verify_mbti_legacy": "passed",
+          "verify_mbti_v2": "passed",
+          "mergeStateStatus": "CLEAN"
+        },
+        "ledger_reconciliation": {
+          "status": "passed",
+          "evidence": "GitHub reports PR #1481 as MERGED with merge commit 1643b4d16acfcc6c8434037948afc337a4b47fd2; origin/main contains the merge commit; remote branch codex/pr-research-01 is absent after prune; local branch codex/pr-research-01 was deleted."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-19T14:42:31Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "history": [
         {
@@ -11952,13 +11956,71 @@
           "at": "2026-05-19T14:31:45Z",
           "status": "ci_fix_local_checks_passed",
           "summary": "Synced backend/docs/contracts/openapi.snapshot.json for the scoped Research routes. OpenApiDiffTest, export_openapi.sh --check, focused BigFive runtime freeze tests, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T15:14:47Z",
+          "status": "merged",
+          "summary": "Reconciled PR-RESEARCH-01 as merged via PR #1481. GitHub checks passed, merge commit is present on origin/main, remote branch is absent, and local branch cleanup was completed before starting PR-RESEARCH-03."
         }
       ],
-      "next_pr": "PR-RESEARCH-02",
+      "next_pr": "PR-RESEARCH-03",
       "allowed_paths": [
         "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
         "backend/docs/contracts/openapi.snapshot.json"
       ]
+    },
+    "PR-RESEARCH-03": {
+      "status": "local_checks_passed",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/pr-research-03",
+      "base": "main",
+      "title": "docs(research): add SEO GEO search channel contract",
+      "depends_on": [
+        "PR-RESEARCH-01"
+      ],
+      "external_dependencies": {
+        "PR-RESEARCH-02": {
+          "repo": "fap-web",
+          "pr_url": "https://github.com/fermatmind/fap-web/pull/848",
+          "merge_commit": "a91e8f75864090ee96ccb49fafc4479b4250b31a",
+          "status": "merged"
+        }
+      },
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_research_seo_geo_search_channel_contract": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "git_diff_cached_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T15:14:47Z",
+          "status": "in_progress",
+          "summary": "Started Research SEO/GEO/Search Channel contract PR. Scope is docs/generated/test metadata only and excludes Research publish, sitemap/llms behavior changes, Search Channel Queue insertion, URL submission, live search APIs, collector writes, scheduler activation, Metabase operations, env edits, deploy, and production operations."
+        },
+        {
+          "at": "2026-05-19T15:16:05Z",
+          "status": "local_checks_passed",
+          "summary": "Focused Research SEO/GEO/Search Channel contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff checks, and allowed-path scope validation passed."
+        }
+      ],
+      "next_pr": "RESEARCH-PUBLISH-READINESS-00"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6160,7 +6160,63 @@ prs:
     research_publish: false
     human_review_required: true
     production_approval_required: false
-    next_task: PR-RESEARCH-02
+    next_task: PR-RESEARCH-03
+
+  - id: PR-RESEARCH-03
+    repo: fap-api
+    depends_on:
+      - PR-RESEARCH-01
+    external_dependencies:
+      - PR-RESEARCH-02 in fap-web merged as https://github.com/fermatmind/fap-web/pull/848 with squash merge a91e8f75864090ee96ccb49fafc4479b4250b31a.
+    branch: codex/pr-research-03
+    base: main
+    title: "docs(research): add SEO GEO search channel contract"
+    name: "Research SEO/GEO/Search Channel contract"
+    train_scope: seo_dash_mvp_closeout_research_train
+    risk_level: docs_generated_test_contract_no_publish_no_runtime_activation
+    type: contract/docs/tests PR
+    scope:
+      - Define gated Research exposure rules for sitemap, llms, Search Channel Queue, URL Truth support, claim boundary, and Dataset schema blocking.
+      - Keep Research page entity type fixed as `research_report`.
+      - Preserve no draft/private/noindex exposure and no Research publish in this PR.
+      - Record fap-web PR-RESEARCH-02 as an external merged dependency without changing fap-web in this PR.
+    allowed_paths:
+      - backend/docs/seo/research-seo-geo-search-channel-contract.md
+      - backend/docs/seo/generated/research-seo-geo-search-channel-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelResearchSeoGeoSearchChannelContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy, edit env files, run collector writes, enable scheduler, connect live search APIs, submit URLs, read production crawler logs, change RDS/DB/users/whitelist, expose Metabase publicly, publish Research content, or create pSEO.
+      - Add Research sitemap entries, llms entries, Search Channel Queue records, Dataset schema, public Research content, frontend runtime changes, or report content imports.
+      - Connect Metabase to business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational tables.
+      - Expand RIASEC, Big Five, career decision, or Research claims into diagnosis, hiring fit, job competency, full career recommendation, exact IQ, or guaranteed outcome claims.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelResearchSeoGeoSearchChannelContract
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/research-seo-geo-search-channel-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    metabase_operation: false
+    research_publish: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: RESEARCH-PUBLISH-READINESS-00
 
 
   - id: RIASEC-FULL-CONTENT-PACK-03-PREFLIGHT


### PR DESCRIPTION
## What changed
- Added the Research SEO/GEO/Search Channel contract for `page_entity_type = research_report`.
- Added a machine-readable contract artifact for sitemap, llms, Search Channel Queue, URL Truth, claim-boundary, and Dataset schema gates.
- Added a focused SeoIntel feature test for the contract.
- Reconciled PR-RESEARCH-01 ledger state as merged after PR #1481 and recorded fap-web PR-RESEARCH-02 as an external merged dependency.

## Why
- Research backend/CMS and fap-web runtime MVPs are merged, but Research still needs an explicit SEO/GEO/Search Channel exposure contract before any publish, sitemap, llms, or queue insertion work.

## Validation
- `cd backend && php artisan test --filter=SeoIntelResearchSeoGeoSearchChannelContract`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/research-seo-geo-search-channel-contract.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred / not changed
- No Research publish.
- No sitemap or llms behavior change.
- No Search Channel Queue insertion or URL submission.
- No live GSC/Baidu/IndexNow/domestic search API connection.
- No scheduler, collector write, Metabase operation, env edit, deploy, RDS/DB/whitelist change, pSEO, or runtime code change.
- No fap-web change in this PR.

## Repository rule impact
- Defines Research as backend/CMS-authoritative and fap-web as backend-payload-only rendering.
- Does not introduce temporary migration fallback or frontend content authority.
- Research remains blocked from sitemap, llms, Search Channel Queue, Dataset schema, and publish until later gated tasks.