### PR TITLE
docs(research): add first Research publish readiness checklist

### DIFF
--- a/backend/docs/seo/generated/research-publish-readiness.v1.json
+++ b/backend/docs/seo/generated/research-publish-readiness.v1.json
@@ -1,0 +1,142 @@
+{
+  "version": "research-publish-readiness.v1",
+  "task": "RESEARCH-PUBLISH-READINESS-00",
+  "title": "First Research publish readiness checklist",
+  "candidate": {
+    "name": "MBTI Salary & Turnover Report",
+    "status": "Research Candidate Frozen Draft",
+    "page_entity_type": "research_report",
+    "authority": "backend_cms_research_asset",
+    "public_route_family": "/research/{slug}",
+    "published_in_this_pr": false,
+    "indexable_in_this_pr": false,
+    "queued_in_this_pr": false,
+    "submitted_in_this_pr": false,
+    "digital_pr_started_in_this_pr": false
+  },
+  "publish_prerequisites": [
+    "research_backend_cms_mvp_merged",
+    "fap_web_runtime_mvp_merged",
+    "research_seo_geo_search_channel_contract_merged",
+    "url_truth_observation_supports_research_report",
+    "metabase_dashboard_visible_to_owner",
+    "claim_linter_passed",
+    "methodology_present",
+    "sample_disclaimer_present",
+    "references_present",
+    "author_present",
+    "reviewer_present",
+    "last_reviewed_at_present",
+    "downloadable_asset_decision_explicit",
+    "dataset_schema_decision_explicit",
+    "sitemap_eligibility_gate_passed_later",
+    "llms_eligibility_gate_passed_later",
+    "search_channel_queue_eligibility_gate_passed_later"
+  ],
+  "completed_prerequisite_evidence": {
+    "research_backend_cms_mvp": {
+      "task": "PR-RESEARCH-01",
+      "repo": "fap-api",
+      "status": "merged",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1481"
+    },
+    "fap_web_runtime_mvp": {
+      "task": "PR-RESEARCH-02",
+      "repo": "fap-web",
+      "status": "merged",
+      "pr_url": "https://github.com/fermatmind/fap-web/pull/848"
+    },
+    "research_seo_geo_search_channel_contract": {
+      "task": "PR-RESEARCH-03",
+      "repo": "fap-api",
+      "status": "merged",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1482"
+    },
+    "seo_dash_mvp": {
+      "status": "minimally_online",
+      "metabase_dashboard": "SEO Intelligence MVP — URL Truth & Issue Queue",
+      "metabase_public_exposure": false
+    }
+  },
+  "candidate_content_requirements": [
+    "executive_summary",
+    "methodology",
+    "sample_disclaimer",
+    "claim_boundary_statement",
+    "author",
+    "reviewer",
+    "references",
+    "last_reviewed_at",
+    "downloadable_asset_placeholder_or_versioned_asset_decision"
+  ],
+  "forbidden_candidate_fields": [
+    "raw_pii",
+    "raw_orders",
+    "raw_payments",
+    "raw_events",
+    "raw_email",
+    "raw_crawler_logs",
+    "cookies",
+    "raw_ips",
+    "provider_payloads",
+    "payment_payloads",
+    "user_specific_private_report_evidence"
+  ],
+  "forbidden_claim_classes": [
+    "diagnosis",
+    "treatment",
+    "cure",
+    "hiring_fit",
+    "job_competency",
+    "exact_iq",
+    "guaranteed_salary",
+    "guaranteed_turnover_prediction",
+    "guaranteed_career_outcome",
+    "ai_career_planning_authority",
+    "full_career_recommendation"
+  ],
+  "later_publication_gate": [
+    "cms_record_approved",
+    "cms_record_published",
+    "cms_record_public",
+    "cms_record_indexable",
+    "canonical_path_present",
+    "locale_explicit",
+    "fap_web_route_backend_payload_only",
+    "url_truth_records_research_url",
+    "seo_geo_search_channel_gates_satisfied",
+    "no_private_noindex_or_draft_exposure"
+  ],
+  "blocked_until_later_task": [
+    "research_publish",
+    "sitemap_inclusion",
+    "llms_inclusion",
+    "search_channel_queue_insertion",
+    "url_submission",
+    "digital_pr",
+    "dataset_schema_if_no_versioned_asset",
+    "pseo_generation"
+  ],
+  "research_publish_in_this_pr": false,
+  "research_content_imported_in_this_pr": false,
+  "sitemap_changed_in_this_pr": false,
+  "llms_changed_in_this_pr": false,
+  "search_channel_queue_inserted_in_this_pr": false,
+  "url_submission_performed": false,
+  "external_api_live_activation": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_executed_in_this_pr": false,
+  "production_crawler_log_read": false,
+  "env_edit_in_this_pr": false,
+  "deployment_performed_in_this_pr": false,
+  "digital_pr_started_in_this_pr": false,
+  "dataset_schema_enabled_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "frontend_fallback_authority_enabled": false,
+  "node2_source_used": false,
+  "metabase_operation_performed": false,
+  "business_db_connected": false,
+  "tencent_rds_connected": false,
+  "node2_db_connected": false,
+  "next_task": "SEO-DASH-MVP-ONLINE-SUMMARY closeout report / next Research publish operation planning"
+}

--- a/backend/docs/seo/research-publish-readiness.md
+++ b/backend/docs/seo/research-publish-readiness.md
@@ -1,0 +1,93 @@
+# Research Publish Readiness Checklist
+
+## Purpose
+
+RESEARCH-PUBLISH-READINESS-00 defines the first Research publish readiness contract. It does not publish Research content, add sitemap entries, add `llms.txt` entries, insert Search Channel Queue records, submit URLs, run collector writes, enable scheduler, create pSEO, or start Digital PR.
+
+## First Candidate
+
+- candidate: MBTI Salary & Turnover Report
+- status: Research Candidate Frozen Draft
+- page entity type: `research_report`
+- intended authority: backend/CMS Research Asset
+- intended public route family: `/research/{slug}`
+
+The candidate remains a frozen draft. It is not public, indexable, queued, submitted, or promoted by this PR.
+
+## Publish Prerequisites
+
+The first Research publish operation is blocked until all prerequisites pass:
+
+- Research backend/CMS MVP is merged and available.
+- fap-web Research runtime MVP is merged and renders backend payloads only.
+- Research SEO/GEO/Search Channel contract is merged.
+- URL Truth observation supports `research_report`.
+- Metabase dashboard is visible to the owner through private access.
+- Claim linter passes for the candidate.
+- Methodology is present.
+- Sample disclaimer is present.
+- References are present.
+- Author and reviewer are present.
+- `last_reviewed_at` is present.
+- Downloadable asset decision is explicit.
+- Dataset schema decision is explicit and remains blocked unless a versioned public downloadable asset is approved.
+- Sitemap eligibility gate passes in a later PR.
+- `llms.txt` eligibility gate passes in a later PR.
+- Search Channel Queue eligibility gate passes in a later PR.
+
+## Candidate Content Requirements
+
+The candidate must include:
+
+- executive summary
+- methodology
+- sample disclaimer
+- claim boundary statement
+- author
+- reviewer
+- references
+- last reviewed date
+- downloadable asset placeholder or versioned downloadable asset decision
+
+The candidate must not include raw PII, raw orders, raw payments, raw events, raw emails, raw crawler logs, cookies, raw IPs, provider payloads, payment payloads, or user-specific private report evidence.
+
+## Claim Boundary
+
+The candidate must not claim diagnosis, treatment, cure, hiring fit, job competency, exact IQ, guaranteed salary, guaranteed turnover prediction, guaranteed career outcome, or AI career planning authority.
+
+RIASEC, Big Five, and career decision copy must remain bounded to research context, self-assessment, methodology, and reference-oriented wording. This readiness contract does not expand those claim boundaries.
+
+## Publication Gate
+
+A later Research publish operation must verify:
+
+- CMS record is approved.
+- CMS record is explicitly published.
+- CMS record is public.
+- CMS record is indexable.
+- canonical path is present.
+- locale is explicit.
+- fap-web route returns backend payload only.
+- URL Truth records the Research URL.
+- SEO/GEO/Search Channel gates remain satisfied.
+- no private/noindex/draft state enters sitemap, `llms.txt`, Search Channel Queue, or URL submission.
+
+## What Was Not Done
+
+- No Research content published.
+- No Research content imported.
+- No sitemap behavior changed.
+- No `llms.txt` behavior changed.
+- No Search Channel Queue insertion performed.
+- No URL submitted to search engines.
+- No live GSC, Baidu, IndexNow, 360, Sogou, or Shenma API connected.
+- No Digital PR started.
+- No scheduler or collector write enabled.
+- No production crawler logs read.
+- No Metabase operation performed.
+- No production env, deploy, RDS, DB user, whitelist, DNS, CDN, or OpenResty change performed.
+- No pSEO created.
+
+## Next Task
+
+Next task: SEO-DASH-MVP-ONLINE-SUMMARY closeout report / next Research publish operation planning.

--- a/backend/tests/Feature/SeoIntel/SeoIntelResearchPublishReadinessTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelResearchPublishReadinessTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelResearchPublishReadinessTest extends TestCase
+{
+    #[Test]
+    public function artifact_locks_first_candidate_as_frozen_draft(): void
+    {
+        $artifact = $this->artifact();
+        $candidate = $artifact['candidate'] ?? [];
+
+        $this->assertSame('research-publish-readiness.v1', $artifact['version'] ?? null);
+        $this->assertSame('RESEARCH-PUBLISH-READINESS-00', $artifact['task'] ?? null);
+        $this->assertSame('MBTI Salary & Turnover Report', $candidate['name'] ?? null);
+        $this->assertSame('Research Candidate Frozen Draft', $candidate['status'] ?? null);
+        $this->assertSame('research_report', $candidate['page_entity_type'] ?? null);
+        $this->assertSame('backend_cms_research_asset', $candidate['authority'] ?? null);
+        $this->assertSame('/research/{slug}', $candidate['public_route_family'] ?? null);
+        $this->assertFalse((bool) ($candidate['published_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($candidate['indexable_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($candidate['queued_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($candidate['submitted_in_this_pr'] ?? true));
+    }
+
+    #[Test]
+    public function publish_prerequisites_cover_backend_runtime_seo_truth_dashboard_and_claim_review(): void
+    {
+        $prerequisites = $this->artifact()['publish_prerequisites'] ?? [];
+
+        foreach ([
+            'research_backend_cms_mvp_merged',
+            'fap_web_runtime_mvp_merged',
+            'research_seo_geo_search_channel_contract_merged',
+            'url_truth_observation_supports_research_report',
+            'metabase_dashboard_visible_to_owner',
+            'claim_linter_passed',
+            'methodology_present',
+            'sample_disclaimer_present',
+            'references_present',
+            'author_present',
+            'reviewer_present',
+            'last_reviewed_at_present',
+        ] as $gate) {
+            $this->assertContains($gate, $prerequisites);
+        }
+    }
+
+    #[Test]
+    public function completed_prerequisite_evidence_references_merged_research_prs(): void
+    {
+        $evidence = $this->artifact()['completed_prerequisite_evidence'] ?? [];
+
+        $this->assertSame('merged', $evidence['research_backend_cms_mvp']['status'] ?? null);
+        $this->assertSame('https://github.com/fermatmind/fap-api/pull/1481', $evidence['research_backend_cms_mvp']['pr_url'] ?? null);
+        $this->assertSame('merged', $evidence['fap_web_runtime_mvp']['status'] ?? null);
+        $this->assertSame('https://github.com/fermatmind/fap-web/pull/848', $evidence['fap_web_runtime_mvp']['pr_url'] ?? null);
+        $this->assertSame('merged', $evidence['research_seo_geo_search_channel_contract']['status'] ?? null);
+        $this->assertSame('https://github.com/fermatmind/fap-api/pull/1482', $evidence['research_seo_geo_search_channel_contract']['pr_url'] ?? null);
+        $this->assertSame('minimally_online', $evidence['seo_dash_mvp']['status'] ?? null);
+        $this->assertFalse((bool) ($evidence['seo_dash_mvp']['metabase_public_exposure'] ?? true));
+    }
+
+    #[Test]
+    public function candidate_requirements_and_forbidden_fields_are_sanitized(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'executive_summary',
+            'methodology',
+            'sample_disclaimer',
+            'claim_boundary_statement',
+            'author',
+            'reviewer',
+            'references',
+            'last_reviewed_at',
+        ] as $field) {
+            $this->assertContains($field, $artifact['candidate_content_requirements'] ?? []);
+        }
+
+        foreach ([
+            'raw_pii',
+            'raw_orders',
+            'raw_payments',
+            'raw_events',
+            'raw_email',
+            'raw_crawler_logs',
+            'cookies',
+            'raw_ips',
+            'provider_payloads',
+            'payment_payloads',
+            'user_specific_private_report_evidence',
+        ] as $field) {
+            $this->assertContains($field, $artifact['forbidden_candidate_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function claim_boundary_and_later_publication_gate_remain_strict(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'diagnosis',
+            'treatment',
+            'cure',
+            'hiring_fit',
+            'job_competency',
+            'exact_iq',
+            'guaranteed_salary',
+            'guaranteed_turnover_prediction',
+            'guaranteed_career_outcome',
+            'ai_career_planning_authority',
+            'full_career_recommendation',
+        ] as $claim) {
+            $this->assertContains($claim, $artifact['forbidden_claim_classes'] ?? []);
+        }
+
+        foreach ([
+            'cms_record_approved',
+            'cms_record_published',
+            'cms_record_public',
+            'cms_record_indexable',
+            'url_truth_records_research_url',
+            'seo_geo_search_channel_gates_satisfied',
+            'no_private_noindex_or_draft_exposure',
+        ] as $gate) {
+            $this->assertContains($gate, $artifact['later_publication_gate'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function publish_sitemap_llms_queue_digital_pr_and_pseo_remain_blocked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'research_publish',
+            'sitemap_inclusion',
+            'llms_inclusion',
+            'search_channel_queue_insertion',
+            'url_submission',
+            'digital_pr',
+            'dataset_schema_if_no_versioned_asset',
+            'pseo_generation',
+        ] as $blocked) {
+            $this->assertContains($blocked, $artifact['blocked_until_later_task'] ?? []);
+        }
+
+        foreach ([
+            'research_publish_in_this_pr',
+            'research_content_imported_in_this_pr',
+            'sitemap_changed_in_this_pr',
+            'llms_changed_in_this_pr',
+            'search_channel_queue_inserted_in_this_pr',
+            'url_submission_performed',
+            'external_api_live_activation',
+            'scheduler_enabled_in_this_pr',
+            'collector_write_executed_in_this_pr',
+            'production_crawler_log_read',
+            'env_edit_in_this_pr',
+            'deployment_performed_in_this_pr',
+            'digital_pr_started_in_this_pr',
+            'dataset_schema_enabled_in_this_pr',
+            'pseo_generation_in_this_pr',
+            'frontend_fallback_authority_enabled',
+            'node2_source_used',
+            'metabase_operation_performed',
+            'business_db_connected',
+            'tencent_rds_connected',
+            'node2_db_connected',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_publish_no_search_submission_no_digital_pr(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/research-publish-readiness.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/research-publish-readiness.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'mbti salary & turnover report',
+            'research candidate frozen draft',
+            'no research content published',
+            'no sitemap behavior changed',
+            'no `llms.txt` behavior changed',
+            'no search channel queue insertion performed',
+            'no url submitted to search engines',
+            'no digital pr started',
+            'no pseo created',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/research-publish-readiness.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T15:41:32Z",
+  "updated_at": "2026-05-19T15:42:22Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -12044,7 +12044,7 @@
       "next_pr": "RESEARCH-PUBLISH-READINESS-00"
     },
     "RESEARCH-PUBLISH-READINESS-00": {
-      "status": "local_checks_passed",
+      "status": "pr_opened_github_checks_pending",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/research-publish-readiness-00",
@@ -12053,8 +12053,8 @@
       "depends_on": [
         "PR-RESEARCH-03"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "4eae44f4",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1485",
       "checks": {
         "local": {
           "php_artisan_test_filter_seo_intel_research_publish_readiness": "passed",
@@ -12067,7 +12067,10 @@
           "git_diff_cached_check": "passed",
           "scope_validation": "passed"
         },
-        "github": {}
+        "github": {
+          "status": "pending",
+          "mergeStateStatus": "UNSTABLE"
+        }
       },
       "failure_reason": null,
       "merged_at": null,
@@ -12084,6 +12087,11 @@
           "at": "2026-05-19T15:41:32Z",
           "status": "local_checks_passed",
           "summary": "Focused Research publish readiness test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff checks, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T15:42:22Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1485. GitHub checks pending."
         }
       ],
       "next_pr": null

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T15:17:24Z",
+  "updated_at": "2026-05-19T15:41:32Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11970,7 +11970,7 @@
       ]
     },
     "PR-RESEARCH-03": {
-      "status": "pr_opened_github_checks_pending",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/pr-research-03",
@@ -11987,7 +11987,7 @@
           "status": "merged"
         }
       },
-      "commit_sha": "de16dbc701404f0d4297d789e906627bb439b2a7",
+      "commit_sha": "9d0de1f4922ad7dcb958ab8cf0d716664ca44cd8",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1482",
       "checks": {
         "local": {
@@ -12002,14 +12002,22 @@
           "scope_validation": "passed"
         },
         "github": {
-          "status": "pending",
-          "mergeStateStatus": "UNSTABLE"
+          "hygiene": "passed",
+          "semgrep_sarif": "passed",
+          "semgrep_oss": "passed",
+          "verify_mbti_legacy": "passed",
+          "verify_mbti_v2": "passed",
+          "mergeStateStatus": "CLEAN"
+        },
+        "ledger_reconciliation": {
+          "status": "passed",
+          "evidence": "GitHub reports PR #1482 as MERGED with squash merge commit 9d0de1f4922ad7dcb958ab8cf0d716664ca44cd8; origin/main contains the merge commit; remote branch codex/pr-research-03 is absent; local cleanup script was executed from the local clone."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-19T15:37:13Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "history": [
         {
@@ -12026,9 +12034,59 @@
           "at": "2026-05-19T15:17:24Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1482. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-19T15:40:30Z",
+          "status": "merged",
+          "summary": "Reconciled PR-RESEARCH-03 as merged via PR #1482. GitHub checks passed, merge commit is present on origin/main, remote branch is absent, and local cleanup was executed before starting RESEARCH-PUBLISH-READINESS-00."
         }
       ],
       "next_pr": "RESEARCH-PUBLISH-READINESS-00"
+    },
+    "RESEARCH-PUBLISH-READINESS-00": {
+      "status": "local_checks_passed",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/research-publish-readiness-00",
+      "base": "main",
+      "title": "docs(research): add first Research publish readiness checklist",
+      "depends_on": [
+        "PR-RESEARCH-03"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_research_publish_readiness": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "git_diff_cached_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T15:40:30Z",
+          "status": "in_progress",
+          "summary": "Started first Research publish readiness checklist PR. Scope is docs/generated/test metadata only and excludes Research publish, sitemap/llms changes, Search Channel Queue insertion, URL submission, Digital PR, pSEO, live search APIs, collector writes, scheduler activation, Metabase operations, env edits, deploy, and production operations."
+        },
+        {
+          "at": "2026-05-19T15:41:32Z",
+          "status": "local_checks_passed",
+          "summary": "Focused Research publish readiness test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff checks, and allowed-path scope validation passed."
+        }
+      ],
+      "next_pr": null
     }
   },
   "SEO-DASH-PROD-03D-FIX": {
@@ -12452,5 +12510,4 @@
     ],
     "next_pr": "RIASEC-FULL-CONTENT-PACK-04"
   }
-
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6218,6 +6218,61 @@ prs:
     production_approval_required: false
     next_task: RESEARCH-PUBLISH-READINESS-00
 
+  - id: RESEARCH-PUBLISH-READINESS-00
+    repo: fap-api
+    depends_on:
+      - PR-RESEARCH-03
+    branch: codex/research-publish-readiness-00
+    base: main
+    title: "docs(research): add first Research publish readiness checklist"
+    name: "First Research publish readiness contract"
+    train_scope: seo_dash_mvp_closeout_research_train
+    risk_level: docs_generated_test_contract_no_publish_no_runtime_activation
+    type: docs/generated/test PR
+    scope:
+      - Define the first Research publish readiness checklist for the MBTI Salary & Turnover Report candidate.
+      - Keep candidate status as Research Candidate Frozen Draft.
+      - Require Research backend/CMS MVP, fap-web runtime MVP, Research SEO/GEO contract, URL Truth observation, private Metabase visibility, claim linter pass, references, methodology, and disclaimer before publication.
+      - Keep Research publish, sitemap, llms, Search Channel Queue insertion, URL submission, Digital PR, and pSEO blocked in this PR.
+    allowed_paths:
+      - backend/docs/seo/research-publish-readiness.md
+      - backend/docs/seo/generated/research-publish-readiness.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelResearchPublishReadinessTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy, edit env files, run collector writes, enable scheduler, connect live search APIs, submit URLs, read production crawler logs, change RDS/DB/users/whitelist, expose Metabase publicly, publish Research content, start Digital PR, or create pSEO.
+      - Add Research sitemap entries, llms entries, Search Channel Queue records, Dataset schema, public Research content, frontend runtime changes, or report content imports.
+      - Connect Metabase to business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational tables.
+      - Expand RIASEC, Big Five, career decision, or Research claims into diagnosis, hiring fit, job competency, full career recommendation, exact IQ, or guaranteed outcome claims.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelResearchPublishReadiness
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/research-publish-readiness.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    metabase_operation: false
+    research_publish: false
+    digital_pr: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: SEO-DASH-MVP-ONLINE-SUMMARY closeout report / next Research publish operation planning
+
 
   - id: RIASEC-FULL-CONTENT-PACK-03-PREFLIGHT
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added the first Research publish readiness checklist for the MBTI Salary & Turnover Report candidate.
- Added a machine-readable readiness artifact and focused SeoIntel test.
- Registered `RESEARCH-PUBLISH-READINESS-00` in the PR train manifest/state.
- Reconciled PR-RESEARCH-03 as merged via PR #1482.

## Why
- Research backend/CMS, fap-web runtime, and SEO/GEO contract are merged, but the first Research candidate still needs an explicit no-publish readiness gate before any content publication, sitemap/llms exposure, Search Channel Queue insertion, Digital PR, or pSEO work.

## Validation
- `cd backend && php artisan test --filter=SeoIntelResearchPublishReadiness`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/research-publish-readiness.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred / not changed
- No Research publish.
- No Research content import.
- No sitemap or llms behavior change.
- No Search Channel Queue insertion or URL submission.
- No live GSC/Baidu/IndexNow/domestic search API connection.
- No Digital PR.
- No scheduler, collector write, Metabase operation, env edit, deploy, RDS/DB/whitelist change, or pSEO.
- No runtime code or migration change.

## Repository rule impact
- Keeps Research candidate backend/CMS-authoritative and draft-gated.
- Does not introduce frontend fallback, temporary migration fallback, or public content authority outside backend/CMS.
- Publish, sitemap, llms, Search Channel Queue, Dataset schema, Digital PR, and pSEO remain blocked pending later explicit gates.