### PR TITLE
docs(seo-intel): add Ops Portal SEO auth audit contract

### DIFF
--- a/backend/docs/seo/generated/ops-portal-seo-auth-audit-permission-contract.v1.json
+++ b/backend/docs/seo/generated/ops-portal-seo-auth-audit-permission-contract.v1.json
@@ -1,0 +1,117 @@
+{
+  "version": "ops-portal-seo-auth-audit-permission-contract.v1",
+  "task": "OPS-PORTAL-SEO-02",
+  "generated_at": "2026-05-19T20:13:48Z",
+  "purpose": "Define auth, permission, owner, audit, revoke, and operator onboarding requirements for /ops/seo.",
+  "auth_stack": {
+    "surface": "fap-api Filament Ops panel",
+    "public_route_outside_ops_panel_allowed": false,
+    "admin_guard_required": true,
+    "filament_ops_auth_required": true,
+    "session_required": true,
+    "csrf_required": true,
+    "totp_required_when_configured": true,
+    "org_context_required_when_panel_requires_it": true,
+    "ops_access_control_required": true,
+    "host_allowlist_respected": true,
+    "ip_allowlist_respected": true,
+    "fail_open_allowed": false
+  },
+  "permission_decision": {
+    "initial_allowed_permissions": [
+      "admin.owner",
+      "admin.ops.read"
+    ],
+    "future_narrow_permission": "admin.seo_intel.read",
+    "normal_operator_unrestricted_sql_allowed": false,
+    "normal_operator_datasource_management_allowed": false,
+    "normal_operator_export_allowed_by_default": false
+  },
+  "owners": [
+    "metabase_admin_owner",
+    "dashboard_owner",
+    "db_access_owner",
+    "export_policy_owner",
+    "emergency_revoke_owner"
+  ],
+  "audit_expectations": [
+    "ops_seo_page_access",
+    "permission_change",
+    "owner_assignment_change",
+    "export_approval_decision",
+    "emergency_revoke_action",
+    "future_bridge_or_proxy_access_event"
+  ],
+  "audit_forbidden_fields": [
+    "password",
+    "token",
+    "cookie",
+    "raw_ip_payload",
+    "order_id",
+    "payment_id",
+    "attempt_id",
+    "raw_email",
+    "provider_payload",
+    "payment_payload",
+    "secret",
+    "api_key"
+  ],
+  "operator_onboarding": {
+    "blocked_until_permissions_plan": true,
+    "normal_operator_users_allowed_now": false,
+    "unrestricted_native_sql_allowed": false,
+    "native_query_access_default": false,
+    "datasource_management_allowed": false,
+    "exports_allowed_by_default": false,
+    "public_sharing_allowed": false,
+    "public_embedding_allowed": false,
+    "anonymous_link_creation_allowed": false
+  },
+  "emergency_revoke_triggers": [
+    "metabase_binds_0_0_0_0",
+    "metabase_public_ipv4_or_eip_present",
+    "public_security_group_ingress_present",
+    "public_sharing_enabled",
+    "anonymous_links_created",
+    "public_embedding_enabled",
+    "unexpected_datasource_present",
+    "business_or_raw_datasource_present",
+    "normal_operator_unrestricted_sql_enabled"
+  ],
+  "emergency_revoke_steps": [
+    "stop_public_access",
+    "disable_unsafe_settings",
+    "confirm_localhost_only_metabase",
+    "review_datasource_inventory",
+    "record_owner_action"
+  ],
+  "forbidden_sources": [
+    "business_db",
+    "tencent_rds_fap_prod",
+    "node2_local_db",
+    "cms_write_tables",
+    "raw_orders",
+    "raw_payments",
+    "raw_events_detail",
+    "raw_email",
+    "raw_reports",
+    "raw_crawler_logs",
+    "provider_payloads",
+    "payment_payloads"
+  ],
+  "production_operations_performed_in_this_pr": false,
+  "runtime_permission_code_changed_in_this_pr": false,
+  "route_shell_added_in_this_pr": false,
+  "metabase_operation_performed_in_this_pr": false,
+  "network_change_performed_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "deploy_performed_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_performed_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "production_crawler_log_read": false,
+  "research_publish_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "next_task": "OPS-PORTAL-SEO-03"
+}

--- a/backend/docs/seo/ops-portal-seo-auth-audit-permission-contract.md
+++ b/backend/docs/seo/ops-portal-seo-auth-audit-permission-contract.md
@@ -1,0 +1,100 @@
+# Ops Portal SEO Auth Audit Permission Contract
+
+## Purpose
+
+OPS-PORTAL-SEO-02 defines the auth, permission, owner, audit, revoke, and operator onboarding contract for `/ops/seo`.
+This is a documentation, generated-contract, and focused-test PR only. It does not add route shell code, runtime permission enforcement code, deploy, edit environment files, change DNS/CDN/OpenResty/Nginx, open ports, change security groups, change RDS whitelists, operate Metabase, add data sources, create dashboards, enable scheduler, run collector writes, call live search APIs, submit URLs, read production crawler logs, publish Research, or create pSEO.
+
+## Required Auth Stack
+
+`/ops/seo` must be served only through the existing fap-api Filament Ops panel.
+
+Required access controls:
+
+- admin guard
+- Filament Ops authentication
+- session cookies
+- CSRF protection
+- TOTP where configured
+- org context where the panel requires it
+- Ops access control middleware
+- host allowlist checks where configured
+- IP allowlist checks where configured
+- fail-closed access behavior
+
+The page must not create a public route outside the Ops panel.
+
+## Permission Decision
+
+Initial MVP access may reuse existing owner or ops read access:
+
+- `admin.owner`
+- `admin.ops.read`
+
+A future narrower permission is reserved:
+
+- `admin.seo_intel.read`
+
+The route shell should start with owner or ops-read visibility unless a later scoped PR adds the narrower permission to the RBAC system.
+Datasource management remains admin-only and must not be granted to normal operators through `/ops/seo`.
+
+## Owner Assignments
+
+The Ops Portal SEO access layer must record the operational owners:
+
+- Metabase admin owner
+- dashboard owner
+- DB access owner
+- export policy owner
+- emergency revoke owner
+
+Owner changes must be auditable and revocable.
+
+## Audit Expectations
+
+The following events must be logged or explicitly covered by a future implementation plan:
+
+- `/ops/seo` page access
+- permission changes
+- owner assignment changes
+- export approval decisions
+- emergency revoke actions
+- future bridge or proxy access events if a bridge is ever approved
+
+The audit trail must not store secrets, raw DB passwords, raw tokens, cookies, raw IP payloads, order IDs, payment IDs, attempt IDs, raw emails, or raw provider payloads.
+
+## Operator Onboarding Boundary
+
+Normal operators are blocked until a separate permissions plan exists.
+
+Normal operators must not receive:
+
+- unrestricted SQL
+- native query access by default
+- datasource management
+- export access by default
+- public sharing access
+- public embedding access
+- anonymous link creation
+
+Only owner-approved sanitized aggregate exports may be allowed in a later scoped task.
+
+## Emergency Revoke Contract
+
+Emergency revoke is required if any of the following appears:
+
+- Metabase binds to `0.0.0.0`
+- Metabase is exposed through public IPv4 or EIP
+- ECS security group is opened publicly
+- public sharing is enabled
+- anonymous links are created
+- public embedding is enabled
+- unexpected data source appears
+- business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational tables are connected
+- normal operators receive unrestricted SQL
+
+Revoke steps must include stopping public access, disabling unsafe settings, confirming localhost-only Metabase, reviewing datasource inventory, and recording owner action.
+
+## Next Task
+
+Next task: `OPS-PORTAL-SEO-03`

--- a/backend/tests/Feature/SeoIntel/SeoIntelOpsPortalSeoAuthAuditPermissionContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelOpsPortalSeoAuthAuditPermissionContractTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelOpsPortalSeoAuthAuditPermissionContractTest extends TestCase
+{
+    #[Test]
+    public function artifact_requires_existing_ops_auth_stack(): void
+    {
+        $artifact = $this->artifact();
+        $auth = $artifact['auth_stack'] ?? [];
+
+        $this->assertSame('ops-portal-seo-auth-audit-permission-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('OPS-PORTAL-SEO-02', $artifact['task'] ?? null);
+        $this->assertSame('fap-api Filament Ops panel', $auth['surface'] ?? null);
+        $this->assertFalse((bool) ($auth['public_route_outside_ops_panel_allowed'] ?? true));
+        $this->assertTrue((bool) ($auth['admin_guard_required'] ?? false));
+        $this->assertTrue((bool) ($auth['filament_ops_auth_required'] ?? false));
+        $this->assertTrue((bool) ($auth['session_required'] ?? false));
+        $this->assertTrue((bool) ($auth['csrf_required'] ?? false));
+        $this->assertTrue((bool) ($auth['totp_required_when_configured'] ?? false));
+        $this->assertTrue((bool) ($auth['org_context_required_when_panel_requires_it'] ?? false));
+        $this->assertTrue((bool) ($auth['ops_access_control_required'] ?? false));
+        $this->assertTrue((bool) ($auth['host_allowlist_respected'] ?? false));
+        $this->assertTrue((bool) ($auth['ip_allowlist_respected'] ?? false));
+        $this->assertFalse((bool) ($auth['fail_open_allowed'] ?? true));
+    }
+
+    #[Test]
+    public function permissions_allow_owner_or_ops_read_and_reserve_narrow_future_permission(): void
+    {
+        $permissions = $this->artifact()['permission_decision'] ?? [];
+
+        $this->assertContains('admin.owner', $permissions['initial_allowed_permissions'] ?? []);
+        $this->assertContains('admin.ops.read', $permissions['initial_allowed_permissions'] ?? []);
+        $this->assertSame('admin.seo_intel.read', $permissions['future_narrow_permission'] ?? null);
+        $this->assertFalse((bool) ($permissions['normal_operator_unrestricted_sql_allowed'] ?? true));
+        $this->assertFalse((bool) ($permissions['normal_operator_datasource_management_allowed'] ?? true));
+        $this->assertFalse((bool) ($permissions['normal_operator_export_allowed_by_default'] ?? true));
+    }
+
+    #[Test]
+    public function owners_and_audit_events_are_explicit(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'metabase_admin_owner',
+            'dashboard_owner',
+            'db_access_owner',
+            'export_policy_owner',
+            'emergency_revoke_owner',
+        ] as $owner) {
+            $this->assertContains($owner, $artifact['owners'] ?? []);
+        }
+
+        foreach ([
+            'ops_seo_page_access',
+            'permission_change',
+            'owner_assignment_change',
+            'export_approval_decision',
+            'emergency_revoke_action',
+            'future_bridge_or_proxy_access_event',
+        ] as $event) {
+            $this->assertContains($event, $artifact['audit_expectations'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function audit_contract_forbids_secrets_and_raw_operational_identifiers(): void
+    {
+        foreach ([
+            'password',
+            'token',
+            'cookie',
+            'raw_ip_payload',
+            'order_id',
+            'payment_id',
+            'attempt_id',
+            'raw_email',
+            'provider_payload',
+            'payment_payload',
+            'secret',
+            'api_key',
+        ] as $field) {
+            $this->assertContains($field, $this->artifact()['audit_forbidden_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function normal_operator_onboarding_remains_blocked_until_permissions_plan(): void
+    {
+        $operator = $this->artifact()['operator_onboarding'] ?? [];
+
+        $this->assertTrue((bool) ($operator['blocked_until_permissions_plan'] ?? false));
+        $this->assertFalse((bool) ($operator['normal_operator_users_allowed_now'] ?? true));
+        $this->assertFalse((bool) ($operator['unrestricted_native_sql_allowed'] ?? true));
+        $this->assertFalse((bool) ($operator['native_query_access_default'] ?? true));
+        $this->assertFalse((bool) ($operator['datasource_management_allowed'] ?? true));
+        $this->assertFalse((bool) ($operator['exports_allowed_by_default'] ?? true));
+        $this->assertFalse((bool) ($operator['public_sharing_allowed'] ?? true));
+        $this->assertFalse((bool) ($operator['public_embedding_allowed'] ?? true));
+        $this->assertFalse((bool) ($operator['anonymous_link_creation_allowed'] ?? true));
+    }
+
+    #[Test]
+    public function revoke_triggers_and_steps_cover_public_metabase_and_forbidden_sources(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'metabase_binds_0_0_0_0',
+            'metabase_public_ipv4_or_eip_present',
+            'public_security_group_ingress_present',
+            'public_sharing_enabled',
+            'anonymous_links_created',
+            'public_embedding_enabled',
+            'unexpected_datasource_present',
+            'business_or_raw_datasource_present',
+            'normal_operator_unrestricted_sql_enabled',
+        ] as $trigger) {
+            $this->assertContains($trigger, $artifact['emergency_revoke_triggers'] ?? []);
+        }
+
+        foreach ([
+            'stop_public_access',
+            'disable_unsafe_settings',
+            'confirm_localhost_only_metabase',
+            'review_datasource_inventory',
+            'record_owner_action',
+        ] as $step) {
+            $this->assertContains($step, $artifact['emergency_revoke_steps'] ?? []);
+        }
+
+        foreach ([
+            'business_db',
+            'tencent_rds_fap_prod',
+            'node2_local_db',
+            'cms_write_tables',
+            'raw_orders',
+            'raw_payments',
+            'raw_events_detail',
+            'raw_email',
+            'raw_reports',
+            'raw_crawler_logs',
+            'provider_payloads',
+            'payment_payloads',
+        ] as $source) {
+            $this->assertContains($source, $artifact['forbidden_sources'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function this_pr_does_not_add_runtime_permission_code_route_shell_or_operations(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'production_operations_performed_in_this_pr',
+            'runtime_permission_code_changed_in_this_pr',
+            'route_shell_added_in_this_pr',
+            'metabase_operation_performed_in_this_pr',
+            'network_change_performed_in_this_pr',
+            'env_edit_in_this_pr',
+            'deploy_performed_in_this_pr',
+            'scheduler_enabled_in_this_pr',
+            'collector_write_performed_in_this_pr',
+            'external_api_live_activation',
+            'url_submission_performed',
+            'production_crawler_log_read',
+            'research_publish_in_this_pr',
+            'pseo_generation_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_auth_audit_permission_contract_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/ops-portal-seo-auth-audit-permission-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/ops-portal-seo-auth-audit-permission-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'ops portal seo auth audit permission contract',
+            'admin guard',
+            'filament ops authentication',
+            'csrf protection',
+            'totp',
+            'org context',
+            'ops access control',
+            'admin.ops.read',
+            'admin.seo_intel.read',
+            'metabase admin owner',
+            'emergency revoke owner',
+            'normal operators are blocked',
+            'unrestricted sql',
+            'next task: `ops-portal-seo-03`',
+            '"next_task": "ops-portal-seo-03"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/ops-portal-seo-auth-audit-permission-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4547,8 +4547,8 @@
         "no fap-web change",
         "no 300/800/2786 expansion execution"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "1c1f2d3b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1488",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -12208,6 +12208,11 @@
           "at": "2026-05-19T20:18:30Z",
           "status": "local_checks_passed",
           "summary": "Focused Ops Portal SEO auth/audit/permission contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T20:22:00Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1488. GitHub checks pending."
         }
       ],
       "next_pr": "OPS-PORTAL-SEO-03"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6058,7 +6058,7 @@
       "repo": "fap-api",
       "branch": "fix/career-progressive-readiness-selection-1",
       "title": "fix(api): add progressive career readiness selection",
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "depends_on": [
         "REPAIR-PROGRESSIVE-LIVE-VERIFICATION-SCALING-1"
       ],
@@ -12097,7 +12097,7 @@
       "next_pr": null
     },
     "OPS-PORTAL-SEO-01": {
-      "status": "in_progress",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/ops-portal-seo-01",
@@ -12106,8 +12106,8 @@
       "depends_on": [
         "RESEARCH-PUBLISH-READINESS-00"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "50a0b9f4f31876b5d6974eed6b5516abab0fa947",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1486",
       "checks": {
         "local": {
           "php_artisan_test_filter_seo_intel_ops_portal_seo_access_architecture": "passed",
@@ -12119,12 +12119,15 @@
           "git_diff_check": "passed",
           "scope_validation": "passed"
         },
-        "github": {}
+        "github": {
+          "status": "pass_no_required_checks_reported",
+          "mergeStateStatus": "CLEAN"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-19T20:13:03Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "RESEARCH-PUBLISH-READINESS-00 ledger stale",
@@ -12156,9 +12159,58 @@
           "at": "2026-05-19T20:15:00Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1486. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-19T20:13:03Z",
+          "status": "merged",
+          "summary": "Merged PR #1486 with squash merge commit 50a0b9f4f31876b5d6974eed6b5516abab0fa947. GitHub reported mergeStateStatus=CLEAN and no required checks; remote branch was deleted and local main synced."
         }
       ],
       "next_pr": "OPS-PORTAL-SEO-02"
+    },
+    "OPS-PORTAL-SEO-02": {
+      "status": "in_progress",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/ops-portal-seo-02",
+      "base": "main",
+      "title": "docs(seo-intel): add Ops Portal SEO auth audit contract",
+      "depends_on": [
+        "OPS-PORTAL-SEO-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_ops_portal_seo_auth_audit_permission_contract": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T20:13:48Z",
+          "status": "in_progress",
+          "summary": "Started docs/generated/test-only Ops Portal SEO auth/audit/permission contract PR. Scope excludes route shell code, runtime permission enforcement code, Metabase iframe/proxy/public exposure, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, and pSEO."
+        },
+        {
+          "at": "2026-05-19T20:18:30Z",
+          "status": "local_checks_passed",
+          "summary": "Focused Ops Portal SEO auth/audit/permission contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        }
+      ],
+      "next_pr": "OPS-PORTAL-SEO-03"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {


### PR DESCRIPTION
## What changed
- Added the Ops Portal SEO auth/audit/permission contract.
- Added a generated v1 artifact covering Ops auth stack, owner roles, audit events, emergency revoke, and operator onboarding boundaries.
- Added a focused SeoIntel contract test.
- Reconciled OPS-PORTAL-SEO-01 as merged in the train state.

## Validation
- `cd backend && php artisan test --filter=SeoIntelOpsPortalSeoAuthAuditPermissionContract`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/ops-portal-seo-auth-audit-permission-contract.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML validation for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## What was not changed
- No route shell or runtime permission enforcement code.
- No Metabase iframe, proxy, public exposure, operation, datasource, dashboard, public sharing, or anonymous links.
- No DNS/CDN/OpenResty/Nginx, ECS security group, RDS whitelist, env, deploy, scheduler, collector, search, crawler, Research publish, pSEO, sitemap, or llms changes.