### PR TITLE
feat(ops): add SEO dashboard access shell

### DIFF
--- a/backend/app/Filament/Ops/Pages/SeoDashboardAccessPage.php
+++ b/backend/app/Filament/Ops/Pages/SeoDashboardAccessPage.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Pages;
+
+use App\Support\Rbac\PermissionNames;
+use Filament\Pages\Page;
+
+class SeoDashboardAccessPage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-chart-bar-square';
+
+    protected static ?string $navigationGroup = 'Content Overview';
+
+    protected static ?string $navigationLabel = 'SEO Intelligence';
+
+    protected static ?int $navigationSort = 6;
+
+    protected static ?string $slug = 'seo';
+
+    protected static string $view = 'filament.ops.pages.seo-dashboard-access';
+
+    /**
+     * @return list<array{label:string,value:string,hint:string}>
+     */
+    public function statusCards(): array
+    {
+        return [
+            [
+                'label' => 'URL Truth rows',
+                'value' => '7',
+                'hint' => 'Verified `seo_urls` count from the SEO Dash MVP online closeout.',
+            ],
+            [
+                'label' => 'Entity mappings',
+                'value' => '7',
+                'hint' => 'Verified `seo_url_entities` count from the SEO Dash MVP online closeout.',
+            ],
+            [
+                'label' => 'Issue queue rows',
+                'value' => '5',
+                'hint' => 'Verified `seo_issue_queue` count from the SEO Dash MVP online closeout.',
+            ],
+            [
+                'label' => 'Verified cards',
+                'value' => '10',
+                'hint' => 'Metabase dashboard card count verified before this route shell PR.',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array{label:string,value:string,hint:string}>
+     */
+    public function boundaryCards(): array
+    {
+        return [
+            [
+                'label' => 'Metabase exposure',
+                'value' => 'Private only',
+                'hint' => 'Metabase remains localhost-bound on the approved private ECS host.',
+            ],
+            [
+                'label' => 'Datasource',
+                'value' => 'seo_intel',
+                'hint' => 'The only approved Metabase datasource uses the readonly account.',
+            ],
+            [
+                'label' => 'Sharing',
+                'value' => 'Disabled',
+                'hint' => 'Public sharing, anonymous links, and public embedding remain blocked.',
+            ],
+            [
+                'label' => 'Operator SQL',
+                'value' => 'Blocked',
+                'hint' => 'Normal operators must not receive unrestricted native SQL access.',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array{title:string,body:string}>
+     */
+    public function accessSteps(): array
+    {
+        return [
+            [
+                'title' => 'Confirm owner approval',
+                'body' => 'Use this page as the Ops entry point and confirm the Metabase admin, dashboard, DB access, export policy, and emergency revoke owners before private access.',
+            ],
+            [
+                'title' => 'Use a private channel',
+                'body' => 'Access Metabase only through Workbench, bastion, VPN, or another approved owner-controlled private channel.',
+            ],
+            [
+                'title' => 'Keep Metabase private',
+                'body' => 'Do not iframe, reverse-proxy, publish, expose, or bind Metabase to a public interface from this page.',
+            ],
+            [
+                'title' => 'Verify datasource boundary',
+                'body' => 'The only approved datasource is `seo_intel` through `seo_intel_metabase_readonly`; business DB, Tencent RDS, Node2, and raw operational sources remain forbidden.',
+            ],
+        ];
+    }
+
+    public function getTitle(): string
+    {
+        return 'SEO Intelligence Access';
+    }
+
+    public static function canAccess(): bool
+    {
+        return self::hasAnyPermission([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private static function hasAnyPermission(array $permissions): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'hasPermission')) {
+            return false;
+        }
+
+        foreach ($permissions as $permission) {
+            if ($user->hasPermission($permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/docs/seo/generated/ops-portal-seo-route-shell.v1.json
+++ b/backend/docs/seo/generated/ops-portal-seo-route-shell.v1.json
@@ -1,0 +1,77 @@
+{
+  "version": "ops-portal-seo-route-shell.v1",
+  "task": "OPS-PORTAL-SEO-03",
+  "generated_at": "2026-05-19T20:18:53Z",
+  "purpose": "Add an authenticated fap-api Filament Ops /ops/seo status and runbook shell without exposing Metabase.",
+  "route": {
+    "path": "/ops/seo",
+    "owner_repo": "fap-api",
+    "surface": "Filament Ops panel",
+    "auth_required": true,
+    "allowed_permissions": [
+      "admin.owner",
+      "admin.ops.read"
+    ],
+    "route_shell_added": true,
+    "runtime_live_db_query_added": false,
+    "metabase_api_call_added": false
+  },
+  "displayed_static_status": {
+    "seo_urls": 7,
+    "seo_url_entities": 7,
+    "seo_issue_queue": 5,
+    "dashboard_name": "SEO Intelligence MVP - URL Truth & Issue Queue",
+    "verified_cards_count": 10,
+    "datasource_name": "seo_intel",
+    "datasource_account": "seo_intel_metabase_readonly"
+  },
+  "page_content": {
+    "shows_dashboard_name": true,
+    "shows_owner_confirmation_step": true,
+    "shows_private_access_channels": true,
+    "shows_forbidden_exposure_warnings": true,
+    "shows_forbidden_source_warnings": true,
+    "shows_operator_sql_warning": true
+  },
+  "metabase_boundary": {
+    "private_only": true,
+    "localhost_only": true,
+    "iframe_added": false,
+    "reverse_proxy_added": false,
+    "public_url_added": false,
+    "public_sharing_enabled": false,
+    "anonymous_links_created": false,
+    "public_embeds_enabled": false,
+    "public_port_opened": false,
+    "dns_cdn_openresty_nginx_changed": false
+  },
+  "forbidden_sources": [
+    "business_db",
+    "tencent_rds_fap_prod",
+    "node2_local_db",
+    "cms_write_tables",
+    "raw_orders",
+    "raw_payments",
+    "raw_events_detail",
+    "raw_email",
+    "raw_reports",
+    "raw_crawler_logs",
+    "provider_payloads",
+    "payment_payloads"
+  ],
+  "production_operations_performed_in_this_pr": false,
+  "metabase_operation_performed_in_this_pr": false,
+  "network_change_performed_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "deploy_performed_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_performed_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "production_crawler_log_read": false,
+  "research_publish_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "sitemap_changed_in_this_pr": false,
+  "llms_changed_in_this_pr": false,
+  "next_task": "OPS-PORTAL-SEO-04"
+}

--- a/backend/docs/seo/ops-portal-seo-route-shell.md
+++ b/backend/docs/seo/ops-portal-seo-route-shell.md
@@ -1,0 +1,51 @@
+# Ops Portal SEO Route Shell
+
+## Purpose
+
+OPS-PORTAL-SEO-03 adds the authenticated `/ops/seo` route shell inside the existing fap-api Filament Ops panel.
+The shell is status and runbook only. It does not deploy, edit environment files, change DNS/CDN/OpenResty/Nginx, open ports, change security groups, change RDS whitelists, operate Metabase, add data sources, create dashboards, enable scheduler, run collector writes, call live search APIs, submit URLs, read production crawler logs, publish Research, create pSEO, change sitemap, or change `llms.txt`.
+
+## Route
+
+The route shell is:
+
+- path: `/ops/seo`
+- owner: fap-api
+- surface: Filament Ops panel
+- auth: existing Ops/Admin auth
+- access: `admin.owner` or `admin.ops.read`
+- content mode: static status and private access runbook
+
+## Displayed Status
+
+The page displays the verified SEO Dash MVP state:
+
+- `seo_urls`: 7
+- `seo_url_entities`: 7
+- `seo_issue_queue`: 5
+- dashboard: `SEO Intelligence MVP - URL Truth & Issue Queue`
+- verified cards: 10
+- datasource: `seo_intel`
+- datasource account: `seo_intel_metabase_readonly`
+
+This status is static documentation. The page does not query production `seo_intel` and does not call the Metabase API.
+
+## Private Metabase Boundary
+
+Metabase remains private:
+
+- localhost-bound on the approved private ECS host
+- no iframe
+- no reverse proxy
+- no public URL
+- no public sharing
+- no anonymous links
+- no public embeds
+- no public port
+- no DNS/CDN/OpenResty/Nginx change
+
+Access remains through Workbench, bastion, VPN, or another approved owner-controlled private channel.
+
+## Next Task
+
+Next task: `OPS-PORTAL-SEO-04`

--- a/backend/resources/views/filament/ops/pages/seo-dashboard-access.blade.php
+++ b/backend/resources/views/filament/ops/pages/seo-dashboard-access.blade.php
@@ -1,0 +1,70 @@
+<x-filament-panels::page>
+    <div class="ops-shell-page">
+        <x-filament-ops::ops-section
+            eyebrow="SEO Intelligence"
+            title="SEO Dash access"
+            description="Authenticated Ops entry for the private SEO Intelligence MVP dashboard. This page is status and runbook only; it does not embed, proxy, or call Metabase."
+        >
+            <x-filament-ops::ops-toolbar>
+                <div class="ops-control-stack">
+                    <span class="ops-control-label">Dashboard</span>
+                    <p class="ops-control-hint">SEO Intelligence MVP - URL Truth &amp; Issue Queue</p>
+                </div>
+
+                <x-slot name="actions">
+                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\SeoOperationsPage::getUrl() }}">
+                        CMS SEO Ops
+                    </x-filament::button>
+                </x-slot>
+            </x-filament-ops::ops-toolbar>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Verified MVP state"
+            description="Static closeout summary from the verified SEO Dash MVP. No live database or Metabase API calls are performed by this page."
+        >
+            <x-filament-ops::ops-field-grid :fields="$this->statusCards()" />
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Access boundary"
+            description="Metabase remains private and read-only over seo_intel. This route is an Ops entry point, not a public dashboard endpoint."
+        >
+            <x-filament-ops::ops-field-grid :fields="$this->boundaryCards()" />
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Private access runbook"
+            description="Use approved private access only. Do not create public links, anonymous links, public embeds, reverse proxies, or iframe exposure."
+        >
+            <div class="ops-card-list">
+                @foreach ($this->accessSteps() as $step)
+                    <x-filament-ops::ops-result-card
+                        :title="$step['title']"
+                        :meta="$step['body']"
+                    />
+                @endforeach
+            </div>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Hard stops"
+            description="Stop and revoke access if any forbidden exposure or source appears."
+        >
+            <div class="ops-card-list">
+                <x-filament-ops::ops-result-card
+                    title="Forbidden exposure"
+                    meta="No public Metabase, no 0.0.0.0 binding, no public port, no security group change, no DNS/CDN/OpenResty/Nginx change."
+                />
+                <x-filament-ops::ops-result-card
+                    title="Forbidden sources"
+                    meta="No business DB, Tencent RDS, Node2 local DB, CMS write tables, raw orders, raw payments, raw events, raw email, raw reports, or raw crawler logs."
+                />
+                <x-filament-ops::ops-result-card
+                    title="Forbidden operator access"
+                    meta="No unrestricted SQL, no datasource management, no default exports, no public sharing, no anonymous links, and no public embeds for normal operators."
+                />
+            </div>
+        </x-filament-ops::ops-section>
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Feature/SeoIntel/SeoIntelOpsPortalSeoRouteShellTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelOpsPortalSeoRouteShellTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Filament\Ops\Pages\SeoDashboardAccessPage;
+use App\Models\AdminUser;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelOpsPortalSeoRouteShellTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    #[Test]
+    public function ops_seo_route_requires_existing_ops_auth(): void
+    {
+        $this->get('/ops/seo')
+            ->assertRedirectContains('/ops/login');
+    }
+
+    #[Test]
+    public function ops_read_admin_can_render_static_seo_dashboard_access_shell(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/seo')
+            ->assertOk()
+            ->assertSee('SEO Intelligence Access')
+            ->assertSee('SEO Dash access')
+            ->assertSee('SEO Intelligence MVP - URL Truth &amp; Issue Queue', false)
+            ->assertSee('URL Truth rows')
+            ->assertSee('Entity mappings')
+            ->assertSee('Issue queue rows')
+            ->assertSee('Verified cards')
+            ->assertSee('Private only')
+            ->assertSee('seo_intel')
+            ->assertSee('seo_intel_metabase_readonly')
+            ->assertSee('Workbench')
+            ->assertSee('bastion')
+            ->assertSee('VPN')
+            ->assertSee('No public Metabase')
+            ->assertDontSee('<iframe', false)
+            ->assertDontSee('business DB source connected');
+    }
+
+    #[Test]
+    public function page_access_uses_owner_or_ops_read_permissions_only(): void
+    {
+        $this->actingAs($this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OPS_READ,
+        ]), (string) config('admin.guard', 'admin'));
+        $this->assertTrue(SeoDashboardAccessPage::canAccess());
+
+        $this->actingAs($this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+        ]), (string) config('admin.guard', 'admin'));
+        $this->assertTrue(SeoDashboardAccessPage::canAccess());
+
+        $this->actingAs($this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+        ]), (string) config('admin.guard', 'admin'));
+        $this->assertFalse(SeoDashboardAccessPage::canAccess());
+    }
+
+    #[Test]
+    public function page_methods_return_static_status_without_runtime_queries_or_metabase_calls(): void
+    {
+        $page = app(SeoDashboardAccessPage::class);
+
+        $this->assertSame([
+            [
+                'label' => 'URL Truth rows',
+                'value' => '7',
+                'hint' => 'Verified `seo_urls` count from the SEO Dash MVP online closeout.',
+            ],
+            [
+                'label' => 'Entity mappings',
+                'value' => '7',
+                'hint' => 'Verified `seo_url_entities` count from the SEO Dash MVP online closeout.',
+            ],
+            [
+                'label' => 'Issue queue rows',
+                'value' => '5',
+                'hint' => 'Verified `seo_issue_queue` count from the SEO Dash MVP online closeout.',
+            ],
+            [
+                'label' => 'Verified cards',
+                'value' => '10',
+                'hint' => 'Metabase dashboard card count verified before this route shell PR.',
+            ],
+        ], $page->statusCards());
+
+        $this->assertCount(4, $page->boundaryCards());
+        $this->assertCount(4, $page->accessSteps());
+    }
+
+    #[Test]
+    public function generated_artifact_locks_route_shell_boundary(): void
+    {
+        $artifact = $this->artifact();
+        $route = $artifact['route'] ?? [];
+        $metabase = $artifact['metabase_boundary'] ?? [];
+
+        $this->assertSame('ops-portal-seo-route-shell.v1', $artifact['version'] ?? null);
+        $this->assertSame('OPS-PORTAL-SEO-03', $artifact['task'] ?? null);
+        $this->assertSame('/ops/seo', $route['path'] ?? null);
+        $this->assertSame('fap-api', $route['owner_repo'] ?? null);
+        $this->assertTrue((bool) ($route['auth_required'] ?? false));
+        $this->assertContains('admin.owner', $route['allowed_permissions'] ?? []);
+        $this->assertContains('admin.ops.read', $route['allowed_permissions'] ?? []);
+        $this->assertTrue((bool) ($route['route_shell_added'] ?? false));
+        $this->assertFalse((bool) ($route['runtime_live_db_query_added'] ?? true));
+        $this->assertFalse((bool) ($route['metabase_api_call_added'] ?? true));
+        $this->assertTrue((bool) ($metabase['private_only'] ?? false));
+        $this->assertFalse((bool) ($metabase['iframe_added'] ?? true));
+        $this->assertFalse((bool) ($metabase['reverse_proxy_added'] ?? true));
+        $this->assertFalse((bool) ($metabase['public_url_added'] ?? true));
+        $this->assertFalse((bool) ($metabase['dns_cdn_openresty_nginx_changed'] ?? true));
+    }
+
+    #[Test]
+    public function docs_and_view_forbid_public_metabase_sources_and_future_runtime_operations(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/ops-portal-seo-route-shell.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/ops-portal-seo-route-shell.v1.json')));
+        $view = strtolower((string) file_get_contents(resource_path('views/filament/ops/pages/seo-dashboard-access.blade.php')));
+        $combined = $doc."\n".$artifactJson."\n".$view;
+
+        foreach ([
+            'ops-portal-seo-03',
+            '/ops/seo',
+            'seo intelligence mvp - url truth & issue queue',
+            'no iframe',
+            'no reverse proxy',
+            'no public url',
+            'no public sharing',
+            'no anonymous links',
+            'no public embeds',
+            'no business db',
+            'tencent rds',
+            'node2 local db',
+            'no unrestricted sql',
+            'next task: `ops-portal-seo-04`',
+            '"next_task": "ops-portal-seo-04"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+
+        foreach ([
+            'production_operations_performed_in_this_pr',
+            'metabase_operation_performed_in_this_pr',
+            'network_change_performed_in_this_pr',
+            'env_edit_in_this_pr',
+            'deploy_performed_in_this_pr',
+            'scheduler_enabled_in_this_pr',
+            'collector_write_performed_in_this_pr',
+            'external_api_live_activation',
+            'url_submission_performed',
+            'production_crawler_log_read',
+            'research_publish_in_this_pr',
+            'pseo_generation_in_this_pr',
+            'sitemap_changed_in_this_pr',
+            'llms_changed_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($this->artifact()[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/ops-portal-seo-route-shell.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5264,8 +5264,8 @@
         "no fap-web change",
         "do not weaken final live acceptance"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "1c376ee0",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1489",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -12265,6 +12265,11 @@
           "at": "2026-05-19T20:24:30Z",
           "status": "local_checks_passed",
           "summary": "Focused Ops Portal SEO route shell test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T20:28:00Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1489. GitHub checks pending."
         }
       ],
       "next_pr": "OPS-PORTAL-SEO-04"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6114,7 +6114,7 @@
       "repo": "fap-api",
       "branch": "codex/repair-progressive-readiness-occupation-aware-selection-1",
       "title": "fix(api): make progressive readiness selection occupation-aware",
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "depends_on": [
         "REPAIR-PROGRESSIVE-READINESS-SELECTION-1"
       ],
@@ -12169,7 +12169,7 @@
       "next_pr": "OPS-PORTAL-SEO-02"
     },
     "OPS-PORTAL-SEO-02": {
-      "status": "in_progress",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/ops-portal-seo-02",
@@ -12178,11 +12178,68 @@
       "depends_on": [
         "OPS-PORTAL-SEO-01"
       ],
+      "commit_sha": "dff93f1b70450cbd0faf9837413f2e7b64d35d11",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1488",
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_ops_portal_seo_auth_audit_permission_contract": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {
+          "status": "pass_no_required_checks_reported",
+          "mergeStateStatus": "CLEAN"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": "2026-05-19T20:17:56Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T20:13:48Z",
+          "status": "in_progress",
+          "summary": "Started docs/generated/test-only Ops Portal SEO auth/audit/permission contract PR. Scope excludes route shell code, runtime permission enforcement code, Metabase iframe/proxy/public exposure, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, and pSEO."
+        },
+        {
+          "at": "2026-05-19T20:18:30Z",
+          "status": "local_checks_passed",
+          "summary": "Focused Ops Portal SEO auth/audit/permission contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T20:22:00Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1488. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-19T20:17:56Z",
+          "status": "merged",
+          "summary": "Merged PR #1488 with squash merge commit dff93f1b70450cbd0faf9837413f2e7b64d35d11. GitHub reported mergeStateStatus=CLEAN and no required checks; remote branch was deleted and local main synced."
+        }
+      ],
+      "next_pr": "OPS-PORTAL-SEO-03"
+    },
+    "OPS-PORTAL-SEO-03": {
+      "status": "in_progress",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/ops-portal-seo-03",
+      "base": "main",
+      "title": "feat(ops): add SEO dashboard access shell",
+      "depends_on": [
+        "OPS-PORTAL-SEO-02"
+      ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
         "local": {
-          "php_artisan_test_filter_seo_intel_ops_portal_seo_auth_audit_permission_contract": "passed",
+          "php_artisan_test_filter_seo_intel_ops_portal_seo_route_shell": "passed",
           "php_artisan_test_filter_seo_intel": "passed",
           "php_artisan_route_list": "passed",
           "pint_test": "passed",
@@ -12200,22 +12257,17 @@
       "sidecar_issues": [],
       "history": [
         {
-          "at": "2026-05-19T20:13:48Z",
+          "at": "2026-05-19T20:18:53Z",
           "status": "in_progress",
-          "summary": "Started docs/generated/test-only Ops Portal SEO auth/audit/permission contract PR. Scope excludes route shell code, runtime permission enforcement code, Metabase iframe/proxy/public exposure, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, and pSEO."
+          "summary": "Started authenticated Filament Ops /ops/seo route shell PR. Scope excludes Metabase iframe/proxy/public exposure, live Metabase API calls, live seo_intel queries, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, pSEO, sitemap changes, and llms changes."
         },
         {
-          "at": "2026-05-19T20:18:30Z",
+          "at": "2026-05-19T20:24:30Z",
           "status": "local_checks_passed",
-          "summary": "Focused Ops Portal SEO auth/audit/permission contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
-        },
-        {
-          "at": "2026-05-19T20:22:00Z",
-          "status": "pr_opened_github_checks_pending",
-          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1488. GitHub checks pending."
+          "summary": "Focused Ops Portal SEO route shell test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
         }
       ],
-      "next_pr": "OPS-PORTAL-SEO-03"
+      "next_pr": "OPS-PORTAL-SEO-04"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {


### PR DESCRIPTION
## What changed
- Added authenticated Filament Ops page shell at `/ops/seo`.
- Added static SEO Dash MVP status and private-access runbook content.
- Added generated route-shell artifact and focused SeoIntel route/auth contract test.
- Reconciled OPS-PORTAL-SEO-02 as merged in train state.

## Validation
- `cd backend && php artisan test --filter=SeoIntelOpsPortalSeoRouteShell`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/ops-portal-seo-route-shell.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML validation for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## What was not changed
- No direct route file edits.
- No fap-web changes.
- No Metabase iframe, reverse proxy, public exposure, API calls, operation, datasource, dashboard, public sharing, or anonymous links.
- No live seo_intel query from the page.
- No DNS/CDN/OpenResty/Nginx, ECS security group, RDS whitelist, env, deploy, scheduler, collector, search, crawler, Research publish, pSEO, sitemap, or llms changes.

## Human review note
This is the route shell PR. Scope is limited to the authenticated Filament Ops page shell, its view, docs/artifact, test, and train state.