### PR TITLE
docs(seo-intel): add private Metabase access bridge contract

### DIFF
--- a/backend/docs/seo/generated/ops-portal-seo-private-metabase-access-bridge.v1.json
+++ b/backend/docs/seo/generated/ops-portal-seo-private-metabase-access-bridge.v1.json
@@ -1,0 +1,86 @@
+{
+  "version": "ops-portal-seo-private-metabase-access-bridge.v1",
+  "task": "OPS-PORTAL-SEO-04",
+  "generated_at": "2026-05-19T20:24:01Z",
+  "purpose": "Define future private Metabase access bridge options without implementing proxy or network changes.",
+  "approved_mvp_access_paths": [
+    "workbench",
+    "ssh_tunnel_through_approved_bastion",
+    "vpn_after_separate_approval",
+    "owner_controlled_private_channel"
+  ],
+  "not_mvp_access_paths": [
+    "raw_public_metabase",
+    "public_dns_to_metabase",
+    "public_cdn_path_to_metabase",
+    "iframe_embedding",
+    "reverse_proxy_through_ops_portal",
+    "public_sharing_links",
+    "anonymous_links",
+    "public_embeds",
+    "normal_operator_unrestricted_sql"
+  ],
+  "bridge_options": {
+    "workbench": {
+      "allowed_for_mvp": true,
+      "requires_dns_change": false,
+      "requires_public_port": false,
+      "requires_security_group_change": false,
+      "requires_rds_whitelist_change": false
+    },
+    "ssh_tunnel_or_bastion": {
+      "allowed_after_approval": true,
+      "requires_owner": true,
+      "requires_auditability": true,
+      "localhost_or_private_only": true,
+      "public_metabase_port_allowed": false
+    },
+    "vpn": {
+      "allowed_after_approval": true,
+      "requires_owner": true,
+      "requires_auditable_membership": true,
+      "requires_revoke_path": true,
+      "public_metabase_exposure_allowed": false
+    },
+    "reverse_proxy_behind_ops_auth": {
+      "allowed_in_this_pr": false,
+      "requires_production_preflight": true,
+      "requires_auth_session_csrf_cookie_review": true,
+      "requires_audit_logging_plan": true,
+      "requires_rate_limit_and_revoke_plan": true,
+      "requires_dns_openresty_nginx_review_if_routing_changes": true
+    }
+  },
+  "production_gates": [
+    "no_metabase_bind_0_0_0_0",
+    "no_public_ecs_port",
+    "no_ecs_public_ipv4_or_eip",
+    "no_security_group_broadening",
+    "no_rds_whitelist_broadening",
+    "no_wildcard_percent",
+    "no_0_0_0_0_0",
+    "no_broad_cidr",
+    "no_public_rds_endpoint",
+    "no_business_db_access",
+    "no_tencent_rds_access",
+    "no_node2_access",
+    "no_dns_cdn_openresty_nginx_change_without_production_approval"
+  ],
+  "production_operations_performed_in_this_pr": false,
+  "proxy_implemented_in_this_pr": false,
+  "metabase_operation_performed_in_this_pr": false,
+  "network_change_performed_in_this_pr": false,
+  "security_group_change_performed_in_this_pr": false,
+  "rds_whitelist_change_performed_in_this_pr": false,
+  "dns_cdn_openresty_nginx_changed_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "deploy_performed_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_performed_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "production_crawler_log_read": false,
+  "research_publish_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "next_task": "OPS-PORTAL-SEO-05"
+}

--- a/backend/docs/seo/ops-portal-seo-private-metabase-access-bridge.md
+++ b/backend/docs/seo/ops-portal-seo-private-metabase-access-bridge.md
@@ -1,0 +1,81 @@
+# Ops Portal SEO Private Metabase Access Bridge Contract
+
+## Purpose
+
+OPS-PORTAL-SEO-04 defines future private Metabase access bridge options without implementing any network, proxy, or Metabase change.
+This PR does not deploy, edit environment files, change DNS/CDN/OpenResty/Nginx, open ports, change ECS security groups, change RDS whitelists, operate Metabase, add data sources, create dashboards, enable scheduler, run collector writes, call live search APIs, submit URLs, read production crawler logs, publish Research, or create pSEO.
+
+## Approved MVP Access
+
+The approved MVP access model remains owner-controlled private access:
+
+- Workbench access
+- SSH tunnel through an approved bastion
+- VPN private access after separate approval
+- equivalent owner-controlled private channel
+
+These options keep Metabase private and localhost-bound.
+
+## Explicitly Not MVP
+
+The following are not MVP access paths:
+
+- raw public Metabase
+- public DNS to Metabase
+- public CDN path to Metabase
+- iframe embedding
+- reverse proxy through Ops Portal
+- public sharing links
+- anonymous links
+- public embeds
+- normal-operator unrestricted SQL
+
+Reverse proxy behind Ops auth remains a future candidate only after a separate production preflight and explicit human approval.
+
+## Bridge Option Policy
+
+Workbench is the safest current access path because it does not require DNS, public ports, security group changes, or RDS whitelist changes.
+
+SSH tunnel or bastion access may be allowed only when:
+
+- bastion ownership is assigned
+- access is authenticated and auditable
+- tunnel scope is localhost/private only
+- no public Metabase port is opened
+- no broad CIDR or wildcard access is added
+
+VPN access may be allowed only when:
+
+- VPN owner is assigned
+- user membership is auditable and revocable
+- Metabase remains private
+- no public sharing or anonymous link is enabled
+
+Reverse proxy behind Ops auth is not authorized by this PR. It would require:
+
+- production operation preflight
+- auth/session/CSRF/cookie review
+- audit logging plan
+- rate limiting and revoke plan
+- DNS/OpenResty/Nginx review if routing changes
+- explicit no-public-sharing verification
+- explicit no-normal-operator-SQL verification
+
+## Production Gates
+
+Any bridge that changes production network state must stop until separately approved.
+Required gates include:
+
+- no Metabase bind to `0.0.0.0`
+- no public ECS port
+- no ECS public IPv4 or EIP
+- no security group broadening
+- no RDS whitelist broadening
+- no `%`, `0.0.0.0/0`, or broad CIDR
+- no public RDS endpoint
+- no business DB, Tencent RDS, or Node2 access
+- no DNS/CDN/OpenResty/Nginx change without production approval
+
+## Next Task
+
+Next task: `OPS-PORTAL-SEO-05`

--- a/backend/tests/Feature/SeoIntel/SeoIntelOpsPortalSeoPrivateAccessBridgeTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelOpsPortalSeoPrivateAccessBridgeTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelOpsPortalSeoPrivateAccessBridgeTest extends TestCase
+{
+    #[Test]
+    public function artifact_allows_only_private_owner_controlled_mvp_access_paths(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('ops-portal-seo-private-metabase-access-bridge.v1', $artifact['version'] ?? null);
+        $this->assertSame('OPS-PORTAL-SEO-04', $artifact['task'] ?? null);
+
+        foreach ([
+            'workbench',
+            'ssh_tunnel_through_approved_bastion',
+            'vpn_after_separate_approval',
+            'owner_controlled_private_channel',
+        ] as $path) {
+            $this->assertContains($path, $artifact['approved_mvp_access_paths'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function public_metabase_iframe_proxy_and_operator_sql_are_not_mvp_paths(): void
+    {
+        foreach ([
+            'raw_public_metabase',
+            'public_dns_to_metabase',
+            'public_cdn_path_to_metabase',
+            'iframe_embedding',
+            'reverse_proxy_through_ops_portal',
+            'public_sharing_links',
+            'anonymous_links',
+            'public_embeds',
+            'normal_operator_unrestricted_sql',
+        ] as $path) {
+            $this->assertContains($path, $this->artifact()['not_mvp_access_paths'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function workbench_requires_no_network_or_rds_changes(): void
+    {
+        $workbench = $this->artifact()['bridge_options']['workbench'] ?? [];
+
+        $this->assertTrue((bool) ($workbench['allowed_for_mvp'] ?? false));
+        $this->assertFalse((bool) ($workbench['requires_dns_change'] ?? true));
+        $this->assertFalse((bool) ($workbench['requires_public_port'] ?? true));
+        $this->assertFalse((bool) ($workbench['requires_security_group_change'] ?? true));
+        $this->assertFalse((bool) ($workbench['requires_rds_whitelist_change'] ?? true));
+    }
+
+    #[Test]
+    public function reverse_proxy_is_future_only_and_requires_preflight(): void
+    {
+        $proxy = $this->artifact()['bridge_options']['reverse_proxy_behind_ops_auth'] ?? [];
+
+        $this->assertFalse((bool) ($proxy['allowed_in_this_pr'] ?? true));
+        $this->assertTrue((bool) ($proxy['requires_production_preflight'] ?? false));
+        $this->assertTrue((bool) ($proxy['requires_auth_session_csrf_cookie_review'] ?? false));
+        $this->assertTrue((bool) ($proxy['requires_audit_logging_plan'] ?? false));
+        $this->assertTrue((bool) ($proxy['requires_rate_limit_and_revoke_plan'] ?? false));
+        $this->assertTrue((bool) ($proxy['requires_dns_openresty_nginx_review_if_routing_changes'] ?? false));
+    }
+
+    #[Test]
+    public function production_gates_block_public_network_and_forbidden_db_access(): void
+    {
+        foreach ([
+            'no_metabase_bind_0_0_0_0',
+            'no_public_ecs_port',
+            'no_ecs_public_ipv4_or_eip',
+            'no_security_group_broadening',
+            'no_rds_whitelist_broadening',
+            'no_wildcard_percent',
+            'no_0_0_0_0_0',
+            'no_broad_cidr',
+            'no_public_rds_endpoint',
+            'no_business_db_access',
+            'no_tencent_rds_access',
+            'no_node2_access',
+            'no_dns_cdn_openresty_nginx_change_without_production_approval',
+        ] as $gate) {
+            $this->assertContains($gate, $this->artifact()['production_gates'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function this_pr_does_not_implement_proxy_network_or_metabase_changes(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'production_operations_performed_in_this_pr',
+            'proxy_implemented_in_this_pr',
+            'metabase_operation_performed_in_this_pr',
+            'network_change_performed_in_this_pr',
+            'security_group_change_performed_in_this_pr',
+            'rds_whitelist_change_performed_in_this_pr',
+            'dns_cdn_openresty_nginx_changed_in_this_pr',
+            'env_edit_in_this_pr',
+            'deploy_performed_in_this_pr',
+            'scheduler_enabled_in_this_pr',
+            'collector_write_performed_in_this_pr',
+            'external_api_live_activation',
+            'url_submission_performed',
+            'production_crawler_log_read',
+            'research_publish_in_this_pr',
+            'pseo_generation_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_private_bridge_policy_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/ops-portal-seo-private-metabase-access-bridge.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/ops-portal-seo-private-metabase-access-bridge.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'private metabase access bridge contract',
+            'workbench access',
+            'ssh tunnel',
+            'bastion',
+            'vpn',
+            'raw public metabase',
+            'iframe embedding',
+            'reverse proxy behind ops auth is not authorized by this pr',
+            'no security group broadening',
+            'no rds whitelist broadening',
+            'no business db',
+            'next task: `ops-portal-seo-05`',
+            '"next_task": "ops-portal-seo-05"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/ops-portal-seo-private-metabase-access-bridge.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5457,8 +5457,8 @@
         "do not weaken final live acceptance",
         "do not mark restricted runtime shells as human reviewed or strong-claim surfaces"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "510876e0",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1490",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -12322,6 +12322,11 @@
           "at": "2026-05-19T20:30:00Z",
           "status": "local_checks_passed",
           "summary": "Focused private Metabase access bridge contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T20:33:00Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1490. GitHub checks pending."
         }
       ],
       "next_pr": "OPS-PORTAL-SEO-05"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6172,7 +6172,7 @@
       "repo": "fap-api",
       "branch": "codex/repair-progressive-runtime-candidate-pool-selection-1",
       "title": "fix(api): consume progressive delta slugs in runtime candidate pool",
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "depends_on": [
         "REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1"
       ],
@@ -12226,7 +12226,7 @@
       "next_pr": "OPS-PORTAL-SEO-03"
     },
     "OPS-PORTAL-SEO-03": {
-      "status": "in_progress",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/ops-portal-seo-03",
@@ -12235,11 +12235,68 @@
       "depends_on": [
         "OPS-PORTAL-SEO-02"
       ],
+      "commit_sha": "66df9a027ab399a1f0c2215407805030b9730119",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1489",
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_ops_portal_seo_route_shell": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {
+          "status": "pass_no_required_checks_reported",
+          "mergeStateStatus": "CLEAN"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": "2026-05-19T20:23:32Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T20:18:53Z",
+          "status": "in_progress",
+          "summary": "Started authenticated Filament Ops /ops/seo route shell PR. Scope excludes Metabase iframe/proxy/public exposure, live Metabase API calls, live seo_intel queries, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, pSEO, sitemap changes, and llms changes."
+        },
+        {
+          "at": "2026-05-19T20:24:30Z",
+          "status": "local_checks_passed",
+          "summary": "Focused Ops Portal SEO route shell test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T20:28:00Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1489. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-19T20:23:32Z",
+          "status": "merged",
+          "summary": "Merged PR #1489 with squash merge commit 66df9a027ab399a1f0c2215407805030b9730119. GitHub reported mergeStateStatus=CLEAN and no required checks; remote branch was deleted and local main synced."
+        }
+      ],
+      "next_pr": "OPS-PORTAL-SEO-04"
+    },
+    "OPS-PORTAL-SEO-04": {
+      "status": "in_progress",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/ops-portal-seo-04",
+      "base": "main",
+      "title": "docs(seo-intel): add private Metabase access bridge contract",
+      "depends_on": [
+        "OPS-PORTAL-SEO-03"
+      ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
         "local": {
-          "php_artisan_test_filter_seo_intel_ops_portal_seo_route_shell": "passed",
+          "php_artisan_test_filter_seo_intel_ops_portal_seo_private_access_bridge": "passed",
           "php_artisan_test_filter_seo_intel": "passed",
           "php_artisan_route_list": "passed",
           "pint_test": "passed",
@@ -12257,22 +12314,17 @@
       "sidecar_issues": [],
       "history": [
         {
-          "at": "2026-05-19T20:18:53Z",
+          "at": "2026-05-19T20:24:01Z",
           "status": "in_progress",
-          "summary": "Started authenticated Filament Ops /ops/seo route shell PR. Scope excludes Metabase iframe/proxy/public exposure, live Metabase API calls, live seo_intel queries, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, pSEO, sitemap changes, and llms changes."
+          "summary": "Started docs/generated/test-only private Metabase access bridge contract PR. Scope excludes actual proxy, Metabase service changes, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, security group changes, RDS whitelist changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, and pSEO."
         },
         {
-          "at": "2026-05-19T20:24:30Z",
+          "at": "2026-05-19T20:30:00Z",
           "status": "local_checks_passed",
-          "summary": "Focused Ops Portal SEO route shell test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
-        },
-        {
-          "at": "2026-05-19T20:28:00Z",
-          "status": "pr_opened_github_checks_pending",
-          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1489. GitHub checks pending."
+          "summary": "Focused private Metabase access bridge contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
         }
       ],
-      "next_pr": "OPS-PORTAL-SEO-04"
+      "next_pr": "OPS-PORTAL-SEO-05"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {


### PR DESCRIPTION
## What changed
- Added private Metabase access bridge contract for Workbench, bastion/SSH tunnel, VPN, and future reverse-proxy preflight boundaries.
- Added generated v1 artifact and focused SeoIntel contract test.
- Reconciled OPS-PORTAL-SEO-03 as merged in train state.

## Validation
- `cd backend && php artisan test --filter=SeoIntelOpsPortalSeoPrivateAccessBridge`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/ops-portal-seo-private-metabase-access-bridge.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML validation for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## What was not changed
- No proxy implementation.
- No Metabase service/config/API operation.
- No DNS/CDN/OpenResty/Nginx, ECS security group, RDS whitelist, env, deploy, scheduler, collector, search, crawler, Research publish, pSEO, sitemap, or llms changes.