### PR TITLE
docs(seo-intel): add Ops Portal SEO access verification contract

### DIFF
--- a/backend/docs/seo/generated/ops-portal-seo-access-export-sharing-verification.v1.json
+++ b/backend/docs/seo/generated/ops-portal-seo-access-export-sharing-verification.v1.json
@@ -1,0 +1,111 @@
+{
+  "version": "ops-portal-seo-access-export-sharing-verification.v1",
+  "task": "OPS-PORTAL-SEO-05",
+  "generated_at": "2026-05-19T20:27:55Z",
+  "purpose": "Define future /ops/seo access, export, sharing, datasource, and revoke verification before production access operation preflight.",
+  "ops_route_verification": {
+    "path": "/ops/seo",
+    "requires_ops_admin_auth": true,
+    "public_metabase_url_exposed": false,
+    "metabase_iframe_present": false,
+    "metabase_reverse_proxy_present": false
+  },
+  "metabase_privacy_verification": {
+    "private_only": true,
+    "localhost_bound": true,
+    "public_ipv4_allowed": false,
+    "public_port_allowed": false,
+    "security_group_change_allowed": false,
+    "rds_whitelist_change_allowed": false
+  },
+  "sharing_verification": {
+    "public_sharing_enabled": false,
+    "anonymous_links_present": false,
+    "public_embeds_enabled": false,
+    "public_dashboard_or_card_tokens_present": false
+  },
+  "datasource_verification": {
+    "expected_datasource_count": 1,
+    "expected_datasource_name": "seo_intel",
+    "expected_datasource_account": "seo_intel_metabase_readonly",
+    "sample_database_allowed": false,
+    "forbidden_sources": [
+      "business_db",
+      "tencent_rds_fap_prod",
+      "node2_local_db",
+      "cms_write_tables",
+      "raw_orders",
+      "raw_payments",
+      "raw_events_detail",
+      "raw_email",
+      "raw_reports",
+      "raw_crawler_logs",
+      "provider_payloads",
+      "payment_payloads"
+    ]
+  },
+  "dashboard_verification": {
+    "dashboard_name": "SEO Intelligence MVP - URL Truth & Issue Queue",
+    "allowed_tables": [
+      "seo_urls",
+      "seo_url_entities",
+      "seo_issue_queue"
+    ],
+    "unsafe_fields_allowed": false
+  },
+  "export_policy": {
+    "normal_operator_exports_allowed_by_default": false,
+    "owner_approval_required": true,
+    "allowed_export_scope": [
+      "sanitized_url_truth_aggregates",
+      "sanitized_issue_queue_summaries",
+      "safe_dashboard_screenshots_without_raw_pii"
+    ],
+    "forbidden_export_fields": [
+      "password",
+      "token",
+      "cookie",
+      "email",
+      "order_id",
+      "payment_id",
+      "attempt_id",
+      "raw_ip",
+      "user_agent",
+      "raw_payload",
+      "provider_payload",
+      "payment_payload",
+      "raw_evidence",
+      "raw_crawler_logs",
+      "business_db_rows"
+    ]
+  },
+  "raw_sql_policy": {
+    "normal_operator_unrestricted_sql_allowed": false,
+    "admin_native_sql_remains_privileged": true,
+    "future_operator_onboarding_requires_permission_setup": true
+  },
+  "audit_owner_revoke_verification": {
+    "metabase_admin_owner_required": true,
+    "dashboard_owner_required": true,
+    "db_access_owner_required": true,
+    "export_policy_owner_required": true,
+    "emergency_revoke_owner_required": true,
+    "audit_path_required": true,
+    "revoke_path_required": true
+  },
+  "production_operations_performed_in_this_pr": false,
+  "metabase_api_operation_performed_in_this_pr": false,
+  "datasource_added_in_this_pr": false,
+  "dashboard_created_in_this_pr": false,
+  "network_change_performed_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "deploy_performed_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_performed_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "production_crawler_log_read": false,
+  "research_publish_in_this_pr": false,
+  "pseo_generation_in_this_pr": false,
+  "next_task": "OPS-PORTAL-SEO-PROD-01"
+}

--- a/backend/docs/seo/ops-portal-seo-access-export-sharing-verification.md
+++ b/backend/docs/seo/ops-portal-seo-access-export-sharing-verification.md
@@ -1,0 +1,52 @@
+# Ops Portal SEO Access Export Sharing Verification Contract
+
+## Purpose
+
+OPS-PORTAL-SEO-05 defines the verification checklist for `/ops/seo` access and Metabase policy before any production access operation.
+This PR does not deploy, edit environment files, change DNS/CDN/OpenResty/Nginx, open ports, change ECS security groups, change RDS whitelists, operate Metabase APIs, add data sources, create dashboards, enable scheduler, run collector writes, call live search APIs, submit URLs, read production crawler logs, publish Research, or create pSEO.
+
+## Required Verification
+
+The future production access preflight must verify:
+
+- `/ops/seo` requires existing Ops/Admin authentication
+- `/ops/seo` does not expose a public Metabase URL
+- `/ops/seo` does not iframe Metabase
+- `/ops/seo` does not reverse-proxy Metabase
+- Metabase remains private and localhost-bound
+- public sharing is disabled
+- anonymous links are absent
+- public embeds are disabled
+- datasource count is exactly 1
+- datasource name is `seo_intel`
+- datasource account is `seo_intel_metabase_readonly`
+- no Sample Database exists
+- no business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational sources exist
+- dashboard cards use only `seo_urls`, `seo_url_entities`, and `seo_issue_queue`
+- exports are owner-approved only
+- no PII export is allowed
+- normal operators have no unrestricted SQL
+- audit, owner, and emergency revoke paths are assigned
+
+## Safe Tables And Cards
+
+The only approved dashboard source tables are:
+
+- `seo_urls`
+- `seo_url_entities`
+- `seo_issue_queue`
+
+The dashboard must remain the verified MVP dashboard:
+
+`SEO Intelligence MVP - URL Truth & Issue Queue`
+
+## Export Policy
+
+Exports are blocked for normal operators by default.
+Owner-approved exports may include only sanitized URL Truth aggregates, sanitized issue queue summaries, and safe screenshots without raw PII.
+
+Exports must not include passwords, tokens, cookies, emails, order IDs, payment IDs, attempt IDs, raw IPs, user agents, raw payloads, provider payloads, payment payloads, raw evidence, raw crawler logs, or business DB rows.
+
+## Next Task
+
+Next task: `OPS-PORTAL-SEO-PROD-01`

--- a/backend/tests/Feature/SeoIntel/SeoIntelOpsPortalSeoAccessExportSharingVerificationTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelOpsPortalSeoAccessExportSharingVerificationTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelOpsPortalSeoAccessExportSharingVerificationTest extends TestCase
+{
+    #[Test]
+    public function artifact_requires_ops_auth_and_forbids_metabase_exposure_from_ops_route(): void
+    {
+        $route = $this->artifact()['ops_route_verification'] ?? [];
+
+        $this->assertSame('ops-portal-seo-access-export-sharing-verification.v1', $this->artifact()['version'] ?? null);
+        $this->assertSame('OPS-PORTAL-SEO-05', $this->artifact()['task'] ?? null);
+        $this->assertSame('/ops/seo', $route['path'] ?? null);
+        $this->assertTrue((bool) ($route['requires_ops_admin_auth'] ?? false));
+        $this->assertFalse((bool) ($route['public_metabase_url_exposed'] ?? true));
+        $this->assertFalse((bool) ($route['metabase_iframe_present'] ?? true));
+        $this->assertFalse((bool) ($route['metabase_reverse_proxy_present'] ?? true));
+    }
+
+    #[Test]
+    public function metabase_privacy_and_sharing_verification_stays_locked_down(): void
+    {
+        $privacy = $this->artifact()['metabase_privacy_verification'] ?? [];
+        $sharing = $this->artifact()['sharing_verification'] ?? [];
+
+        $this->assertTrue((bool) ($privacy['private_only'] ?? false));
+        $this->assertTrue((bool) ($privacy['localhost_bound'] ?? false));
+        $this->assertFalse((bool) ($privacy['public_ipv4_allowed'] ?? true));
+        $this->assertFalse((bool) ($privacy['public_port_allowed'] ?? true));
+        $this->assertFalse((bool) ($privacy['security_group_change_allowed'] ?? true));
+        $this->assertFalse((bool) ($privacy['rds_whitelist_change_allowed'] ?? true));
+        $this->assertFalse((bool) ($sharing['public_sharing_enabled'] ?? true));
+        $this->assertFalse((bool) ($sharing['anonymous_links_present'] ?? true));
+        $this->assertFalse((bool) ($sharing['public_embeds_enabled'] ?? true));
+        $this->assertFalse((bool) ($sharing['public_dashboard_or_card_tokens_present'] ?? true));
+    }
+
+    #[Test]
+    public function datasource_boundary_allows_only_seo_intel_readonly_source(): void
+    {
+        $datasource = $this->artifact()['datasource_verification'] ?? [];
+
+        $this->assertSame(1, $datasource['expected_datasource_count'] ?? null);
+        $this->assertSame('seo_intel', $datasource['expected_datasource_name'] ?? null);
+        $this->assertSame('seo_intel_metabase_readonly', $datasource['expected_datasource_account'] ?? null);
+        $this->assertFalse((bool) ($datasource['sample_database_allowed'] ?? true));
+
+        foreach ([
+            'business_db',
+            'tencent_rds_fap_prod',
+            'node2_local_db',
+            'cms_write_tables',
+            'raw_orders',
+            'raw_payments',
+            'raw_events_detail',
+            'raw_email',
+            'raw_reports',
+            'raw_crawler_logs',
+            'provider_payloads',
+            'payment_payloads',
+        ] as $source) {
+            $this->assertContains($source, $datasource['forbidden_sources'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function dashboard_tables_and_export_fields_are_safe_only(): void
+    {
+        $dashboard = $this->artifact()['dashboard_verification'] ?? [];
+        $export = $this->artifact()['export_policy'] ?? [];
+
+        $this->assertSame('SEO Intelligence MVP - URL Truth & Issue Queue', $dashboard['dashboard_name'] ?? null);
+        $this->assertSame([
+            'seo_urls',
+            'seo_url_entities',
+            'seo_issue_queue',
+        ], $dashboard['allowed_tables'] ?? []);
+        $this->assertFalse((bool) ($dashboard['unsafe_fields_allowed'] ?? true));
+        $this->assertFalse((bool) ($export['normal_operator_exports_allowed_by_default'] ?? true));
+        $this->assertTrue((bool) ($export['owner_approval_required'] ?? false));
+
+        foreach ([
+            'password',
+            'token',
+            'cookie',
+            'email',
+            'order_id',
+            'payment_id',
+            'attempt_id',
+            'raw_ip',
+            'user_agent',
+            'raw_payload',
+            'provider_payload',
+            'payment_payload',
+            'raw_evidence',
+            'raw_crawler_logs',
+            'business_db_rows',
+        ] as $field) {
+            $this->assertContains($field, $export['forbidden_export_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function raw_sql_audit_owner_and_revoke_policies_are_required(): void
+    {
+        $sql = $this->artifact()['raw_sql_policy'] ?? [];
+        $revoke = $this->artifact()['audit_owner_revoke_verification'] ?? [];
+
+        $this->assertFalse((bool) ($sql['normal_operator_unrestricted_sql_allowed'] ?? true));
+        $this->assertTrue((bool) ($sql['admin_native_sql_remains_privileged'] ?? false));
+        $this->assertTrue((bool) ($sql['future_operator_onboarding_requires_permission_setup'] ?? false));
+
+        foreach ([
+            'metabase_admin_owner_required',
+            'dashboard_owner_required',
+            'db_access_owner_required',
+            'export_policy_owner_required',
+            'emergency_revoke_owner_required',
+            'audit_path_required',
+            'revoke_path_required',
+        ] as $flag) {
+            $this->assertTrue((bool) ($revoke[$flag] ?? false), $flag.' must be true');
+        }
+    }
+
+    #[Test]
+    public function this_pr_does_not_operate_metabase_or_production_systems(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'production_operations_performed_in_this_pr',
+            'metabase_api_operation_performed_in_this_pr',
+            'datasource_added_in_this_pr',
+            'dashboard_created_in_this_pr',
+            'network_change_performed_in_this_pr',
+            'env_edit_in_this_pr',
+            'deploy_performed_in_this_pr',
+            'scheduler_enabled_in_this_pr',
+            'collector_write_performed_in_this_pr',
+            'external_api_live_activation',
+            'url_submission_performed',
+            'production_crawler_log_read',
+            'research_publish_in_this_pr',
+            'pseo_generation_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_verification_policy_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/ops-portal-seo-access-export-sharing-verification.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/ops-portal-seo-access-export-sharing-verification.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'access export sharing verification contract',
+            '/ops/seo',
+            'requires existing ops/admin authentication',
+            'does not expose a public metabase url',
+            'public sharing is disabled',
+            'anonymous links are absent',
+            'datasource count is exactly 1',
+            'seo_intel_metabase_readonly',
+            'seo_urls',
+            'seo_url_entities',
+            'seo_issue_queue',
+            'no pii export',
+            'normal operators have no unrestricted sql',
+            'emergency revoke',
+            'next task: `ops-portal-seo-prod-01`',
+            '"next_task": "ops-portal-seo-prod-01"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/ops-portal-seo-access-export-sharing-verification.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6010,7 +6010,7 @@
         "no fap-web change"
       ],
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1491",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -12283,7 +12283,7 @@
       "next_pr": "OPS-PORTAL-SEO-04"
     },
     "OPS-PORTAL-SEO-04": {
-      "status": "in_progress",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/ops-portal-seo-04",
@@ -12292,11 +12292,68 @@
       "depends_on": [
         "OPS-PORTAL-SEO-03"
       ],
+      "commit_sha": "f37e028796907b29b42b696c8ca8e8c6f221243f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1490",
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_ops_portal_seo_private_access_bridge": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {
+          "status": "pass_no_required_checks_reported",
+          "mergeStateStatus": "CLEAN"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": "2026-05-19T20:27:28Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T20:24:01Z",
+          "status": "in_progress",
+          "summary": "Started docs/generated/test-only private Metabase access bridge contract PR. Scope excludes actual proxy, Metabase service changes, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, security group changes, RDS whitelist changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, and pSEO."
+        },
+        {
+          "at": "2026-05-19T20:30:00Z",
+          "status": "local_checks_passed",
+          "summary": "Focused private Metabase access bridge contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T20:33:00Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1490. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-19T20:27:28Z",
+          "status": "merged",
+          "summary": "Merged PR #1490 with squash merge commit f37e028796907b29b42b696c8ca8e8c6f221243f. GitHub reported mergeStateStatus=CLEAN and no required checks; remote branch was deleted and local main synced."
+        }
+      ],
+      "next_pr": "OPS-PORTAL-SEO-05"
+    },
+    "OPS-PORTAL-SEO-05": {
+      "status": "in_progress",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/ops-portal-seo-05",
+      "base": "main",
+      "title": "docs(seo-intel): add Ops Portal SEO access verification contract",
+      "depends_on": [
+        "OPS-PORTAL-SEO-04"
+      ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
         "local": {
-          "php_artisan_test_filter_seo_intel_ops_portal_seo_private_access_bridge": "passed",
+          "php_artisan_test_filter_seo_intel_ops_portal_seo_access_export_sharing_verification": "passed",
           "php_artisan_test_filter_seo_intel": "passed",
           "php_artisan_route_list": "passed",
           "pint_test": "passed",
@@ -12314,22 +12371,22 @@
       "sidecar_issues": [],
       "history": [
         {
-          "at": "2026-05-19T20:24:01Z",
+          "at": "2026-05-19T20:27:55Z",
           "status": "in_progress",
-          "summary": "Started docs/generated/test-only private Metabase access bridge contract PR. Scope excludes actual proxy, Metabase service changes, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, security group changes, RDS whitelist changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, and pSEO."
+          "summary": "Started docs/generated/test-only Ops Portal SEO access export sharing verification contract PR. Scope excludes runtime proxy behavior, Metabase API operations, DNS/CDN/OpenResty/Nginx changes, env edits, deploy, network changes, security group changes, RDS whitelist changes, datasource changes, dashboards, collector writes, scheduler activation, live search APIs, URL submission, crawler log reads, Research publish, pSEO, sitemap changes, and llms changes."
         },
         {
-          "at": "2026-05-19T20:30:00Z",
+          "at": "2026-05-19T20:36:00Z",
           "status": "local_checks_passed",
-          "summary": "Focused private Metabase access bridge contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+          "summary": "Focused access/export/sharing verification contract test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
         },
         {
-          "at": "2026-05-19T20:33:00Z",
+          "at": "2026-05-19T20:39:00Z",
           "status": "pr_opened_github_checks_pending",
-          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1490. GitHub checks pending."
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1491. GitHub checks pending."
         }
       ],
-      "next_pr": "OPS-PORTAL-SEO-05"
+      "next_pr": "OPS-PORTAL-SEO-PROD-01"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {


### PR DESCRIPTION
## What changed
- Added the OPS-PORTAL-SEO-05 access/export/sharing verification contract.
- Added the generated machine-readable v1 artifact for the verification checklist.
- Added focused SeoIntel coverage for route auth expectations, Metabase privacy, datasource boundary, dashboard safe-table boundary, export/raw SQL policy, audit/owner/revoke requirements, and no production operation flags.
- Reconciled OPS-PORTAL-SEO-04 as merged in the train ledger and registered OPS-PORTAL-SEO-05 local validation state.

## Validation
- cd backend && php artisan test --filter=SeoIntelOpsPortalSeoAccessExportSharingVerification
- cd backend && php artisan test --filter=SeoIntel
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/ops-portal-seo-access-export-sharing-verification.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- git diff --check
- git diff --cached --check

## Intentionally deferred / not changed
- No deploy, env edit, DNS/CDN/OpenResty/Nginx change, ECS security group change, or RDS whitelist change.
- No Metabase API operation, public exposure, iframe, reverse proxy, datasource addition, or dashboard creation.
- No scheduler, collector write, live search API, URL submission, crawler log read, Research publish, pSEO, sitemap, or llms behavior change.