### PR TITLE
RIASEC-FULL-CONTENT-PACK-08: Low quality / confidence / near-tie copy asset import

### DIFF
--- a/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
+++ b/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
@@ -14,6 +14,7 @@ final class RiasecContentRegistrySlotContract
         'dimension_deep_copy',
         'pair_blend_copy',
         'quality_copy',
+        'interpretation_state_copy',
         'module_visibility_copy',
         '140q_layer_copy',
         'structural_difference_copy',
@@ -104,6 +105,18 @@ final class RiasecContentRegistrySlotContract
         'cautious_reading_copy' => [
             'slot_group' => 'quality_copy',
             'required_versions' => ['quality_rule_version'],
+        ],
+        'profile_shape_copy' => [
+            'slot_group' => 'interpretation_state_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        'top_code_confidence_copy' => [
+            'slot_group' => 'interpretation_state_copy',
+            'required_versions' => ['interpretation_rule_version'],
+        ],
+        'near_tie_alternate_code_copy' => [
+            'slot_group' => 'interpretation_state_copy',
+            'required_versions' => ['interpretation_rule_version'],
         ],
         'structural_difference_copy' => [
             'slot_group' => 'structural_difference_copy',

--- a/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+++ b/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
@@ -16,6 +16,14 @@ final class RiasecDeepCopySlotRegistry
 
     private const LAYER_140Q_ASSET_PATH = '/content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl';
 
+    private const LOW_QUALITY_ASSET_PATH = '/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json';
+
+    private const PROFILE_SHAPE_ASSET_PATH = '/content_assets/riasec/profile_shape_copy_v1.zh-CN.json';
+
+    private const TOP_CODE_CONFIDENCE_ASSET_PATH = '/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json';
+
+    private const NEAR_TIE_ASSET_PATH = '/content_assets/riasec/near_tie_alternate_code_copy_v1.zh-CN.json';
+
     /** @var array<string,array<string,mixed>>|null */
     private ?array $dimensionContentCache = null;
 
@@ -27,6 +35,18 @@ final class RiasecDeepCopySlotRegistry
 
     /** @var array<string,array<string,mixed>>|null */
     private ?array $layer140qContentCache = null;
+
+    /** @var array<string,mixed>|null */
+    private ?array $lowQualityAssetCache = null;
+
+    /** @var array<string,mixed>|null */
+    private ?array $profileShapeAssetCache = null;
+
+    /** @var array<string,mixed>|null */
+    private ?array $topCodeConfidenceAssetCache = null;
+
+    /** @var array<string,mixed>|null */
+    private ?array $nearTieAssetCache = null;
 
     /** @var list<string> */
     public const DIMENSIONS = ['R', 'I', 'A', 'S', 'E', 'C'];
@@ -81,6 +101,33 @@ final class RiasecDeepCopySlotRegistry
         'low_quality',
         'retake_recommended',
         'minimal_quality_boundary_60q',
+    ];
+
+    /** @var list<string> */
+    public const PROFILE_SHAPES = [
+        'clear_code',
+        'blended_code',
+        'broad_profile',
+        'near_tie',
+        'low_quality',
+        'low_clarity',
+    ];
+
+    /** @var list<string> */
+    public const TOP_CODE_CONFIDENCE_STATES = [
+        'high_confidence',
+        'moderate_confidence',
+        'near_tie',
+        'broad_profile',
+        'low_clarity',
+    ];
+
+    /** @var list<string> */
+    public const NEAR_TIE_COPY_STATES = [
+        'top1_top2_near_tie',
+        'top2_top3_near_tie',
+        'multi_near_tie',
+        'alternate_code_available',
     ];
 
     /** @var list<string> */
@@ -360,7 +407,7 @@ final class RiasecDeepCopySlotRegistry
      */
     public function lowQualitySlots(): array
     {
-        return [
+        $slots = [
             'top_notice' => $this->qualitySlot('low_quality_copy', 'top_notice', [
                 'title' => '这次结果适合谨慎阅读',
                 'summary' => '本次结果可以作为初步兴趣线索，但不适合用三字母代码做强结论。更稳妥的做法是先看六维概览，或稍后在状态更稳定时重测。',
@@ -407,6 +454,54 @@ final class RiasecDeepCopySlotRegistry
                 'quality_state' => 'minimal_quality_boundary_60q',
             ]),
         ];
+
+        foreach ($this->lowQualitySlotsFromAsset() as $slotName => $content) {
+            if (! array_key_exists($slotName, $slots)) {
+                continue;
+            }
+            $slotKey = (string) ($slots[$slotName]['slot_key'] ?? 'low_quality_copy');
+            $slots[$slotName] = $this->qualitySlot($slotKey, $slotName, array_merge($content, [
+                'quality_state' => (string) ($slots[$slotName]['quality_state'] ?? $content['quality_state'] ?? 'low_quality'),
+            ]));
+        }
+
+        return $slots;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    public function interpretationStateCopySlots(): array
+    {
+        return array_filter(array_merge(
+            $this->profileShapeCopySlots(),
+            $this->topCodeConfidenceCopySlots(),
+            $this->nearTieAlternateCodeCopySlots()
+        ), fn (array $slot): bool => $this->validateSlot($slot) === []);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function resolveInterpretationStateCopySlot(string $slotKey, string $slotName): array
+    {
+        $slotName = trim($slotName);
+        $slotId = trim($slotKey).':'.$slotName;
+        $slot = $this->interpretationStateCopySlots()[$slotId] ?? null;
+
+        if ($slot === null) {
+            return [
+                'slot_key' => trim($slotKey),
+                'slot_name' => $slotName,
+                'content_status' => 'unavailable',
+                'module_state' => 'omitted',
+                'fallback_behavior' => 'omit_module',
+                'frontend_fallback_allowed' => false,
+                'reason' => 'unsupported_interpretation_state_copy_slot',
+            ];
+        }
+
+        return $slot;
     }
 
     /**
@@ -423,6 +518,103 @@ final class RiasecDeepCopySlotRegistry
             'measured_holland_code_mutation_allowed' => false,
             'frontend_fallback_allowed' => false,
         ];
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function profileShapeCopySlots(): array
+    {
+        $asset = $this->profileShapeAsset();
+        $slots = [];
+        foreach ((array) ($asset['profile_shapes'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $shape = trim((string) ($row['shape'] ?? ''));
+            if (! in_array($shape, self::PROFILE_SHAPES, true)) {
+                continue;
+            }
+
+            $slot = $this->interpretationStateSlot('profile_shape_copy', $shape, [
+                'profile_shape' => $shape,
+                'title' => (string) ($row['title'] ?? ''),
+                'summary' => (string) ($row['summary'] ?? ''),
+                'body' => (string) ($row['summary'] ?? ''),
+                'module_policy' => (string) ($row['module_policy'] ?? ''),
+                'content_version' => (string) ($asset['asset_id'] ?? 'profile_shape_copy_v1.zh-CN'),
+                'user_visible_boundary' => 'Profile shape 只说明本次兴趣线索的阅读方式，不是人格身份、职业结论或能力判断。',
+                'source_review_status' => (string) ($asset['review_status'] ?? ''),
+            ]);
+            $slots[(string) $slot['slot_key'].':'.$shape] = $slot;
+        }
+
+        return $slots;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function topCodeConfidenceCopySlots(): array
+    {
+        $asset = $this->topCodeConfidenceAsset();
+        $slots = [];
+        foreach ((array) ($asset['states'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $state = trim((string) ($row['state'] ?? ''));
+            if (! in_array($state, self::TOP_CODE_CONFIDENCE_STATES, true)) {
+                continue;
+            }
+
+            $slot = $this->interpretationStateSlot('top_code_confidence_copy', $state, [
+                'confidence_state' => $state,
+                'title' => (string) ($row['label'] ?? ''),
+                'label' => (string) ($row['label'] ?? ''),
+                'summary' => (string) ($row['copy'] ?? ''),
+                'body' => (string) ($row['copy'] ?? ''),
+                'copy' => (string) ($row['copy'] ?? ''),
+                'content_version' => (string) ($asset['asset_id'] ?? 'top_code_confidence_copy_v1.zh-CN'),
+                'user_visible_boundary' => (string) ($asset['user_visible_boundary'] ?? '结果阅读力度只说明线索集中程度，不是准确率、职业前景或能力判断。'),
+                'source_review_status' => (string) ($asset['review_status'] ?? ''),
+            ]);
+            $slots[(string) $slot['slot_key'].':'.$state] = $slot;
+        }
+
+        return $slots;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function nearTieAlternateCodeCopySlots(): array
+    {
+        $asset = $this->nearTieAsset();
+        $slots = [];
+        foreach ((array) ($asset['states'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $state = trim((string) ($row['state'] ?? ''));
+            if (! in_array($state, self::NEAR_TIE_COPY_STATES, true)) {
+                continue;
+            }
+
+            $slot = $this->interpretationStateSlot('near_tie_alternate_code_copy', $state, [
+                'near_tie_copy_state' => $state,
+                'title' => (string) ($row['title'] ?? ''),
+                'summary' => (string) ($row['copy'] ?? ''),
+                'body' => (string) ($row['copy'] ?? ''),
+                'copy' => (string) ($row['copy'] ?? ''),
+                'content_version' => (string) ($asset['asset_id'] ?? 'near_tie_alternate_code_copy_v1.zh-CN'),
+                'user_visible_boundary' => (string) ($asset['user_visible_boundary'] ?? 'Alternate code 是并读参考，不是新的身份标签或测评分数变化。'),
+                'source_review_status' => (string) ($asset['review_status'] ?? ''),
+            ]);
+            $slots[(string) $slot['slot_key'].':'.$state] = $slot;
+        }
+
+        return $slots;
     }
 
     /**
@@ -1500,6 +1692,137 @@ final class RiasecDeepCopySlotRegistry
     }
 
     /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function lowQualitySlotsFromAsset(): array
+    {
+        $asset = $this->lowQualityAsset();
+        $copyBySlot = [];
+        foreach ((array) ($asset['copy_slots'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $slotName = match ((string) ($row['slot'] ?? '')) {
+                'top_notice' => 'top_notice',
+                'retake_guidance' => 'retake_guidance',
+                'module_downgrade' => 'hidden_modules_explanation',
+                'share_pdf_note' => 'share_pdf_boundary',
+                default => null,
+            };
+            if ($slotName === null) {
+                continue;
+            }
+            $copyBySlot[$slotName] = [
+                'title' => (string) ($this->lowQualitySlotTitle($slotName)),
+                'summary' => (string) ($row['text'] ?? ''),
+                'content_version' => (string) ($asset['asset_id'] ?? 'low_quality_cautious_reading_v1.zh-CN'),
+                'user_visible_boundary' => '质量状态只限制本次结果的阅读强度，不评价用户，也不改变分数或 Holland Code。',
+            ];
+        }
+
+        $states = [];
+        foreach ((array) ($asset['states'] ?? []) as $row) {
+            if (is_array($row) && isset($row['quality_state'])) {
+                $states[(string) $row['quality_state']] = (string) ($row['copy'] ?? '');
+            }
+        }
+        if (($states['caution'] ?? '') !== '') {
+            $copyBySlot['cautious_reading_notice'] = [
+                'title' => '轻量参考',
+                'summary' => $states['caution'],
+                'quality_state' => 'caution',
+                'content_version' => (string) ($asset['asset_id'] ?? 'low_quality_cautious_reading_v1.zh-CN'),
+                'user_visible_boundary' => '谨慎阅读只说明本次线索需要验证，不是结果无效，也不是能力判断。',
+            ];
+        }
+        if (($states['minimal_60q'] ?? '') !== '') {
+            $copyBySlot['minimal_quality_boundary_60q'] = [
+                'title' => '60Q 最小质量边界',
+                'summary' => $states['minimal_60q'],
+                'quality_state' => 'minimal_quality_boundary_60q',
+                'content_version' => (string) ($asset['asset_id'] ?? 'low_quality_cautious_reading_v1.zh-CN'),
+                'user_visible_boundary' => '60Q 的质量边界只限制阅读方式，不比较 60Q 和 140Q 的正确性。',
+            ];
+        }
+
+        return $copyBySlot;
+    }
+
+    private function lowQualitySlotTitle(string $slotName): string
+    {
+        return match ($slotName) {
+            'top_notice' => '这次结果需要谨慎阅读',
+            'retake_guidance' => '稍后重测建议',
+            'hidden_modules_explanation' => '页面会减少强解释',
+            'share_pdf_boundary' => '分享和 PDF 边界',
+            default => '谨慎阅读提示',
+        };
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function lowQualityAsset(): array
+    {
+        if ($this->lowQualityAssetCache !== null) {
+            return $this->lowQualityAssetCache;
+        }
+
+        return $this->lowQualityAssetCache = $this->jsonAsset(self::LOW_QUALITY_ASSET_PATH);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function profileShapeAsset(): array
+    {
+        if ($this->profileShapeAssetCache !== null) {
+            return $this->profileShapeAssetCache;
+        }
+
+        return $this->profileShapeAssetCache = $this->jsonAsset(self::PROFILE_SHAPE_ASSET_PATH);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function topCodeConfidenceAsset(): array
+    {
+        if ($this->topCodeConfidenceAssetCache !== null) {
+            return $this->topCodeConfidenceAssetCache;
+        }
+
+        return $this->topCodeConfidenceAssetCache = $this->jsonAsset(self::TOP_CODE_CONFIDENCE_ASSET_PATH);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function nearTieAsset(): array
+    {
+        if ($this->nearTieAssetCache !== null) {
+            return $this->nearTieAssetCache;
+        }
+
+        return $this->nearTieAssetCache = $this->jsonAsset(self::NEAR_TIE_ASSET_PATH);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonAsset(string $relativePath): array
+    {
+        $path = dirname(__DIR__, 3).$relativePath;
+        if (! is_file($path)) {
+            return [];
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
      * @param  array<string,mixed>  $content
      * @return array<string,mixed>
      */
@@ -1565,6 +1888,43 @@ final class RiasecDeepCopySlotRegistry
             'evidence_level' => 'expert_reviewed',
             'source_status' => 'reviewed_content_copy',
             'review_status' => 'approved_for_staging',
+            'fallback_behavior' => 'omit_module',
+            'content_status' => 'authored',
+            'frontend_fallback_allowed' => false,
+        ], $content);
+    }
+
+    /**
+     * @param  array<string,mixed>  $content
+     * @return array<string,mixed>
+     */
+    private function interpretationStateSlot(string $slotKey, string $slotName, array $content): array
+    {
+        return array_merge([
+            'slot_key' => $slotKey,
+            'slot_group' => 'interpretation_state_copy',
+            'scale_code' => 'RIASEC',
+            'locale' => 'zh-CN',
+            'content_version' => 'riasec_interpretation_state_copy_v1.zh-CN',
+            'interpretation_rule_version' => 'riasec_interpretation_rule_spec_v2',
+            'applicable_form_codes' => ['riasec_60', 'riasec_140'],
+            'applicable_profile_shapes' => ['clear_code', 'blended_code', 'broad_profile', 'near_tie', 'low_quality', 'low_clarity'],
+            'applicable_quality_states' => ['normal', 'caution', 'low_quality'],
+            'applicable_codes' => [$slotName],
+            'slot_name' => $slotName,
+            'forbidden_claims' => [
+                'personality_identity',
+                'career_recommendation',
+                'job_fit',
+                'success_prediction',
+                'accuracy_probability',
+                'ability_or_skill_inference',
+            ],
+            'required_boundaries' => $this->requiredBoundaries(),
+            'user_visible_boundary' => '这些内容只说明结果阅读方式，不改变分数、Holland Code 或职业结论。',
+            'evidence_level' => 'expert_reviewed',
+            'source_status' => 'reviewed_content_copy',
+            'review_status' => 'content_review',
             'fallback_behavior' => 'omit_module',
             'content_status' => 'authored',
             'frontend_fallback_allowed' => false,

--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -255,6 +255,10 @@ final class RiasecPublicProjectionService
             }
         }
 
+        foreach ($this->selectedInterpretationStateCopySlots((array) ($projection['interpretation_state'] ?? []), $qualityState) as $slot) {
+            $this->appendRenderableSlot($slots, $slot, 'result_reading_boundary', $modulePolicy, $locale, 'collapsed');
+        }
+
         if ($formCode === 'riasec_140' && ! in_array($qualityState, ['low_quality', 'retake_recommended'], true)) {
             foreach ($this->deepCopySlots->structuralDifferenceSlots() as $slot) {
                 $this->appendRenderableSlot($slots, $slot, 'structural_difference', $modulePolicy, $locale, 'collapsed');
@@ -435,6 +439,64 @@ final class RiasecPublicProjectionService
     }
 
     /**
+     * @param  array<string,mixed>  $interpretationState
+     * @return list<array<string,mixed>>
+     */
+    private function selectedInterpretationStateCopySlots(array $interpretationState, string $qualityState): array
+    {
+        $slots = [];
+        $profileShape = (string) ($interpretationState['profile_shape'] ?? '');
+        if ($profileShape !== '') {
+            $slots[] = $this->deepCopySlots->resolveInterpretationStateCopySlot('profile_shape_copy', $profileShape);
+        }
+
+        $confidenceState = $this->confidenceCopyState($interpretationState, $qualityState);
+        if ($confidenceState !== null) {
+            $slots[] = $this->deepCopySlots->resolveInterpretationStateCopySlot('top_code_confidence_copy', $confidenceState);
+        }
+
+        $nearTieState = (string) data_get($interpretationState, 'near_tie_state.state', 'none');
+        if ($qualityState !== 'low_quality' && $nearTieState !== '' && $nearTieState !== 'none') {
+            $slots[] = $this->deepCopySlots->resolveInterpretationStateCopySlot('near_tie_alternate_code_copy', $nearTieState);
+            if ((bool) data_get($interpretationState, 'alternate_code.show', false)) {
+                $slots[] = $this->deepCopySlots->resolveInterpretationStateCopySlot('near_tie_alternate_code_copy', 'alternate_code_available');
+            }
+        }
+
+        return array_values(array_filter(
+            $slots,
+            static fn (array $slot): bool => ($slot['content_status'] ?? null) === 'authored'
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $interpretationState
+     */
+    private function confidenceCopyState(array $interpretationState, string $qualityState): ?string
+    {
+        $profileShape = (string) ($interpretationState['profile_shape'] ?? '');
+        if ($qualityState === 'low_quality' || in_array($profileShape, ['low_quality', 'low_clarity'], true)) {
+            return 'low_clarity';
+        }
+        if ($profileShape === 'near_tie') {
+            return 'near_tie';
+        }
+        if ($profileShape === 'broad_profile') {
+            return 'broad_profile';
+        }
+
+        $level = (string) data_get($interpretationState, 'top_code_confidence.level', '');
+        if (in_array($level, ['high', 'medium_high'], true)) {
+            return 'high_confidence';
+        }
+        if (in_array($level, ['medium', 'low'], true)) {
+            return 'moderate_confidence';
+        }
+
+        return null;
+    }
+
+    /**
      * @param  array<string,mixed>  $slot
      * @return array<string,mixed>
      */
@@ -473,6 +535,9 @@ final class RiasecPublicProjectionService
             'when_not_to_overread',
             'free_page_teaser',
             'deep_report_extension',
+            'label',
+            'copy',
+            'module_policy',
             'example_question',
             'task_activity_card',
             'environment_card',
@@ -519,6 +584,9 @@ final class RiasecPublicProjectionService
                 'slot_name' => $slot['slot_name'] ?? null,
                 'layer_state' => $slot['layer_state'] ?? null,
                 'quality_state' => $slot['quality_state'] ?? null,
+                'profile_shape' => $slot['profile_shape'] ?? null,
+                'confidence_state' => $slot['confidence_state'] ?? null,
+                'near_tie_copy_state' => $slot['near_tie_copy_state'] ?? null,
                 'structural_difference_state' => $slot['structural_difference_state'] ?? null,
                 'aspirations_state' => $slot['aspirations_state'] ?? null,
                 'disagree_state' => $slot['disagree_state'] ?? null,

--- a/backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json
+++ b/backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json
@@ -1,0 +1,117 @@
+{
+  "asset_id": "low_quality_cautious_reading_v1.zh-CN",
+  "asset_status": "content_review_v7_3_final_preflight_candidate",
+  "locale": "zh-CN",
+  "scale_code": "RIASEC",
+  "review_status": "content_review_v7_3_final_preflight_candidate",
+  "target_review_status_after_owner_signoff": "owner_signoff_required_before_runtime_import_after_owner_signoff",
+  "global_message": "这次结果请谨慎阅读。它可以作为六维兴趣草图，帮助你先观察哪些活动让你愿意靠近、哪些活动明显消耗；暂时不适合展开强组合解释、职业场景例子或深度承接。",
+  "states": [
+    {
+      "quality_state": "normal",
+      "visible_modules": [
+        "hero",
+        "dimension_map",
+        "pair_blend",
+        "activity_explorer",
+        "140q_cta"
+      ],
+      "copy": "本次结果可以作为职业兴趣探索入口。"
+    },
+    {
+      "quality_state": "caution",
+      "visible_modules": [
+        "hero",
+        "dimension_map",
+        "pair_blend_collapsed",
+        "activity_explorer_limited"
+      ],
+      "copy": "本次结果可读，但建议把强结论降级为“待验证线索”。"
+    },
+    {
+      "quality_state": "low_quality",
+      "visible_modules": [
+        "dimension_map_only",
+        "retake_guidance"
+      ],
+      "copy": "先暂缓强调三字母 Code，只看六维初步线索，并建议稍后重测。"
+    },
+    {
+      "quality_state": "minimal_60q",
+      "visible_modules": [
+        "dimension_map",
+        "method_boundary"
+      ],
+      "copy": "60Q 当前只在明确缺题或完成度不足时强降级；其他情况只做谨慎提示。"
+    },
+    {
+      "quality_state": "retake_recommended",
+      "visible_modules": [
+        "retake_card",
+        "safe_boundary"
+      ],
+      "copy": "重测建议是为了获得更稳定的兴趣线索，不是为了追求某个“好看结果”。"
+    }
+  ],
+  "copy_slots": [
+    {
+      "slot": "top_notice",
+      "text": "本次结果需要谨慎阅读。你可以先保留它作为初步兴趣线索。"
+    },
+    {
+      "slot": "retake_guidance",
+      "text": "如果你当时注意力分散、赶时间或对题目想象不清，可以稍后在状态稳定时重测。"
+    },
+    {
+      "slot": "module_downgrade",
+      "text": "页面会减少强解释和职业场景展示，避免把不稳定结果读成方向判断。"
+    },
+    {
+      "slot": "share_pdf_note",
+      "text": "谨慎阅读结果在分享和 PDF 中应默认展示边界提示，不展示强活动链。"
+    }
+  ],
+  "upsell_140q_allowed": false,
+  "user_blame_allowed": false,
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "examples_not_matches",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "forbidden_claims": [
+    "personality_identity",
+    "ability_or_skill_inference",
+    "career_match",
+    "career_recommendation",
+    "job_fit",
+    "fit_score",
+    "occupation_ranking",
+    "success_prediction",
+    "hiring_suitability",
+    "screening_use",
+    "140q_more_accurate",
+    "raw_score_delta",
+    "onet_soc_source_invention"
+  ],
+  "frontend_fallback_allowed": false,
+  "fallback_behavior": "omit_module",
+  "commercial_operations_internal_notes": {
+    "trust_policy": "不责备用户，不推销 140Q，不输出强结论",
+    "recommended_next_step": "休息后重测，或只做一个低风险活动检查",
+    "hidden_or_collapsed_modules": [
+      "strong_pair_chain",
+      "occupation_examples",
+      "deep_report_cta"
+    ]
+  }
+}

--- a/backend/content_assets/riasec/near_tie_alternate_code_copy_v1.zh-CN.json
+++ b/backend/content_assets/riasec/near_tie_alternate_code_copy_v1.zh-CN.json
@@ -1,0 +1,63 @@
+{
+  "asset_id": "near_tie_alternate_code_copy_v1.zh-CN",
+  "asset_status": "content_review_v7_3_final_preflight_candidate",
+  "locale": "zh-CN",
+  "scale_code": "RIASEC",
+  "review_status": "content_review_v7_3_final_preflight_candidate",
+  "target_review_status_after_owner_signoff": "owner_signoff_required_before_runtime_import_after_owner_signoff",
+  "states": [
+    {
+      "state": "top1_top2_near_tie",
+      "title": "前两维接近",
+      "copy": "主读当前 Code，同时参考前两维交换顺序后的活动链。你不是“另一个 Code”，而是两条兴趣入口接近。"
+    },
+    {
+      "state": "top2_top3_near_tie",
+      "title": "第二、第三维接近",
+      "copy": "第三维不是边缘装饰。它可能决定这条活动链最终面向材料、表达、真实人、目标还是秩序。"
+    },
+    {
+      "state": "multi_near_tie",
+      "title": "多维接近",
+      "copy": "请先看活动，而不是看字母。多维接近时，真正有用的是用小任务验证哪类活动更有能量。"
+    },
+    {
+      "state": "alternate_code_available",
+      "title": "可参考 alternate code",
+      "copy": "alternate code 是阅读辅助，不是第二个答案。它帮助你理解不同排序下活动链的重心变化。"
+    }
+  ],
+  "user_visible_boundary": "Alternate code 是并读参考，不是推翻结果，也不是新的身份标签。",
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "examples_not_matches",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "forbidden_claims": [
+    "personality_identity",
+    "ability_or_skill_inference",
+    "career_match",
+    "career_recommendation",
+    "job_fit",
+    "fit_score",
+    "occupation_ranking",
+    "success_prediction",
+    "hiring_suitability",
+    "screening_use",
+    "140q_more_accurate",
+    "raw_score_delta",
+    "onet_soc_source_invention"
+  ],
+  "frontend_fallback_allowed": false,
+  "fallback_behavior": "omit_module"
+}

--- a/backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json
+++ b/backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json
@@ -1,0 +1,79 @@
+{
+  "asset_id": "profile_shape_copy_v1.zh-CN",
+  "asset_status": "content_review_v7_3_final_preflight_candidate",
+  "locale": "zh-CN",
+  "scale_code": "RIASEC",
+  "review_status": "content_review_v7_3_final_preflight_candidate",
+  "target_review_status_after_owner_signoff": "owner_signoff_required_before_runtime_import_after_owner_signoff",
+  "profile_shapes": [
+    {
+      "shape": "clear_code",
+      "title": "主线索清楚",
+      "summary": "你可以先从三字母活动链进入结果，但不要把它读成固定身份。第二、第三维决定了这条活动链如何落地。",
+      "module_policy": "show_standard_chain_and_pair_blends"
+    },
+    {
+      "shape": "blended_code",
+      "title": "混合型结果",
+      "summary": "前两到三条兴趣线索都在参与结果。建议重点看 pair blend 和 Top3 chain，而不是只看第一个字母。",
+      "module_policy": "show_pair_blend_first"
+    },
+    {
+      "shape": "broad_profile",
+      "title": "广谱兴趣",
+      "summary": "多个维度接近时，系统不应强行给出单一路径。先用活动和小实验收窄：哪些任务让你更有能量，哪些只是看起来有吸引力。",
+      "module_policy": "hide_strong_code_claims"
+    },
+    {
+      "shape": "near_tie",
+      "title": "近似并列",
+      "summary": "字母顺序只是本次排序，不是身份高低。请同时阅读 alternate code 的组合解释，并用 1–2 个真实任务验证。",
+      "module_policy": "show_alternate_code_boundary"
+    },
+    {
+      "shape": "low_quality",
+      "title": "谨慎阅读",
+      "summary": "这次结果不适合输出强结论。页面应先保护用户：弱化三字码、隐藏职业例子、建议重测或仅看六维。",
+      "module_policy": "show_minimal_dimension_only"
+    },
+    {
+      "shape": "low_clarity",
+      "title": "低清晰度",
+      "summary": "结果并非无效，但主线不够清楚。更适合看候选活动，而不是马上形成方向判断。",
+      "module_policy": "show_candidate_activities"
+    }
+  ],
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "examples_not_matches",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "forbidden_claims": [
+    "personality_identity",
+    "ability_or_skill_inference",
+    "career_match",
+    "career_recommendation",
+    "job_fit",
+    "fit_score",
+    "occupation_ranking",
+    "success_prediction",
+    "hiring_suitability",
+    "screening_use",
+    "140q_more_accurate",
+    "raw_score_delta",
+    "onet_soc_source_invention"
+  ],
+  "frontend_fallback_allowed": false,
+  "fallback_behavior": "omit_module",
+  "v5_editorial_note": "Profile-shape copy reviewed for clear, blended, broad, near-tie, and low-quality reading without identity framing."
+}

--- a/backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json
+++ b/backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json
@@ -1,0 +1,68 @@
+{
+  "asset_id": "top_code_confidence_copy_v1.zh-CN",
+  "asset_status": "content_review_v7_3_final_preflight_candidate",
+  "locale": "zh-CN",
+  "scale_code": "RIASEC",
+  "review_status": "content_review_v7_3_final_preflight_candidate",
+  "target_review_status_after_owner_signoff": "owner_signoff_required_before_runtime_import_after_owner_signoff",
+  "states": [
+    {
+      "state": "high_confidence",
+      "label": "主线索清楚",
+      "copy": "第一维与后续维度差距较明显，可以把三字码作为本次兴趣探索入口；仍需同时阅读第二、第三维，因为它们决定活动链如何展开。"
+    },
+    {
+      "state": "moderate_confidence",
+      "label": "可正常阅读",
+      "copy": "主线索可读，但不是单一结论。建议先看 Top2 组合，再看 Top3 活动链。"
+    },
+    {
+      "state": "near_tie",
+      "label": "近似并列",
+      "copy": "前两维或前三维接近时，不要急着固定一个字母顺序。把它读成几条活动线索的接近竞争，并用小实验验证。"
+    },
+    {
+      "state": "broad_profile",
+      "label": "兴趣较广",
+      "copy": "多个维度都较接近时，页面应少强调单一 Code，更多展示可验证活动与低风险选择。"
+    },
+    {
+      "state": "low_clarity",
+      "label": "谨慎阅读",
+      "copy": "本次结果更适合当作初步线索。建议先看六维分布，不输出强活动链。"
+    }
+  ],
+  "user_visible_boundary": "结果阅读力度只说明本次兴趣线索是否集中、接近或需要谨慎阅读；它不是准确率、职业前景或能力判断。",
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "examples_not_matches",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "forbidden_claims": [
+    "personality_identity",
+    "ability_or_skill_inference",
+    "career_match",
+    "career_recommendation",
+    "job_fit",
+    "fit_score",
+    "occupation_ranking",
+    "success_prediction",
+    "hiring_suitability",
+    "screening_use",
+    "140q_more_accurate",
+    "raw_score_delta",
+    "onet_soc_source_invention"
+  ],
+  "frontend_fallback_allowed": false,
+  "fallback_behavior": "omit_module"
+}

--- a/backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
@@ -34,6 +34,9 @@ final class RiasecContentRegistrySlotContractTest extends TestCase
         $this->assertContains('140q_tension_copy', $slotKeys);
         $this->assertContains('low_quality_copy', $slotKeys);
         $this->assertContains('cautious_reading_copy', $slotKeys);
+        $this->assertContains('profile_shape_copy', $slotKeys);
+        $this->assertContains('top_code_confidence_copy', $slotKeys);
+        $this->assertContains('near_tie_alternate_code_copy', $slotKeys);
         $this->assertContains('structural_difference_copy', $slotKeys);
         $this->assertContains('aspirations_calibration_copy', $slotKeys);
         $this->assertContains('disagree_path_copy', $slotKeys);

--- a/backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php
@@ -40,6 +40,48 @@ final class RiasecLowQualityCopySlotRegistryTest extends TestCase
 
             $this->assertSame([], $registry->validateSlot($slot), $slotName.' should be contract-clean.');
         }
+
+        $this->assertSame('low_quality_cautious_reading_v1.zh-CN', $slots['top_notice']['content_version']);
+        $this->assertStringContainsString('谨慎阅读', $slots['top_notice']['summary']);
+    }
+
+    public function test_interpretation_state_assets_are_backend_authored_and_fail_closed(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slots = $registry->interpretationStateCopySlots();
+
+        foreach ([
+            'profile_shape_copy:near_tie',
+            'top_code_confidence_copy:near_tie',
+            'near_tie_alternate_code_copy:top1_top2_near_tie',
+            'near_tie_alternate_code_copy:alternate_code_available',
+        ] as $slotId) {
+            $slot = $slots[$slotId] ?? null;
+            $this->assertIsArray($slot, $slotId.' slot should exist.');
+            $this->assertSame('interpretation_state_copy', $slot['slot_group']);
+            $this->assertSame('authored', $slot['content_status']);
+            $this->assertFalse($slot['frontend_fallback_allowed']);
+            $this->assertSame([], $registry->validateSlot($slot), $slotId.' should be contract-clean.');
+        }
+
+        $this->assertSame(
+            'unavailable',
+            $registry->resolveInterpretationStateCopySlot('top_code_confidence_copy', 'unsupported')['content_status']
+        );
+    }
+
+    public function test_confidence_and_near_tie_copy_do_not_claim_probability_or_identity(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slots = $registry->interpretationStateCopySlots();
+
+        $confidence = $slots['top_code_confidence_copy:near_tie'];
+        $this->assertStringContainsString('不是准确率', $confidence['user_visible_boundary']);
+        $this->assertStringNotContainsString('成功概率', $confidence['summary']);
+
+        $nearTie = $slots['near_tie_alternate_code_copy:alternate_code_available'];
+        $this->assertStringContainsString('不是第二个答案', $nearTie['summary']);
+        $this->assertStringNotContainsString('你其实是另一个 Code', $nearTie['summary']);
     }
 
     public function test_low_quality_downgrade_policy_hides_strong_modules(): void

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -13062,7 +13062,7 @@
     "merge_commit": "6f83ae6c06875b71af1dd8950e3b5352567290b4"
   },
   "RIASEC-FULL-CONTENT-PACK-08": {
-    "status": "pr_open_github_checks_pending",
+    "status": "github_checks_passed_ready_to_merge",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/riasec-full-content-pack-08",
@@ -13071,7 +13071,7 @@
     "depends_on": [
       "RIASEC-FULL-CONTENT-PACK-07"
     ],
-    "commit_sha": "d8cad18f58f645ac449295a0a1fdb9b5fc18a371",
+    "commit_sha": "b864549f4e802e3e7b527cc7216e705ad190e5a9",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1494",
     "checks": {
       "dependency_gate": {
@@ -13109,8 +13109,8 @@
         "summary": "Changed files are limited to PACK-08 RIASEC quality/interpretation assets, backend registry/projection/contract tests, and authorized PR train metadata; no scorer, quality math, question pack, frontend fallback, career matching, feedback mutation, analytics, or production data changes."
       },
       "github_required_checks": {
-        "status": "pending",
-        "summary": "PR #1494 opened; GitHub required checks pending."
+        "status": "pass",
+        "summary": "PR #1494 passed hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2 before merge review."
       }
     },
     "failure_reason": null,
@@ -13133,6 +13133,11 @@
         "at": "2026-05-19T21:22:41Z",
         "status": "pr_opened_github_checks_pending",
         "summary": "Opened https://github.com/fermatmind/fap-api/pull/1494 for PACK-08. GitHub checks pending."
+      },
+      {
+        "at": "2026-05-19T21:29:29Z",
+        "status": "github_checks_passed_ready_to_merge",
+        "summary": "GitHub required checks passed for PR #1494; ready for final merge-state review."
       }
     ],
     "next_pr": "RIASEC-FULL-CONTENT-PACK-05"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12968,7 +12968,7 @@
     "merge_commit": "150acbda417bbfd56ab319620080cde392188b65"
   },
   "RIASEC-FULL-CONTENT-PACK-07": {
-    "status": "github_checks_passed_ready_to_merge",
+    "status": "merged",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/riasec-full-content-pack-07",
@@ -12977,7 +12977,7 @@
     "depends_on": [
       "RIASEC-FULL-CONTENT-PACK-04"
     ],
-    "commit_sha": "c5663e60fc6cc8ce04b4f445566a61575b692871",
+    "commit_sha": "6f83ae6c06875b71af1dd8950e3b5352567290b4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1493",
     "checks": {
       "dependency_gate": {
@@ -13018,13 +13018,13 @@
       },
       "github_required_checks": {
         "status": "pass",
-        "summary": "PR #1493 passed hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2 before merge review."
+        "summary": "PR #1493 passed hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2 before squash merge."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-19T21:11:58Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [],
     "history": [
       {
@@ -13051,12 +13051,18 @@
         "at": "2026-05-19T21:05:36Z",
         "status": "github_checks_passed_ready_to_merge",
         "summary": "GitHub required checks passed for PR #1493; ready for final merge-state review."
+      },
+      {
+        "at": "2026-05-19T21:21:15Z",
+        "status": "merged_reconciled",
+        "summary": "Reconciled PACK-07 before PACK-08: PR #1493 merged with squash commit 6f83ae6c06875b71af1dd8950e3b5352567290b4; origin/main contains the merge commit and remote/local branch cleanup completed."
       }
     ],
-    "next_pr": "RIASEC-FULL-CONTENT-PACK-08"
+    "next_pr": "RIASEC-FULL-CONTENT-PACK-08",
+    "merge_commit": "6f83ae6c06875b71af1dd8950e3b5352567290b4"
   },
   "RIASEC-FULL-CONTENT-PACK-08": {
-    "status": "registered",
+    "status": "local_validation_passed",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/riasec-full-content-pack-08",
@@ -13067,7 +13073,42 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "dependency_gate": {
+        "status": "pass",
+        "summary": "PACK-07 was merged and reconciled before PACK-08 implementation continued."
+      },
+      "targeted_phpunit": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi",
+        "summary": "28 tests passed; imported low-quality, confidence, profile-shape, and near-tie assets validate and projection/report regression coverage passed."
+      },
+      "scoped_pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecPublicProjectionService.php app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php"
+      },
+      "json_validation": {
+        "status": "pass",
+        "command": "python3 JSON parse for low_quality, top_code_confidence, near_tie, and profile_shape RIASEC assets",
+        "summary": "4 JSON assets parsed successfully."
+      },
+      "forbidden_claim_scan": {
+        "status": "pass",
+        "summary": "Imported PACK-08 assets scan found 0 forbidden user claims; 1 allowed boundary hit for negated near-tie “推翻” boundary."
+      },
+      "frontend_fallback_scan": {
+        "status": "pass",
+        "summary": "No frontend_fallback_allowed=true hits in imported assets or touched RIASEC services/tests."
+      },
+      "git_diff_check": {
+        "status": "pass",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "scope_validation": {
+        "status": "pass",
+        "summary": "Changed files are limited to PACK-08 RIASEC quality/interpretation assets, backend registry/projection/contract tests, and authorized PR train metadata; no scorer, quality math, question pack, frontend fallback, career matching, feedback mutation, analytics, or production data changes."
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -13078,6 +13119,11 @@
         "at": "2026-05-19T20:06:36Z",
         "status": "registered",
         "summary": "Registered RIASEC-FULL-CONTENT-PACK-08 for RIASEC Full Content Pack PHASE2 after user-authorized manifest/state update."
+      },
+      {
+        "at": "2026-05-19T21:21:15Z",
+        "status": "local_validation_passed",
+        "summary": "Imported low-quality, confidence, profile-shape, and near-tie assets; added backend interpretation-state slots and passed targeted PHPUnit, scoped Pint, JSON validation, forbidden-claim scan, fallback scan, and diff checks locally."
       }
     ],
     "next_pr": "RIASEC-FULL-CONTENT-PACK-05"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -13062,7 +13062,7 @@
     "merge_commit": "6f83ae6c06875b71af1dd8950e3b5352567290b4"
   },
   "RIASEC-FULL-CONTENT-PACK-08": {
-    "status": "local_validation_passed",
+    "status": "pr_open_github_checks_pending",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/riasec-full-content-pack-08",
@@ -13071,8 +13071,8 @@
     "depends_on": [
       "RIASEC-FULL-CONTENT-PACK-07"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "d8cad18f58f645ac449295a0a1fdb9b5fc18a371",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1494",
     "checks": {
       "dependency_gate": {
         "status": "pass",
@@ -13107,6 +13107,10 @@
       "scope_validation": {
         "status": "pass",
         "summary": "Changed files are limited to PACK-08 RIASEC quality/interpretation assets, backend registry/projection/contract tests, and authorized PR train metadata; no scorer, quality math, question pack, frontend fallback, career matching, feedback mutation, analytics, or production data changes."
+      },
+      "github_required_checks": {
+        "status": "pending",
+        "summary": "PR #1494 opened; GitHub required checks pending."
       }
     },
     "failure_reason": null,
@@ -13124,6 +13128,11 @@
         "at": "2026-05-19T21:21:15Z",
         "status": "local_validation_passed",
         "summary": "Imported low-quality, confidence, profile-shape, and near-tie assets; added backend interpretation-state slots and passed targeted PHPUnit, scoped Pint, JSON validation, forbidden-claim scan, fallback scan, and diff checks locally."
+      },
+      {
+        "at": "2026-05-19T21:22:41Z",
+        "status": "pr_opened_github_checks_pending",
+        "summary": "Opened https://github.com/fermatmind/fap-api/pull/1494 for PACK-08. GitHub checks pending."
       }
     ],
     "next_pr": "RIASEC-FULL-CONTENT-PACK-05"


### PR DESCRIPTION
## What changed
- Imported V7.3 backend-authoritative RIASEC assets for low-quality cautious reading, profile-shape copy, top-code confidence copy, and near-tie/alternate-code copy.
- Added backend interpretation-state content slots with fail-closed resolution and generic projection through `deep_content_slots_v1`.
- Kept low-quality module downgrade behavior: strong modules/140Q CTA stay hidden or downgraded, with no score or Holland Code mutation.
- Reconciled PACK-07 train ledger state after PR #1493 was merged.

## Why
PACK-08 completes the result-reading boundary layer after 140Q narrative import: cautious reading, top-code confidence, and near-tie copy are backend-owned and explicitly framed as readability guidance, not probability, identity, or a career conclusion.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecPublicProjectionService.php app/Services/Riasec/RiasecContentRegistrySlotContract.php tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- JSON parse for all four imported assets
- Forbidden-claim scan over user-facing imported asset fields: 0 forbidden user claims, 1 allowed boundary hit for negated near-tie boundary
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` and YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- PACK-05 activity/task examples and PACK-06 occupation examples.
- Any fap-web renderer changes unless a future backend contract requires it.
- Any changes to scorer math, quality math, question packs, career matching, or feedback mutation.

## Repository rule impact
RIASEC interpretation copy remains backend-authoritative and fail-closed. This PR does not add frontend fallback copy, scoring changes, question pack changes, career match/job fit/ranking/success prediction, “140Q more accurate” claims, or feedback/aspiration score mutation.