### PR TITLE
fix(security): avoid token-like phpunit app key

### DIFF
--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -26,7 +26,7 @@
     <php>
         <ini name="memory_limit" value="512M"/>
         <env name="APP_ENV" value="testing"/>
-        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
+        <env name="APP_KEY" value="fap_api_phpunit_test_key_32bytes"/>
         <env name="APP_CONFIG_CACHE" value="bootstrap/cache/config-testing.php"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>


### PR DESCRIPTION
## What changed
- Replaced the PHPUnit `APP_KEY` fixture with a non-token-shaped 32-byte test key.
- Keeps the key scoped to local/test configuration only; no runtime behavior changes.

## Why
- Semgrep reported the old token-shaped test fixture as a Telegram bot API key secret.
- The new fixture preserves Laravel test key behavior without resembling an external credential.

## Validation
- `cd backend && php artisan test --filter=PiiCipherEnvelopeTest`
- `cd backend && php artisan route:list`
- `cd backend && git diff --check`

## Deferred
- No production secrets or runtime config changes are included.
