### PR TITLE
docs(seo-intel): finalize SEO Dash MVP online closeout

### DIFF
--- a/backend/docs/seo/generated/seo-dash-mvp-online-final-closeout.v1.json
+++ b/backend/docs/seo/generated/seo-dash-mvp-online-final-closeout.v1.json
@@ -1,0 +1,109 @@
+{
+  "schema_version": "seo-dash-mvp-online-final-closeout.v1",
+  "task": "SEO-DASH-MVP-ONLINE-FINAL-CLOSEOUT",
+  "generated_at": "2026-05-19T23:05:07Z",
+  "final_decision": "seo_dash_mvp_online_with_ops_entry_verified",
+  "current_counts": {
+    "seo_urls": 7,
+    "seo_url_entities": 7,
+    "seo_issue_queue": 5,
+    "dashboard_cards": 10
+  },
+  "metabase": {
+    "private_only": true,
+    "localhost_binding": "127.0.0.1:3000",
+    "application_database": "metabase_app",
+    "application_database_engine": "postgresql",
+    "datasource": "seo_intel",
+    "readonly_account": "seo_intel_metabase_readonly",
+    "read_verification_passed": true,
+    "write_deny_verification_passed": true,
+    "public_sharing_disabled": true,
+    "embedding_disabled_where_supported": true,
+    "anonymous_links_absent": true,
+    "public_exposure": false
+  },
+  "ops_portal": {
+    "ops_seo_route_verified": true,
+    "route": "/ops/seo",
+    "production_url": "https://ops.fermatmind.com/ops/seo",
+    "auth_required": true,
+    "unauthenticated_redirect": "/ops/login",
+    "admin_redirect": "/ops",
+    "metabase_exposed": false,
+    "iframe_present": false,
+    "reverse_proxy_present": false,
+    "raw_credentials_exposed": false
+  },
+  "dashboard": {
+    "name": "SEO Intelligence MVP - URL Truth & Issue Queue",
+    "cards_verified": 10,
+    "allowed_datasource": "seo_intel",
+    "allowed_tables": [
+      "seo_urls",
+      "seo_url_entities",
+      "seo_issue_queue"
+    ]
+  },
+  "completed_phases": [
+    "runtime_authority_backend_convergence_foundation",
+    "seo_dash_foundation",
+    "production_seo_intel_db_migration",
+    "production_collector_dry_run",
+    "url_truth_controlled_write_canaries",
+    "drift_issue_queue_controlled_write_canary",
+    "metabase_private_mvp",
+    "research_mvp_foundation",
+    "ops_portal_seo_access_layer_pr_train",
+    "ops_seo_production_access_verification"
+  ],
+  "not_completed": [
+    "scheduler",
+    "gsc_live",
+    "baidu_live",
+    "indexnow_live",
+    "sogou_360_shenma_live",
+    "live_search",
+    "production_crawler_log_read",
+    "crawler_log",
+    "search_channel_live_submission",
+    "research_publish",
+    "digital_pr_outreach",
+    "pseo",
+    "public_metabase_exposure",
+    "normal_operator_onboarding",
+    "unrestricted_sql_export"
+  ],
+  "next_phase": "RESEARCH-PUBLISH-01",
+  "hard_stops": [
+    "no public Metabase",
+    "no business DB in Metabase",
+    "no Node2 local DB",
+    "no Tencent RDS",
+    "no unrestricted SQL for operators",
+    "no Search submission outside Search Channel Queue",
+    "no production crawler log read without explicit approval",
+    "no Research publish outside CMS Draft Gate",
+    "no pSEO until after controlled operating loop",
+    "no claim expansion for RIASEC / Big Five / Career"
+  ],
+  "authority_boundary": {
+    "cms_backend_truth_owner": true,
+    "fap_web_deterministic_public_runtime": true,
+    "seo_dash_observation_layer_only": true,
+    "metabase_observation_layer_only": true,
+    "frontend_fallback_is_not_seo_truth": true
+  },
+  "runtime_operations_performed_in_this_pr": false,
+  "production_operations_performed_in_this_pr": false,
+  "metabase_operation_performed_in_this_pr": false,
+  "env_edit_in_this_pr": false,
+  "deploy_performed_in_this_pr": false,
+  "scheduler_enabled_in_this_pr": false,
+  "collector_write_performed_in_this_pr": false,
+  "external_api_live_activation": false,
+  "url_submission_performed": false,
+  "production_crawler_log_read_in_this_pr": false,
+  "research_publish_in_this_pr": false,
+  "pseo_generation_in_this_pr": false
+}

--- a/backend/docs/seo/seo-dash-mvp-online-final-closeout.md
+++ b/backend/docs/seo/seo-dash-mvp-online-final-closeout.md
@@ -1,0 +1,114 @@
+# SEO Dash MVP Online Final Closeout
+
+## Final State
+
+SEO Dash MVP is minimally online with an authenticated Ops Portal entry. The dashboard is an observation layer only; CMS/backend remains the source of truth, fap-web remains the deterministic public runtime, and Metabase remains private.
+
+Verified current state:
+
+- `seo_urls`: 7
+- `seo_url_entities`: 7
+- `seo_issue_queue`: 5
+- Dashboard cards: 10
+- Dashboard: `SEO Intelligence MVP - URL Truth & Issue Queue`
+- Metabase datasource: `seo_intel` only
+- Metabase datasource account: `seo_intel_metabase_readonly`
+- Write-deny verification: passed
+- Public sharing: disabled
+- Anonymous links: absent
+- Public Metabase exposure: false
+- `/ops/seo`: production access verified behind Ops auth
+
+The production Ops Portal route `https://ops.fermatmind.com/ops/seo` was verified after deployment. Unauthenticated access redirects to `/ops/login`, authenticated Ops/Admin sessions render the SEO Intelligence Access page, and `/admin` redirects to `/ops`. The page exposes status and private access instructions only. It does not iframe Metabase, reverse-proxy Metabase, expose a public Metabase URL, or expose raw database credentials.
+
+Metabase remains private on the approved Aliyun ECS and listens only on `127.0.0.1:3000`. Access remains limited to approved private channels such as Workbench, bastion, VPN, or another owner-controlled private channel.
+
+## Completed Phases
+
+- Runtime Authority / backend convergence foundation
+- SEO-DASH foundation
+- Production `seo_intel` DB/migration
+- Production collector dry-run
+- URL Truth controlled write canaries
+- Drift / Issue Queue controlled write canary
+- Metabase private MVP
+- Research MVP foundation
+- Ops Portal SEO access layer PR train
+- `/ops/seo` production access verification
+
+## Not Completed
+
+These remain explicitly not started or not completed:
+
+- scheduler
+- GSC live
+- Baidu live
+- IndexNow live
+- 360/Sogou/Shenma live
+- production crawler log read
+- Search Channel live submission
+- Research publish
+- Digital PR outreach
+- pSEO
+- public Metabase exposure
+- normal operator onboarding
+- unrestricted SQL/export
+
+## Next Roadmap
+
+### Phase 2 Research Publish
+
+- `RESEARCH-PUBLISH-01`
+- `RESEARCH-PUBLISH-02`
+- `DIGITAL-PR-01`
+
+### Phase 3 Search Channel Live
+
+- `GSC-LIVE-00`
+- `GSC-LIVE-01`
+- `BAIDU-LIVE-00`
+- `INDEXNOW-LIVE-00`
+- `SEARCH-CHANNEL-LIVE-01`
+
+### Phase 4 Crawler Logs
+
+- `CRAWLER-LOG-01`
+- `CRAWLER-LOG-02`
+- `CRAWLER-LOG-03`
+- `CRAWLER-LOG-04`
+
+### Phase 5 Content Ops / Internal Link / Claim Runtime
+
+- `CONTENT-OPS-02`
+- `INTERNAL-LINK-01`
+- `CLAIM-LINT-01`
+- `SEO-OPS-SOP-01`
+
+### Phase 6 Growth Expansion
+
+- `ADS-VALIDATION-01`
+- `EMAIL-ACCESS / EMAIL-OPS`
+- `REPORT-BOUNDARY / RESULT-WOW`
+- `DIGITAL-PR-02`
+- pSEO / new languages / Career expansion
+
+Completing Phase 5 means the SEO main operating loop is ready for full operational iteration. Phase 6 is growth expansion and is not required before SEO operations start.
+
+## Hard Boundaries
+
+- No public Metabase exposure.
+- No business DB in Metabase.
+- No Node2 local DB access.
+- No Tencent RDS access.
+- No unrestricted SQL for operators.
+- No Search submission outside Search Channel Queue.
+- No production crawler log read without explicit approval.
+- No Research publish outside CMS Draft Gate.
+- No pSEO until after the controlled operating loop.
+- No claim expansion for RIASEC / Big Five / Career into precise job recommendation, hiring suitability, AI career planning, or career success prediction.
+
+## Closeout Decision
+
+Final decision: `seo_dash_mvp_online_with_ops_entry_verified`
+
+Next task: `RESEARCH-PUBLISH-01`

--- a/backend/tests/Feature/SeoIntel/SeoIntelDashMvpOnlineFinalCloseoutTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelDashMvpOnlineFinalCloseoutTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelDashMvpOnlineFinalCloseoutTest extends TestCase
+{
+    #[Test]
+    public function final_closeout_markdown_and_artifact_exist(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-dash-mvp-online-final-closeout.md'));
+        $this->assertFileExists($this->artifactPath());
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo_dash_mvp_online_with_ops_entry_verified', $artifact['final_decision'] ?? null);
+    }
+
+    #[Test]
+    public function final_closeout_locks_verified_counts_and_metabase_boundary(): void
+    {
+        $artifact = $this->artifact();
+        $counts = $artifact['current_counts'] ?? [];
+        $metabase = $artifact['metabase'] ?? [];
+
+        $this->assertSame(7, $counts['seo_urls'] ?? null);
+        $this->assertSame(7, $counts['seo_url_entities'] ?? null);
+        $this->assertSame(5, $counts['seo_issue_queue'] ?? null);
+        $this->assertSame(10, $counts['dashboard_cards'] ?? null);
+
+        $this->assertTrue((bool) ($metabase['private_only'] ?? false));
+        $this->assertSame('seo_intel', $metabase['datasource'] ?? null);
+        $this->assertSame('seo_intel_metabase_readonly', $metabase['readonly_account'] ?? null);
+        $this->assertTrue((bool) ($metabase['write_deny_verification_passed'] ?? false));
+        $this->assertTrue((bool) ($metabase['public_sharing_disabled'] ?? false));
+        $this->assertTrue((bool) ($metabase['anonymous_links_absent'] ?? false));
+        $this->assertFalse((bool) ($metabase['public_exposure'] ?? true));
+    }
+
+    #[Test]
+    public function ops_portal_route_is_verified_without_metabase_exposure(): void
+    {
+        $opsPortal = $this->artifact()['ops_portal'] ?? [];
+
+        $this->assertTrue((bool) ($opsPortal['ops_seo_route_verified'] ?? false));
+        $this->assertSame('/ops/seo', $opsPortal['route'] ?? null);
+        $this->assertTrue((bool) ($opsPortal['auth_required'] ?? false));
+        $this->assertFalse((bool) ($opsPortal['metabase_exposed'] ?? true));
+        $this->assertFalse((bool) ($opsPortal['iframe_present'] ?? true));
+        $this->assertFalse((bool) ($opsPortal['reverse_proxy_present'] ?? true));
+        $this->assertFalse((bool) ($opsPortal['raw_credentials_exposed'] ?? true));
+    }
+
+    #[Test]
+    public function scheduler_live_search_crawler_research_publish_and_pseo_are_not_completed(): void
+    {
+        $notCompleted = $this->artifact()['not_completed'] ?? [];
+
+        foreach ([
+            'scheduler',
+            'live_search',
+            'crawler_log',
+            'research_publish',
+            'pseo',
+        ] as $blocked) {
+            $this->assertContains($blocked, $notCompleted);
+        }
+    }
+
+    #[Test]
+    public function hard_stops_preserve_security_source_and_claim_boundaries(): void
+    {
+        $hardStops = $this->artifact()['hard_stops'] ?? [];
+
+        foreach ([
+            'no public Metabase',
+            'no business DB in Metabase',
+            'no Node2 local DB',
+            'no unrestricted SQL for operators',
+            'no claim expansion for RIASEC / Big Five / Career',
+        ] as $hardStop) {
+            $this->assertContains($hardStop, $hardStops);
+        }
+    }
+
+    #[Test]
+    public function markdown_records_operating_status_and_next_task(): void
+    {
+        $markdown = strtolower((string) file_get_contents(base_path('docs/seo/seo-dash-mvp-online-final-closeout.md')));
+
+        foreach ([
+            'seo dash mvp is minimally online',
+            '`/ops/seo`: production access verified behind ops auth',
+            'completing phase 5 means the seo main operating loop is ready for full operational iteration',
+            'phase 6 is growth expansion',
+            'final decision: `seo_dash_mvp_online_with_ops_entry_verified`',
+            'next task: `research-publish-01`',
+        ] as $required) {
+            $this->assertStringContainsString($required, $markdown);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $decoded = json_decode((string) file_get_contents($this->artifactPath()), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function artifactPath(): string
+    {
+        return base_path('docs/seo/generated/seo-dash-mvp-online-final-closeout.v1.json');
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T15:42:22Z",
+  "updated_at": "2026-05-19T23:07:40Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6303,7 +6303,7 @@
       "branch": "fix/career-runtime-projection-lookup-latest-selection-1",
       "title": "fix(api): select newest career runtime projection artifact",
       "name": "Fix latest materialized Career runtime projection lookup selection",
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "depends_on": [
         "REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1"
       ],
@@ -12402,6 +12402,94 @@
         }
       ],
       "next_pr": "OPS-PORTAL-SEO-PROD-01"
+    },
+    "OPS-PORTAL-SEO-PROD-03": {
+      "status": "verified",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": null,
+      "base": "main",
+      "title": "/ops/seo production access verification",
+      "depends_on": [
+        "OPS-PORTAL-SEO-05"
+      ],
+      "commit_sha": "5e3e97bb14296f22f105a86f157b16a1208261aa",
+      "pr_url": null,
+      "checks": {
+        "production_verification": {
+          "ops_seo_route_available": "passed",
+          "unauthenticated_redirect_to_ops_login": "passed",
+          "authenticated_ops_admin_rendering": "passed",
+          "admin_redirect_to_ops": "passed",
+          "page_content_boundary": "passed",
+          "no_metabase_iframe": "passed",
+          "no_metabase_reverse_proxy": "passed",
+          "no_public_metabase_url": "passed",
+          "no_raw_db_credentials": "passed",
+          "public_metabase_port_check": "timeout_expected",
+          "public_api_home_sitemap_llms_smoke": "passed",
+          "production_mutation_performed": false
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": null,
+      "local_cleanup_executed": null,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T23:05:07Z",
+          "status": "verified",
+          "summary": "OPS-PORTAL-SEO-PROD-03 verified https://ops.fermatmind.com/ops/seo as an authenticated Ops Portal route with no Metabase iframe, reverse proxy, public Metabase URL, raw credentials, production mutation, or public port 3000 exposure."
+        }
+      ],
+      "next_pr": "SEO-DASH-MVP-ONLINE-FINAL-CLOSEOUT"
+    },
+    "SEO-DASH-MVP-ONLINE-FINAL-CLOSEOUT": {
+      "status": "in_progress",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/seo-dash-mvp-online-final-closeout",
+      "base": "main",
+      "title": "docs(seo-intel): finalize SEO Dash MVP online closeout",
+      "depends_on": [
+        "OPS-PORTAL-SEO-05"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_dash_mvp_online_final_closeout": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {
+          "status": "not_started"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-19T23:05:07Z",
+          "status": "in_progress",
+          "summary": "Started scoped final closeout PR to record SEO Dash MVP and /ops/seo production access as verified. Scope is limited to docs, generated artifact, focused SeoIntel test, and PR-train metadata; no production operation, Metabase operation, runtime code, migration, env, network, scheduler, collector, search submission, crawler log, Research publish, or pSEO change is allowed."
+        },
+        {
+          "at": "2026-05-19T23:07:40Z",
+          "status": "local_checks_passed",
+          "summary": "Focused final closeout test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        }
+      ],
+      "next_pr": "RESEARCH-PUBLISH-01"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T23:07:40Z",
+  "updated_at": "2026-05-19T23:08:58Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -5981,7 +5981,7 @@
       "repo": "fap-api",
       "branch": "fix/career-progressive-live-verification-scaling-1",
       "title": "fix(api): add chunked career live verification scaling",
-      "status": "local_checks_passed",
+      "status": "pr_opened_github_checks_pending",
       "depends_on": [
         "REPAIR-PROGRESSIVE-CLOSEOUT-1"
       ],
@@ -6009,8 +6009,8 @@
         "no deploy",
         "no fap-web change"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "53511fe6c1d5fa3070e22a437a95bc7bc4b32b63",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1498",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -12469,7 +12469,7 @@
           "scope_validation": "passed"
         },
         "github": {
-          "status": "not_started"
+          "status": "pending"
         }
       },
       "failure_reason": null,
@@ -12487,6 +12487,11 @@
           "at": "2026-05-19T23:07:40Z",
           "status": "local_checks_passed",
           "summary": "Focused final closeout test, full SeoIntel filter, route list, Pint, JSON/YAML validation, git diff --check, and allowed-path scope validation passed."
+        },
+        {
+          "at": "2026-05-19T23:08:58Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1498. GitHub checks pending."
         }
       ],
       "next_pr": "RESEARCH-PUBLISH-01"

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6540,6 +6540,61 @@ prs:
     production_approval_required: false
     next_task: OPS-PORTAL-SEO-PROD-01
 
+  - id: SEO-DASH-MVP-ONLINE-FINAL-CLOSEOUT
+    repo: fap-api
+    depends_on:
+      - OPS-PORTAL-SEO-05
+    branch: codex/seo-dash-mvp-online-final-closeout
+    base: main
+    title: "docs(seo-intel): finalize SEO Dash MVP online closeout"
+    name: "SEO Dash MVP online final closeout"
+    train_scope: seo_dash_mvp_final_closeout
+    risk_level: low_docs_generated_tests_no_runtime_activation
+    type: docs/generated/test PR
+    scope:
+      - Record SEO Dash MVP and `/ops/seo` production access as verified.
+      - Freeze current counts, private Metabase read-only datasource boundary, dashboard verification, access policy, completed phases, deferred work, roadmap, and hard stops.
+      - Preserve CMS/backend truth, fap-web deterministic runtime, and SEO Dash/Metabase observation-layer boundaries.
+      - Add a focused SeoIntel contract test.
+    allowed_paths:
+      - backend/docs/seo/seo-dash-mvp-online-final-closeout.md
+      - backend/docs/seo/generated/seo-dash-mvp-online-final-closeout.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelDashMvpOnlineFinalCloseoutTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy, roll back, edit env files, change DNS/CDN/OpenResty/Nginx, open public ports, change ECS security groups, change RDS whitelists, expose Metabase publicly, bind Metabase to 0.0.0.0, add datasources, create dashboards, enable scheduler, run collector writes, connect live search APIs, submit URLs, read production crawler logs, publish Research, or create pSEO.
+      - Change runtime app/services/controllers/routes, migrations, config, deploy files, Metabase runtime files, fap-web runtime files, sitemap behavior, llms behavior, scheduler code, collector code, Research publish content, or pSEO content.
+      - Connect Metabase to business DB, Tencent RDS, Node2 local DB, CMS write tables, or raw operational tables.
+      - Expand RIASEC, Big Five, or Career claims into precise job recommendation, hiring suitability, AI career planning, or career success prediction claims.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelDashMvpOnlineFinalCloseout
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-dash-mvp-online-final-closeout.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    metabase_operation: false
+    network_operation: false
+    research_publish: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: RESEARCH-PUBLISH-01
+
   - id: RIASEC-FULL-CONTENT-PACK-03-PREFLIGHT
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the SEO Dash MVP online final closeout markdown.
- Added a generated machine-readable final closeout artifact.
- Added focused SeoIntel test coverage for counts, Metabase privacy, /ops/seo auth boundary, deferred work, and hard stops.
- Registered the final closeout PR and OPS-PORTAL-SEO-PROD-03 verification in PR-train metadata.

## Validation
- cd backend && php artisan test --filter=SeoIntelDashMvpOnlineFinalCloseout
- cd backend && php artisan test --filter=SeoIntel
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-dash-mvp-online-final-closeout.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No deploy, rollback, env edit, DNS/CDN/OpenResty/Nginx change, public port, security group change, RDS whitelist change, Metabase exposure, datasource/dashboard creation, scheduler, collector write, live search API, URL submission, production crawler log read, Research publish, pSEO, or runtime code change.

Next task: RESEARCH-PUBLISH-01