### PR TITLE
feat(seo-intel): add Research report URL Truth observation

### DIFF
--- a/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
+++ b/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\SeoIntel\Sources;
 
+use App\Models\ResearchReport;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\SeoIntel\UrlTruthInventoryRecord;
 use Illuminate\Support\Carbon;
@@ -16,18 +17,22 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
 
     private ?string $scaleCatalogUnavailableReason = null;
 
+    private bool $researchReportsAttempted = false;
+
+    private bool $researchReportsAvailable = false;
+
+    private ?string $researchReportsUnavailableReason = null;
+
     /**
      * @return list<UrlTruthInventoryRecord>
      */
     public function candidates(): array
     {
-        $records = $this->scaleCatalogCandidates();
-
-        if ($records !== []) {
-            return $records;
-        }
-
-        return $this->configuredBackendAuthorityCandidates();
+        return $this->uniqueRecords([
+            ...$this->scaleCatalogCandidates(),
+            ...$this->researchReportCandidates(),
+            ...$this->configuredBackendAuthorityCandidates(),
+        ]);
     }
 
     public function metadata(): array
@@ -39,6 +44,9 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
             'scale_catalog_attempted' => $this->scaleCatalogAttempted,
             'scale_catalog_available' => $this->scaleCatalogAvailable,
             'scale_catalog_unavailable_reason' => $this->scaleCatalogUnavailableReason,
+            'research_reports_attempted' => $this->researchReportsAttempted,
+            'research_reports_available' => $this->researchReportsAvailable,
+            'research_reports_unavailable_reason' => $this->researchReportsUnavailableReason,
             'configured_backend_authority_canary_available' => $this->configuredBackendAuthorityCandidates() !== [],
             'fetches_public_html' => false,
             'external_api_calls' => false,
@@ -112,6 +120,73 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
     /**
      * @return list<UrlTruthInventoryRecord>
      */
+    private function researchReportCandidates(): array
+    {
+        $this->researchReportsAttempted = true;
+
+        try {
+            $reports = ResearchReport::query()
+                ->publiclyReadable()
+                ->orderBy('locale')
+                ->orderBy('slug')
+                ->limit(max(1, (int) config('seo_intel.url_truth_inventory.research_report_candidate_limit', 100)))
+                ->get();
+        } catch (\Throwable) {
+            $this->researchReportsUnavailableReason = 'research_reports_unavailable';
+
+            return [];
+        }
+
+        $records = [];
+        foreach ($reports as $report) {
+            if (! $report instanceof ResearchReport) {
+                continue;
+            }
+
+            $path = $this->researchCanonicalPath($report);
+            if ($path === null || ! $this->hasRequiredResearchSafetyFields($report)) {
+                continue;
+            }
+
+            $updatedAt = $report->updated_at instanceof Carbon ? $report->updated_at : null;
+
+            $records[] = new UrlTruthInventoryRecord(
+                canonicalUrl: $this->canonicalUrl($path),
+                locale: $report->locale,
+                pageEntityType: ResearchReport::PAGE_ENTITY_TYPE,
+                entityIdOrSlug: $report->slug,
+                sourceAuthority: 'backend_cms',
+                indexabilityState: 'indexable',
+                lastmodAt: $updatedAt,
+                lastmodSource: 'research_reports.updated_at',
+                cluster: 'research',
+                entitySource: 'research_reports',
+                authorityStatus: 'published_approved',
+                sourceUpdatedAt: $updatedAt,
+                metadata: [
+                    'source_table_hash' => hash('sha256', 'research_reports'),
+                    'canonical_path_hash' => hash('sha256', $path),
+                    'research_type_hash' => hash('sha256', (string) $report->research_type),
+                ],
+                attributes: [
+                    'source_authority' => 'backend_cms',
+                    'claim_safe' => true,
+                    'research_type_hash' => hash('sha256', (string) $report->research_type),
+                ],
+            );
+        }
+
+        $this->researchReportsAvailable = $records !== [];
+        if (! $this->researchReportsAvailable) {
+            $this->researchReportsUnavailableReason = 'research_reports_empty_or_ineligible';
+        }
+
+        return $records;
+    }
+
+    /**
+     * @return list<UrlTruthInventoryRecord>
+     */
     private function configuredBackendAuthorityCandidates(): array
     {
         $records = [];
@@ -156,6 +231,74 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
         }
 
         return $records;
+    }
+
+    private function researchCanonicalPath(ResearchReport $report): ?string
+    {
+        $slug = trim((string) $report->slug);
+        if ($slug === '' || str_contains($slug, 'turnover-rate-report')) {
+            return null;
+        }
+
+        $canonicalPath = trim((string) $report->canonical_path);
+        if ($canonicalPath !== '') {
+            if (! $this->isSafeResearchRoutePath($canonicalPath, $slug)) {
+                return null;
+            }
+
+            return $canonicalPath;
+        }
+
+        $localeSegment = match ($report->locale) {
+            'zh-CN', 'zh' => 'zh',
+            'en' => 'en',
+            default => null,
+        };
+
+        if ($localeSegment === null) {
+            return null;
+        }
+
+        return '/'.$localeSegment.'/research/'.$slug;
+    }
+
+    private function isSafeResearchRoutePath(string $path, string $slug): bool
+    {
+        $normalized = '/'.ltrim($path, '/');
+
+        return (bool) preg_match('#^/(en|zh)/research/'.preg_quote($slug, '#').'$#', $normalized)
+            && ! str_contains($normalized, '/articles/')
+            && ! str_contains($normalized, '/reports/')
+            && ! str_contains($normalized, 'turnover-rate-report');
+    }
+
+    private function hasRequiredResearchSafetyFields(ResearchReport $report): bool
+    {
+        if (
+            trim((string) $report->methodology) === ''
+            || trim((string) $report->sample_disclaimer) === ''
+            || trim((string) $report->claim_boundary) === ''
+        ) {
+            return false;
+        }
+
+        return is_array($report->references) && $report->references !== [];
+    }
+
+    /**
+     * @param  list<UrlTruthInventoryRecord>  $records
+     * @return list<UrlTruthInventoryRecord>
+     */
+    private function uniqueRecords(array $records): array
+    {
+        $unique = [];
+
+        foreach ($records as $record) {
+            $key = $record->locale.'|'.$record->canonicalUrlHash();
+            $unique[$key] ??= $record;
+        }
+
+        return array_values($unique);
     }
 
     private function canonicalUrl(string $path): string

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -30,6 +30,7 @@ return [
         'canary_default_limit' => 10,
         'canary_max_limit' => 50,
         'write_requires_bound' => true,
+        'research_report_candidate_limit' => 100,
         'source_authority' => 'backend_sitemap_source',
         'allowed_page_entity_types' => [
             'home',
@@ -43,6 +44,7 @@ return [
             'methodology',
             'dataset',
             'report_preview',
+            'research_report',
             'landing_page',
         ],
         'forbidden_page_entity_types' => [
@@ -61,6 +63,7 @@ return [
             'cms_personality',
             'cms_career_job',
             'cms_career_recommendation',
+            'backend_cms',
             'scale_catalog',
             'backend_public_surface',
         ],

--- a/backend/docs/seo/generated/research-url-truth-observation.v1.json
+++ b/backend/docs/seo/generated/research-url-truth-observation.v1.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "research-url-truth-observation.v1",
+  "task": "RESEARCH-PUBLISH-02-FIX",
+  "collector": "url_truth_inventory",
+  "page_entity_type": "research_report",
+  "source_authority_allowlist": [
+    "backend_cms"
+  ],
+  "eligible_states": [
+    "status_published",
+    "review_state_approved",
+    "is_public_true",
+    "is_indexable_true",
+    "published_at_now_or_past",
+    "canonical_research_route",
+    "methodology_present",
+    "sample_disclaimer_present",
+    "claim_boundary_present",
+    "references_present"
+  ],
+  "forbidden_states": [
+    "draft",
+    "unpublished",
+    "private",
+    "noindex",
+    "unapproved",
+    "claim_unsafe",
+    "missing_methodology",
+    "missing_sample_disclaimer",
+    "missing_claim_boundary",
+    "missing_references",
+    "stale_turnover_rate_slug",
+    "articles_route",
+    "reports_route",
+    "frontend_fallback",
+    "static_sitemap_fallback",
+    "static_llms_fallback",
+    "node2_local_source",
+    "node2_local_db",
+    "production_crawler_logs"
+  ],
+  "target_tables": [
+    "seo_urls",
+    "seo_url_entities"
+  ],
+  "no_external_api": true,
+  "no_search_submission": true,
+  "no_crawler_log_read": true,
+  "no_scheduler_activation": true,
+  "no_sitemap_change": true,
+  "no_llms_change": true,
+  "no_metabase_change": true,
+  "write_boundary": {
+    "dry_run_default": true,
+    "bounded_write_required": true,
+    "allowed_write_tables": [
+      "seo_urls",
+      "seo_url_entities"
+    ]
+  },
+  "next_task": "RESEARCH-PUBLISH-02-RERUN"
+}

--- a/backend/docs/seo/research-url-truth-observation.md
+++ b/backend/docs/seo/research-url-truth-observation.md
@@ -1,0 +1,69 @@
+# Research URL Truth Observation
+
+## Purpose
+
+`RESEARCH-PUBLISH-02-FIX` adds backend/CMS Research report candidates to the disabled-by-default `url_truth_inventory` collector so published Research URLs can be observed by SEO Dash after a controlled publish.
+
+This PR does not publish Research content, submit URLs, run production collector writes, enable scheduler, read crawler logs, deploy, or change sitemap/llms behavior.
+
+## Candidate Source
+
+Research candidates are sourced only from backend/CMS `research_reports` records.
+
+Eligible records must be:
+
+- `status = published`
+- `review_state = approved`
+- `is_public = true`
+- `is_indexable = true`
+- published now or earlier
+- canonical Research route family: `/en/research/{slug}` or `/zh/research/{slug}`
+- methodology present
+- sample disclaimer present
+- claim boundary present
+- references present
+
+The emitted URL Truth record uses:
+
+- `page_entity_type = research_report`
+- `source_authority = backend_cms`
+- `indexability_state = indexable`
+- `entity_source = research_reports`
+- target tables: `seo_urls`, `seo_url_entities`
+
+## Safety Gates
+
+The source skips:
+
+- drafts
+- unpublished records
+- private records
+- noindex records
+- unapproved or claim-unsafe records
+- missing methodology, sample disclaimer, claim boundary, or references
+- missing or stale slugs
+- the stale `turnover-rate-report` slug
+- `/articles` paths
+- `/reports` paths
+- frontend fallback
+- static sitemap fallback
+- static llms fallback
+- Node2 local sources
+
+The collector remains dry-run by default and bounded writes still require `--limit` or `--canary` with write enablement explicitly set by the operator.
+
+## Non-goals
+
+- No Research content publish.
+- No CMS record creation or mutation.
+- No production collector write.
+- No scheduler activation.
+- No GSC, Baidu, IndexNow, 360, Sogou, or Shenma live call.
+- No crawler log read.
+- No sitemap or llms behavior change.
+- No Metabase change.
+- No deployment.
+
+## Next Task
+
+Next task: `RESEARCH-PUBLISH-02-RERUN`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelResearchUrlTruthObservationTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelResearchUrlTruthObservationTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ResearchReport;
+use App\Services\SeoIntel\SeoIntelCollectorManager;
+use App\Services\SeoIntel\Sources\BackendAuthorityUrlTruthSource;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelResearchUrlTruthObservationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function published_claim_safe_research_report_emits_url_truth_candidate(): void
+    {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
+        $this->createResearchReport([
+            'slug' => 'mbti-personality-types-salary-turnover-report',
+            'locale' => 'en',
+            'canonical_path' => '/en/research/mbti-personality-types-salary-turnover-report',
+        ]);
+
+        $source = new BackendAuthorityUrlTruthSource;
+        $records = array_values(array_filter(
+            $source->candidates(),
+            static fn ($record): bool => $record->pageEntityType === ResearchReport::PAGE_ENTITY_TYPE
+        ));
+
+        $this->assertCount(1, $records);
+
+        $record = $records[0];
+
+        $this->assertSame('https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report', $record->canonicalUrl);
+        $this->assertSame('en', $record->locale);
+        $this->assertSame('research_report', $record->pageEntityType);
+        $this->assertSame('mbti-personality-types-salary-turnover-report', $record->entityIdOrSlug);
+        $this->assertSame('backend_cms', $record->sourceAuthority);
+        $this->assertSame('indexable', $record->indexabilityState);
+        $this->assertSame('research_reports', $record->entitySource);
+        $this->assertSame('published_approved', $record->authorityStatus);
+        $this->assertFalse($record->isPrivateFlow);
+        $this->assertSame(true, $record->attributes['claim_safe'] ?? null);
+
+        $metadata = $source->metadata();
+        $this->assertTrue((bool) ($metadata['research_reports_attempted'] ?? false));
+        $this->assertTrue((bool) ($metadata['research_reports_available'] ?? false));
+        $this->assertFalse((bool) ($metadata['external_api_calls'] ?? true));
+        $this->assertFalse((bool) ($metadata['frontend_fallback_data_source'] ?? true));
+        $this->assertFalse((bool) ($metadata['node2_local_db_data_source'] ?? true));
+    }
+
+    #[Test]
+    public function research_url_truth_skips_draft_private_noindex_unapproved_and_unsafe_routes(): void
+    {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
+        $this->createResearchReport([
+            'slug' => 'valid-research-report',
+            'locale' => 'zh-CN',
+            'canonical_path' => '/zh/research/valid-research-report',
+        ]);
+        $this->createResearchReport(['slug' => 'draft-report', 'status' => ResearchReport::STATUS_DRAFT]);
+        $this->createResearchReport(['slug' => 'private-report', 'is_public' => false]);
+        $this->createResearchReport(['slug' => 'noindex-report', 'is_indexable' => false]);
+        $this->createResearchReport(['slug' => 'claim-unsafe-report', 'review_state' => ResearchReport::REVIEW_CLAIM]);
+        $this->createResearchReport(['slug' => 'mbti-personality-types-salary-turnover-rate-report']);
+        $this->createResearchReport([
+            'slug' => 'article-route-report',
+            'canonical_path' => '/en/articles/article-route-report',
+        ]);
+        $this->createResearchReport([
+            'slug' => 'missing-methodology-report',
+            'methodology' => '',
+        ]);
+
+        $result = (new SeoIntelCollectorManager)->collect('url_truth_inventory', [
+            'dry_run' => true,
+            'limit' => 20,
+            'page_type' => ResearchReport::PAGE_ENTITY_TYPE,
+        ]);
+
+        $this->assertSame('success', $result->status);
+        $this->assertTrue($result->dryRun);
+        $this->assertFalse($result->writesAttempted);
+        $this->assertFalse($result->writesCommitted);
+        $this->assertFalse($result->externalCallsAttempted);
+        $this->assertSame(1, $result->metadata['planned_url_count'] ?? null);
+        $this->assertSame(1, $result->metadata['planned_entity_count'] ?? null);
+        $this->assertSame(['seo_urls', 'seo_url_entities'], $result->metadata['target_tables'] ?? null);
+        $this->assertSame(['backend_cms' => 1], $result->metadata['source_authority_breakdown'] ?? null);
+        $this->assertSame('research_report', $result->metadata['page_type_filter'] ?? null);
+        $this->assertFalse((bool) ($result->metadata['external_api_calls'] ?? true));
+        $this->assertFalse((bool) ($result->metadata['search_url_submission'] ?? true));
+        $this->assertFalse((bool) ($result->metadata['source']['node2_local_db_data_source'] ?? true));
+    }
+
+    #[Test]
+    public function command_page_type_filter_observes_research_report_without_writes(): void
+    {
+        $this->createResearchReport([
+            'slug' => 'mbti-personality-types-salary-turnover-report',
+            'locale' => 'en',
+            'canonical_path' => '/en/research/mbti-personality-types-salary-turnover-report',
+        ]);
+
+        $exitCode = Artisan::call('seo-intel:collect', [
+            '--collector' => 'url_truth_inventory',
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--limit' => 20,
+            '--page-type' => 'research_report',
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('url_truth_inventory', $decoded['collector'] ?? null);
+        $this->assertTrue((bool) ($decoded['dry_run'] ?? false));
+        $this->assertFalse((bool) ($decoded['writes_committed'] ?? true));
+        $this->assertSame('research_report', data_get($decoded, 'metadata.page_type_filter'));
+        $this->assertGreaterThan(0, (int) data_get($decoded, 'metadata.planned_url_count'));
+        $this->assertSame(['seo_urls', 'seo_url_entities'], data_get($decoded, 'metadata.target_tables'));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.source.external_api_calls', true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.source.static_llms_fallback_graph_truth', true));
+    }
+
+    #[Test]
+    public function generated_artifact_locks_research_url_truth_observation_boundary(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('research-url-truth-observation.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('url_truth_inventory', $artifact['collector'] ?? null);
+        $this->assertSame('research_report', $artifact['page_entity_type'] ?? null);
+        $this->assertContains('backend_cms', $artifact['source_authority_allowlist'] ?? []);
+        $this->assertSame(['seo_urls', 'seo_url_entities'], $artifact['target_tables'] ?? null);
+        $this->assertTrue((bool) ($artifact['no_external_api'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_search_submission'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_crawler_log_read'] ?? false));
+        $this->assertSame('RESEARCH-PUBLISH-02-RERUN', $artifact['next_task'] ?? null);
+
+        foreach ([
+            'draft',
+            'private',
+            'noindex',
+            'unapproved',
+            'claim_unsafe',
+            'frontend_fallback',
+            'static_sitemap_fallback',
+            'static_llms_fallback',
+            'node2_local_source',
+            'articles_route',
+            'reports_route',
+        ] as $forbidden) {
+            $this->assertContains($forbidden, $artifact['forbidden_states'] ?? []);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createResearchReport(array $overrides = []): ResearchReport
+    {
+        $slug = (string) ($overrides['slug'] ?? 'safe-research-report');
+        $locale = (string) ($overrides['locale'] ?? 'en');
+        $localeSegment = $locale === 'zh-CN' ? 'zh' : $locale;
+
+        return ResearchReport::query()->create($overrides + [
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => 'Safe Research Report',
+            'executive_summary' => 'Directional research summary.',
+            'body_md' => 'Research body.',
+            'research_type' => 'salary_turnover',
+            'methodology' => 'Modeled index methodology.',
+            'sample_disclaimer' => 'Exploratory, non-diagnostic, not hiring advice.',
+            'claim_boundary' => 'No salary guarantee or individual prediction.',
+            'author_name' => 'FermatMind Research',
+            'reviewer_name' => 'FermatMind Review',
+            'references' => [['title' => 'Reference', 'url' => 'https://example.com/reference']],
+            'downloadable_asset_placeholder' => 'Dataset schema blocked for first publish.',
+            'status' => ResearchReport::STATUS_PUBLISHED,
+            'review_state' => ResearchReport::REVIEW_APPROVED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'last_reviewed_at' => now()->subDay(),
+            'published_at' => now()->subHour(),
+            'seo_title' => 'Safe Research Report',
+            'seo_description' => 'Safe Research Report description.',
+            'canonical_path' => '/'.$localeSegment.'/research/'.$slug,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/research-url-truth-observation.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-20T01:03:00Z",
+  "updated_at": "2026-05-20T01:06:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -12497,7 +12497,7 @@
       "next_pr": "RESEARCH-PUBLISH-01"
     },
     "RESEARCH-PUBLISH-02-FIX": {
-      "status": "in_progress",
+      "status": "pr_opened_github_checks_pending",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/research-publish-02-fix-url-truth-research-report",
@@ -12506,8 +12506,8 @@
       "depends_on": [
         "RESEARCH-PUBLISH-READINESS-00"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "85980e6304aa941f16b019474c7b669f717debf3",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1504",
       "checks": {
         "local": {
           "php_artisan_test_filter_seo_intel_research_url_truth_observation": "passed",
@@ -12540,6 +12540,11 @@
           "at": "2026-05-20T01:03:00Z",
           "status": "local_checks_passed",
           "summary": "Focused Research URL Truth test, full SeoIntel filter, route list, Pint, JSON/YAML validation, dry-run collector commands, git diff checks, and allowed-path scope validation passed. The clean local worktree has no published Research DB rows, so the page-type dry-run returned zero locally while the fixture test proves nonzero behavior when eligible Research records exist."
+        },
+        {
+          "at": "2026-05-20T01:06:00Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1504 for RESEARCH-PUBLISH-02-FIX. GitHub checks pending."
         }
       ],
       "next_pr": "RESEARCH-PUBLISH-02-RERUN"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-19T23:08:58Z",
+  "updated_at": "2026-05-20T01:03:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6552,7 +6552,7 @@
       "branch": "codex/repair-explicit-rollout-batch-ledger-authority-1",
       "title": "fix(api): honor explicit rollout batch ledger authority",
       "name": "Repair explicit rollout batch ledger authority after 800 apply verification",
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "depends_on": [
         "REPAIR-PROGRESSIVE-READINESS-SOFTWARE-MANUAL-HOLD-EXCLUSION-1"
       ],
@@ -12495,6 +12495,54 @@
         }
       ],
       "next_pr": "RESEARCH-PUBLISH-01"
+    },
+    "RESEARCH-PUBLISH-02-FIX": {
+      "status": "in_progress",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/research-publish-02-fix-url-truth-research-report",
+      "base": "main",
+      "title": "feat(seo-intel): add Research report URL Truth observation",
+      "depends_on": [
+        "RESEARCH-PUBLISH-READINESS-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_research_url_truth_observation": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "url_truth_inventory_dry_run_limit_20": "passed",
+          "url_truth_inventory_dry_run_research_report_filter": "passed_no_local_research_rows",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed"
+        },
+        "github": {
+          "status": "pending"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-20T00:40:00Z",
+          "status": "in_progress",
+          "summary": "Started scoped URL Truth observation fix so url_truth_inventory can emit published, approved, public, indexable, claim-safe backend/CMS Research report candidates. No Research publish, collector production write, scheduler, search submission, crawler log read, deploy, env edit, fap-web change, or Metabase change is allowed."
+        },
+        {
+          "at": "2026-05-20T01:03:00Z",
+          "status": "local_checks_passed",
+          "summary": "Focused Research URL Truth test, full SeoIntel filter, route list, Pint, JSON/YAML validation, dry-run collector commands, git diff checks, and allowed-path scope validation passed. The clean local worktree has no published Research DB rows, so the page-type dry-run returned zero locally while the fixture test proves nonzero behavior when eligible Research records exist."
+        }
+      ],
+      "next_pr": "RESEARCH-PUBLISH-02-RERUN"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6273,6 +6273,61 @@ prs:
     production_approval_required: false
     next_task: SEO-DASH-MVP-ONLINE-SUMMARY closeout report / next Research publish operation planning
 
+  - id: RESEARCH-PUBLISH-02-FIX
+    repo: fap-api
+    depends_on:
+      - RESEARCH-PUBLISH-READINESS-00
+    branch: codex/research-publish-02-fix-url-truth-research-report
+    base: main
+    title: "feat(seo-intel): add Research report URL Truth observation"
+    name: "Research report URL Truth observation source"
+    train_scope: research_publish_observation_fix
+    risk_level: backend_observation_source_no_publish_no_write
+    type: backend code/docs/tests PR
+    scope:
+      - Add Research Report candidates to the disabled-by-default URL Truth inventory collector.
+      - Include only backend/CMS Research records that are published, approved, public, indexable, claim-safe, and canonical under `/research`.
+      - Keep target tables limited to `seo_urls` and `seo_url_entities`.
+      - Keep dry-run/no-write behavior as the default and preserve bounded write requirements.
+    allowed_paths:
+      - backend/config/seo_intel.php
+      - backend/app/Services/SeoIntel/**
+      - backend/tests/Feature/SeoIntel/**Research*Test.php
+      - backend/tests/Feature/SeoIntel/**UrlTruth*Test.php
+      - backend/docs/seo/research-url-truth-observation.md
+      - backend/docs/seo/generated/research-url-truth-observation.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish Research content, create CMS records, change published Research records, run production collector writes, enable scheduler, submit URLs, connect live search APIs, read production crawler logs, deploy, edit env, or modify fap-web.
+      - Change sitemap or llms behavior.
+      - Use frontend fallback, static sitemap fallback, static llms fallback, Node2 local sources, business DB, Tencent RDS, or Metabase changes as URL Truth authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --limit=20
+      - cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --limit=20 --page-type=research_report
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/research-url-truth-observation.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    research_publish: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: RESEARCH-PUBLISH-02-RERUN
+
   - id: OPS-PORTAL-SEO-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added backend/CMS Research report candidates to `url_truth_inventory` through `BackendAuthorityUrlTruthSource`.
- Added `research_report` and `backend_cms` to the SEO Intel URL Truth allowlists.
- Added focused tests proving published/approved/public/indexable Research reports are observed, while draft/private/noindex/unapproved/unsafe routes are skipped.
- Added docs, generated artifact, and PR-train metadata for `RESEARCH-PUBLISH-02-FIX`.

## Why RESEARCH-PUBLISH-02 was blocked
- The controlled publish passed, but `url_truth_inventory --page-type=research_report` planned zero candidates because the collector did not emit Research report records from backend/CMS authority.

## Research report gates
- Includes only `status=published`, `review_state=approved`, `is_public=true`, `is_indexable=true`, published-now-or-earlier records.
- Requires `/en/research/{slug}` or `/zh/research/{slug}` route shape, methodology, sample disclaimer, claim boundary, and references.
- Skips stale `turnover-rate-report` slugs, `/articles`, `/reports`, frontend fallback, static sitemap/llms fallback, Node2 sources, private/noindex/unapproved states, and missing safety fields.
- Target tables remain only `seo_urls` and `seo_url_entities`.

## Validation commands
- `cd backend && php artisan test --filter=SeoIntelResearchUrlTruthObservation`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --limit=20`
- `cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --limit=20 --page-type=research_report`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/research-url-truth-observation.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check && git diff --cached --check`

Note: the clean local worktree has no local published Research DB rows, so the live dry-run with `--page-type=research_report` returns zero locally. The new fixture test proves nonzero behavior when eligible published Research records exist.

## What was not done
- No Research publish or CMS record mutation.
- No search submission or live GSC/Baidu/IndexNow call.
- No production collector write.
- No scheduler activation.
- No crawler log read.
- No deployment.
- No Metabase changes.
- No fap-web changes.
