### PR TITLE
ci(actions): upgrade workflows to Node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Guard no committed secrets (H-02)
         run: bash backend/scripts/ci/guard_no_committed_secrets.sh
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -68,12 +68,12 @@ jobs:
             mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3, pdo_mysql, redis
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Cache Composer
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             backend/vendor
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload verify_mbti artifacts (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci_verify_mbti_${{ matrix.mode }}
           path: backend/artifacts/verify_mbti

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -84,7 +84,7 @@ jobs:
             mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3, pdo_mysql, redis
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -135,7 +135,7 @@ jobs:
           echo "AUTH_GUEST_CHECK_URL=$AUTH_GUEST_CHECK_URL"
 
       - name: Cache Composer
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             backend/vendor
@@ -228,7 +228,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -309,7 +309,7 @@ jobs:
 
       - name: Set up SSH
         if: steps.stale_guard.outputs.skip_deploy != 'true'
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
## What changed
- Upgrade GitHub JavaScript actions to versions that declare Node 24 runtimes.
- Keep project build Node pinned to `node-version: '20'` for a separate follow-up PR.

Updated actions:
- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-node@v4` -> `actions/setup-node@v6`
- `actions/cache@v4` -> `actions/cache@v5`
- `actions/upload-artifact@v4` -> `actions/upload-artifact@v7`
- `actions/setup-python@v5` -> `actions/setup-python@v6`
- `webfactory/ssh-agent@v0.9.0` -> `webfactory/ssh-agent@v0.10.0`

## Why
GitHub Actions is deprecating Node 20 for JavaScript action runtimes. These workflow action upgrades move CI, code scanning, and deploy orchestration onto action versions that run on Node 24, reducing deprecation noise and avoiding the upcoming default runtime transition risk.

## Validation commands
```bash
ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "parsed #{f}" }'
rg -n "uses: actions/checkout@v4|uses: actions/setup-node@v4|uses: actions/cache@v4|uses: actions/upload-artifact@v4|uses: actions/setup-python@v5|uses: webfactory/ssh-agent@v0.9.0" .github/workflows || true
git diff --check -- .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/deploy.yml
```

## Intentionally deferred
- Project build Node remains `node-version: '20'`; moving backend Vite/Tailwind builds to Node 24 should be a separate PR with build validation.
- No deploy was triggered by this branch.

## Repository rule impact
This changes CI/deploy workflow dependencies only. It does not affect CMS authority, SEO/GEO enumeration, API contracts, or application runtime behavior.