### PR TITLE
RIASEC-FULL-CONTENT-PACK-13-BE: Backend full content fixture matrix and forbidden claim freeze

### DIFF
--- a/backend/docs/riasec/full-content-fixture-freeze-pack-13-be.md
+++ b/backend/docs/riasec/full-content-fixture-freeze-pack-13-be.md
@@ -1,0 +1,45 @@
+# RIASEC Full Content Fixture Freeze — PACK-13-BE
+
+## Scope
+
+This PR freezes backend verification coverage for the RIASEC full content pack after backend-authoritative imports for:
+
+- pair blend
+- top3 chain
+- activity/task examples
+- occupation examples boundary
+- 140Q narrative
+- low quality / confidence / near-tie
+- aspirations / disagree path
+- feedback overlay safe payload bridge
+- lifecycle copy
+
+No new runtime content authority is introduced here. This PR is a backend verification freeze only.
+
+## Frozen backend coverage
+
+- 15 pair blend slots remain backend-authored and fail closed without frontend fallback.
+- 20 unordered top3 chain slots remain backend-authored and fail closed without frontend fallback.
+- Activity/task examples remain examples-only and deterministic.
+- Occupation examples remain activity-linked examples only, not matches.
+- Aspirations and disagree content remain exploration-only and non-mutating.
+- Feedback Action Lab / Next Exploration Nodes remain safe static payloads with no score/code/snapshot mutation.
+- Lifecycle copy remains public-safe and snapshot-bound.
+- Module visibility remains backend-owned across clear, blended, broad, near-tie, low-quality, and 140Q states.
+
+## Explicit boundaries frozen by test
+
+- no career match / occupation match / job fit / ranking / success prediction
+- no ability proof / skill proof
+- no `140Q more accurate`
+- no raw score delta or `60Q wrong`
+- no feedback / aspirations mutation of measured Holland Code or scores
+- no report snapshot mutation
+- no raw feedback or internal snapshot id public exposure
+- no frontend fallback copy
+
+## Sidecars
+
+- `PACK-10-FE`: deferred unless Action Lab / Next Exploration Nodes must become visible frontend modules
+- `PACK-11-FE`: deferred unless lifecycle copy needs explicit frontend route consumption beyond current fail-closed behavior
+- `PACK-14`: separate smoke acceptance / release freeze work; not started here

--- a/backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php
@@ -1,0 +1,401 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Models\Result;
+use App\Services\Riasec\RiasecActivityExplorerService;
+use App\Services\Riasec\RiasecDeepCopySlotRegistry;
+use App\Services\Riasec\RiasecExplorationFeedbackOverlayService;
+use App\Services\Riasec\RiasecLifecycleCopyService;
+use App\Services\Riasec\RiasecReportModuleSelector;
+use Tests\TestCase;
+
+final class RiasecFullContentFixtureMatrixTest extends TestCase
+{
+    private const FORBIDDEN_USER_CLAIMS = [
+        'career match',
+        'occupation match',
+        'job fit',
+        'fit score',
+        'success prediction',
+        'success probability',
+        'recommended career',
+        'best career',
+        'career recommendation',
+        'occupation ranking',
+        'hiring suitability',
+        'ability proof',
+        'skill inference',
+        '140Q more accurate',
+        'raw score delta',
+        '60Q wrong',
+        '职业匹配',
+        '岗位匹配',
+        '匹配度',
+        '适合度',
+        '最适合',
+        '推荐职业',
+        '职业推荐',
+        '岗位胜任',
+        '成功概率',
+        '职业成功',
+        '更准确',
+        '更准',
+        '140题更准确',
+        '60题错了',
+        '推翻',
+        '最终答案',
+        '你就是',
+        '天生适合',
+        '能力证明',
+        '技能证明',
+        '招聘筛选',
+        '录取依据',
+        '晋升依据',
+        '淘汰依据',
+    ];
+
+    public function test_backend_full_content_matrix_counts_and_boundaries_are_frozen(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $activityExplorer = new RiasecActivityExplorerService;
+        $lifecycle = new RiasecLifecycleCopyService;
+        $overlay = $this->overlay('IAS', 'riasec_60', 'riasec_60_likert5_activity_sum_space.v1');
+
+        $pairSlots = array_values(array_filter(
+            $registry->pairBlendSlots(),
+            static fn (array $slot): bool => ($slot['content_version'] ?? null) === 'riasec_pair_blend_15_pairs_v1.zh-CN'
+        ));
+        $top3Slots = array_values(array_filter(
+            $registry->top3ChainSlots(),
+            static fn (array $slot): bool => ($slot['content_version'] ?? null) === 'riasec_top3_code_chain_strategy_v1.zh-CN'
+        ));
+        $aspirationSlots = array_values(array_filter(
+            $registry->aspirationsSlots(),
+            static fn (array $slot): bool => ($slot['content_version'] ?? null) === 'aspirations_calibration_v1.zh-CN'
+        ));
+        $disagreeSlots = array_values(array_filter(
+            $registry->disagreePathSlots(),
+            static fn (array $slot): bool => ($slot['content_version'] ?? null) === 'disagree_path_v1.zh-CN'
+        ));
+
+        $this->assertCount(15, $pairSlots);
+        $this->assertCount(20, $top3Slots);
+        $this->assertCount(70, $aspirationSlots);
+        $this->assertCount(45, $disagreeSlots);
+
+        foreach ([$pairSlots, $top3Slots, $aspirationSlots, $disagreeSlots] as $slotGroup) {
+            foreach ($slotGroup as $slot) {
+                $this->assertSame('authored', $slot['content_status']);
+                $this->assertFalse((bool) ($slot['frontend_fallback_allowed'] ?? true));
+            }
+        }
+
+        $ias = $activityExplorer->build('IAS', 'zh-CN');
+        $this->assertSame('available', data_get($ias, 'code_activity_pack.status'));
+        $this->assertCount(9, (array) data_get($ias, 'code_activity_pack.activities'));
+        $this->assertSame(
+            18,
+            array_sum(array_map(
+                static fn (array $activity): int => count((array) ($activity['occupation_examples'] ?? [])),
+                (array) data_get($ias, 'code_activity_pack.activities', [])
+            ))
+        );
+        $this->assertFalse((bool) data_get($ias, 'boundary.fit_score_allowed'));
+        $this->assertFalse((bool) data_get($ias, 'boundary.success_prediction_allowed'));
+
+        $lifecycleContract = $lifecycle->lifecycleCopyContract(true);
+        $this->assertSame('riasec.lifecycle_copy.v1', $lifecycleContract['schema_version']);
+        $this->assertCount(7, (array) $lifecycleContract['surfaces']);
+        $this->assertCount(20, (array) $lifecycleContract['faq_items']);
+        $this->assertFalse($lifecycleContract['frontend_fallback_allowed']);
+        $this->assertFalse($lifecycleContract['measured_payload_mutation_allowed']);
+        $this->assertFalse($lifecycleContract['report_snapshot_mutation_allowed']);
+        $this->assertFalse($lifecycleContract['raw_feedback_public_exposure_allowed']);
+        $this->assertFalse($lifecycleContract['internal_snapshot_id_public_exposure_allowed']);
+
+        $this->assertCount(6, $lifecycle->technicalNoteSummarySections());
+        $this->assertCount(8, $lifecycle->professionalMethodBoundarySections());
+
+        $this->assertSame('available_static_safe_bridge', data_get($overlay, 'action_lab_v1.status'));
+        $this->assertCount(18, (array) data_get($overlay, 'action_lab_v1.starter_actions'));
+        $this->assertSame('available_static_safe_bridge', data_get($overlay, 'next_exploration_nodes_v1.status'));
+        $this->assertCount(6, (array) data_get($overlay, 'next_exploration_nodes_v1.nodes'));
+        $this->assertFalse((bool) data_get($overlay, 'surface_policy.share_pdf_exposure_allowed'));
+        $this->assertFalse((bool) data_get($overlay, 'surface_policy.raw_feedback_public_exposure_allowed'));
+        $this->assertFalse((bool) data_get($overlay, 'measured_result_guard.scores_mutation_allowed'));
+        $this->assertFalse((bool) data_get($overlay, 'measured_result_guard.holland_code_mutation_allowed'));
+    }
+
+    public function test_module_visibility_matrix_freezes_clear_blended_broad_near_tie_low_quality_and_140q_states(): void
+    {
+        $selector = new RiasecReportModuleSelector;
+
+        $clear = $selector->build($this->projectionContext('normal', 'clear_code', 'riasec_60'));
+        $this->assertSame('visible', $this->moduleVisibility($clear, 'hero_activity_chain'));
+        $this->assertSame('visible', $this->moduleVisibility($clear, 'pair_blend'));
+        $this->assertSame('collapsed', $this->moduleVisibility($clear, 'occupation_examples'));
+        $this->assertSame('visible', $this->moduleVisibility($clear, '140q_cta'));
+        $this->assertSame('hidden', $this->moduleVisibility($clear, '140q_context_cards'));
+
+        $blended = $selector->build($this->projectionContext('normal', 'blended_code', 'riasec_60'));
+        $this->assertSame('visible', $this->moduleVisibility($blended, 'hero_activity_chain'));
+        $this->assertSame('visible', $this->moduleVisibility($blended, 'pair_blend'));
+        $this->assertSame('collapsed', $this->moduleVisibility($blended, 'occupation_examples'));
+
+        $broad = $selector->build($this->projectionContext('normal', 'broad_profile', 'riasec_60'));
+        $this->assertSame('hidden', $this->moduleVisibility($broad, 'hero_activity_chain'));
+        $this->assertSame('hidden', $this->moduleVisibility($broad, 'occupation_examples'));
+
+        $nearTie = $selector->build($this->projectionContext('normal', 'near_tie', 'riasec_60'));
+        $this->assertSame('collapsed', $this->moduleVisibility($nearTie, 'hero_activity_chain'));
+        $this->assertSame('visible', $this->moduleVisibility($nearTie, 'pair_blend'));
+
+        $lowQuality = $selector->build($this->projectionContext('low_quality', 'low_quality', 'riasec_60'));
+        $this->assertSame('hidden', $this->moduleVisibility($lowQuality, 'pair_blend'));
+        $this->assertSame('hidden', $this->moduleVisibility($lowQuality, 'occupation_examples'));
+        $this->assertSame('collapsed', $this->moduleVisibility($lowQuality, 'share_card'));
+        $this->assertSame('collapsed', $this->moduleVisibility($lowQuality, 'pdf'));
+
+        $enhanced140 = $selector->build($this->projectionContext('normal', 'clear_code', 'riasec_140'));
+        $this->assertSame('hidden', $this->moduleVisibility($enhanced140, '140q_cta'));
+        $this->assertSame('visible', $this->moduleVisibility($enhanced140, '140q_context_cards'));
+    }
+
+    public function test_backend_full_content_outputs_reject_forbidden_claims_and_public_exposure(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $activityExplorer = new RiasecActivityExplorerService;
+        $lifecycle = new RiasecLifecycleCopyService;
+
+        $payload = [
+            'pairs' => array_values($registry->pairBlendSlots()),
+            'top3' => array_values($registry->top3ChainSlots()),
+            'aspirations' => array_values($registry->aspirationsSlots()),
+            'disagree' => array_values($registry->disagreePathSlots()),
+            'activity_explorer' => [
+                $activityExplorer->build('IAS', 'zh-CN'),
+                $activityExplorer->build('RCE', 'zh-CN'),
+            ],
+            'feedback_overlay' => [
+                $this->overlay('IAS', 'riasec_60', 'riasec_60_likert5_activity_sum_space.v1'),
+                $this->overlay('RIA', 'riasec_140', 'riasec_140_likert5_activity_context_space.v1'),
+            ],
+            'lifecycle' => $lifecycle->lifecycleCopyContract(true),
+            'technical_note_summary' => $lifecycle->technicalNoteSummarySections(),
+            'professional_method_boundary' => $lifecycle->professionalMethodBoundarySections(),
+        ];
+
+        $serialized = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        $hits = [];
+        foreach ($this->visibleRows($payload) as $source => $texts) {
+            foreach ($texts as $text) {
+                foreach (self::FORBIDDEN_USER_CLAIMS as $claim) {
+                    if (! $this->containsTerm($text, $claim)) {
+                        continue;
+                    }
+
+                    if ($this->isNegatedBoundary($text, $claim)) {
+                        continue;
+                    }
+
+                    $hits[] = "{$source}: {$claim} in {$text}";
+                }
+            }
+        }
+
+        $this->assertSame([], $hits, 'Visible backend full-content outputs must keep forbidden claims only in negative boundary contexts.');
+
+        $this->assertStringNotContainsString('"frontend_fallback_allowed":true', $serialized);
+        $this->assertStringNotContainsString('"raw_feedback"', $serialized);
+        $this->assertStringNotContainsString('"snapshot_id"', $serialized);
+        $this->assertStringNotContainsString('"source_url"', $serialized);
+        $this->assertStringNotContainsString('"onet_code"', $serialized);
+        $this->assertStringNotContainsString('"soc_code"', $serialized);
+        $this->assertStringContainsString('content_example_not_registry_match', $serialized);
+        $this->assertStringContainsString('riasec.lifecycle_copy.v1', $serialized);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function projectionContext(string $qualityState, string $profileShape, string $formCode): array
+    {
+        return [
+            'quality' => [
+                'quality_state' => $qualityState,
+            ],
+            'interpretation_state' => [
+                'profile_shape' => $profileShape,
+            ],
+            'form' => [
+                'form_code' => $formCode,
+            ],
+        ];
+    }
+
+    private function moduleVisibility(array $policy, string $moduleKey): ?string
+    {
+        foreach ((array) ($policy['modules'] ?? []) as $module) {
+            if (($module['key'] ?? null) === $moduleKey) {
+                return (string) ($module['visibility'] ?? '');
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function overlay(string $code, string $formCode, string $scoreSpaceVersion): array
+    {
+        return (new RiasecExplorationFeedbackOverlayService)->build(
+            new Result([
+                'scale_code' => 'RIASEC',
+                'type_code' => $code,
+                'result_json' => [
+                    'form_code' => $formCode,
+                    'score_space_version' => $scoreSpaceVersion,
+                ],
+            ]),
+            [
+                'holland_code' => [
+                    'code' => $code,
+                ],
+                'form' => [
+                    'form_code' => $formCode,
+                    'score_space_version' => $scoreSpaceVersion,
+                ],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,list<string>>
+     */
+    private function visibleRows(array $payload): array
+    {
+        $visible = [];
+
+        foreach ((array) ($payload['pairs'] ?? []) as $index => $slot) {
+            $visible['pair '.($index + 1)] = array_values(array_filter([
+                (string) ($slot['pair_label'] ?? ''),
+                (string) ($slot['short_label'] ?? ''),
+                (string) ($slot['chemistry'] ?? ''),
+                (string) ($slot['positive_value'] ?? ''),
+                (string) ($slot['real_world_cost'] ?? ''),
+                (string) ($slot['common_misread'] ?? ''),
+                (string) ($slot['micro_experiment'] ?? ''),
+                (string) ($slot['result_page_teaser'] ?? ''),
+                (string) ($slot['deep_report_extension_hint'] ?? ''),
+                (string) ($slot['user_visible_boundary'] ?? ''),
+            ]));
+        }
+
+        foreach ((array) ($payload['top3'] ?? []) as $index => $slot) {
+            $visible['top3 '.($index + 1)] = array_values(array_filter([
+                (string) ($slot['title'] ?? ''),
+                (string) ($slot['primary_activity_chain'] ?? ''),
+                (string) ($slot['secondary_support_line'] ?? ''),
+                (string) ($slot['tertiary_stabilizer'] ?? ''),
+                (string) ($slot['likely_tension'] ?? ''),
+                (string) ($slot['first_experiment'] ?? ''),
+                (string) ($slot['free_page_teaser'] ?? ''),
+                (string) ($slot['deep_report_extension'] ?? ''),
+                (string) ($slot['user_visible_boundary'] ?? ''),
+            ]));
+        }
+
+        foreach ((array) ($payload['aspirations'] ?? []) as $index => $slot) {
+            $visible['aspiration '.($index + 1)] = array_values(array_filter([
+                (string) ($slot['title'] ?? ''),
+                (string) ($slot['summary'] ?? ''),
+                (string) ($slot['body'] ?? ''),
+            ]));
+        }
+
+        foreach ((array) ($payload['disagree'] ?? []) as $index => $slot) {
+            $visible['disagree '.($index + 1)] = array_values(array_filter([
+                (string) ($slot['title'] ?? ''),
+                (string) ($slot['summary'] ?? ''),
+                (string) ($slot['body'] ?? ''),
+            ]));
+        }
+
+        foreach ((array) data_get($payload, 'activity_explorer', []) as $index => $explorer) {
+            foreach ((array) data_get($explorer, 'code_activity_pack.activities', []) as $activityIndex => $activity) {
+                $visible["activity {$index}:".($activityIndex + 1)] = array_values(array_filter([
+                    (string) ($activity['activity_name'] ?? ''),
+                    (string) ($activity['task_example'] ?? ''),
+                    (string) ($activity['validation_question'] ?? ''),
+                    (string) ($activity['expected_observation'] ?? ''),
+                    (string) ($activity['boundary'] ?? ''),
+                    (string) ($activity['not_a_recommendation'] ?? ''),
+                ]));
+
+                foreach ((array) ($activity['occupation_examples'] ?? []) as $occupationIndex => $example) {
+                    $visible["occupation {$index}:".($occupationIndex + 1)] = array_values(array_filter([
+                        (string) ($example['occupation_example'] ?? ''),
+                        (string) ($example['display_label'] ?? ''),
+                        (string) ($example['user_visible_boundary'] ?? ''),
+                        (string) ($example['education_boundary'] ?? ''),
+                        (string) ($example['skill_boundary'] ?? ''),
+                        (string) ($example['qualification_boundary'] ?? ''),
+                    ]));
+                }
+            }
+        }
+
+        foreach ((array) data_get($payload, 'feedback_overlay', []) as $index => $overlay) {
+            foreach ((array) data_get($overlay, 'action_lab_v1.starter_actions', []) as $actionIndex => $action) {
+                $visible["action_lab {$index}:".($actionIndex + 1)] = array_values(array_filter([
+                    (string) ($action['user_copy'] ?? ''),
+                    (string) ($action['system_response'] ?? ''),
+                    (string) ($action['next_step_copy'] ?? ''),
+                ]));
+            }
+
+            foreach ((array) data_get($overlay, 'next_exploration_nodes_v1.nodes', []) as $nodeIndex => $node) {
+                $visible["next_node {$index}:".($nodeIndex + 1)] = array_values(array_filter([
+                    (string) ($node['title'] ?? ''),
+                    (string) ($node['summary'] ?? ''),
+                    (string) ($node['instruction'] ?? ''),
+                ]));
+            }
+        }
+
+        foreach ((array) data_get($payload, 'lifecycle.surfaces', []) as $index => $surface) {
+            $visible['lifecycle surface '.($index + 1)] = [(string) ($surface['copy'] ?? '')];
+        }
+        foreach ((array) data_get($payload, 'lifecycle.faq_items', []) as $index => $faq) {
+            $visible['lifecycle faq '.($index + 1)] = [(string) ($faq['q'] ?? ''), (string) ($faq['a'] ?? '')];
+        }
+        foreach ((array) ($payload['technical_note_summary'] ?? []) as $index => $section) {
+            $visible['technical note '.($index + 1)] = [(string) ($section['title'] ?? ''), (string) ($section['copy'] ?? '')];
+        }
+        foreach ((array) ($payload['professional_method_boundary'] ?? []) as $index => $section) {
+            $visible['method boundary '.($index + 1)] = [(string) ($section['title'] ?? ''), (string) ($section['body'] ?? '')];
+        }
+
+        return $visible;
+    }
+
+    private function containsTerm(string $text, string $term): bool
+    {
+        return mb_stripos($text, $term) !== false;
+    }
+
+    private function isNegatedBoundary(string $text, string $term): bool
+    {
+        $quoted = preg_quote($term, '/');
+
+        return preg_match('/(不|不是|不能|不会|不得|不应|不该|不测|只说明|不代表|不能用于).{0,30}'.$quoted.'/u', $text) === 1
+            || preg_match('/'.$quoted.'.{0,10}(不是|不代表|不能|不会|不得)/u', $text) === 1;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14099,7 +14099,7 @@
     "merge_commit": "923d27cde622eaaa235830df1ba49098a793e8af"
   },
   "RIASEC-FULL-CONTENT-PACK-11-BE": {
-    "status": "pr_opened_github_checks_pending",
+    "status": "merged",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/riasec-full-content-pack-11-be",
@@ -14151,14 +14151,19 @@
         "summary": "Changed files are limited to lifecycle assets, lifecycle backend bridge services, lifecycle/technical-note tests, lifecycle docs, and current PR manifest/state updates; no fap-web, scorer, question-pack, analytics, or measured-payload mutation logic touched."
       },
       "github_required_checks": {
-        "status": "pending",
-        "summary": "PR #1509 opened; GitHub required checks pending."
+        "status": "pass",
+        "summary": "GitHub required checks passed before merge for PR #1509."
+      },
+      "ledger_reconciliation": {
+        "status": "pass",
+        "summary": "GitHub PR #1509 is merged and origin/main contains 9a5bcdc43080d0d0420e1499e0ad0f8e2a1abc7f; reconciled before PACK-13-BE.",
+        "source_of_truth": "GitHub PR + origin/main"
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-20T02:44:41Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [],
     "history": [
       {
@@ -14175,6 +14180,94 @@
         "at": "2026-05-20T02:41:00Z",
         "status": "pr_opened_github_checks_pending",
         "summary": "Opened https://github.com/fermatmind/fap-api/pull/1509 for PACK-11-BE. GitHub checks pending."
+      },
+      {
+        "at": "2026-05-20T11:20:00+08:00",
+        "status": "merged",
+        "summary": "Reconciled after GitHub confirmed PR #1509 merged and origin/main contains merge commit 9a5bcdc43080d0d0420e1499e0ad0f8e2a1abc7f."
+      }
+    ],
+    "merge_commit": "9a5bcdc43080d0d0420e1499e0ad0f8e2a1abc7f"
+  },
+  "RIASEC-FULL-CONTENT-PACK-13-BE": {
+    "status": "local_validation_passed",
+    "repo": "fap-api",
+    "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+    "branch": "codex/riasec-full-content-pack-13-be",
+    "base": "main",
+    "title": "RIASEC-FULL-CONTENT-PACK-13-BE: Backend full content fixture matrix and forbidden claim freeze",
+    "depends_on": [
+      "RIASEC-FULL-CONTENT-PACK-03",
+      "RIASEC-FULL-CONTENT-PACK-04",
+      "RIASEC-FULL-CONTENT-PACK-05",
+      "RIASEC-FULL-CONTENT-PACK-06",
+      "RIASEC-FULL-CONTENT-PACK-07",
+      "RIASEC-FULL-CONTENT-PACK-08",
+      "RIASEC-FULL-CONTENT-PACK-09",
+      "RIASEC-FULL-CONTENT-PACK-10-BE",
+      "RIASEC-FULL-CONTENT-PACK-11-BE"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "pack_11_be_ledger_reconciliation": {
+        "status": "pass",
+        "summary": "PACK-11-BE reconciled to merged before PACK-13-BE registration."
+      },
+      "dependency_gate": {
+        "status": "pass",
+        "summary": "PACK-03, PACK-04, PACK-05, PACK-06, PACK-07, PACK-08, PACK-09, PACK-10-BE, and PACK-11-BE merge commits are present in origin/main."
+      },
+      "targeted_phpunit": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi",
+        "summary": "14 test methods passed with 23 non-blocking file_get_contents warnings from existing Laravel wrappers; backend full-content fixture matrix, imported content boundaries, and assessment flow contracts remained green."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+        "summary": "7 files passed."
+      },
+      "asset_validation": {
+        "status": "pass",
+        "summary": "Validated JSONL counts for pair/top3/activity/occupation/aspirations/disagree/feedback/next-node assets and parsed lifecycle JSON plus FAQ markdown presence."
+      },
+      "manifest_state_validation": {
+        "status": "pass",
+        "summary": "pr-train-state JSON and pr-train YAML parsed successfully."
+      },
+      "forbidden_claim_scan": {
+        "status": "pass",
+        "summary": "Backend full-content visible outputs keep forbidden phrases only in negative boundary contexts; no positive user-facing forbidden claims were introduced. Documentation and manifest contain allowed governance hits only."
+      },
+      "technical_key_exposure_scan": {
+        "status": "pass",
+        "summary": "No new user-facing technical key exposure was introduced by the backend fixture matrix freeze."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "scope_validation": {
+        "status": "pass",
+        "summary": "Changed files are limited to PACK-11-BE ledger reconciliation, PACK-13-BE manifest/state registration, backend fixture-freeze docs, and backend RIASEC verification tests. No frontend, scorer, question-pack, analytics, or measured-payload mutation logic touched."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "history": [
+      {
+        "at": "2026-05-20T11:20:00+08:00",
+        "status": "in_progress",
+        "summary": "Registered PACK-13-BE after PACK-11-BE reconciliation. Scope is backend fixture matrix and forbidden-claim freeze only; no fap-web or PACK-14 work in this PR."
+      },
+      {
+        "at": "2026-05-20T11:35:00+08:00",
+        "status": "local_validation_passed",
+        "summary": "Added backend full-content fixture matrix freeze coverage and documentation. Local checks passed; no runtime semantic change was required."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14190,7 +14190,7 @@
     "merge_commit": "9a5bcdc43080d0d0420e1499e0ad0f8e2a1abc7f"
   },
   "RIASEC-FULL-CONTENT-PACK-13-BE": {
-    "status": "local_validation_passed",
+    "status": "pr_opened_github_checks_pending",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/riasec-full-content-pack-13-be",
@@ -14207,8 +14207,8 @@
       "RIASEC-FULL-CONTENT-PACK-10-BE",
       "RIASEC-FULL-CONTENT-PACK-11-BE"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "471187ff",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1511",
     "checks": {
       "pack_11_be_ledger_reconciliation": {
         "status": "pass",
@@ -14251,6 +14251,10 @@
       "scope_validation": {
         "status": "pass",
         "summary": "Changed files are limited to PACK-11-BE ledger reconciliation, PACK-13-BE manifest/state registration, backend fixture-freeze docs, and backend RIASEC verification tests. No frontend, scorer, question-pack, analytics, or measured-payload mutation logic touched."
+      },
+      "github_required_checks": {
+        "status": "pending",
+        "summary": "PR #1511 opened; GitHub required checks pending."
       }
     },
     "failure_reason": null,
@@ -14268,6 +14272,11 @@
         "at": "2026-05-20T11:35:00+08:00",
         "status": "local_validation_passed",
         "summary": "Added backend full-content fixture matrix freeze coverage and documentation. Local checks passed; no runtime semantic change was required."
+      },
+      {
+        "at": "2026-05-20T11:42:00+08:00",
+        "status": "pr_opened_github_checks_pending",
+        "summary": "Opened https://github.com/fermatmind/fap-api/pull/1511 for PACK-13-BE. GitHub required checks pending."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -7376,3 +7376,59 @@ prs:
       github_checks_required: true
       squash: true
       auto_merge: true
+
+  - id: RIASEC-FULL-CONTENT-PACK-13-BE
+    repo: fap-api
+    depends_on:
+      - RIASEC-FULL-CONTENT-PACK-03
+      - RIASEC-FULL-CONTENT-PACK-04
+      - RIASEC-FULL-CONTENT-PACK-05
+      - RIASEC-FULL-CONTENT-PACK-06
+      - RIASEC-FULL-CONTENT-PACK-07
+      - RIASEC-FULL-CONTENT-PACK-08
+      - RIASEC-FULL-CONTENT-PACK-09
+      - RIASEC-FULL-CONTENT-PACK-10-BE
+      - RIASEC-FULL-CONTENT-PACK-11-BE
+    branch: codex/riasec-full-content-pack-13-be
+    base: main
+    title: "RIASEC-FULL-CONTENT-PACK-13-BE: Backend full content fixture matrix and forbidden claim freeze"
+    name: "Backend full content freeze and fixture matrix"
+    train_scope: riasec_full_content_pack
+    risk_level: L1
+    type: backend verification and fixture freeze PR
+    scope:
+      - Reconcile PACK-11-BE ledger state as merged from GitHub and origin/main before continuing the train.
+      - Freeze backend full-content coverage for pair blend, top3 chain, activity/task, occupation examples, 140Q, low quality, aspirations, disagree path, feedback overlay, and lifecycle payloads.
+      - Add backend fixture-matrix and forbidden-claim regression tests only, unless a tiny test-driven guard fix is required within existing RIASEC backend services.
+      - Preserve fail-closed behavior and public-safety boundaries; do not start PACK-13-FE or PACK-14 from this PR alone.
+    allowed_paths:
+      - backend/tests/Unit/Services/Riasec/*Fixture*Matrix*.php
+      - backend/tests/Unit/Services/Riasec/*Freeze*.php
+      - backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php
+      - backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+      - backend/docs/riasec/**
+      - backend/app/Services/Riasec/** # only if a tiny test-driven guard fix is required
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Touch scorer math, question packs, Holland Code generation, frontend fallback behavior, analytics runtime, production data, or career registry source rows.
+      - Introduce new runtime editorial copy, new public payload semantics, or lifecycle/share/PDF/history measured payload mutation.
+      - Expose raw feedback or internal snapshot identifiers publicly.
+      - Add career recommendation, job fit, occupation match, ranking, success prediction, ability proof, skill proof, raw score delta, 140Q more accurate, or AI-generated formal report runtime.
+      - Start PACK-13-FE or PACK-14.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi
+      - cd backend && vendor/bin/pint --test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'
+      - php -r 'foreach(["backend/content_assets/riasec/pair_blend_15_pairs_v1.zh-CN.jsonl"=>15,"backend/content_assets/riasec/top3_code_chain_strategy_v1.zh-CN.jsonl"=>20,"backend/content_assets/riasec/activity_task_examples_v1.zh-CN.jsonl"=>360,"backend/content_assets/riasec/occupation_examples_boundary_v1.zh-CN.jsonl"=>360,"backend/content_assets/riasec/aspirations_calibration_v1.zh-CN.jsonl"=>70,"backend/content_assets/riasec/disagree_path_v1.zh-CN.jsonl"=>45,"backend/content_assets/riasec/feedback_action_lab_v1.zh-CN.jsonl"=>204,"backend/content_assets/riasec/next_exploration_nodes_v1.zh-CN.jsonl"=>270] as $file=>$expected){$n=0; foreach(file($file, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) as $line){$n++; json_decode($line,true,512,JSON_THROW_ON_ERROR);} if($n!==$expected){throw new RuntimeException("$file expected $expected got $n");}} foreach(["backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json","backend/content_assets/riasec/faq_v1.zh-CN.json","backend/content_assets/riasec/technical_note_user_summary_v1.zh-CN.json","backend/content_assets/riasec/professional_method_boundary_v1.zh-CN.json"] as $file){json_decode(file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);} if (trim((string) file_get_contents("backend/content_assets/riasec/faq_v1.zh-CN.md")) === "") { throw new RuntimeException("faq markdown asset is empty"); }'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true


### PR DESCRIPTION
## What changed
- reconciled `RIASEC-FULL-CONTENT-PACK-11-BE` ledger state to merged using GitHub/origin-main as source of truth
- registered `RIASEC-FULL-CONTENT-PACK-13-BE` in `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json`
- added backend freeze coverage in `backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php`
- added backend docs note in `backend/docs/riasec/full-content-fixture-freeze-pack-13-be.md`

## Why
`PACK-13-BE` freezes backend-authoritative RIASEC full-content coverage after the backend imports landed. The new matrix test locks public-safety, fail-closed behavior, module visibility states, and forbidden-claim boundaries without changing runtime semantics.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`
- `php -r 'foreach(["backend/content_assets/riasec/pair_blend_15_pairs_v1.zh-CN.jsonl"=>15,"backend/content_assets/riasec/top3_code_chain_strategy_v1.zh-CN.jsonl"=>20,"backend/content_assets/riasec/activity_task_examples_v1.zh-CN.jsonl"=>360,"backend/content_assets/riasec/occupation_examples_boundary_v1.zh-CN.jsonl"=>360,"backend/content_assets/riasec/aspirations_calibration_v1.zh-CN.jsonl"=>70,"backend/content_assets/riasec/disagree_path_v1.zh-CN.jsonl"=>45,"backend/content_assets/riasec/feedback_action_lab_v1.zh-CN.jsonl"=>204,"backend/content_assets/riasec/next_exploration_nodes_v1.zh-CN.jsonl"=>270] as $file=>$expected){$n=0; foreach(file($file, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) as $line){$n++; json_decode($line,true,512,JSON_THROW_ON_ERROR);} if($n!==$expected){throw new RuntimeException("$file expected $expected got $n");}} foreach(["backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json","backend/content_assets/riasec/faq_v1.zh-CN.json","backend/content_assets/riasec/technical_note_user_summary_v1.zh-CN.json","backend/content_assets/riasec/professional_method_boundary_v1.zh-CN.json"] as $file){json_decode(file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);} if (trim((string) file_get_contents("backend/content_assets/riasec/faq_v1.zh-CN.md")) === "") { throw new RuntimeException("faq markdown asset is empty"); }'`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- `RIASEC-FULL-CONTENT-PACK-13-FE`
- `RIASEC-FULL-CONTENT-PACK-14`
- any frontend renderer work, lifecycle routing work, deploy work, or runtime semantic changes
