### PR TITLE
feat(seo-intel): add two-stage URL Truth handoff

### DIFF
--- a/backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
+++ b/backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\ResearchReport;
+use App\Services\SeoIntel\Sources\BackendAuthorityUrlTruthSource;
+use App\Services\SeoIntel\UrlTruthHandoffArtifact;
+use App\Services\SeoIntel\UrlTruthInventoryRecord;
+use App\Services\SeoIntel\UrlTruthInventoryRecordWriter;
+use Illuminate\Console\Command;
+
+final class SeoIntelUrlTruthHandoffCommand extends Command
+{
+    protected $signature = 'seo-intel:url-truth-handoff
+        {--export= : Export a dry-run/no-write URL Truth handoff JSON artifact}
+        {--import= : Import and validate a URL Truth handoff JSON artifact}
+        {--dry-run : Validate or export without writes}
+        {--write : Execute bounded write from a validated import artifact}
+        {--limit=20 : Bound exported or imported candidates}
+        {--page-type=research_report : Required page entity type}
+        {--confirm-artifact-sha256= : Required SHA256 confirmation for write mode}
+        {--json : Output safe machine-readable JSON}';
+
+    protected $description = 'Export or validate bounded Research URL Truth handoff artifacts without cross-cloud direct writes.';
+
+    public function handle(UrlTruthHandoffArtifact $artifact): int
+    {
+        $exportPath = $this->stringOption($this->option('export'));
+        $importPath = $this->stringOption($this->option('import'));
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run') || ! $write;
+        $limit = $this->boundedLimit($this->option('limit'));
+        $pageType = $this->stringOption($this->option('page-type')) ?? ResearchReport::PAGE_ENTITY_TYPE;
+
+        if (($exportPath === null && $importPath === null) || ($exportPath !== null && $importPath !== null)) {
+            return $this->finish([
+                'status' => 'blocked',
+                'issues' => ['exactly_one_of_export_or_import_required'],
+                'dry_run' => true,
+                'writes_committed' => false,
+            ]);
+        }
+
+        if ($pageType !== ResearchReport::PAGE_ENTITY_TYPE) {
+            return $this->finish([
+                'status' => 'blocked',
+                'issues' => ['only_research_report_page_type_supported'],
+                'dry_run' => true,
+                'writes_committed' => false,
+            ]);
+        }
+
+        if ($exportPath !== null) {
+            return $this->export($artifact, $exportPath, $limit);
+        }
+
+        return $this->import($artifact, (string) $importPath, $limit, $dryRun, $write);
+    }
+
+    private function export(UrlTruthHandoffArtifact $artifact, string $path, int $limit): int
+    {
+        $source = new BackendAuthorityUrlTruthSource;
+        $records = array_values(array_filter(
+            $source->candidates(),
+            static fn (UrlTruthInventoryRecord $record): bool => $record->pageEntityType === ResearchReport::PAGE_ENTITY_TYPE
+                && $record->sourceAuthority === UrlTruthHandoffArtifact::SOURCE_AUTHORITY
+        ));
+
+        usort($records, static fn (UrlTruthInventoryRecord $a, UrlTruthInventoryRecord $b): int => strcmp(
+            $a->canonicalUrlHash(),
+            $b->canonicalUrlHash(),
+        ));
+
+        $payload = $artifact->fromRecords($records, $source->metadata(), $limit);
+        $validation = $artifact->validate($payload, $limit);
+
+        if ($validation['status'] === 'blocked') {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'export',
+                'issues' => $validation['issues'],
+                'dry_run' => true,
+                'writes_committed' => false,
+            ]);
+        }
+
+        $artifact->writeJson($path, $payload);
+
+        return $this->finish([
+            'status' => 'success',
+            'mode' => 'export',
+            'artifact_path' => $path,
+            'artifact_sha256' => $artifact->sha256($path),
+            'dry_run' => true,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'planned_url_count' => $validation['metadata']['planned_url_count'],
+            'planned_entity_count' => $validation['metadata']['planned_entity_count'],
+            'target_tables' => ['seo_urls', 'seo_url_entities'],
+            'external_api_calls' => false,
+            'search_url_submission' => false,
+            'crawler_log_read' => false,
+            'issues' => [],
+        ]);
+    }
+
+    private function import(UrlTruthHandoffArtifact $artifact, string $path, int $limit, bool $dryRun, bool $write): int
+    {
+        if (! is_file($path)) {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'import',
+                'issues' => ['handoff_artifact_missing'],
+                'dry_run' => true,
+                'writes_committed' => false,
+            ]);
+        }
+
+        $sha256 = $artifact->sha256($path);
+        $payload = $artifact->readJson($path);
+        $validation = $artifact->validate($payload, $limit);
+
+        if ($validation['status'] === 'blocked') {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'import',
+                'artifact_sha256' => $sha256,
+                'issues' => $validation['issues'],
+                'dry_run' => true,
+                'writes_committed' => false,
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+            ]);
+        }
+
+        if ($write && $dryRun) {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'import',
+                'artifact_sha256' => $sha256,
+                'issues' => ['write_mode_cannot_be_dry_run'],
+                'dry_run' => true,
+                'writes_committed' => false,
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+            ]);
+        }
+
+        if (! $write) {
+            return $this->finish([
+                'status' => 'success',
+                'mode' => 'import_dry_run',
+                'artifact_sha256' => $sha256,
+                'dry_run' => true,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'planned_url_count' => $validation['metadata']['planned_url_count'],
+                'planned_entity_count' => $validation['metadata']['planned_entity_count'],
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+                'external_api_calls' => false,
+                'search_url_submission' => false,
+                'crawler_log_read' => false,
+                'issues' => [],
+            ]);
+        }
+
+        if ($validation['records'] === []) {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'import_write',
+                'artifact_sha256' => $sha256,
+                'issues' => ['handoff_artifact_has_no_candidates'],
+                'dry_run' => false,
+                'writes_committed' => false,
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+            ]);
+        }
+
+        $confirmation = $this->stringOption($this->option('confirm-artifact-sha256'));
+        if ($confirmation === null || ! hash_equals($sha256, $confirmation)) {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'import_write',
+                'artifact_sha256' => $sha256,
+                'issues' => ['artifact_sha256_confirmation_required'],
+                'dry_run' => false,
+                'writes_committed' => false,
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+            ]);
+        }
+
+        if (! (bool) config('seo_intel.enabled', false) || ! (bool) config('seo_intel.write_enabled', false)) {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'import_write',
+                'artifact_sha256' => $sha256,
+                'issues' => ['seo_intel_write_flags_disabled'],
+                'dry_run' => false,
+                'writes_committed' => false,
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+            ]);
+        }
+
+        $written = (new UrlTruthInventoryRecordWriter)->write($validation['records']);
+
+        return $this->finish([
+            'status' => 'success',
+            'mode' => 'import_write',
+            'artifact_sha256' => $sha256,
+            'dry_run' => false,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'written_records' => $written,
+            'planned_url_count' => $validation['metadata']['planned_url_count'],
+            'planned_entity_count' => $validation['metadata']['planned_entity_count'],
+            'target_tables' => ['seo_urls', 'seo_url_entities'],
+            'external_api_calls' => false,
+            'search_url_submission' => false,
+            'crawler_log_read' => false,
+            'issues' => [],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload): int
+    {
+        $output = [
+            'task' => 'SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00',
+            'collector' => UrlTruthHandoffArtifact::COLLECTOR,
+            'page_entity_type' => UrlTruthHandoffArtifact::PAGE_ENTITY_TYPE,
+            'source_authority' => UrlTruthHandoffArtifact::SOURCE_AUTHORITY,
+            'target_tables' => ['seo_urls', 'seo_url_entities'],
+            'external_api_calls' => false,
+            'search_url_submission' => false,
+            'crawler_log_read' => false,
+        ] + $payload;
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($output, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        } else {
+            $this->line('status='.$output['status']);
+            $this->line('mode='.($output['mode'] ?? 'n/a'));
+            $this->line('dry_run='.((bool) ($output['dry_run'] ?? true) ? '1' : '0'));
+            $this->line('writes_committed='.((bool) ($output['writes_committed'] ?? false) ? '1' : '0'));
+        }
+
+        return ($output['status'] ?? null) === 'blocked' ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function boundedLimit(mixed $rawLimit): int
+    {
+        $max = max(1, (int) config('seo_intel.url_truth_inventory.canary_max_limit', 50));
+
+        if ($rawLimit === null || $rawLimit === '') {
+            return min($max, 20);
+        }
+
+        return min($max, max(1, (int) $rawLimit));
+    }
+
+    private function stringOption(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/SeoIntel/Collectors/UrlTruthInventoryCollector.php
+++ b/backend/app/Services/SeoIntel/Collectors/UrlTruthInventoryCollector.php
@@ -8,7 +8,7 @@ use App\Services\SeoIntel\SeoIntelCollector;
 use App\Services\SeoIntel\SeoIntelCollectorResult;
 use App\Services\SeoIntel\Sources\UrlTruthInventorySource;
 use App\Services\SeoIntel\UrlTruthInventoryRecord;
-use Illuminate\Support\Facades\DB;
+use App\Services\SeoIntel\UrlTruthInventoryRecordWriter;
 use Illuminate\Support\Str;
 
 final class UrlTruthInventoryCollector implements SeoIntelCollector
@@ -126,7 +126,7 @@ final class UrlTruthInventoryCollector implements SeoIntelCollector
         $writesCommitted = false;
 
         if ($writesAttempted) {
-            $this->writeRecords($validRecords);
+            (new UrlTruthInventoryRecordWriter)->write($validRecords);
             $writesCommitted = true;
         }
 
@@ -222,63 +222,6 @@ final class UrlTruthInventoryCollector implements SeoIntelCollector
     public function allowedSourceAuthorities(): array
     {
         return $this->stringList(config('seo_intel.url_truth_inventory.allowed_source_authorities', []));
-    }
-
-    /**
-     * @param  list<UrlTruthInventoryRecord>  $records
-     */
-    private function writeRecords(array $records): void
-    {
-        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
-        $now = now();
-
-        foreach ($records as $record) {
-            $hash = $record->canonicalUrlHash();
-
-            $connection->table('seo_urls')->updateOrInsert(
-                [
-                    'canonical_url_hash' => $hash,
-                    'locale' => $record->locale,
-                ],
-                [
-                    'canonical_url' => $record->canonicalUrl,
-                    'page_entity_type' => $record->pageEntityType,
-                    'entity_id_or_slug' => $record->entityIdOrSlug,
-                    'cluster' => $record->cluster,
-                    'source_authority' => $record->sourceAuthority,
-                    'indexability_state' => $record->indexabilityState,
-                    'lastmod_at' => $record->lastmodAt,
-                    'lastmod_source' => $record->lastmodSource,
-                    'is_private_flow' => false,
-                    'first_seen_at' => $now,
-                    'last_seen_at' => $now,
-                    'metadata_json' => json_encode($record->metadata, JSON_THROW_ON_ERROR),
-                    'created_at' => $now,
-                    'updated_at' => $now,
-                ]
-            );
-
-            if ($record->entityIdOrSlug === null || $record->entityIdOrSlug === '') {
-                continue;
-            }
-
-            $connection->table('seo_url_entities')->updateOrInsert(
-                [
-                    'canonical_url_hash' => $hash,
-                    'locale' => $record->locale,
-                    'page_entity_type' => $record->pageEntityType,
-                    'entity_id_or_slug' => $record->entityIdOrSlug,
-                ],
-                [
-                    'entity_source' => $record->entitySource,
-                    'authority_status' => $record->authorityStatus,
-                    'source_updated_at' => $record->sourceUpdatedAt,
-                    'attributes_json' => json_encode($record->attributes, JSON_THROW_ON_ERROR),
-                    'created_at' => $now,
-                    'updated_at' => $now,
-                ]
-            );
-        }
     }
 
     /**

--- a/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
+++ b/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+final class UrlTruthHandoffArtifact
+{
+    public const SCHEMA_VERSION = 'seo-intel-url-truth-handoff.v1';
+
+    public const COLLECTOR = 'url_truth_inventory';
+
+    public const PAGE_ENTITY_TYPE = 'research_report';
+
+    public const SOURCE_AUTHORITY = 'backend_cms';
+
+    /**
+     * @param  list<UrlTruthInventoryRecord>  $records
+     * @param  array<string, mixed>  $sourceMetadata
+     * @return array<string, mixed>
+     */
+    public function fromRecords(array $records, array $sourceMetadata = [], ?int $limit = null): array
+    {
+        $boundedRecords = $limit === null ? $records : array_slice($records, 0, max(0, $limit));
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'collector' => self::COLLECTOR,
+            'mode' => 'two_stage_research_report_url_truth_handoff',
+            'generated_at' => now()->toIso8601String(),
+            'dry_run_required_on_source' => true,
+            'source_environment_role' => 'candidate_export_only',
+            'runner_environment_role' => 'validate_then_bounded_write_only',
+            'constraints' => [
+                'allowed_page_entity_type' => self::PAGE_ENTITY_TYPE,
+                'allowed_source_authority' => self::SOURCE_AUTHORITY,
+                'allowed_route_regex' => '^/(en|zh)/research/[a-z0-9][a-z0-9-]*$',
+                'forbidden_route_fragments' => ['/articles', '/reports', 'turnover-rate-report'],
+                'forbidden_states' => ['private', 'draft', 'noindex', 'claim_unsafe'],
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+                'no_external_api' => true,
+                'no_search_submission' => true,
+                'no_crawler_log_read' => true,
+            ],
+            'target_tables' => ['seo_urls', 'seo_url_entities'],
+            'candidate_count' => count($boundedRecords),
+            'source_metadata' => $this->safeMetadata($sourceMetadata),
+            'candidates' => array_map(fn (UrlTruthInventoryRecord $record): array => $this->serializeRecord($record), array_values($boundedRecords)),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return array{status:string, issues:list<string>, records:list<UrlTruthInventoryRecord>, metadata:array<string, mixed>}
+     */
+    public function validate(array $artifact, ?int $limit = null): array
+    {
+        $issues = [];
+        $records = [];
+
+        if (($artifact['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $issues[] = 'invalid_schema_version';
+        }
+
+        if (($artifact['collector'] ?? null) !== self::COLLECTOR) {
+            $issues[] = 'invalid_collector';
+        }
+
+        if (($artifact['target_tables'] ?? null) !== ['seo_urls', 'seo_url_entities']) {
+            $issues[] = 'invalid_target_tables';
+        }
+
+        foreach (['no_external_api', 'no_search_submission', 'no_crawler_log_read'] as $flag) {
+            if ((bool) data_get($artifact, 'constraints.'.$flag, false) !== true) {
+                $issues[] = 'missing_safety_flag:'.$flag;
+            }
+        }
+
+        $candidates = $artifact['candidates'] ?? null;
+        if (! is_array($candidates)) {
+            $issues[] = 'missing_candidates';
+            $candidates = [];
+        }
+
+        $boundedCandidates = $limit === null ? $candidates : array_slice($candidates, 0, max(0, $limit));
+
+        foreach (array_values($boundedCandidates) as $index => $candidate) {
+            if (! is_array($candidate)) {
+                $issues[] = 'invalid_candidate:'.$index;
+
+                continue;
+            }
+
+            $recordIssues = $this->validateCandidate($candidate, $index);
+            if ($recordIssues !== []) {
+                array_push($issues, ...$recordIssues);
+
+                continue;
+            }
+
+            $records[] = $this->hydrateRecord($candidate);
+        }
+
+        return [
+            'status' => $issues === [] ? 'success' : 'blocked',
+            'issues' => array_values(array_unique($issues)),
+            'records' => $records,
+            'metadata' => [
+                'planned_url_count' => count($records),
+                'planned_entity_count' => count($records),
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+                'page_entity_type' => self::PAGE_ENTITY_TYPE,
+                'source_authority' => self::SOURCE_AUTHORITY,
+                'limit' => $limit,
+            ],
+        ];
+    }
+
+    public function writeJson(string $path, array $artifact): void
+    {
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public function sha256(string $path): string
+    {
+        return hash_file('sha256', $path) ?: '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeRecord(UrlTruthInventoryRecord $record): array
+    {
+        $payload = [
+            'canonical_url' => $record->canonicalUrl,
+            'canonical_url_hash' => $record->canonicalUrlHash(),
+            'locale' => $record->locale,
+            'page_entity_type' => $record->pageEntityType,
+            'entity_id_or_slug' => $record->entityIdOrSlug,
+            'source_authority' => $record->sourceAuthority,
+            'indexability_state' => $record->indexabilityState,
+            'lastmod_at' => $this->formatCarbon($record->lastmodAt),
+            'lastmod_source' => $record->lastmodSource,
+            'cluster' => $record->cluster,
+            'entity_source' => $record->entitySource,
+            'authority_status' => $record->authorityStatus,
+            'source_updated_at' => $this->formatCarbon($record->sourceUpdatedAt),
+            'is_private_flow' => $record->isPrivateFlow,
+            'metadata' => $this->safeMetadata($record->metadata),
+            'attributes' => $this->safeMetadata($record->attributes),
+        ];
+
+        $payload['row_fingerprint'] = $this->rowFingerprint($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return list<string>
+     */
+    private function validateCandidate(array $candidate, int $index): array
+    {
+        $issues = [];
+        $url = (string) ($candidate['canonical_url'] ?? '');
+        $path = (string) (parse_url($url, PHP_URL_PATH) ?: '');
+        $pathLocale = Str::before(Str::after($path, '/'), '/');
+        $locale = (string) ($candidate['locale'] ?? '');
+
+        if (($candidate['page_entity_type'] ?? null) !== self::PAGE_ENTITY_TYPE) {
+            $issues[] = 'candidate_not_research_report:'.$index;
+        }
+
+        if (($candidate['source_authority'] ?? null) !== self::SOURCE_AUTHORITY) {
+            $issues[] = 'candidate_source_authority_not_backend_cms:'.$index;
+        }
+
+        if (($candidate['entity_source'] ?? null) !== 'research_reports') {
+            $issues[] = 'candidate_entity_source_not_research_reports:'.$index;
+        }
+
+        if (($candidate['authority_status'] ?? null) !== 'published_approved') {
+            $issues[] = 'candidate_not_published_approved:'.$index;
+        }
+
+        if (($candidate['indexability_state'] ?? null) !== 'indexable') {
+            $issues[] = 'candidate_not_indexable:'.$index;
+        }
+
+        if ((bool) ($candidate['is_private_flow'] ?? true)) {
+            $issues[] = 'candidate_private_flow:'.$index;
+        }
+
+        if (! (bool) data_get($candidate, 'attributes.claim_safe', false)) {
+            $issues[] = 'candidate_claim_unsafe:'.$index;
+        }
+
+        if (! preg_match('#^/(en|zh)/research/[a-z0-9][a-z0-9-]*$#', $path)) {
+            $issues[] = 'candidate_route_not_research:'.$index;
+        }
+
+        foreach (['/articles', '/reports', 'turnover-rate-report'] as $fragment) {
+            if (str_contains($path, $fragment)) {
+                $issues[] = 'candidate_forbidden_route_fragment:'.$fragment.':'.$index;
+            }
+        }
+
+        if (! in_array($pathLocale, ['en', 'zh'], true)) {
+            $issues[] = 'candidate_locale_path_invalid:'.$index;
+        }
+
+        if ($pathLocale === 'en' && $locale !== 'en') {
+            $issues[] = 'candidate_locale_mismatch:'.$index;
+        }
+
+        if ($pathLocale === 'zh' && ! in_array($locale, ['zh', 'zh-CN'], true)) {
+            $issues[] = 'candidate_locale_mismatch:'.$index;
+        }
+
+        if (($candidate['canonical_url_hash'] ?? null) !== hash('sha256', $url)) {
+            $issues[] = 'candidate_hash_mismatch:'.$index;
+        }
+
+        if (($candidate['row_fingerprint'] ?? null) !== $this->rowFingerprint($candidate)) {
+            $issues[] = 'candidate_row_fingerprint_mismatch:'.$index;
+        }
+
+        if ($this->containsForbiddenDetail((array) ($candidate['metadata'] ?? [])) || $this->containsForbiddenDetail((array) ($candidate['attributes'] ?? []))) {
+            $issues[] = 'candidate_forbidden_detail_key:'.$index;
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function hydrateRecord(array $candidate): UrlTruthInventoryRecord
+    {
+        return new UrlTruthInventoryRecord(
+            canonicalUrl: (string) $candidate['canonical_url'],
+            locale: (string) $candidate['locale'],
+            pageEntityType: (string) $candidate['page_entity_type'],
+            entityIdOrSlug: (string) $candidate['entity_id_or_slug'],
+            sourceAuthority: (string) $candidate['source_authority'],
+            indexabilityState: (string) $candidate['indexability_state'],
+            lastmodAt: $this->parseCarbon($candidate['lastmod_at'] ?? null),
+            lastmodSource: $this->nullableString($candidate['lastmod_source'] ?? null),
+            cluster: $this->nullableString($candidate['cluster'] ?? null),
+            entitySource: (string) $candidate['entity_source'],
+            authorityStatus: (string) $candidate['authority_status'],
+            sourceUpdatedAt: $this->parseCarbon($candidate['source_updated_at'] ?? null),
+            isPrivateFlow: false,
+            metadata: (array) ($candidate['metadata'] ?? []),
+            attributes: (array) ($candidate['attributes'] ?? []),
+        );
+    }
+
+    private function rowFingerprint(array $candidate): string
+    {
+        $payload = [
+            'canonical_url' => $candidate['canonical_url'] ?? null,
+            'locale' => $candidate['locale'] ?? null,
+            'page_entity_type' => $candidate['page_entity_type'] ?? null,
+            'entity_id_or_slug' => $candidate['entity_id_or_slug'] ?? null,
+            'source_authority' => $candidate['source_authority'] ?? null,
+            'indexability_state' => $candidate['indexability_state'] ?? null,
+            'entity_source' => $candidate['entity_source'] ?? null,
+            'authority_status' => $candidate['authority_status'] ?? null,
+            'is_private_flow' => (bool) ($candidate['is_private_flow'] ?? true),
+        ];
+
+        return hash('sha256', json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function safeMetadata(array $payload): array
+    {
+        ksort($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function containsForbiddenDetail(array $payload): bool
+    {
+        $forbiddenFragments = [
+            'email',
+            'order_no',
+            'attempt_id',
+            'payment_id',
+            'provider_event_id',
+            'cookie',
+            'raw_payload',
+            'payment_payload',
+            'provider_payload',
+            'raw_email',
+            'raw_order_no',
+            'raw_attempt_id',
+            'raw_ip',
+            'raw_cookie',
+            'raw_user_agent',
+            'token',
+            'api_key',
+            'secret',
+        ];
+
+        foreach (array_keys($payload) as $key) {
+            $normalized = Str::lower((string) $key);
+            foreach ($forbiddenFragments as $fragment) {
+                if (str_contains($normalized, $fragment)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function formatCarbon(?Carbon $value): ?string
+    {
+        return $value?->toIso8601String();
+    }
+
+    private function parseCarbon(mixed $value): ?Carbon
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return Carbon::parse((string) $value);
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $string = trim((string) $value);
+
+        return $string === '' ? null : $string;
+    }
+}

--- a/backend/app/Services/SeoIntel/UrlTruthInventoryRecordWriter.php
+++ b/backend/app/Services/SeoIntel/UrlTruthInventoryRecordWriter.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use Illuminate\Support\Facades\DB;
+
+final class UrlTruthInventoryRecordWriter
+{
+    /**
+     * @param  list<UrlTruthInventoryRecord>  $records
+     */
+    public function write(array $records): int
+    {
+        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
+        $now = now();
+        $written = 0;
+
+        foreach ($records as $record) {
+            $hash = $record->canonicalUrlHash();
+
+            $connection->table('seo_urls')->updateOrInsert(
+                [
+                    'canonical_url_hash' => $hash,
+                    'locale' => $record->locale,
+                ],
+                [
+                    'canonical_url' => $record->canonicalUrl,
+                    'page_entity_type' => $record->pageEntityType,
+                    'entity_id_or_slug' => $record->entityIdOrSlug,
+                    'cluster' => $record->cluster,
+                    'source_authority' => $record->sourceAuthority,
+                    'indexability_state' => $record->indexabilityState,
+                    'lastmod_at' => $record->lastmodAt,
+                    'lastmod_source' => $record->lastmodSource,
+                    'is_private_flow' => false,
+                    'first_seen_at' => $now,
+                    'last_seen_at' => $now,
+                    'metadata_json' => json_encode($record->metadata, JSON_THROW_ON_ERROR),
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]
+            );
+
+            if ($record->entityIdOrSlug === null || $record->entityIdOrSlug === '') {
+                $written++;
+
+                continue;
+            }
+
+            $connection->table('seo_url_entities')->updateOrInsert(
+                [
+                    'canonical_url_hash' => $hash,
+                    'locale' => $record->locale,
+                    'page_entity_type' => $record->pageEntityType,
+                    'entity_id_or_slug' => $record->entityIdOrSlug,
+                ],
+                [
+                    'entity_source' => $record->entitySource,
+                    'authority_status' => $record->authorityStatus,
+                    'source_updated_at' => $record->sourceUpdatedAt,
+                    'attributes_json' => json_encode($record->attributes, JSON_THROW_ON_ERROR),
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]
+            );
+
+            $written++;
+        }
+
+        return $written;
+    }
+}

--- a/backend/docs/seo/generated/seo-intel-two-stage-url-truth-handoff.v1.json
+++ b/backend/docs/seo/generated/seo-intel-two-stage-url-truth-handoff.v1.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "seo-intel-two-stage-url-truth-handoff.v1",
+  "task": "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00",
+  "collector": "url_truth_inventory",
+  "handoff_artifact_schema": "seo-intel-url-truth-handoff.v1",
+  "source_environment": {
+    "role": "candidate_export_only",
+    "allowed_mode": "dry_run_no_write",
+    "writes_allowed": false,
+    "external_api_calls_allowed": false,
+    "search_submission_allowed": false,
+    "crawler_log_read_allowed": false
+  },
+  "runner_environment": {
+    "role": "validate_then_bounded_write_only",
+    "requires_artifact_sha256_confirmation": true,
+    "write_requires_explicit_flags": true,
+    "target_tables": [
+      "seo_urls",
+      "seo_url_entities"
+    ]
+  },
+  "allowed_candidates": {
+    "page_entity_type": "research_report",
+    "source_authority": "backend_cms",
+    "entity_source": "research_reports",
+    "authority_status": "published_approved",
+    "indexability_state": "indexable",
+    "route_families": [
+      "/en/research/{slug}",
+      "/zh/research/{slug}"
+    ],
+    "claim_safe_required": true,
+    "private_flow_allowed": false
+  },
+  "forbidden": {
+    "route_fragments": [
+      "/articles",
+      "/reports",
+      "turnover-rate-report"
+    ],
+    "candidate_states": [
+      "draft",
+      "private",
+      "noindex",
+      "claim_unsafe"
+    ],
+    "sources": [
+      "frontend_fallback",
+      "static_sitemap_fallback",
+      "static_llms_fallback",
+      "node2_local_laravel",
+      "node2_local_db"
+    ],
+    "tables": [
+      "seo_issue_queue",
+      "seo_gsc_daily",
+      "seo_baidu_push_logs",
+      "seo_indexnow_submissions",
+      "seo_domestic_submission_logs",
+      "seo_crawler_logs_daily",
+      "seo_event_funnel_daily",
+      "seo_revenue_daily",
+      "seo_cluster_daily",
+      "seo_consent_daily",
+      "orders",
+      "payment_events",
+      "attempts",
+      "results",
+      "users"
+    ]
+  },
+  "no_cross_cloud_private_networking_required": true,
+  "tencent_prod_direct_write_to_aliyun_rds_allowed": false,
+  "no_external_api": true,
+  "no_search_submission": true,
+  "no_crawler_log_read": true,
+  "no_scheduler": true,
+  "next_task": "RESEARCH-PUBLISH-02-RERUN"
+}

--- a/backend/docs/seo/seo-intel-two-stage-url-truth-handoff.md
+++ b/backend/docs/seo/seo-intel-two-stage-url-truth-handoff.md
@@ -1,0 +1,97 @@
+# SEO Intel Two-stage URL Truth Handoff
+
+## Decision
+
+`SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00` defines a controlled handoff path for Research URL Truth observation while `fap-api` production and the verified `seo_intel` RDS remain split across clouds.
+
+The current MVP policy is:
+
+- Tencent `fap-api-prod` may run `url_truth_inventory` in dry-run/no-write mode and export a handoff JSON artifact.
+- Aliyun runner validates that artifact before any write.
+- Aliyun runner may perform a bounded write only after validation passes and only with explicit write flags.
+- The handoff writes only to `seo_urls` and `seo_url_entities`.
+- `seo_issue_queue`, Search Channel submission tables, crawler log tables, attribution tables, business tables, and Metabase configuration are not touched by this handoff.
+
+This avoids cross-cloud private networking work for this stage and avoids making Tencent `fap-api-prod` a direct writer to Aliyun RDS.
+
+## Source-side Export
+
+The source side uses:
+
+```bash
+php artisan seo-intel:url-truth-handoff \
+  --export=/secure/path/research-url-truth-handoff.json \
+  --dry-run \
+  --json \
+  --limit=20 \
+  --page-type=research_report
+```
+
+The export is candidate-only. It does not write to `seo_intel`, does not call external search APIs, does not read crawler logs, and does not submit URLs.
+
+## Runner-side Validation
+
+The Aliyun runner validates the artifact with:
+
+```bash
+php artisan seo-intel:url-truth-handoff \
+  --import=/secure/path/research-url-truth-handoff.json \
+  --dry-run \
+  --json \
+  --limit=20
+```
+
+Validation is fail-closed. The artifact is accepted only when every candidate is:
+
+- `page_entity_type = research_report`
+- `source_authority = backend_cms`
+- `entity_source = research_reports`
+- `authority_status = published_approved`
+- `indexability_state = indexable`
+- non-private
+- claim-safe
+- routed under `/en/research/{slug}` or `/zh/research/{slug}`
+
+Validation rejects `/articles`, `/reports`, stale `turnover-rate-report` slugs, draft/private/noindex/claim-unsafe candidates, and sensitive metadata keys.
+
+## Runner-side Bounded Write
+
+The runner may write only after validation and SHA256 confirmation:
+
+```bash
+SEO_INTEL_ENABLED=true \
+SEO_INTEL_WRITE_ENABLED=true \
+php artisan seo-intel:url-truth-handoff \
+  --import=/secure/path/research-url-truth-handoff.json \
+  --write \
+  --confirm-artifact-sha256=<artifact_sha256> \
+  --json \
+  --limit=20
+```
+
+Write mode is still bounded by `--limit`, requires a matching artifact SHA256, and targets only:
+
+- `seo_urls`
+- `seo_url_entities`
+
+## Hard Boundaries
+
+This handoff does not:
+
+- submit URLs to Google, Baidu, IndexNow, 360, Sogou, or Shenma
+- run scheduler
+- read production crawler logs
+- call external search APIs
+- connect business DB
+- connect Tencent RDS
+- connect Node2 local DB
+- expose Metabase publicly
+- create Metabase dashboards or datasources
+- write `seo_issue_queue`
+- change sitemap or `llms.txt`
+
+## Next Task
+
+After this PR is deployed to the runner/source environments, the next operation is:
+
+`RESEARCH-PUBLISH-02-RERUN`

--- a/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ResearchReport;
+use App\Services\SeoIntel\UrlTruthHandoffArtifact;
+use App\Services\SeoIntel\UrlTruthInventoryRecord;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_exports_and_validates_research_report_handoff_artifact_without_writes(): void
+    {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+        $this->createResearchReport([
+            'slug' => 'mbti-personality-types-salary-turnover-report',
+            'locale' => 'en',
+            'canonical_path' => '/en/research/mbti-personality-types-salary-turnover-report',
+        ]);
+
+        $path = sys_get_temp_dir().'/research-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+
+        $exportExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--export' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 20,
+            '--page-type' => 'research_report',
+        ]);
+        $exportOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exportExitCode);
+        $this->assertSame('success', $exportOutput['status'] ?? null);
+        $this->assertTrue((bool) ($exportOutput['dry_run'] ?? false));
+        $this->assertFalse((bool) ($exportOutput['writes_committed'] ?? true));
+        $this->assertSame(1, $exportOutput['planned_url_count'] ?? null);
+        $this->assertFileExists($path);
+
+        $artifact = json_decode((string) file_get_contents($path), true);
+        $this->assertSame(UrlTruthHandoffArtifact::SCHEMA_VERSION, $artifact['schema_version'] ?? null);
+        $this->assertSame(['seo_urls', 'seo_url_entities'], $artifact['target_tables'] ?? null);
+        $this->assertSame('research_report', data_get($artifact, 'candidates.0.page_entity_type'));
+        $this->assertSame('backend_cms', data_get($artifact, 'candidates.0.source_authority'));
+        $this->assertSame('/en/research/mbti-personality-types-salary-turnover-report', parse_url((string) data_get($artifact, 'candidates.0.canonical_url'), PHP_URL_PATH));
+
+        $importExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 20,
+        ]);
+        $importOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $importExitCode);
+        $this->assertSame('success', $importOutput['status'] ?? null);
+        $this->assertSame('import_dry_run', $importOutput['mode'] ?? null);
+        $this->assertSame(1, $importOutput['planned_url_count'] ?? null);
+        $this->assertFalse((bool) ($importOutput['writes_committed'] ?? true));
+    }
+
+    #[Test]
+    public function import_validation_rejects_non_research_article_or_claim_unsafe_candidates(): void
+    {
+        $artifact = new UrlTruthHandoffArtifact;
+        $payload = $artifact->fromRecords([$this->validRecord()]);
+        $payload['candidates'][0]['canonical_url'] = 'https://www.fermatmind.com/en/articles/mbti-personality-types-salary-turnover-report';
+        $payload['candidates'][0]['canonical_url_hash'] = hash('sha256', (string) $payload['candidates'][0]['canonical_url']);
+        $payload['candidates'][0]['page_entity_type'] = 'article';
+        $payload['candidates'][0]['source_authority'] = 'cms_article';
+        $payload['candidates'][0]['attributes']['claim_safe'] = false;
+
+        $path = sys_get_temp_dir().'/invalid-research-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+        $artifact->writeJson($path, $payload);
+
+        $exitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 20,
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertContains('candidate_not_research_report:0', $output['issues'] ?? []);
+        $this->assertContains('candidate_source_authority_not_backend_cms:0', $output['issues'] ?? []);
+        $this->assertContains('candidate_claim_unsafe:0', $output['issues'] ?? []);
+        $this->assertContains('candidate_route_not_research:0', $output['issues'] ?? []);
+        $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+    }
+
+    #[Test]
+    public function bounded_import_write_requires_sha_confirmation_and_targets_only_url_truth_tables(): void
+    {
+        $this->prepareSeoIntelSqliteConnection();
+        config([
+            'seo_intel.enabled' => true,
+            'seo_intel.write_enabled' => true,
+        ]);
+
+        $artifact = new UrlTruthHandoffArtifact;
+        $path = sys_get_temp_dir().'/write-research-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+        $artifact->writeJson($path, $artifact->fromRecords([$this->validRecord()]));
+
+        $blockedExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $path,
+            '--write' => true,
+            '--json' => true,
+            '--limit' => 20,
+        ]);
+        $blockedOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $blockedExitCode);
+        $this->assertContains('artifact_sha256_confirmation_required', $blockedOutput['issues'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_urls')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_url_entities')->count());
+
+        $writeExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $path,
+            '--write' => true,
+            '--confirm-artifact-sha256' => $artifact->sha256($path),
+            '--json' => true,
+            '--limit' => 20,
+        ]);
+        $writeOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $writeExitCode);
+        $this->assertSame('success', $writeOutput['status'] ?? null);
+        $this->assertSame('import_write', $writeOutput['mode'] ?? null);
+        $this->assertTrue((bool) ($writeOutput['writes_committed'] ?? false));
+        $this->assertSame(['seo_urls', 'seo_url_entities'], $writeOutput['target_tables'] ?? null);
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_urls')->count());
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_url_entities')->count());
+    }
+
+    #[Test]
+    public function generated_artifact_locks_two_stage_handoff_boundary(): void
+    {
+        $path = base_path('docs/seo/generated/seo-intel-two-stage-url-truth-handoff.v1.json');
+
+        $this->assertFileExists($path);
+
+        $artifact = json_decode((string) file_get_contents($path), true);
+
+        $this->assertSame('seo-intel-two-stage-url-truth-handoff.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00', $artifact['task'] ?? null);
+        $this->assertSame(UrlTruthHandoffArtifact::SCHEMA_VERSION, $artifact['handoff_artifact_schema'] ?? null);
+        $this->assertSame('dry_run_no_write', data_get($artifact, 'source_environment.allowed_mode'));
+        $this->assertFalse((bool) data_get($artifact, 'source_environment.writes_allowed', true));
+        $this->assertSame(['seo_urls', 'seo_url_entities'], data_get($artifact, 'runner_environment.target_tables'));
+        $this->assertSame('research_report', data_get($artifact, 'allowed_candidates.page_entity_type'));
+        $this->assertSame('backend_cms', data_get($artifact, 'allowed_candidates.source_authority'));
+        $this->assertFalse((bool) ($artifact['tencent_prod_direct_write_to_aliyun_rds_allowed'] ?? true));
+        $this->assertTrue((bool) ($artifact['no_cross_cloud_private_networking_required'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_search_submission'] ?? false));
+        $this->assertContains('/articles', data_get($artifact, 'forbidden.route_fragments', []));
+        $this->assertContains('seo_issue_queue', data_get($artifact, 'forbidden.tables', []));
+        $this->assertSame('RESEARCH-PUBLISH-02-RERUN', $artifact['next_task'] ?? null);
+    }
+
+    private function validRecord(): UrlTruthInventoryRecord
+    {
+        return new UrlTruthInventoryRecord(
+            canonicalUrl: 'https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            locale: 'en',
+            pageEntityType: 'research_report',
+            entityIdOrSlug: 'mbti-personality-types-salary-turnover-report',
+            sourceAuthority: 'backend_cms',
+            indexabilityState: 'indexable',
+            lastmodAt: now()->subHour(),
+            lastmodSource: 'research_reports.updated_at',
+            cluster: 'research',
+            entitySource: 'research_reports',
+            authorityStatus: 'published_approved',
+            sourceUpdatedAt: now()->subHour(),
+            isPrivateFlow: false,
+            metadata: [
+                'canonical_path_hash' => hash('sha256', '/en/research/mbti-personality-types-salary-turnover-report'),
+                'source_table_hash' => hash('sha256', 'research_reports'),
+            ],
+            attributes: [
+                'claim_safe' => true,
+                'source_authority' => 'backend_cms',
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createResearchReport(array $overrides = []): ResearchReport
+    {
+        $slug = (string) ($overrides['slug'] ?? 'safe-research-report');
+        $locale = (string) ($overrides['locale'] ?? 'en');
+        $localeSegment = $locale === 'zh-CN' ? 'zh' : $locale;
+
+        return ResearchReport::query()->create($overrides + [
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => 'Safe Research Report',
+            'executive_summary' => 'Directional research summary.',
+            'body_md' => 'Research body.',
+            'research_type' => 'salary_turnover',
+            'methodology' => 'Modeled index methodology.',
+            'sample_disclaimer' => 'Exploratory, non-diagnostic, not hiring advice.',
+            'claim_boundary' => 'No salary guarantee or individual prediction.',
+            'author_name' => 'FermatMind Research',
+            'reviewer_name' => 'FermatMind Review',
+            'references' => [['title' => 'Reference', 'url' => 'https://example.com/reference']],
+            'downloadable_asset_placeholder' => 'Dataset schema blocked for first publish.',
+            'status' => ResearchReport::STATUS_PUBLISHED,
+            'review_state' => ResearchReport::REVIEW_APPROVED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'last_reviewed_at' => now()->subDay(),
+            'published_at' => now()->subHour(),
+            'seo_title' => 'Safe Research Report',
+            'seo_description' => 'Safe Research Report description.',
+            'canonical_path' => '/'.$localeSegment.'/research/'.$slug,
+        ]);
+    }
+
+    private function prepareSeoIntelSqliteConnection(): void
+    {
+        config([
+            'seo_intel.connection' => 'seo_intel',
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 64)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+            $table->unique(['canonical_url_hash', 'locale']);
+        });
+
+        Schema::connection('seo_intel')->create('seo_url_entities', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255);
+            $table->string('entity_source', 64);
+            $table->string('authority_status', 64);
+            $table->timestamp('source_updated_at')->nullable();
+            $table->json('attributes_json')->nullable();
+            $table->timestamps();
+        });
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -379,6 +379,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_intel_two_stage_url_truth_handoff_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php',
+            'backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php',
+            'backend/app/Services/SeoIntel/UrlTruthInventoryRecordWriter.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_drift_foundation_files(): void
     {
         $changed = [
@@ -1715,6 +1726,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoIntelTwoStageUrlTruthHandoffFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelDriftFoundationFile($file)) {
                 continue;
             }
@@ -2190,6 +2205,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php',
             'backend/app/Services/SeoIntel/Sources/UrlTruthInventorySource.php',
             'backend/app/Services/SeoIntel/UrlTruthInventoryRecord.php',
+        ], true);
+    }
+
+    private function isSeoIntelTwoStageUrlTruthHandoffFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php',
+            'backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php',
+            'backend/app/Services/SeoIntel/UrlTruthInventoryRecordWriter.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-20T01:06:00Z",
+  "updated_at": "2026-05-20T03:53:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -12497,7 +12497,7 @@
       "next_pr": "RESEARCH-PUBLISH-01"
     },
     "RESEARCH-PUBLISH-02-FIX": {
-      "status": "pr_opened_github_checks_pending",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/research-publish-02-fix-url-truth-research-report",
@@ -12506,7 +12506,7 @@
       "depends_on": [
         "RESEARCH-PUBLISH-READINESS-00"
       ],
-      "commit_sha": "85980e6304aa941f16b019474c7b669f717debf3",
+      "commit_sha": "3ac3e446840afe04752e0291715d3d4be34ebb94",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1504",
       "checks": {
         "local": {
@@ -12522,13 +12522,14 @@
           "scope_validation": "passed"
         },
         "github": {
-          "status": "pending"
+          "status": "merged_reconciled",
+          "mergeStateStatus": "CLEAN"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-20T00:56:13Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "history": [
         {
@@ -12545,6 +12546,91 @@
           "at": "2026-05-20T01:06:00Z",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1504 for RESEARCH-PUBLISH-02-FIX. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-20T03:35:34Z",
+          "status": "merged_reconciled",
+          "summary": "Reconciled GitHub PR #1504 as merged with squash merge commit 3ac3e446840afe04752e0291715d3d4be34ebb94; origin/main contains the merge commit and the remote branch is absent."
+        }
+      ],
+      "next_pr": "RESEARCH-PUBLISH-02-RERUN"
+    },
+    "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00": {
+      "status": "ci_fix_local_validation_passed",
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "branch": "codex/seo-intel-two-stage-url-truth-handoff-pr-00",
+      "base": "main",
+      "title": "feat(seo-intel): add two-stage URL Truth handoff",
+      "depends_on": [
+        "RESEARCH-PUBLISH-02-FIX"
+      ],
+      "commit_sha": "1c0fdd6e9ab327c9886b74546d973c5f8c94d22b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1512",
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_seo_intel_two_stage_url_truth_handoff": "passed",
+          "php_artisan_test_filter_seo_intel": "passed",
+          "url_truth_handoff_export_dry_run": "passed_no_local_research_rows",
+          "url_truth_handoff_import_dry_run": "passed_no_local_research_rows",
+          "php_artisan_route_list": "passed",
+          "pint_test": "passed",
+          "json_validation": "passed",
+          "yaml_validation": "passed",
+          "git_diff_check": "passed",
+          "scope_validation": "passed",
+          "bigfive_runtime_freeze_test": "passed",
+          "bigfive_runtime_freeze_scope_allowlist": "passed"
+        },
+        "github": {
+          "status": "failed_ci_fix_pending_push",
+          "failed_checks": [
+            "verify-mbti-legacy",
+            "verify-mbti-v2"
+          ],
+          "failure_summary": "BigFive runtime freeze flagged scoped SEO Intel handoff command/service files as MBTI-impacting runtime changes before a narrow allowlist was added."
+        }
+      },
+      "failure_reason": "GitHub checks failed on BigFive runtime freeze false positive; scoped allowlist added for the three SEO Intel two-stage handoff files and focused BigFive runtime freeze test passed locally.",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "history": [
+        {
+          "at": "2026-05-20T03:35:34Z",
+          "status": "in_progress",
+          "summary": "Started scoped two-stage Research URL Truth handoff PR. Scope adds candidate export/validation/SHA-confirmed bounded write support for research_report/backend_cms candidates only; no production writes, scheduler, external search submission, crawler log read, env edit, deploy, network change, Metabase mutation, business DB access, Node2 access, sitemap change, llms change, or fap-web change is allowed."
+        },
+        {
+          "at": "2026-05-20T03:38:10Z",
+          "status": "local_checks_passed",
+          "summary": "Focused two-stage handoff test, full SeoIntel filter, route list, Pint, JSON/YAML validation, dry-run export/import handoff commands, and git diff --check passed. Local command smoke has no published Research rows, so planned candidate counts are zero locally; fixture tests verify candidate export, validation, SHA confirmation, and bounded writes when eligible Research rows exist."
+        },
+        {
+          "at": "2026-05-20T03:38:32Z",
+          "status": "scope_validation_passed",
+          "summary": "Changed files are limited to the approved SEO Intel handoff command/service/test/docs/generated artifact and PR-train metadata paths."
+        },
+        {
+          "at": "2026-05-20T03:39:19Z",
+          "status": "committed_local",
+          "summary": "Created local scoped commit for two-stage Research URL Truth handoff after local validation and scope validation passed."
+        },
+        {
+          "at": "2026-05-20T03:40:37Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1512. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-20T03:52:00Z",
+          "status": "github_checks_failed",
+          "summary": "GitHub verify-mbti-legacy and verify-mbti-v2 failed because the BigFive runtime freeze classifier flagged the scoped SEO Intel handoff command/service files as MBTI-impacting runtime changes."
+        },
+        {
+          "at": "2026-05-20T03:53:00Z",
+          "status": "ci_fix_local_validation_passed",
+          "summary": "Added a narrow BigFive runtime-freeze allowlist for exactly the SEO Intel two-stage handoff command/service files, updated manifest scope, and reran the focused BigFive freeze test successfully."
         }
       ],
       "next_pr": "RESEARCH-PUBLISH-02-RERUN"

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -7432,3 +7432,56 @@ prs:
       github_checks_required: true
       squash: true
       auto_merge: true
+
+  - id: SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00
+    repo: fap-api
+    depends_on:
+      - RESEARCH-PUBLISH-02-FIX
+    branch: codex/seo-intel-two-stage-url-truth-handoff-pr-00
+    base: main
+    title: "feat(seo-intel): add two-stage URL Truth handoff"
+    name: "Two-stage Research URL Truth handoff"
+    train_scope: seo_intel_research_publish_observation
+    risk_level: L2
+    type: backend code/docs/test PR
+    scope:
+      - Add a controlled Research URL Truth handoff command so Tencent fap-api-prod exports dry-run/no-write candidate JSON only.
+      - Add Aliyun runner-side JSON validation for research_report/backend_cms candidates before any bounded write.
+      - Allow explicit, SHA-confirmed bounded write only to seo_urls and seo_url_entities.
+      - Preserve no scheduler, no external search submission, no crawler log read, no business DB, no Node2, no Metabase mutation, and no cross-cloud private network change.
+    allowed_paths:
+      - backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
+      - backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
+      - backend/app/Services/SeoIntel/UrlTruthInventoryRecordWriter.php
+      - backend/app/Services/SeoIntel/Collectors/UrlTruthInventoryCollector.php
+      - backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/seo/seo-intel-two-stage-url-truth-handoff.md
+      - backend/docs/seo/generated/seo-intel-two-stage-url-truth-handoff.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run collector production writes from this PR task.
+      - Enable scheduler.
+      - Submit URLs to search engines.
+      - Connect live GSC, Baidu, IndexNow, 360, Sogou, or Shenma.
+      - Read production crawler logs.
+      - Change sitemap or llms behavior.
+      - Edit env, deploy, change DNS/CDN/OpenResty/Nginx, security groups, RDS users, grants, or whitelists.
+      - Connect business DB, Tencent RDS, Node2 local DB, or Metabase business datasource.
+      - Touch fap-web.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelTwoStageUrlTruthHandoff
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan seo-intel:url-truth-handoff --export=/tmp/research-url-truth-handoff.json --dry-run --json --limit=20 --page-type=research_report
+      - cd backend && php artisan seo-intel:url-truth-handoff --import=/tmp/research-url-truth-handoff.json --dry-run --json --limit=20
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-intel-two-stage-url-truth-handoff.v1.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true


### PR DESCRIPTION
## What changed
- Added `seo-intel:url-truth-handoff` to export Research URL Truth candidates as a dry-run/no-write JSON handoff artifact.
- Added strict artifact validation for Aliyun runner-side import: only `research_report`, only `backend_cms`, only `/en|/zh/research/...`, claim-safe/indexable/non-private/published-approved candidates.
- Added SHA-confirmed bounded import write mode that targets only `seo_urls` and `seo_url_entities`.
- Extracted the existing URL Truth upsert logic into `UrlTruthInventoryRecordWriter` so the collector and handoff path share the same target-table writer.
- Added docs, generated contract artifact, focused tests, and PR-train ledger/manifest entries. Reconciled PR #1504 as merged because this task depends on it.

## Why
`RESEARCH-PUBLISH-02-RERUN` should not make Tencent `fap-api-prod` write directly to Aliyun RDS and should not require cross-cloud private networking right now. This PR creates a two-stage path: Tencent exports safe candidate JSON, then an Aliyun same-VPC runner validates and performs an explicit bounded write only after artifact SHA confirmation.

## Validation
- `cd backend && php artisan test --filter=SeoIntelTwoStageUrlTruthHandoff`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan seo-intel:url-truth-handoff --export=/tmp/research-url-truth-handoff.json --dry-run --json --limit=20 --page-type=research_report`
- `cd backend && php artisan seo-intel:url-truth-handoff --import=/tmp/research-url-truth-handoff.json --dry-run --json --limit=20`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-intel-two-stage-url-truth-handoff.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

Local command smoke has no published Research rows, so export/import command counts are zero locally; the focused fixture test verifies nonzero candidate export/import/write behavior when eligible Research records exist.

## What was not changed
- No production collector write was run.
- No scheduler was enabled.
- No search submission or live GSC/Baidu/IndexNow/360/Sogou/Shenma call was added.
- No production crawler logs were read.
- No env, deploy, DNS/CDN/OpenResty/Nginx, security group, RDS user/grant/whitelist, or Metabase change was made.
- No business DB, Tencent RDS, Node2 local DB, or fap-web change.
- No sitemap or llms behavior change.
