### PR TITLE
SEARCH-CHANNEL-LIVE-00｜Search Channel readiness split scan

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-readiness-scan.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-readiness-scan.v1.json
@@ -1,0 +1,59 @@
+{
+  "version": "search-channel-live-readiness-scan.v1",
+  "task": "SEARCH-CHANNEL-LIVE-00",
+  "type": "read_only_split_scan",
+  "accepted_verified_current_state": {
+    "seo_urls": 9,
+    "seo_url_entities": 9,
+    "seo_issue_queue": 5,
+    "research_report_rows": 2,
+    "production_db_queried_by_this_scan": false
+  },
+  "contracts_confirmed": [
+    "research_url_truth_observation",
+    "research_seo_geo_search_channel_contract",
+    "search_channel_queue_contract",
+    "chinese_claim_boundary_linter"
+  ],
+  "research_url_truth": {
+    "page_entity_type": "research_report",
+    "source_authority": "backend_cms",
+    "requires_published_state": true,
+    "requires_indexable_state": true,
+    "requires_claim_boundary_safe": true,
+    "forbidden_states": [
+      "draft",
+      "private",
+      "noindex",
+      "unapproved",
+      "unsupported_route",
+      "claim_unsafe"
+    ]
+  },
+  "search_channel_queue_contract_exists": true,
+  "sitemap_changed_in_this_train": false,
+  "llms_changed_in_this_train": false,
+  "live_search_channel_operation_already_run_by_this_train": false,
+  "url_submission_performed": false,
+  "live_external_api_call_performed": false,
+  "production_crawler_log_read": false,
+  "scheduler_enabled": false,
+  "collector_write_executed": false,
+  "production_env_edited": false,
+  "forbidden_authority_inputs": [
+    "frontend_fallback",
+    "static_sitemap_fallback",
+    "static_llms_fallback",
+    "production_crawler_logs",
+    "live_search_engine_response_as_page_truth",
+    "node2_local_db",
+    "business_db_raw_tables"
+  ],
+  "next_tasks": [
+    "GSC-LIVE-00",
+    "BAIDU-LIVE-00",
+    "INDEXNOW-LIVE-00",
+    "SEARCH-CHANNEL-LIVE-01-PREFLIGHT"
+  ],
+  "final_decision": "ready_for_search_channel_readiness_pr_train"
+}

--- a/backend/docs/seo/search-channel-live-readiness-scan.md
+++ b/backend/docs/seo/search-channel-live-readiness-scan.md
@@ -1,0 +1,60 @@
+# Search Channel Live Readiness Split Scan
+
+## Purpose
+
+SEARCH-CHANNEL-LIVE-00 confirms the current Search Channel live readiness boundary and splits the next readiness contracts before any live submission work.
+
+This scan is read-only and local-contract based. It does not submit URLs, call Google Search Console, call Baidu Resource Platform, call IndexNow, connect domestic search APIs, read production crawler logs, enable scheduler jobs, run collector writes, deploy services, edit environment files, change DNS/CDN/OpenResty/Nginx, or change sitemap/llms behavior.
+
+## Current Readiness Findings
+
+- `seo_urls` and `seo_url_entities` are expected to include Research URL Truth rows from the verified SEO Dash MVP state. The accepted current operational count is `seo_urls = 9`, `seo_url_entities = 9`, and `research_report rows = 2`; this scan does not re-query production databases.
+- Local backend URL Truth contracts include `research_report` candidates through `BackendAuthorityUrlTruthSource` and require `backend_cms` authority, published state, indexability, and claim safety.
+- Research URL Truth excludes draft, private, noindex, unapproved, unsupported-route, and claim-unsafe Research records.
+- The Search Channel Queue contract exists as `SEARCH-CHANNEL-QUEUE-00` and is documented in `docs/seo/search-channel-queue-contract.md` with generated artifact `docs/seo/generated/search-channel-queue-contract.v1.json`.
+- Current sitemap and `llms.txt` behavior remains gated by existing backend/runtime contracts and is not changed by this train.
+- No live Search Channel operation is introduced by this scan. Existing contracts continue to record no URL submission, no live GSC activation, no Baidu push, no IndexNow submission, no scheduler enablement, no collector write, and no production crawler log read.
+
+## Exclusion Rules Confirmed
+
+The readiness train must exclude any URL with one or more of these states:
+
+- draft
+- private
+- noindex
+- unapproved
+- unsupported page type
+- missing canonical
+- non-backend-authoritative
+- claim-unsafe
+- private-flow path
+- query-string-only candidate
+
+Frontend fallback, static sitemap fallback, static `llms.txt` fallback, production crawler logs, live search engine responses, Node2 local DB, and raw business DB tables must not become Search Channel URL authority.
+
+## Split Follow-Up Tasks
+
+1. `GSC-LIVE-00` defines Google Search Console readiness as read-only/status-check preparation only.
+2. `BAIDU-LIVE-00` defines Baidu Resource Platform readiness without URL push or token exposure.
+3. `INDEXNOW-LIVE-00` defines IndexNow readiness without key leakage or submission.
+4. `SEARCH-CHANNEL-LIVE-01-PREFLIGHT` performs local/report-only URL eligibility preflight and no-submit channel readiness assessment.
+
+These tasks are readiness contracts, not live submission tasks.
+
+## What Was Not Done
+
+- No URL submitted to Google, Baidu, IndexNow, Bing, 360, Sogou, Shenma, or any search engine.
+- No indexing request made.
+- No live external Search Channel API called.
+- No production crawler log read.
+- No scheduler enabled.
+- No collector write run.
+- No production env edited.
+- No sitemap or `llms.txt` behavior changed.
+- No Research content published.
+- No pSEO created.
+- No token, API key, cookie, session, email, order ID, attempt ID, payment ID, raw IP, or secret exposed.
+
+## Final Decision
+
+ready_for_search_channel_readiness_pr_train

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveReadinessScanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveReadinessScanTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLiveReadinessScanTest extends TestCase
+{
+    #[Test]
+    public function scan_artifact_locks_read_only_no_submit_boundary(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('search-channel-live-readiness-scan.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEARCH-CHANNEL-LIVE-00', $artifact['task'] ?? null);
+        $this->assertSame('ready_for_search_channel_readiness_pr_train', $artifact['final_decision'] ?? null);
+
+        foreach ([
+            'production_db_queried_by_this_scan',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'accepted_verified_current_state.'.$flag), $flag.' must remain false');
+        }
+
+        foreach ([
+            'sitemap_changed_in_this_train',
+            'llms_changed_in_this_train',
+            'live_search_channel_operation_already_run_by_this_train',
+            'url_submission_performed',
+            'live_external_api_call_performed',
+            'production_crawler_log_read',
+            'scheduler_enabled',
+            'collector_write_executed',
+            'production_env_edited',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function scan_confirms_research_truth_and_queue_contracts(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(9, data_get($artifact, 'accepted_verified_current_state.seo_urls'));
+        $this->assertSame(9, data_get($artifact, 'accepted_verified_current_state.seo_url_entities'));
+        $this->assertSame(2, data_get($artifact, 'accepted_verified_current_state.research_report_rows'));
+        $this->assertTrue((bool) ($artifact['search_channel_queue_contract_exists'] ?? false));
+        $this->assertSame('research_report', data_get($artifact, 'research_url_truth.page_entity_type'));
+        $this->assertSame('backend_cms', data_get($artifact, 'research_url_truth.source_authority'));
+
+        foreach ([
+            'research_url_truth_observation',
+            'research_seo_geo_search_channel_contract',
+            'search_channel_queue_contract',
+            'chinese_claim_boundary_linter',
+        ] as $contract) {
+            $this->assertContains($contract, $artifact['contracts_confirmed'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function scan_excludes_unsafe_url_authority_and_splits_readiness_tasks(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'draft',
+            'private',
+            'noindex',
+            'unapproved',
+            'unsupported_route',
+            'claim_unsafe',
+        ] as $state) {
+            $this->assertContains($state, data_get($artifact, 'research_url_truth.forbidden_states', []));
+        }
+
+        foreach ([
+            'frontend_fallback',
+            'static_sitemap_fallback',
+            'static_llms_fallback',
+            'production_crawler_logs',
+            'live_search_engine_response_as_page_truth',
+            'node2_local_db',
+            'business_db_raw_tables',
+        ] as $input) {
+            $this->assertContains($input, $artifact['forbidden_authority_inputs'] ?? []);
+        }
+
+        $this->assertSame([
+            'GSC-LIVE-00',
+            'BAIDU-LIVE-00',
+            'INDEXNOW-LIVE-00',
+            'SEARCH-CHANNEL-LIVE-01-PREFLIGHT',
+        ], $artifact['next_tasks'] ?? []);
+    }
+
+    #[Test]
+    public function docs_lock_no_live_submission_language(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/search-channel-live-readiness-scan.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/search-channel-live-readiness-scan.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'does not submit urls',
+            'no indexing request made',
+            'no live external search channel api called',
+            'no production crawler log read',
+            'no scheduler enabled',
+            'no collector write run',
+            'no sitemap or `llms.txt` behavior changed',
+            'ready_for_search_channel_readiness_pr_train',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/search-channel-live-readiness-scan.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3516,7 +3516,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-05-content-registry-readiness",
       "title": "feat(riasec): add content registry readiness contract",
-      "status": "local_validation_passed",
+      "status": "pr_opened_github_checks_pending",
       "depends_on": [
         "RIASEC-PERSONALIZATION-04"
       ],
@@ -6083,8 +6083,8 @@
         "no fap-web",
         "no live crawl"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "6e603fa8",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1513",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -14337,6 +14337,14 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "git_diff_cached_check": {
+          "status": "pass",
+          "command": "git diff --cached --check"
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "summary": "PR #1513 opened; GitHub checks pending."
         }
       },
       "failure_reason": null,
@@ -14360,6 +14368,11 @@
           "at": "2026-05-20T12:30:00+08:00",
           "status": "local_validation_passed",
           "summary": "Read-only scan docs/generated/test and train metadata validation passed. No live search API, URL submission, production crawler log read, scheduler, collector write, env edit, sitemap change, or llms change occurred."
+        },
+        {
+          "at": "2026-05-20T12:34:00+08:00",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1513 for SEARCH-CHANNEL-LIVE-00. GitHub checks pending."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-20T03:53:00Z",
+  "updated_at": "2026-05-20T04:20:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6644,7 +6644,7 @@
       "branch": "codex/repair-2786-final-public-resolution-partition-1-202605160412",
       "title": "fix(api): partition final career 2786 public resolution",
       "name": "Partition final 2786 public-resolution assets before candidate prep",
-      "status": "in_progress",
+      "status": "local_validation_passed",
       "depends_on": [
         "800-CLOSEOUT-1"
       ],
@@ -12556,7 +12556,7 @@
       "next_pr": "RESEARCH-PUBLISH-02-RERUN"
     },
     "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00": {
-      "status": "ci_fix_local_validation_passed",
+      "status": "merged",
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "branch": "codex/seo-intel-two-stage-url-truth-handoff-pr-00",
@@ -12565,7 +12565,7 @@
       "depends_on": [
         "RESEARCH-PUBLISH-02-FIX"
       ],
-      "commit_sha": "1c0fdd6e9ab327c9886b74546d973c5f8c94d22b",
+      "commit_sha": "1cd5d3d0e2eeb14896ad9446ce53da5fb5c35e47",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1512",
       "checks": {
         "local": {
@@ -12583,18 +12583,26 @@
           "bigfive_runtime_freeze_scope_allowlist": "passed"
         },
         "github": {
-          "status": "failed_ci_fix_pending_push",
-          "failed_checks": [
+          "status": "passed",
+          "checks": [
+            "hygiene",
             "verify-mbti-legacy",
-            "verify-mbti-v2"
+            "verify-mbti-v2",
+            "semgrep sarif",
+            "Semgrep OSS"
           ],
-          "failure_summary": "BigFive runtime freeze flagged scoped SEO Intel handoff command/service files as MBTI-impacting runtime changes before a narrow allowlist was added."
+          "merge_state": "MERGED",
+          "merge_commit": "1cd5d3d0e2eeb14896ad9446ce53da5fb5c35e47"
+        },
+        "ledger_reconciliation": {
+          "status": "pass",
+          "summary": "GitHub PR #1512 is merged, origin/main contains merge commit 1cd5d3d0e2eeb14896ad9446ce53da5fb5c35e47, and the remote branch is deleted."
         }
       },
-      "failure_reason": "GitHub checks failed on BigFive runtime freeze false positive; scoped allowlist added for the three SEO Intel two-stage handoff files and focused BigFive runtime freeze test passed locally.",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "failure_reason": null,
+      "merged_at": "2026-05-20T04:00:03Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "history": [
         {
@@ -12631,6 +12639,11 @@
           "at": "2026-05-20T03:53:00Z",
           "status": "ci_fix_local_validation_passed",
           "summary": "Added a narrow BigFive runtime-freeze allowlist for exactly the SEO Intel two-stage handoff command/service files, updated manifest scope, and reran the focused BigFive freeze test successfully."
+        },
+        {
+          "at": "2026-05-20T12:24:00+08:00",
+          "status": "reconciled_merged",
+          "summary": "Reconciled GitHub PR #1512 as merged with green checks. origin/main contains merge commit 1cd5d3d0e2eeb14896ad9446ce53da5fb5c35e47 and the remote branch is deleted."
         }
       ],
       "next_pr": "RESEARCH-PUBLISH-02-RERUN"
@@ -14275,7 +14288,198 @@
     ],
     "merge_commit": "9a5bcdc43080d0d0420e1499e0ad0f8e2a1abc7f"
   },
-  "RIASEC-FULL-CONTENT-PACK-13-BE": {
+    "SEARCH-CHANNEL-LIVE-00": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-00-readiness-split-scan",
+      "status": "in_progress",
+      "depends_on": [
+        "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "scope_validation": {
+          "status": "pass",
+          "summary": "Changed files are limited to Search Channel live readiness split scan docs/generated/test, stale SEO handoff ledger reconciliation, and PR train metadata. Unrelated docs/audits/eq/ remains unstaged."
+        },
+        "dependency_reconciliation": {
+          "status": "pass",
+          "summary": "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00 is merged on GitHub, origin/main contains merge commit 1cd5d3d0e2eeb14896ad9446ce53da5fb5c35e47, and the remote branch is deleted."
+        },
+        "live_operation_guard": {
+          "status": "pass",
+          "summary": "No URL submission, live external search API call, production crawler log read, scheduler enablement, collector write, production env edit, sitemap change, or llms change performed."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelSearchChannelLiveReadinessScan",
+          "summary": "4 tests passed, 51 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "summary": "227 tests passed, 3877 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "summary": "Route list rendered successfully; 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "summary": "3410 files passed."
+        },
+        "json_yaml_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/search-channel-live-readiness-scan.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "Readiness scan uses accepted verified production counts without re-querying production DB",
+          "status": "recorded_avoided",
+          "summary": "The train forbids business DB / Tencent RDS / Node2 DB access. Counts are recorded from the user-provided verified SEO Dash MVP state and guarded by local contract tests."
+        }
+      ],
+      "history": [
+        {
+          "at": "2026-05-20T12:20:00+08:00",
+          "status": "in_progress",
+          "summary": "Initialized SEARCH-CHANNEL-LIVE-00 after explicit /goal authorization. Added local read-only split scan docs/generated/test and registered the GSC, Baidu, IndexNow, and preflight follow-up tasks."
+        },
+        {
+          "at": "2026-05-20T12:30:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Read-only scan docs/generated/test and train metadata validation passed. No live search API, URL submission, production crawler log read, scheduler, collector write, env edit, sitemap change, or llms change occurred."
+        }
+      ]
+    },
+    "GSC-LIVE-00": {
+      "repo": "fap-api",
+      "branch": "codex/gsc-live-00-readiness-contract",
+      "status": "initialized",
+      "depends_on": [
+        "SEARCH-CHANNEL-LIVE-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "GSC credentials/property may be unavailable",
+          "status": "sidecar_not_blocking_docs_contract",
+          "summary": "No live GSC API call or credential validation is required for GSC-LIVE-00."
+        }
+      ],
+      "history": [
+        {
+          "at": "2026-05-20T12:20:00+08:00",
+          "status": "initialized",
+          "summary": "Registered GSC-LIVE-00 from explicit /goal scope for a no-live-call readiness contract."
+        }
+      ]
+    },
+    "BAIDU-LIVE-00": {
+      "repo": "fap-api",
+      "branch": "codex/baidu-live-00-readiness-contract",
+      "status": "initialized",
+      "depends_on": [
+        "GSC-LIVE-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "Baidu token/site ownership may be unavailable",
+          "status": "sidecar_not_blocking_docs_contract",
+          "summary": "No Baidu push or token validation is required for BAIDU-LIVE-00."
+        }
+      ],
+      "history": [
+        {
+          "at": "2026-05-20T12:20:00+08:00",
+          "status": "initialized",
+          "summary": "Registered BAIDU-LIVE-00 from explicit /goal scope for a no-push readiness contract."
+        }
+      ]
+    },
+    "INDEXNOW-LIVE-00": {
+      "repo": "fap-api",
+      "branch": "codex/indexnow-live-00-readiness-contract",
+      "status": "initialized",
+      "depends_on": [
+        "BAIDU-LIVE-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "IndexNow key may be unavailable",
+          "status": "sidecar_not_blocking_docs_contract",
+          "summary": "No IndexNow submission or key validation is required for INDEXNOW-LIVE-00."
+        }
+      ],
+      "history": [
+        {
+          "at": "2026-05-20T12:20:00+08:00",
+          "status": "initialized",
+          "summary": "Registered INDEXNOW-LIVE-00 from explicit /goal scope for a no-submit readiness contract."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-LIVE-01-PREFLIGHT": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-01-preflight",
+      "status": "initialized",
+      "depends_on": [
+        "INDEXNOW-LIVE-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "Search Channel Queue runtime may be missing",
+          "status": "record_for_preflight",
+          "summary": "The preflight must decide between live canary approval readiness and SEARCH-CHANNEL-QUEUE-01 runtime MVP."
+        }
+      ],
+      "history": [
+        {
+          "at": "2026-05-20T12:20:00+08:00",
+          "status": "initialized",
+          "summary": "Registered SEARCH-CHANNEL-LIVE-01-PREFLIGHT from explicit /goal scope for URL eligibility and no-submit preflight."
+        }
+      ]
+    },
+    "RIASEC-FULL-CONTENT-PACK-13-BE": {
     "status": "pr_opened_github_checks_pending",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -7485,3 +7485,196 @@ prs:
       github_checks_required: true
       squash: true
       auto_merge: true
+
+  - id: SEARCH-CHANNEL-LIVE-00
+    repo: fap-api
+    depends_on:
+      - SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00
+    branch: codex/search-channel-live-00-readiness-split-scan
+    base: main
+    title: "SEARCH-CHANNEL-LIVE-00｜Search Channel readiness split scan"
+    name: "Search Channel readiness split scan"
+    train_scope: search_channel_live_readiness
+    risk_level: L2
+    type: backend docs/generated/test metadata PR
+    scope:
+      - Confirm Research URL Truth, Search Channel Queue contract, exclusion rules, and no-live-operation boundaries before live readiness contracts.
+      - Register the explicitly authorized Search Channel live readiness train tasks.
+      - Preserve sitemap, llms, scheduler, crawler-log, collector-write, production env, and live search API boundaries.
+    allowed_paths:
+      - backend/docs/seo/search-channel-live-readiness-scan.md
+      - backend/docs/seo/generated/search-channel-live-readiness-scan.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveReadinessScanTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Submit URLs or request indexing.
+      - Connect live GSC, Baidu, IndexNow, Bing, 360, Sogou, Shenma, or other search APIs.
+      - Read production crawler logs, run collector writes, enable scheduler, deploy, edit production env, change DNS/CDN/OpenResty/Nginx, or change sitemap/llms behavior.
+      - Use frontend fallback, static sitemap, static llms, production crawler logs, live search responses, Node2 local DB, or business DB tables as Search Channel URL authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLiveReadinessScan
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-readiness-scan.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+
+  - id: GSC-LIVE-00
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-LIVE-00
+    branch: codex/gsc-live-00-readiness-contract
+    base: main
+    title: "GSC-LIVE-00｜Google Search Console readiness contract"
+    name: "Google Search Console readiness contract"
+    train_scope: search_channel_live_readiness
+    risk_level: L2
+    type: backend docs/generated/test PR
+    scope:
+      - Define Google Search Console readiness without live calls, URL submission, indexing requests, scheduler enablement, or connector activation.
+      - Preserve CMS/backend URL Truth authority and make GSC feedback/readiness only.
+    allowed_paths:
+      - backend/docs/seo/gsc-live-readiness-contract.md
+      - backend/docs/seo/generated/gsc-live-readiness-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGscLiveReadinessContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Call live GSC APIs, request indexing, submit URLs, activate a live connector, enable scheduler, edit env, or change sitemap/llms behavior.
+      - Let GSC create URLs or override CMS/backend URL Truth.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGscLiveReadinessContract
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/gsc-live-readiness-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+
+  - id: BAIDU-LIVE-00
+    repo: fap-api
+    depends_on:
+      - GSC-LIVE-00
+    branch: codex/baidu-live-00-readiness-contract
+    base: main
+    title: "BAIDU-LIVE-00｜Baidu Resource Platform readiness contract"
+    name: "Baidu Resource Platform readiness contract"
+    train_scope: search_channel_live_readiness
+    risk_level: L2
+    type: backend docs/generated/test PR
+    scope:
+      - Define Baidu Resource Platform readiness without URL push, token exposure, alternate Baidu page truth, scheduler enablement, or live connector activation.
+      - Preserve Search Channel Queue, CMS/backend URL Truth, and Chinese claim boundary linter requirements.
+    allowed_paths:
+      - backend/docs/seo/baidu-live-readiness-contract.md
+      - backend/docs/seo/generated/baidu-live-readiness-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelBaiduLiveReadinessContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Push URLs to Baidu, expose tokens, call live Baidu APIs, enable scheduler, edit env, or change sitemap/llms behavior.
+      - Create a Baidu-only page set or separate Baidu authority layer.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelBaiduLiveReadinessContract
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/baidu-live-readiness-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+
+  - id: INDEXNOW-LIVE-00
+    repo: fap-api
+    depends_on:
+      - BAIDU-LIVE-00
+    branch: codex/indexnow-live-00-readiness-contract
+    base: main
+    title: "INDEXNOW-LIVE-00｜IndexNow readiness contract"
+    name: "IndexNow readiness contract"
+    train_scope: search_channel_live_readiness
+    risk_level: L2
+    type: backend docs/generated/test PR
+    scope:
+      - Define IndexNow readiness without live submission, public key/token leakage, scheduler enablement, or connector activation.
+      - Require key verification, allowed host controls, and Search Channel Queue approved URL eligibility before any future submission.
+    allowed_paths:
+      - backend/docs/seo/indexnow-live-readiness-contract.md
+      - backend/docs/seo/generated/indexnow-live-readiness-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelIndexNowLiveReadinessContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Submit URLs to IndexNow, expose keys, call live IndexNow endpoints, enable scheduler, edit env, or change sitemap/llms behavior.
+      - Bypass CMS/backend URL Truth or Search Channel Queue approval.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelIndexNowLiveReadinessContract
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/indexnow-live-readiness-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+
+  - id: SEARCH-CHANNEL-LIVE-01-PREFLIGHT
+    repo: fap-api
+    depends_on:
+      - INDEXNOW-LIVE-00
+    branch: codex/search-channel-live-01-preflight
+    base: main
+    title: "SEARCH-CHANNEL-LIVE-01-PREFLIGHT｜URL eligibility and no-submit preflight"
+    name: "URL eligibility and no-submit preflight"
+    train_scope: search_channel_live_readiness
+    risk_level: L2
+    type: backend docs/generated/test report PR
+    scope:
+      - Produce the consolidated no-submit Search Channel live readiness report from local contracts and accepted verified SEO state.
+      - Verify URL eligibility boundaries, channel readiness status, and Search Channel Queue runtime/contract readiness without live API calls or submissions.
+    allowed_paths:
+      - backend/docs/seo/search-channel-live-preflight.md
+      - backend/docs/seo/generated/search-channel-live-preflight.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLivePreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Submit URLs, call live GSC/Baidu/IndexNow APIs, enable scheduler, read production crawler logs, run collector writes, edit env, deploy, or change sitemap/llms behavior.
+      - Treat draft/private/noindex/claim-unsafe URLs as eligible.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLivePreflight
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-preflight.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true


### PR DESCRIPTION
## What changed
- Added the read-only Search Channel live readiness split scan doc and generated artifact.
- Added a focused SeoIntel test locking no-submit/no-live-operation boundaries and follow-up task split.
- Registered the explicitly authorized GSC/Baidu/IndexNow/preflight readiness train tasks and reconciled the already-merged two-stage URL Truth handoff ledger entry.

## Why
- Prepare the Search Channel live readiness train without submitting URLs, calling live search APIs, enabling scheduler/jobs, reading production crawler logs, or changing sitemap/llms behavior.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelLiveReadinessScan`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/search-channel-live-readiness-scan.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No live GSC, Baidu, IndexNow, Bing, 360, Sogou, Shenma, or search-engine submission.
- No URL indexing request.
- No production crawler log read, scheduler enablement, collector write, env edit, deployment, DNS/CDN/OpenResty/Nginx change, sitemap change, or llms change.
- GSC/Baidu/IndexNow credential readiness remains sidecar for later explicit approval.

## Repository rule impact
- CMS/backend remains the URL and SEO authority. This PR does not add frontend fallback, static sitemap fallback, static llms fallback, alternate domestic page truth, pSEO, Research publishing, or claim expansion.