### PR TITLE
GSC-LIVE-00｜Google Search Console readiness contract

### DIFF
--- a/backend/docs/seo/generated/gsc-live-readiness-contract.v1.json
+++ b/backend/docs/seo/generated/gsc-live-readiness-contract.v1.json
@@ -1,0 +1,78 @@
+{
+  "version": "gsc-live-readiness-contract.v1",
+  "task": "GSC-LIVE-00",
+  "type": "docs_generated_test_contract",
+  "channel": "gsc",
+  "authority_boundary": {
+    "gsc_is_feedback_readiness_source": true,
+    "gsc_is_content_authority": false,
+    "gsc_is_url_truth_authority": false,
+    "gsc_is_sitemap_authority": false,
+    "gsc_is_llms_authority": false,
+    "gsc_is_purchase_truth": false,
+    "gsc_creates_urls": false,
+    "gsc_overrides_cms_backend_url_truth": false
+  },
+  "ownership_requirements": [
+    "verified_search_console_property",
+    "documented_property_owner",
+    "documented_operator_responsibility",
+    "approved_service_account_or_oauth_access",
+    "safe_secret_channel_only"
+  ],
+  "read_only_data_window": {
+    "maximum_contract_window": "last_16_months_max",
+    "preferred_initial_windows": [
+      "last_28_days",
+      "last_90_days"
+    ],
+    "raw_sensitive_query_output_allowed": false
+  },
+  "url_inspection_readiness": {
+    "read_only_status_check_only": true,
+    "requires_explicit_future_approval": true,
+    "requires_safe_credentials": true,
+    "allowed_url_source": "cms_backend_url_truth_approved_canonical_urls",
+    "indexing_request_allowed": false,
+    "url_submission_allowed": false,
+    "queue_creation_by_gsc_allowed": false
+  },
+  "sitemap_authority_check": {
+    "compare_gsc_feedback_to_backend_expectations": true,
+    "changes_sitemap_generation": false,
+    "changes_llms_generation": false,
+    "changes_cms_publication_state": false,
+    "changes_url_truth_eligibility": false
+  },
+  "forbidden_url_classes": [
+    "draft",
+    "private",
+    "noindex",
+    "unsupported_page_type",
+    "stale_slug",
+    "claim_unsafe",
+    "non_backend_authoritative"
+  ],
+  "forbidden_sensitive_outputs": [
+    "token",
+    "api_key",
+    "cookie",
+    "session",
+    "email",
+    "order_id",
+    "attempt_id",
+    "payment_id",
+    "raw_ip"
+  ],
+  "live_api_call_in_this_pr": false,
+  "url_submission_performed": false,
+  "indexing_request_performed": false,
+  "scheduler_enabled": false,
+  "collector_write_executed": false,
+  "live_connector_activated": false,
+  "credentials_added_in_this_pr": false,
+  "production_env_edited": false,
+  "sitemap_changed_in_this_pr": false,
+  "llms_changed_in_this_pr": false,
+  "next_task": "BAIDU-LIVE-00"
+}

--- a/backend/docs/seo/gsc-live-readiness-contract.md
+++ b/backend/docs/seo/gsc-live-readiness-contract.md
@@ -1,0 +1,75 @@
+# Google Search Console Live Readiness Contract
+
+## Purpose
+
+GSC-LIVE-00 defines Google Search Console readiness for Search Channel live preparation without making live calls or requesting indexing.
+
+This PR does not connect a live GSC connector, submit URLs, request indexing, activate scheduler jobs, run collector writes, edit environment files, deploy services, or change sitemap/llms behavior.
+
+## Authority Boundary
+
+Google Search Console is a feedback and readiness source only. It is not content authority, URL Truth authority, sitemap authority, `llms.txt` authority, purchase truth, or Search Channel submission authority.
+
+GSC must not:
+
+- create URLs
+- discover URLs that bypass CMS/backend URL Truth
+- override backend canonical URLs
+- override CMS publication, indexability, or claim boundary state
+- make draft, private, noindex, unsupported, stale-slug, or claim-unsafe URLs eligible
+
+GSC must not create URLs or promote discovered URLs around backend approval.
+
+CMS/backend URL Truth remains the source of truth for canonical URLs, source authority, publication state, indexability state, and claim safety.
+
+## Ownership And Access Requirements
+
+Before any future read-only GSC operation:
+
+- the FermatMind site property must be verified in Google Search Console
+- property ownership and operator responsibility must be documented
+- access must use approved service account or OAuth credentials from a safe secret channel
+- credentials must not be committed, printed, logged, pasted into docs, or stored in generated artifacts
+- the connector must run read-only until a separate explicit approval changes that boundary
+
+Missing property ownership, service account, OAuth approval, or operator account readiness is a sidecar blocker for live operation, not a blocker for this docs/test contract.
+
+## Read-Only Data Window
+
+A future GSC readiness check may read Search Console performance or index status only within an approved bounded window. The initial contract window is `last_16_months_max`, with future operational runs expected to use a narrower window such as `last_28_days` or `last_90_days` unless explicitly approved.
+
+Any read output must be aggregated and sanitized. It must not expose raw queries containing emails, tokens, order IDs, attempt IDs, payment IDs, sessions, cookies, or raw IPs.
+
+## URL Inspection Readiness
+
+URL Inspection may be used only as a read-only/status check after explicit approval and safe credentials are available.
+
+URL Inspection must:
+
+- inspect only CMS/backend URL Truth approved canonical URLs
+- treat status as feedback, not authority
+- never request indexing from this readiness contract
+- never create queue records by itself
+- never override draft/private/noindex/claim-unsafe exclusions
+
+## Sitemap Authority Check
+
+GSC sitemap feedback may compare submitted sitemap status against backend-authoritative sitemap expectations. It must not change sitemap generation, `llms.txt` generation, CMS publication state, or URL Truth eligibility.
+
+## Stop Conditions
+
+Stop immediately if:
+
+- a live GSC API call is attempted in this PR
+- a URL indexing request is attempted
+- a URL submission is attempted
+- a credential, token, API key, cookie, session, email, order ID, attempt ID, payment ID, or raw IP is printed or committed
+- GSC is used as URL Truth authority
+- sitemap or `llms.txt` behavior changes
+- scheduler or collector writes are enabled
+
+No live GSC API call is allowed in GSC-LIVE-00.
+
+## Next Task
+
+Next task: BAIDU-LIVE-00.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscLiveReadinessContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscLiveReadinessContractTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscLiveReadinessContractTest extends TestCase
+{
+    #[Test]
+    public function artifact_locks_gsc_as_feedback_not_authority(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('gsc-live-readiness-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('GSC-LIVE-00', $artifact['task'] ?? null);
+        $this->assertSame('gsc', $artifact['channel'] ?? null);
+        $this->assertTrue((bool) data_get($artifact, 'authority_boundary.gsc_is_feedback_readiness_source'));
+
+        foreach ([
+            'gsc_is_content_authority',
+            'gsc_is_url_truth_authority',
+            'gsc_is_sitemap_authority',
+            'gsc_is_llms_authority',
+            'gsc_is_purchase_truth',
+            'gsc_creates_urls',
+            'gsc_overrides_cms_backend_url_truth',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'authority_boundary.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function ownership_and_read_only_requirements_are_explicit(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'verified_search_console_property',
+            'documented_property_owner',
+            'documented_operator_responsibility',
+            'approved_service_account_or_oauth_access',
+            'safe_secret_channel_only',
+        ] as $requirement) {
+            $this->assertContains($requirement, $artifact['ownership_requirements'] ?? []);
+        }
+
+        $this->assertSame('last_16_months_max', data_get($artifact, 'read_only_data_window.maximum_contract_window'));
+        $this->assertContains('last_28_days', data_get($artifact, 'read_only_data_window.preferred_initial_windows', []));
+        $this->assertFalse((bool) data_get($artifact, 'read_only_data_window.raw_sensitive_query_output_allowed', true));
+    }
+
+    #[Test]
+    public function url_inspection_is_read_only_status_check_without_submission(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue((bool) data_get($artifact, 'url_inspection_readiness.read_only_status_check_only'));
+        $this->assertTrue((bool) data_get($artifact, 'url_inspection_readiness.requires_explicit_future_approval'));
+        $this->assertSame('cms_backend_url_truth_approved_canonical_urls', data_get($artifact, 'url_inspection_readiness.allowed_url_source'));
+
+        foreach ([
+            'indexing_request_allowed',
+            'url_submission_allowed',
+            'queue_creation_by_gsc_allowed',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'url_inspection_readiness.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function sitemap_check_does_not_change_runtime_or_url_truth(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue((bool) data_get($artifact, 'sitemap_authority_check.compare_gsc_feedback_to_backend_expectations'));
+
+        foreach ([
+            'changes_sitemap_generation',
+            'changes_llms_generation',
+            'changes_cms_publication_state',
+            'changes_url_truth_eligibility',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'sitemap_authority_check.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function no_live_api_or_secret_exposure_is_allowed_in_this_pr(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'live_api_call_in_this_pr',
+            'url_submission_performed',
+            'indexing_request_performed',
+            'scheduler_enabled',
+            'collector_write_executed',
+            'live_connector_activated',
+            'credentials_added_in_this_pr',
+            'production_env_edited',
+            'sitemap_changed_in_this_pr',
+            'llms_changed_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+
+        foreach (['draft', 'private', 'noindex', 'claim_unsafe'] as $forbidden) {
+            $this->assertContains($forbidden, $artifact['forbidden_url_classes'] ?? []);
+        }
+
+        foreach (['token', 'api_key', 'cookie', 'session', 'email', 'order_id', 'attempt_id', 'payment_id', 'raw_ip'] as $field) {
+            $this->assertContains($field, $artifact['forbidden_sensitive_outputs'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function docs_lock_gsc_no_submit_language_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/gsc-live-readiness-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/gsc-live-readiness-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'feedback and readiness source only',
+            'must not create urls',
+            'read-only/status check',
+            'never request indexing',
+            'does not connect a live gsc connector',
+            'no live gsc api call',
+            'next task: baidu-live-00',
+            '"next_task": "baidu-live-00"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/gsc-live-readiness-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3241,7 +3241,7 @@
       "branch": "fix/career-80-candidate-readiness-selector-1",
       "title": "fix(api): add career 80 candidate readiness selector",
       "name": "Add career 80 candidate readiness selector",
-      "status": "pr_opened_github_checks_pending",
+      "status": "merged",
       "depends_on": [
         "REPAIR-ENTITY-1",
         "SCAN-3"
@@ -6083,7 +6083,7 @@
         "no fap-web",
         "no live crawl"
       ],
-      "commit_sha": "6e603fa8",
+      "commit_sha": "4898eb6c3bc74c33ec6136f18f010c7a3d73fc54",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1513",
       "checks": {
         "authorization": {
@@ -6747,7 +6747,7 @@
       "branch": "codex/2786-cn-proxy-public-owner-pr-train-1",
       "title": "fix(api): gate reviewed CN proxy public owner plan",
       "name": "Gate reviewed CN proxy public owner plan for 2786",
-      "status": "in_progress",
+      "status": "local_validation_passed",
       "depends_on": [
         "REPAIR-2786-FINAL-PUBLIC-RESOLUTION-PARTITION-1",
         "CN-PROXY-AUTHORITY-POLICY-DECISION-1",
@@ -14343,14 +14343,18 @@
           "command": "git diff --cached --check"
         },
         "github_required_checks": {
-          "status": "pending",
-          "summary": "PR #1513 opened; GitHub checks pending."
+          "status": "pass",
+          "summary": "PR #1513 passed hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS. mergeStateStatus was CLEAN before squash merge."
+        },
+        "merge": {
+          "status": "pass",
+          "summary": "Squash merged PR #1513 as 4898eb6c3bc74c33ec6136f18f010c7a3d73fc54."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-20T13:08:36Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "Readiness scan uses accepted verified production counts without re-querying production DB",
@@ -14373,19 +14377,61 @@
           "at": "2026-05-20T12:34:00+08:00",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1513 for SEARCH-CHANNEL-LIVE-00. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-20T21:08:36+08:00",
+          "status": "merged",
+          "summary": "GitHub checks passed, PR #1513 was squash merged as 4898eb6c3bc74c33ec6136f18f010c7a3d73fc54, the remote branch was deleted, and local post-merge cleanup executed."
         }
       ]
     },
     "GSC-LIVE-00": {
       "repo": "fap-api",
       "branch": "codex/gsc-live-00-readiness-contract",
-      "status": "initialized",
+      "status": "in_progress",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-00"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "summary": "SEARCH-CHANNEL-LIVE-00 merged as 4898eb6c3bc74c33ec6136f18f010c7a3d73fc54 and origin/main contains it."
+        },
+        "live_operation_guard": {
+          "status": "pass",
+          "summary": "No GSC live API call, URL submission, indexing request, scheduler enablement, collector write, production env edit, sitemap change, or llms change performed."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelGscLiveReadinessContract",
+          "summary": "6 tests passed, 71 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "summary": "233 tests passed, 3948 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "summary": "Route list rendered successfully; 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "summary": "3411 files passed."
+        },
+        "json_yaml_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/gsc-live-readiness-contract.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14402,6 +14448,16 @@
           "at": "2026-05-20T12:20:00+08:00",
           "status": "initialized",
           "summary": "Registered GSC-LIVE-00 from explicit /goal scope for a no-live-call readiness contract."
+        },
+        {
+          "at": "2026-05-20T21:10:00+08:00",
+          "status": "in_progress",
+          "summary": "Started GSC-LIVE-00 after SEARCH-CHANNEL-LIVE-00 merged. Scope is docs/generated/test readiness contract only; no live GSC API call or indexing request is allowed."
+        },
+        {
+          "at": "2026-05-20T21:16:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "GSC readiness contract docs/generated/test passed focused and full SeoIntel validation, route list, Pint, JSON/YAML, and diff checks. No live GSC call or URL indexing request occurred."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the Google Search Console live readiness contract and generated artifact.
- Added focused SeoIntel coverage for GSC authority boundaries, property/access requirements, read-only data windows, URL Inspection status-only readiness, sitemap feedback boundaries, and no-submit/no-indexing rules.
- Reconciled SEARCH-CHANNEL-LIVE-00 as merged in the train ledger.

## Why
- Prepare GSC readiness without live GSC calls, URL submission, indexing requests, scheduler activation, connector activation, or sitemap/llms behavior changes.

## Validation
- `cd backend && php artisan test --filter=SeoIntelGscLiveReadinessContract`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/gsc-live-readiness-contract.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No live GSC API call.
- No URL Inspection execution.
- No indexing request or URL submission.
- No live connector activation, scheduler enablement, collector write, env edit, production operation, sitemap change, or llms change.

## Repository rule impact
- CMS/backend URL Truth remains authority. GSC is feedback/readiness only and cannot create URLs, override backend truth, or make draft/private/noindex/claim-unsafe URLs eligible.