### PR TITLE
BAIDU-LIVE-00｜Baidu Resource Platform readiness contract

### DIFF
--- a/backend/docs/seo/baidu-live-readiness-contract.md
+++ b/backend/docs/seo/baidu-live-readiness-contract.md
@@ -1,0 +1,72 @@
+# Baidu Resource Platform Live Readiness Contract
+
+## Purpose
+
+BAIDU-LIVE-00 defines Baidu Resource Platform readiness for Search Channel live preparation without pushing URLs.
+
+This PR does not call live Baidu APIs, push URLs, expose tokens, activate a live connector, enable scheduler jobs, run collector writes, edit environment files, deploy services, or change sitemap/llms behavior.
+
+## Authority Boundary
+
+Baidu is a distribution and feedback channel. It is not content authority, URL Truth authority, sitemap authority, `llms.txt` authority, or a separate domestic page truth layer.
+
+Baidu must use the same canonical CMS/backend URL Truth as other Search Channel adapters. It must not create a Baidu-only page set, separate slugs, alternate metadata, domestic-only editorial content, or frontend fallback content.
+
+## Ownership Requirements
+
+Before any future Baidu live operation:
+
+- the FermatMind site must be verified in Baidu Resource Platform
+- the Baidu Resource Platform account owner must be documented
+- operator responsibility must be documented
+- push endpoint and quota policy must be approved
+- push token storage must use an approved safe secret channel
+- token rotation and revocation ownership must be documented
+
+Unavailable site ownership, operator readiness, token readiness, or endpoint approval is a sidecar blocker for live operation, not a blocker for this docs/test contract.
+
+## Token And Endpoint Handling
+
+Baidu push tokens and endpoints must never be committed, printed, logged, pasted into docs, stored in generated artifacts, or exposed in public error output.
+
+Only masked endpoint descriptions and credential readiness states may appear in reports. Raw tokens, cookies, sessions, emails, order IDs, attempt IDs, payment IDs, raw IPs, and raw payloads are forbidden.
+
+## Sitemap And Push Eligibility
+
+Baidu sitemap and push readiness must start from Search Channel Queue approved canonical URLs. Eligibility requires:
+
+- backend/CMS source authority
+- canonical URL present
+- published state
+- indexable state
+- supported URL Truth page type
+- claim boundary safe
+- Chinese claim boundary linter pass where Chinese copy or domestic search copy is involved
+- no private-flow path
+- no query-string-only candidate
+- no stale slug
+
+Draft, private, noindex, claim-unsafe, unsupported, stale-slug, missing-canonical, or non-backend-authoritative URLs must never be pushed.
+
+## Search Channel Queue Requirement
+
+Baidu push must be driven by Search Channel Queue records after a separate explicit live approval. A Baidu adapter must not bypass URL Truth, create URLs, or submit directly from frontend sitemap, static `llms.txt`, local content copies, production crawler logs, live Baidu responses, Node2 local DB, or raw business DB tables.
+
+## Stop Conditions
+
+Stop immediately if:
+
+- a Baidu URL push is attempted in this PR
+- a live Baidu API call is attempted in this PR
+- a Baidu token or endpoint secret is exposed
+- a draft/private/noindex/claim-unsafe URL becomes eligible
+- a Baidu-only page set or alternate Baidu truth layer is introduced
+- frontend fallback becomes search truth
+- scheduler or collector writes are enabled
+- sitemap or `llms.txt` behavior changes
+
+No Baidu push is allowed in BAIDU-LIVE-00.
+
+## Next Task
+
+Next task: INDEXNOW-LIVE-00.

--- a/backend/docs/seo/generated/baidu-live-readiness-contract.v1.json
+++ b/backend/docs/seo/generated/baidu-live-readiness-contract.v1.json
@@ -1,0 +1,86 @@
+{
+  "version": "baidu-live-readiness-contract.v1",
+  "task": "BAIDU-LIVE-00",
+  "type": "docs_generated_test_contract",
+  "channel": "baidu",
+  "authority_boundary": {
+    "baidu_is_distribution_channel": true,
+    "baidu_is_content_authority": false,
+    "baidu_is_url_truth_authority": false,
+    "baidu_is_sitemap_authority": false,
+    "baidu_is_llms_authority": false,
+    "baidu_only_page_truth_allowed": false,
+    "alternate_baidu_page_set_allowed": false,
+    "frontend_fallback_allowed_as_search_truth": false
+  },
+  "ownership_requirements": [
+    "verified_baidu_resource_platform_site",
+    "documented_account_owner",
+    "documented_operator_responsibility",
+    "approved_push_endpoint_and_quota_policy",
+    "safe_secret_channel_only",
+    "documented_token_rotation_and_revocation_owner"
+  ],
+  "token_endpoint_policy": {
+    "raw_token_in_docs_allowed": false,
+    "raw_token_in_logs_allowed": false,
+    "raw_endpoint_secret_in_generated_artifact_allowed": false,
+    "public_token_exposure_allowed": false,
+    "masked_readiness_state_allowed": true
+  },
+  "eligibility_requires": [
+    "search_channel_queue_approved",
+    "backend_cms_source_authority",
+    "canonical_url_present",
+    "published_state",
+    "indexable_state",
+    "url_truth_supported_page_type",
+    "claim_boundary_safe",
+    "chinese_claim_boundary_linter_passed_when_applicable",
+    "not_private_flow",
+    "not_query_string_only",
+    "not_stale_slug"
+  ],
+  "excluded_url_classes": [
+    "draft",
+    "private",
+    "noindex",
+    "claim_unsafe",
+    "unsupported_page_type",
+    "stale_slug",
+    "missing_canonical",
+    "non_backend_authoritative"
+  ],
+  "forbidden_authority_inputs": [
+    "frontend_sitemap",
+    "static_llms",
+    "local_content_copies",
+    "production_crawler_logs",
+    "live_baidu_response_as_page_truth",
+    "node2_local_db",
+    "business_db_raw_tables"
+  ],
+  "forbidden_sensitive_outputs": [
+    "token",
+    "api_key",
+    "cookie",
+    "session",
+    "email",
+    "order_id",
+    "attempt_id",
+    "payment_id",
+    "raw_ip",
+    "raw_payload"
+  ],
+  "baidu_push_performed": false,
+  "live_api_call_in_this_pr": false,
+  "url_submission_performed": false,
+  "scheduler_enabled": false,
+  "collector_write_executed": false,
+  "live_connector_activated": false,
+  "credentials_added_in_this_pr": false,
+  "production_env_edited": false,
+  "sitemap_changed_in_this_pr": false,
+  "llms_changed_in_this_pr": false,
+  "next_task": "INDEXNOW-LIVE-00"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelBaiduLiveReadinessContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelBaiduLiveReadinessContractTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelBaiduLiveReadinessContractTest extends TestCase
+{
+    #[Test]
+    public function artifact_locks_baidu_to_distribution_not_authority(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('baidu-live-readiness-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('BAIDU-LIVE-00', $artifact['task'] ?? null);
+        $this->assertSame('baidu', $artifact['channel'] ?? null);
+        $this->assertTrue((bool) data_get($artifact, 'authority_boundary.baidu_is_distribution_channel'));
+
+        foreach ([
+            'baidu_is_content_authority',
+            'baidu_is_url_truth_authority',
+            'baidu_is_sitemap_authority',
+            'baidu_is_llms_authority',
+            'baidu_only_page_truth_allowed',
+            'alternate_baidu_page_set_allowed',
+            'frontend_fallback_allowed_as_search_truth',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'authority_boundary.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function ownership_token_and_endpoint_policies_are_explicit(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'verified_baidu_resource_platform_site',
+            'documented_account_owner',
+            'documented_operator_responsibility',
+            'approved_push_endpoint_and_quota_policy',
+            'safe_secret_channel_only',
+            'documented_token_rotation_and_revocation_owner',
+        ] as $requirement) {
+            $this->assertContains($requirement, $artifact['ownership_requirements'] ?? []);
+        }
+
+        foreach ([
+            'raw_token_in_docs_allowed',
+            'raw_token_in_logs_allowed',
+            'raw_endpoint_secret_in_generated_artifact_allowed',
+            'public_token_exposure_allowed',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'token_endpoint_policy.'.$flag, true), $flag.' must remain false');
+        }
+
+        $this->assertTrue((bool) data_get($artifact, 'token_endpoint_policy.masked_readiness_state_allowed'));
+    }
+
+    #[Test]
+    public function baidu_push_requires_search_channel_queue_and_claim_safety(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'search_channel_queue_approved',
+            'backend_cms_source_authority',
+            'canonical_url_present',
+            'published_state',
+            'indexable_state',
+            'url_truth_supported_page_type',
+            'claim_boundary_safe',
+            'chinese_claim_boundary_linter_passed_when_applicable',
+            'not_private_flow',
+            'not_query_string_only',
+            'not_stale_slug',
+        ] as $gate) {
+            $this->assertContains($gate, $artifact['eligibility_requires'] ?? []);
+        }
+
+        foreach (['draft', 'private', 'noindex', 'claim_unsafe', 'stale_slug', 'non_backend_authoritative'] as $class) {
+            $this->assertContains($class, $artifact['excluded_url_classes'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function forbidden_sources_and_sensitive_outputs_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'frontend_sitemap',
+            'static_llms',
+            'local_content_copies',
+            'production_crawler_logs',
+            'live_baidu_response_as_page_truth',
+            'node2_local_db',
+            'business_db_raw_tables',
+        ] as $source) {
+            $this->assertContains($source, $artifact['forbidden_authority_inputs'] ?? []);
+        }
+
+        foreach (['token', 'api_key', 'cookie', 'session', 'email', 'order_id', 'attempt_id', 'payment_id', 'raw_ip', 'raw_payload'] as $field) {
+            $this->assertContains($field, $artifact['forbidden_sensitive_outputs'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function no_push_or_live_activation_is_allowed_in_this_pr(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'baidu_push_performed',
+            'live_api_call_in_this_pr',
+            'url_submission_performed',
+            'scheduler_enabled',
+            'collector_write_executed',
+            'live_connector_activated',
+            'credentials_added_in_this_pr',
+            'production_env_edited',
+            'sitemap_changed_in_this_pr',
+            'llms_changed_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_baidu_push_language_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/baidu-live-readiness-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/baidu-live-readiness-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'does not call live baidu apis',
+            'no baidu push is allowed',
+            'must not create a baidu-only page set',
+            'chinese claim boundary linter pass',
+            'search channel queue records',
+            'next task: indexnow-live-00',
+            '"next_task": "indexnow-live-00"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/baidu-live-readiness-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4247,7 +4247,7 @@
       "branch": "fix/career-surface-context-export-producer",
       "title": "fix(api): add career surface context export producer",
       "name": "Add read-only Career 2786 surface context artifact producer",
-      "status": "local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "RUN-1D",
         "REPAIR-80-CANDIDATE-1"
@@ -6141,8 +6141,8 @@
         "no production DB query",
         "no live crawl"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "c95a25819d3c76f2298d87f3bd139557a1954b6e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1514",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -6841,7 +6841,7 @@
       "branch": "codex/repair-2786-final-readiness-public-owner-partition-authority-1",
       "title": "fix(api): account reviewed public owner partition in 2786 readiness",
       "name": "Account reviewed CN proxy public-owner partition in final 2786 readiness",
-      "status": "in_progress",
+      "status": "local_validation_passed",
       "depends_on": [
         "2786-CN-PROXY-PUBLIC-OWNER-PLAN-1"
       ],
@@ -14430,12 +14430,20 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "summary": "PR #1514 passed hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS. mergeStateStatus was CLEAN before squash merge."
+        },
+        "merge": {
+          "status": "pass",
+          "summary": "Squash merged PR #1514 as c95a25819d3c76f2298d87f3bd139557a1954b6e."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-20T13:18:38Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "GSC credentials/property may be unavailable",
@@ -14458,19 +14466,61 @@
           "at": "2026-05-20T21:16:00+08:00",
           "status": "local_validation_passed",
           "summary": "GSC readiness contract docs/generated/test passed focused and full SeoIntel validation, route list, Pint, JSON/YAML, and diff checks. No live GSC call or URL indexing request occurred."
+        },
+        {
+          "at": "2026-05-20T21:18:38+08:00",
+          "status": "merged",
+          "summary": "GitHub checks passed, PR #1514 was squash merged as c95a25819d3c76f2298d87f3bd139557a1954b6e, the remote branch was deleted, and local post-merge cleanup executed."
         }
       ]
     },
     "BAIDU-LIVE-00": {
       "repo": "fap-api",
       "branch": "codex/baidu-live-00-readiness-contract",
-      "status": "initialized",
+      "status": "in_progress",
       "depends_on": [
         "GSC-LIVE-00"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "summary": "GSC-LIVE-00 merged as c95a25819d3c76f2298d87f3bd139557a1954b6e and origin/main contains it."
+        },
+        "live_operation_guard": {
+          "status": "pass",
+          "summary": "No Baidu push, live Baidu API call, token exposure, scheduler enablement, collector write, production env edit, sitemap change, or llms change performed."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelBaiduLiveReadinessContract",
+          "summary": "6 tests passed, 83 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "summary": "239 tests passed, 4031 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "summary": "Route list rendered successfully; 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "summary": "3412 files passed."
+        },
+        "json_yaml_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/baidu-live-readiness-contract.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14487,6 +14537,16 @@
           "at": "2026-05-20T12:20:00+08:00",
           "status": "initialized",
           "summary": "Registered BAIDU-LIVE-00 from explicit /goal scope for a no-push readiness contract."
+        },
+        {
+          "at": "2026-05-20T21:20:00+08:00",
+          "status": "in_progress",
+          "summary": "Started BAIDU-LIVE-00 after GSC-LIVE-00 merged. Scope is docs/generated/test readiness contract only; no Baidu push or live Baidu API call is allowed."
+        },
+        {
+          "at": "2026-05-20T21:27:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Baidu readiness contract docs/generated/test passed focused and full SeoIntel validation, route list, Pint, JSON/YAML, and diff checks. No Baidu push, token exposure, or live Baidu API call occurred."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the Baidu Resource Platform live readiness contract and generated artifact.
- Added focused SeoIntel coverage for Baidu authority boundaries, ownership requirements, token/endpoint handling, Search Channel Queue-driven eligibility, Chinese claim-boundary dependency, and no-push rules.
- Reconciled GSC-LIVE-00 as merged in the train ledger.

## Why
- Prepare Baidu readiness without pushing URLs, calling live Baidu APIs, exposing tokens, enabling scheduler, activating connectors, or changing sitemap/llms behavior.

## Validation
- `cd backend && php artisan test --filter=SeoIntelBaiduLiveReadinessContract`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/baidu-live-readiness-contract.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No Baidu URL push.
- No live Baidu API call.
- No token or endpoint secret exposure.
- No live connector activation, scheduler enablement, collector write, env edit, production operation, sitemap change, or llms change.

## Repository rule impact
- CMS/backend URL Truth remains authority. Baidu must use Search Channel Queue approved canonical URLs only and cannot introduce Baidu-only pages, frontend fallback truth, or alternate domestic page authority.