### PR TITLE
INDEXNOW-LIVE-00｜IndexNow readiness contract

### DIFF
--- a/backend/docs/seo/generated/indexnow-live-readiness-contract.v1.json
+++ b/backend/docs/seo/generated/indexnow-live-readiness-contract.v1.json
@@ -1,0 +1,93 @@
+{
+  "version": "indexnow-live-readiness-contract.v1",
+  "task": "INDEXNOW-LIVE-00",
+  "type": "docs_generated_test_contract",
+  "channel": "indexnow",
+  "authority_boundary": {
+    "indexnow_is_url_update_signal_channel": true,
+    "indexnow_is_content_authority": false,
+    "indexnow_is_url_truth_authority": false,
+    "indexnow_is_sitemap_authority": false,
+    "indexnow_is_llms_authority": false,
+    "indexnow_is_indexing_or_ranking_proof": false,
+    "bypass_url_truth_allowed": false,
+    "bypass_search_channel_queue_allowed": false
+  },
+  "key_requirements": [
+    "documented_indexnow_key_owner",
+    "documented_key_rotation_and_revocation_owner",
+    "safe_secret_channel_only",
+    "approved_key_file_hosting",
+    "verified_key_file_content",
+    "verified_key_url",
+    "verified_allowed_hosts"
+  ],
+  "key_policy": {
+    "raw_key_in_docs_allowed": false,
+    "raw_key_in_logs_allowed": false,
+    "raw_key_in_generated_artifact_allowed": false,
+    "public_token_leakage_allowed": false,
+    "key_file_hosting_changed_in_this_pr": false
+  },
+  "allowed_host_policy": {
+    "allowed_hosts_must_be_explicit": true,
+    "initial_policy": "fermatmind_owned_canonical_public_hosts_only",
+    "unknown_hosts_allowed": false,
+    "localhost_allowed": false,
+    "private_network_hosts_allowed": false,
+    "third_party_hosts_allowed": false,
+    "canonical_host_mismatch_allowed": false
+  },
+  "submission_requires": [
+    "explicit_human_live_submission_approval",
+    "indexnow_key_verified",
+    "allowed_host_verified",
+    "search_channel_queue_approved",
+    "backend_cms_source_authority",
+    "canonical_url_present",
+    "published_state",
+    "indexable_state",
+    "url_truth_supported_page_type",
+    "claim_boundary_safe"
+  ],
+  "bulk_submission_contract": {
+    "bounded_batches_required": true,
+    "sanitized_logs_required": true,
+    "queue_records_required": true,
+    "raw_payload_storage_allowed": false
+  },
+  "excluded_url_classes": [
+    "draft",
+    "private",
+    "noindex",
+    "claim_unsafe",
+    "stale_slug",
+    "missing_canonical",
+    "unsupported_page_type",
+    "non_backend_authoritative"
+  ],
+  "forbidden_sensitive_outputs": [
+    "indexnow_key",
+    "token",
+    "api_key",
+    "cookie",
+    "session",
+    "email",
+    "order_id",
+    "attempt_id",
+    "payment_id",
+    "raw_ip",
+    "raw_payload"
+  ],
+  "live_submission_performed": false,
+  "live_api_call_in_this_pr": false,
+  "url_submission_performed": false,
+  "scheduler_enabled": false,
+  "collector_write_executed": false,
+  "live_connector_activated": false,
+  "credentials_added_in_this_pr": false,
+  "production_env_edited": false,
+  "sitemap_changed_in_this_pr": false,
+  "llms_changed_in_this_pr": false,
+  "next_task": "SEARCH-CHANNEL-LIVE-01-PREFLIGHT"
+}

--- a/backend/docs/seo/indexnow-live-readiness-contract.md
+++ b/backend/docs/seo/indexnow-live-readiness-contract.md
@@ -1,0 +1,69 @@
+# IndexNow Live Readiness Contract
+
+## Purpose
+
+INDEXNOW-LIVE-00 defines IndexNow readiness for Search Channel live preparation without submitting URLs.
+
+This PR does not call live IndexNow endpoints, submit URLs, expose keys, activate a live connector, enable scheduler jobs, run collector writes, edit environment files, deploy services, or change sitemap/llms behavior.
+
+## Authority Boundary
+
+IndexNow is a URL update signal channel. It is not content authority, URL Truth authority, sitemap authority, `llms.txt` authority, or indexing/ranking proof.
+
+IndexNow must not bypass CMS/backend URL Truth or Search Channel Queue approval. It must not submit draft, private, noindex, claim-unsafe, stale-slug, missing-canonical, unsupported, or non-backend-authoritative URLs.
+
+## Key Ownership And Verification
+
+Before any future IndexNow submission:
+
+- IndexNow key ownership must be documented
+- key rotation and revocation ownership must be documented
+- the key must be stored only in a safe secret channel
+- public key-file hosting must be explicitly approved
+- key file content and key URL must be verified before submission
+- host verification must pass for every allowed host
+
+Unavailable key ownership, key-file hosting, key URL verification, or host verification is a sidecar blocker for live operation, not a blocker for this docs/test contract.
+
+## Allowed Hosts
+
+Allowed hosts must be configured explicitly before future live use. The initial allowed host policy is FermatMind-owned canonical public hosts only.
+
+The adapter must reject:
+
+- unknown hosts
+- staging hosts unless explicitly approved for testing
+- localhost and private network hosts
+- third-party hosts
+- URLs whose canonical host differs from URL Truth
+
+## Submission Contract
+
+A future IndexNow adapter may submit URLs only after:
+
+- explicit human approval for live submission
+- key verification has passed
+- allowed host verification has passed
+- Search Channel Queue marks the URL approved for IndexNow
+- backend CMS URL Truth confirms canonical URL, published state, indexable state, supported page type, and claim safety
+
+Bulk URL submission must use bounded batches, sanitized logs, and queue records. It must not store raw keys, raw payloads, cookies, raw IPs, emails, order IDs, attempt IDs, payment IDs, or sessions.
+
+## Stop Conditions
+
+Stop immediately if:
+
+- a live IndexNow endpoint is called in this PR
+- a URL is submitted in this PR
+- an IndexNow key is printed, committed, logged, or stored in generated artifacts
+- key-file hosting is changed in this PR
+- a draft/private/noindex/claim-unsafe URL becomes eligible
+- IndexNow bypasses URL Truth or Search Channel Queue
+- scheduler or collector writes are enabled
+- sitemap or `llms.txt` behavior changes
+
+No live IndexNow submission is allowed in INDEXNOW-LIVE-00.
+
+## Next Task
+
+Next task: SEARCH-CHANNEL-LIVE-01-PREFLIGHT.

--- a/backend/tests/Feature/SeoIntel/SeoIntelIndexNowLiveReadinessContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelIndexNowLiveReadinessContractTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelIndexNowLiveReadinessContractTest extends TestCase
+{
+    #[Test]
+    public function artifact_locks_indexnow_as_signal_channel_not_authority(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('indexnow-live-readiness-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('INDEXNOW-LIVE-00', $artifact['task'] ?? null);
+        $this->assertSame('indexnow', $artifact['channel'] ?? null);
+        $this->assertTrue((bool) data_get($artifact, 'authority_boundary.indexnow_is_url_update_signal_channel'));
+
+        foreach ([
+            'indexnow_is_content_authority',
+            'indexnow_is_url_truth_authority',
+            'indexnow_is_sitemap_authority',
+            'indexnow_is_llms_authority',
+            'indexnow_is_indexing_or_ranking_proof',
+            'bypass_url_truth_allowed',
+            'bypass_search_channel_queue_allowed',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'authority_boundary.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function key_ownership_hosting_and_verification_are_required(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'documented_indexnow_key_owner',
+            'documented_key_rotation_and_revocation_owner',
+            'safe_secret_channel_only',
+            'approved_key_file_hosting',
+            'verified_key_file_content',
+            'verified_key_url',
+            'verified_allowed_hosts',
+        ] as $requirement) {
+            $this->assertContains($requirement, $artifact['key_requirements'] ?? []);
+        }
+
+        foreach ([
+            'raw_key_in_docs_allowed',
+            'raw_key_in_logs_allowed',
+            'raw_key_in_generated_artifact_allowed',
+            'public_token_leakage_allowed',
+            'key_file_hosting_changed_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'key_policy.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function allowed_host_policy_rejects_unapproved_hosts(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue((bool) data_get($artifact, 'allowed_host_policy.allowed_hosts_must_be_explicit'));
+        $this->assertSame('fermatmind_owned_canonical_public_hosts_only', data_get($artifact, 'allowed_host_policy.initial_policy'));
+
+        foreach ([
+            'unknown_hosts_allowed',
+            'localhost_allowed',
+            'private_network_hosts_allowed',
+            'third_party_hosts_allowed',
+            'canonical_host_mismatch_allowed',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'allowed_host_policy.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function submission_requires_queue_approval_and_backend_truth(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'explicit_human_live_submission_approval',
+            'indexnow_key_verified',
+            'allowed_host_verified',
+            'search_channel_queue_approved',
+            'backend_cms_source_authority',
+            'canonical_url_present',
+            'published_state',
+            'indexable_state',
+            'url_truth_supported_page_type',
+            'claim_boundary_safe',
+        ] as $gate) {
+            $this->assertContains($gate, $artifact['submission_requires'] ?? []);
+        }
+
+        foreach (['draft', 'private', 'noindex', 'claim_unsafe', 'stale_slug', 'non_backend_authoritative'] as $class) {
+            $this->assertContains($class, $artifact['excluded_url_classes'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function bulk_submission_contract_and_secret_outputs_are_sanitized(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue((bool) data_get($artifact, 'bulk_submission_contract.bounded_batches_required'));
+        $this->assertTrue((bool) data_get($artifact, 'bulk_submission_contract.sanitized_logs_required'));
+        $this->assertTrue((bool) data_get($artifact, 'bulk_submission_contract.queue_records_required'));
+        $this->assertFalse((bool) data_get($artifact, 'bulk_submission_contract.raw_payload_storage_allowed', true));
+
+        foreach (['indexnow_key', 'token', 'api_key', 'cookie', 'session', 'email', 'order_id', 'attempt_id', 'payment_id', 'raw_ip', 'raw_payload'] as $field) {
+            $this->assertContains($field, $artifact['forbidden_sensitive_outputs'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function no_live_submission_or_activation_is_allowed_in_this_pr(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'live_submission_performed',
+            'live_api_call_in_this_pr',
+            'url_submission_performed',
+            'scheduler_enabled',
+            'collector_write_executed',
+            'live_connector_activated',
+            'credentials_added_in_this_pr',
+            'production_env_edited',
+            'sitemap_changed_in_this_pr',
+            'llms_changed_in_this_pr',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_indexnow_submission_language_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/indexnow-live-readiness-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/indexnow-live-readiness-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'does not call live indexnow endpoints',
+            'no live indexnow submission is allowed',
+            'must not bypass cms/backend url truth',
+            'key file content and key url must be verified',
+            'bulk url submission must use bounded batches',
+            'next task: search-channel-live-01-preflight',
+            '"next_task": "search-channel-live-01-preflight"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/indexnow-live-readiness-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5430,7 +5430,7 @@
       "repo": "fap-api",
       "branch": "fix/career-80-live-surface-authority-1",
       "title": "fix(api): align career 80 live surface with runtime authority",
-      "status": "local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "REPAIR-POST-ROLLOUT-RUNTIME-PROJECTION-AUTHORITY-1"
       ],
@@ -6198,8 +6198,8 @@
         "no production DB query",
         "no live crawl"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "25449bd1dcd28f3e6cdb810af3030324db48d1dc",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1515",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -6943,7 +6943,7 @@
       "branch": "fix/career-2786-final-readiness-software-manual-hold-authority-1",
       "title": "fix(api): account software manual hold in 2786 readiness",
       "name": "Account software-developers manual-hold decision in final 2786 readiness",
-      "status": "in_progress",
+      "status": "local_validation_passed",
       "depends_on": [
         "SOFTWARE_MANUAL_HOLD_FINAL_POLICY_DECISION_1",
         "REPAIR-2786-FINAL-READINESS-PUBLIC-OWNER-PARTITION-AUTHORITY-1"
@@ -14519,12 +14519,20 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "summary": "PR #1515 passed hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS. mergeStateStatus was CLEAN before squash merge."
+        },
+        "merge": {
+          "status": "pass",
+          "summary": "Squash merged PR #1515 as 25449bd1dcd28f3e6cdb810af3030324db48d1dc."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-20T13:29:33Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "Baidu token/site ownership may be unavailable",
@@ -14547,19 +14555,61 @@
           "at": "2026-05-20T21:27:00+08:00",
           "status": "local_validation_passed",
           "summary": "Baidu readiness contract docs/generated/test passed focused and full SeoIntel validation, route list, Pint, JSON/YAML, and diff checks. No Baidu push, token exposure, or live Baidu API call occurred."
+        },
+        {
+          "at": "2026-05-20T21:29:33+08:00",
+          "status": "merged",
+          "summary": "GitHub checks passed, PR #1515 was squash merged as 25449bd1dcd28f3e6cdb810af3030324db48d1dc, the remote branch was deleted, and local post-merge cleanup executed."
         }
       ]
     },
     "INDEXNOW-LIVE-00": {
       "repo": "fap-api",
       "branch": "codex/indexnow-live-00-readiness-contract",
-      "status": "initialized",
+      "status": "in_progress",
       "depends_on": [
         "BAIDU-LIVE-00"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "summary": "BAIDU-LIVE-00 merged as 25449bd1dcd28f3e6cdb810af3030324db48d1dc and origin/main contains it."
+        },
+        "live_operation_guard": {
+          "status": "pass",
+          "summary": "No IndexNow submission, live IndexNow endpoint call, key exposure, scheduler enablement, collector write, production env edit, sitemap change, or llms change performed."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelIndexNowLiveReadinessContract",
+          "summary": "7 tests passed, 90 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "summary": "246 tests passed, 4121 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "summary": "Route list rendered successfully; 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "summary": "3413 files passed."
+        },
+        "json_yaml_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/indexnow-live-readiness-contract.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14576,6 +14626,16 @@
           "at": "2026-05-20T12:20:00+08:00",
           "status": "initialized",
           "summary": "Registered INDEXNOW-LIVE-00 from explicit /goal scope for a no-submit readiness contract."
+        },
+        {
+          "at": "2026-05-20T21:31:00+08:00",
+          "status": "in_progress",
+          "summary": "Started INDEXNOW-LIVE-00 after BAIDU-LIVE-00 merged. Scope is docs/generated/test readiness contract only; no IndexNow submission or live endpoint call is allowed."
+        },
+        {
+          "at": "2026-05-20T21:37:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "IndexNow readiness contract docs/generated/test passed focused and full SeoIntel validation, route list, Pint, JSON/YAML, and diff checks. No IndexNow submission, key exposure, or live endpoint call occurred."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the IndexNow live readiness contract and generated artifact.
- Added focused SeoIntel coverage for IndexNow authority boundaries, key ownership and verification, allowed host policy, queue-approved submission requirements, bounded bulk submission, and no-submit/no-key-leakage rules.
- Reconciled BAIDU-LIVE-00 as merged in the train ledger.

## Why
- Prepare IndexNow readiness without live submission, endpoint calls, key leakage, scheduler activation, connector activation, or sitemap/llms behavior changes.

## Validation
- `cd backend && php artisan test --filter=SeoIntelIndexNowLiveReadinessContract`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/indexnow-live-readiness-contract.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No IndexNow URL submission.
- No live IndexNow endpoint call.
- No key-file hosting change or key exposure.
- No live connector activation, scheduler enablement, collector write, env edit, production operation, sitemap change, or llms change.

## Repository rule impact
- CMS/backend URL Truth and Search Channel Queue remain mandatory. IndexNow cannot bypass backend truth, cannot prove indexing/ranking, and cannot submit draft/private/noindex/claim-unsafe URLs.