### PR TITLE
SEARCH-CHANNEL-LIVE-01-PREFLIGHT｜URL eligibility and no-submit preflight

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-preflight.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-preflight.v1.json
@@ -1,0 +1,96 @@
+{
+  "version": "search-channel-live-preflight.v1",
+  "task": "SEARCH-CHANNEL-LIVE-01-PREFLIGHT",
+  "report_title": "SEARCH-CHANNEL-LIVE-READINESS-TRAIN Report",
+  "accepted_verified_current_state": {
+    "seo_urls": 9,
+    "seo_url_entities": 9,
+    "seo_issue_queue": 5,
+    "research_report_rows": 2,
+    "production_db_queried_by_this_preflight": false,
+    "production_crawler_logs_read": false
+  },
+  "contract_results": {
+    "gsc": {
+      "status": "passed_readiness_contract",
+      "live_request_made": false,
+      "indexing_request_made": false,
+      "credentials_required_for_future_live_operation": true
+    },
+    "baidu": {
+      "status": "passed_readiness_contract",
+      "live_push_made": false,
+      "token_required_for_future_live_operation": true
+    },
+    "indexnow": {
+      "status": "passed_readiness_contract",
+      "live_submission_made": false,
+      "key_required_for_future_live_operation": true
+    }
+  },
+  "url_eligibility": {
+    "research_urls_candidate_only_if": [
+      "backend_cms_source_authority",
+      "published_state",
+      "public_state",
+      "indexable_state",
+      "canonical_url_present",
+      "url_truth_supported_page_type",
+      "claim_boundary_safe"
+    ],
+    "excluded_url_classes": [
+      "test_take",
+      "test_result",
+      "order",
+      "share",
+      "pay",
+      "report_private",
+      "draft_research",
+      "stale_slug",
+      "noindex",
+      "private",
+      "unsupported_page_type",
+      "claim_unsafe",
+      "non_backend_authoritative"
+    ],
+    "forbidden_authority_inputs": [
+      "frontend_fallback",
+      "static_sitemap_fallback",
+      "static_llms_fallback",
+      "local_content_copies",
+      "production_crawler_logs",
+      "live_search_responses",
+      "node2_local_db",
+      "business_db_raw_tables"
+    ],
+    "eligible_url_exported_from_production": false,
+    "url_submission_performed": false
+  },
+  "search_channel_queue_readiness": {
+    "contract_exists": true,
+    "runtime_queue_exists": false,
+    "runtime_queue_tables_or_models_confirmed": false,
+    "runtime_canary_submitter_exists": false,
+    "controlled_approval_state_exists": false,
+    "blocking_reason": "Search Channel Queue contract exists, but controlled runtime queue implementation for live submission approval/execution/audit is missing."
+  },
+  "forbidden_operations": {
+    "google_url_submission": false,
+    "gsc_live_request": false,
+    "gsc_indexing_request": false,
+    "baidu_push": false,
+    "indexnow_post": false,
+    "scheduler_enabled": false,
+    "collector_write_executed": false,
+    "production_crawler_log_read": false,
+    "production_env_edited": false,
+    "dns_cdn_openresty_nginx_changed": false,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "research_published": false,
+    "pseo_created": false,
+    "secret_exposed": false
+  },
+  "final_decision": "blocked_search_channel_queue_runtime_missing",
+  "next_task": "SEARCH-CHANNEL-QUEUE-01 runtime MVP"
+}

--- a/backend/docs/seo/search-channel-live-preflight.md
+++ b/backend/docs/seo/search-channel-live-preflight.md
@@ -1,0 +1,100 @@
+# SEARCH-CHANNEL-LIVE-READINESS-TRAIN Report
+
+## 1. Executive Summary
+
+SEARCH-CHANNEL-LIVE-01-PREFLIGHT completed a local, no-submit readiness preflight after the GSC, Baidu, and IndexNow readiness contracts were defined.
+
+Final decision: `blocked_search_channel_queue_runtime_missing`.
+
+The readiness contracts are in place and URL eligibility rules are safe, but the Search Channel Queue exists only as a contract. No runtime queue implementation is available to drive controlled live submission. The next task is `SEARCH-CHANNEL-QUEUE-01 runtime MVP`.
+
+## 2. Current SEO / Research URL Truth State
+
+Accepted verified SEO state:
+
+- `seo_urls = 9`
+- `seo_url_entities = 9`
+- `seo_issue_queue = 5`
+- `research_report rows = 2`
+
+This preflight did not query production databases, Tencent RDS, Node2 DB, business DB tables, or production crawler logs.
+
+Local URL Truth contracts confirm that Research URL Truth can emit `research_report` candidates from backend/CMS authority only when the record is published, public, indexable, approved, canonical, methodologically complete, and claim-safe.
+
+Draft, private, noindex, unapproved, unsupported-route, stale-slug, and claim-unsafe Research records remain excluded.
+
+## 3. GSC Readiness Contract Result
+
+Result: passed for readiness contract.
+
+GSC-LIVE-00 defines Google Search Console as feedback/readiness only. GSC must not create URLs, override CMS/backend URL Truth, request indexing, submit URLs, activate a live connector, enable scheduler jobs, run collector writes, or change sitemap/llms behavior.
+
+Credential/property readiness remains sidecar for future live operation. No GSC live request was made.
+
+## 4. Baidu Readiness Contract Result
+
+Result: passed for readiness contract.
+
+BAIDU-LIVE-00 defines Baidu Resource Platform readiness without push. Baidu must use the same canonical CMS/backend URL Truth and Search Channel Queue approval. It must not create Baidu-only pages, expose tokens, bypass claim review, enable scheduler jobs, run collector writes, or change sitemap/llms behavior.
+
+Baidu site/token/operator readiness remains sidecar for future live operation. No Baidu push was made.
+
+## 5. IndexNow Readiness Contract Result
+
+Result: passed for readiness contract.
+
+INDEXNOW-LIVE-00 defines IndexNow readiness without submission. IndexNow requires key ownership, key-file hosting approval, key URL verification, host verification, explicit live approval, and Search Channel Queue approval before any future submission.
+
+IndexNow key readiness remains sidecar for future live operation. No IndexNow endpoint was called.
+
+## 6. URL Eligibility Preflight
+
+Candidate channel posture:
+
+- Google/GSC: readiness contract only; no indexing request.
+- Baidu: readiness contract only; no URL push.
+- IndexNow: readiness contract only; no live submission.
+
+Candidate URL posture:
+
+- Research URLs may be candidates only when backend/CMS URL Truth marks them published, public, indexable, canonical, supported, and claim-safe.
+- Candidate URLs must exclude test take/result/order/share/pay/report-private flows.
+- Candidate URLs must exclude draft Research, stale slugs, noindex records, private records, unsupported page types, and claim-unsafe records.
+- Candidate URLs must not be sourced from frontend fallback, static sitemap fallback, static `llms.txt` fallback, local content copies, production crawler logs, live search responses, Node2 local DB, or raw business DB tables.
+
+No live candidate list was exported from production and no URL was submitted.
+
+## 7. Search Channel Queue Readiness
+
+Result: blocked.
+
+The Search Channel Queue contract exists as `SEARCH-CHANNEL-QUEUE-00`, but this preflight found no runtime Search Channel Queue implementation that can safely approve, batch, execute, audit, and retry live URL submissions across GSC readiness, Baidu push, and IndexNow.
+
+Existing foundation tables for IndexNow submissions and domestic submission logs are not a controlled Search Channel Queue runtime. They do not replace a queue that owns eligibility state, approval state, channel state, operator approval, sanitized audit fields, and no-submit dry-run reporting.
+
+Because queue runtime is missing, live canary approval is blocked.
+
+## 8. What Was Not Done
+
+- No URLs were submitted to Google, Baidu, IndexNow, Bing, 360, Sogou, Shenma, or any search engine.
+- No indexing request was made.
+- No live GSC request was made.
+- No Baidu push was made.
+- No IndexNow POST was made.
+- No scheduler was enabled.
+- No collector writes were run.
+- No production crawler logs were read.
+- No production env was edited.
+- No DNS/CDN/OpenResty/Nginx changes were made.
+- No sitemap or `llms.txt` behavior was changed.
+- No Research content was published.
+- No pSEO was created.
+- No tokens, API keys, cookies, sessions, emails, order IDs, attempt IDs, payment IDs, raw IPs, or secrets were exposed.
+
+## 9. Final Decision
+
+blocked_search_channel_queue_runtime_missing
+
+## 10. Next Task
+
+SEARCH-CHANNEL-QUEUE-01 runtime MVP

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLivePreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLivePreflightTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLivePreflightTest extends TestCase
+{
+    #[Test]
+    public function preflight_artifact_records_current_state_without_production_reads(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('search-channel-live-preflight.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEARCH-CHANNEL-LIVE-01-PREFLIGHT', $artifact['task'] ?? null);
+        $this->assertSame('SEARCH-CHANNEL-LIVE-READINESS-TRAIN Report', $artifact['report_title'] ?? null);
+        $this->assertSame(9, data_get($artifact, 'accepted_verified_current_state.seo_urls'));
+        $this->assertSame(9, data_get($artifact, 'accepted_verified_current_state.seo_url_entities'));
+        $this->assertSame(2, data_get($artifact, 'accepted_verified_current_state.research_report_rows'));
+        $this->assertFalse((bool) data_get($artifact, 'accepted_verified_current_state.production_db_queried_by_this_preflight', true));
+        $this->assertFalse((bool) data_get($artifact, 'accepted_verified_current_state.production_crawler_logs_read', true));
+    }
+
+    #[Test]
+    public function channel_contract_results_are_readiness_only(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('passed_readiness_contract', data_get($artifact, 'contract_results.gsc.status'));
+        $this->assertSame('passed_readiness_contract', data_get($artifact, 'contract_results.baidu.status'));
+        $this->assertSame('passed_readiness_contract', data_get($artifact, 'contract_results.indexnow.status'));
+
+        $this->assertFalse((bool) data_get($artifact, 'contract_results.gsc.live_request_made', true));
+        $this->assertFalse((bool) data_get($artifact, 'contract_results.gsc.indexing_request_made', true));
+        $this->assertFalse((bool) data_get($artifact, 'contract_results.baidu.live_push_made', true));
+        $this->assertFalse((bool) data_get($artifact, 'contract_results.indexnow.live_submission_made', true));
+    }
+
+    #[Test]
+    public function url_eligibility_excludes_private_noindex_claim_unsafe_and_forbidden_sources(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'backend_cms_source_authority',
+            'published_state',
+            'public_state',
+            'indexable_state',
+            'canonical_url_present',
+            'url_truth_supported_page_type',
+            'claim_boundary_safe',
+        ] as $gate) {
+            $this->assertContains($gate, data_get($artifact, 'url_eligibility.research_urls_candidate_only_if', []));
+        }
+
+        foreach ([
+            'test_take',
+            'test_result',
+            'order',
+            'share',
+            'pay',
+            'report_private',
+            'draft_research',
+            'stale_slug',
+            'noindex',
+            'private',
+            'claim_unsafe',
+        ] as $class) {
+            $this->assertContains($class, data_get($artifact, 'url_eligibility.excluded_url_classes', []));
+        }
+
+        foreach ([
+            'frontend_fallback',
+            'static_sitemap_fallback',
+            'static_llms_fallback',
+            'production_crawler_logs',
+            'live_search_responses',
+            'node2_local_db',
+            'business_db_raw_tables',
+        ] as $source) {
+            $this->assertContains($source, data_get($artifact, 'url_eligibility.forbidden_authority_inputs', []));
+        }
+    }
+
+    #[Test]
+    public function queue_contract_exists_but_runtime_is_missing(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue((bool) data_get($artifact, 'search_channel_queue_readiness.contract_exists'));
+
+        foreach ([
+            'runtime_queue_exists',
+            'runtime_queue_tables_or_models_confirmed',
+            'runtime_canary_submitter_exists',
+            'controlled_approval_state_exists',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'search_channel_queue_readiness.'.$flag, true), $flag.' must remain false');
+        }
+
+        $this->assertSame('blocked_search_channel_queue_runtime_missing', $artifact['final_decision'] ?? null);
+        $this->assertSame('SEARCH-CHANNEL-QUEUE-01 runtime MVP', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function forbidden_operations_remain_false(): void
+    {
+        foreach ($this->artifact()['forbidden_operations'] ?? [] as $operation => $performed) {
+            $this->assertFalse((bool) $performed, $operation.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function report_has_required_sections_and_no_submit_decision(): void
+    {
+        $report = strtolower((string) file_get_contents(base_path('docs/seo/search-channel-live-preflight.md')));
+
+        foreach ([
+            '# search-channel-live-readiness-train report',
+            '## 1. executive summary',
+            '## 2. current seo / research url truth state',
+            '## 3. gsc readiness contract result',
+            '## 4. baidu readiness contract result',
+            '## 5. indexnow readiness contract result',
+            '## 6. url eligibility preflight',
+            '## 7. search channel queue readiness',
+            '## 8. what was not done',
+            '## 9. final decision',
+            '## 10. next task',
+            'blocked_search_channel_queue_runtime_missing',
+            'search-channel-queue-01 runtime mvp',
+            'no urls were submitted',
+            'no gsc live request was made',
+            'no baidu push was made',
+            'no indexnow post was made',
+        ] as $required) {
+            $this->assertStringContainsString($required, $report);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/search-channel-live-preflight.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6644,7 +6644,7 @@
       "branch": "codex/repair-2786-final-public-resolution-partition-1-202605160412",
       "title": "fix(api): partition final career 2786 public resolution",
       "name": "Partition final 2786 public-resolution assets before candidate prep",
-      "status": "local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "800-CLOSEOUT-1"
       ],
@@ -6674,8 +6674,8 @@
         "do not weaken CN proxy or software-developers rollout rejection",
         "do not mark unresolved policy or occupation-missing rows as rollout candidates"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "84dac5c278ba531a3e156432f7419a67535df35f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1516",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -7900,7 +7900,7 @@
       "depends_on": [
         "AUDIT-API-CAREER-ARTIFACT-READINESS"
       ],
-      "status": "in_progress",
+      "status": "local_validation_passed",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): require editorial approval for controlled article publish",
@@ -14608,12 +14608,20 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "summary": "PR #1516 passed hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS. mergeStateStatus was CLEAN before squash merge."
+        },
+        "merge": {
+          "status": "pass",
+          "summary": "Squash merged PR #1516 as 84dac5c278ba531a3e156432f7419a67535df35f."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-20T13:39:10Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "IndexNow key may be unavailable",
@@ -14636,19 +14644,65 @@
           "at": "2026-05-20T21:37:00+08:00",
           "status": "local_validation_passed",
           "summary": "IndexNow readiness contract docs/generated/test passed focused and full SeoIntel validation, route list, Pint, JSON/YAML, and diff checks. No IndexNow submission, key exposure, or live endpoint call occurred."
+        },
+        {
+          "at": "2026-05-20T21:39:10+08:00",
+          "status": "merged",
+          "summary": "GitHub checks passed, PR #1516 was squash merged as 84dac5c278ba531a3e156432f7419a67535df35f, the remote branch was deleted, and local post-merge cleanup executed."
         }
       ]
     },
     "SEARCH-CHANNEL-LIVE-01-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-01-preflight",
-      "status": "initialized",
+      "status": "in_progress",
       "depends_on": [
         "INDEXNOW-LIVE-00"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "summary": "INDEXNOW-LIVE-00 merged as 84dac5c278ba531a3e156432f7419a67535df35f and origin/main contains it."
+        },
+        "live_operation_guard": {
+          "status": "pass",
+          "summary": "No URL submission, GSC live request, Baidu push, IndexNow POST, scheduler enablement, collector write, production crawler log read, production env edit, sitemap change, or llms change performed."
+        },
+        "preflight_decision": {
+          "status": "blocked_search_channel_queue_runtime_missing",
+          "summary": "Search Channel Queue contract exists, but no controlled runtime queue implementation exists for live approval/execution/audit."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelSearchChannelLivePreflight",
+          "summary": "6 tests passed, 89 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "summary": "252 tests passed, 4210 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "summary": "Route list rendered successfully; 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "summary": "3414 files passed."
+        },
+        "json_yaml_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/search-channel-live-preflight.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14665,6 +14719,16 @@
           "at": "2026-05-20T12:20:00+08:00",
           "status": "initialized",
           "summary": "Registered SEARCH-CHANNEL-LIVE-01-PREFLIGHT from explicit /goal scope for URL eligibility and no-submit preflight."
+        },
+        {
+          "at": "2026-05-20T21:41:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEARCH-CHANNEL-LIVE-01-PREFLIGHT after INDEXNOW-LIVE-00 merged. Scope is local report/docs/generated/test only; live search submission and production reads remain forbidden."
+        },
+        {
+          "at": "2026-05-20T21:48:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "No-submit preflight report passed focused and full SeoIntel validation, route list, Pint, JSON/YAML, and diff checks. Final decision is blocked_search_channel_queue_runtime_missing; next task is SEARCH-CHANNEL-QUEUE-01 runtime MVP."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the final no-submit Search Channel live readiness report and generated artifact.
- Added focused SeoIntel coverage for accepted current SEO state, GSC/Baidu/IndexNow readiness results, URL eligibility exclusions, forbidden operations, and queue-runtime readiness.
- Reconciled INDEXNOW-LIVE-00 as merged in the train ledger.

## Why
- Complete the readiness train without live submission and record the final decision: `blocked_search_channel_queue_runtime_missing`.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelLivePreflight`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/search-channel-live-preflight.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No Google/GSC live request, URL submission, or indexing request.
- No Baidu push.
- No IndexNow POST.
- No scheduler enablement, collector write, production crawler log read, env edit, production operation, sitemap change, or llms change.
- Live canary approval is deferred until Search Channel Queue runtime exists.

## Repository rule impact
- CMS/backend URL Truth remains authority. The report blocks live canary until a controlled Search Channel Queue runtime owns eligibility, approval, channel execution, and sanitized audit state.