### PR TITLE
ci(deploy): audit Composer lockfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Composer audit
         working-directory: backend
-        run: composer audit --no-interaction --ignore-unreachable
+        run: composer audit --locked --no-interaction --ignore-unreachable
 
       - name: Install backend dependencies
         working-directory: backend


### PR DESCRIPTION
## What changed
- Changes Deploy Application Composer audit to use `composer audit --locked`.

## Why
- Deploy checks restore `backend/vendor` from cache before the audit step.
- After the Symfony lockfile security update, the runner still audited stale cached installed packages and failed incorrectly.
- Auditing the lockfile matches the source of truth that is committed and later installed by deploy.

## Validation
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `git diff --check`

## Deferred / not done
- No dependency changes in this PR.
- No production env edits.
- No Search Channel URL submission or live search API calls.

## Repository rule impact
- No CMS authority, SEO/GEO enumeration, sitemap/llms, or content ownership behavior changes.
