### PR TITLE
fix(ci): guard GitHub output path

### DIFF
--- a/backend/app/Console/Commands/CiScaleImpact.php
+++ b/backend/app/Console/Commands/CiScaleImpact.php
@@ -127,8 +127,8 @@ final class CiScaleImpact extends Command
      */
     private function writeGithubOutput(array $payload): void
     {
-        $target = trim((string) ($_SERVER['GITHUB_OUTPUT'] ?? $_ENV['GITHUB_OUTPUT'] ?? ''));
-        if ($target === '') {
+        $target = $this->resolveGithubOutputPath();
+        if ($target === null) {
             return;
         }
 
@@ -145,6 +145,31 @@ final class CiScaleImpact extends Command
             'reason='.(string) ($payload['reason'] ?? ''),
         ];
 
+        // nosemgrep: php.lang.security.injection.tainted-filename.tainted-filename
+        // GITHUB_OUTPUT is accepted only after rejecting stream wrappers and non-local paths.
         file_put_contents($target, implode(PHP_EOL, $lines).PHP_EOL, FILE_APPEND);
+    }
+
+    private function resolveGithubOutputPath(): ?string
+    {
+        $target = trim((string) ($_SERVER['GITHUB_OUTPUT'] ?? $_ENV['GITHUB_OUTPUT'] ?? ''));
+        if ($target === '' || str_contains($target, "\0")) {
+            return null;
+        }
+
+        if (! str_starts_with($target, DIRECTORY_SEPARATOR) || parse_url($target, PHP_URL_SCHEME) !== null) {
+            return null;
+        }
+
+        $directory = dirname($target);
+        if (! is_dir($directory) || ! is_writable($directory)) {
+            return null;
+        }
+
+        if (file_exists($target) && (! is_file($target) || ! is_writable($target))) {
+            return null;
+        }
+
+        return $target;
     }
 }

--- a/backend/tests/Unit/Ci/CiScaleImpactGithubOutputTest.php
+++ b/backend/tests/Unit/Ci/CiScaleImpactGithubOutputTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Ci;
+
+use App\Console\Commands\CiScaleImpact;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class CiScaleImpactGithubOutputTest extends TestCase
+{
+    private string $originalServerGithubOutput = '';
+
+    private bool $hadServerGithubOutput = false;
+
+    private string $originalEnvGithubOutput = '';
+
+    private bool $hadEnvGithubOutput = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->hadServerGithubOutput = array_key_exists('GITHUB_OUTPUT', $_SERVER);
+        $this->originalServerGithubOutput = (string) ($_SERVER['GITHUB_OUTPUT'] ?? '');
+        $this->hadEnvGithubOutput = array_key_exists('GITHUB_OUTPUT', $_ENV);
+        $this->originalEnvGithubOutput = (string) ($_ENV['GITHUB_OUTPUT'] ?? '');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->hadServerGithubOutput) {
+            $_SERVER['GITHUB_OUTPUT'] = $this->originalServerGithubOutput;
+        } else {
+            unset($_SERVER['GITHUB_OUTPUT']);
+        }
+
+        if ($this->hadEnvGithubOutput) {
+            $_ENV['GITHUB_OUTPUT'] = $this->originalEnvGithubOutput;
+        } else {
+            unset($_ENV['GITHUB_OUTPUT']);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_github_output_rejects_php_stream_wrappers_without_writing(): void
+    {
+        $targetFile = tempnam(sys_get_temp_dir(), 'ci_scale_impact_output_');
+        $this->assertIsString($targetFile);
+        file_put_contents($targetFile, '');
+
+        $_SERVER['GITHUB_OUTPUT'] = 'php://filter/write=string.rot13/resource='.$targetFile;
+        unset($_ENV['GITHUB_OUTPUT']);
+
+        $this->writeGithubOutput([
+            'run_big5_ocean_gate' => true,
+            'scale_scope' => 'full_regression',
+            'reason' => 'semgrep_stream_wrapper_regression',
+        ]);
+
+        $this->assertSame('', file_get_contents($targetFile));
+
+        @unlink($targetFile);
+    }
+
+    public function test_github_output_allows_local_runner_output_file(): void
+    {
+        $targetFile = tempnam(sys_get_temp_dir(), 'ci_scale_impact_output_');
+        $this->assertIsString($targetFile);
+        file_put_contents($targetFile, '');
+
+        $_SERVER['GITHUB_OUTPUT'] = $targetFile;
+        unset($_ENV['GITHUB_OUTPUT']);
+
+        $this->writeGithubOutput([
+            'run_big5_ocean_gate' => true,
+            'scale_scope' => 'full_regression',
+            'reason' => 'local_runner_output',
+        ]);
+
+        $output = (string) file_get_contents($targetFile);
+
+        $this->assertStringContainsString('run_big5_ocean_gate=1', $output);
+        $this->assertStringContainsString('scale_scope=full_regression', $output);
+        $this->assertStringContainsString('reason=local_runner_output', $output);
+
+        @unlink($targetFile);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function writeGithubOutput(array $payload): void
+    {
+        $method = new ReflectionMethod(CiScaleImpact::class, 'writeGithubOutput');
+        $method->invoke(new CiScaleImpact, $payload);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -198,6 +198,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_ci_scale_impact_command_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/CiScaleImpact.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_public_healthz_alias_route_addition(): void
     {
         $changed = [
@@ -1678,6 +1687,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCiScaleImpactCommandFile($file)) {
+                continue;
+            }
+
             if ($this->isContentReleaseRevalidateAutomationFile($file)) {
                 continue;
             }
@@ -2096,6 +2109,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isStorageReleaseRootsAuditCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/StorageReleaseRootsAudit.php';
+    }
+
+    private function isCiScaleImpactCommandFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/CiScaleImpact.php';
     }
 
     private function isContentReleaseRevalidateAutomationFile(string $file): bool


### PR DESCRIPTION
## What changed
- Validate `GITHUB_OUTPUT` before appending CI scale impact outputs.
- Reject stream wrappers, non-absolute paths, null bytes, missing/unwritable directories, and non-file targets.
- Add a focused regression test proving `GITHUB_OUTPUT=php://...` does not write through a PHP stream wrapper, plus a local-file positive path check.
- Mark `CiScaleImpact.php` as CI-only for the Big Five runtime-freeze classifier so this command hardening does not falsely trip MBTI/Big Five runtime gates.

## Why
GitHub code scanning flagged `CiScaleImpact.php` because the GitHub output file path came directly from environment/server input and was passed to `file_put_contents()`. The command should only append to a local GitHub Actions output file.

## Validation
- `php -l app/Console/Commands/CiScaleImpact.php && php -l tests/Unit/Ci/CiScaleImpactGithubOutputTest.php`
- `php -l tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `./vendor/bin/phpunit --filter CiScaleImpactGithubOutputTest`
- `./vendor/bin/phpunit --filter 'runtime_paths_have_no_uncommitted_diff|ci_scale_impact_command_changes' tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `./vendor/bin/phpunit tests/Unit/Ci/ScaleImpactResolverTest.php tests/Unit/Ci/CiScaleImpactGithubOutputTest.php`
- `tmp=$(mktemp); GITHUB_OUTPUT="$tmp" php artisan ci:scale-impact --base=HEAD --head=HEAD --format=env --write-github-output >/tmp/ci-scale-impact-smoke.out`
- `php artisan route:list --no-ansi`
- `bash scripts/ci_verify_mbti.sh`

Notes:
- `php artisan migrate` was not run directly against the local default DB because this PR has no migrations; `bash scripts/ci_verify_mbti.sh` prepared SQLite and ran the full migration baseline.
- curl/API route examples are not applicable; this PR only changes a CI console command and CI classifier test coverage.
- GitHub `Semgrep OSS` and `semgrep sarif` checks passed on the pushed branch.

## Deferred
- None.
