### PR TITLE
BACKEND-DEPLOY-TARGET-ALIYUN-01｜Point production backend deploy target at Aliyun ECS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,10 +57,10 @@ jobs:
       # ====== production ======
       DEPLOY_USER_PROD: "ubuntu"
       DEPLOY_PORT_PROD: "22"
-      DEPLOY_HOST_PROD: "122.152.221.126"
+      DEPLOY_HOST_PROD: "139.224.130.204"
       DEPLOY_PATH_PROD: "/var/www/fap-api"
-      HEALTHCHECK_URL_PROD: "https://fermatmind.com/api/healthz"
-      AUTH_GUEST_CHECK_URL_PROD: "https://fermatmind.com/api/v0.3/auth/guest"
+      HEALTHCHECK_URL_PROD: "https://api.fermatmind.com/api/healthz"
+      AUTH_GUEST_CHECK_URL_PROD: "https://api.fermatmind.com/api/v0.3/auth/guest"
 
       # ====== staging ======
       DEPLOY_USER_STG: "ubuntu"
@@ -118,6 +118,11 @@ jobs:
               exit 2
               ;;
           esac
+
+          if [ "$TARGET" = "production" ] && [ "$DEPLOY_HOST" = "122.152.221.126" ]; then
+            echo "Refusing production deploy to retired Tencent Node3: $DEPLOY_HOST"
+            exit 1
+          fi
 
           {
             echo "DEPLOY_HOST=$DEPLOY_HOST"
@@ -213,10 +218,10 @@ jobs:
       # ====== production ======
       DEPLOY_USER_PROD: "ubuntu"
       DEPLOY_PORT_PROD: "22"
-      DEPLOY_HOST_PROD: "122.152.221.126"
+      DEPLOY_HOST_PROD: "139.224.130.204"
       DEPLOY_PATH_PROD: "/var/www/fap-api"
-      HEALTHCHECK_URL_PROD: "https://fermatmind.com/api/healthz"
-      AUTH_GUEST_CHECK_URL_PROD: "https://fermatmind.com/api/v0.3/auth/guest"
+      HEALTHCHECK_URL_PROD: "https://api.fermatmind.com/api/healthz"
+      AUTH_GUEST_CHECK_URL_PROD: "https://api.fermatmind.com/api/v0.3/auth/guest"
 
       # ====== staging ======
       DEPLOY_USER_STG: "ubuntu"
@@ -263,6 +268,11 @@ jobs:
               exit 2
               ;;
           esac
+
+          if [ "$TARGET" = "production" ] && [ "$DEPLOY_HOST" = "122.152.221.126" ]; then
+            echo "Refusing production deploy to retired Tencent Node3: $DEPLOY_HOST"
+            exit 1
+          fi
 
           {
             echo "DEPLOY_HOST=$DEPLOY_HOST"

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -50,7 +50,10 @@ Truth Source: `backend/composer.json` / `backend/package.json` / `backend/config
 以 `backend/.env.example` 为模板，生产必须由密钥系统注入。
 
 Deployer SSH 约定：
-- 默认 production 仍走 `DEPLOY_HOST_PROD=122.152.221.126`、`DEPLOY_USER_PROD=ubuntu`
+- 默认 production 走阿里云 ECS `DEPLOY_HOST_PROD=139.224.130.204`、`DEPLOY_USER_PROD=ubuntu`
+- `122.152.221.126` 是退役中的腾讯云 Node3，不允许作为 production deploy target
+- GitHub Actions production deploy 使用 release layout：`DEPLOY_PATH_PROD=/var/www/fap-api`
+- 阿里云 host bootstrap 后，nginx / Supervisor / cron 应指向 `/var/www/fap-api/current/backend`；迁移期可让 `current` 临时指向手工 runtime，首次标准 Deployer release 会替换该 symlink
 - 若本机存在 `~/.ssh/fap_prod` 或 `~/.ssh/fap_api_gha`，`deploy.php` 会自动将其作为 production `IdentityFile`
 - staging 若本机存在 `~/.ssh/fap_actions_staging`，会自动作为 staging `IdentityFile`
 - 如需显式覆盖，使用：

--- a/deploy.php
+++ b/deploy.php
@@ -234,11 +234,11 @@ $stagingIdentityFile = resolveDeployIdentityFile('DEPLOY_IDENTITY_FILE_STG', [
  */
 /** @var \Deployer\Host\Host $productionHost */
 $productionHost = host('production')
-    ->setHostname(getenv('DEPLOY_HOST_PROD') ?: '122.152.221.126')
+    ->setHostname(getenv('DEPLOY_HOST_PROD') ?: '139.224.130.204')
     ->setRemoteUser(getenv('DEPLOY_USER_PROD') ?: 'ubuntu')
     ->setPort((int) (getenv('DEPLOY_PORT_PROD') ?: 22))
     ->set('deploy_path', getenv('DEPLOY_PATH_PROD') ?: '/var/www/fap-api')
-    ->set('healthcheck_host', getenv('HEALTHCHECK_HOST_PROD') ?: 'fermatmind.com')
+    ->set('healthcheck_host', getenv('HEALTHCHECK_HOST_PROD') ?: 'api.fermatmind.com')
     ->set('static_media_healthcheck_host', getenv('STATIC_MEDIA_HEALTHCHECK_HOST_PROD') ?: 'api.fermatmind.com')
     ->set('scale_lookup_healthcheck_host', getenv('SCALE_LOOKUP_HEALTHCHECK_HOST_PROD') ?: 'api.fermatmind.com')
     ->set('ops_entry_host', getenv('OPS_ENTRY_HOST_PROD') ?: 'ops.fermatmind.com')

--- a/docs/04-ops/backend-deploy-target-aliyun-01.md
+++ b/docs/04-ops/backend-deploy-target-aliyun-01.md
@@ -30,11 +30,30 @@ Nginx, Supervisor, and cron point to `/var/www/fap-api/current/backend`. The fir
 
 Node3 queue workers and Laravel scheduler were stopped after `api.fermatmind.com` and `ops.fermatmind.com` resolved to Aliyun. Node3 nginx was left running temporarily only for stale DNS-cache tail traffic.
 
+## Certificate Renewal
+
+`ops.fermatmind.com` uses a Let's Encrypt certificate on Aliyun. The certificate now renews with HTTP-01/webroot instead of manual DNS-01:
+
+- Cert path: `/etc/letsencrypt/live/ops.fermatmind.com/fullchain.pem`
+- Renewal authenticator: `webroot`
+- Webroot: `/var/www/fap-api/current/backend/public`
+- Nginx reload hook: `/etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh`
+- Certbot timer: enabled and active
+
+`certbot renew --dry-run --cert-name ops.fermatmind.com --no-random-sleep-on-renew` succeeded on Aliyun.
+
+## Retired Node3 Deploy Webhook
+
+The old GitHub push webhook that targeted `http://122.152.221.126:9000/hooks/deploy-fap-api` has been disabled in GitHub. Node3 `webhook.service` is stopped and disabled, and Node3 has a host firewall reject rule for TCP/9000.
+
+Production deployment should use the GitHub Actions/Deployer SSH path to Aliyun, not the old Node3 webhook.
+
 ## Acceptance Checks
 
 ```bash
 rg -n '122\.152\.221\.126|DEPLOY_HOST_PROD' deploy.php .github/workflows/deploy.yml README_DEPLOY.md
 php -l deploy.php
+certbot renew --dry-run --cert-name ops.fermatmind.com --no-random-sleep-on-renew
 ```
 
 Expected result:
@@ -43,3 +62,5 @@ Expected result:
 - The workflow refuses `DEPLOY_HOST_PROD=122.152.221.126`.
 - Production health and auth smoke use `https://api.fermatmind.com`.
 - Production Deployer host defaults use `api.fermatmind.com` as the backend healthcheck host.
+- `ops.fermatmind.com` certificate renewal succeeds without DNSPod manual TXT records.
+- GitHub repository webhook for the old Node3 deploy endpoint is inactive.

--- a/docs/04-ops/backend-deploy-target-aliyun-01.md
+++ b/docs/04-ops/backend-deploy-target-aliyun-01.md
@@ -1,0 +1,45 @@
+# BACKEND-DEPLOY-TARGET-ALIYUN-01
+
+Status: completed
+Owner: backend deploy
+Last updated: 2026-05-21
+
+## Decision
+
+Production backend deploy target is Aliyun ECS `fap-api-prod-ali-01`:
+
+- Public IP: `139.224.130.204`
+- Runtime host user: `ubuntu`
+- Standard deploy root: `/var/www/fap-api`
+- Public API host: `api.fermatmind.com`
+- Ops host: `ops.fermatmind.com`
+
+Tencent Node3 `122.152.221.126` is retired as a production deploy target. Deploy automation must fail closed instead of deploying new production releases to Node3.
+
+## Runtime Bootstrap
+
+The emergency migration runtime was mounted behind the standard deploy path so future releases have one stable target:
+
+- `/var/www/fap-api/current -> /opt/fap-api`
+- `/var/www/fap-api/releases`
+- `/var/www/fap-api/shared/backend/.env`
+- `/var/www/fap-api/shared/backend/storage`
+- `/var/www/fap-api/shared/content_packages`
+
+Nginx, Supervisor, and cron point to `/var/www/fap-api/current/backend`. The first standard Deployer release may replace the temporary `current` symlink with a managed release symlink.
+
+Node3 queue workers and Laravel scheduler were stopped after `api.fermatmind.com` and `ops.fermatmind.com` resolved to Aliyun. Node3 nginx was left running temporarily only for stale DNS-cache tail traffic.
+
+## Acceptance Checks
+
+```bash
+rg -n '122\.152\.221\.126|DEPLOY_HOST_PROD' deploy.php .github/workflows/deploy.yml README_DEPLOY.md
+php -l deploy.php
+```
+
+Expected result:
+
+- Production defaults resolve to `139.224.130.204`.
+- The workflow refuses `DEPLOY_HOST_PROD=122.152.221.126`.
+- Production health and auth smoke use `https://api.fermatmind.com`.
+- Production Deployer host defaults use `api.fermatmind.com` as the backend healthcheck host.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T18:29:00+08:00",
+  "updated_at": "2026-05-21T18:40:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15032,6 +15032,14 @@
         "github_pr": {
           "status": "pending",
           "summary": "Opened draft PR #1524; GitHub checks pending."
+        },
+        "ops_cert_renewal": {
+          "status": "pass",
+          "summary": "ops.fermatmind.com renewal was converted from manual DNS-01 to HTTP-01 webroot on Aliyun; certbot renew --dry-run succeeded and nginx reload hook is installed."
+        },
+        "node3_deploy_webhook_retired": {
+          "status": "pass",
+          "summary": "GitHub repository push webhook pointing to http://122.152.221.126:9000/hooks/deploy-fap-api was set inactive; Node3 webhook.service is stopped and disabled."
         }
       },
       "failure_reason": null,
@@ -15058,6 +15066,11 @@
           "at": "2026-05-21T18:29:00+08:00",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened draft PR https://github.com/fermatmind/fap-api/pull/1524 for BACKEND-DEPLOY-TARGET-ALIYUN-01. GitHub checks pending."
+        },
+        {
+          "at": "2026-05-21T18:40:00+08:00",
+          "status": "residual_ops_closed",
+          "summary": "Closed residual Aliyun ops certificate renewal and Node3 deploy webhook retirement items after production cutover."
         }
       ]
     },
@@ -15086,6 +15099,10 @@
         "ops_http": {
           "status": "pass",
           "summary": "https://ops.fermatmind.com/ops/login returned HTTP 200 from Aliyun certificate/runtime."
+        },
+        "automated_cert_renewal": {
+          "status": "pass",
+          "summary": "ops.fermatmind.com renewal config now uses authenticator=webroot with webroot_path=/var/www/fap-api/current/backend/public; certbot timer is enabled/active and dry-run renewal succeeded."
         }
       },
       "failure_reason": null,
@@ -15097,6 +15114,11 @@
           "at": "2026-05-21T18:20:00+08:00",
           "status": "completed_external_operation",
           "summary": "Completed Ops domain migration to Aliyun and verified DNS/TLS/runtime."
+        },
+        {
+          "at": "2026-05-21T18:40:00+08:00",
+          "status": "cert_renewal_automated",
+          "summary": "Replaced the manual DNS-01 renewal path for ops.fermatmind.com with HTTP-01/webroot renewal and nginx deploy reload hook."
         }
       ]
     },
@@ -15125,6 +15147,10 @@
         "nginx_tail": {
           "status": "info",
           "summary": "Node3 nginx was left running temporarily for stale DNS-cache tail traffic; Node3 was not powered off or deleted."
+        },
+        "deploy_webhook_retired": {
+          "status": "pass",
+          "summary": "GitHub hook id 598987512 for Node3 deploy endpoint is inactive; Node3 webhook.service is inactive/disabled and TCP/9000 is rejected on the host."
         }
       },
       "failure_reason": null,
@@ -15136,6 +15162,11 @@
           "at": "2026-05-21T18:20:00+08:00",
           "status": "completed_external_operation",
           "summary": "Completed controlled Node3 retirement preflight and stopped old queue/scheduler without shutting down the host."
+        },
+        {
+          "at": "2026-05-21T18:40:00+08:00",
+          "status": "deploy_webhook_retired",
+          "summary": "Disabled the old GitHub push deploy webhook and stopped/disabled Node3 webhook.service so production deployment no longer depends on Node3 port 9000."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-20T04:20:00Z",
+  "updated_at": "2026-05-21T18:29:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14854,11 +14854,11 @@
     "SEARCH-CHANNEL-QUEUE-01": {
       "repo": "fap-api",
       "branch": "codex/search-channel-queue-01-runtime-mvp",
-      "status": "ci_fix_local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-01-PREFLIGHT"
       ],
-      "commit_sha": "46413dcee8f9ae2dce74a95422aa591a80a26110",
+      "commit_sha": "b340c18d4f7d1e86d879d34014c4337e505f2595",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1518",
       "checks": {
         "dependency": {
@@ -14930,11 +14930,15 @@
           "status": "pass",
           "command": "cd backend && php artisan test --filter=SeoIntelSearchChannelQueue",
           "summary": "22 tests passed, 200 assertions."
+        },
+        "github_merge_reconciliation": {
+          "status": "pass",
+          "summary": "GitHub PR #1518 is merged, origin/main contains merge commit b340c18d4f7d1e86d879d34014c4337e505f2595, and the remote branch is absent."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-20T14:40:06Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "sidecar_issues": [
         {
@@ -14968,6 +14972,319 @@
           "at": "2026-05-20T22:47:00+08:00",
           "status": "ci_fix_local_validation_passed",
           "summary": "Inspected GitHub check failure. It was the BigFive runtime freeze guard flagging scoped SeoIntel queue files. Added narrow allowlist coverage in the permitted BigFive freeze test and reran the queue tests plus the full BigFive freeze file locally."
+        },
+        {
+          "at": "2026-05-21T18:20:00+08:00",
+          "status": "merged_reconciled",
+          "summary": "Reconciled SEARCH-CHANNEL-QUEUE-01 as merged before registering Aliyun production migration and deploy-target ledger tasks."
+        }
+      ]
+    },
+    "BACKEND-DEPLOY-TARGET-ALIYUN-01": {
+      "repo": "fap-api",
+      "branch": "codex/backend-deploy-target-aliyun-01",
+      "status": "pr_opened_github_checks_pending",
+      "depends_on": [
+        "SEARCH-CHANNEL-QUEUE-01"
+      ],
+      "commit_sha": "8dd8adc763f55522fb5bc596e719e5f6e33840c3",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1524",
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "summary": "SEARCH-CHANNEL-QUEUE-01 merged as b340c18d4f7d1e86d879d34014c4337e505f2595 and origin/main contains it."
+        },
+        "deploy_target": {
+          "status": "pass",
+          "summary": "Production deploy defaults now target Aliyun ECS 139.224.130.204 and refuse retired Tencent Node3 122.152.221.126."
+        },
+        "host_bootstrap": {
+          "status": "pass",
+          "summary": "Aliyun host has /var/www/fap-api layout, current symlink to /opt/fap-api, shared .env/storage/content_packages seeded, and nginx/Supervisor/cron point to /var/www/fap-api/current/backend."
+        },
+        "runtime_smoke": {
+          "status": "pass",
+          "summary": "Aliyun local Host-forced API and Ops curls returned 200; frontend Node1 traffic reached Aliyun API and returned 200 after bootstrap."
+        },
+        "php_lint": {
+          "status": "pass",
+          "command": "php -l deploy.php",
+          "summary": "No syntax errors detected in deploy.php."
+        },
+        "yaml_validation": {
+          "status": "pass",
+          "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/deploy.yml').read_text()); yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"",
+          "summary": "Workflow YAML and PR train manifest parsed successfully."
+        },
+        "json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        },
+        "deploy_target_rg": {
+          "status": "pass",
+          "command": "rg -n \"122\\.152\\.221\\.126|139\\.224\\.130\\.204|DEPLOY_HOST_PROD|HEALTHCHECK_URL_PROD|AUTH_GUEST_CHECK_URL_PROD\" deploy.php .github/workflows/deploy.yml README_DEPLOY.md docs/04-ops/backend-deploy-target-aliyun-01.md",
+          "summary": "Verified Aliyun deploy target, Node3 refusal guard, and production smoke URLs."
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "github_pr": {
+          "status": "pending",
+          "summary": "Opened draft PR #1524; GitHub checks pending."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-21T18:20:00+08:00",
+          "status": "in_progress",
+          "summary": "Started Aliyun backend deploy target PR after production cutover. No GitHub Actions deploy was run from this branch."
+        },
+        {
+          "at": "2026-05-21T18:23:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Deploy-target config and PR-train ledger passed php lint, YAML/JSON validation, deploy-target grep check, and git diff whitespace check."
+        },
+        {
+          "at": "2026-05-21T18:26:00+08:00",
+          "status": "commit_created",
+          "summary": "Created local commit 725e5abe6edc53b1d603ec0726367aeeed91812b for Aliyun backend deploy target and migration ledger."
+        },
+        {
+          "at": "2026-05-21T18:29:00+08:00",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened draft PR https://github.com/fermatmind/fap-api/pull/1524 for BACKEND-DEPLOY-TARGET-ALIYUN-01. GitHub checks pending."
+        }
+      ]
+    },
+    "OPS-DOMAIN-MIGRATION-01": {
+      "repo": "fap-api",
+      "branch": "codex/backend-deploy-target-aliyun-01",
+      "status": "completed_external_operation",
+      "depends_on": [
+        "BACKEND-DEPLOY-TARGET-ALIYUN-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "aliyun_tls": {
+          "status": "pass",
+          "summary": "Aliyun nginx serves api.fermatmind.com and ops.fermatmind.com with Let's Encrypt certificates valid until 2026-08-19."
+        },
+        "dnspod_dns": {
+          "status": "pass",
+          "summary": "DNSPod A record ops.fermatmind.com was changed from 122.152.221.126 to 139.224.130.204 after Tencent MFA."
+        },
+        "public_dns": {
+          "status": "pass",
+          "summary": "Cloudflare and Google public DNS returned 139.224.130.204 for api.fermatmind.com and ops.fermatmind.com."
+        },
+        "ops_http": {
+          "status": "pass",
+          "summary": "https://ops.fermatmind.com/ops/login returned HTTP 200 from Aliyun certificate/runtime."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-21T18:20:00+08:00",
+          "status": "completed_external_operation",
+          "summary": "Completed Ops domain migration to Aliyun and verified DNS/TLS/runtime."
+        }
+      ]
+    },
+    "NODE3-RETIREMENT-PREFLIGHT": {
+      "repo": "fap-api",
+      "branch": "codex/backend-deploy-target-aliyun-01",
+      "status": "completed_external_operation",
+      "depends_on": [
+        "OPS-DOMAIN-MIGRATION-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "traffic_preflight": {
+          "status": "pass",
+          "summary": "api.fermatmind.com and ops.fermatmind.com public DNS resolve to Aliyun 139.224.130.204; recent Node3 access log traffic was before DNS cutover."
+        },
+        "queue_workers": {
+          "status": "pass",
+          "summary": "Stopped Node3 supervisor groups fap-queue-default-high:* and fap-queue-reports:*."
+        },
+        "scheduler": {
+          "status": "pass",
+          "summary": "Commented Node3 ubuntu and www-data Laravel scheduler cron lines with NODE3_RETIRED_20260521180344 and saved crontab backups under /home/ubuntu/node3-retirement-preflight/."
+        },
+        "nginx_tail": {
+          "status": "info",
+          "summary": "Node3 nginx was left running temporarily for stale DNS-cache tail traffic; Node3 was not powered off or deleted."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-21T18:20:00+08:00",
+          "status": "completed_external_operation",
+          "summary": "Completed controlled Node3 retirement preflight and stopped old queue/scheduler without shutting down the host."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION-PREFLIGHT": {
+      "repo": "fap-api",
+      "branch": "codex/backend-deploy-target-aliyun-01",
+      "status": "completed_external_operation",
+      "depends_on": [
+        "SEARCH-CHANNEL-QUEUE-01",
+        "BACKEND-DEPLOY-TARGET-ALIYUN-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "rds_network": {
+          "status": "pass",
+          "summary": "Aliyun ECS private IP 172.19.243.190 was appended to RDS whitelist and TCP 3306 to rm-uf6u2498t7nk2faya.rwlb.rds.aliyuncs.com succeeded."
+        },
+        "migration_status": {
+          "status": "pass",
+          "summary": "migrate:status --database=seo_intel --path=database/migrations/seo_intel ran successfully."
+        },
+        "source_counts": {
+          "status": "pass",
+          "summary": "seo_urls=9, seo_url_entities=9, seo_issue_queue=5."
+        },
+        "dry_run_no_write": {
+          "status": "pass",
+          "summary": "seo-intel:search-channel-queue --dry-run --no-write --json --limit=3 succeeded with no writes, no external calls, and no search submission."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-21T18:20:00+08:00",
+          "status": "completed_external_operation",
+          "summary": "Completed Search Channel Queue production migration preflight on Aliyun backend."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION": {
+      "repo": "fap-api",
+      "branch": "codex/backend-deploy-target-aliyun-01",
+      "status": "completed_external_operation",
+      "depends_on": [
+        "SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION-PREFLIGHT"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "permission_gate": {
+          "status": "pass",
+          "summary": "User authorized changing seo_intel_writer to ReadWrite. GrantAccountPrivilege succeeded; SHOW GRANTS reported ALL PRIVILEGES on seo_intel.* as the RDS ReadWrite mapping."
+        },
+        "pretend": {
+          "status": "pass",
+          "summary": "Isolated --pretend output showed only seo_search_channel_queue_batches, seo_search_channel_queue_items, and seo_search_channel_queue_events table creation plus indexes."
+        },
+        "migration": {
+          "status": "pass",
+          "summary": "php artisan migrate --database=seo_intel --path=database/migrations/seo_intel --force completed 2026_05_20_220000_create_seo_search_channel_queue_tables."
+        },
+        "status": {
+          "status": "pass",
+          "summary": "migrate:status shows 2026_05_20_220000_create_seo_search_channel_queue_tables as batch [2] Ran."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-21T18:20:00+08:00",
+          "status": "completed_external_operation",
+          "summary": "Completed isolated seo_intel Search Channel Queue production schema migration."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-QUEUE-01-PROD-DRY-RUN": {
+      "repo": "fap-api",
+      "branch": "codex/backend-deploy-target-aliyun-01",
+      "status": "completed_external_operation",
+      "depends_on": [
+        "SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dry_run_limit_20": {
+          "status": "pass",
+          "summary": "candidate_count=9, eligible_count=9, planned_queue_count=72, writes_committed=false, external_calls_attempted=false, search_submission_attempted=false."
+        },
+        "dry_run_indexnow": {
+          "status": "pass",
+          "summary": "candidate_count=9, eligible_count=9, planned_queue_count=9 for channel indexnow with no writes or external calls."
+        },
+        "dry_run_research_report": {
+          "status": "pass",
+          "summary": "candidate_count=2, eligible_count=2, planned_queue_count=16 for research_report with no writes or external calls."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-21T18:20:00+08:00",
+          "status": "completed_external_operation",
+          "summary": "Completed production no-write Search Channel Queue dry-runs after schema migration."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE": {
+      "repo": "fap-api",
+      "branch": "codex/backend-deploy-target-aliyun-01",
+      "status": "completed_external_operation",
+      "depends_on": [
+        "SEARCH-CHANNEL-QUEUE-01-PROD-DRY-RUN"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "pre_counts": {
+          "status": "pass",
+          "summary": "Queue tables started empty: batches=0, items=0, events=0."
+        },
+        "canary_enqueue": {
+          "status": "pass",
+          "summary": "One command-session write gate run for --channel=indexnow --limit=1 succeeded with writes_committed=true, written_items=1, external_calls_attempted=false, search_submission_attempted=false."
+        },
+        "post_counts": {
+          "status": "pass",
+          "summary": "Queue tables after canary: batches=1, items=1, events=2. Latest item id=1 channel=indexnow approval_state=pending execution_state=dry_run_ready canonical_url=https://fermatmind.com/en."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-21T18:20:00+08:00",
+          "status": "completed_external_operation",
+          "summary": "Completed minimal no-submit canary enqueue for Search Channel Queue."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -7735,3 +7735,260 @@ prs:
     external_api_credentials_required: false
     scheduler_activation: false
     next_task: SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION-PREFLIGHT
+
+  - id: BACKEND-DEPLOY-TARGET-ALIYUN-01
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-QUEUE-01
+    branch: codex/backend-deploy-target-aliyun-01
+    base: main
+    title: "BACKEND-DEPLOY-TARGET-ALIYUN-01｜Point production backend deploy target at Aliyun ECS"
+    name: "Point production backend deploy target at Aliyun ECS"
+    train_scope: aliyun_backend_migration
+    risk_level: L2
+    type: backend deploy config / ops ledger PR
+    scope:
+      - Retarget production backend deploy defaults from retired Tencent Node3 to Aliyun ECS `139.224.130.204`.
+      - Keep production deploys fail-closed if `DEPLOY_HOST_PROD` is set to Node3 `122.152.221.126`.
+      - Document the Aliyun release layout bootstrap and linked production cutover evidence.
+      - Register the linked Node3 retirement, Ops DNS migration, and Search Channel production migration ledger tasks.
+    allowed_paths:
+      - .github/workflows/deploy.yml
+      - README_DEPLOY.md
+      - deploy.php
+      - docs/04-ops/backend-deploy-target-aliyun-01.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy from GitHub Actions, merge a release, rotate secrets, delete Node3 resources, stop Node3 nginx, or change fap-web runtime code in this PR.
+      - Enable live search submission, scheduler submission jobs, or external search API calls.
+    validation:
+      - php -l deploy.php
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/deploy.yml').read_text()); yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - rg -n "122\\.152\\.221\\.126|139\\.224\\.130\\.204|DEPLOY_HOST_PROD|HEALTHCHECK_URL_PROD|AUTH_GUEST_CHECK_URL_PROD" deploy.php .github/workflows/deploy.yml README_DEPLOY.md docs/04-ops/backend-deploy-target-aliyun-01.md
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false
+    next_task: NODE3-RETIREMENT-PREFLIGHT
+
+  - id: NODE3-RETIREMENT-PREFLIGHT
+    repo: fap-api
+    depends_on:
+      - BACKEND-DEPLOY-TARGET-ALIYUN-01
+    branch: codex/backend-deploy-target-aliyun-01
+    base: main
+    title: "NODE3-RETIREMENT-PREFLIGHT｜Confirm Node3 is safe to retire"
+    name: "Confirm Node3 is safe to retire"
+    train_scope: aliyun_backend_migration
+    risk_level: L2
+    type: production ops ledger
+    scope:
+      - Confirm public API/Ops traffic moved to Aliyun before stopping old Node3 queue and scheduler processes.
+      - Stop only Node3 Laravel scheduler and queue workers after DNS cutover verification.
+      - Leave Node3 nginx online temporarily for stale DNS-cache tail traffic.
+    allowed_paths:
+      - docs/04-ops/backend-deploy-target-aliyun-01.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Delete, power off, or reset Node3.
+      - Stop Node3 nginx, MySQL, Redis, SSH, or unknown webhook listeners without a separate approval.
+    validation:
+      - Node3 supervisor shows fap queue groups stopped.
+      - Node3 ubuntu and www-data Laravel scheduler cron lines are commented with `NODE3_RETIRED`.
+      - api.fermatmind.com and ops.fermatmind.com resolve to Aliyun `139.224.130.204`.
+    merge_policy:
+      github_checks_required: false
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false
+    next_task: OPS-DOMAIN-MIGRATION-01
+
+  - id: OPS-DOMAIN-MIGRATION-01
+    repo: fap-api
+    depends_on:
+      - BACKEND-DEPLOY-TARGET-ALIYUN-01
+    branch: codex/backend-deploy-target-aliyun-01
+    base: main
+    title: "OPS-DOMAIN-MIGRATION-01｜Move ops.fermatmind.com to Aliyun backend"
+    name: "Move ops.fermatmind.com to Aliyun backend"
+    train_scope: aliyun_backend_migration
+    risk_level: L2
+    type: production ops ledger
+    scope:
+      - Install and verify the `ops.fermatmind.com` TLS runtime on Aliyun.
+      - Move DNSPod A record for `ops.fermatmind.com` from Node3 to Aliyun `139.224.130.204`.
+      - Verify public DNS, TLS SAN, and Ops login HTTP response after cutover.
+    allowed_paths:
+      - docs/04-ops/backend-deploy-target-aliyun-01.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change frontend runtime code, rotate admin credentials, or remove Node3 before DNS and runtime verification.
+    validation:
+      - DNSPod A record `ops.fermatmind.com` equals `139.224.130.204`.
+      - Public DNS resolvers return Aliyun `139.224.130.204`.
+      - "`ops.fermatmind.com` TLS certificate SAN includes `ops.fermatmind.com`."
+      - "`https://ops.fermatmind.com/ops/login` returns 200 from Aliyun runtime."
+    merge_policy:
+      github_checks_required: false
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false
+    next_task: SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION-PREFLIGHT
+
+  - id: SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION-PREFLIGHT
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-QUEUE-01
+      - BACKEND-DEPLOY-TARGET-ALIYUN-01
+    branch: codex/backend-deploy-target-aliyun-01
+    base: main
+    title: "SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION-PREFLIGHT｜Verify seo_intel production readiness"
+    name: "Verify seo_intel production readiness"
+    train_scope: search_channel_queue_runtime
+    risk_level: L2
+    type: production preflight ledger
+    scope:
+      - Verify Aliyun backend can reach `seo_intel` RDS.
+      - Verify `seo_urls`, `seo_url_entities`, and `seo_issue_queue` minimum production counts.
+      - Run no-write Search Channel Queue production dry-run before any schema/write operation.
+    allowed_paths:
+      - docs/04-ops/backend-deploy-target-aliyun-01.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run schema migration, enable write gate, or enqueue items in this preflight task.
+    validation:
+      - Aliyun ECS TCP connection to `rm-uf6u2498t7nk2faya.rwlb.rds.aliyuncs.com:3306` succeeds.
+      - "`migrate:status --database=seo_intel --path=database/migrations/seo_intel` runs."
+      - "`seo_urls >= 9`, `seo_url_entities >= 9`, and `seo_issue_queue >= 5`."
+      - "`seo-intel:search-channel-queue --dry-run --no-write --json --limit=3` succeeds with no writes and no external calls."
+    merge_policy:
+      github_checks_required: false
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false
+    next_task: SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION
+
+  - id: SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION-PREFLIGHT
+    branch: codex/backend-deploy-target-aliyun-01
+    base: main
+    title: "SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION｜Run seo_intel queue schema migration"
+    name: "Run seo_intel queue schema migration"
+    train_scope: search_channel_queue_runtime
+    risk_level: L2
+    type: production migration ledger
+    scope:
+      - Run only the isolated `database/migrations/seo_intel` production migration path.
+      - Create Search Channel Queue batch, item, and event tables in `seo_intel`.
+      - Keep live search submission disabled.
+    allowed_paths:
+      - docs/04-ops/backend-deploy-target-aliyun-01.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run full default Laravel migrations or change business DB schema.
+      - Submit URLs or call external search APIs.
+    validation:
+      - "`migrate --pretend --database=seo_intel --path=database/migrations/seo_intel --force` shows only Search Channel Queue tables."
+      - "`migrate --database=seo_intel --path=database/migrations/seo_intel --force` succeeds."
+      - "`migrate:status --database=seo_intel --path=database/migrations/seo_intel` shows `2026_05_20_220000_create_seo_search_channel_queue_tables` as ran."
+    merge_policy:
+      github_checks_required: false
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: true
+    external_api_credentials_required: false
+    scheduler_activation: false
+    next_task: SEARCH-CHANNEL-QUEUE-01-PROD-DRY-RUN
+
+  - id: SEARCH-CHANNEL-QUEUE-01-PROD-DRY-RUN
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-QUEUE-01-PROD-MIGRATION
+    branch: codex/backend-deploy-target-aliyun-01
+    base: main
+    title: "SEARCH-CHANNEL-QUEUE-01-PROD-DRY-RUN｜Run production no-write queue dry-runs"
+    name: "Run production no-write queue dry-runs"
+    train_scope: search_channel_queue_runtime
+    risk_level: L2
+    type: production dry-run ledger
+    scope:
+      - Run Search Channel Queue production dry-runs after schema migration.
+      - Verify no writes occur with the write gate disabled and `--no-write` set.
+    allowed_paths:
+      - docs/04-ops/backend-deploy-target-aliyun-01.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Enable write gate or submit URLs.
+    validation:
+      - "`seo-intel:search-channel-queue --dry-run --no-write --json --limit=20` succeeds."
+      - "`seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=20` succeeds."
+      - "`seo-intel:search-channel-queue --dry-run --no-write --json --page-type=research_report --limit=20` succeeds."
+    merge_policy:
+      github_checks_required: false
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false
+    next_task: SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE
+
+  - id: SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-QUEUE-01-PROD-DRY-RUN
+    branch: codex/backend-deploy-target-aliyun-01
+    base: main
+    title: "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE｜Canary enqueue one no-submit queue item"
+    name: "Canary enqueue one no-submit queue item"
+    train_scope: search_channel_queue_runtime
+    risk_level: L2
+    type: production canary ledger
+    scope:
+      - Enable the Search Channel Queue write gate only for one command session.
+      - Canary enqueue one `indexnow` dry-run-ready queue item with no live submission.
+      - Verify queue batch, item, and event counts after the write.
+    allowed_paths:
+      - docs/04-ops/backend-deploy-target-aliyun-01.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Persist `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=true`.
+      - Submit URLs, call external search APIs, or enable scheduler.
+    validation:
+      - "`SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=true php artisan seo-intel:search-channel-queue --json --channel=indexnow --limit=1` succeeds."
+      - Output reports `writes_committed=true`, `written_items=1`, `external_calls_attempted=false`, and `search_submission_attempted=false`.
+      - Queue tables contain one batch, one item, and two audit events after canary.
+    merge_policy:
+      github_checks_required: false
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false


### PR DESCRIPTION
## What changed
- Retargeted production backend deploy defaults from Tencent Node3 `122.152.221.126` to Aliyun ECS `139.224.130.204`.
- Updated production smoke URLs to `https://api.fermatmind.com` and added fail-closed guards against deploying production to Node3.
- Added the Aliyun backend cutover/host bootstrap ledger and registered the linked Node3 retirement, Ops DNS migration, and Search Channel production migration tasks in the PR-train manifest/state.

## Why
Node3 is expiring and production API/Ops runtime has been moved to Aliyun. The repo deploy target needs to stop pointing at the retired Tencent host and preserve the operational evidence for the migration steps already performed.

## Validation
- `php -l deploy.php`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/deploy.yml').read_text()); yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No GitHub Actions production deploy was run from this PR.
- Node3 nginx was left online temporarily for stale DNS-cache tail traffic; Node3 was not powered off or deleted.
- No live search-engine URL submission was enabled; Search Channel canary only wrote one no-submit queue item.
