### PR TITLE
PR-EQ-V5-04A: backend EQ v5 canonical contract fixtures

### DIFF
--- a/backend/tests/Feature/Report/Eq60V5ReportContractTest.php
+++ b/backend/tests/Feature/Report/Eq60V5ReportContractTest.php
@@ -1,0 +1,466 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Assessment\Scorers\Eq60ScorerV1NormedValidity;
+use App\Services\Content\Eq60PackLoader;
+use App\Services\Report\Eq60ReportComposer;
+use App\Services\Report\ReportAccess;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class Eq60V5ReportContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array<string,array{case_id:string,locale:string,file:string,formulation:string,action:string}>
+     */
+    public static function fixtureCases(): array
+    {
+        return [
+            'balanced_zh' => [
+                'EQ60_BALANCED_HIGH_ZH',
+                'zh-CN',
+                'eq60_v5_balanced_integrated_zh.json',
+                'balanced_integrated',
+                'emotion_labeling',
+            ],
+            'high_empathy_zh' => [
+                'EQ60_COMPASSION_OVERLOAD_ZH',
+                'zh-CN',
+                'eq60_v5_high_empathy_low_recovery_zh.json',
+                'high_empathy_low_recovery',
+                'empathy_boundary',
+            ],
+            'low_confidence_zh' => [
+                'EQ60_SPEEDING_C_ZH',
+                'zh-CN',
+                'eq60_v5_low_confidence_zh.json',
+                'low_confidence_result',
+                'retest_reflection',
+            ],
+            'balanced_en' => [
+                'EQ60_BALANCED_HIGH_ZH',
+                'en',
+                'eq60_v5_balanced_integrated_en.json',
+                'balanced_integrated',
+                'emotion_labeling',
+            ],
+            'high_empathy_en' => [
+                'EQ60_COMPASSION_OVERLOAD_ZH',
+                'en',
+                'eq60_v5_high_empathy_low_recovery_en.json',
+                'high_empathy_low_recovery',
+                'empathy_boundary',
+            ],
+            'low_confidence_en' => [
+                'EQ60_SPEEDING_C_ZH',
+                'en',
+                'eq60_v5_low_confidence_en.json',
+                'low_confidence_result',
+                'retest_reflection',
+            ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('fixtureCases')]
+    public function test_canonical_v5_fixture_matches_composer_output(
+        string $caseId,
+        string $locale,
+        string $file,
+        string $formulation,
+        string $action
+    ): void {
+        $this->prepareEqContent();
+
+        $fixture = $this->canonicalFixture($caseId, $locale);
+        $this->maybeUpdateFixture($file, $fixture);
+
+        $this->assertSame($this->loadFixture($file), $fixture);
+        $this->assertCommonV5Contract($fixture);
+        $this->assertSame($formulation, (string) data_get($fixture, 'report.interpretation.core_formulation_id'));
+        $this->assertSame($formulation, (string) data_get($fixture, 'report.assets.core_formulation.id'));
+        $this->assertSame($action, (string) data_get($fixture, 'report.interpretation.action_prescription_id'));
+        $this->assertSame($action, (string) data_get($fixture, 'report.assets.action_prescription.id'));
+    }
+
+    public function test_high_empathy_low_recovery_contract_has_resolved_v5_assets(): void
+    {
+        $this->prepareEqContent();
+
+        $fixture = $this->canonicalFixture('EQ60_COMPASSION_OVERLOAD_ZH', 'zh-CN');
+
+        $this->assertSame('high_empathy_low_recovery', (string) data_get($fixture, 'report.interpretation.core_formulation_id'));
+        $this->assertSame('empathy_boundary', (string) data_get($fixture, 'report.interpretation.action_prescription_id'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.interpretation.primary_mechanism_ids'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.interpretation.primary_scene_ids'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.interpretation.career_environment_ids'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.assets.mechanisms'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.assets.reality_scenes'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.assets.career_environment'));
+    }
+
+    public function test_low_confidence_contract_routes_to_cautious_formulation(): void
+    {
+        $this->prepareEqContent();
+
+        $fixture = $this->canonicalFixture('EQ60_SPEEDING_C_ZH', 'zh-CN');
+
+        $this->assertSame('low_confidence_result', (string) data_get($fixture, 'report.interpretation.core_formulation_id'));
+        $this->assertSame('retest_reflection', (string) data_get($fixture, 'report.interpretation.action_prescription_id'));
+        $this->assertSame('low', (string) data_get($fixture, 'report.quality.confidence_label'));
+        $this->assertSame([], (array) data_get($fixture, 'report.interpretation.primary_mechanism_ids'));
+        $this->assertNotSame('high_empathy_low_recovery', (string) data_get($fixture, 'report.assets.core_formulation.id'));
+        $this->assertNotSame('balanced_integrated', (string) data_get($fixture, 'report.assets.core_formulation.id'));
+    }
+
+    public function test_eq_v5_payload_has_no_user_visible_paywall_runtime_contract(): void
+    {
+        $this->prepareEqContent();
+
+        $fixture = $this->canonicalFixture('EQ60_COMPASSION_OVERLOAD_ZH', 'zh-CN');
+        $json = json_encode($fixture, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+
+        $this->assertFalse((bool) data_get($fixture, 'report_access.payload.locked', true));
+        $this->assertNull(data_get($fixture, 'report_access.payload.upgrade_sku'));
+        $this->assertNull(data_get($fixture, 'report_access.payload.upgrade_sku_effective'));
+        $this->assertSame([], (array) data_get($fixture, 'report_access.payload.offers'));
+        $this->assertFalse((bool) data_get($fixture, 'report_access.payload.view_policy.blur_others', true));
+        $this->assertFalse((bool) data_get($fixture, 'report.access.locked', true));
+        $this->assertFalse((bool) data_get($fixture, 'report.access.blur', true));
+        $this->assertFalse((bool) data_get($fixture, 'report.access.paywall', true));
+        $this->assertStringNotContainsString('SKU_EQ_60_FULL_299', $json);
+        $this->assertStringNotContainsString('EQ_60_FULL', $json);
+        $this->assertStringNotContainsString('"locked":true', $json);
+        $this->assertStringNotContainsString('"blur_others":true', $json);
+        $this->assertStringNotContainsString('"paywall":true', $json);
+    }
+
+    private function prepareEqContent(): void
+    {
+        $this->artisan('content:compile --pack=EQ_60 --pack-version=v1')->assertExitCode(0);
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function canonicalFixture(string $caseId, string $locale): array
+    {
+        $case = $this->goldenCase($caseId);
+        $anonId = 'anon_eq_v5_'.Str::slug($caseId, '_').'_'.Str::slug($locale, '_');
+        $attemptId = $this->createAttemptWithResult($case, $locale, $anonId);
+        $token = $this->issueAnonToken($anonId);
+
+        $access = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access')
+            ->assertOk()
+            ->json();
+
+        /** @var Eq60ReportComposer $composer */
+        $composer = app(Eq60ReportComposer::class);
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        $result = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+        $composed = $composer->composeVariant(
+            $attempt,
+            $result,
+            ReportAccess::VARIANT_FULL,
+            ['modules_allowed' => ReportAccess::eq60AllRuntimeModules()]
+        );
+
+        $this->assertTrue((bool) ($composed['ok'] ?? false));
+
+        return $this->canonicalize([
+            'fixture_schema' => 'eq60.v5.report_contract_fixture.v1',
+            'case_id' => $caseId,
+            'locale' => $locale,
+            'report_access' => $this->stableReportAccess($access),
+            'report' => $this->stableReport((array) ($composed['report'] ?? [])),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $fixture
+     */
+    private function assertCommonV5Contract(array $fixture): void
+    {
+        $this->assertSame('ready', (string) data_get($fixture, 'report_access.access_state'));
+        $this->assertSame('ready', (string) data_get($fixture, 'report_access.report_state'));
+        $this->assertSame(ReportAccess::VARIANT_FULL, (string) data_get($fixture, 'report_access.payload.variant'));
+        $this->assertSame(ReportAccess::REPORT_ACCESS_FULL, (string) data_get($fixture, 'report_access.payload.access_level'));
+        $this->assertFalse((bool) data_get($fixture, 'report_access.payload.locked', true));
+        $this->assertNull(data_get($fixture, 'report_access.payload.upgrade_sku'));
+        $this->assertSame([], (array) data_get($fixture, 'report_access.payload.offers'));
+        $this->assertSame(ReportAccess::eq60FreeSectionKeys(), (array) data_get($fixture, 'report_access.payload.view_policy.free_sections'));
+        $this->assertFalse((bool) data_get($fixture, 'report_access.payload.view_policy.blur_others', true));
+
+        $this->assertSame('self_report', (string) data_get($fixture, 'report.eq_report_mode'));
+        $this->assertSame('self_report_trait_mixed_ei', (string) data_get($fixture, 'report.measurement_type'));
+        $this->assertTrue((bool) data_get($fixture, 'report.access.all_results_free'));
+        $this->assertFalse((bool) data_get($fixture, 'report.access.locked', true));
+        $this->assertFalse((bool) data_get($fixture, 'report.access.blur', true));
+        $this->assertFalse((bool) data_get($fixture, 'report.access.paywall', true));
+        $this->assertIsArray(data_get($fixture, 'report.scores.global'));
+        foreach (['SA', 'ER', 'EM', 'RM'] as $code) {
+            $this->assertIsArray(data_get($fixture, 'report.scores.dimensions.'.$code));
+        }
+        $this->assertCount(4, (array) data_get($fixture, 'report.dimension_summary', []));
+        $this->assertNotSame('', (string) data_get($fixture, 'report.quality.confidence_label'));
+        $this->assertNotSame('', (string) data_get($fixture, 'report.interpretation.core_formulation_id'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.asset_refs'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.assets'));
+        $this->assertFalse((bool) data_get($fixture, 'report.next_module.available', true));
+        $this->assertSame('planned', (string) data_get($fixture, 'report.next_module.status'));
+        $this->assertNotSame('', (string) data_get($fixture, 'report.methodology.report_version'));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function stableReportAccess(array $access): array
+    {
+        return [
+            'access_state' => (string) data_get($access, 'access_state'),
+            'report_state' => (string) data_get($access, 'report_state'),
+            'payload' => [
+                'access_level' => data_get($access, 'payload.access_level'),
+                'access' => data_get($access, 'payload.access'),
+                'locked' => data_get($access, 'payload.locked', false),
+                'modules_allowed' => data_get($access, 'payload.modules_allowed', []),
+                'modules_preview' => data_get($access, 'payload.modules_preview', []),
+                'offers' => data_get($access, 'payload.offers', []),
+                'unlock_source' => data_get($access, 'payload.unlock_source'),
+                'unlock_stage' => data_get($access, 'payload.unlock_stage'),
+                'upgrade_sku' => data_get($access, 'payload.upgrade_sku'),
+                'upgrade_sku_effective' => data_get($access, 'payload.upgrade_sku_effective'),
+                'variant' => data_get($access, 'payload.variant'),
+                'view_policy' => data_get($access, 'payload.view_policy'),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function stableReport(array $report): array
+    {
+        $report['generated_at'] = '2026-05-21T00:00:00.000000Z';
+
+        return $report;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function goldenCase(string $caseId): array
+    {
+        /** @var Eq60PackLoader $loader */
+        $loader = app(Eq60PackLoader::class);
+        foreach ($loader->loadGoldenCases('v1') as $case) {
+            if ((string) ($case['case_id'] ?? '') === $caseId) {
+                return $case;
+            }
+        }
+
+        $this->fail('Missing EQ_60 golden case: '.$caseId);
+    }
+
+    /**
+     * @param  array<string,mixed>  $case
+     */
+    private function createAttemptWithResult(array $case, string $locale, string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $attempt = Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'EQ_60',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 60,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'eq_v5_contract_fixture'],
+            'started_at' => now()->subSeconds((int) ($case['time_seconds_total'] ?? 420)),
+            'submitted_at' => now(),
+            'pack_id' => 'EQ_60',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'eq60_spec_2026_v2',
+        ]);
+
+        $score = $this->scoreCase($case, $locale);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'EQ_60',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => (array) ($score['scores'] ?? []),
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'v1',
+            'result_json' => [
+                'scale_code' => 'EQ_60',
+                'quality' => $score['quality'] ?? [],
+                'norms' => $score['norms'] ?? [],
+                'scores' => $score['scores'] ?? [],
+                'report' => $score['report'] ?? [],
+                'report_tags' => $score['report_tags'] ?? [],
+                'version_snapshot' => $score['version_snapshot'] ?? [],
+                'normed_json' => $score,
+                'breakdown_json' => ['score_result' => $score],
+                'axis_scores_json' => ['score_result' => $score],
+            ],
+            'pack_id' => 'EQ_60',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'eq60_spec_2026_v2',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attempt->id;
+    }
+
+    /**
+     * @param  array<string,mixed>  $case
+     * @return array<string,mixed>
+     */
+    private function scoreCase(array $case, string $locale): array
+    {
+        /** @var Eq60PackLoader $loader */
+        $loader = app(Eq60PackLoader::class);
+        /** @var Eq60ScorerV1NormedValidity $scorer */
+        $scorer = app(Eq60ScorerV1NormedValidity::class);
+
+        return $scorer->score(
+            $this->resolveAnswersMap($case),
+            $loader->loadQuestionIndex('v1'),
+            $loader->loadPolicy('v1'),
+            [
+                'pack_id' => 'EQ_60',
+                'dir_version' => 'v1',
+                'content_manifest_hash' => $loader->resolveManifestHash('v1'),
+                'score_map' => data_get($loader->loadOptions('v1'), 'score_map', []),
+                'server_duration_seconds' => (int) ($case['time_seconds_total'] ?? 420),
+                'locale' => $locale,
+                'region' => 'CN_MAINLAND',
+            ]
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $case
+     * @return array<int,string>
+     */
+    private function resolveAnswersMap(array $case): array
+    {
+        $answersByQid = is_array($case['answers_by_qid'] ?? null) ? $case['answers_by_qid'] : [];
+        $normalized = [];
+        foreach ($answersByQid as $qidRaw => $codeRaw) {
+            $qid = (int) $qidRaw;
+            $code = strtoupper(trim((string) $codeRaw));
+            if ($qid >= 1 && $qid <= 60 && in_array($code, ['A', 'B', 'C', 'D', 'E'], true)) {
+                $normalized[$qid] = $code;
+            }
+        }
+
+        ksort($normalized, SORT_NUMERIC);
+        $this->assertCount(60, $normalized);
+
+        return $normalized;
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    /**
+     * @param  array<string,mixed>  $fixture
+     * @return array<string,mixed>
+     */
+    private function canonicalize(array $fixture): array
+    {
+        foreach ($fixture as $key => $value) {
+            if (is_array($value)) {
+                $fixture[$key] = $this->canonicalize($value);
+            }
+        }
+
+        if (! array_is_list($fixture)) {
+            ksort($fixture);
+        }
+
+        return $fixture;
+    }
+
+    /**
+     * @param  array<string,mixed>  $fixture
+     */
+    private function maybeUpdateFixture(string $file, array $fixture): void
+    {
+        if (! filter_var(env('UPDATE_EQ60_V5_FIXTURES', false), FILTER_VALIDATE_BOOL)) {
+            return;
+        }
+
+        File::ensureDirectoryExists($this->fixtureDir());
+        File::put(
+            $this->fixturePath($file),
+            json_encode($fixture, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function loadFixture(string $file): array
+    {
+        $path = $this->fixturePath($file);
+        $this->assertFileExists($path);
+        $decoded = json_decode(File::get($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function fixturePath(string $file): string
+    {
+        return $this->fixtureDir().DIRECTORY_SEPARATOR.$file;
+    }
+
+    private function fixtureDir(): string
+    {
+        return base_path('tests/Fixtures/eq/v5');
+    }
+}

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_en.json
@@ -1,0 +1,733 @@
+{
+    "case_id": "EQ60_BALANCED_HIGH_ZH",
+    "fixture_schema": "eq60.v5.report_contract_fixture.v1",
+    "locale": "en",
+    "report": {
+        "access": {
+            "all_results_free": true,
+            "blur": false,
+            "locked": false,
+            "paywall": false
+        },
+        "asset_refs": {
+            "action_prescription_id": "emotion_labeling",
+            "career_environment_ids": [
+                "interpersonal_density_medium",
+                "feedback_intensity_medium",
+                "autonomy_recovery_medium"
+            ],
+            "core_formulation_id": "balanced_integrated",
+            "mechanism_ids": [
+                "SA_ER_high_high",
+                "EM_RM_high_high"
+            ],
+            "quality_explanation_asset_id": "eq.quality.level.A",
+            "scene_ids": [
+                "feedback",
+                "team_collaboration",
+                "career_environment"
+            ],
+            "scientific_contract_id": "eq.scientific_contract.default",
+            "score_system_id": "eq.score_system.default",
+            "sjt_bridge_id": "eq.sjt_bridge.planned"
+        },
+        "assets": {
+            "action_prescription": {
+                "do_today": "Choose one specific emotion word today and write the triggering context.",
+                "id": "emotion_labeling",
+                "script": "What I feel now is X; it does not mean I must decide immediately.",
+                "seven_day_plan": [
+                    "Day 1: record one emotion word.",
+                    "Day 2: add body sensations.",
+                    "Day 3: write the trigger.",
+                    "Day 4: separate fact and interpretation.",
+                    "Day 5: write one controllable action.",
+                    "Day 6: review one conversation.",
+                    "Day 7: identify the most common trigger."
+                ],
+                "title": "Emotion Labeling",
+                "watch_out": "Do not turn emotion words into self-judgment.",
+                "why_this_matters": "Naming comes before choosing a response."
+            },
+            "career_environment": [
+                {
+                    "fit_signal": "Fits switching between collaboration and independent work.",
+                    "id": "interpersonal_density_medium",
+                    "label": "Medium Interpersonal Density",
+                    "level": "medium",
+                    "meaning": "Regular collaboration without constant social demand.",
+                    "strain_signal": "Too many meetings can still drain.",
+                    "variable": "interpersonal_density",
+                    "what_to_verify": "Check weekly meetings, syncs, and cross-team collaboration frequency."
+                },
+                {
+                    "fit_signal": "Fits turning feedback into learning.",
+                    "id": "feedback_intensity_medium",
+                    "label": "Medium Feedback Intensity",
+                    "level": "medium",
+                    "meaning": "Regular review, revision, and evaluation.",
+                    "strain_signal": "Weak recovery may lead to replaying feedback.",
+                    "variable": "feedback_intensity",
+                    "what_to_verify": "Check whether feedback is specific, actionable, and not overly public."
+                },
+                {
+                    "fit_signal": "Helps most people sustain performance.",
+                    "id": "autonomy_recovery_medium",
+                    "label": "Medium Autonomy Recovery",
+                    "level": "medium",
+                    "meaning": "Some independent rhythm exists, though team rhythm still matters.",
+                    "strain_signal": "Busy or crisis periods may compress it.",
+                    "variable": "autonomy_recovery",
+                    "what_to_verify": "Check recovery arrangements during peak periods."
+                }
+            ],
+            "core_formulation": {
+                "core_claim": "You usually notice yourself, understand others, and maintain usable responses across many contexts.",
+                "development_lever": "Choose one real situation for precise review rather than trying to improve everything.",
+                "do_not_overread": "This does not mean you will never be triggered.",
+                "evidence_basis": [
+                    "Four dimensions are relatively balanced",
+                    "No single severe gap stands out"
+                ],
+                "id": "balanced_integrated",
+                "likely_cost": "You may underestimate how specific high-pressure contexts drain you.",
+                "one_liner": "Your emotional and relational signals are relatively balanced; stability is the main strength.",
+                "primary_strength": "Stability and transfer across contexts.",
+                "title": "Balanced Integration"
+            },
+            "mechanisms": [
+                {
+                    "cost": "You may over-rely on self-control and miss rest needs.",
+                    "development_lever": "Make reset actions lighter.",
+                    "id": "SA_ER_high_high",
+                    "micro_action": "Name the emotion in one sentence, then choose the next sentence.",
+                    "pair": "SA_ER",
+                    "state": "high_high",
+                    "strength": "Less rumination; more action from emotional information.",
+                    "title": "You notice yourself and can reset",
+                    "what_it_feels_like": "You can usually name what is happening and find the next step.",
+                    "why_it_matters": "Self-awareness becomes real-world stability only when it connects to regulation."
+                },
+                {
+                    "cost": "You may overtake the coordinator role.",
+                    "development_lever": "Clarify responsibility boundaries.",
+                    "id": "EM_RM_high_high",
+                    "micro_action": "Ask: which part of this is mine to own?",
+                    "pair": "EM_RM",
+                    "state": "high_high",
+                    "strength": "Useful for complex collaboration and repair.",
+                    "title": "You read others and manage the relationship",
+                    "what_it_feels_like": "You can read the room and move the relationship back to communication.",
+                    "why_it_matters": "When understanding and action combine, empathy becomes workable collaboration."
+                }
+            ],
+            "quality": {
+                "confidence_label": "high",
+                "explanation_asset_id": "eq.quality.level.A"
+            },
+            "reality_scenes": [
+                {
+                    "better_move": "Separate facts, feeling, and next step: what was said, what I feel, what I need to clarify.",
+                    "cost": "When recovery is weak, feedback may feel like rejection.",
+                    "id": "feedback",
+                    "strength": "You can notice intent and relational temperature behind feedback.",
+                    "title": "Feedback",
+                    "typical_response": "When receiving critique or edits, you may notice tone and relational cues before processing the information."
+                },
+                {
+                    "better_move": "Turn observations into concrete collaboration requests instead of silently compensating.",
+                    "cost": "If you always coordinate, you may carry too much emotional labor.",
+                    "id": "team_collaboration",
+                    "strength": "You can notice hidden friction in collaboration.",
+                    "title": "Team Collaboration",
+                    "typical_response": "In group work, you may track task, relationship, and emotional climate at the same time."
+                },
+                {
+                    "better_move": "When evaluating roles, ask about interaction frequency, conflict frequency, and recovery space.",
+                    "cost": "Job titles alone can hide the conditions that actually drain you.",
+                    "id": "career_environment",
+                    "strength": "Understanding environmental variables helps you choose a better work rhythm.",
+                    "title": "Career Environment",
+                    "typical_response": "Interpersonal density, emotional labor, and feedback intensity can drain you differently across roles."
+                }
+            ],
+            "scientific_contract": {
+                "non_ability_statement": "This report is not a certified ability assessment and does not claim to measure true emotional intelligence ability.",
+                "non_clinical_statement": "This report is not for clinical diagnosis, treatment advice, or crisis evaluation.",
+                "non_hiring_statement": "This report is not for hiring, selection, promotion, or other high-stakes employment decisions.",
+                "norm_status_statement": "Current norms are provisional. Percentiles and standard scores explain relative position and will be recalibrated as samples grow.",
+                "quality_rules_statement": "The system considers response time, long-string patterns, extreme responding, neutral responding, and consistency signals to estimate interpretation confidence.",
+                "self_report_statement": "This report reflects your subjective self-perception of emotional and relational patterns. It is not an objective ability test.",
+                "test_definition": "This is an emotional and relational pattern report based on 60 self-report items. It explains how you notice, regulate, respond to, and manage emotions in yourself and others.",
+                "version_statement": "Report version eq_report_v5_assets, scoring version v1.0_normed_validity, content version EQ_60/v1."
+            },
+            "score_system": {
+                "bands": {
+                    "developing": "Developing: usable foundations are present, but the pattern may be less stable under pressure or relational complexity.",
+                    "foundational": "Foundational: the current signal suggests this area benefits from more structure, practice, and review.",
+                    "integrated": "Integrated: this dimension is prominent; the key is avoiding overuse and staying contextually flexible.",
+                    "proficient": "Proficient: this dimension is usually a reliable strength signal and may also carry related costs.",
+                    "stable": "Stable: generally usable in everyday contexts, while interpretation still depends on how it combines with other dimensions."
+                },
+                "dimensions": {
+                    "EM": {
+                        "band_explanations": {
+                            "developing": "Empathy has a base, but hidden emotion or real needs may be missed.",
+                            "foundational": "Empathy is foundational; start by confirming the other person's feeling.",
+                            "integrated": "Empathy is highly integrated; avoid over-carrying other people's emotions.",
+                            "proficient": "Empathy is mature enough to notice relational and emotional cues with nuance.",
+                            "stable": "Empathy is stable and usually helps you grasp basic feelings in others."
+                        },
+                        "definition": "The tendency to understand other people's emotions, perspectives, and relational cues.",
+                        "label": "Empathy"
+                    },
+                    "ER": {
+                        "band_explanations": {
+                            "developing": "Emotion regulation has a base, but strong feedback or conflict may still destabilize it.",
+                            "foundational": "Emotion regulation is foundational; build a pause and recovery process first.",
+                            "integrated": "Emotion regulation is highly integrated; avoid over-control and keep authentic feeling available.",
+                            "proficient": "Emotion regulation is mature enough to return to communication after being triggered.",
+                            "stable": "Emotion regulation is stable and usually supports recovery in everyday pressure."
+                        },
+                        "definition": "The tendency to recover, pause, and choose responses during pressure, feedback, or conflict.",
+                        "label": "Emotion Regulation"
+                    },
+                    "RM": {
+                        "band_explanations": {
+                            "developing": "Relationship management has a base, but conflict, boundaries, or repair may be unstable.",
+                            "foundational": "Relationship management is foundational; start with low-risk communication scripts.",
+                            "integrated": "Relationship management is highly integrated; avoid taking too much coordination responsibility.",
+                            "proficient": "Relationship management is mature enough to actively support communication, coordination, and repair.",
+                            "stable": "Relationship management is stable and usually supports constructive action in collaboration."
+                        },
+                        "definition": "The tendency to act constructively in communication, collaboration, repair, and boundaries.",
+                        "label": "Relationship Management"
+                    },
+                    "SA": {
+                        "band_explanations": {
+                            "developing": "Self-awareness has a base, but real triggers may be noticed late under pressure.",
+                            "foundational": "Self-awareness is foundational; start by naming emotions with specific words.",
+                            "integrated": "Self-awareness is highly integrated; the focus is avoiding over-analysis and moving to action.",
+                            "proficient": "Self-awareness is mature enough to catch shifts and underlying needs quickly.",
+                            "stable": "Self-awareness is stable and usually helps you understand key emotional cues."
+                        },
+                        "definition": "The tendency to notice, name, and understand emotional cues in yourself.",
+                        "label": "Self-Awareness"
+                    }
+                },
+                "global_index": {
+                    "label": "Emotional & Relational Functioning Index",
+                    "meaning": "A combined self-report signal across four dimensions, describing the current stability of emotional and relational functioning."
+                },
+                "score_notes": {
+                    "percentile": "Percentiles indicate relative position in the current reference sample and are not ability certification.",
+                    "standard_score": "Standard scores are interpreted against provisional norms. Scores near the mean indicate a stable usable range."
+                }
+            },
+            "sjt_bridge": {
+                "available": false,
+                "button_label": "Scenario module planned",
+                "description": "The current report is based on EQ-60 self-report. A future EQ-SJT 16 module will add how you choose responses in feedback, conflict, boundary, and pressure situations.",
+                "id": "eq.sjt_bridge.planned",
+                "status": "planned",
+                "title": "A 16-item scenario module is planned",
+                "what_it_adds": "It supplements self-report by comparing self-perception with scenario choices.",
+                "what_it_is_not": "It is not MSCEIT, not a certified ability assessment, and not for hiring or clinical decisions."
+            }
+        },
+        "compat": {
+            "free_blocks": [
+                {
+                    "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                    "id": "eq60_disclaimer_top_en",
+                    "section_key": "disclaimer_top",
+                    "title": "Important Notice"
+                },
+                {
+                    "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
+                    "id": "eq60_quality_level_A_en",
+                    "section_key": "quality_notice",
+                    "title": "Response Quality"
+                },
+                {
+                    "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
+                    "id": "eq60_global_overview_en",
+                    "section_key": "global_overview",
+                    "title": "Overview"
+                },
+                {
+                    "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
+                    "id": "eq60_sa_proficient_en",
+                    "section_key": "self_awareness",
+                    "title": "Self‑Awareness · Proficient"
+                },
+                {
+                    "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
+                    "id": "eq60_er_proficient_en",
+                    "section_key": "emotion_regulation",
+                    "title": "Emotion Regulation · Proficient"
+                },
+                {
+                    "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
+                    "id": "eq60_em_proficient_en",
+                    "section_key": "empathy",
+                    "title": "Social Awareness & Empathy · Proficient"
+                },
+                {
+                    "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
+                    "id": "eq60_rm_proficient_en",
+                    "section_key": "relationship_management",
+                    "title": "Relationship Management · Proficient"
+                },
+                {
+                    "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nPremium breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What premium adds**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
+                    "id": "eq60_profile_balanced_high_en",
+                    "section_key": "cross_quadrant_insight",
+                    "title": "Balanced High EQ"
+                },
+                {
+                    "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
+                    "id": "eq60_plan_maintenance_en",
+                    "section_key": "action_plan_14d",
+                    "title": "High‑Level Consolidation"
+                },
+                {
+                    "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) Premium content adds cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                    "id": "eq60_methodology_en",
+                    "section_key": "methodology",
+                    "title": "Methodology"
+                },
+                {
+                    "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                    "id": "eq60_disclaimer_bottom_en",
+                    "section_key": "disclaimer_bottom",
+                    "title": "Closing Notes"
+                }
+            ],
+            "paid_blocks": []
+        },
+        "dimension_summary": [
+            {
+                "band": "proficient",
+                "code": "SA",
+                "label": "Self-Awareness",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "ER",
+                "label": "Emotion Regulation",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "EM",
+                "label": "Empathy",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "RM",
+                "label": "Relationship Management",
+                "percentile": 80.69,
+                "standard_score": 113
+            }
+        ],
+        "eq_report_mode": "self_report",
+        "generated_at": "2026-05-21T00:00:00.000000Z",
+        "interpretation": {
+            "action_prescription_id": "emotion_labeling",
+            "career_environment_ids": [
+                "interpersonal_density_medium",
+                "feedback_intensity_medium",
+                "autonomy_recovery_medium"
+            ],
+            "core_formulation_id": "balanced_integrated",
+            "development_lever": "SA",
+            "primary_mechanism_ids": [
+                "SA_ER_high_high",
+                "EM_RM_high_high"
+            ],
+            "primary_scene_ids": [
+                "feedback",
+                "team_collaboration",
+                "career_environment"
+            ],
+            "strongest_dimension": "SA"
+        },
+        "legacy_scores": {
+            "EM": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "ER": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "RM": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "SA": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "emotion_regulation": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "empathy": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "global": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 240,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "relationship_management": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "self_awareness": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            }
+        },
+        "locale": "en",
+        "measurement_type": "self_report_trait_mixed_ei",
+        "methodology": {
+            "content_version": "EQ_60/v1",
+            "norm_status": "provisional",
+            "report_version": "eq_report_v5_assets",
+            "scoring_version": "v1.0_normed_validity"
+        },
+        "next_module": {
+            "available": false,
+            "cta_asset_id": "eq.sjt_bridge.planned",
+            "module_code": "EQ_SJT_16",
+            "status": "planned"
+        },
+        "quality": {
+            "completion_time_seconds": 420,
+            "confidence_label": "high",
+            "explanation_asset_id": "eq.quality.level.A",
+            "extreme_rate": 0,
+            "flags": [],
+            "inconsistency_index": 0,
+            "level": "A",
+            "longstring_max": 10,
+            "metrics": {
+                "completion_time_seconds": 420,
+                "extreme_rate": 0,
+                "inconsistency_index": 0,
+                "longstring_max": 10,
+                "neutral_rate": 0
+            },
+            "neutral_rate": 0
+        },
+        "report": {
+            "primary_profile": "profile:balanced_high_eq",
+            "tags": [
+                "quality_level:A",
+                "profile:balanced_high_eq"
+            ]
+        },
+        "report_tags": [
+            "quality_level:A",
+            "profile:balanced_high_eq"
+        ],
+        "scale_code": "EQ_60",
+        "schema_version": "eq_60.report.v2",
+        "scores": {
+            "dimensions": {
+                "EM": {
+                    "band": "proficient",
+                    "label": "Empathy",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "Empathy",
+                    "standard_score": 113
+                },
+                "ER": {
+                    "band": "proficient",
+                    "label": "Emotion Regulation",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "Emotion Regulation",
+                    "standard_score": 113
+                },
+                "RM": {
+                    "band": "proficient",
+                    "label": "Relationship Management",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "Relationship Management",
+                    "standard_score": 113
+                },
+                "SA": {
+                    "band": "proficient",
+                    "label": "Self-Awareness",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "Self-Awareness",
+                    "standard_score": 113
+                }
+            },
+            "global": {
+                "band": "proficient",
+                "label": "Emotional & Relational Functioning Index",
+                "percentile": 80.69,
+                "raw_score": 240,
+                "standard_score": 113
+            }
+        },
+        "sections": [
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                        "id": "eq60_disclaimer_top_en",
+                        "title": "Important Notice",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_top",
+                "module_code": "eq_core",
+                "title": "Important Notice"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
+                        "id": "eq60_quality_level_A_en",
+                        "title": "Response Quality",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "quality_notice",
+                "module_code": "eq_core",
+                "title": "Response Quality"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
+                        "id": "eq60_global_overview_en",
+                        "title": "Overview",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "global_overview",
+                "module_code": "eq_core",
+                "title": "Overview"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
+                        "id": "eq60_sa_proficient_en",
+                        "title": "Self‑Awareness · Proficient",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "self_awareness",
+                "module_code": "eq_core",
+                "title": "Self‑Awareness"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
+                        "id": "eq60_er_proficient_en",
+                        "title": "Emotion Regulation · Proficient",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "emotion_regulation",
+                "module_code": "eq_core",
+                "title": "Emotion Regulation"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
+                        "id": "eq60_em_proficient_en",
+                        "title": "Social Awareness & Empathy · Proficient",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "empathy",
+                "module_code": "eq_core",
+                "title": "Social Awareness & Empathy"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
+                        "id": "eq60_rm_proficient_en",
+                        "title": "Relationship Management · Proficient",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "relationship_management",
+                "module_code": "eq_core",
+                "title": "Relationship Management"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nPremium breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What premium adds**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
+                        "id": "eq60_profile_balanced_high_en",
+                        "title": "Balanced High EQ",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "cross_quadrant_insight",
+                "module_code": "eq_cross_insights",
+                "title": "Cross‑Quadrant Insight"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
+                        "id": "eq60_plan_maintenance_en",
+                        "title": "High‑Level Consolidation",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "action_plan_14d",
+                "module_code": "eq_growth_plan",
+                "title": "14‑Day Plan"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) Premium content adds cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                        "id": "eq60_methodology_en",
+                        "title": "Methodology",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "methodology",
+                "module_code": "eq_core",
+                "title": "Methodology"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                        "id": "eq60_disclaimer_bottom_en",
+                        "title": "Closing Notes",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_bottom",
+                "module_code": "eq_core",
+                "title": "Closing Notes"
+            }
+        ],
+        "variant": "full"
+    },
+    "report_access": {
+        "access_state": "ready",
+        "payload": {
+            "access": {
+                "all_results_free": true,
+                "blur": false,
+                "locked": false,
+                "paywall": false
+            },
+            "access_level": "full",
+            "locked": false,
+            "modules_allowed": [
+                "eq_core",
+                "eq_full",
+                "eq_cross_insights",
+                "eq_growth_plan"
+            ],
+            "modules_preview": [],
+            "offers": [],
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "upgrade_sku": null,
+            "upgrade_sku_effective": null,
+            "variant": "full",
+            "view_policy": {
+                "blur_others": false,
+                "free_sections": [
+                    "disclaimer_top",
+                    "quality_notice",
+                    "global_overview",
+                    "self_awareness",
+                    "emotion_regulation",
+                    "empathy",
+                    "relationship_management",
+                    "cross_quadrant_insight",
+                    "action_plan_14d",
+                    "methodology",
+                    "disclaimer_bottom"
+                ]
+            }
+        },
+        "report_state": "ready"
+    }
+}

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_zh.json
@@ -1,0 +1,733 @@
+{
+    "case_id": "EQ60_BALANCED_HIGH_ZH",
+    "fixture_schema": "eq60.v5.report_contract_fixture.v1",
+    "locale": "zh-CN",
+    "report": {
+        "access": {
+            "all_results_free": true,
+            "blur": false,
+            "locked": false,
+            "paywall": false
+        },
+        "asset_refs": {
+            "action_prescription_id": "emotion_labeling",
+            "career_environment_ids": [
+                "interpersonal_density_medium",
+                "feedback_intensity_medium",
+                "autonomy_recovery_medium"
+            ],
+            "core_formulation_id": "balanced_integrated",
+            "mechanism_ids": [
+                "SA_ER_high_high",
+                "EM_RM_high_high"
+            ],
+            "quality_explanation_asset_id": "eq.quality.level.A",
+            "scene_ids": [
+                "feedback",
+                "team_collaboration",
+                "career_environment"
+            ],
+            "scientific_contract_id": "eq.scientific_contract.default",
+            "score_system_id": "eq.score_system.default",
+            "sjt_bridge_id": "eq.sjt_bridge.planned"
+        },
+        "assets": {
+            "action_prescription": {
+                "do_today": "今天选择一个具体情绪词，写下触发它的场景。",
+                "id": "emotion_labeling",
+                "script": "我现在感到的是 X，不代表我必须立刻做决定。",
+                "seven_day_plan": [
+                    "第 1 天：记录一个情绪词。",
+                    "第 2 天：补充身体感受。",
+                    "第 3 天：写下触发场景。",
+                    "第 4 天：区分事实和解释。",
+                    "第 5 天：写一个可控动作。",
+                    "第 6 天：复盘一次沟通。",
+                    "第 7 天：选出最常见触发点。"
+                ],
+                "title": "情绪命名处方",
+                "watch_out": "不要把情绪词变成自我评价。",
+                "why_this_matters": "先命名，才有可能选择回应。"
+            },
+            "career_environment": [
+                {
+                    "fit_signal": "适合在协作和独立之间切换。",
+                    "id": "interpersonal_density_medium",
+                    "label": "中等人际密度",
+                    "level": "medium",
+                    "meaning": "日常有固定协作，但不是持续社交。",
+                    "strain_signal": "会议过多时仍会消耗。",
+                    "variable": "interpersonal_density",
+                    "what_to_verify": "确认每周会议、同步和跨团队协作频率。"
+                },
+                {
+                    "fit_signal": "适合把反馈转成学习。",
+                    "id": "feedback_intensity_medium",
+                    "label": "中等反馈强度",
+                    "level": "medium",
+                    "meaning": "定期复盘、修改和评价。",
+                    "strain_signal": "恢复不足时可能反复回想。",
+                    "variable": "feedback_intensity",
+                    "what_to_verify": "确认反馈是否具体、可执行、不过度公开。"
+                },
+                {
+                    "fit_signal": "适合多数人维持稳定表现。",
+                    "id": "autonomy_recovery_medium",
+                    "label": "中等自主恢复空间",
+                    "level": "medium",
+                    "meaning": "有一定独立安排，但仍受团队节奏影响。",
+                    "strain_signal": "忙季或危机期可能被压缩。",
+                    "variable": "autonomy_recovery",
+                    "what_to_verify": "确认高峰期的恢复安排。"
+                }
+            ],
+            "core_formulation": {
+                "core_claim": "你通常能同时看见自己、理解他人，并在多数情境中维持可用的回应方式。",
+                "development_lever": "选择一个真实场景做精细化复盘，而不是泛泛提升。",
+                "do_not_overread": "这不代表你在任何情境中都不会被触发。",
+                "evidence_basis": [
+                    "四维分数相对均衡",
+                    "无明显单一短板"
+                ],
+                "id": "balanced_integrated",
+                "likely_cost": "容易低估特定高压情境对自己的消耗。",
+                "one_liner": "你的情绪与关系信号比较均衡，优势在于稳定和可迁移。",
+                "primary_strength": "稳定性和多场景适应能力。",
+                "title": "均衡整合型"
+            },
+            "mechanisms": [
+                {
+                    "cost": "可能过度依赖自我控制，忽略休息需求。",
+                    "development_lever": "让复位动作更轻量。",
+                    "id": "SA_ER_high_high",
+                    "micro_action": "用一句话命名情绪，再决定下一句怎么说。",
+                    "pair": "SA_ER",
+                    "state": "high_high",
+                    "strength": "减少反复内耗，把情绪信息转成行动。",
+                    "title": "知道自己，也能复位",
+                    "what_it_feels_like": "你通常能说清自己怎么了，并较快找到下一步。",
+                    "why_it_matters": "自我觉察只有接上调节动作，才会变成现实中的稳定回应。"
+                },
+                {
+                    "cost": "可能过度承担协调者角色。",
+                    "development_lever": "把责任边界说清楚。",
+                    "id": "EM_RM_high_high",
+                    "micro_action": "问：这件事我能负责哪一部分？",
+                    "pair": "EM_RM",
+                    "state": "high_high",
+                    "strength": "适合复杂协作和关系修复。",
+                    "title": "读懂别人，也能处理关系",
+                    "what_it_feels_like": "你能读懂现场气氛，并推动关系回到可沟通状态。",
+                    "why_it_matters": "理解和行动结合时，共情更容易变成有效协作。"
+                }
+            ],
+            "quality": {
+                "confidence_label": "high",
+                "explanation_asset_id": "eq.quality.level.A"
+            },
+            "reality_scenes": [
+                {
+                    "better_move": "先拆分事实、情绪和下一步：对方说了什么，我有什么感受，我要确认什么。",
+                    "cost": "如果恢复不足，容易把反馈体验成否定。",
+                    "id": "feedback",
+                    "strength": "能注意到反馈背后的真实意图和关系温度。",
+                    "title": "反馈场景",
+                    "typical_response": "收到评价或修改意见时，你可能先捕捉语气和关系信号，再处理信息本身。"
+                },
+                {
+                    "better_move": "把观察转成具体协作请求，而不是默默补位。",
+                    "cost": "如果总是主动协调，容易承担过多情绪劳动。",
+                    "id": "team_collaboration",
+                    "strength": "能发现协作中的隐性阻力。",
+                    "title": "团队协作",
+                    "typical_response": "在多人协作中，你可能同时追踪任务、关系和现场情绪。"
+                },
+                {
+                    "better_move": "评估岗位时优先询问互动频率、冲突频率和恢复空间。",
+                    "cost": "只看职位名称，容易忽略真正消耗你的工作条件。",
+                    "id": "career_environment",
+                    "strength": "理解环境变量后，更容易选择适合自己的工作节奏。",
+                    "title": "职业环境",
+                    "typical_response": "你对岗位中的人际密度、情绪劳动和反馈强度会有不同消耗。"
+                }
+            ],
+            "scientific_contract": {
+                "non_ability_statement": "本报告不是认证能力测验，也不声称测量真实情商能力。",
+                "non_clinical_statement": "本报告不用于临床诊断、治疗建议或危机评估。",
+                "non_hiring_statement": "本报告不用于招聘筛选、录用、晋升或其他高风险人事决策。",
+                "norm_status_statement": "当前常模为阶段性常模，百分位和标准分用于解释相对位置，后续会随样本增长持续校准。",
+                "quality_rules_statement": "系统会参考作答时长、长串作答、极端反应、中立反应和一致性信号，给出解释置信度。",
+                "self_report_statement": "本报告反映你对自身情绪与关系模式的主观感知，不等同于客观能力测验。",
+                "test_definition": "这是一份基于 60 道自我报告题的情绪与关系模式报告，用于解释你如何感知、调节、回应和管理自己与他人的情绪。",
+                "version_statement": "报告版本 eq_report_v5_assets，计分版本 v1.0_normed_validity，内容版本 EQ_60/v1。"
+            },
+            "score_system": {
+                "bands": {
+                    "developing": "发展中：已经有可用基础，但在压力或复杂关系中可能不够稳定。",
+                    "foundational": "基础发展中：当前信号提示该能力更需要外部结构、练习和复盘支持。",
+                    "integrated": "高度整合：该维度表现突出，重点是避免过度使用并保持情境灵活性。",
+                    "proficient": "熟练成熟：该维度通常是可依赖的优势信号，也可能带来相应消耗。",
+                    "stable": "稳定可用：多数日常场景中可以发挥作用，但仍需要看和其他维度的组合。"
+                },
+                "dimensions": {
+                    "EM": {
+                        "band_explanations": {
+                            "developing": "共情理解已有基础，但可能错过隐性情绪或真实需求。",
+                            "foundational": "共情理解处于基础发展中，建议先练习确认对方感受。",
+                            "integrated": "共情理解高度整合，重点是避免过度承接他人情绪。",
+                            "proficient": "共情理解较成熟，能较细腻地捕捉关系和情绪线索。",
+                            "stable": "共情理解稳定可用，多数场景能把握他人基本感受。"
+                        },
+                        "definition": "理解他人情绪、立场和关系线索的倾向。",
+                        "label": "共情理解"
+                    },
+                    "ER": {
+                        "band_explanations": {
+                            "developing": "情绪调节已有基础，但强反馈或冲突中仍可能不稳定。",
+                            "foundational": "情绪调节处于基础发展中，建议先建立暂停和恢复流程。",
+                            "integrated": "情绪调节高度整合，重点是避免过度控制并保留真实感受。",
+                            "proficient": "情绪调节较成熟，能在触发后较快回到可沟通状态。",
+                            "stable": "情绪调节稳定可用，多数日常压力下能找到恢复方式。"
+                        },
+                        "definition": "在压力、反馈或冲突中恢复、暂停和选择回应方式的倾向。",
+                        "label": "情绪调节"
+                    },
+                    "RM": {
+                        "band_explanations": {
+                            "developing": "关系管理已有基础，但在冲突、边界或修复中可能不稳定。",
+                            "foundational": "关系管理处于基础发展中，建议先学习低风险沟通脚本。",
+                            "integrated": "关系管理高度整合，重点是避免承担过多协调责任。",
+                            "proficient": "关系管理较成熟，能主动推进沟通、协调和修复。",
+                            "stable": "关系管理稳定可用，多数协作场景中能采取建设性行动。"
+                        },
+                        "definition": "在沟通、协作、修复和边界中采取建设性行动的倾向。",
+                        "label": "关系管理"
+                    },
+                    "SA": {
+                        "band_explanations": {
+                            "developing": "自我觉察已有基础，但在压力下可能较晚发现真实触发点。",
+                            "foundational": "自我觉察处于基础发展中，建议先练习用具体词语命名情绪。",
+                            "integrated": "自我觉察高度整合，重点是避免过度分析并转向行动。",
+                            "proficient": "自我觉察较成熟，能较快捕捉情绪变化和背后需求。",
+                            "stable": "自我觉察稳定可用，通常能理解自己的主要情绪线索。"
+                        },
+                        "definition": "识别、命名和理解自身情绪线索的倾向。",
+                        "label": "自我觉察"
+                    }
+                },
+                "global_index": {
+                    "label": "情绪与关系综合指数",
+                    "meaning": "综合四个维度的自我报告信号，描述当前情绪与关系功能的整体稳定度。"
+                },
+                "score_notes": {
+                    "percentile": "百分位表示在当前参考样本中的相对位置，不代表能力认证。",
+                    "standard_score": "标准分以阶段性常模为参照，平均附近代表稳定可用。"
+                }
+            },
+            "sjt_bridge": {
+                "available": false,
+                "button_label": "情境判断模块规划中",
+                "description": "当前报告基于 EQ-60 自我报告。未来 EQ-SJT 16 会补充你在反馈、冲突、边界和压力情境中的选择方式。",
+                "id": "eq.sjt_bridge.planned",
+                "status": "planned",
+                "title": "未来将支持 16 道情境判断模块",
+                "what_it_adds": "它用于补充 self-report，帮助比较自我感知与情境选择之间的一致和差距。",
+                "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，也不用于招聘筛选或临床判断。"
+            }
+        },
+        "compat": {
+            "free_blocks": [
+                {
+                    "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                    "id": "eq60_disclaimer_top_zh",
+                    "section_key": "disclaimer_top",
+                    "title": "重要声明"
+                },
+                {
+                    "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
+                    "id": "eq60_quality_level_A_zh",
+                    "section_key": "quality_notice",
+                    "title": "作答质量提示"
+                },
+                {
+                    "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
+                    "id": "eq60_global_overview_zh",
+                    "section_key": "global_overview",
+                    "title": "综合概览"
+                },
+                {
+                    "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
+                    "id": "eq60_sa_proficient_zh",
+                    "section_key": "self_awareness",
+                    "title": "自我情绪认知 · 成熟（Proficient）"
+                },
+                {
+                    "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
+                    "id": "eq60_er_proficient_zh",
+                    "section_key": "emotion_regulation",
+                    "title": "情绪调节与控制 · 成熟（Proficient）"
+                },
+                {
+                    "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
+                    "id": "eq60_em_proficient_zh",
+                    "section_key": "empathy",
+                    "title": "同理心与社会感知 · 成熟（Proficient）"
+                },
+                {
+                    "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
+                    "id": "eq60_rm_proficient_zh",
+                    "section_key": "relationship_management",
+                    "title": "社交技能与人际管理 · 成熟（Proficient）"
+                },
+                {
+                    "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n付费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在付费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
+                    "id": "eq60_profile_balanced_high_zh",
+                    "section_key": "cross_quadrant_insight",
+                    "title": "四维均衡高"
+                },
+                {
+                    "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
+                    "id": "eq60_plan_maintenance_zh",
+                    "section_key": "action_plan_14d",
+                    "title": "高水平巩固"
+                },
+                {
+                    "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 付费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                    "id": "eq60_methodology_zh",
+                    "section_key": "methodology",
+                    "title": "方法说明"
+                },
+                {
+                    "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                    "id": "eq60_disclaimer_bottom_zh",
+                    "section_key": "disclaimer_bottom",
+                    "title": "结尾提示"
+                }
+            ],
+            "paid_blocks": []
+        },
+        "dimension_summary": [
+            {
+                "band": "proficient",
+                "code": "SA",
+                "label": "自我觉察",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "ER",
+                "label": "情绪调节",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "EM",
+                "label": "共情理解",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "RM",
+                "label": "关系管理",
+                "percentile": 80.69,
+                "standard_score": 113
+            }
+        ],
+        "eq_report_mode": "self_report",
+        "generated_at": "2026-05-21T00:00:00.000000Z",
+        "interpretation": {
+            "action_prescription_id": "emotion_labeling",
+            "career_environment_ids": [
+                "interpersonal_density_medium",
+                "feedback_intensity_medium",
+                "autonomy_recovery_medium"
+            ],
+            "core_formulation_id": "balanced_integrated",
+            "development_lever": "SA",
+            "primary_mechanism_ids": [
+                "SA_ER_high_high",
+                "EM_RM_high_high"
+            ],
+            "primary_scene_ids": [
+                "feedback",
+                "team_collaboration",
+                "career_environment"
+            ],
+            "strongest_dimension": "SA"
+        },
+        "legacy_scores": {
+            "EM": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "ER": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "RM": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "SA": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "emotion_regulation": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "empathy": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "global": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 240,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "relationship_management": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "self_awareness": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            }
+        },
+        "locale": "zh-CN",
+        "measurement_type": "self_report_trait_mixed_ei",
+        "methodology": {
+            "content_version": "EQ_60/v1",
+            "norm_status": "provisional",
+            "report_version": "eq_report_v5_assets",
+            "scoring_version": "v1.0_normed_validity"
+        },
+        "next_module": {
+            "available": false,
+            "cta_asset_id": "eq.sjt_bridge.planned",
+            "module_code": "EQ_SJT_16",
+            "status": "planned"
+        },
+        "quality": {
+            "completion_time_seconds": 420,
+            "confidence_label": "high",
+            "explanation_asset_id": "eq.quality.level.A",
+            "extreme_rate": 0,
+            "flags": [],
+            "inconsistency_index": 0,
+            "level": "A",
+            "longstring_max": 10,
+            "metrics": {
+                "completion_time_seconds": 420,
+                "extreme_rate": 0,
+                "inconsistency_index": 0,
+                "longstring_max": 10,
+                "neutral_rate": 0
+            },
+            "neutral_rate": 0
+        },
+        "report": {
+            "primary_profile": "profile:balanced_high_eq",
+            "tags": [
+                "quality_level:A",
+                "profile:balanced_high_eq"
+            ]
+        },
+        "report_tags": [
+            "quality_level:A",
+            "profile:balanced_high_eq"
+        ],
+        "scale_code": "EQ_60",
+        "schema_version": "eq_60.report.v2",
+        "scores": {
+            "dimensions": {
+                "EM": {
+                    "band": "proficient",
+                    "label": "共情理解",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "共情理解",
+                    "standard_score": 113
+                },
+                "ER": {
+                    "band": "proficient",
+                    "label": "情绪调节",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "情绪调节",
+                    "standard_score": 113
+                },
+                "RM": {
+                    "band": "proficient",
+                    "label": "关系管理",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "关系管理",
+                    "standard_score": 113
+                },
+                "SA": {
+                    "band": "proficient",
+                    "label": "自我觉察",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "自我觉察",
+                    "standard_score": 113
+                }
+            },
+            "global": {
+                "band": "proficient",
+                "label": "情绪与关系综合指数",
+                "percentile": 80.69,
+                "raw_score": 240,
+                "standard_score": 113
+            }
+        },
+        "sections": [
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                        "id": "eq60_disclaimer_top_zh",
+                        "title": "重要声明",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_top",
+                "module_code": "eq_core",
+                "title": "重要声明"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
+                        "id": "eq60_quality_level_A_zh",
+                        "title": "作答质量提示",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "quality_notice",
+                "module_code": "eq_core",
+                "title": "作答质量提示"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
+                        "id": "eq60_global_overview_zh",
+                        "title": "综合概览",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "global_overview",
+                "module_code": "eq_core",
+                "title": "综合概览"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
+                        "id": "eq60_sa_proficient_zh",
+                        "title": "自我情绪认知 · 成熟（Proficient）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "self_awareness",
+                "module_code": "eq_core",
+                "title": "自我情绪认知"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
+                        "id": "eq60_er_proficient_zh",
+                        "title": "情绪调节与控制 · 成熟（Proficient）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "emotion_regulation",
+                "module_code": "eq_core",
+                "title": "情绪调节与控制"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
+                        "id": "eq60_em_proficient_zh",
+                        "title": "同理心与社会感知 · 成熟（Proficient）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "empathy",
+                "module_code": "eq_core",
+                "title": "同理心与社会感知"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
+                        "id": "eq60_rm_proficient_zh",
+                        "title": "社交技能与人际管理 · 成熟（Proficient）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "relationship_management",
+                "module_code": "eq_core",
+                "title": "社交技能与人际管理"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n付费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在付费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
+                        "id": "eq60_profile_balanced_high_zh",
+                        "title": "四维均衡高",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "cross_quadrant_insight",
+                "module_code": "eq_cross_insights",
+                "title": "交叉洞察长文"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
+                        "id": "eq60_plan_maintenance_zh",
+                        "title": "高水平巩固",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "action_plan_14d",
+                "module_code": "eq_growth_plan",
+                "title": "14 天游程"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 付费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                        "id": "eq60_methodology_zh",
+                        "title": "方法说明",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "methodology",
+                "module_code": "eq_core",
+                "title": "方法说明"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                        "id": "eq60_disclaimer_bottom_zh",
+                        "title": "结尾提示",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_bottom",
+                "module_code": "eq_core",
+                "title": "结尾提示"
+            }
+        ],
+        "variant": "full"
+    },
+    "report_access": {
+        "access_state": "ready",
+        "payload": {
+            "access": {
+                "all_results_free": true,
+                "blur": false,
+                "locked": false,
+                "paywall": false
+            },
+            "access_level": "full",
+            "locked": false,
+            "modules_allowed": [
+                "eq_core",
+                "eq_full",
+                "eq_cross_insights",
+                "eq_growth_plan"
+            ],
+            "modules_preview": [],
+            "offers": [],
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "upgrade_sku": null,
+            "upgrade_sku_effective": null,
+            "variant": "full",
+            "view_policy": {
+                "blur_others": false,
+                "free_sections": [
+                    "disclaimer_top",
+                    "quality_notice",
+                    "global_overview",
+                    "self_awareness",
+                    "emotion_regulation",
+                    "empathy",
+                    "relationship_management",
+                    "cross_quadrant_insight",
+                    "action_plan_14d",
+                    "methodology",
+                    "disclaimer_bottom"
+                ]
+            }
+        },
+        "report_state": "ready"
+    }
+}

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_en.json
@@ -1,0 +1,726 @@
+{
+    "case_id": "EQ60_COMPASSION_OVERLOAD_ZH",
+    "fixture_schema": "eq60.v5.report_contract_fixture.v1",
+    "locale": "en",
+    "report": {
+        "access": {
+            "all_results_free": true,
+            "blur": false,
+            "locked": false,
+            "paywall": false
+        },
+        "asset_refs": {
+            "action_prescription_id": "empathy_boundary",
+            "career_environment_ids": [
+                "emotional_labor_high",
+                "autonomy_recovery_medium",
+                "interpersonal_density_medium"
+            ],
+            "core_formulation_id": "high_empathy_low_recovery",
+            "mechanism_ids": [
+                "EM_ER_high_low"
+            ],
+            "quality_explanation_asset_id": "eq.quality.level.A",
+            "scene_ids": [
+                "feedback",
+                "conflict",
+                "relationship_boundary"
+            ],
+            "scientific_contract_id": "eq.scientific_contract.default",
+            "score_system_id": "eq.score_system.default",
+            "sjt_bridge_id": "eq.sjt_bridge.planned"
+        },
+        "assets": {
+            "action_prescription": {
+                "do_today": "Before supporting someone, decide how far you can support.",
+                "id": "empathy_boundary",
+                "script": "I can listen for ten minutes, then we can look at the next step together.",
+                "seven_day_plan": [
+                    "Day 1: identify what you are carrying.",
+                    "Day 2: practice a time boundary.",
+                    "Day 3: practice a responsibility boundary.",
+                    "Day 4: recover after support.",
+                    "Day 5: separate understanding from replacing.",
+                    "Day 6: review one help-seeking situation.",
+                    "Day 7: write your support boundary."
+                ],
+                "title": "Empathy Boundary",
+                "watch_out": "Do not replace boundaries with coldness.",
+                "why_this_matters": "High empathy needs boundaries to remain sustainable."
+            },
+            "career_environment": [
+                {
+                    "fit_signal": "High-empathy people can build trust.",
+                    "id": "emotional_labor_high",
+                    "label": "High Emotional Labor",
+                    "level": "high",
+                    "meaning": "Frequent exposure to anxiety, complaints, conflict, or vulnerability.",
+                    "strain_signal": "Low recovery can make the emotional field pull you in.",
+                    "variable": "emotional_labor",
+                    "what_to_verify": "Check whether supervision, review, and rest systems are real."
+                },
+                {
+                    "fit_signal": "Helps most people sustain performance.",
+                    "id": "autonomy_recovery_medium",
+                    "label": "Medium Autonomy Recovery",
+                    "level": "medium",
+                    "meaning": "Some independent rhythm exists, though team rhythm still matters.",
+                    "strain_signal": "Busy or crisis periods may compress it.",
+                    "variable": "autonomy_recovery",
+                    "what_to_verify": "Check recovery arrangements during peak periods."
+                },
+                {
+                    "fit_signal": "Fits switching between collaboration and independent work.",
+                    "id": "interpersonal_density_medium",
+                    "label": "Medium Interpersonal Density",
+                    "level": "medium",
+                    "meaning": "Regular collaboration without constant social demand.",
+                    "strain_signal": "Too many meetings can still drain.",
+                    "variable": "interpersonal_density",
+                    "what_to_verify": "Check weekly meetings, syncs, and cross-team collaboration frequency."
+                }
+            ],
+            "core_formulation": {
+                "core_claim": "You may absorb other people's emotions quickly without separating their state from your own soon enough.",
+                "development_lever": "Build boundaries and recovery after empathy.",
+                "do_not_overread": "The goal is not less empathy; it is empathy with clearer boundaries.",
+                "evidence_basis": [
+                    "EM is meaningfully higher than ER",
+                    "Empathy signal is stronger than recovery signal"
+                ],
+                "id": "high_empathy_low_recovery",
+                "likely_cost": "Conflict, support, and high emotional-labor settings may pull you in too deeply.",
+                "one_liner": "You tend to understand others quickly, while recovery and boundaries are the current lever.",
+                "primary_strength": "Sensitivity to others and trust building.",
+                "title": "High Empathy, Low Recovery"
+            },
+            "mechanisms": [
+                {
+                    "cost": "You may absorb too much emotional labor.",
+                    "development_lever": "Add one boundary check after empathy.",
+                    "id": "EM_ER_high_low",
+                    "micro_action": "Say internally: this is their feeling; I can support without replacing them.",
+                    "pair": "EM_ER",
+                    "state": "high_low",
+                    "strength": "People often feel seen by you.",
+                    "title": "Strong empathy, weaker boundaries and recovery",
+                    "what_it_feels_like": "When someone is distressed, you may quickly move into helping or self-blame.",
+                    "why_it_matters": "The more you understand others, the more you need to know what is not yours to carry."
+                }
+            ],
+            "quality": {
+                "confidence_label": "high",
+                "explanation_asset_id": "eq.quality.level.A"
+            },
+            "reality_scenes": [
+                {
+                    "better_move": "Separate facts, feeling, and next step: what was said, what I feel, what I need to clarify.",
+                    "cost": "When recovery is weak, feedback may feel like rejection.",
+                    "id": "feedback",
+                    "strength": "You can notice intent and relational temperature behind feedback.",
+                    "title": "Feedback",
+                    "typical_response": "When receiving critique or edits, you may notice tone and relational cues before processing the information."
+                },
+                {
+                    "better_move": "Name the shared goal first, then discuss one specific issue.",
+                    "cost": "Without a pause process, you may over-explain, avoid, or rush repair.",
+                    "id": "conflict",
+                    "strength": "You can often see needs on both sides.",
+                    "title": "Conflict",
+                    "typical_response": "During disagreement, you may move between preserving the relationship and expressing yourself."
+                },
+                {
+                    "better_move": "Ask yourself: how far can I support, and which part remains theirs?",
+                    "cost": "The line between supporting and replacing can blur.",
+                    "id": "relationship_boundary",
+                    "strength": "Others may feel received and understood.",
+                    "title": "Relationship Boundaries",
+                    "typical_response": "When someone needs support, you may quickly move into understanding or taking responsibility."
+                }
+            ],
+            "scientific_contract": {
+                "non_ability_statement": "This report is not a certified ability assessment and does not claim to measure true emotional intelligence ability.",
+                "non_clinical_statement": "This report is not for clinical diagnosis, treatment advice, or crisis evaluation.",
+                "non_hiring_statement": "This report is not for hiring, selection, promotion, or other high-stakes employment decisions.",
+                "norm_status_statement": "Current norms are provisional. Percentiles and standard scores explain relative position and will be recalibrated as samples grow.",
+                "quality_rules_statement": "The system considers response time, long-string patterns, extreme responding, neutral responding, and consistency signals to estimate interpretation confidence.",
+                "self_report_statement": "This report reflects your subjective self-perception of emotional and relational patterns. It is not an objective ability test.",
+                "test_definition": "This is an emotional and relational pattern report based on 60 self-report items. It explains how you notice, regulate, respond to, and manage emotions in yourself and others.",
+                "version_statement": "Report version eq_report_v5_assets, scoring version v1.0_normed_validity, content version EQ_60/v1."
+            },
+            "score_system": {
+                "bands": {
+                    "developing": "Developing: usable foundations are present, but the pattern may be less stable under pressure or relational complexity.",
+                    "foundational": "Foundational: the current signal suggests this area benefits from more structure, practice, and review.",
+                    "integrated": "Integrated: this dimension is prominent; the key is avoiding overuse and staying contextually flexible.",
+                    "proficient": "Proficient: this dimension is usually a reliable strength signal and may also carry related costs.",
+                    "stable": "Stable: generally usable in everyday contexts, while interpretation still depends on how it combines with other dimensions."
+                },
+                "dimensions": {
+                    "EM": {
+                        "band_explanations": {
+                            "developing": "Empathy has a base, but hidden emotion or real needs may be missed.",
+                            "foundational": "Empathy is foundational; start by confirming the other person's feeling.",
+                            "integrated": "Empathy is highly integrated; avoid over-carrying other people's emotions.",
+                            "proficient": "Empathy is mature enough to notice relational and emotional cues with nuance.",
+                            "stable": "Empathy is stable and usually helps you grasp basic feelings in others."
+                        },
+                        "definition": "The tendency to understand other people's emotions, perspectives, and relational cues.",
+                        "label": "Empathy"
+                    },
+                    "ER": {
+                        "band_explanations": {
+                            "developing": "Emotion regulation has a base, but strong feedback or conflict may still destabilize it.",
+                            "foundational": "Emotion regulation is foundational; build a pause and recovery process first.",
+                            "integrated": "Emotion regulation is highly integrated; avoid over-control and keep authentic feeling available.",
+                            "proficient": "Emotion regulation is mature enough to return to communication after being triggered.",
+                            "stable": "Emotion regulation is stable and usually supports recovery in everyday pressure."
+                        },
+                        "definition": "The tendency to recover, pause, and choose responses during pressure, feedback, or conflict.",
+                        "label": "Emotion Regulation"
+                    },
+                    "RM": {
+                        "band_explanations": {
+                            "developing": "Relationship management has a base, but conflict, boundaries, or repair may be unstable.",
+                            "foundational": "Relationship management is foundational; start with low-risk communication scripts.",
+                            "integrated": "Relationship management is highly integrated; avoid taking too much coordination responsibility.",
+                            "proficient": "Relationship management is mature enough to actively support communication, coordination, and repair.",
+                            "stable": "Relationship management is stable and usually supports constructive action in collaboration."
+                        },
+                        "definition": "The tendency to act constructively in communication, collaboration, repair, and boundaries.",
+                        "label": "Relationship Management"
+                    },
+                    "SA": {
+                        "band_explanations": {
+                            "developing": "Self-awareness has a base, but real triggers may be noticed late under pressure.",
+                            "foundational": "Self-awareness is foundational; start by naming emotions with specific words.",
+                            "integrated": "Self-awareness is highly integrated; the focus is avoiding over-analysis and moving to action.",
+                            "proficient": "Self-awareness is mature enough to catch shifts and underlying needs quickly.",
+                            "stable": "Self-awareness is stable and usually helps you understand key emotional cues."
+                        },
+                        "definition": "The tendency to notice, name, and understand emotional cues in yourself.",
+                        "label": "Self-Awareness"
+                    }
+                },
+                "global_index": {
+                    "label": "Emotional & Relational Functioning Index",
+                    "meaning": "A combined self-report signal across four dimensions, describing the current stability of emotional and relational functioning."
+                },
+                "score_notes": {
+                    "percentile": "Percentiles indicate relative position in the current reference sample and are not ability certification.",
+                    "standard_score": "Standard scores are interpreted against provisional norms. Scores near the mean indicate a stable usable range."
+                }
+            },
+            "sjt_bridge": {
+                "available": false,
+                "button_label": "Scenario module planned",
+                "description": "The current report is based on EQ-60 self-report. A future EQ-SJT 16 module will add how you choose responses in feedback, conflict, boundary, and pressure situations.",
+                "id": "eq.sjt_bridge.planned",
+                "status": "planned",
+                "title": "A 16-item scenario module is planned",
+                "what_it_adds": "It supplements self-report by comparing self-perception with scenario choices.",
+                "what_it_is_not": "It is not MSCEIT, not a certified ability assessment, and not for hiring or clinical decisions."
+            }
+        },
+        "compat": {
+            "free_blocks": [
+                {
+                    "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                    "id": "eq60_disclaimer_top_en",
+                    "section_key": "disclaimer_top",
+                    "title": "Important Notice"
+                },
+                {
+                    "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
+                    "id": "eq60_quality_level_A_en",
+                    "section_key": "quality_notice",
+                    "title": "Response Quality"
+                },
+                {
+                    "content": "Your overall EQ standard score is **99.5** (population mean 100, SD 15), at the **48.67** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
+                    "id": "eq60_global_overview_en",
+                    "section_key": "global_overview",
+                    "title": "Overview"
+                },
+                {
+                    "content": "**Dimension: Self‑Awareness**\n\nStandard score: **97** (42.07 percentile), band: **Competent**.\n\nYou usually identify emotions and connect them to triggers and needs. In many situations you can say things like “I’m tense,” “I need a moment,” or “I felt overlooked.” This reduces misunderstanding and rumination, keeping conversations closer to the real issue.\n\n**Practice**: Before a key conversation, write one sentence: “What matters most to me here?”",
+                    "id": "eq60_sa_competent_en",
+                    "section_key": "self_awareness",
+                    "title": "Self‑Awareness · Competent"
+                },
+                {
+                    "content": "**Dimension: Emotion Regulation**\n\nStandard score: **83** (12.85 percentile), band: **Baseline**.\n\nUnder pressure or triggers, emotions can take over the action system—impulses, rumination, sleep disruption, or prolonged tension. This is not a “willpower” label; it reflects a toolbox that isn’t automatic yet. Regulation aims to bring intensity and duration back into a manageable range, not to erase emotions.\n\n**90‑second reset**: Pause → slow exhale 6 times → feel your feet on the ground to create space before reacting.",
+                    "id": "eq60_er_baseline_en",
+                    "section_key": "emotion_regulation",
+                    "title": "Emotion Regulation · Baseline"
+                },
+                {
+                    "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **119** (89.74 percentile), band: **Exceptional**.\n\nYour empathy is exceptionally strong. Even in noisy environments you read emotions and motives accurately and respond with warmth. This is a foundation of influence. Keep boundaries to prevent emotional overload.\n\n**Practice**: Use: “I see this is hard for you. I can stay with you for a bit,” while keeping your limits.",
+                    "id": "eq60_em_exceptional_en",
+                    "section_key": "empathy",
+                    "title": "Social Awareness & Empathy · Exceptional"
+                },
+                {
+                    "content": "**Dimension: Relationship Management**\n\nStandard score: **99** (47.34 percentile), band: **Competent**.\n\nYou communicate and collaborate well, maintain trust, and manage disagreements without breaking the relationship. You tend to balance authenticity with relationship care.\n\n**Practice**: In conflict, align on the shared goal first, then discuss options.",
+                    "id": "eq60_rm_competent_en",
+                    "section_key": "relationship_management",
+                    "title": "Relationship Management · Competent"
+                },
+                {
+                    "content": "**Primary profile: Compassion Overload (High Empathy + Low Regulation)**\n\nYour results show Empathy **119** very high and Emotion Regulation **83** lower. You feel others’ pain and stress strongly, and group climate can affect you quickly. The gift is warmth and attunement; the cost is overload and blurry boundaries.\n\n**Typical strengths**\n- High resonance: people open up to you easily.\n- Strong ‘room reading’: you sense shifts and hidden tension.\n- Care motive: a real drive to help.\n\n**Typical costs**\n- Emotional contagion: others’ feelings enter your body and drain sleep/energy.\n- Rescue reflex: urgency to fix, leading to over‑involvement.\n- Boundary loss: ‘empathy’ turns into ‘carrying,’ then burnout.\n\n**Key shift: bounded care**\nHigh empathy doesn’t require self‑sacrifice. Training focuses on three boundaries:\n1) **Emotional boundary**: “This is theirs” vs “this is mine.”\n2) **Time boundary**: define how long you can be available.\n3) **Action boundary**: move from ‘fixing’ to ‘helping them see choices.’\n\n**Support scripts**\n- “I hear this is hard. I can stay with you for 10 minutes to sort it out.”\n- “What I can offer is … The deeper choice is yours.”\n- “I care about you, and I also need to protect my energy.”\n\n**What premium adds**\n- Boundary training to turn empathy into a resource.\n- Regulation tools to prevent overload spillover.\n- 14‑day plan for sustainable helping.",
+                    "id": "eq60_profile_compassion_overload_en",
+                    "section_key": "cross_quadrant_insight",
+                    "title": "Compassion Overload"
+                },
+                {
+                    "content": "**14‑Day Plan: Boundaried Care (10–15 min/day)**\n\nGoal: keep your warmth and sensitivity while building emotional, time, and action boundaries to prevent overload.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Mine vs yours | Note one contagion moment: whose emotion is it? what can I do? |\n| Day 2 | Emotional boundary | Practice: “I see it’s hard for you. This is your feeling. I’m here with you.” |\n| Day 3 | Time boundary | Set a time cap (10/20 min) and write an ending script. |\n| Day 4 | Action boundary | Shift from fixing to options: write 3 guiding questions. |\n| Day 5 | Back to body | 2‑minute tactile grounding (cup/table texture). |\n| Day 6 | Self‑compassion | Write 3 lines: this is hard; I’m not alone; I’ll be kind to myself. |\n| Day 7 | Support & referral | List 3 resources you can hand off to; don’t carry alone. |\n| Day 8 | Empathize without spiraling | Reflect feeling, then ask: listen or brainstorm? |\n| Day 9 | Energy return | After deep listening: 5 minutes walk/breath to reset. |\n| Day10 | State limits | Use: “I can stay up to here; then I need rest.” once. |\n| Day11 | Load monitoring | Rate emotional load 0–10; above 7, reduce inputs intentionally. |\n| Day12 | One smallest act | Keep helping action to 1 minimal step; avoid over‑involvement. |\n| Day13 | Relationship structure | Pick one draining relationship: what boundary makes it sustainable? |\n| Day14 | Consolidate | 3 boundary principles + 3 care scripts. |\n\nBoundaries aren’t coldness—they make care sustainable.",
+                    "id": "eq60_plan_boundary_en",
+                    "section_key": "action_plan_14d",
+                    "title": "Boundaried Care"
+                },
+                {
+                    "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) Premium content adds cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                    "id": "eq60_methodology_en",
+                    "section_key": "methodology",
+                    "title": "Methodology"
+                },
+                {
+                    "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                    "id": "eq60_disclaimer_bottom_en",
+                    "section_key": "disclaimer_bottom",
+                    "title": "Closing Notes"
+                }
+            ],
+            "paid_blocks": []
+        },
+        "dimension_summary": [
+            {
+                "band": "stable",
+                "code": "SA",
+                "label": "Self-Awareness",
+                "percentile": 42.07,
+                "standard_score": 97
+            },
+            {
+                "band": "foundational",
+                "code": "ER",
+                "label": "Emotion Regulation",
+                "percentile": 12.85,
+                "standard_score": 83
+            },
+            {
+                "band": "integrated",
+                "code": "EM",
+                "label": "Empathy",
+                "percentile": 89.74,
+                "standard_score": 119
+            },
+            {
+                "band": "stable",
+                "code": "RM",
+                "label": "Relationship Management",
+                "percentile": 47.34,
+                "standard_score": 99
+            }
+        ],
+        "eq_report_mode": "self_report",
+        "generated_at": "2026-05-21T00:00:00.000000Z",
+        "interpretation": {
+            "action_prescription_id": "empathy_boundary",
+            "career_environment_ids": [
+                "emotional_labor_high",
+                "autonomy_recovery_medium",
+                "interpersonal_density_medium"
+            ],
+            "core_formulation_id": "high_empathy_low_recovery",
+            "development_lever": "ER",
+            "primary_mechanism_ids": [
+                "EM_ER_high_low"
+            ],
+            "primary_scene_ids": [
+                "feedback",
+                "conflict",
+                "relationship_boundary"
+            ],
+            "strongest_dimension": "EM"
+        },
+        "legacy_scores": {
+            "EM": {
+                "level": "exceptional",
+                "percentile": 89.74,
+                "pomp": 80,
+                "raw_mean": 4.2,
+                "raw_sum": 63,
+                "std_score": 119,
+                "z": 1.266667
+            },
+            "ER": {
+                "level": "baseline",
+                "percentile": 12.85,
+                "pomp": 50,
+                "raw_mean": 3,
+                "raw_sum": 45,
+                "std_score": 83,
+                "z": -1.133333
+            },
+            "RM": {
+                "level": "competent",
+                "percentile": 47.34,
+                "pomp": 63.33,
+                "raw_mean": 3.5333,
+                "raw_sum": 53,
+                "std_score": 99,
+                "z": -0.066667
+            },
+            "SA": {
+                "level": "competent",
+                "percentile": 42.07,
+                "pomp": 61.67,
+                "raw_mean": 3.4667,
+                "raw_sum": 52,
+                "std_score": 97,
+                "z": -0.2
+            },
+            "emotion_regulation": {
+                "level": "baseline",
+                "percentile": 12.85,
+                "pomp": 50,
+                "raw_mean": 3,
+                "raw_sum": 45,
+                "std_score": 83,
+                "z": -1.133333
+            },
+            "empathy": {
+                "level": "exceptional",
+                "percentile": 89.74,
+                "pomp": 80,
+                "raw_mean": 4.2,
+                "raw_sum": 63,
+                "std_score": 119,
+                "z": 1.266667
+            },
+            "global": {
+                "level": "competent",
+                "percentile": 48.67,
+                "pomp": 63.75,
+                "raw_mean": 3.55,
+                "raw_sum": 213,
+                "std_score": 99.5,
+                "z": -0.033333
+            },
+            "relationship_management": {
+                "level": "competent",
+                "percentile": 47.34,
+                "pomp": 63.33,
+                "raw_mean": 3.5333,
+                "raw_sum": 53,
+                "std_score": 99,
+                "z": -0.066667
+            },
+            "self_awareness": {
+                "level": "competent",
+                "percentile": 42.07,
+                "pomp": 61.67,
+                "raw_mean": 3.4667,
+                "raw_sum": 52,
+                "std_score": 97,
+                "z": -0.2
+            }
+        },
+        "locale": "en",
+        "measurement_type": "self_report_trait_mixed_ei",
+        "methodology": {
+            "content_version": "EQ_60/v1",
+            "norm_status": "provisional",
+            "report_version": "eq_report_v5_assets",
+            "scoring_version": "v1.0_normed_validity"
+        },
+        "next_module": {
+            "available": false,
+            "cta_asset_id": "eq.sjt_bridge.planned",
+            "module_code": "EQ_SJT_16",
+            "status": "planned"
+        },
+        "quality": {
+            "completion_time_seconds": 420,
+            "confidence_label": "high",
+            "explanation_asset_id": "eq.quality.level.A",
+            "extreme_rate": 0.05,
+            "flags": [],
+            "inconsistency_index": 10,
+            "level": "A",
+            "longstring_max": 15,
+            "metrics": {
+                "completion_time_seconds": 420,
+                "extreme_rate": 0.05,
+                "inconsistency_index": 10,
+                "longstring_max": 15,
+                "neutral_rate": 0.2667
+            },
+            "neutral_rate": 0.2667
+        },
+        "report": {
+            "primary_profile": "profile:compassion_overload",
+            "tags": [
+                "quality_level:A",
+                "profile:compassion_overload",
+                "focus:boundary_setting"
+            ]
+        },
+        "report_tags": [
+            "quality_level:A",
+            "profile:compassion_overload",
+            "focus:boundary_setting"
+        ],
+        "scale_code": "EQ_60",
+        "schema_version": "eq_60.report.v2",
+        "scores": {
+            "dimensions": {
+                "EM": {
+                    "band": "integrated",
+                    "label": "Empathy",
+                    "percentile": 89.74,
+                    "raw_score": 63,
+                    "short_label": "Empathy",
+                    "source_band": "exceptional",
+                    "standard_score": 119
+                },
+                "ER": {
+                    "band": "foundational",
+                    "label": "Emotion Regulation",
+                    "percentile": 12.85,
+                    "raw_score": 45,
+                    "short_label": "Emotion Regulation",
+                    "source_band": "baseline",
+                    "standard_score": 83
+                },
+                "RM": {
+                    "band": "stable",
+                    "label": "Relationship Management",
+                    "percentile": 47.34,
+                    "raw_score": 53,
+                    "short_label": "Relationship Management",
+                    "source_band": "competent",
+                    "standard_score": 99
+                },
+                "SA": {
+                    "band": "stable",
+                    "label": "Self-Awareness",
+                    "percentile": 42.07,
+                    "raw_score": 52,
+                    "short_label": "Self-Awareness",
+                    "source_band": "competent",
+                    "standard_score": 97
+                }
+            },
+            "global": {
+                "band": "stable",
+                "label": "Emotional & Relational Functioning Index",
+                "percentile": 48.67,
+                "raw_score": 213,
+                "source_band": "competent",
+                "standard_score": 99.5
+            }
+        },
+        "sections": [
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                        "id": "eq60_disclaimer_top_en",
+                        "title": "Important Notice",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_top",
+                "module_code": "eq_core",
+                "title": "Important Notice"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
+                        "id": "eq60_quality_level_A_en",
+                        "title": "Response Quality",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "quality_notice",
+                "module_code": "eq_core",
+                "title": "Response Quality"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "Your overall EQ standard score is **99.5** (population mean 100, SD 15), at the **48.67** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
+                        "id": "eq60_global_overview_en",
+                        "title": "Overview",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "global_overview",
+                "module_code": "eq_core",
+                "title": "Overview"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **97** (42.07 percentile), band: **Competent**.\n\nYou usually identify emotions and connect them to triggers and needs. In many situations you can say things like “I’m tense,” “I need a moment,” or “I felt overlooked.” This reduces misunderstanding and rumination, keeping conversations closer to the real issue.\n\n**Practice**: Before a key conversation, write one sentence: “What matters most to me here?”",
+                        "id": "eq60_sa_competent_en",
+                        "title": "Self‑Awareness · Competent",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "self_awareness",
+                "module_code": "eq_core",
+                "title": "Self‑Awareness"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **83** (12.85 percentile), band: **Baseline**.\n\nUnder pressure or triggers, emotions can take over the action system—impulses, rumination, sleep disruption, or prolonged tension. This is not a “willpower” label; it reflects a toolbox that isn’t automatic yet. Regulation aims to bring intensity and duration back into a manageable range, not to erase emotions.\n\n**90‑second reset**: Pause → slow exhale 6 times → feel your feet on the ground to create space before reacting.",
+                        "id": "eq60_er_baseline_en",
+                        "title": "Emotion Regulation · Baseline",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "emotion_regulation",
+                "module_code": "eq_core",
+                "title": "Emotion Regulation"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **119** (89.74 percentile), band: **Exceptional**.\n\nYour empathy is exceptionally strong. Even in noisy environments you read emotions and motives accurately and respond with warmth. This is a foundation of influence. Keep boundaries to prevent emotional overload.\n\n**Practice**: Use: “I see this is hard for you. I can stay with you for a bit,” while keeping your limits.",
+                        "id": "eq60_em_exceptional_en",
+                        "title": "Social Awareness & Empathy · Exceptional",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "empathy",
+                "module_code": "eq_core",
+                "title": "Social Awareness & Empathy"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Relationship Management**\n\nStandard score: **99** (47.34 percentile), band: **Competent**.\n\nYou communicate and collaborate well, maintain trust, and manage disagreements without breaking the relationship. You tend to balance authenticity with relationship care.\n\n**Practice**: In conflict, align on the shared goal first, then discuss options.",
+                        "id": "eq60_rm_competent_en",
+                        "title": "Relationship Management · Competent",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "relationship_management",
+                "module_code": "eq_core",
+                "title": "Relationship Management"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Primary profile: Compassion Overload (High Empathy + Low Regulation)**\n\nYour results show Empathy **119** very high and Emotion Regulation **83** lower. You feel others’ pain and stress strongly, and group climate can affect you quickly. The gift is warmth and attunement; the cost is overload and blurry boundaries.\n\n**Typical strengths**\n- High resonance: people open up to you easily.\n- Strong ‘room reading’: you sense shifts and hidden tension.\n- Care motive: a real drive to help.\n\n**Typical costs**\n- Emotional contagion: others’ feelings enter your body and drain sleep/energy.\n- Rescue reflex: urgency to fix, leading to over‑involvement.\n- Boundary loss: ‘empathy’ turns into ‘carrying,’ then burnout.\n\n**Key shift: bounded care**\nHigh empathy doesn’t require self‑sacrifice. Training focuses on three boundaries:\n1) **Emotional boundary**: “This is theirs” vs “this is mine.”\n2) **Time boundary**: define how long you can be available.\n3) **Action boundary**: move from ‘fixing’ to ‘helping them see choices.’\n\n**Support scripts**\n- “I hear this is hard. I can stay with you for 10 minutes to sort it out.”\n- “What I can offer is … The deeper choice is yours.”\n- “I care about you, and I also need to protect my energy.”\n\n**What premium adds**\n- Boundary training to turn empathy into a resource.\n- Regulation tools to prevent overload spillover.\n- 14‑day plan for sustainable helping.",
+                        "id": "eq60_profile_compassion_overload_en",
+                        "title": "Compassion Overload",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "cross_quadrant_insight",
+                "module_code": "eq_cross_insights",
+                "title": "Cross‑Quadrant Insight"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**14‑Day Plan: Boundaried Care (10–15 min/day)**\n\nGoal: keep your warmth and sensitivity while building emotional, time, and action boundaries to prevent overload.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Mine vs yours | Note one contagion moment: whose emotion is it? what can I do? |\n| Day 2 | Emotional boundary | Practice: “I see it’s hard for you. This is your feeling. I’m here with you.” |\n| Day 3 | Time boundary | Set a time cap (10/20 min) and write an ending script. |\n| Day 4 | Action boundary | Shift from fixing to options: write 3 guiding questions. |\n| Day 5 | Back to body | 2‑minute tactile grounding (cup/table texture). |\n| Day 6 | Self‑compassion | Write 3 lines: this is hard; I’m not alone; I’ll be kind to myself. |\n| Day 7 | Support & referral | List 3 resources you can hand off to; don’t carry alone. |\n| Day 8 | Empathize without spiraling | Reflect feeling, then ask: listen or brainstorm? |\n| Day 9 | Energy return | After deep listening: 5 minutes walk/breath to reset. |\n| Day10 | State limits | Use: “I can stay up to here; then I need rest.” once. |\n| Day11 | Load monitoring | Rate emotional load 0–10; above 7, reduce inputs intentionally. |\n| Day12 | One smallest act | Keep helping action to 1 minimal step; avoid over‑involvement. |\n| Day13 | Relationship structure | Pick one draining relationship: what boundary makes it sustainable? |\n| Day14 | Consolidate | 3 boundary principles + 3 care scripts. |\n\nBoundaries aren’t coldness—they make care sustainable.",
+                        "id": "eq60_plan_boundary_en",
+                        "title": "Boundaried Care",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "action_plan_14d",
+                "module_code": "eq_growth_plan",
+                "title": "14‑Day Plan"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) Premium content adds cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                        "id": "eq60_methodology_en",
+                        "title": "Methodology",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "methodology",
+                "module_code": "eq_core",
+                "title": "Methodology"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                        "id": "eq60_disclaimer_bottom_en",
+                        "title": "Closing Notes",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_bottom",
+                "module_code": "eq_core",
+                "title": "Closing Notes"
+            }
+        ],
+        "variant": "full"
+    },
+    "report_access": {
+        "access_state": "ready",
+        "payload": {
+            "access": {
+                "all_results_free": true,
+                "blur": false,
+                "locked": false,
+                "paywall": false
+            },
+            "access_level": "full",
+            "locked": false,
+            "modules_allowed": [
+                "eq_core",
+                "eq_full",
+                "eq_cross_insights",
+                "eq_growth_plan"
+            ],
+            "modules_preview": [],
+            "offers": [],
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "upgrade_sku": null,
+            "upgrade_sku_effective": null,
+            "variant": "full",
+            "view_policy": {
+                "blur_others": false,
+                "free_sections": [
+                    "disclaimer_top",
+                    "quality_notice",
+                    "global_overview",
+                    "self_awareness",
+                    "emotion_regulation",
+                    "empathy",
+                    "relationship_management",
+                    "cross_quadrant_insight",
+                    "action_plan_14d",
+                    "methodology",
+                    "disclaimer_bottom"
+                ]
+            }
+        },
+        "report_state": "ready"
+    }
+}

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_zh.json
@@ -1,0 +1,726 @@
+{
+    "case_id": "EQ60_COMPASSION_OVERLOAD_ZH",
+    "fixture_schema": "eq60.v5.report_contract_fixture.v1",
+    "locale": "zh-CN",
+    "report": {
+        "access": {
+            "all_results_free": true,
+            "blur": false,
+            "locked": false,
+            "paywall": false
+        },
+        "asset_refs": {
+            "action_prescription_id": "empathy_boundary",
+            "career_environment_ids": [
+                "emotional_labor_high",
+                "autonomy_recovery_medium",
+                "interpersonal_density_medium"
+            ],
+            "core_formulation_id": "high_empathy_low_recovery",
+            "mechanism_ids": [
+                "EM_ER_high_low"
+            ],
+            "quality_explanation_asset_id": "eq.quality.level.A",
+            "scene_ids": [
+                "feedback",
+                "conflict",
+                "relationship_boundary"
+            ],
+            "scientific_contract_id": "eq.scientific_contract.default",
+            "score_system_id": "eq.score_system.default",
+            "sjt_bridge_id": "eq.sjt_bridge.planned"
+        },
+        "assets": {
+            "action_prescription": {
+                "do_today": "支持别人前先确认自己能支持到哪里。",
+                "id": "empathy_boundary",
+                "script": "我愿意听你说十分钟，然后我们一起看下一步。",
+                "seven_day_plan": [
+                    "第 1 天：识别一次我在承担什么。",
+                    "第 2 天：练习时间边界。",
+                    "第 3 天：练习责任边界。",
+                    "第 4 天：支持后做恢复。",
+                    "第 5 天：区分理解和代替。",
+                    "第 6 天：复盘一次求助场景。",
+                    "第 7 天：写下自己的支持边界。"
+                ],
+                "title": "共情边界处方",
+                "watch_out": "不要用冷漠来替代边界。",
+                "why_this_matters": "高共情需要边界，才能长期有效。"
+            },
+            "career_environment": [
+                {
+                    "fit_signal": "高共情者能建立信任。",
+                    "id": "emotional_labor_high",
+                    "label": "高情绪劳动",
+                    "level": "high",
+                    "meaning": "经常承接焦虑、投诉、冲突或脆弱情绪。",
+                    "strain_signal": "低恢复者容易被情绪场拖走。",
+                    "variable": "emotional_labor",
+                    "what_to_verify": "确认督导、复盘和休息制度是否真实存在。"
+                },
+                {
+                    "fit_signal": "适合多数人维持稳定表现。",
+                    "id": "autonomy_recovery_medium",
+                    "label": "中等自主恢复空间",
+                    "level": "medium",
+                    "meaning": "有一定独立安排，但仍受团队节奏影响。",
+                    "strain_signal": "忙季或危机期可能被压缩。",
+                    "variable": "autonomy_recovery",
+                    "what_to_verify": "确认高峰期的恢复安排。"
+                },
+                {
+                    "fit_signal": "适合在协作和独立之间切换。",
+                    "id": "interpersonal_density_medium",
+                    "label": "中等人际密度",
+                    "level": "medium",
+                    "meaning": "日常有固定协作，但不是持续社交。",
+                    "strain_signal": "会议过多时仍会消耗。",
+                    "variable": "interpersonal_density",
+                    "what_to_verify": "确认每周会议、同步和跨团队协作频率。"
+                }
+            ],
+            "core_formulation": {
+                "core_claim": "你可能很快接住别人的情绪，却不一定能及时把对方状态和自己的状态分开。",
+                "development_lever": "共情之后建立边界和恢复动作。",
+                "do_not_overread": "发展方向不是减少共情，而是让共情更有边界。",
+                "evidence_basis": [
+                    "EM 明显高于 ER",
+                    "共情信号强于恢复信号"
+                ],
+                "id": "high_empathy_low_recovery",
+                "likely_cost": "在冲突、求助或高情绪劳动场景中容易被卷入。",
+                "one_liner": "你容易理解他人感受，但恢复和边界是当前杠杆。",
+                "primary_strength": "对他人状态敏感，容易建立信任。",
+                "title": "高共情，低恢复"
+            },
+            "mechanisms": [
+                {
+                    "cost": "容易吸收过多情绪劳动。",
+                    "development_lever": "共情后加一句边界确认。",
+                    "id": "EM_ER_high_low",
+                    "micro_action": "在心里说：这是对方的感受，我可以支持，但不需要代替。",
+                    "pair": "EM_ER",
+                    "state": "high_low",
+                    "strength": "容易让人感到被看见。",
+                    "title": "共情强，边界和恢复偏弱",
+                    "what_it_feels_like": "别人难受时，你可能很快进入帮助或自责状态。",
+                    "why_it_matters": "你越能理解别人，越需要知道哪些情绪不是你要承担的。"
+                }
+            ],
+            "quality": {
+                "confidence_label": "high",
+                "explanation_asset_id": "eq.quality.level.A"
+            },
+            "reality_scenes": [
+                {
+                    "better_move": "先拆分事实、情绪和下一步：对方说了什么，我有什么感受，我要确认什么。",
+                    "cost": "如果恢复不足，容易把反馈体验成否定。",
+                    "id": "feedback",
+                    "strength": "能注意到反馈背后的真实意图和关系温度。",
+                    "title": "反馈场景",
+                    "typical_response": "收到评价或修改意见时，你可能先捕捉语气和关系信号，再处理信息本身。"
+                },
+                {
+                    "better_move": "先确认共同目标，再只讨论一个具体问题。",
+                    "cost": "如果没有暂停流程，容易过度解释、回避或急于修复。",
+                    "id": "conflict",
+                    "strength": "有机会同时看见双方需求。",
+                    "title": "冲突场景",
+                    "typical_response": "出现分歧时，你可能在维护关系和表达自己之间摇摆。"
+                },
+                {
+                    "better_move": "先问自己：我能支持到哪里，哪一部分仍然属于对方。",
+                    "cost": "支持和代替之间的边界可能变模糊。",
+                    "id": "relationship_boundary",
+                    "strength": "容易让对方感到被接住。",
+                    "title": "关系边界",
+                    "typical_response": "当别人需要你支持时，你可能很快进入理解或承担。"
+                }
+            ],
+            "scientific_contract": {
+                "non_ability_statement": "本报告不是认证能力测验，也不声称测量真实情商能力。",
+                "non_clinical_statement": "本报告不用于临床诊断、治疗建议或危机评估。",
+                "non_hiring_statement": "本报告不用于招聘筛选、录用、晋升或其他高风险人事决策。",
+                "norm_status_statement": "当前常模为阶段性常模，百分位和标准分用于解释相对位置，后续会随样本增长持续校准。",
+                "quality_rules_statement": "系统会参考作答时长、长串作答、极端反应、中立反应和一致性信号，给出解释置信度。",
+                "self_report_statement": "本报告反映你对自身情绪与关系模式的主观感知，不等同于客观能力测验。",
+                "test_definition": "这是一份基于 60 道自我报告题的情绪与关系模式报告，用于解释你如何感知、调节、回应和管理自己与他人的情绪。",
+                "version_statement": "报告版本 eq_report_v5_assets，计分版本 v1.0_normed_validity，内容版本 EQ_60/v1。"
+            },
+            "score_system": {
+                "bands": {
+                    "developing": "发展中：已经有可用基础，但在压力或复杂关系中可能不够稳定。",
+                    "foundational": "基础发展中：当前信号提示该能力更需要外部结构、练习和复盘支持。",
+                    "integrated": "高度整合：该维度表现突出，重点是避免过度使用并保持情境灵活性。",
+                    "proficient": "熟练成熟：该维度通常是可依赖的优势信号，也可能带来相应消耗。",
+                    "stable": "稳定可用：多数日常场景中可以发挥作用，但仍需要看和其他维度的组合。"
+                },
+                "dimensions": {
+                    "EM": {
+                        "band_explanations": {
+                            "developing": "共情理解已有基础，但可能错过隐性情绪或真实需求。",
+                            "foundational": "共情理解处于基础发展中，建议先练习确认对方感受。",
+                            "integrated": "共情理解高度整合，重点是避免过度承接他人情绪。",
+                            "proficient": "共情理解较成熟，能较细腻地捕捉关系和情绪线索。",
+                            "stable": "共情理解稳定可用，多数场景能把握他人基本感受。"
+                        },
+                        "definition": "理解他人情绪、立场和关系线索的倾向。",
+                        "label": "共情理解"
+                    },
+                    "ER": {
+                        "band_explanations": {
+                            "developing": "情绪调节已有基础，但强反馈或冲突中仍可能不稳定。",
+                            "foundational": "情绪调节处于基础发展中，建议先建立暂停和恢复流程。",
+                            "integrated": "情绪调节高度整合，重点是避免过度控制并保留真实感受。",
+                            "proficient": "情绪调节较成熟，能在触发后较快回到可沟通状态。",
+                            "stable": "情绪调节稳定可用，多数日常压力下能找到恢复方式。"
+                        },
+                        "definition": "在压力、反馈或冲突中恢复、暂停和选择回应方式的倾向。",
+                        "label": "情绪调节"
+                    },
+                    "RM": {
+                        "band_explanations": {
+                            "developing": "关系管理已有基础，但在冲突、边界或修复中可能不稳定。",
+                            "foundational": "关系管理处于基础发展中，建议先学习低风险沟通脚本。",
+                            "integrated": "关系管理高度整合，重点是避免承担过多协调责任。",
+                            "proficient": "关系管理较成熟，能主动推进沟通、协调和修复。",
+                            "stable": "关系管理稳定可用，多数协作场景中能采取建设性行动。"
+                        },
+                        "definition": "在沟通、协作、修复和边界中采取建设性行动的倾向。",
+                        "label": "关系管理"
+                    },
+                    "SA": {
+                        "band_explanations": {
+                            "developing": "自我觉察已有基础，但在压力下可能较晚发现真实触发点。",
+                            "foundational": "自我觉察处于基础发展中，建议先练习用具体词语命名情绪。",
+                            "integrated": "自我觉察高度整合，重点是避免过度分析并转向行动。",
+                            "proficient": "自我觉察较成熟，能较快捕捉情绪变化和背后需求。",
+                            "stable": "自我觉察稳定可用，通常能理解自己的主要情绪线索。"
+                        },
+                        "definition": "识别、命名和理解自身情绪线索的倾向。",
+                        "label": "自我觉察"
+                    }
+                },
+                "global_index": {
+                    "label": "情绪与关系综合指数",
+                    "meaning": "综合四个维度的自我报告信号，描述当前情绪与关系功能的整体稳定度。"
+                },
+                "score_notes": {
+                    "percentile": "百分位表示在当前参考样本中的相对位置，不代表能力认证。",
+                    "standard_score": "标准分以阶段性常模为参照，平均附近代表稳定可用。"
+                }
+            },
+            "sjt_bridge": {
+                "available": false,
+                "button_label": "情境判断模块规划中",
+                "description": "当前报告基于 EQ-60 自我报告。未来 EQ-SJT 16 会补充你在反馈、冲突、边界和压力情境中的选择方式。",
+                "id": "eq.sjt_bridge.planned",
+                "status": "planned",
+                "title": "未来将支持 16 道情境判断模块",
+                "what_it_adds": "它用于补充 self-report，帮助比较自我感知与情境选择之间的一致和差距。",
+                "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，也不用于招聘筛选或临床判断。"
+            }
+        },
+        "compat": {
+            "free_blocks": [
+                {
+                    "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                    "id": "eq60_disclaimer_top_zh",
+                    "section_key": "disclaimer_top",
+                    "title": "重要声明"
+                },
+                {
+                    "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
+                    "id": "eq60_quality_level_A_zh",
+                    "section_key": "quality_notice",
+                    "title": "作答质量提示"
+                },
+                {
+                    "content": "你的综合 EQ 标准分为 **99.5**（人群平均 100，标准差 15），处于第 **48.67** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
+                    "id": "eq60_global_overview_zh",
+                    "section_key": "global_overview",
+                    "title": "综合概览"
+                },
+                {
+                    "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**97**（第 42.07 百分位），阶段：**稳定可用（Competent）**。\n\n你通常能识别情绪，并把情绪与触发点、需求联系起来。你能在大部分场景下清楚表达“我正在紧张/我需要时间/我被忽视了”。这种能力能明显降低误解与内耗，让沟通更聚焦问题本身，而不是被情绪噪音牵着走。\n\n**练习提示**：在关键对话前，用一句话写清“我在乎什么”，让表达更稳定。",
+                    "id": "eq60_sa_competent_zh",
+                    "section_key": "self_awareness",
+                    "title": "自我情绪认知 · 稳定可用（Competent）"
+                },
+                {
+                    "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**83**（第 12.85 百分位），阶段：**觉察盲区（Baseline）**。\n\n在高压或被触发时，情绪更容易接管行动系统，出现冲动反应、反复纠结、睡眠受影响或持续紧绷。这个分数不代表意志力不足，而是调节工具箱尚未形成稳定的自动化。调节的目标不是“把情绪消灭”，而是把强度与持续时间拉回可管理范围。\n\n**练习提示（90秒）**：停下→缓慢呼气 6 次→把注意力放回脚底触地感，给自己争取“反应前的空隙”。",
+                    "id": "eq60_er_baseline_zh",
+                    "section_key": "emotion_regulation",
+                    "title": "情绪调节与控制 · 觉察盲区（Baseline）"
+                },
+                {
+                    "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**119**（第 89.74 百分位），阶段：**卓越稀缺（Exceptional）**。\n\n你的共情能力极强，能在高噪音环境里仍准确读到他人的情绪与动机，并用温和方式回应。这是影响力的重要底座。需要留意的点是：共情强度越高，越要建立边界，避免把别人的情绪带回自己的生活节奏里。\n\n**练习提示**：把“我也很难受”改成“我看见你很难受，我愿意陪你一会儿”，保留边界感。",
+                    "id": "eq60_em_exceptional_zh",
+                    "section_key": "empathy",
+                    "title": "同理心与社会感知 · 卓越稀缺（Exceptional）"
+                },
+                {
+                    "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**99**（第 47.34 百分位），阶段：**稳定可用（Competent）**。\n\n你具备良好的沟通与协作能力，能建立稳定的人际网络与信任。你能在多数场景里表达观点、处理分歧、维持关系质量。你通常能在“真实表达”和“关系维护”之间找到平衡。\n\n**练习提示**：遇到分歧时先对齐共同目标，再讨论方案。",
+                    "id": "eq60_rm_competent_zh",
+                    "section_key": "relationship_management",
+                    "title": "社交技能与人际管理 · 稳定可用（Competent）"
+                },
+                {
+                    "content": "**你的主要画像：情绪海绵型（高同理心 + 低情绪调节）**\n\n本次测评显示：同理心与社会感知 **119** 很高，情绪调节 **83** 偏低。你对他人的痛苦与压力高度敏感，常常会“替别人难受”，也更容易被群体氛围影响。优势是真诚、温暖、能看见别人；代价是情绪过载与边界模糊。\n\n**你常见的优势**\n- 高共鸣：别人更愿意向你倾诉，信任建立更快。\n- 读空气能力强：能敏锐捕捉情绪变化与隐性冲突。\n- 关怀动机：有强烈的助人倾向与责任感。\n\n**常见代价**\n- 情绪感染：别人的情绪进入你的身体，影响睡眠与精力。\n- 救援反射：看到痛苦就想立刻解决，容易过度卷入。\n- 边界消失：把“同理”误用成“承担”，最后自己被掏空。\n\n**关键转折：把共情变成“有边界的关怀”**\n高共情不需要牺牲自我。训练重点是三层边界：\n1) **情绪边界**：区分“这是对方的感受”与“这是我的感受”。\n2) **时间边界**：明确陪伴时长与可用精力。\n3) **行动边界**：从“替你解决”转成“陪你一起看见选择”。\n\n**适合你的回应句式**\n- “我听见你很难受，我愿意陪你 10 分钟，先把事情捋清。”\n- “我能提供的是……更深入的部分需要你自己决定。”\n- “我很在乎你，我也需要先照顾好自己的精力。”\n\n**你会在付费报告里得到什么**\n- 边界训练：把共情从消耗变成资源。\n- 调节工具：让情绪不过载、不回流到生活里。\n- 14 天游程：建立可持续的助人方式。",
+                    "id": "eq60_profile_compassion_overload_zh",
+                    "section_key": "cross_quadrant_insight",
+                    "title": "情绪海绵型"
+                },
+                {
+                    "content": "**14 天游程：共情边界与可持续关怀（每天 10–15 分钟）**\n\n目标：保留你的温暖与敏锐，同时建立情绪、时间与行动边界，避免情绪过载。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 区分“我的/你的” | 写下今天一次情绪感染：这是谁的情绪？我能做的是什么？ |\n| Day 2 | 情绪隔离 | 练习一句话：“我看见你很难受，这是你的感受，我在这里陪你。” |\n| Day 3 | 时间边界 | 设定陪伴时长（10/20 分钟），并写下结束句式。 |\n| Day 4 | 行动边界 | 把“替你解决”改成“我陪你看见选择”，写 3 个提问。 |\n| Day 5 | 身体回到自己 | 2 分钟触感练习：握杯子/触摸桌面，回到身体。 |\n| Day 6 | 自我慈悲 | 写 3 句：这很难；我并不孤单；我愿意善待自己。 |\n| Day 7 | 求助与转介 | 列出 3 个可转介资源（朋友/专业/工具），不独自承担。 |\n| Day 8 | 同理而不内卷 | 对话中先复述感受，再问“你想要倾听还是建议？” |\n| Day 9 | 关怀后回收 | 每次深度倾听后做 5 分钟走动/呼吸，回收能量。 |\n| Day10 | 说出限制 | 练习：“我能陪你到这里，之后我需要休息。”并使用 1 次。 |\n| Day11 | 负荷监测 | 今日给情绪负荷打分 0–10，超过 7 时主动减少输入。 |\n| Day12 | 只做一件事 | 把助人行动缩到 1 个最小动作，避免过度卷入。 |\n| Day13 | 关系结构 | 写下 1 段高消耗关系：我需要怎样的边界才能持续？ |\n| Day14 | 复盘与巩固 | 总结 3 条你的边界原则 + 3 句你的关怀脚本。 |\n\n**使用方式**：边界不是冷漠，是让你的关怀变得可持续。",
+                    "id": "eq60_plan_boundary_zh",
+                    "section_key": "action_plan_14d",
+                    "title": "共情边界"
+                },
+                {
+                    "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 付费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                    "id": "eq60_methodology_zh",
+                    "section_key": "methodology",
+                    "title": "方法说明"
+                },
+                {
+                    "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                    "id": "eq60_disclaimer_bottom_zh",
+                    "section_key": "disclaimer_bottom",
+                    "title": "结尾提示"
+                }
+            ],
+            "paid_blocks": []
+        },
+        "dimension_summary": [
+            {
+                "band": "stable",
+                "code": "SA",
+                "label": "自我觉察",
+                "percentile": 42.07,
+                "standard_score": 97
+            },
+            {
+                "band": "foundational",
+                "code": "ER",
+                "label": "情绪调节",
+                "percentile": 12.85,
+                "standard_score": 83
+            },
+            {
+                "band": "integrated",
+                "code": "EM",
+                "label": "共情理解",
+                "percentile": 89.74,
+                "standard_score": 119
+            },
+            {
+                "band": "stable",
+                "code": "RM",
+                "label": "关系管理",
+                "percentile": 47.34,
+                "standard_score": 99
+            }
+        ],
+        "eq_report_mode": "self_report",
+        "generated_at": "2026-05-21T00:00:00.000000Z",
+        "interpretation": {
+            "action_prescription_id": "empathy_boundary",
+            "career_environment_ids": [
+                "emotional_labor_high",
+                "autonomy_recovery_medium",
+                "interpersonal_density_medium"
+            ],
+            "core_formulation_id": "high_empathy_low_recovery",
+            "development_lever": "ER",
+            "primary_mechanism_ids": [
+                "EM_ER_high_low"
+            ],
+            "primary_scene_ids": [
+                "feedback",
+                "conflict",
+                "relationship_boundary"
+            ],
+            "strongest_dimension": "EM"
+        },
+        "legacy_scores": {
+            "EM": {
+                "level": "exceptional",
+                "percentile": 89.74,
+                "pomp": 80,
+                "raw_mean": 4.2,
+                "raw_sum": 63,
+                "std_score": 119,
+                "z": 1.266667
+            },
+            "ER": {
+                "level": "baseline",
+                "percentile": 12.85,
+                "pomp": 50,
+                "raw_mean": 3,
+                "raw_sum": 45,
+                "std_score": 83,
+                "z": -1.133333
+            },
+            "RM": {
+                "level": "competent",
+                "percentile": 47.34,
+                "pomp": 63.33,
+                "raw_mean": 3.5333,
+                "raw_sum": 53,
+                "std_score": 99,
+                "z": -0.066667
+            },
+            "SA": {
+                "level": "competent",
+                "percentile": 42.07,
+                "pomp": 61.67,
+                "raw_mean": 3.4667,
+                "raw_sum": 52,
+                "std_score": 97,
+                "z": -0.2
+            },
+            "emotion_regulation": {
+                "level": "baseline",
+                "percentile": 12.85,
+                "pomp": 50,
+                "raw_mean": 3,
+                "raw_sum": 45,
+                "std_score": 83,
+                "z": -1.133333
+            },
+            "empathy": {
+                "level": "exceptional",
+                "percentile": 89.74,
+                "pomp": 80,
+                "raw_mean": 4.2,
+                "raw_sum": 63,
+                "std_score": 119,
+                "z": 1.266667
+            },
+            "global": {
+                "level": "competent",
+                "percentile": 48.67,
+                "pomp": 63.75,
+                "raw_mean": 3.55,
+                "raw_sum": 213,
+                "std_score": 99.5,
+                "z": -0.033333
+            },
+            "relationship_management": {
+                "level": "competent",
+                "percentile": 47.34,
+                "pomp": 63.33,
+                "raw_mean": 3.5333,
+                "raw_sum": 53,
+                "std_score": 99,
+                "z": -0.066667
+            },
+            "self_awareness": {
+                "level": "competent",
+                "percentile": 42.07,
+                "pomp": 61.67,
+                "raw_mean": 3.4667,
+                "raw_sum": 52,
+                "std_score": 97,
+                "z": -0.2
+            }
+        },
+        "locale": "zh-CN",
+        "measurement_type": "self_report_trait_mixed_ei",
+        "methodology": {
+            "content_version": "EQ_60/v1",
+            "norm_status": "provisional",
+            "report_version": "eq_report_v5_assets",
+            "scoring_version": "v1.0_normed_validity"
+        },
+        "next_module": {
+            "available": false,
+            "cta_asset_id": "eq.sjt_bridge.planned",
+            "module_code": "EQ_SJT_16",
+            "status": "planned"
+        },
+        "quality": {
+            "completion_time_seconds": 420,
+            "confidence_label": "high",
+            "explanation_asset_id": "eq.quality.level.A",
+            "extreme_rate": 0.05,
+            "flags": [],
+            "inconsistency_index": 10,
+            "level": "A",
+            "longstring_max": 15,
+            "metrics": {
+                "completion_time_seconds": 420,
+                "extreme_rate": 0.05,
+                "inconsistency_index": 10,
+                "longstring_max": 15,
+                "neutral_rate": 0.2667
+            },
+            "neutral_rate": 0.2667
+        },
+        "report": {
+            "primary_profile": "profile:compassion_overload",
+            "tags": [
+                "quality_level:A",
+                "profile:compassion_overload",
+                "focus:boundary_setting"
+            ]
+        },
+        "report_tags": [
+            "quality_level:A",
+            "profile:compassion_overload",
+            "focus:boundary_setting"
+        ],
+        "scale_code": "EQ_60",
+        "schema_version": "eq_60.report.v2",
+        "scores": {
+            "dimensions": {
+                "EM": {
+                    "band": "integrated",
+                    "label": "共情理解",
+                    "percentile": 89.74,
+                    "raw_score": 63,
+                    "short_label": "共情理解",
+                    "source_band": "exceptional",
+                    "standard_score": 119
+                },
+                "ER": {
+                    "band": "foundational",
+                    "label": "情绪调节",
+                    "percentile": 12.85,
+                    "raw_score": 45,
+                    "short_label": "情绪调节",
+                    "source_band": "baseline",
+                    "standard_score": 83
+                },
+                "RM": {
+                    "band": "stable",
+                    "label": "关系管理",
+                    "percentile": 47.34,
+                    "raw_score": 53,
+                    "short_label": "关系管理",
+                    "source_band": "competent",
+                    "standard_score": 99
+                },
+                "SA": {
+                    "band": "stable",
+                    "label": "自我觉察",
+                    "percentile": 42.07,
+                    "raw_score": 52,
+                    "short_label": "自我觉察",
+                    "source_band": "competent",
+                    "standard_score": 97
+                }
+            },
+            "global": {
+                "band": "stable",
+                "label": "情绪与关系综合指数",
+                "percentile": 48.67,
+                "raw_score": 213,
+                "source_band": "competent",
+                "standard_score": 99.5
+            }
+        },
+        "sections": [
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                        "id": "eq60_disclaimer_top_zh",
+                        "title": "重要声明",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_top",
+                "module_code": "eq_core",
+                "title": "重要声明"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
+                        "id": "eq60_quality_level_A_zh",
+                        "title": "作答质量提示",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "quality_notice",
+                "module_code": "eq_core",
+                "title": "作答质量提示"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "你的综合 EQ 标准分为 **99.5**（人群平均 100，标准差 15），处于第 **48.67** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
+                        "id": "eq60_global_overview_zh",
+                        "title": "综合概览",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "global_overview",
+                "module_code": "eq_core",
+                "title": "综合概览"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**97**（第 42.07 百分位），阶段：**稳定可用（Competent）**。\n\n你通常能识别情绪，并把情绪与触发点、需求联系起来。你能在大部分场景下清楚表达“我正在紧张/我需要时间/我被忽视了”。这种能力能明显降低误解与内耗，让沟通更聚焦问题本身，而不是被情绪噪音牵着走。\n\n**练习提示**：在关键对话前，用一句话写清“我在乎什么”，让表达更稳定。",
+                        "id": "eq60_sa_competent_zh",
+                        "title": "自我情绪认知 · 稳定可用（Competent）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "self_awareness",
+                "module_code": "eq_core",
+                "title": "自我情绪认知"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**83**（第 12.85 百分位），阶段：**觉察盲区（Baseline）**。\n\n在高压或被触发时，情绪更容易接管行动系统，出现冲动反应、反复纠结、睡眠受影响或持续紧绷。这个分数不代表意志力不足，而是调节工具箱尚未形成稳定的自动化。调节的目标不是“把情绪消灭”，而是把强度与持续时间拉回可管理范围。\n\n**练习提示（90秒）**：停下→缓慢呼气 6 次→把注意力放回脚底触地感，给自己争取“反应前的空隙”。",
+                        "id": "eq60_er_baseline_zh",
+                        "title": "情绪调节与控制 · 觉察盲区（Baseline）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "emotion_regulation",
+                "module_code": "eq_core",
+                "title": "情绪调节与控制"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**119**（第 89.74 百分位），阶段：**卓越稀缺（Exceptional）**。\n\n你的共情能力极强，能在高噪音环境里仍准确读到他人的情绪与动机，并用温和方式回应。这是影响力的重要底座。需要留意的点是：共情强度越高，越要建立边界，避免把别人的情绪带回自己的生活节奏里。\n\n**练习提示**：把“我也很难受”改成“我看见你很难受，我愿意陪你一会儿”，保留边界感。",
+                        "id": "eq60_em_exceptional_zh",
+                        "title": "同理心与社会感知 · 卓越稀缺（Exceptional）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "empathy",
+                "module_code": "eq_core",
+                "title": "同理心与社会感知"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**99**（第 47.34 百分位），阶段：**稳定可用（Competent）**。\n\n你具备良好的沟通与协作能力，能建立稳定的人际网络与信任。你能在多数场景里表达观点、处理分歧、维持关系质量。你通常能在“真实表达”和“关系维护”之间找到平衡。\n\n**练习提示**：遇到分歧时先对齐共同目标，再讨论方案。",
+                        "id": "eq60_rm_competent_zh",
+                        "title": "社交技能与人际管理 · 稳定可用（Competent）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "relationship_management",
+                "module_code": "eq_core",
+                "title": "社交技能与人际管理"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**你的主要画像：情绪海绵型（高同理心 + 低情绪调节）**\n\n本次测评显示：同理心与社会感知 **119** 很高，情绪调节 **83** 偏低。你对他人的痛苦与压力高度敏感，常常会“替别人难受”，也更容易被群体氛围影响。优势是真诚、温暖、能看见别人；代价是情绪过载与边界模糊。\n\n**你常见的优势**\n- 高共鸣：别人更愿意向你倾诉，信任建立更快。\n- 读空气能力强：能敏锐捕捉情绪变化与隐性冲突。\n- 关怀动机：有强烈的助人倾向与责任感。\n\n**常见代价**\n- 情绪感染：别人的情绪进入你的身体，影响睡眠与精力。\n- 救援反射：看到痛苦就想立刻解决，容易过度卷入。\n- 边界消失：把“同理”误用成“承担”，最后自己被掏空。\n\n**关键转折：把共情变成“有边界的关怀”**\n高共情不需要牺牲自我。训练重点是三层边界：\n1) **情绪边界**：区分“这是对方的感受”与“这是我的感受”。\n2) **时间边界**：明确陪伴时长与可用精力。\n3) **行动边界**：从“替你解决”转成“陪你一起看见选择”。\n\n**适合你的回应句式**\n- “我听见你很难受，我愿意陪你 10 分钟，先把事情捋清。”\n- “我能提供的是……更深入的部分需要你自己决定。”\n- “我很在乎你，我也需要先照顾好自己的精力。”\n\n**你会在付费报告里得到什么**\n- 边界训练：把共情从消耗变成资源。\n- 调节工具：让情绪不过载、不回流到生活里。\n- 14 天游程：建立可持续的助人方式。",
+                        "id": "eq60_profile_compassion_overload_zh",
+                        "title": "情绪海绵型",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "cross_quadrant_insight",
+                "module_code": "eq_cross_insights",
+                "title": "交叉洞察长文"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**14 天游程：共情边界与可持续关怀（每天 10–15 分钟）**\n\n目标：保留你的温暖与敏锐，同时建立情绪、时间与行动边界，避免情绪过载。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 区分“我的/你的” | 写下今天一次情绪感染：这是谁的情绪？我能做的是什么？ |\n| Day 2 | 情绪隔离 | 练习一句话：“我看见你很难受，这是你的感受，我在这里陪你。” |\n| Day 3 | 时间边界 | 设定陪伴时长（10/20 分钟），并写下结束句式。 |\n| Day 4 | 行动边界 | 把“替你解决”改成“我陪你看见选择”，写 3 个提问。 |\n| Day 5 | 身体回到自己 | 2 分钟触感练习：握杯子/触摸桌面，回到身体。 |\n| Day 6 | 自我慈悲 | 写 3 句：这很难；我并不孤单；我愿意善待自己。 |\n| Day 7 | 求助与转介 | 列出 3 个可转介资源（朋友/专业/工具），不独自承担。 |\n| Day 8 | 同理而不内卷 | 对话中先复述感受，再问“你想要倾听还是建议？” |\n| Day 9 | 关怀后回收 | 每次深度倾听后做 5 分钟走动/呼吸，回收能量。 |\n| Day10 | 说出限制 | 练习：“我能陪你到这里，之后我需要休息。”并使用 1 次。 |\n| Day11 | 负荷监测 | 今日给情绪负荷打分 0–10，超过 7 时主动减少输入。 |\n| Day12 | 只做一件事 | 把助人行动缩到 1 个最小动作，避免过度卷入。 |\n| Day13 | 关系结构 | 写下 1 段高消耗关系：我需要怎样的边界才能持续？ |\n| Day14 | 复盘与巩固 | 总结 3 条你的边界原则 + 3 句你的关怀脚本。 |\n\n**使用方式**：边界不是冷漠，是让你的关怀变得可持续。",
+                        "id": "eq60_plan_boundary_zh",
+                        "title": "共情边界",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "action_plan_14d",
+                "module_code": "eq_growth_plan",
+                "title": "14 天游程"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 付费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                        "id": "eq60_methodology_zh",
+                        "title": "方法说明",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "methodology",
+                "module_code": "eq_core",
+                "title": "方法说明"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                        "id": "eq60_disclaimer_bottom_zh",
+                        "title": "结尾提示",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_bottom",
+                "module_code": "eq_core",
+                "title": "结尾提示"
+            }
+        ],
+        "variant": "full"
+    },
+    "report_access": {
+        "access_state": "ready",
+        "payload": {
+            "access": {
+                "all_results_free": true,
+                "blur": false,
+                "locked": false,
+                "paywall": false
+            },
+            "access_level": "full",
+            "locked": false,
+            "modules_allowed": [
+                "eq_core",
+                "eq_full",
+                "eq_cross_insights",
+                "eq_growth_plan"
+            ],
+            "modules_preview": [],
+            "offers": [],
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "upgrade_sku": null,
+            "upgrade_sku_effective": null,
+            "variant": "full",
+            "view_policy": {
+                "blur_others": false,
+                "free_sections": [
+                    "disclaimer_top",
+                    "quality_notice",
+                    "global_overview",
+                    "self_awareness",
+                    "emotion_regulation",
+                    "empathy",
+                    "relationship_management",
+                    "cross_quadrant_insight",
+                    "action_plan_14d",
+                    "methodology",
+                    "disclaimer_bottom"
+                ]
+            }
+        },
+        "report_state": "ready"
+    }
+}

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_en.json
@@ -1,0 +1,718 @@
+{
+    "case_id": "EQ60_SPEEDING_C_ZH",
+    "fixture_schema": "eq60.v5.report_contract_fixture.v1",
+    "locale": "en",
+    "report": {
+        "access": {
+            "all_results_free": true,
+            "blur": false,
+            "locked": false,
+            "paywall": false
+        },
+        "asset_refs": {
+            "action_prescription_id": "retest_reflection",
+            "career_environment_ids": [
+                "feedback_intensity_low",
+                "conflict_frequency_low",
+                "autonomy_recovery_high"
+            ],
+            "core_formulation_id": "low_confidence_result",
+            "mechanism_ids": [],
+            "quality_explanation_asset_id": "eq.quality.level.C",
+            "scene_ids": [
+                "pressure_recovery",
+                "feedback",
+                "career_environment"
+            ],
+            "scientific_contract_id": "eq.scientific_contract.default",
+            "score_system_id": "eq.score_system.default",
+            "sjt_bridge_id": "eq.sjt_bridge.planned"
+        },
+        "assets": {
+            "action_prescription": {
+                "do_today": "Record only one cue that feels useful; do not form a stable conclusion.",
+                "id": "retest_reflection",
+                "script": "I will treat this result as a reminder and retake when I am more settled.",
+                "seven_day_plan": [
+                    "Day 1: record your state during response.",
+                    "Day 2: check if you were too fast or tired.",
+                    "Day 3: observe one real situation.",
+                    "Day 4: avoid labeling yourself.",
+                    "Day 5: choose a retest time.",
+                    "Day 6: ensure a quiet setting.",
+                    "Day 7: complete the test again."
+                ],
+                "title": "Retest and Low-Risk Reflection",
+                "watch_out": "Do not use a low-confidence result for major decisions.",
+                "why_this_matters": "Low-confidence results should not drive strong interpretation; they are better used as a retest cue."
+            },
+            "career_environment": [
+                {
+                    "fit_signal": "Fits people sensitive to evaluation who need a steadier rhythm.",
+                    "id": "feedback_intensity_low",
+                    "label": "Low Feedback Intensity",
+                    "level": "low",
+                    "meaning": "Evaluation and revision are less frequent.",
+                    "strain_signal": "Growth feedback may be insufficient.",
+                    "variable": "feedback_intensity",
+                    "what_to_verify": "Check whether clear goals and periodic review still exist."
+                },
+                {
+                    "fit_signal": "Reduces regulation pressure.",
+                    "id": "conflict_frequency_low",
+                    "label": "Low Conflict Frequency",
+                    "level": "low",
+                    "meaning": "Fewer negotiations, complaints, or strong disagreements.",
+                    "strain_signal": "May offer less practice in conflict repair.",
+                    "variable": "conflict_frequency",
+                    "what_to_verify": "Check whether conflict is merely hidden in async communication."
+                },
+                {
+                    "fit_signal": "Helpful for sensitive, reflective, or high-recovery-need people.",
+                    "id": "autonomy_recovery_high",
+                    "label": "High Autonomy Recovery",
+                    "level": "high",
+                    "meaning": "More control over rhythm, communication windows, and deep-work time.",
+                    "strain_signal": "Can also create isolation or insufficient feedback.",
+                    "variable": "autonomy_recovery",
+                    "what_to_verify": "Check that autonomy does not mean lack of support."
+                }
+            ],
+            "core_formulation": {
+                "core_claim": "The system detected response patterns that can reduce interpretive stability, so strong personality claims should not be made.",
+                "development_lever": "Retake when stable, or use only low-risk suggestions.",
+                "do_not_overread": "Do not treat this result as a stable conclusion.",
+                "evidence_basis": [
+                    "Quality level is C or D",
+                    "Speed, long-string, extreme, neutral, or inconsistency signals are present"
+                ],
+                "id": "low_confidence_result",
+                "likely_cost": "Specific dimensions and patterns may be overread.",
+                "one_liner": "Response-quality signals reduce interpretation confidence; read this result cautiously.",
+                "primary_strength": "It can still serve as a reflection cue.",
+                "title": "Lower Confidence Result"
+            },
+            "mechanisms": [],
+            "quality": {
+                "confidence_label": "low",
+                "explanation_asset_id": "eq.quality.level.C"
+            },
+            "reality_scenes": [
+                {
+                    "better_move": "Limit review to three facts, one feeling, and one next action.",
+                    "cost": "Without recovery boundaries, review turns into rumination.",
+                    "id": "pressure_recovery",
+                    "strength": "Review can help you learn patterns.",
+                    "title": "Pressure Recovery",
+                    "typical_response": "After pressure, you may replay conversations, judgments, or details in your head."
+                },
+                {
+                    "better_move": "Separate facts, feeling, and next step: what was said, what I feel, what I need to clarify.",
+                    "cost": "When recovery is weak, feedback may feel like rejection.",
+                    "id": "feedback",
+                    "strength": "You can notice intent and relational temperature behind feedback.",
+                    "title": "Feedback",
+                    "typical_response": "When receiving critique or edits, you may notice tone and relational cues before processing the information."
+                },
+                {
+                    "better_move": "When evaluating roles, ask about interaction frequency, conflict frequency, and recovery space.",
+                    "cost": "Job titles alone can hide the conditions that actually drain you.",
+                    "id": "career_environment",
+                    "strength": "Understanding environmental variables helps you choose a better work rhythm.",
+                    "title": "Career Environment",
+                    "typical_response": "Interpersonal density, emotional labor, and feedback intensity can drain you differently across roles."
+                }
+            ],
+            "scientific_contract": {
+                "non_ability_statement": "This report is not a certified ability assessment and does not claim to measure true emotional intelligence ability.",
+                "non_clinical_statement": "This report is not for clinical diagnosis, treatment advice, or crisis evaluation.",
+                "non_hiring_statement": "This report is not for hiring, selection, promotion, or other high-stakes employment decisions.",
+                "norm_status_statement": "Current norms are provisional. Percentiles and standard scores explain relative position and will be recalibrated as samples grow.",
+                "quality_rules_statement": "The system considers response time, long-string patterns, extreme responding, neutral responding, and consistency signals to estimate interpretation confidence.",
+                "self_report_statement": "This report reflects your subjective self-perception of emotional and relational patterns. It is not an objective ability test.",
+                "test_definition": "This is an emotional and relational pattern report based on 60 self-report items. It explains how you notice, regulate, respond to, and manage emotions in yourself and others.",
+                "version_statement": "Report version eq_report_v5_assets, scoring version v1.0_normed_validity, content version EQ_60/v1."
+            },
+            "score_system": {
+                "bands": {
+                    "developing": "Developing: usable foundations are present, but the pattern may be less stable under pressure or relational complexity.",
+                    "foundational": "Foundational: the current signal suggests this area benefits from more structure, practice, and review.",
+                    "integrated": "Integrated: this dimension is prominent; the key is avoiding overuse and staying contextually flexible.",
+                    "proficient": "Proficient: this dimension is usually a reliable strength signal and may also carry related costs.",
+                    "stable": "Stable: generally usable in everyday contexts, while interpretation still depends on how it combines with other dimensions."
+                },
+                "dimensions": {
+                    "EM": {
+                        "band_explanations": {
+                            "developing": "Empathy has a base, but hidden emotion or real needs may be missed.",
+                            "foundational": "Empathy is foundational; start by confirming the other person's feeling.",
+                            "integrated": "Empathy is highly integrated; avoid over-carrying other people's emotions.",
+                            "proficient": "Empathy is mature enough to notice relational and emotional cues with nuance.",
+                            "stable": "Empathy is stable and usually helps you grasp basic feelings in others."
+                        },
+                        "definition": "The tendency to understand other people's emotions, perspectives, and relational cues.",
+                        "label": "Empathy"
+                    },
+                    "ER": {
+                        "band_explanations": {
+                            "developing": "Emotion regulation has a base, but strong feedback or conflict may still destabilize it.",
+                            "foundational": "Emotion regulation is foundational; build a pause and recovery process first.",
+                            "integrated": "Emotion regulation is highly integrated; avoid over-control and keep authentic feeling available.",
+                            "proficient": "Emotion regulation is mature enough to return to communication after being triggered.",
+                            "stable": "Emotion regulation is stable and usually supports recovery in everyday pressure."
+                        },
+                        "definition": "The tendency to recover, pause, and choose responses during pressure, feedback, or conflict.",
+                        "label": "Emotion Regulation"
+                    },
+                    "RM": {
+                        "band_explanations": {
+                            "developing": "Relationship management has a base, but conflict, boundaries, or repair may be unstable.",
+                            "foundational": "Relationship management is foundational; start with low-risk communication scripts.",
+                            "integrated": "Relationship management is highly integrated; avoid taking too much coordination responsibility.",
+                            "proficient": "Relationship management is mature enough to actively support communication, coordination, and repair.",
+                            "stable": "Relationship management is stable and usually supports constructive action in collaboration."
+                        },
+                        "definition": "The tendency to act constructively in communication, collaboration, repair, and boundaries.",
+                        "label": "Relationship Management"
+                    },
+                    "SA": {
+                        "band_explanations": {
+                            "developing": "Self-awareness has a base, but real triggers may be noticed late under pressure.",
+                            "foundational": "Self-awareness is foundational; start by naming emotions with specific words.",
+                            "integrated": "Self-awareness is highly integrated; the focus is avoiding over-analysis and moving to action.",
+                            "proficient": "Self-awareness is mature enough to catch shifts and underlying needs quickly.",
+                            "stable": "Self-awareness is stable and usually helps you understand key emotional cues."
+                        },
+                        "definition": "The tendency to notice, name, and understand emotional cues in yourself.",
+                        "label": "Self-Awareness"
+                    }
+                },
+                "global_index": {
+                    "label": "Emotional & Relational Functioning Index",
+                    "meaning": "A combined self-report signal across four dimensions, describing the current stability of emotional and relational functioning."
+                },
+                "score_notes": {
+                    "percentile": "Percentiles indicate relative position in the current reference sample and are not ability certification.",
+                    "standard_score": "Standard scores are interpreted against provisional norms. Scores near the mean indicate a stable usable range."
+                }
+            },
+            "sjt_bridge": {
+                "available": false,
+                "button_label": "Scenario module planned",
+                "description": "The current report is based on EQ-60 self-report. A future EQ-SJT 16 module will add how you choose responses in feedback, conflict, boundary, and pressure situations.",
+                "id": "eq.sjt_bridge.planned",
+                "status": "planned",
+                "title": "A 16-item scenario module is planned",
+                "what_it_adds": "It supplements self-report by comparing self-perception with scenario choices.",
+                "what_it_is_not": "It is not MSCEIT, not a certified ability assessment, and not for hiring or clinical decisions."
+            }
+        },
+        "compat": {
+            "free_blocks": [
+                {
+                    "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                    "id": "eq60_disclaimer_top_en",
+                    "section_key": "disclaimer_top",
+                    "title": "Important Notice"
+                },
+                {
+                    "content": "Completion time **90s** is notably short. Very fast responses reduce precision—consider retaking.",
+                    "id": "eq60_quality_flag_SPEEDING_en",
+                    "section_key": "quality_notice",
+                    "title": "Quality Detail"
+                },
+                {
+                    "content": "Response quality is **C**: notable response‑style or consistency issues; treat results as a rough reference and consider retaking.",
+                    "id": "eq60_quality_level_C_en",
+                    "section_key": "quality_notice",
+                    "title": "Response Quality"
+                },
+                {
+                    "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **C**.",
+                    "id": "eq60_global_overview_en",
+                    "section_key": "global_overview",
+                    "title": "Overview"
+                },
+                {
+                    "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
+                    "id": "eq60_sa_proficient_en",
+                    "section_key": "self_awareness",
+                    "title": "Self‑Awareness · Proficient"
+                },
+                {
+                    "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
+                    "id": "eq60_er_proficient_en",
+                    "section_key": "emotion_regulation",
+                    "title": "Emotion Regulation · Proficient"
+                },
+                {
+                    "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
+                    "id": "eq60_em_proficient_en",
+                    "section_key": "empathy",
+                    "title": "Social Awareness & Empathy · Proficient"
+                },
+                {
+                    "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
+                    "id": "eq60_rm_proficient_en",
+                    "section_key": "relationship_management",
+                    "title": "Relationship Management · Proficient"
+                },
+                {
+                    "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nPremium breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What premium adds**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
+                    "id": "eq60_profile_balanced_high_en",
+                    "section_key": "cross_quadrant_insight",
+                    "title": "Balanced High EQ"
+                },
+                {
+                    "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
+                    "id": "eq60_plan_maintenance_en",
+                    "section_key": "action_plan_14d",
+                    "title": "High‑Level Consolidation"
+                },
+                {
+                    "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) Premium content adds cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                    "id": "eq60_methodology_en",
+                    "section_key": "methodology",
+                    "title": "Methodology"
+                },
+                {
+                    "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                    "id": "eq60_disclaimer_bottom_en",
+                    "section_key": "disclaimer_bottom",
+                    "title": "Closing Notes"
+                }
+            ],
+            "paid_blocks": []
+        },
+        "dimension_summary": [
+            {
+                "band": "proficient",
+                "code": "SA",
+                "label": "Self-Awareness",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "ER",
+                "label": "Emotion Regulation",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "EM",
+                "label": "Empathy",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "RM",
+                "label": "Relationship Management",
+                "percentile": 80.69,
+                "standard_score": 113
+            }
+        ],
+        "eq_report_mode": "self_report",
+        "generated_at": "2026-05-21T00:00:00.000000Z",
+        "interpretation": {
+            "action_prescription_id": "retest_reflection",
+            "career_environment_ids": [
+                "feedback_intensity_low",
+                "conflict_frequency_low",
+                "autonomy_recovery_high"
+            ],
+            "core_formulation_id": "low_confidence_result",
+            "development_lever": "SA",
+            "primary_mechanism_ids": [],
+            "primary_scene_ids": [
+                "pressure_recovery",
+                "feedback",
+                "career_environment"
+            ],
+            "strongest_dimension": "SA"
+        },
+        "legacy_scores": {
+            "EM": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "ER": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "RM": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "SA": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "emotion_regulation": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "empathy": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "global": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 240,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "relationship_management": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "self_awareness": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            }
+        },
+        "locale": "en",
+        "measurement_type": "self_report_trait_mixed_ei",
+        "methodology": {
+            "content_version": "EQ_60/v1",
+            "norm_status": "provisional",
+            "report_version": "eq_report_v5_assets",
+            "scoring_version": "v1.0_normed_validity"
+        },
+        "next_module": {
+            "available": false,
+            "cta_asset_id": "eq.sjt_bridge.planned",
+            "module_code": "EQ_SJT_16",
+            "status": "planned"
+        },
+        "quality": {
+            "completion_time_seconds": 90,
+            "confidence_label": "low",
+            "explanation_asset_id": "eq.quality.level.C",
+            "extreme_rate": 0,
+            "flags": [
+                "SPEEDING"
+            ],
+            "inconsistency_index": 0,
+            "level": "C",
+            "longstring_max": 10,
+            "metrics": {
+                "completion_time_seconds": 90,
+                "extreme_rate": 0,
+                "inconsistency_index": 0,
+                "longstring_max": 10,
+                "neutral_rate": 0
+            },
+            "neutral_rate": 0
+        },
+        "report": {
+            "primary_profile": "profile:balanced_high_eq",
+            "tags": [
+                "quality_level:C",
+                "quality_flag:SPEEDING",
+                "profile:balanced_high_eq"
+            ]
+        },
+        "report_tags": [
+            "quality_level:C",
+            "quality_flag:SPEEDING",
+            "profile:balanced_high_eq"
+        ],
+        "scale_code": "EQ_60",
+        "schema_version": "eq_60.report.v2",
+        "scores": {
+            "dimensions": {
+                "EM": {
+                    "band": "proficient",
+                    "label": "Empathy",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "Empathy",
+                    "standard_score": 113
+                },
+                "ER": {
+                    "band": "proficient",
+                    "label": "Emotion Regulation",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "Emotion Regulation",
+                    "standard_score": 113
+                },
+                "RM": {
+                    "band": "proficient",
+                    "label": "Relationship Management",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "Relationship Management",
+                    "standard_score": 113
+                },
+                "SA": {
+                    "band": "proficient",
+                    "label": "Self-Awareness",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "Self-Awareness",
+                    "standard_score": 113
+                }
+            },
+            "global": {
+                "band": "proficient",
+                "label": "Emotional & Relational Functioning Index",
+                "percentile": 80.69,
+                "raw_score": 240,
+                "standard_score": 113
+            }
+        },
+        "sections": [
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                        "id": "eq60_disclaimer_top_en",
+                        "title": "Important Notice",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_top",
+                "module_code": "eq_core",
+                "title": "Important Notice"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "Completion time **90s** is notably short. Very fast responses reduce precision—consider retaking.",
+                        "id": "eq60_quality_flag_SPEEDING_en",
+                        "title": "Quality Detail",
+                        "type": "markdown"
+                    },
+                    {
+                        "content": "Response quality is **C**: notable response‑style or consistency issues; treat results as a rough reference and consider retaking.",
+                        "id": "eq60_quality_level_C_en",
+                        "title": "Response Quality",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "quality_notice",
+                "module_code": "eq_core",
+                "title": "Response Quality"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **C**.",
+                        "id": "eq60_global_overview_en",
+                        "title": "Overview",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "global_overview",
+                "module_code": "eq_core",
+                "title": "Overview"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
+                        "id": "eq60_sa_proficient_en",
+                        "title": "Self‑Awareness · Proficient",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "self_awareness",
+                "module_code": "eq_core",
+                "title": "Self‑Awareness"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
+                        "id": "eq60_er_proficient_en",
+                        "title": "Emotion Regulation · Proficient",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "emotion_regulation",
+                "module_code": "eq_core",
+                "title": "Emotion Regulation"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
+                        "id": "eq60_em_proficient_en",
+                        "title": "Social Awareness & Empathy · Proficient",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "empathy",
+                "module_code": "eq_core",
+                "title": "Social Awareness & Empathy"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
+                        "id": "eq60_rm_proficient_en",
+                        "title": "Relationship Management · Proficient",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "relationship_management",
+                "module_code": "eq_core",
+                "title": "Relationship Management"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nPremium breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What premium adds**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
+                        "id": "eq60_profile_balanced_high_en",
+                        "title": "Balanced High EQ",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "cross_quadrant_insight",
+                "module_code": "eq_cross_insights",
+                "title": "Cross‑Quadrant Insight"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
+                        "id": "eq60_plan_maintenance_en",
+                        "title": "High‑Level Consolidation",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "action_plan_14d",
+                "module_code": "eq_growth_plan",
+                "title": "14‑Day Plan"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) Premium content adds cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                        "id": "eq60_methodology_en",
+                        "title": "Methodology",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "methodology",
+                "module_code": "eq_core",
+                "title": "Methodology"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                        "id": "eq60_disclaimer_bottom_en",
+                        "title": "Closing Notes",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_bottom",
+                "module_code": "eq_core",
+                "title": "Closing Notes"
+            }
+        ],
+        "variant": "full"
+    },
+    "report_access": {
+        "access_state": "ready",
+        "payload": {
+            "access": {
+                "all_results_free": true,
+                "blur": false,
+                "locked": false,
+                "paywall": false
+            },
+            "access_level": "full",
+            "locked": false,
+            "modules_allowed": [
+                "eq_core",
+                "eq_full",
+                "eq_cross_insights",
+                "eq_growth_plan"
+            ],
+            "modules_preview": [],
+            "offers": [],
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "upgrade_sku": null,
+            "upgrade_sku_effective": null,
+            "variant": "full",
+            "view_policy": {
+                "blur_others": false,
+                "free_sections": [
+                    "disclaimer_top",
+                    "quality_notice",
+                    "global_overview",
+                    "self_awareness",
+                    "emotion_regulation",
+                    "empathy",
+                    "relationship_management",
+                    "cross_quadrant_insight",
+                    "action_plan_14d",
+                    "methodology",
+                    "disclaimer_bottom"
+                ]
+            }
+        },
+        "report_state": "ready"
+    }
+}

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_zh.json
@@ -1,0 +1,718 @@
+{
+    "case_id": "EQ60_SPEEDING_C_ZH",
+    "fixture_schema": "eq60.v5.report_contract_fixture.v1",
+    "locale": "zh-CN",
+    "report": {
+        "access": {
+            "all_results_free": true,
+            "blur": false,
+            "locked": false,
+            "paywall": false
+        },
+        "asset_refs": {
+            "action_prescription_id": "retest_reflection",
+            "career_environment_ids": [
+                "feedback_intensity_low",
+                "conflict_frequency_low",
+                "autonomy_recovery_high"
+            ],
+            "core_formulation_id": "low_confidence_result",
+            "mechanism_ids": [],
+            "quality_explanation_asset_id": "eq.quality.level.C",
+            "scene_ids": [
+                "pressure_recovery",
+                "feedback",
+                "career_environment"
+            ],
+            "scientific_contract_id": "eq.scientific_contract.default",
+            "score_system_id": "eq.score_system.default",
+            "sjt_bridge_id": "eq.sjt_bridge.planned"
+        },
+        "assets": {
+            "action_prescription": {
+                "do_today": "只记录一个你认可的线索，不做稳定结论。",
+                "id": "retest_reflection",
+                "script": "这次结果我先当作提醒，等状态稳定后再复测。",
+                "seven_day_plan": [
+                    "第 1 天：记录作答时状态。",
+                    "第 2 天：检查是否太快或太累。",
+                    "第 3 天：观察一个真实场景。",
+                    "第 4 天：不做标签化解释。",
+                    "第 5 天：选择复测时间。",
+                    "第 6 天：保证安静环境。",
+                    "第 7 天：重新完成测试。"
+                ],
+                "title": "复测与低风险反思处方",
+                "watch_out": "不要用低置信度结果做重大决定。",
+                "why_this_matters": "低置信度结果不适合强解释，更适合作为复测提醒。"
+            },
+            "career_environment": [
+                {
+                    "fit_signal": "适合对评价敏感且需要稳定节奏的人。",
+                    "id": "feedback_intensity_low",
+                    "label": "低反馈强度",
+                    "level": "low",
+                    "meaning": "评价和修改频率较低。",
+                    "strain_signal": "成长反馈可能不足。",
+                    "variable": "feedback_intensity",
+                    "what_to_verify": "确认是否仍有清晰目标和周期复盘。"
+                },
+                {
+                    "fit_signal": "降低情绪调节压力。",
+                    "id": "conflict_frequency_low",
+                    "label": "低冲突频率",
+                    "level": "low",
+                    "meaning": "较少谈判、投诉或强分歧。",
+                    "strain_signal": "可能较少训练冲突修复。",
+                    "variable": "conflict_frequency",
+                    "what_to_verify": "确认冲突是否只是被隐藏到异步沟通中。"
+                },
+                {
+                    "fit_signal": "有利于敏感、深度复盘或高恢复需求者。",
+                    "id": "autonomy_recovery_high",
+                    "label": "高自主恢复空间",
+                    "level": "high",
+                    "meaning": "可以较多控制节奏、沟通窗口和深度工作时间。",
+                    "strain_signal": "也可能带来孤立或反馈不足。",
+                    "variable": "autonomy_recovery",
+                    "what_to_verify": "确认独立性不会变成缺少支持。"
+                }
+            ],
+            "core_formulation": {
+                "core_claim": "系统检测到会影响解释稳定性的作答模式，因此不应输出强人格判断。",
+                "development_lever": "在状态稳定时复测，或只使用低风险建议。",
+                "do_not_overread": "不要把这次结果作为稳定结论。",
+                "evidence_basis": [
+                    "质量等级为 C 或 D",
+                    "存在速度、长串、极端、中立或不一致信号"
+                ],
+                "id": "low_confidence_result",
+                "likely_cost": "具体维度和画像容易被误读。",
+                "one_liner": "本次作答质量信号降低了解释置信度，建议先谨慎阅读。",
+                "primary_strength": "仍可作为反思线索。",
+                "title": "本次结果置信度不足"
+            },
+            "mechanisms": [],
+            "quality": {
+                "confidence_label": "low",
+                "explanation_asset_id": "eq.quality.level.C"
+            },
+            "reality_scenes": [
+                {
+                    "better_move": "给复盘设限：只写三个事实、一个感受、一个下次动作。",
+                    "cost": "没有恢复边界时，复盘会变成反刍。",
+                    "id": "pressure_recovery",
+                    "strength": "复盘能力可以帮助你学习模式。",
+                    "title": "压力恢复",
+                    "typical_response": "高压后你可能仍在脑内回放对话、评价或细节。"
+                },
+                {
+                    "better_move": "先拆分事实、情绪和下一步：对方说了什么，我有什么感受，我要确认什么。",
+                    "cost": "如果恢复不足，容易把反馈体验成否定。",
+                    "id": "feedback",
+                    "strength": "能注意到反馈背后的真实意图和关系温度。",
+                    "title": "反馈场景",
+                    "typical_response": "收到评价或修改意见时，你可能先捕捉语气和关系信号，再处理信息本身。"
+                },
+                {
+                    "better_move": "评估岗位时优先询问互动频率、冲突频率和恢复空间。",
+                    "cost": "只看职位名称，容易忽略真正消耗你的工作条件。",
+                    "id": "career_environment",
+                    "strength": "理解环境变量后，更容易选择适合自己的工作节奏。",
+                    "title": "职业环境",
+                    "typical_response": "你对岗位中的人际密度、情绪劳动和反馈强度会有不同消耗。"
+                }
+            ],
+            "scientific_contract": {
+                "non_ability_statement": "本报告不是认证能力测验，也不声称测量真实情商能力。",
+                "non_clinical_statement": "本报告不用于临床诊断、治疗建议或危机评估。",
+                "non_hiring_statement": "本报告不用于招聘筛选、录用、晋升或其他高风险人事决策。",
+                "norm_status_statement": "当前常模为阶段性常模，百分位和标准分用于解释相对位置，后续会随样本增长持续校准。",
+                "quality_rules_statement": "系统会参考作答时长、长串作答、极端反应、中立反应和一致性信号，给出解释置信度。",
+                "self_report_statement": "本报告反映你对自身情绪与关系模式的主观感知，不等同于客观能力测验。",
+                "test_definition": "这是一份基于 60 道自我报告题的情绪与关系模式报告，用于解释你如何感知、调节、回应和管理自己与他人的情绪。",
+                "version_statement": "报告版本 eq_report_v5_assets，计分版本 v1.0_normed_validity，内容版本 EQ_60/v1。"
+            },
+            "score_system": {
+                "bands": {
+                    "developing": "发展中：已经有可用基础，但在压力或复杂关系中可能不够稳定。",
+                    "foundational": "基础发展中：当前信号提示该能力更需要外部结构、练习和复盘支持。",
+                    "integrated": "高度整合：该维度表现突出，重点是避免过度使用并保持情境灵活性。",
+                    "proficient": "熟练成熟：该维度通常是可依赖的优势信号，也可能带来相应消耗。",
+                    "stable": "稳定可用：多数日常场景中可以发挥作用，但仍需要看和其他维度的组合。"
+                },
+                "dimensions": {
+                    "EM": {
+                        "band_explanations": {
+                            "developing": "共情理解已有基础，但可能错过隐性情绪或真实需求。",
+                            "foundational": "共情理解处于基础发展中，建议先练习确认对方感受。",
+                            "integrated": "共情理解高度整合，重点是避免过度承接他人情绪。",
+                            "proficient": "共情理解较成熟，能较细腻地捕捉关系和情绪线索。",
+                            "stable": "共情理解稳定可用，多数场景能把握他人基本感受。"
+                        },
+                        "definition": "理解他人情绪、立场和关系线索的倾向。",
+                        "label": "共情理解"
+                    },
+                    "ER": {
+                        "band_explanations": {
+                            "developing": "情绪调节已有基础，但强反馈或冲突中仍可能不稳定。",
+                            "foundational": "情绪调节处于基础发展中，建议先建立暂停和恢复流程。",
+                            "integrated": "情绪调节高度整合，重点是避免过度控制并保留真实感受。",
+                            "proficient": "情绪调节较成熟，能在触发后较快回到可沟通状态。",
+                            "stable": "情绪调节稳定可用，多数日常压力下能找到恢复方式。"
+                        },
+                        "definition": "在压力、反馈或冲突中恢复、暂停和选择回应方式的倾向。",
+                        "label": "情绪调节"
+                    },
+                    "RM": {
+                        "band_explanations": {
+                            "developing": "关系管理已有基础，但在冲突、边界或修复中可能不稳定。",
+                            "foundational": "关系管理处于基础发展中，建议先学习低风险沟通脚本。",
+                            "integrated": "关系管理高度整合，重点是避免承担过多协调责任。",
+                            "proficient": "关系管理较成熟，能主动推进沟通、协调和修复。",
+                            "stable": "关系管理稳定可用，多数协作场景中能采取建设性行动。"
+                        },
+                        "definition": "在沟通、协作、修复和边界中采取建设性行动的倾向。",
+                        "label": "关系管理"
+                    },
+                    "SA": {
+                        "band_explanations": {
+                            "developing": "自我觉察已有基础，但在压力下可能较晚发现真实触发点。",
+                            "foundational": "自我觉察处于基础发展中，建议先练习用具体词语命名情绪。",
+                            "integrated": "自我觉察高度整合，重点是避免过度分析并转向行动。",
+                            "proficient": "自我觉察较成熟，能较快捕捉情绪变化和背后需求。",
+                            "stable": "自我觉察稳定可用，通常能理解自己的主要情绪线索。"
+                        },
+                        "definition": "识别、命名和理解自身情绪线索的倾向。",
+                        "label": "自我觉察"
+                    }
+                },
+                "global_index": {
+                    "label": "情绪与关系综合指数",
+                    "meaning": "综合四个维度的自我报告信号，描述当前情绪与关系功能的整体稳定度。"
+                },
+                "score_notes": {
+                    "percentile": "百分位表示在当前参考样本中的相对位置，不代表能力认证。",
+                    "standard_score": "标准分以阶段性常模为参照，平均附近代表稳定可用。"
+                }
+            },
+            "sjt_bridge": {
+                "available": false,
+                "button_label": "情境判断模块规划中",
+                "description": "当前报告基于 EQ-60 自我报告。未来 EQ-SJT 16 会补充你在反馈、冲突、边界和压力情境中的选择方式。",
+                "id": "eq.sjt_bridge.planned",
+                "status": "planned",
+                "title": "未来将支持 16 道情境判断模块",
+                "what_it_adds": "它用于补充 self-report，帮助比较自我感知与情境选择之间的一致和差距。",
+                "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，也不用于招聘筛选或临床判断。"
+            }
+        },
+        "compat": {
+            "free_blocks": [
+                {
+                    "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                    "id": "eq60_disclaimer_top_zh",
+                    "section_key": "disclaimer_top",
+                    "title": "重要声明"
+                },
+                {
+                    "content": "完成用时 **90 秒**，明显偏短。快速作答会降低区分度，建议复测以获得更稳的画像。",
+                    "id": "eq60_quality_flag_SPEEDING_zh",
+                    "section_key": "quality_notice",
+                    "title": "作答质量细节"
+                },
+                {
+                    "content": "本次答卷质量等级为 **C**：存在明显作答风格或一致性问题，结果用于自我参考更合适；建议在精力更稳定时复测。",
+                    "id": "eq60_quality_level_C_zh",
+                    "section_key": "quality_notice",
+                    "title": "作答质量提示"
+                },
+                {
+                    "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**C**。",
+                    "id": "eq60_global_overview_zh",
+                    "section_key": "global_overview",
+                    "title": "综合概览"
+                },
+                {
+                    "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
+                    "id": "eq60_sa_proficient_zh",
+                    "section_key": "self_awareness",
+                    "title": "自我情绪认知 · 成熟（Proficient）"
+                },
+                {
+                    "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
+                    "id": "eq60_er_proficient_zh",
+                    "section_key": "emotion_regulation",
+                    "title": "情绪调节与控制 · 成熟（Proficient）"
+                },
+                {
+                    "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
+                    "id": "eq60_em_proficient_zh",
+                    "section_key": "empathy",
+                    "title": "同理心与社会感知 · 成熟（Proficient）"
+                },
+                {
+                    "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
+                    "id": "eq60_rm_proficient_zh",
+                    "section_key": "relationship_management",
+                    "title": "社交技能与人际管理 · 成熟（Proficient）"
+                },
+                {
+                    "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n付费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在付费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
+                    "id": "eq60_profile_balanced_high_zh",
+                    "section_key": "cross_quadrant_insight",
+                    "title": "四维均衡高"
+                },
+                {
+                    "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
+                    "id": "eq60_plan_maintenance_zh",
+                    "section_key": "action_plan_14d",
+                    "title": "高水平巩固"
+                },
+                {
+                    "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 付费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                    "id": "eq60_methodology_zh",
+                    "section_key": "methodology",
+                    "title": "方法说明"
+                },
+                {
+                    "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                    "id": "eq60_disclaimer_bottom_zh",
+                    "section_key": "disclaimer_bottom",
+                    "title": "结尾提示"
+                }
+            ],
+            "paid_blocks": []
+        },
+        "dimension_summary": [
+            {
+                "band": "proficient",
+                "code": "SA",
+                "label": "自我觉察",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "ER",
+                "label": "情绪调节",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "EM",
+                "label": "共情理解",
+                "percentile": 80.69,
+                "standard_score": 113
+            },
+            {
+                "band": "proficient",
+                "code": "RM",
+                "label": "关系管理",
+                "percentile": 80.69,
+                "standard_score": 113
+            }
+        ],
+        "eq_report_mode": "self_report",
+        "generated_at": "2026-05-21T00:00:00.000000Z",
+        "interpretation": {
+            "action_prescription_id": "retest_reflection",
+            "career_environment_ids": [
+                "feedback_intensity_low",
+                "conflict_frequency_low",
+                "autonomy_recovery_high"
+            ],
+            "core_formulation_id": "low_confidence_result",
+            "development_lever": "SA",
+            "primary_mechanism_ids": [],
+            "primary_scene_ids": [
+                "pressure_recovery",
+                "feedback",
+                "career_environment"
+            ],
+            "strongest_dimension": "SA"
+        },
+        "legacy_scores": {
+            "EM": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "ER": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "RM": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "SA": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "emotion_regulation": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "empathy": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "global": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 240,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "relationship_management": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            },
+            "self_awareness": {
+                "level": "proficient",
+                "percentile": 80.69,
+                "pomp": 75,
+                "raw_mean": 4,
+                "raw_sum": 60,
+                "std_score": 113,
+                "z": 0.866667
+            }
+        },
+        "locale": "zh-CN",
+        "measurement_type": "self_report_trait_mixed_ei",
+        "methodology": {
+            "content_version": "EQ_60/v1",
+            "norm_status": "provisional",
+            "report_version": "eq_report_v5_assets",
+            "scoring_version": "v1.0_normed_validity"
+        },
+        "next_module": {
+            "available": false,
+            "cta_asset_id": "eq.sjt_bridge.planned",
+            "module_code": "EQ_SJT_16",
+            "status": "planned"
+        },
+        "quality": {
+            "completion_time_seconds": 90,
+            "confidence_label": "low",
+            "explanation_asset_id": "eq.quality.level.C",
+            "extreme_rate": 0,
+            "flags": [
+                "SPEEDING"
+            ],
+            "inconsistency_index": 0,
+            "level": "C",
+            "longstring_max": 10,
+            "metrics": {
+                "completion_time_seconds": 90,
+                "extreme_rate": 0,
+                "inconsistency_index": 0,
+                "longstring_max": 10,
+                "neutral_rate": 0
+            },
+            "neutral_rate": 0
+        },
+        "report": {
+            "primary_profile": "profile:balanced_high_eq",
+            "tags": [
+                "quality_level:C",
+                "quality_flag:SPEEDING",
+                "profile:balanced_high_eq"
+            ]
+        },
+        "report_tags": [
+            "quality_level:C",
+            "quality_flag:SPEEDING",
+            "profile:balanced_high_eq"
+        ],
+        "scale_code": "EQ_60",
+        "schema_version": "eq_60.report.v2",
+        "scores": {
+            "dimensions": {
+                "EM": {
+                    "band": "proficient",
+                    "label": "共情理解",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "共情理解",
+                    "standard_score": 113
+                },
+                "ER": {
+                    "band": "proficient",
+                    "label": "情绪调节",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "情绪调节",
+                    "standard_score": 113
+                },
+                "RM": {
+                    "band": "proficient",
+                    "label": "关系管理",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "关系管理",
+                    "standard_score": 113
+                },
+                "SA": {
+                    "band": "proficient",
+                    "label": "自我觉察",
+                    "percentile": 80.69,
+                    "raw_score": 60,
+                    "short_label": "自我觉察",
+                    "standard_score": 113
+                }
+            },
+            "global": {
+                "band": "proficient",
+                "label": "情绪与关系综合指数",
+                "percentile": 80.69,
+                "raw_score": 240,
+                "standard_score": 113
+            }
+        },
+        "sections": [
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                        "id": "eq60_disclaimer_top_zh",
+                        "title": "重要声明",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_top",
+                "module_code": "eq_core",
+                "title": "重要声明"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "完成用时 **90 秒**，明显偏短。快速作答会降低区分度，建议复测以获得更稳的画像。",
+                        "id": "eq60_quality_flag_SPEEDING_zh",
+                        "title": "作答质量细节",
+                        "type": "markdown"
+                    },
+                    {
+                        "content": "本次答卷质量等级为 **C**：存在明显作答风格或一致性问题，结果用于自我参考更合适；建议在精力更稳定时复测。",
+                        "id": "eq60_quality_level_C_zh",
+                        "title": "作答质量提示",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "quality_notice",
+                "module_code": "eq_core",
+                "title": "作答质量提示"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**C**。",
+                        "id": "eq60_global_overview_zh",
+                        "title": "综合概览",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "global_overview",
+                "module_code": "eq_core",
+                "title": "综合概览"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
+                        "id": "eq60_sa_proficient_zh",
+                        "title": "自我情绪认知 · 成熟（Proficient）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "self_awareness",
+                "module_code": "eq_core",
+                "title": "自我情绪认知"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
+                        "id": "eq60_er_proficient_zh",
+                        "title": "情绪调节与控制 · 成熟（Proficient）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "emotion_regulation",
+                "module_code": "eq_core",
+                "title": "情绪调节与控制"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
+                        "id": "eq60_em_proficient_zh",
+                        "title": "同理心与社会感知 · 成熟（Proficient）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "empathy",
+                "module_code": "eq_core",
+                "title": "同理心与社会感知"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
+                        "id": "eq60_rm_proficient_zh",
+                        "title": "社交技能与人际管理 · 成熟（Proficient）",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "relationship_management",
+                "module_code": "eq_core",
+                "title": "社交技能与人际管理"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n付费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在付费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
+                        "id": "eq60_profile_balanced_high_zh",
+                        "title": "四维均衡高",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "cross_quadrant_insight",
+                "module_code": "eq_cross_insights",
+                "title": "交叉洞察长文"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
+                        "id": "eq60_plan_maintenance_zh",
+                        "title": "高水平巩固",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "action_plan_14d",
+                "module_code": "eq_growth_plan",
+                "title": "14 天游程"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 付费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                        "id": "eq60_methodology_zh",
+                        "title": "方法说明",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "methodology",
+                "module_code": "eq_core",
+                "title": "方法说明"
+            },
+            {
+                "access_level": "free",
+                "blocks": [
+                    {
+                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                        "id": "eq60_disclaimer_bottom_zh",
+                        "title": "结尾提示",
+                        "type": "markdown"
+                    }
+                ],
+                "key": "disclaimer_bottom",
+                "module_code": "eq_core",
+                "title": "结尾提示"
+            }
+        ],
+        "variant": "full"
+    },
+    "report_access": {
+        "access_state": "ready",
+        "payload": {
+            "access": {
+                "all_results_free": true,
+                "blur": false,
+                "locked": false,
+                "paywall": false
+            },
+            "access_level": "full",
+            "locked": false,
+            "modules_allowed": [
+                "eq_core",
+                "eq_full",
+                "eq_cross_insights",
+                "eq_growth_plan"
+            ],
+            "modules_preview": [],
+            "offers": [],
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "upgrade_sku": null,
+            "upgrade_sku_effective": null,
+            "variant": "full",
+            "view_policy": {
+                "blur_others": false,
+                "free_sections": [
+                    "disclaimer_top",
+                    "quality_notice",
+                    "global_overview",
+                    "self_awareness",
+                    "emotion_regulation",
+                    "empathy",
+                    "relationship_management",
+                    "cross_quadrant_insight",
+                    "action_plan_14d",
+                    "methodology",
+                    "disclaimer_bottom"
+                ]
+            }
+        },
+        "report_state": "ready"
+    }
+}


### PR DESCRIPTION
## What changed
- Adds EQ v5 canonical report/report-access fixtures for balanced, high-empathy-low-recovery, and low-confidence cases in zh-CN and en.
- Adds Eq60V5ReportContractTest to assert fixtures match current composer output and lock v5 fields, resolved assets, SJT planned state, and all-free/no-paywall invariants.

## Why
PR-EQ-V5-01/02 established the backend all-free contract and v5 asset layer. This PR freezes representative payloads so frontend contract/e2e tests can sync against backend-owned fixtures and future changes do not silently break EQ v5.

## Validation
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=Eq60V5ReportContractTest
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=Eq60ReportPaywallTest
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=Eq60SubmitQualityContractTest
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=Eq60GoldenCasesTest
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check

## Intentionally deferred
- No frontend fixture consumption in this backend PR; handled by PR-EQ-V5-04B.
- No EQ scoring, norm, question, SJT, or paywall changes.