### PR TITLE
NODE3-RETIREMENT-FINAL-CHECK｜Final read-only Node3 retirement verification

### DIFF
--- a/docs/04-ops/backend-deploy-target-aliyun-01.md
+++ b/docs/04-ops/backend-deploy-target-aliyun-01.md
@@ -48,6 +48,21 @@ The old GitHub push webhook that targeted `http://122.152.221.126:9000/hooks/dep
 
 Production deployment should use the GitHub Actions/Deployer SSH path to Aliyun, not the old Node3 webhook.
 
+## Node3 Final Check
+
+`NODE3-RETIREMENT-FINAL-CHECK` completed on 2026-05-21:
+
+- Cloudflare and Google public DNS resolve `api.fermatmind.com` and `ops.fermatmind.com` to Aliyun `139.224.130.204`.
+- Aliyun Host-forced smoke checks returned 200 for the public API questions endpoint and Ops login.
+- The old GitHub deploy webhook for Node3 TCP/9000 is inactive.
+- Node3 `webhook.service` is inactive and disabled.
+- Node3 has no TCP/9000 listener, and Aliyun cannot connect to Node3 TCP/9000.
+- Node3 queue worker supervisor groups remain stopped.
+- Node3 ubuntu and www-data Laravel scheduler cron lines remain commented with `NODE3_RETIRED_20260521180344`.
+- Recent Node3 nginx access-log tail showed no API/Ops traffic after the earlier DNS-cutover tail.
+
+Conclusion: Node3 can expire without affecting the current production API/Ops/queue/scheduler/deploy path. Node2 and the still-Tencent DB/Redis path remain separate dependencies until their later migration.
+
 ## Acceptance Checks
 
 ```bash

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T19:05:00+08:00",
+  "updated_at": "2026-05-21T19:08:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15331,7 +15331,7 @@
     "NODE3-RETIREMENT-FINAL-CHECK": {
       "repo": "fap-api",
       "branch": "codex/node3-retirement-final-check",
-      "status": "registered",
+      "status": "completed_external_operation",
       "depends_on": [
         "BACKEND-DEPLOY-TARGET-ALIYUN-01",
         "NODE3-RETIREMENT-PREFLIGHT",
@@ -15340,9 +15340,41 @@
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "dependency_plan": {
-          "status": "pending",
-          "summary": "Requires merged Aliyun deploy target plus completed Node3 preflight and Ops domain migration evidence."
+        "dependencies": {
+          "status": "pass",
+          "summary": "BACKEND-DEPLOY-TARGET-ALIYUN-01 is merged; NODE3-RETIREMENT-PREFLIGHT and OPS-DOMAIN-MIGRATION-01 are completed external operations."
+        },
+        "public_dns": {
+          "status": "pass",
+          "summary": "Cloudflare and Google public DNS resolve api.fermatmind.com and ops.fermatmind.com to Aliyun 139.224.130.204."
+        },
+        "aliyun_runtime_smoke": {
+          "status": "pass",
+          "summary": "Aliyun Host-forced API questions endpoint and Ops login checks returned HTTP 200."
+        },
+        "github_deploy_webhook": {
+          "status": "pass",
+          "summary": "GitHub hook id 598987512 targeting http://122.152.221.126:9000/hooks/deploy-fap-api is inactive."
+        },
+        "node3_webhook": {
+          "status": "pass",
+          "summary": "Node3 webhook.service is inactive/disabled; Node3 has no TCP/9000 listener and Aliyun cannot connect to Node3 TCP/9000."
+        },
+        "node3_queue_workers": {
+          "status": "pass",
+          "summary": "Node3 fap-queue-default-high and fap-queue-reports supervisor groups remain STOPPED."
+        },
+        "node3_scheduler": {
+          "status": "pass",
+          "summary": "Node3 ubuntu and www-data Laravel scheduler cron entries remain commented with NODE3_RETIRED_20260521180344."
+        },
+        "node3_nginx_tail": {
+          "status": "pass",
+          "summary": "Recent Node3 nginx access-log tail showed only earlier DNS-cutover tail traffic and no API/Ops hits after the final check window."
+        },
+        "deploy_target_refusal": {
+          "status": "pass",
+          "summary": "Production deploy config defaults to Aliyun and workflow refuses retired Node3 as DEPLOY_HOST_PROD."
         }
       },
       "failure_reason": null,
@@ -15354,6 +15386,11 @@
           "at": "2026-05-21T19:05:00+08:00",
           "status": "registered",
           "summary": "Registered final read-only Node3 retirement verification before the Tencent Node3 expiry; no poweroff/delete/reboot/DNS/deploy action is authorized."
+        },
+        {
+          "at": "2026-05-21T19:08:00+08:00",
+          "status": "completed_external_operation",
+          "summary": "Completed final read-only Node3 retirement verification. Node3 can expire without affecting current API/Ops/queue/scheduler/deploy paths; Node2 and Tencent DB/Redis remain separate dependencies."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Recorded the final read-only Node3 retirement check.
- Updated the Aliyun backend migration ops ledger with DNS, runtime, webhook, queue, scheduler, port 9000, and deploy-target evidence.
- Marked NODE3-RETIREMENT-FINAL-CHECK as completed in PR-train state.

## Why
Node3 is expiring and should no longer be required for production API/Ops/queue/scheduler/deploy paths.

## Validation
- Public DNS via Cloudflare and Google resolves api.fermatmind.com and ops.fermatmind.com to Aliyun.
- Aliyun Host-forced API and Ops smoke checks returned HTTP 200.
- GitHub deploy webhook targeting Node3 port 9000 is inactive.
- Node3 webhook.service is inactive/disabled, no TCP/9000 listener is present, and Aliyun cannot connect to Node3 TCP/9000.
- Node3 queue workers remain STOPPED.
- Node3 scheduler cron lines remain commented with NODE3_RETIRED_20260521180344.
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check

## Deferred
- No Node3 poweroff, delete, renew, reboot, DNS change, deploy, or service restart was performed.
- Node2 and Tencent DB/Redis remain separate dependencies until their later migration.

## Repository rule impact
Ops ledger only. No CMS authority, SEO/GEO runtime enumeration, frontend fallback, deploy implementation, or production runtime code changed.