### PR TITLE
SEARCH-CHANNEL-LIVE-02-PREFLIGHT｜Block live canary until executor exists

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-02-preflight.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-02-preflight.v1.json
@@ -1,0 +1,58 @@
+{
+  "id": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT",
+  "status": "blocked_live_submission_executor_missing",
+  "checked_at": "2026-05-21T19:12:00+08:00",
+  "live_submission_performed": false,
+  "external_calls_attempted": false,
+  "search_submission_attempted": false,
+  "scheduler_activation": false,
+  "queue_item": {
+    "id": 1,
+    "batch_id": 1,
+    "channel": "indexnow",
+    "canonical_url": "https://fermatmind.com/en",
+    "locale": "en",
+    "page_entity_type": "home",
+    "entity_type": "home",
+    "entity_id": "home:en",
+    "source_authority": "backend_public_surface",
+    "source_table": "backend_authority_canary_contract",
+    "eligibility_state": "eligible",
+    "approval_state": "pending",
+    "execution_state": "dry_run_ready",
+    "indexability_state": "indexable",
+    "claim_boundary_state": "claim_safe",
+    "private_flow": false
+  },
+  "fresh_dry_run": {
+    "status": "success",
+    "dry_run": true,
+    "no_write": true,
+    "candidate_count": 1,
+    "eligible_count": 1,
+    "blocked_count": 0,
+    "planned_queue_count": 1,
+    "channel_breakdown": {
+      "indexnow": 1
+    },
+    "page_type_breakdown": {
+      "home": 1
+    },
+    "writes_attempted": false,
+    "writes_committed": false,
+    "external_calls_attempted": false,
+    "search_submission_attempted": false,
+    "write_gate_enabled": false
+  },
+  "public_url_smoke": {
+    "url": "https://fermatmind.com/en",
+    "http_status": 200
+  },
+  "blockers": [
+    "No live Search Channel submission executor exists in the current backend.",
+    "The current queue command explicitly keeps search_submission_attempted=false and safety_flags.no_live_submission=true.",
+    "Existing IndexNow/Baidu collector foundations block real URL submission."
+  ],
+  "approval_phrase": null,
+  "next_allowed_action": "Add a separate guarded live submission executor before SEARCH-CHANNEL-LIVE-02 can be approved."
+}

--- a/backend/docs/seo/search-channel-live-02-preflight.md
+++ b/backend/docs/seo/search-channel-live-02-preflight.md
@@ -1,0 +1,47 @@
+# SEARCH-CHANNEL-LIVE-02-PREFLIGHT
+
+Status: blocked
+Date: 2026-05-21
+
+## Scope
+
+This preflight checks whether the already-enqueued Search Channel Queue canary item can safely advance to a human-approved small live URL submission.
+
+No live search API call, URL submission, scheduler activation, production env edit, deploy, or additional queue write was performed.
+
+## Evidence
+
+- `SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE` completed with one IndexNow queue item.
+- The latest queue item is `id=1`, `channel=indexnow`, `canonical_url=https://fermatmind.com/en`.
+- The item is `approval_state=pending`, `execution_state=dry_run_ready`, `eligibility_state=eligible`, `indexability_state=indexable`, and `claim_boundary_state=claim_safe`.
+- `source_authority=backend_public_surface`, `source_table=backend_authority_canary_contract`.
+- The queue write gate is disabled.
+- Public `https://fermatmind.com/en` returns HTTP 200.
+- A fresh no-write dry-run for `--channel=indexnow --limit=1` returned `candidate_count=1`, `eligible_count=1`, `planned_queue_count=1`, `writes_committed=false`, `external_calls_attempted=false`, and `search_submission_attempted=false`.
+
+## Blocker
+
+The current backend has no live submission executor for Search Channel Queue items.
+
+`seo-intel:search-channel-queue` can plan and enqueue dry-run-ready items, but its command contract and implementation explicitly keep:
+
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `safety_flags.no_live_submission=true`
+- `safety_flags.no_submit_mode=true`
+
+The existing IndexNow/Baidu collector foundations also block real URL submission. Because there is no live executor to approve, this preflight must not output a live submission approval phrase.
+
+## Decision
+
+`SEARCH-CHANNEL-LIVE-02` is blocked until a separate scoped runtime task adds a guarded live submission executor with:
+
+- exact approved URL and channel matching;
+- one-shot human approval phrase enforcement;
+- queue item approval transition;
+- idempotency protection;
+- external response capture;
+- audit events before and after submission;
+- hard scheduler and bulk-submission disablement.
+
+The current approved action remains: no live submission.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T19:08:00+08:00",
+  "updated_at": "2026-05-21T19:12:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15397,7 +15397,7 @@
     "SEARCH-CHANNEL-LIVE-02-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-preflight",
-      "status": "registered",
+      "status": "blocked_live_submission_executor_missing",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE",
         "NODE3-RETIREMENT-FINAL-CHECK"
@@ -15405,12 +15405,36 @@
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "approval_gate": {
-          "status": "required_before_next_task",
-          "summary": "Must output an exact human approval phrase before SEARCH-CHANNEL-LIVE-02 can perform any live submission."
+        "dependencies": {
+          "status": "pass",
+          "summary": "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE and NODE3-RETIREMENT-FINAL-CHECK are completed."
+        },
+        "queue_item": {
+          "status": "pass",
+          "summary": "Latest queue item id=1 is indexnow https://fermatmind.com/en with approval_state=pending and execution_state=dry_run_ready."
+        },
+        "url_health": {
+          "status": "pass",
+          "summary": "https://fermatmind.com/en returned HTTP 200."
+        },
+        "fresh_dry_run": {
+          "status": "pass",
+          "summary": "seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1 returned candidate_count=1, eligible_count=1, planned_queue_count=1, writes_committed=false, external_calls_attempted=false, search_submission_attempted=false."
+        },
+        "write_gate": {
+          "status": "pass",
+          "summary": "Search Channel Queue write gate is disabled for normal runtime."
+        },
+        "live_executor": {
+          "status": "blocked",
+          "summary": "No guarded live submission executor exists. The current queue command explicitly reports search_submission_attempted=false and safety_flags.no_live_submission=true."
+        },
+        "approval_phrase": {
+          "status": "blocked",
+          "summary": "No SEARCH-CHANNEL-LIVE-02 approval phrase was produced because there is no live executor to approve."
         }
       },
-      "failure_reason": null,
+      "failure_reason": "blocked_live_submission_executor_missing: current backend can plan/enqueue queue items but cannot execute a live IndexNow/Search Channel URL submission.",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -15419,6 +15443,18 @@
           "at": "2026-05-21T19:05:00+08:00",
           "status": "registered",
           "summary": "Registered preflight for a small human-approved Search Channel live submission canary; no live submission is authorized in this preflight."
+        },
+        {
+          "at": "2026-05-21T19:12:00+08:00",
+          "status": "blocked_live_submission_executor_missing",
+          "summary": "Completed preflight checks and blocked SEARCH-CHANNEL-LIVE-02 because no live Search Channel submission executor exists. No approval phrase, live submission, external API call, scheduler activation, env edit, or deploy occurred."
+        }
+      ],
+      "sidecar_issues": [
+        {
+          "title": "Live submission executor missing",
+          "status": "blocking_next_task",
+          "summary": "SEARCH-CHANNEL-LIVE-02 cannot run until a separate scoped runtime task adds a guarded live submission executor with exact URL/channel approval, idempotency, response capture, and audit events."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Recorded SEARCH-CHANNEL-LIVE-02-PREFLIGHT evidence for the existing IndexNow canary queue item.
- Added generated preflight artifact and markdown report.
- Marked the preflight as blocked because no guarded live submission executor exists.

## Why
The queue canary item is healthy, but the current backend only supports planning/enqueueing dry-run-ready Search Channel Queue items. It does not execute live Search Channel submissions.

## Validation
- Latest queue item id=1 is indexnow https://fermatmind.com/en with approval_state=pending and execution_state=dry_run_ready.
- https://fermatmind.com/en returned HTTP 200.
- Fresh dry-run: seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1 returned candidate_count=1, eligible_count=1, planned_queue_count=1, writes_committed=false, external_calls_attempted=false, search_submission_attempted=false.
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-preflight.v1.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check

## Deferred
- No live URL submission was performed.
- No approval phrase was produced because there is no live executor to approve.
- SEARCH-CHANNEL-LIVE-02, DIGITAL-PR-01E-24H-REVIEW, and OPS-SEO-NATIVE-DASH-00 remain blocked behind this preflight.

## Repository rule impact
SEO ops ledger/documentation only. No CMS authority, sitemap/llms behavior, production env, deploy target, frontend fallback, scheduler, or live submission behavior changed.