### PR TITLE
SEARCH-CHANNEL-LIVE-02-EXECUTOR｜Guarded Search Channel live submission executor

### DIFF
--- a/backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php
+++ b/backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueLiveSubmissionExecutor;
+use Illuminate\Console\Command;
+
+final class SeoIntelSearchChannelSubmitCommand extends Command
+{
+    protected $signature = 'seo-intel:search-channel-submit
+        {--queue-item-id= : Exact Search Channel Queue item id}
+        {--approval-phrase= : Exact human approval phrase}
+        {--actor=operator : Sanitized actor id for audit events}
+        {--dry-run : Validate without writes or external calls}
+        {--json : Output safe machine-readable JSON}';
+
+    protected $description = 'Execute a guarded Search Channel live submission for one approved queue item.';
+
+    public function handle(SearchChannelQueueLiveSubmissionExecutor $executor): int
+    {
+        $queueItemId = (int) $this->option('queue-item-id');
+
+        if ($queueItemId < 1) {
+            $payload = [
+                'runtime' => 'search_channel_live_submission',
+                'status' => 'blocked',
+                'issues' => ['queue_item_id_required'],
+                'external_calls_attempted' => false,
+                'search_submission_attempted' => false,
+                'writes_committed' => false,
+            ];
+
+            return $this->finish($payload);
+        }
+
+        $payload = $executor->submit(
+            $queueItemId,
+            $this->nullableOption('approval-phrase'),
+            $this->actor(),
+            (bool) $this->option('dry-run'),
+        );
+
+        return $this->finish($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_SLASHES));
+        } else {
+            foreach (['status', 'queue_item_id', 'channel', 'dry_run', 'external_calls_attempted', 'search_submission_attempted', 'writes_committed', 'submission_status'] as $key) {
+                $this->line($key.'='.$this->stringValue($payload[$key] ?? null));
+            }
+        }
+
+        return ($payload['status'] ?? null) === 'success' ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function nullableOption(string $key): ?string
+    {
+        $value = $this->option($key);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function actor(): string
+    {
+        $actor = preg_replace('/[^A-Za-z0-9:_@.-]/', '_', (string) ($this->option('actor') ?: 'operator'));
+
+        return substr((string) $actor, 0, 128);
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_array($value)) {
+            return (string) json_encode($value, JSON_UNESCAPED_SLASHES);
+        }
+
+        return (string) $value;
+    }
+}

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\SearchChannelQueue;
+
+use App\Services\SeoIntel\SearchChannelSubmissionStatusNormalizer;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+final class SearchChannelQueueLiveSubmissionExecutor
+{
+    public function __construct(
+        private readonly SearchChannelQueueAuditLogger $events,
+        private readonly SearchChannelSubmissionStatusNormalizer $statusNormalizer,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function submit(int $queueItemId, ?string $approvalPhrase, string $actorId, bool $dryRun): array
+    {
+        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
+        $item = $connection->table('seo_search_channel_queue_items')->where('id', $queueItemId)->first();
+
+        if ($item === null) {
+            return $this->blocked($queueItemId, null, ['queue_item_not_found'], $dryRun);
+        }
+
+        $expectedPhrase = $this->approvalPhrase((int) $item->id, (string) $item->channel, (string) $item->canonical_url);
+        $validationIssues = $this->validateItem($item);
+        $gateIssues = $dryRun ? [] : $this->validateLiveGates($item, $approvalPhrase, $expectedPhrase);
+        $issues = array_values(array_unique([...$validationIssues, ...$gateIssues]));
+
+        if ($issues !== []) {
+            return [
+                ...$this->basePayload($item, $dryRun, $expectedPhrase),
+                'status' => 'blocked',
+                'issues' => $issues,
+            ];
+        }
+
+        if ($dryRun) {
+            return [
+                ...$this->basePayload($item, true, $expectedPhrase),
+                'status' => 'success',
+                'issues' => [],
+            ];
+        }
+
+        $now = now();
+        $endpoint = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.endpoint');
+        $key = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.key');
+        $keyLocation = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.key_location');
+        $canonicalUrl = (string) $item->canonical_url;
+        $host = (string) parse_url($canonicalUrl, PHP_URL_HOST);
+
+        $claimed = $connection->table('seo_search_channel_queue_items')
+            ->where('id', (int) $item->id)
+            ->where('approval_state', 'pending')
+            ->where('execution_state', 'dry_run_ready')
+            ->update([
+                'approval_state' => 'approved',
+                'execution_state' => 'submitting',
+                'approved_by' => $actorId,
+                'approved_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+        if ($claimed !== 1) {
+            return [
+                ...$this->basePayload($item, false, $expectedPhrase),
+                'status' => 'blocked',
+                'issues' => ['queue_item_already_claimed'],
+                'writes_attempted' => true,
+            ];
+        }
+
+        $this->events->log($connection, (int) $item->id, is_numeric($item->batch_id) ? (int) $item->batch_id : null, 'live_submission_approved', [
+            'channel' => (string) $item->channel,
+            'url_hash' => (string) $item->url_hash,
+            'approval_phrase_hash' => hash('sha256', $expectedPhrase),
+        ], 'operator', $actorId);
+
+        $httpStatus = null;
+        $accepted = false;
+        $exceptionClass = null;
+
+        try {
+            $response = Http::timeout(max(1, (int) config('seo_intel.search_channel_queue.live_submission.indexnow.timeout_seconds', 10)))
+                ->asJson()
+                ->post($endpoint, [
+                    'host' => $host,
+                    'key' => $key,
+                    'keyLocation' => $keyLocation,
+                    'urlList' => [$canonicalUrl],
+                ]);
+
+            $httpStatus = $response->status();
+            $accepted = $response->successful();
+        } catch (Throwable $exception) {
+            $exceptionClass = $exception::class;
+        }
+
+        $submissionStatus = $this->statusNormalizer->normalize($accepted ? 'accepted' : 'failed');
+        $executionState = $accepted ? 'submitted' : 'submit_failed';
+
+        $connection->table('seo_search_channel_queue_items')
+            ->where('id', (int) $item->id)
+            ->update([
+                'execution_state' => $executionState,
+                'updated_at' => now(),
+            ]);
+
+        $this->events->log($connection, (int) $item->id, is_numeric($item->batch_id) ? (int) $item->batch_id : null, 'live_submission_response', [
+            'channel' => (string) $item->channel,
+            'url_hash' => (string) $item->url_hash,
+            'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+            'http_status' => $httpStatus,
+            'submission_status' => $submissionStatus,
+            'exception_class' => $exceptionClass,
+        ], 'system', 'seo-intel:search-channel-submit');
+
+        return [
+            ...$this->basePayload($item, false, $expectedPhrase),
+            'status' => $accepted ? 'success' : 'failed',
+            'issues' => $accepted ? [] : ['submission_failed'],
+            'external_calls_attempted' => true,
+            'search_submission_attempted' => true,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'submission_status' => $submissionStatus,
+            'execution_state' => $executionState,
+            'http_status' => $httpStatus,
+        ];
+    }
+
+    public function approvalPhrase(int $queueItemId, string $channel, string $canonicalUrl): string
+    {
+        return sprintf(
+            'I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item %d channel %s URL %s.',
+            $queueItemId,
+            $channel,
+            $canonicalUrl,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function validateItem(object $item): array
+    {
+        $issues = [];
+        $url = trim((string) $item->canonical_url);
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+
+        if (! in_array((string) $item->channel, config('seo_intel.search_channel_queue.live_submission.allowed_channels', []), true)) {
+            $issues[] = 'channel_not_live_submission_enabled';
+        }
+
+        if ((string) $item->eligibility_state !== 'eligible') {
+            $issues[] = 'item_not_eligible';
+        }
+
+        if ((string) $item->approval_state !== 'pending') {
+            $issues[] = 'approval_state_not_pending';
+        }
+
+        if ((string) $item->execution_state !== 'dry_run_ready') {
+            $issues[] = 'execution_state_not_dry_run_ready';
+        }
+
+        if ((string) $item->indexability_state !== 'indexable') {
+            $issues[] = 'non_indexable_rejected';
+        }
+
+        if ((string) $item->claim_boundary_state !== 'claim_safe') {
+            $issues[] = 'claim_unsafe_rejected';
+        }
+
+        if ((bool) $item->private_flow) {
+            $issues[] = 'private_flow_rejected';
+        }
+
+        if (! in_array((string) $item->source_authority, config('seo_intel.search_channel_queue.approved_source_authorities', []), true)) {
+            $issues[] = 'source_authority_not_approved';
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            $issues[] = 'invalid_canonical_url';
+        }
+
+        if ($scheme !== 'https') {
+            $issues[] = 'non_https_url_rejected';
+        }
+
+        if (! in_array($host, config('seo_intel.search_channel_queue.live_submission.allowed_hosts', []), true)) {
+            $issues[] = 'host_not_allowed';
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function validateLiveGates(object $item, ?string $approvalPhrase, string $expectedPhrase): array
+    {
+        $issues = [];
+
+        if ($approvalPhrase !== $expectedPhrase) {
+            $issues[] = 'approval_phrase_mismatch';
+        }
+
+        if (! (bool) config('seo_intel.search_channel_queue.live_submission.enabled', false)) {
+            $issues[] = 'live_submission_gate_disabled';
+        }
+
+        if (! (bool) config('seo_intel.search_channel_queue.live_submission.external_api_calls_enabled', false)) {
+            $issues[] = 'external_api_gate_disabled';
+        }
+
+        if ((string) $item->channel === 'indexnow' && ! (bool) config('seo_intel.indexnow_live_api_enabled', false)) {
+            $issues[] = 'indexnow_live_api_disabled';
+        }
+
+        if (trim((string) config('seo_intel.search_channel_queue.live_submission.indexnow.key')) === '') {
+            $issues[] = 'indexnow_key_missing';
+        }
+
+        if (trim((string) config('seo_intel.search_channel_queue.live_submission.indexnow.key_location')) === '') {
+            $issues[] = 'indexnow_key_location_missing';
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function basePayload(object $item, bool $dryRun, string $approvalPhrase): array
+    {
+        return [
+            'runtime' => 'search_channel_live_submission',
+            'queue_item_id' => (int) $item->id,
+            'channel' => (string) $item->channel,
+            'canonical_url' => (string) $item->canonical_url,
+            'dry_run' => $dryRun,
+            'approval_phrase' => $approvalPhrase,
+            'external_calls_attempted' => false,
+            'search_submission_attempted' => false,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'submission_status' => 'not_attempted',
+            'execution_state' => (string) $item->execution_state,
+            'safety_flags' => [
+                'scheduler_enabled' => false,
+                'bulk_submission' => false,
+                'raw_secret_output' => false,
+                'sitemap_llms_behavior_changed' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blocked(int $queueItemId, ?object $item, array $issues, bool $dryRun): array
+    {
+        return [
+            'runtime' => 'search_channel_live_submission',
+            'status' => 'blocked',
+            'queue_item_id' => $queueItemId,
+            'channel' => $item === null ? null : (string) $item->channel,
+            'canonical_url' => $item === null ? null : (string) $item->canonical_url,
+            'dry_run' => $dryRun,
+            'approval_phrase' => null,
+            'external_calls_attempted' => false,
+            'search_submission_attempted' => false,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'submission_status' => 'not_attempted',
+            'execution_state' => $item === null ? null : (string) $item->execution_state,
+            'issues' => $issues,
+            'safety_flags' => [
+                'scheduler_enabled' => false,
+                'bulk_submission' => false,
+                'raw_secret_output' => false,
+                'sitemap_llms_behavior_changed' => false,
+            ],
+        ];
+    }
+}

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -219,7 +219,7 @@ return [
     'baidu_enabled' => env('SEO_INTEL_BAIDU_ENABLED', false),
     'baidu_live_api_enabled' => false,
     'indexnow_enabled' => env('SEO_INTEL_INDEXNOW_ENABLED', false),
-    'indexnow_live_api_enabled' => false,
+    'indexnow_live_api_enabled' => env('SEO_INTEL_INDEXNOW_LIVE_API_ENABLED', false),
     'baidu_source_engine' => 'baidu',
     'indexnow_source_engine' => 'bing_indexnow',
     'baidu_foundation' => [
@@ -307,6 +307,22 @@ return [
             'seo_baidu_push_logs',
             'seo_indexnow_submissions',
             'seo_domestic_submission_logs',
+        ],
+        'live_submission' => [
+            'enabled' => env('SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED', false),
+            'external_api_calls_enabled' => env('SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED', false),
+            'allowed_channels' => [
+                'indexnow',
+            ],
+            'allowed_hosts' => [
+                'fermatmind.com',
+            ],
+            'indexnow' => [
+                'endpoint' => env('SEO_INTEL_INDEXNOW_ENDPOINT', 'https://api.indexnow.org/indexnow'),
+                'key' => env('SEO_INTEL_INDEXNOW_KEY'),
+                'key_location' => env('SEO_INTEL_INDEXNOW_KEY_LOCATION'),
+                'timeout_seconds' => env('SEO_INTEL_INDEXNOW_TIMEOUT_SECONDS', 10),
+            ],
         ],
     ],
     'so360_enabled' => env('SEO_INTEL_SO360_ENABLED', false),

--- a/backend/docs/seo/generated/search-channel-live-02-executor.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-02-executor.v1.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "search-channel-live-02-executor.v1",
+  "task_id": "SEARCH-CHANNEL-LIVE-02-EXECUTOR",
+  "runtime": "search_channel_live_submission",
+  "command": "seo-intel:search-channel-submit",
+  "next_task": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT",
+  "live_submission_performed_in_this_task": false,
+  "default_live_submission_enabled": false,
+  "scheduler_registered": false,
+  "bulk_submission_supported": false,
+  "atomic_single_item_claim_required": true,
+  "raw_secret_output_allowed": false,
+  "sitemap_llms_behavior_changed": false,
+  "supported_live_channels": [
+    "indexnow"
+  ],
+  "allowed_hosts": [
+    "fermatmind.com"
+  ],
+  "required_env_gates": [
+    "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED",
+    "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED",
+    "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED",
+    "SEO_INTEL_INDEXNOW_KEY",
+    "SEO_INTEL_INDEXNOW_KEY_LOCATION"
+  ],
+  "approval_phrase_template": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item <id> channel <channel> URL <canonical_url>.",
+  "required_queue_item_state": {
+    "eligibility_state": "eligible",
+    "approval_state": "pending",
+    "execution_state": "dry_run_ready",
+    "indexability_state": "indexable",
+    "claim_boundary_state": "claim_safe",
+    "private_flow": false
+  },
+  "target_tables": [
+    "seo_search_channel_queue_items",
+    "seo_search_channel_queue_events"
+  ],
+  "audit_events": [
+    "live_submission_approved",
+    "live_submission_response"
+  ],
+  "protected_boundaries": {
+    "no_scheduler_activation": true,
+    "no_bulk_submission": true,
+    "single_item_idempotency_guard": true,
+    "no_production_env_edit": true,
+    "no_deploy": true,
+    "no_raw_key_or_key_location_output": true,
+    "no_full_url_in_audit_event_payload": true
+  }
+}

--- a/backend/docs/seo/search-channel-live-02-executor.md
+++ b/backend/docs/seo/search-channel-live-02-executor.md
@@ -1,0 +1,94 @@
+# Search Channel Live 02 Executor
+
+Task: `SEARCH-CHANNEL-LIVE-02-EXECUTOR`
+
+This task adds the guarded executor needed before rerunning
+`SEARCH-CHANNEL-LIVE-02-PREFLIGHT`. It does not authorize or perform a live
+submission by itself.
+
+## Runtime Contract
+
+- Command: `seo-intel:search-channel-submit`
+- Scope: exactly one existing queue item selected by `--queue-item-id`
+- Supported live channel in this task: `indexnow`
+- Allowed host in this task: `fermatmind.com`
+- Default mode: blocked unless every live gate is explicitly enabled
+- Scheduler: not registered
+- Bulk submission: not supported
+- Idempotency: the item is atomically claimed from `pending/dry_run_ready`
+  before any provider request
+- Secrets: not printed in command output or audit event payloads
+- Sitemap and `llms.txt` behavior: unchanged
+
+Dry-run command:
+
+```bash
+php artisan seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json
+```
+
+Live command shape, for a later human-approved canary only:
+
+```bash
+php artisan seo-intel:search-channel-submit --queue-item-id=1 --approval-phrase="<exact phrase>" --actor=operator --json
+```
+
+The exact phrase is generated from the queue item id, channel, and canonical URL:
+
+```text
+I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item <id> channel <channel> URL <canonical_url>.
+```
+
+## Required Gates
+
+Actual live submission requires all of these gates:
+
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=true`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=true`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=true`
+- `SEO_INTEL_INDEXNOW_KEY` is present
+- `SEO_INTEL_INDEXNOW_KEY_LOCATION` is present
+- The exact human approval phrase is supplied
+
+Default config keeps these gates disabled or empty.
+
+## Queue Item Requirements
+
+The executor rejects the item unless it is:
+
+- `eligibility_state=eligible`
+- `approval_state=pending`
+- `execution_state=dry_run_ready`
+- `indexability_state=indexable`
+- `claim_boundary_state=claim_safe`
+- `private_flow=false`
+- `source_authority` is backend-approved
+- HTTPS URL under an allowed host
+
+After an accepted IndexNow response, the executor sets:
+
+- `approval_state=approved`
+- `execution_state=submitted`
+- `approved_by=<actor>`
+- `approved_at=<timestamp>`
+
+Failed provider calls are recorded as `execution_state=submit_failed`.
+
+If another process has already claimed or submitted the item, the executor
+blocks before any external call.
+
+## Audit Events
+
+The executor writes only Search Channel Queue audit events:
+
+- `live_submission_approved`
+- `live_submission_response`
+
+Event payloads use `url_hash`, endpoint host, HTTP status, normalized submission
+status, and optional exception class. They do not contain raw keys or the full
+submitted URL.
+
+## Deferred
+
+Next task: rerun `SEARCH-CHANNEL-LIVE-02-PREFLIGHT` after this executor is
+merged. The later preflight must verify the production queue item, emit the
+exact approval phrase, and still perform no live submission.

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveSubmissionExecutorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveSubmissionExecutorTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueLiveSubmissionExecutor;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLiveSubmissionExecutorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+            'seo_intel.indexnow_live_api_enabled' => false,
+            'seo_intel.search_channel_queue.live_submission.enabled' => false,
+            'seo_intel.search_channel_queue.live_submission.external_api_calls_enabled' => false,
+            'seo_intel.search_channel_queue.live_submission.allowed_channels' => ['indexnow'],
+            'seo_intel.search_channel_queue.live_submission.allowed_hosts' => ['fermatmind.com'],
+            'seo_intel.search_channel_queue.live_submission.indexnow.endpoint' => 'https://api.indexnow.test/indexnow',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key' => null,
+            'seo_intel.search_channel_queue.live_submission.indexnow.key_location' => null,
+            'seo_intel.search_channel_queue.approved_source_authorities' => [
+                'backend_cms',
+                'backend_public_surface',
+                'scale_catalog',
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function dry_run_outputs_exact_phrase_without_external_call_or_writes(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem();
+
+        [$exitCode, $payload] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertSame(
+            'I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item '.$queueItemId.' channel indexnow URL https://fermatmind.com/en.',
+            $payload['approval_phrase'] ?? null,
+        );
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+
+        $item = DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->first();
+        $this->assertSame('pending', $item->approval_state);
+        $this->assertSame('dry_run_ready', $item->execution_state);
+        $this->assertNull($item->approved_by);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function live_submission_requires_exact_phrase_and_all_gates(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem();
+
+        [$exitCode, $payload] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--approval-phrase' => 'wrong approval phrase',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('approval_phrase_mismatch', $payload['issues'] ?? []);
+        $this->assertContains('live_submission_gate_disabled', $payload['issues'] ?? []);
+        $this->assertContains('external_api_gate_disabled', $payload['issues'] ?? []);
+        $this->assertContains('indexnow_live_api_disabled', $payload['issues'] ?? []);
+        $this->assertContains('indexnow_key_missing', $payload['issues'] ?? []);
+        $this->assertContains('indexnow_key_location_missing', $payload['issues'] ?? []);
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function approved_indexnow_submission_updates_queue_and_logs_sanitized_events(): void
+    {
+        config([
+            'seo_intel.indexnow_live_api_enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.external_api_calls_enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.indexnow.key' => 'secret-indexnow-key',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key_location' => 'https://fermatmind.com/indexnow.txt',
+        ]);
+
+        Http::fake([
+            'api.indexnow.test/*' => Http::response('', 202),
+        ]);
+
+        $queueItemId = $this->seedQueueItem();
+        $approvalPhrase = app(SearchChannelQueueLiveSubmissionExecutor::class)
+            ->approvalPhrase($queueItemId, 'indexnow', 'https://fermatmind.com/en');
+
+        [$exitCode, $payload, $rawOutput] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--approval-phrase' => $approvalPhrase,
+            '--actor' => 'seo-ops@example.com',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['external_calls_attempted'] ?? false));
+        $this->assertTrue((bool) ($payload['search_submission_attempted'] ?? false));
+        $this->assertSame('accepted', $payload['submission_status'] ?? null);
+        $this->assertSame('submitted', $payload['execution_state'] ?? null);
+        $this->assertSame(202, $payload['http_status'] ?? null);
+        $this->assertStringNotContainsString('secret-indexnow-key', $rawOutput);
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://api.indexnow.test/indexnow'
+                && $request['host'] === 'fermatmind.com'
+                && $request['urlList'] === ['https://fermatmind.com/en']
+                && $request['key'] === 'secret-indexnow-key'
+                && $request['keyLocation'] === 'https://fermatmind.com/indexnow.txt';
+        });
+
+        $item = DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->first();
+        $this->assertSame('approved', $item->approval_state);
+        $this->assertSame('submitted', $item->execution_state);
+        $this->assertSame('seo-ops@example.com', $item->approved_by);
+        $this->assertNotNull($item->approved_at);
+
+        $events = DB::connection('seo_intel')
+            ->table('seo_search_channel_queue_events')
+            ->where('queue_item_id', $queueItemId)
+            ->orderBy('id')
+            ->get();
+
+        $this->assertSame(['live_submission_approved', 'live_submission_response'], $events->pluck('event_type')->all());
+        $this->assertSame('operator', $events[0]->actor_type);
+        $this->assertSame('seo-ops@example.com', $events[0]->actor_id);
+        $this->assertSame('system', $events[1]->actor_type);
+
+        foreach ($events as $event) {
+            $this->assertStringNotContainsString('secret-indexnow-key', (string) $event->event_payload);
+            $this->assertStringNotContainsString('https://fermatmind.com/en', (string) $event->event_payload);
+        }
+
+        [$secondExitCode, $secondPayload] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--approval-phrase' => $approvalPhrase,
+            '--actor' => 'seo-ops@example.com',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $secondExitCode);
+        $this->assertSame('blocked', $secondPayload['status'] ?? null);
+        $this->assertContains('approval_state_not_pending', $secondPayload['issues'] ?? []);
+        $this->assertContains('execution_state_not_dry_run_ready', $secondPayload['issues'] ?? []);
+        Http::assertSentCount(1);
+    }
+
+    #[Test]
+    public function unsafe_queue_item_is_rejected_without_writes_or_external_calls(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem([
+            'canonical_url' => 'https://example.com/en',
+            'indexability_state' => 'noindex',
+        ]);
+
+        [$exitCode, $payload] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('non_indexable_rejected', $payload['issues'] ?? []);
+        $this->assertContains('host_not_allowed', $payload['issues'] ?? []);
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function generated_artifact_locks_executor_safety_boundary(): void
+    {
+        $artifactPath = base_path('docs/seo/generated/search-channel-live-02-executor.v1.json');
+        $this->assertFileExists($artifactPath);
+
+        $artifact = json_decode((string) file_get_contents($artifactPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('search-channel-live-02-executor.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('SEARCH-CHANNEL-LIVE-02-EXECUTOR', $artifact['task_id'] ?? null);
+        $this->assertSame('seo-intel:search-channel-submit', $artifact['command'] ?? null);
+        $this->assertSame('SEARCH-CHANNEL-LIVE-02-PREFLIGHT', $artifact['next_task'] ?? null);
+        $this->assertFalse((bool) ($artifact['live_submission_performed_in_this_task'] ?? true));
+        $this->assertFalse((bool) ($artifact['scheduler_registered'] ?? true));
+        $this->assertFalse((bool) ($artifact['bulk_submission_supported'] ?? true));
+        $this->assertTrue((bool) ($artifact['atomic_single_item_claim_required'] ?? false));
+        $this->assertFalse((bool) ($artifact['raw_secret_output_allowed'] ?? true));
+        $this->assertContains('indexnow', $artifact['supported_live_channels'] ?? []);
+        $this->assertContains('fermatmind.com', $artifact['allowed_hosts'] ?? []);
+        $this->assertContains('SEO_INTEL_INDEXNOW_LIVE_API_ENABLED', $artifact['required_env_gates'] ?? []);
+        $this->assertSame('dry_run_ready', data_get($artifact, 'required_queue_item_state.execution_state'));
+        $this->assertTrue((bool) data_get($artifact, 'protected_boundaries.no_full_url_in_audit_event_payload'));
+        $this->assertTrue((bool) data_get($artifact, 'protected_boundaries.single_item_idempotency_guard'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array{0:int,1:array<string,mixed>,2:string}
+     */
+    private function runSubmitCommand(array $arguments): array
+    {
+        $exitCode = Artisan::call('seo-intel:search-channel-submit', $arguments);
+        $rawOutput = trim(Artisan::output());
+
+        $this->assertNotSame('', $rawOutput);
+        $payload = json_decode($rawOutput, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return [$exitCode, $payload, $rawOutput];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedQueueItem(array $overrides = []): int
+    {
+        $canonicalUrl = (string) ($overrides['canonical_url'] ?? 'https://fermatmind.com/en');
+        $channel = (string) ($overrides['channel'] ?? 'indexnow');
+        $now = now();
+
+        return (int) DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insertGetId([
+            'batch_id' => $overrides['batch_id'] ?? 1,
+            'canonical_url' => $canonicalUrl,
+            'locale' => $overrides['locale'] ?? 'en',
+            'page_entity_type' => $overrides['page_entity_type'] ?? 'home',
+            'entity_type' => $overrides['entity_type'] ?? 'home',
+            'entity_id' => $overrides['entity_id'] ?? 'home:en',
+            'source_authority' => $overrides['source_authority'] ?? 'backend_public_surface',
+            'source_table' => $overrides['source_table'] ?? 'backend_authority_canary_contract',
+            'channel' => $channel,
+            'eligibility_state' => $overrides['eligibility_state'] ?? 'eligible',
+            'approval_state' => $overrides['approval_state'] ?? 'pending',
+            'execution_state' => $overrides['execution_state'] ?? 'dry_run_ready',
+            'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
+            'claim_boundary_state' => $overrides['claim_boundary_state'] ?? 'claim_safe',
+            'private_flow' => (bool) ($overrides['private_flow'] ?? false),
+            'reason_codes' => $overrides['reason_codes'] ?? null,
+            'lastmod' => $now,
+            'content_hash' => hash('sha256', 'home:en'),
+            'url_hash' => hash('sha256', $canonicalUrl),
+            'idempotency_key' => hash('sha256', $canonicalUrl.'|'.$channel),
+            'approved_by' => null,
+            'approved_at' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_events', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('queue_item_id')->nullable();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->string('event_type', 96);
+            $table->json('event_payload')->nullable();
+            $table->string('actor_type', 64)->default('system');
+            $table->string('actor_id', 128)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -536,11 +536,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php',
+            'backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueAuditLogger.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueChannelMapper.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityEvaluator.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityResult.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php',
+            'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueWriteService.php',
             'backend/database/migrations/seo_intel/2026_05_20_220000_create_seo_search_channel_queue_tables.php',
@@ -2387,11 +2389,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php',
+            'backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueAuditLogger.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueChannelMapper.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityEvaluator.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityResult.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php',
+            'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueWriteService.php',
             'backend/database/migrations/seo_intel/2026_05_20_220000_create_seo_search_channel_queue_tables.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T19:52:00+08:00",
+  "updated_at": "2026-05-21T19:55:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15470,12 +15470,12 @@
     "SEARCH-CHANNEL-LIVE-02-EXECUTOR": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-executor",
-      "status": "local_validation_passed",
+      "status": "pr_opened_github_checks_pending",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-02-PREFLIGHT"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "3151d3388972bf1e358bef547229c1665389e995",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1529",
       "checks": {
         "dependencies": {
           "status": "pass",
@@ -15518,6 +15518,10 @@
           "status": "pass",
           "command": "python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-executor.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\" && git diff --check",
           "summary": "Generated JSON, PR-train state JSON, PR-train YAML, and whitespace diff check passed."
+        },
+        "github_pr": {
+          "status": "pending",
+          "summary": "Opened PR #1529 for SEARCH-CHANNEL-LIVE-02-EXECUTOR; GitHub checks are pending."
         }
       },
       "failure_reason": null,
@@ -15544,6 +15548,11 @@
           "at": "2026-05-21T19:50:00+08:00",
           "status": "idempotency_guard_added",
           "summary": "Tightened executor to atomically claim a pending/dry_run_ready queue item before any provider request and verified repeat execution does not send a second HTTP call."
+        },
+        {
+          "at": "2026-05-21T19:55:00+08:00",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1529 for the guarded live submission executor. No live submission or production operation occurred."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T19:12:00+08:00",
+  "updated_at": "2026-05-21T19:52:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15397,13 +15397,13 @@
     "SEARCH-CHANNEL-LIVE-02-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-preflight",
-      "status": "blocked_live_submission_executor_missing",
+      "status": "merged",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE",
         "NODE3-RETIREMENT-FINAL-CHECK"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "b70820f751ce5b7a26552145e9e49efc70d6b195",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1528",
       "checks": {
         "dependencies": {
           "status": "pass",
@@ -15432,12 +15432,16 @@
         "approval_phrase": {
           "status": "blocked",
           "summary": "No SEARCH-CHANNEL-LIVE-02 approval phrase was produced because there is no live executor to approve."
+        },
+        "github_merge_reconciliation": {
+          "status": "pass",
+          "summary": "GitHub PR #1528 is MERGED and origin/main contains merge commit b70820f751ce5b7a26552145e9e49efc70d6b195; remote task branch is absent."
         }
       },
       "failure_reason": "blocked_live_submission_executor_missing: current backend can plan/enqueue queue items but cannot execute a live IndexNow/Search Channel URL submission.",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-21T11:21:58Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-21T19:05:00+08:00",
@@ -15448,6 +15452,11 @@
           "at": "2026-05-21T19:12:00+08:00",
           "status": "blocked_live_submission_executor_missing",
           "summary": "Completed preflight checks and blocked SEARCH-CHANNEL-LIVE-02 because no live Search Channel submission executor exists. No approval phrase, live submission, external API call, scheduler activation, env edit, or deploy occurred."
+        },
+        {
+          "at": "2026-05-21T19:34:00+08:00",
+          "status": "merged_blocked_live_submission_executor_missing",
+          "summary": "Reconciled SEARCH-CHANNEL-LIVE-02-PREFLIGHT as merged via PR #1528 while preserving the executor-missing blocker; this unblocks the separate executor task only, not live submission."
         }
       ],
       "sidecar_issues": [
@@ -15455,6 +15464,86 @@
           "title": "Live submission executor missing",
           "status": "blocking_next_task",
           "summary": "SEARCH-CHANNEL-LIVE-02 cannot run until a separate scoped runtime task adds a guarded live submission executor with exact URL/channel approval, idempotency, response capture, and audit events."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-LIVE-02-EXECUTOR": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-02-executor",
+      "status": "local_validation_passed",
+      "depends_on": [
+        "SEARCH-CHANNEL-LIVE-02-PREFLIGHT"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependencies": {
+          "status": "pass",
+          "summary": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT is merged via PR #1528 and recorded as blocked only by missing executor."
+        },
+        "scope": {
+          "status": "pass",
+          "summary": "Scope is limited to guarded single-item live submission executor, atomic claim/idempotency guard, config gates, docs/generated artifact, focused tests, BigFive runtime-freeze guard allowlist, and PR-train metadata."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelSearchChannelLiveSubmissionExecutor",
+          "summary": "5 tests passed, 83 assertions after adding atomic single-item claim/idempotency coverage."
+        },
+        "live_submission": {
+          "status": "pass_no_live_submission",
+          "summary": "No production live submission, external provider call, scheduler activation, env edit, deployment, or DNS/runtime change occurred in this task."
+        },
+        "bigfive_runtime_freeze_guard": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff",
+          "summary": "1 test passed, 3 assertions; new SeoIntel executor files are excluded from MBTI runtime-impact classification."
+        },
+        "queue_runtime_regression": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelSearchChannelQueueRuntime",
+          "summary": "17 tests passed, 104 assertions; queue planner/enqueue remains no-submit by default."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "summary": "Route list rendered successfully."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "summary": "3429 files passed after final atomic claim/idempotency update."
+        },
+        "json_yaml_diff": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-executor.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\" && git diff --check",
+          "summary": "Generated JSON, PR-train state JSON, PR-train YAML, and whitespace diff check passed."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-21T19:34:00+08:00",
+          "status": "registered",
+          "summary": "Registered separate scoped executor task after SEARCH-CHANNEL-LIVE-02-PREFLIGHT found no guarded live submission executor."
+        },
+        {
+          "at": "2026-05-21T19:34:00+08:00",
+          "status": "in_progress",
+          "summary": "Implemented guarded single-item IndexNow executor with exact approval phrase, explicit gates, safe audit events, no scheduler, no bulk submission, and faked-only tests."
+        },
+        {
+          "at": "2026-05-21T19:46:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Local validation passed for executor focused tests, BigFive runtime freeze guard, queue runtime regression, route list, Pint, JSON/YAML validation, and git diff check. No live submission or production operation occurred."
+        },
+        {
+          "at": "2026-05-21T19:50:00+08:00",
+          "status": "idempotency_guard_added",
+          "summary": "Tightened executor to atomically claim a pending/dry_run_ready queue item before any provider request and verified repeat execution does not send a second HTTP call."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -8076,7 +8076,58 @@ prs:
     production_migration_execution_allowed: false
     external_api_credentials_required: true
     scheduler_activation: false
-    next_task: SEARCH-CHANNEL-LIVE-02
+    next_task: SEARCH-CHANNEL-LIVE-02-EXECUTOR
+
+  - id: SEARCH-CHANNEL-LIVE-02-EXECUTOR
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-LIVE-02-PREFLIGHT
+    branch: codex/search-channel-live-02-executor
+    base: main
+    title: "SEARCH-CHANNEL-LIVE-02-EXECUTOR｜Guarded Search Channel live submission executor"
+    name: "Guarded Search Channel live submission executor"
+    train_scope: search_channel_live_submission
+    risk_level: L2
+    type: runtime guardrail
+    scope:
+      - Add a guarded single-item Search Channel live submission executor.
+      - Require exact human approval phrase, explicit live gates, backend-authoritative queue state, and safe audit events.
+      - Keep live submission disabled by default and return to SEARCH-CHANNEL-LIVE-02-PREFLIGHT after merge.
+    allowed_paths:
+      - backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php
+      - backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php
+      - backend/config/seo_intel.php
+      - backend/docs/seo/search-channel-live-02-executor.md
+      - backend/docs/seo/generated/search-channel-live-02-executor.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveSubmissionExecutorTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Execute live submission or call live search APIs outside faked tests.
+      - Enable scheduler, bulk submission, persistent live gates, env edits, deploy, or DNS/runtime changes.
+      - Add, print, commit, or expose raw search-provider credentials.
+      - Change sitemap, llms.txt, URL authority, queue enqueue semantics, or frontend SEO authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLiveSubmissionExecutor
+      - cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelQueueRuntime
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-executor.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+    merge_policy:
+      github_checks_required: false
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false
+    live_external_submission_allowed: false
+    next_task: SEARCH-CHANNEL-LIVE-02-PREFLIGHT
 
   - id: SEARCH-CHANNEL-LIVE-02
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added `seo-intel:search-channel-submit` for one guarded Search Channel queue item.
- Added `SearchChannelQueueLiveSubmissionExecutor` with exact approval phrase, disabled-by-default live gates, atomic single-item claim, safe audit events, and faked IndexNow submission coverage.
- Added executor SOP/generated artifact and registered `SEARCH-CHANNEL-LIVE-02-EXECUTOR` in the PR train before rerunning `SEARCH-CHANNEL-LIVE-02-PREFLIGHT`.
- Updated the BigFive runtime freeze guard so scoped SeoIntel executor files do not trip MBTI runtime impact checks.

## Why
`SEARCH-CHANNEL-LIVE-02-PREFLIGHT` was merged with a blocker: the backend could enqueue a canary item but had no guarded live submission executor. This PR adds the missing runtime path without performing any live submission.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelLiveSubmissionExecutor`
- `cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff`
- `cd backend && php artisan test --filter=SeoIntelSearchChannelQueueRuntime`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-executor.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`

## Deferred
- No live submission was executed in this PR.
- No production env, scheduler, deploy, DNS, sitemap, or `llms.txt` behavior was changed.
- Next step after merge is rerunning `SEARCH-CHANNEL-LIVE-02-PREFLIGHT` to verify the production canary item and produce the exact human approval phrase.

## Repository rule impact
This keeps URL authority backend/Search Channel Queue controlled. It does not add frontend fallback content, change CMS authority, or change sitemap/llms enumeration.
