### PR TITLE
SEARCH-CHANNEL-LIVE-02-PREFLIGHT｜Block until production executor deploy

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-02-preflight.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-02-preflight.v1.json
@@ -1,11 +1,47 @@
 {
   "id": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT",
-  "status": "blocked_live_submission_executor_missing",
-  "checked_at": "2026-05-21T19:12:00+08:00",
+  "status": "blocked_production_executor_not_deployed",
+  "checked_at": "2026-05-21T20:15:00+08:00",
   "live_submission_performed": false,
   "external_calls_attempted": false,
   "search_submission_attempted": false,
   "scheduler_activation": false,
+  "production_env_edit_performed": false,
+  "production_deploy_performed_in_this_task": false,
+  "dns_change_performed": false,
+  "executor": {
+    "task_id": "SEARCH-CHANNEL-LIVE-02-EXECUTOR",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1529",
+    "merged_at": "2026-05-21T11:53:15Z",
+    "merge_commit": "af8a050bfed88631cfc687775402548848ba87a1",
+    "github_checks": "success",
+    "command": "seo-intel:search-channel-submit",
+    "command_available_on_main": true,
+    "single_queue_item_required": true,
+    "exact_approval_phrase_required": true,
+    "atomic_claim_required": true,
+    "scheduler_registered": false,
+    "bulk_submission_supported": false,
+    "deployment_scope_after_merge": "staging_only",
+    "staging_deploy_run_id": 26224261797,
+    "staging_deploy_completed_at": "2026-05-21T12:03:43Z",
+    "production_deploy_after_merge": false
+  },
+  "production_runtime": {
+    "target_host": "139.224.130.204",
+    "target_path": "/var/www/fap-api/current/backend",
+    "required_deploy_sha": "af8a050bfed88631cfc687775402548848ba87a1",
+    "last_successful_production_deploy_run_id": 26174360293,
+    "last_successful_production_deploy_completed_at": "2026-05-20T16:17:20Z",
+    "last_successful_production_deploy_sha": "effadd311f6c6bdfee137f8c9d10d9edb4ee23c4",
+    "production_executor_presence_verified": false,
+    "remote_read_only_command_verified": false,
+    "local_ssh_attempt": {
+      "target": "ubuntu@139.224.130.204",
+      "tcp_22_open": true,
+      "result": "failed_banner_timeout_after_tcp_22_open"
+    }
+  },
   "queue_item": {
     "id": 1,
     "batch_id": 1,
@@ -22,37 +58,42 @@
     "execution_state": "dry_run_ready",
     "indexability_state": "indexable",
     "claim_boundary_state": "claim_safe",
-    "private_flow": false
+    "private_flow": false,
+    "verification_state": "carried_forward_not_refreshed",
+    "verification_source": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT PR #1528; production DB state was not refreshed in this rerun because production is not verified at the executor SHA."
   },
   "fresh_dry_run": {
-    "status": "success",
-    "dry_run": true,
-    "no_write": true,
-    "candidate_count": 1,
-    "eligible_count": 1,
-    "blocked_count": 0,
-    "planned_queue_count": 1,
-    "channel_breakdown": {
-      "indexnow": 1
-    },
-    "page_type_breakdown": {
-      "home": 1
-    },
-    "writes_attempted": false,
-    "writes_committed": false,
+    "status": "not_run_on_production",
+    "reason": "Production runtime is not verified to contain seo-intel:search-channel-submit at the executor SHA.",
     "external_calls_attempted": false,
     "search_submission_attempted": false,
-    "write_gate_enabled": false
+    "writes_attempted": false,
+    "writes_committed": false
   },
-  "public_url_smoke": {
-    "url": "https://fermatmind.com/en",
-    "http_status": 200
+  "executor_dry_run": {
+    "command": "php artisan seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json",
+    "status": "not_run_on_production",
+    "reason": "Production runtime requires backend deploy/read-only verification first.",
+    "external_calls_attempted": false,
+    "search_submission_attempted": false,
+    "writes_attempted": false,
+    "writes_committed": false
   },
-  "blockers": [
-    "No live Search Channel submission executor exists in the current backend.",
-    "The current queue command explicitly keeps search_submission_attempted=false and safety_flags.no_live_submission=true.",
-    "Existing IndexNow/Baidu collector foundations block real URL submission."
-  ],
+  "blocker": {
+    "code": "production_deploy_required",
+    "summary": "The guarded executor is merged to main but has not been confirmed on production; live canary approval phrase is withheld until production deploy readiness, production deploy, and a fresh production dry-run pass."
+  },
   "approval_phrase": null,
-  "next_allowed_action": "Add a separate guarded live submission executor before SEARCH-CHANNEL-LIVE-02 can be approved."
+  "withheld_approval_phrase_reason": "Do not output a live approval phrase until the production runtime contains the executor and a fresh production dry-run confirms queue item 1 is still pending/dry_run_ready.",
+  "required_rerun_commands": [
+    "cd /var/www/fap-api/current/backend",
+    "php artisan seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json",
+    "php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1"
+  ],
+  "next_allowed_action": {
+    "summary": "Run backend production deploy readiness/deploy for the executor SHA, then rerun SEARCH-CHANNEL-LIVE-02-PREFLIGHT. Do not run the live canary yet.",
+    "task_after_backend_deploy": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT",
+    "canary_task_after_passing_preflight": "SEARCH-CHANNEL-LIVE-02",
+    "deployment_readiness_prompt": "Use $fermatmind-deploy-readiness to prepare production deployment. I explicitly allow read-only SSH verification. Do local readiness and read-only remote readiness, resolve backend/frontend SHAs and latest merged PRs, decide whether deploy is necessary, and output the exact confirmation phrases for any required deploy. Do not deploy yet."
+  }
 }

--- a/backend/docs/seo/search-channel-live-02-preflight.md
+++ b/backend/docs/seo/search-channel-live-02-preflight.md
@@ -1,47 +1,77 @@
 # SEARCH-CHANNEL-LIVE-02-PREFLIGHT
 
-Status: blocked
+Status: blocked on production executor deploy/read-only verification
 Date: 2026-05-21
 
 ## Scope
 
-This preflight checks whether the already-enqueued Search Channel Queue canary item can safely advance to a human-approved small live URL submission.
+This rerun returns to the small human-approved Search Channel live submission canary after `SEARCH-CHANNEL-LIVE-02-EXECUTOR` added the guarded single-item executor.
 
-No live search API call, URL submission, scheduler activation, production env edit, deploy, or additional queue write was performed.
+No live search API call, URL submission, scheduler activation, production env edit, production deploy, DNS change, or additional queue write was performed.
 
-## Evidence
+## Executor Evidence
 
-- `SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE` completed with one IndexNow queue item.
-- The latest queue item is `id=1`, `channel=indexnow`, `canonical_url=https://fermatmind.com/en`.
-- The item is `approval_state=pending`, `execution_state=dry_run_ready`, `eligibility_state=eligible`, `indexability_state=indexable`, and `claim_boundary_state=claim_safe`.
-- `source_authority=backend_public_surface`, `source_table=backend_authority_canary_contract`.
-- The queue write gate is disabled.
-- Public `https://fermatmind.com/en` returns HTTP 200.
-- A fresh no-write dry-run for `--channel=indexnow --limit=1` returned `candidate_count=1`, `eligible_count=1`, `planned_queue_count=1`, `writes_committed=false`, `external_calls_attempted=false`, and `search_submission_attempted=false`.
+- `SEARCH-CHANNEL-LIVE-02-EXECUTOR` merged in PR #1529.
+- Merge commit: `af8a050bfed88631cfc687775402548848ba87a1`.
+- GitHub checks for PR #1529 passed.
+- The merged executor adds `seo-intel:search-channel-submit` with single queue item enforcement, exact approval phrase enforcement, disabled-by-default live gates, atomic claim/idempotency protection, sanitized audit events, and no scheduler or bulk mode.
+- The push to `main` after PR #1529 deployed staging only. It did not deploy production.
+- Latest confirmed production workflow dispatch is still run `26174360293`, completed on 2026-05-20, at SHA `effadd311f6c6bdfee137f8c9d10d9edb4ee23c4`.
+
+## Canary Carried Forward
+
+The carried-forward canary from PR #1528 remains the intended production canary candidate:
+
+- queue item `id=1`
+- channel `indexnow`
+- canonical URL `https://fermatmind.com/en`
+- `approval_state=pending`
+- `execution_state=dry_run_ready`
+- `eligibility_state=eligible`
+- `indexability_state=indexable`
+- `claim_boundary_state=claim_safe`
+- `source_authority=backend_public_surface`
+- `source_table=backend_authority_canary_contract`
+
+This rerun did not refresh production DB state because the production executor is not verified on the active production runtime.
 
 ## Blocker
 
-The current backend has no live submission executor for Search Channel Queue items.
+`SEARCH-CHANNEL-LIVE-02` is still blocked.
 
-`seo-intel:search-channel-queue` can plan and enqueue dry-run-ready items, but its command contract and implementation explicitly keep:
+The blocker changed from "executor missing" to "executor not yet verified on production runtime":
 
-- `external_calls_attempted=false`
-- `search_submission_attempted=false`
-- `safety_flags.no_live_submission=true`
-- `safety_flags.no_submit_mode=true`
+- `main` contains the executor at `af8a050bfed88631cfc687775402548848ba87a1`.
+- Production has not been confirmed deployed to that SHA.
+- Local read-only SSH to `ubuntu@139.224.130.204` reached TCP/22 but timed out during SSH banner exchange, so this preflight could not run `php artisan seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json` on production.
+- The exact live approval phrase is intentionally withheld until production is deployed to the executor SHA and a production read-only dry-run confirms the current queue item state.
 
-The existing IndexNow/Baidu collector foundations also block real URL submission. Because there is no live executor to approve, this preflight must not output a live submission approval phrase.
+## Required Rerun
+
+Before producing the live canary approval phrase, run backend deployment readiness for the current `main` SHA, deploy production only after the explicit deploy approval phrase, then rerun this preflight.
+
+Required production read-only checks after deploy:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json
+php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1
+```
+
+Passing criteria:
+
+- active production runtime is at `af8a050bfed88631cfc687775402548848ba87a1` or newer;
+- queue item `1` is still `pending` and `dry_run_ready`;
+- executor dry-run returns `status=success`;
+- `external_calls_attempted=false`;
+- `search_submission_attempted=false`;
+- `writes_attempted=false`;
+- `writes_committed=false`;
+- scheduler remains disabled for live submission;
+- the approval phrase is produced only from that production dry-run evidence.
 
 ## Decision
 
-`SEARCH-CHANNEL-LIVE-02` is blocked until a separate scoped runtime task adds a guarded live submission executor with:
+Do not run `SEARCH-CHANNEL-LIVE-02` yet.
 
-- exact approved URL and channel matching;
-- one-shot human approval phrase enforcement;
-- queue item approval transition;
-- idempotency protection;
-- external response capture;
-- audit events before and after submission;
-- hard scheduler and bulk-submission disablement.
-
-The current approved action remains: no live submission.
+Next operational step is backend deploy readiness/deploy for the executor SHA, followed by another `SEARCH-CHANNEL-LIVE-02-PREFLIGHT` rerun. Only that rerun may output the exact human approval phrase for the live canary.

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLive02PreflightTest extends TestCase
+{
+    #[Test]
+    public function generated_artifact_blocks_until_production_executor_is_deployed_and_verified(): void
+    {
+        $artifactPath = base_path('docs/seo/generated/search-channel-live-02-preflight.v1.json');
+        $this->assertFileExists($artifactPath);
+
+        $artifact = json_decode((string) file_get_contents($artifactPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('SEARCH-CHANNEL-LIVE-02-PREFLIGHT', $artifact['id'] ?? null);
+        $this->assertSame('blocked_production_executor_not_deployed', $artifact['status'] ?? null);
+        $this->assertFalse((bool) ($artifact['live_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($artifact['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($artifact['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($artifact['scheduler_activation'] ?? true));
+        $this->assertNull($artifact['approval_phrase'] ?? null);
+
+        $this->assertSame(1, data_get($artifact, 'queue_item.id'));
+        $this->assertSame('indexnow', data_get($artifact, 'queue_item.channel'));
+        $this->assertSame('https://fermatmind.com/en', data_get($artifact, 'queue_item.canonical_url'));
+        $this->assertSame('pending', data_get($artifact, 'queue_item.approval_state'));
+        $this->assertSame('dry_run_ready', data_get($artifact, 'queue_item.execution_state'));
+        $this->assertSame('carried_forward_not_refreshed', data_get($artifact, 'queue_item.verification_state'));
+
+        $this->assertSame('https://github.com/fermatmind/fap-api/pull/1529', data_get($artifact, 'executor.pr_url'));
+        $this->assertSame('af8a050bfed88631cfc687775402548848ba87a1', data_get($artifact, 'executor.merge_commit'));
+        $this->assertSame('success', data_get($artifact, 'executor.github_checks'));
+        $this->assertSame('staging_only', data_get($artifact, 'executor.deployment_scope_after_merge'));
+
+        $this->assertSame('effadd311f6c6bdfee137f8c9d10d9edb4ee23c4', data_get($artifact, 'production_runtime.last_successful_production_deploy_sha'));
+        $this->assertFalse((bool) data_get($artifact, 'production_runtime.production_executor_presence_verified', true));
+        $this->assertFalse((bool) data_get($artifact, 'production_runtime.remote_read_only_command_verified', true));
+        $this->assertSame('failed_banner_timeout_after_tcp_22_open', data_get($artifact, 'production_runtime.local_ssh_attempt.result'));
+
+        $this->assertSame('production_deploy_required', data_get($artifact, 'blocker.code'));
+        $this->assertStringContainsString(
+            'seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json',
+            implode("\n", data_get($artifact, 'required_rerun_commands', [])),
+        );
+        $this->assertSame('SEARCH-CHANNEL-LIVE-02-PREFLIGHT', data_get($artifact, 'next_allowed_action.task_after_backend_deploy'));
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T20:25:00+08:00",
+  "updated_at": "2026-05-21T20:30:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15397,13 +15397,13 @@
     "SEARCH-CHANNEL-LIVE-02-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-preflight",
-      "status": "local_validation_passed_blocked",
+      "status": "pr_opened_blocked_preflight",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE",
         "NODE3-RETIREMENT-FINAL-CHECK"
       ],
-      "commit_sha": "d20d309d610507de80efb3982ec9d891c9e3de66",
-      "pr_url": null,
+      "commit_sha": "d0b3c0712be802bd13e9620ca772567b02a8e504",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1530",
       "checks": {
         "dependencies": {
           "status": "pass",
@@ -15484,6 +15484,11 @@
           "at": "2026-05-21T20:25:00+08:00",
           "status": "commit_created",
           "summary": "Committed the blocked preflight rerun artifact and ledger update on codex/search-channel-live-02-preflight."
+        },
+        {
+          "at": "2026-05-21T20:30:00+08:00",
+          "status": "pr_opened_blocked_preflight",
+          "summary": "Opened PR #1530 for the blocked preflight rerun. This PR records that production deploy/read-only executor verification is required before live canary approval."
         }
       ],
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T20:20:00+08:00",
+  "updated_at": "2026-05-21T20:25:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15397,12 +15397,12 @@
     "SEARCH-CHANNEL-LIVE-02-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-preflight",
-      "status": "blocked_production_executor_not_deployed",
+      "status": "local_validation_passed_blocked",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE",
         "NODE3-RETIREMENT-FINAL-CHECK"
       ],
-      "commit_sha": null,
+      "commit_sha": "d20d309d610507de80efb3982ec9d891c9e3de66",
       "pr_url": null,
       "checks": {
         "dependencies": {
@@ -15479,6 +15479,11 @@
           "at": "2026-05-21T20:20:00+08:00",
           "status": "local_validation_passed_blocked",
           "summary": "Local validation passed for the blocked preflight artifact and metadata. The live canary remains blocked until production deploy/read-only executor dry-run."
+        },
+        {
+          "at": "2026-05-21T20:25:00+08:00",
+          "status": "commit_created",
+          "summary": "Committed the blocked preflight rerun artifact and ledger update on codex/search-channel-live-02-preflight."
         }
       ],
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T19:55:00+08:00",
+  "updated_at": "2026-05-21T20:20:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15397,51 +15397,63 @@
     "SEARCH-CHANNEL-LIVE-02-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-preflight",
-      "status": "merged",
+      "status": "blocked_production_executor_not_deployed",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE",
         "NODE3-RETIREMENT-FINAL-CHECK"
       ],
-      "commit_sha": "b70820f751ce5b7a26552145e9e49efc70d6b195",
-      "pr_url": "https://github.com/fermatmind/fap-api/pull/1528",
+      "commit_sha": null,
+      "pr_url": null,
       "checks": {
         "dependencies": {
           "status": "pass",
-          "summary": "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE and NODE3-RETIREMENT-FINAL-CHECK are completed."
+          "summary": "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE and NODE3-RETIREMENT-FINAL-CHECK were already completed; executor sidecar PR #1529 is now merged."
+        },
+        "executor_merged": {
+          "status": "pass",
+          "summary": "SEARCH-CHANNEL-LIVE-02-EXECUTOR merged via PR #1529 at af8a050bfed88631cfc687775402548848ba87a1 with passing GitHub checks."
+        },
+        "production_deploy_scope": {
+          "status": "blocked",
+          "summary": "The push after PR #1529 deployed staging only. Latest confirmed production workflow_dispatch remains run 26174360293 at SHA effadd311f6c6bdfee137f8c9d10d9edb4ee23c4."
+        },
+        "production_read_only_executor_dry_run": {
+          "status": "blocked",
+          "command": "cd /var/www/fap-api/current/backend && php artisan seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json",
+          "summary": "Not run because production is not verified at the executor SHA; local SSH to ubuntu@139.224.130.204 reached TCP/22 but timed out during SSH banner exchange."
         },
         "queue_item": {
-          "status": "pass",
-          "summary": "Latest queue item id=1 is indexnow https://fermatmind.com/en with approval_state=pending and execution_state=dry_run_ready."
-        },
-        "url_health": {
-          "status": "pass",
-          "summary": "https://fermatmind.com/en returned HTTP 200."
-        },
-        "fresh_dry_run": {
-          "status": "pass",
-          "summary": "seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1 returned candidate_count=1, eligible_count=1, planned_queue_count=1, writes_committed=false, external_calls_attempted=false, search_submission_attempted=false."
-        },
-        "write_gate": {
-          "status": "pass",
-          "summary": "Search Channel Queue write gate is disabled for normal runtime."
-        },
-        "live_executor": {
-          "status": "blocked",
-          "summary": "No guarded live submission executor exists. The current queue command explicitly reports search_submission_attempted=false and safety_flags.no_live_submission=true."
+          "status": "carried_forward_not_refreshed",
+          "summary": "Prior canary item remains the intended candidate: id=1 indexnow https://fermatmind.com/en pending/dry_run_ready; production DB state was not refreshed in this rerun."
         },
         "approval_phrase": {
-          "status": "blocked",
-          "summary": "No SEARCH-CHANNEL-LIVE-02 approval phrase was produced because there is no live executor to approve."
+          "status": "withheld",
+          "summary": "No SEARCH-CHANNEL-LIVE-02 live approval phrase is output until production is deployed to the executor SHA and a fresh production executor dry-run passes."
         },
-        "github_merge_reconciliation": {
+        "no_live_submission": {
           "status": "pass",
-          "summary": "GitHub PR #1528 is MERGED and origin/main contains merge commit b70820f751ce5b7a26552145e9e49efc70d6b195; remote task branch is absent."
+          "summary": "No live submission, external API call, queue write, scheduler activation, env edit, DNS change, or production deploy occurred in this preflight rerun."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelSearchChannelLive02",
+          "summary": "1 test passed, 25 assertions; generated preflight artifact remains blocked until production executor deploy/read-only verification."
+        },
+        "pint_targeted": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php",
+          "summary": "Targeted Pint check passed for the new preflight artifact guard test."
+        },
+        "json_yaml_diff": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-preflight.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\" && git diff --check",
+          "summary": "Generated JSON, PR-train state JSON, PR-train YAML, and whitespace diff check passed."
         }
       },
-      "failure_reason": "blocked_live_submission_executor_missing: current backend can plan/enqueue queue items but cannot execute a live IndexNow/Search Channel URL submission.",
-      "merged_at": "2026-05-21T11:21:58Z",
-      "remote_branch_deleted": true,
-      "local_cleanup_executed": true,
+      "failure_reason": "blocked_production_executor_not_deployed: executor is merged to main, but production has not been confirmed deployed to af8a050bfed88631cfc687775402548848ba87a1 and the production read-only executor dry-run could not be run.",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
       "history": [
         {
           "at": "2026-05-21T19:05:00+08:00",
@@ -15457,24 +15469,39 @@
           "at": "2026-05-21T19:34:00+08:00",
           "status": "merged_blocked_live_submission_executor_missing",
           "summary": "Reconciled SEARCH-CHANNEL-LIVE-02-PREFLIGHT as merged via PR #1528 while preserving the executor-missing blocker; this unblocks the separate executor task only, not live submission."
+        },
+        {
+          "at": "2026-05-21T20:15:00+08:00",
+          "status": "blocked_production_executor_not_deployed",
+          "summary": "Reran preflight after executor merge. The executor is on main and staging, but production is not verified at the executor SHA, so the live approval phrase is withheld and SEARCH-CHANNEL-LIVE-02 remains blocked. No live submission or production operation occurred."
+        },
+        {
+          "at": "2026-05-21T20:20:00+08:00",
+          "status": "local_validation_passed_blocked",
+          "summary": "Local validation passed for the blocked preflight artifact and metadata. The live canary remains blocked until production deploy/read-only executor dry-run."
         }
       ],
       "sidecar_issues": [
         {
-          "title": "Live submission executor missing",
-          "status": "blocking_next_task",
-          "summary": "SEARCH-CHANNEL-LIVE-02 cannot run until a separate scoped runtime task adds a guarded live submission executor with exact URL/channel approval, idempotency, response capture, and audit events."
+          "title": "Production executor deploy/read-only verification required",
+          "status": "blocking_live_canary",
+          "summary": "Executor exists on main but SEARCH-CHANNEL-LIVE-02 remains blocked until production deploy readiness/deploy and a fresh production dry-run confirm queue item 1 is still pending/dry_run_ready."
+        },
+        {
+          "title": "Previous live executor missing blocker resolved",
+          "status": "resolved_by_pr_1529",
+          "summary": "The missing executor blocker from PR #1528 was resolved by SEARCH-CHANNEL-LIVE-02-EXECUTOR in PR #1529."
         }
       ]
     },
     "SEARCH-CHANNEL-LIVE-02-EXECUTOR": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-executor",
-      "status": "pr_opened_github_checks_pending",
+      "status": "merged",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-02-PREFLIGHT"
       ],
-      "commit_sha": "3151d3388972bf1e358bef547229c1665389e995",
+      "commit_sha": "af8a050bfed88631cfc687775402548848ba87a1",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1529",
       "checks": {
         "dependencies": {
@@ -15520,14 +15547,18 @@
           "summary": "Generated JSON, PR-train state JSON, PR-train YAML, and whitespace diff check passed."
         },
         "github_pr": {
-          "status": "pending",
-          "summary": "Opened PR #1529 for SEARCH-CHANNEL-LIVE-02-EXECUTOR; GitHub checks are pending."
+          "status": "merged_success",
+          "summary": "PR #1529 merged at af8a050bfed88631cfc687775402548848ba87a1 after all GitHub checks passed."
+        },
+        "github_merge_reconciliation": {
+          "status": "pass",
+          "summary": "GitHub PR #1529 is MERGED, origin/main contains merge commit af8a050bfed88631cfc687775402548848ba87a1, GitHub checks passed, and the remote task branch is deleted."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-21T11:53:15Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-21T19:34:00+08:00",
@@ -15553,13 +15584,18 @@
           "at": "2026-05-21T19:55:00+08:00",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1529 for the guarded live submission executor. No live submission or production operation occurred."
+        },
+        {
+          "at": "2026-05-21T20:15:00+08:00",
+          "status": "merged_reconciled",
+          "summary": "Reconciled SEARCH-CHANNEL-LIVE-02-EXECUTOR after PR #1529 merged. Main now contains the guarded live submission executor; no live submission occurred."
         }
       ]
     },
     "SEARCH-CHANNEL-LIVE-02": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-canary-submission",
-      "status": "registered",
+      "status": "blocked_waiting_for_production_executor_preflight",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-02-PREFLIGHT"
       ],
@@ -15569,9 +15605,13 @@
         "human_approval": {
           "status": "required",
           "summary": "Live external submission is blocked until the exact human approval phrase is present."
+        },
+        "preflight": {
+          "status": "blocked",
+          "summary": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT has not produced an approval phrase because production is not verified at the executor SHA."
         }
       },
-      "failure_reason": null,
+      "failure_reason": "blocked_waiting_for_production_executor_preflight",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -15580,6 +15620,11 @@
           "at": "2026-05-21T19:05:00+08:00",
           "status": "registered",
           "summary": "Registered human-approved small URL submission canary. This task may not execute without the exact approval phrase produced by SEARCH-CHANNEL-LIVE-02-PREFLIGHT."
+        },
+        {
+          "at": "2026-05-21T20:15:00+08:00",
+          "status": "blocked_waiting_for_production_executor_preflight",
+          "summary": "Live canary remains blocked until backend production deploy/read-only preflight rerun outputs the exact approval phrase."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -8061,6 +8061,7 @@ prs:
       - Enable scheduler, persist write gates, edit env, rotate credentials, deploy, or change sitemap/llms behavior.
       - Approve draft/private/noindex/claim-unsafe/stale/frontend-fallback/static-sitemap/static-llms URLs.
     validation:
+      - Production runtime is confirmed to contain the guarded live submission executor before any approval phrase is produced.
       - Queue canary item exists with approval_state=pending and execution_state=dry_run_ready.
       - Candidate URL set is small, explicit, canonical, backend-authoritative, indexable, and channel-eligible.
       - Dry-run/no-write command succeeds immediately before live approval.
@@ -8076,7 +8077,7 @@ prs:
     production_migration_execution_allowed: false
     external_api_credentials_required: true
     scheduler_activation: false
-    next_task: SEARCH-CHANNEL-LIVE-02-EXECUTOR
+    next_task: SEARCH-CHANNEL-LIVE-02
 
   - id: SEARCH-CHANNEL-LIVE-02-EXECUTOR
     repo: fap-api


### PR DESCRIPTION
## What changed
- Reruns `SEARCH-CHANNEL-LIVE-02-PREFLIGHT` after the guarded executor merged in PR #1529.
- Reconciles `SEARCH-CHANNEL-LIVE-02-EXECUTOR` as merged in the PR-train state ledger.
- Records the new blocker: the executor is on `main` and staging, but production has not been verified deployed to `af8a050bfed88631cfc687775402548848ba87a1`.
- Adds a focused artifact guard test for the blocked preflight generated JSON.

## Why
The live canary must not receive an approval phrase until production contains the executor and a fresh production dry-run proves queue item `1` is still `pending` / `dry_run_ready` with no writes or external calls.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelLive02`
- `cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php`
- `python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-preflight.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`

## Intentionally deferred
- No production deploy.
- No live URL submission.
- No approval phrase output.
- No scheduler activation, env edit, DNS change, or external search API call.

## Repository rule impact
This is a Search Channel ops/preflight ledger update. It does not change CMS authority, frontend content authority, sitemap/llms enumeration, runtime URL authority, or deployment automation.
