### PR TITLE
PR-EQ-V5-04C: Fix EQ v5 report delivery fallback

### DIFF
--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -234,7 +234,8 @@ class ReportGatekeeper
         $snapshotStrictMode = in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true) ? false : $this->strictSnapshotModeEnabled();
         $shouldReadFromSnapshot = $unlockStage !== ReportAccess::UNLOCK_STAGE_PARTIAL
             && ($snapshotStrictMode || $shouldUseSnapshot);
-        $allowLiveBuildFallbackForSnapshot = $scaleCode === ReportAccess::SCALE_ENNEAGRAM && ! $snapshotStrictMode;
+        $allowLiveBuildFallbackForSnapshot = $scaleCode === ReportAccess::SCALE_EQ_60
+            || ($scaleCode === ReportAccess::SCALE_ENNEAGRAM && ! $snapshotStrictMode);
         if ($requiresSnapshotBoundReport) {
             $snapshotResult = $this->snapshotStore->createSnapshotForAttempt([
                 'org_id' => $effectiveOrgId,
@@ -276,7 +277,7 @@ class ReportGatekeeper
                 ->where('attempt_id', $attemptId)
                 ->first();
 
-            if ($snapshotStrictMode && ($snapshotRow === null || $forceRefresh)) {
+            if ($snapshotStrictMode && ($snapshotRow === null || $forceRefresh) && ! $allowLiveBuildFallbackForSnapshot) {
                 $this->enqueueSnapshotBuild($effectiveOrgId, $attempt, $result);
 
                 return $this->responsePayload(
@@ -438,7 +439,7 @@ class ReportGatekeeper
             }
         }
 
-        if ($snapshotStrictMode && $unlockStage !== ReportAccess::UNLOCK_STAGE_PARTIAL) {
+        if ($snapshotStrictMode && ! $allowLiveBuildFallbackForSnapshot && $unlockStage !== ReportAccess::UNLOCK_STAGE_PARTIAL) {
             return $this->responsePayload(
                 $locked,
                 $reportAccessLevel,

--- a/backend/tests/Feature/Report/Eq60V5ReportDeliveryTest.php
+++ b/backend/tests/Feature/Report/Eq60V5ReportDeliveryTest.php
@@ -1,0 +1,369 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Jobs\GenerateReportSnapshotJob;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Assessment\Scorers\Eq60ScorerV1NormedValidity;
+use App\Services\Content\Eq60PackLoader;
+use App\Services\Report\ReportAccess;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class Eq60V5ReportDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_eq60_report_access_ready_delivers_v5_report_when_snapshot_missing_in_strict_mode(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->prepareEqContent();
+
+        $anonId = 'anon_eq_v5_delivery_missing_snapshot';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId);
+
+        Queue::fake();
+
+        $access = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access');
+
+        $access->assertOk()
+            ->assertJsonPath('access_state', 'ready')
+            ->assertJsonPath('report_state', 'ready')
+            ->assertJsonPath('payload.locked', false)
+            ->assertJsonPath('payload.variant', ReportAccess::VARIANT_FULL)
+            ->assertJsonPath('payload.access_level', ReportAccess::REPORT_ACCESS_FULL)
+            ->assertJsonPath('payload.upgrade_sku', null)
+            ->assertJsonPath('payload.offers', [])
+            ->assertJsonPath('payload.view_policy.blur_others', false);
+
+        $this->assertFalse(DB::table('report_snapshots')->where('attempt_id', $attemptId)->exists());
+
+        $report = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+
+        $report->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('generating', false)
+            ->assertJsonPath('locked', false)
+            ->assertJsonPath('variant', ReportAccess::VARIANT_FULL)
+            ->assertJsonPath('access_level', ReportAccess::REPORT_ACCESS_FULL)
+            ->assertJsonPath('upgrade_sku', null)
+            ->assertJsonPath('offers', [])
+            ->assertJsonPath('report.eq_report_mode', 'self_report')
+            ->assertJsonPath('report.measurement_type', 'self_report_trait_mixed_ei')
+            ->assertJsonPath('report.access.all_results_free', true)
+            ->assertJsonPath('report.access.locked', false)
+            ->assertJsonPath('report.access.blur', false)
+            ->assertJsonPath('report.access.paywall', false)
+            ->assertJsonPath('report.next_module.available', false)
+            ->assertJsonPath('report.next_module.status', 'planned');
+
+        $this->assertIsArray($report->json('report.scores.global'));
+        foreach (['SA', 'ER', 'EM', 'RM'] as $code) {
+            $this->assertIsArray($report->json('report.scores.dimensions.'.$code));
+        }
+        $this->assertCount(4, (array) $report->json('report.dimension_summary'));
+        $this->assertNotSame('', (string) $report->json('report.quality.confidence_label'));
+        $this->assertNotSame('', (string) $report->json('report.interpretation.core_formulation_id'));
+        $this->assertNotEmpty((array) $report->json('report.asset_refs'));
+        $this->assertNotEmpty((array) $report->json('report.assets'));
+
+        $json = json_encode($report->json(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+        $this->assertStringNotContainsString('SKU_EQ_60_FULL_299', $json);
+        $this->assertStringNotContainsString('EQ_60_FULL', $json);
+        $this->assertStringNotContainsString('"locked":true', $json);
+        $this->assertStringNotContainsString('"paywall":true', $json);
+        $this->assertStringNotContainsString('"blur_others":true', $json);
+
+        $snapshot = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($snapshot);
+        $this->assertSame('ready', (string) ($snapshot->status ?? ''));
+
+        Queue::assertNotPushed(GenerateReportSnapshotJob::class);
+    }
+
+    public function test_eq60_pending_snapshot_does_not_block_v5_report_delivery(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->prepareEqContent();
+
+        $anonId = 'anon_eq_v5_delivery_pending_snapshot';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId);
+        $this->insertPendingSnapshot($attemptId, 'EQ_60');
+
+        $report = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+
+        $report->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('generating', false)
+            ->assertJsonPath('locked', false)
+            ->assertJsonPath('report.eq_report_mode', 'self_report')
+            ->assertJsonPath('report.measurement_type', 'self_report_trait_mixed_ei');
+
+        $this->assertIsArray($report->json('report.scores.dimensions.SA'));
+        $this->assertNotEmpty((array) $report->json('report.assets'));
+        $this->assertSame('ready', (string) DB::table('report_snapshots')->where('attempt_id', $attemptId)->value('status'));
+    }
+
+    public function test_strict_snapshot_behavior_for_mbti_is_unchanged(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
+
+        $anonId = 'anon_mbti_strict_still_snapshot_bound';
+        $token = $this->issueAuthToken($anonId);
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+
+        Queue::fake();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('generating', true)
+            ->assertJsonPath('snapshot_error', false)
+            ->assertJsonPath('variant', ReportAccess::VARIANT_FREE)
+            ->assertJsonPath('locked', true);
+
+        $this->assertSame([], (array) $response->json('report'));
+        $this->assertSame('pending', (string) DB::table('report_snapshots')->where('attempt_id', $attemptId)->value('status'));
+
+        Queue::assertPushed(GenerateReportSnapshotJob::class, function (GenerateReportSnapshotJob $job) use ($attemptId): bool {
+            return $job->orgId === 0
+                && $job->attemptId === $attemptId
+                && $job->triggerSource === 'report_api';
+        });
+    }
+
+    private function prepareEqContent(): void
+    {
+        $this->artisan('content:compile --pack=EQ_60 --pack-version=v1')->assertExitCode(0);
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function issueFmToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function issueAuthToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('auth_tokens')->insert([
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'meta_json' => null,
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createEqAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $attempt = Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'EQ_60',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 60,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(8),
+            'submitted_at' => now(),
+            'pack_id' => 'EQ_60',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'eq60_spec_2026_v2',
+        ]);
+
+        $score = $this->scoreEq60([
+            'started_at' => $attempt->started_at,
+            'submitted_at' => $attempt->submitted_at,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'EQ_60',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => (array) ($score['scores'] ?? []),
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'v1',
+            'result_json' => [
+                'scale_code' => 'EQ_60',
+                'quality' => $score['quality'] ?? [],
+                'norms' => $score['norms'] ?? [],
+                'scores' => $score['scores'] ?? [],
+                'report_tags' => $score['report_tags'] ?? [],
+                'version_snapshot' => $score['version_snapshot'] ?? [],
+                'normed_json' => $score,
+                'breakdown_json' => ['score_result' => $score],
+                'axis_scores_json' => ['score_result' => $score],
+            ],
+            'pack_id' => 'EQ_60',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'eq60_spec_2026_v2',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => ['EI' => 50, 'SN' => 50, 'TF' => 50, 'JP' => 50, 'AT' => 50],
+            'axis_states' => ['EI' => 'clear', 'SN' => 'clear', 'TF' => 'clear', 'JP' => 'clear', 'AT' => 'clear'],
+            'content_package_version' => 'v0.3',
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     * @return array<string,mixed>
+     */
+    private function scoreEq60(array $ctx = []): array
+    {
+        /** @var Eq60PackLoader $loader */
+        $loader = app(Eq60PackLoader::class);
+        /** @var Eq60ScorerV1NormedValidity $scorer */
+        $scorer = app(Eq60ScorerV1NormedValidity::class);
+
+        $answers = [];
+        for ($i = 1; $i <= 60; $i++) {
+            $answers[$i] = 'C';
+        }
+
+        return $scorer->score(
+            $answers,
+            $loader->loadQuestionIndex('v1'),
+            $loader->loadPolicy('v1'),
+            array_merge([
+                'pack_id' => 'EQ_60',
+                'dir_version' => 'v1',
+                'score_map' => data_get($loader->loadOptions('v1'), 'score_map', []),
+                'server_duration_seconds' => 420,
+            ], $ctx)
+        );
+    }
+
+    private function insertPendingSnapshot(string $attemptId, string $scaleCode): void
+    {
+        DB::table('report_snapshots')->insert([
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'order_no' => null,
+            'scale_code' => $scaleCode,
+            'pack_id' => $scaleCode === 'EQ_60' ? 'EQ_60' : (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => $scaleCode === 'EQ_60' ? 'v1' : (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => $scaleCode === 'EQ_60' ? 'eq60_spec_2026_v2' : '2026.01',
+            'report_engine_version' => 'v1.2',
+            'snapshot_version' => 'v1',
+            'report_json' => '{}',
+            'report_free_json' => '{}',
+            'report_full_json' => '{}',
+            'status' => 'pending',
+            'last_error' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/docs/audits/eq/eq_v5_smoke_qa_2026-05-21.md
+++ b/docs/audits/eq/eq_v5_smoke_qa_2026-05-21.md
@@ -1,0 +1,330 @@
+# EQ v5 Smoke QA Report - 2026-05-21
+
+## 1. Executive Summary
+
+Status: **STOPPED - P0 blocker found**
+
+The EQ-60 v5 smoke was run against staging, not production. The staging questions and submit path are reachable, and `report-access` returns the expected all-free contract. However, the staging `/report` endpoint did not return the EQ v5 report payload after repeated polling. It continued returning `generating=true` with an empty `report=[]`.
+
+Per the execution gate, PR-EQ-V5-05 must not continue because the live smoke could not verify the v5 report payload or EQResultV5 page rendering from a real staging attempt.
+
+## 2. Environment
+
+| Item | Value |
+| --- | --- |
+| Environment type | staging |
+| Frontend URL | `https://staging.fermatmind.com/en/tests/eq-test-emotional-intelligence-assessment/take` |
+| Backend API URL | `https://staging-api.fermatmind.com` |
+| Production used | No |
+| Login required | No |
+| Paid transaction used | No |
+| Private API used | No |
+
+## 3. Attempt / Session
+
+| Item | Value |
+| --- | --- |
+| Anonymous ID | `codex_eq_v5_smoke_20260521211025` |
+| Attempt ID | `92045de8-c53f-407a-af37-2b8c5651d95b` |
+| Evidence directory | `/tmp/eq_v5_smoke_codex_eq_v5_smoke_20260521211025` |
+
+## 4. EQ Test Page / Questions
+
+Result: **PASS**
+
+Staging questions endpoint:
+
+- `ok=true`
+- `scale_code=EQ_60`
+- question count: `60`
+- dimension codes: `SA`, `ER`, `EM`, `RM`
+- zh-CN option anchors available
+- en option anchors available
+
+The smoke did not find a 50-question regression in staging questions metadata.
+
+## 5. Submit Path
+
+Result: **PASS**
+
+The staging public API accepted a new anonymous EQ-60 attempt and accepted a complete 60-answer submit payload.
+
+Start response summary:
+
+```json
+{"ok":true,"scale_code":"EQ_60","question_count":60,"attempt_id":"92045de8-c53f-407a-af37-2b8c5651d95b"}
+```
+
+Submit response summary:
+
+```json
+{"ok":true,"attempt_id":"92045de8-c53f-407a-af37-2b8c5651d95b"}
+```
+
+Note: the submit response did not include full result detail in the sampled staging response. The result/report verification therefore depended on `report-access` and `/report`.
+
+## 6. Report Access
+
+Result: **PASS**
+
+`/api/v0.3/attempts/{attempt_id}/report-access` returned the expected all-free runtime contract:
+
+```json
+{
+  "ok": true,
+  "access_state": "ready",
+  "report_state": "ready",
+  "payload": {
+    "locked": false,
+    "variant": "full",
+    "access_level": "full",
+    "modules_allowed": [
+      "eq_core",
+      "eq_full",
+      "eq_cross_insights",
+      "eq_growth_plan"
+    ],
+    "modules_preview": [],
+    "offers": [],
+    "upgrade_sku": null,
+    "upgrade_sku_effective": null,
+    "blur_others": false,
+    "free_sections": [
+      "disclaimer_top",
+      "quality_notice",
+      "global_overview",
+      "self_awareness",
+      "emotion_regulation",
+      "empathy",
+      "relationship_management",
+      "cross_quadrant_insight",
+      "action_plan_14d",
+      "methodology",
+      "disclaimer_bottom"
+    ]
+  }
+}
+```
+
+No staging `report-access` evidence showed `locked=true`, `blur_others=true`, paid offers, or EQ SKU exposure.
+
+## 7. Report Payload
+
+Result: **FAIL - P0**
+
+Expected:
+
+- `eq_report_mode`
+- `measurement_type`
+- `scores.global`
+- `scores.dimensions`
+- `dimension_summary`
+- `quality`
+- `interpretation`
+- `asset_refs` or resolved assets
+- `next_module.available=false`
+- `next_module.status=planned`
+- `methodology`
+
+Actual after repeated polling:
+
+```json
+{
+  "ok": true,
+  "generating": true,
+  "locked": false,
+  "variant": "full",
+  "access_level": "full",
+  "upgrade_sku": null,
+  "upgrade_sku_effective": null,
+  "offers": [],
+  "report_type": "array",
+  "report_len": 0,
+  "meta": {
+    "generating": true,
+    "snapshot_error": false,
+    "retry_after_seconds": 3,
+    "scale_code": "EQ_60",
+    "scale_code_legacy": "EQ_60",
+    "scale_code_v2": "EQ_EMOTIONAL_INTELLIGENCE",
+    "scale_uid": "66666666-6666-4666-8666-666666666666",
+    "pack_id": "EQ_60",
+    "dir_version": "v1",
+    "content_package_version": "v1",
+    "scoring_spec_version": "eq60_spec_2026_v2",
+    "report_engine_version": "v1.2"
+  }
+}
+```
+
+This means the staging live attempt did not expose the v5 report payload required for the EQResultV5 renderer.
+
+## 8. Renderer / Page Sections
+
+Result: **NOT VERIFIED IN STAGING - blocked by P0 report payload**
+
+Because `/report` did not return an object report payload, staging page rendering could not be verified as a true live EQResultV5 path for this attempt.
+
+Local/test evidence was used only as a control:
+
+- `pnpm exec vitest run tests/contracts/eq-result-v5-renderer.contract.test.tsx` passed.
+- `NEXT_PUBLIC_API_URL=https://staging-api.fermatmind.com pnpm exec playwright test tests/e2e/iq-eq-result-regression.spec.ts --grep "EQ uses option anchors"` passed with canonical EQ v5 fixture mocks.
+- `php artisan test --filter=Eq60V5ReportContractTest` passed.
+
+These tests prove the merged code and fixtures can render EQ v5 when the v5 payload exists, but they do not clear the staging live smoke P0.
+
+## 9. Forbidden Terms / Fields
+
+Staging API result:
+
+- `report-access`: **PASS**
+- `/report`: **PARTIAL PASS**
+- rendered page: **NOT VERIFIED**
+
+Observed API payload did not expose:
+
+- `SKU_EQ_60_FULL_299`
+- `EQ_60_FULL`
+- `paywall=true`
+- `locked=true`
+- `blur_others=true`
+- paid offers
+
+Rendered page forbidden terms could not be verified because the live report payload remained empty/generating.
+
+## 10. SJT Bridge
+
+Result: **NOT VERIFIED IN STAGING - blocked by P0 report payload**
+
+The live staging `/report` payload did not include `next_module`. Therefore the smoke could not verify:
+
+- `next_module.available=false`
+- `next_module.status=planned`
+- no clickable SJT entry
+- no MSCEIT / ability-test / certified-test claim
+
+Canonical fixture and frontend contract tests cover this path, but staging live smoke did not.
+
+## 11. i18n
+
+| Locale | Status | Evidence |
+| --- | --- | --- |
+| zh-CN | Partial pass | Questions endpoint returns 60 EQ items and zh-CN anchors; live report payload blocked. |
+| en | Partial pass | Questions endpoint returns 60 EQ items and en anchors; live report payload blocked. |
+
+## 12. Low-Confidence Path
+
+Result: **VERIFIED BY CANONICAL FIXTURE / CONTRACT TEST ONLY**
+
+The low-confidence path was not forced on staging. This follows the execution boundary: do not intentionally create abnormal production-like data just to trigger low-confidence.
+
+Evidence:
+
+- `php artisan test --filter=Eq60V5ReportContractTest` passed and covers `low_confidence_result`.
+- `pnpm exec vitest run tests/contracts/eq-result-v5-renderer.contract.test.tsx` passed and covers low-confidence rendering without strong formulation claims.
+
+## 13. Issues
+
+### P0
+
+1. **Staging `/report` did not return EQ v5 payload**
+   - Evidence: repeated polling returned `generating=true`, `report=[]`.
+   - Impact: the smoke cannot verify live EQResultV5 rendering, v5 fields, resolved assets, SJT planned state, or page-level forbidden terms.
+   - Gate result: stop and do not continue PR-EQ-V5-05.
+
+### P1
+
+None confirmed. Several P1 checks remain unverified because the P0 report payload blocker prevents page rendering verification.
+
+### P2
+
+1. Submit response summary did not include result detail in the sampled staging response.
+   - This is not a blocker by itself because report generation is expected to be checked through report-access/report.
+
+### P3
+
+None.
+
+## 14. Validation Commands / Evidence
+
+Backend control:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=Eq60V5ReportContractTest
+```
+
+Result: passed, 9 tests / 273 assertions.
+
+Frontend control:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-web
+pnpm exec vitest run tests/contracts/eq-result-v5-renderer.contract.test.tsx
+```
+
+Result: passed, 7 tests.
+
+Frontend e2e control:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-web
+NEXT_PUBLIC_API_URL=https://staging-api.fermatmind.com pnpm exec playwright test tests/e2e/iq-eq-result-regression.spec.ts --grep "EQ uses option anchors"
+```
+
+Result: passed, 1 test.
+
+## 15. Continue PR-EQ-V5-05?
+
+Decision: **NO**
+
+Reason: P0 smoke blocker. The staging live `/report` endpoint did not produce the required EQ v5 payload. Per the plan, PR-EQ-V5-05 must not proceed until this is understood or explicitly overridden by the user.
+
+## 16. Resolution / Retest - PR-EQ-V5-04C
+
+Status: **fixed in code, pending staging deployment retest**
+
+Root cause:
+
+- `report-access` correctly returned ready/full/all-free for EQ when a submitted attempt result existed.
+- `/report` was still governed by strict snapshot delivery.
+- When the report snapshot row was missing or pending, strict snapshot mode returned `generating=true` with an empty `report=[]`.
+- EQ did not have a synchronous live-build fallback in that snapshot-missing path, so `report-access` readiness and `/report` deliverability could diverge.
+
+Fix applied:
+
+- Added an EQ-only synchronous compose fallback in `ReportGatekeeper`.
+- When scale is `EQ_60`, access is full, and submitted scoring result data exists, `/report` can now build the EQ v5 payload through the existing report composer even if the snapshot is missing or still pending.
+- The snapshot path remains in place. The fallback is only a delivery path for snapshot lag or absence.
+- Non-EQ strict snapshot behavior is preserved by regression test coverage.
+
+Local retest:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=Eq60V5ReportDeliveryTest
+php artisan test --filter=Eq60V5ReportContractTest
+php artisan test --filter=Eq60ReportPaywallTest
+php artisan test --filter=Eq60SubmitQualityContractTest
+php artisan test --filter=Eq60GoldenCasesTest
+php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff'
+bash scripts/ci_verify_mbti.sh
+```
+
+Result:
+
+- `Eq60V5ReportDeliveryTest`: passed, 3 tests / 64 assertions.
+- `Eq60V5ReportContractTest`: passed, 9 tests / 273 assertions.
+- `Eq60ReportPaywallTest`: passed, 4 tests / 110 assertions.
+- `Eq60SubmitQualityContractTest`: passed, 1 test / 16 assertions.
+- `Eq60GoldenCasesTest`: passed, 1 test / 208 assertions.
+- Big Five runtime guard: passed, 1 test / 3 assertions.
+- `scripts/ci_verify_mbti.sh`: passed.
+
+Staging retest:
+
+- Not fully re-run from this local branch because the fix has not yet been deployed to staging.
+- Required post-deploy retest: repeat the same staging attempt flow against `https://staging.fermatmind.com` and `https://staging-api.fermatmind.com`.
+- The P0 can be considered closed only after staging `/report` returns `generating=false` and an EQ v5 object payload containing `eq_report_mode`, `scores.dimensions`, `dimension_summary`, `assets` or `asset_refs`, `next_module.available=false`, and `methodology`.
+
+PR-EQ-V5-05 remains blocked until staging retest confirms the fixed `/report` delivery path.


### PR DESCRIPTION
## What changed
- Added an EQ-only synchronous report delivery fallback in `ReportGatekeeper` when strict snapshot delivery has no ready snapshot but a submitted EQ result exists.
- Added `Eq60V5ReportDeliveryTest` to lock the staging split-brain regression: `report-access` ready/full/all-free must imply `/report` can deliver the EQ v5 payload for EQ_60.
- Added the EQ v5 smoke QA report documenting the staging P0 and the local fix validation.

## Why
Smoke QA found a P0 on staging: EQ attempts could submit and `report-access` returned ready/full/all-free, but `/report` kept returning `generating=true` with `report=[]`. This prevented live validation of EQResultV5, resolved assets, SJT planned state, and no-paywall rendering.

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter=Eq60V5ReportDeliveryTest
php artisan test --filter=Eq60V5ReportContractTest
php artisan test --filter=Eq60ReportPaywallTest
php artisan test --filter=Eq60SubmitQualityContractTest
php artisan test --filter=Eq60GoldenCasesTest
php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff'
bash scripts/ci_verify_mbti.sh
cd /Users/rainie/Desktop/GitHub/fap-api
git diff --check
```

All commands passed locally.

## Intentionally deferred
- No frontend changes.
- No SJT implementation, scorer, route, take page, or item bank.
- No EQ question, reverse-key, scoring, or norm changes.
- No paid/locked/paywall/SKU changes.
- No PR train manifest/state changes.
- Staging live retest is pending deployment of this branch; the QA report records that boundary.
