### PR TITLE
SEARCH-CHANNEL-LIVE-02｜Human-approved small URL submission canary

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-02-canary.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-02-canary.v1.json
@@ -1,0 +1,68 @@
+{
+  "id": "SEARCH-CHANNEL-LIVE-02",
+  "status": "blocked_missing_indexnow_live_configuration",
+  "checked_at": "2026-05-21T22:54:00+08:00",
+  "approval_phrase_present": true,
+  "approved_queue_item_id": 1,
+  "approved_channel": "indexnow",
+  "approved_url": "https://fermatmind.com/en",
+  "preflight_pr": "https://github.com/fermatmind/fap-api/pull/1533",
+  "preflight_merge_commit": "3426bfaff578f72980c6bd5e7a0ab182d14d227b",
+  "production_release": "20260521220637",
+  "production_revision": "35d1f33b038df4eac330475d072f25fbbfd66364",
+  "live_submission_performed": false,
+  "external_calls_attempted": false,
+  "search_submission_attempted": false,
+  "writes_attempted": false,
+  "writes_committed": false,
+  "scheduler_activation": false,
+  "bulk_submission": false,
+  "production_env_edit_performed": false,
+  "dns_change_performed": false,
+  "command": "php artisan seo-intel:search-channel-submit --queue-item-id=1 --approval-phrase=<exact approved phrase> --actor=rainie-codex --json",
+  "result": {
+    "runtime": "search_channel_live_submission",
+    "queue_item_id": 1,
+    "channel": "indexnow",
+    "canonical_url": "https://fermatmind.com/en",
+    "dry_run": false,
+    "approval_phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 1 channel indexnow URL https://fermatmind.com/en.",
+    "external_calls_attempted": false,
+    "search_submission_attempted": false,
+    "writes_attempted": false,
+    "writes_committed": false,
+    "submission_status": "not_attempted",
+    "execution_state": "dry_run_ready",
+    "safety_flags": {
+      "scheduler_enabled": false,
+      "bulk_submission": false,
+      "raw_secret_output": false,
+      "sitemap_llms_behavior_changed": false
+    },
+    "status": "blocked",
+    "issues": [
+      "live_submission_gate_disabled",
+      "external_api_gate_disabled",
+      "indexnow_live_api_disabled",
+      "indexnow_key_missing",
+      "indexnow_key_location_missing"
+    ]
+  },
+  "blocker": {
+    "code": "missing_indexnow_live_configuration",
+    "issues": [
+      "live_submission_gate_disabled",
+      "external_api_gate_disabled",
+      "indexnow_live_api_disabled",
+      "indexnow_key_missing",
+      "indexnow_key_location_missing"
+    ],
+    "summary": "The exact approval phrase was present, but production live gates are disabled and IndexNow key/keyLocation are not configured in the production runtime. The guarded executor blocked before writes or external calls."
+  },
+  "next_allowed_action": {
+    "summary": "Configure IndexNow credentials and one-shot live gates through an explicitly approved secure production configuration path, rebuild config cache, rerun SEARCH-CHANNEL-LIVE-02-PREFLIGHT, then request a fresh exact approval phrase before retrying live submission.",
+    "requires_secret_configuration": true,
+    "requires_fresh_preflight": true,
+    "do_not_retry_without_new_preflight": true
+  }
+}

--- a/backend/docs/seo/search-channel-live-02-canary.md
+++ b/backend/docs/seo/search-channel-live-02-canary.md
@@ -1,0 +1,63 @@
+# SEARCH-CHANNEL-LIVE-02
+
+Status: blocked on missing IndexNow live configuration
+Date: 2026-05-21
+
+## Scope
+
+This task attempted only the explicitly approved small URL Search Channel live submission canary:
+
+- queue item `1`
+- channel `indexnow`
+- URL `https://fermatmind.com/en`
+
+The exact human approval phrase was present. No scheduler activation, bulk submission, production env edit, DNS change, or additional URL submission was performed.
+
+## Dependency Evidence
+
+- `SEARCH-CHANNEL-LIVE-02-PREFLIGHT` merged in PR #1533.
+- Preflight merge commit: `3426bfaff578f72980c6bd5e7a0ab182d14d227b`.
+- Production release: `20260521220637`.
+- Production revision: `35d1f33b038df4eac330475d072f25fbbfd66364`.
+- The production runtime contains the guarded live submission executor.
+
+## Command
+
+The approved live command was executed through the guarded executor:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-submit \
+  --queue-item-id=1 \
+  --approval-phrase="<exact approved phrase>" \
+  --actor=rainie-codex \
+  --json
+```
+
+## Result
+
+The executor blocked before any write or external call:
+
+- `status=blocked`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `writes_attempted=false`
+- `writes_committed=false`
+- `submission_status=not_attempted`
+- `execution_state=dry_run_ready`
+- `scheduler_enabled=false`
+- `bulk_submission=false`
+
+Blocking issues:
+
+- `live_submission_gate_disabled`
+- `external_api_gate_disabled`
+- `indexnow_live_api_disabled`
+- `indexnow_key_missing`
+- `indexnow_key_location_missing`
+
+## Decision
+
+`SEARCH-CHANNEL-LIVE-02` did not submit the URL.
+
+The next step is not to retry immediately. Production needs a separately approved secure configuration path for IndexNow credentials and one-shot live gates, followed by config cache rebuild, a fresh `SEARCH-CHANNEL-LIVE-02-PREFLIGHT`, and a fresh exact approval phrase before another live submission attempt.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15621,24 +15621,41 @@
     "SEARCH-CHANNEL-LIVE-02": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-canary-submission",
-      "status": "blocked_waiting_for_exact_human_approval_phrase",
+      "status": "blocked_missing_indexnow_live_configuration",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-02-PREFLIGHT"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
+        "dependency_preflight": {
+          "status": "pass",
+          "summary": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT merged via PR #1533 at 3426bfaff578f72980c6bd5e7a0ab182d14d227b and produced the exact approval phrase."
+        },
         "human_approval": {
-          "status": "required",
-          "summary": "Live external submission is blocked until the exact human approval phrase is present.",
+          "status": "pass",
+          "summary": "Exact approval phrase was provided by the user.",
           "phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 1 channel indexnow URL https://fermatmind.com/en."
         },
-        "preflight": {
+        "approved_scope": {
           "status": "pass",
-          "summary": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT passed after production executor dry-run and produced the exact approval phrase."
+          "summary": "Attempt was limited to queue item 1, channel indexnow, URL https://fermatmind.com/en."
+        },
+        "live_command": {
+          "status": "blocked",
+          "command": "cd /var/www/fap-api/current/backend && php artisan seo-intel:search-channel-submit --queue-item-id=1 --approval-phrase=<exact approved phrase> --actor=rainie-codex --json",
+          "summary": "The guarded executor returned status=blocked with issues live_submission_gate_disabled, external_api_gate_disabled, indexnow_live_api_disabled, indexnow_key_missing, and indexnow_key_location_missing."
+        },
+        "no_external_call_or_write": {
+          "status": "pass",
+          "summary": "external_calls_attempted=false, search_submission_attempted=false, writes_attempted=false, writes_committed=false, scheduler_enabled=false, and bulk_submission=false."
+        },
+        "next_gate": {
+          "status": "blocked",
+          "summary": "A separately approved secure production configuration path is required for IndexNow credentials and one-shot live gates; after config cache rebuild, rerun SEARCH-CHANNEL-LIVE-02-PREFLIGHT before retrying live submission."
         }
       },
-      "failure_reason": "blocked_waiting_for_exact_human_approval_phrase",
+      "failure_reason": "blocked_missing_indexnow_live_configuration: exact approval phrase was present, but production live gates are disabled and IndexNow key/keyLocation are missing; guarded executor blocked before writes or external calls.",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -15657,13 +15674,18 @@
           "at": "2026-05-21T22:40:00+08:00",
           "status": "blocked_waiting_for_exact_human_approval_phrase",
           "summary": "Preflight passed and produced the exact approval phrase; live canary still must not run until the user sends that exact phrase."
+        },
+        {
+          "at": "2026-05-21T22:54:00+08:00",
+          "status": "blocked_missing_indexnow_live_configuration",
+          "summary": "Executed the exact approved guarded live command for queue item 1. The executor blocked before writes or external calls because live gates are disabled and IndexNow key/keyLocation are missing."
         }
       ]
     },
     "DIGITAL-PR-01E-24H-REVIEW": {
       "repo": "fap-api",
       "branch": "codex/digital-pr-01e-24h-review",
-      "status": "registered",
+      "status": "blocked_waiting_for_successful_live_canary",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-02"
       ],
@@ -15673,9 +15695,13 @@
         "review_window": {
           "status": "pending",
           "summary": "Should run after roughly 24 hours of canary observation."
+        },
+        "dependency": {
+          "status": "blocked",
+          "summary": "SEARCH-CHANNEL-LIVE-02 did not submit because production IndexNow live configuration is missing."
         }
       },
-      "failure_reason": null,
+      "failure_reason": "blocked_waiting_for_successful_live_canary",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -15684,6 +15710,11 @@
           "at": "2026-05-21T19:05:00+08:00",
           "status": "registered",
           "summary": "Registered 24h review task after the small URL submission canary; no retry, expansion, or extra submission is authorized."
+        },
+        {
+          "at": "2026-05-21T22:54:00+08:00",
+          "status": "blocked_waiting_for_successful_live_canary",
+          "summary": "24h review cannot start because no live canary submission occurred."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15621,12 +15621,12 @@
     "SEARCH-CHANNEL-LIVE-02": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-canary-submission",
-      "status": "blocked_missing_indexnow_live_configuration",
+      "status": "pr_opened_blocked_missing_indexnow_live_configuration",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-02-PREFLIGHT"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "823c3600",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1534",
       "checks": {
         "dependency_preflight": {
           "status": "pass",
@@ -15679,6 +15679,11 @@
           "at": "2026-05-21T22:54:00+08:00",
           "status": "blocked_missing_indexnow_live_configuration",
           "summary": "Executed the exact approved guarded live command for queue item 1. The executor blocked before writes or external calls because live gates are disabled and IndexNow key/keyLocation are missing."
+        },
+        {
+          "at": "2026-05-21T22:56:00+08:00",
+          "status": "pr_opened_blocked_missing_indexnow_live_configuration",
+          "summary": "Opened PR #1534 to record the guarded canary attempt blocked before writes or external calls due to missing IndexNow live configuration."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Recorded the human-approved SEARCH-CHANNEL-LIVE-02 canary attempt for queue item 1, channel indexnow, URL https://fermatmind.com/en.
- Added the canary markdown and generated JSON ledger artifact.
- Updated PR train state to mark the task blocked on missing IndexNow live configuration and to block the 24h review until a successful live canary exists.

## Result
The exact approval phrase was present, but the guarded executor blocked before writes or external calls because production live gates are disabled and IndexNow key/keyLocation are not configured in the production runtime.

## Validation
- Production guarded command: `php artisan seo-intel:search-channel-submit --queue-item-id=1 --approval-phrase=<exact approved phrase> --actor=rainie-codex --json`
- Local: `python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-canary.v1.json >/dev/null`
- Local: `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- Local: `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- Local: `git diff --check`

## Safety
- No live URL submission occurred.
- `external_calls_attempted=false`
- `search_submission_attempted=false`
- `writes_attempted=false`
- `writes_committed=false`
- No scheduler activation, bulk submission, production env edit, DNS change, or extra URL submission occurred.

## Intentionally deferred
- Configure IndexNow credentials and one-shot live gates through a separately approved secure production configuration path.
- Rebuild config cache, rerun SEARCH-CHANNEL-LIVE-02-PREFLIGHT, and request a fresh exact approval phrase before retrying live submission.

## Repository rule impact
No content authority changes. SEO/Search Channel authority remains backend-owned; this PR records a guarded production canary attempt that was blocked before external calls or writes.