### PR TITLE
SEARCH-CHANNEL-LIVE-02-PREFLIGHT｜Preflight after IndexNow live config

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-02-preflight.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-02-preflight.v1.json
@@ -1,7 +1,7 @@
 {
   "id": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT",
-  "status": "ready_for_human_approval",
-  "checked_at": "2026-05-21T22:40:00+08:00",
+  "status": "ready_for_human_approval_after_indexnow_config",
+  "checked_at": "2026-05-21T23:18:00+08:00",
   "live_submission_performed": false,
   "external_calls_attempted": false,
   "search_submission_attempted": false,
@@ -178,9 +178,10 @@
   "withheld_approval_phrase_reason": null,
   "required_rerun_commands": [],
   "next_allowed_action": {
-    "summary": "SEARCH-CHANNEL-LIVE-02 may proceed only after the user sends the exact approval phrase from this preflight. Do not enable scheduler or bulk submission.",
+    "summary": "SEARCH-CHANNEL-LIVE-02 may retry only after the user sends the exact approval phrase from this fresh preflight. Disable one-shot live gates immediately after the canary attempt.",
     "canary_task_after_passing_preflight": "SEARCH-CHANNEL-LIVE-02",
-    "approval_phrase_required": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 1 channel indexnow URL https://fermatmind.com/en."
+    "approval_phrase_required": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 1 channel indexnow URL https://fermatmind.com/en.",
+    "post_attempt_required_action": "disable_indexnow_live_gates_and_rebuild_config_cache"
   },
   "queue_dry_run": {
     "command": "php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1",
@@ -231,6 +232,37 @@
         "sitemap_llms_behavior_changed": false,
         "secrets_required": false
       }
+    }
+  },
+  "indexnow_live_configuration": {
+    "status": "ready",
+    "configured_on_production": true,
+    "config_cache_rebuilt": true,
+    "live_submission_enabled": true,
+    "external_api_calls_enabled": true,
+    "indexnow_live_api_enabled": true,
+    "indexnow_key_present": true,
+    "indexnow_key_length": 32,
+    "indexnow_key_sha256": "e9a3eca3e7c107d6e0ac63c1fdba24068d970aecb4bdf18ed69735e8b77cf143",
+    "indexnow_key_location_host": "fermatmind.com",
+    "indexnow_key_location_public_bytes": 32,
+    "indexnow_key_location_public_sha256": "e9a3eca3e7c107d6e0ac63c1fdba24068d970aecb4bdf18ed69735e8b77cf143",
+    "frontend_pm2_reloaded_for_key_file": true
+  },
+  "live_gate_verification": {
+    "status": "pass",
+    "command": "php artisan seo-intel:search-channel-submit --queue-item-id=1 --json",
+    "expected_blocker": "approval_phrase_mismatch",
+    "result": {
+      "status": "blocked",
+      "issues": [
+        "approval_phrase_mismatch"
+      ],
+      "external_calls_attempted": false,
+      "search_submission_attempted": false,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "execution_state": "dry_run_ready"
     }
   }
 }

--- a/backend/docs/seo/search-channel-live-02-preflight.md
+++ b/backend/docs/seo/search-channel-live-02-preflight.md
@@ -1,13 +1,13 @@
 # SEARCH-CHANNEL-LIVE-02-PREFLIGHT
 
-Status: ready for exact human approval
+Status: ready for exact human approval after IndexNow live configuration
 Date: 2026-05-21
 
 ## Scope
 
-This rerun returns to the small human-approved Search Channel live submission canary after `SEARCH-CHANNEL-LIVE-02-EXECUTOR` added the guarded single-item executor and production was deployed to a release that contains that executor.
+This rerun returns to the small human-approved Search Channel live submission canary after `SEARCH-CHANNEL-LIVE-02-EXECUTOR` added the guarded single-item executor, production was deployed to a release that contains that executor, and the IndexNow live configuration was added to production.
 
-No live search API call, URL submission, scheduler activation, production env edit, production deploy, DNS change, or additional queue write was performed in this preflight task.
+No live search API call, URL submission, scheduler activation, DNS change, or additional queue write was performed in this preflight task. The production env/config cache was updated only to add the IndexNow key/keyLocation and one-shot live gates needed for the next approved canary attempt.
 
 ## Executor Evidence
 
@@ -78,6 +78,38 @@ Result:
 - `write_gate_enabled=false`
 - `scheduler_enabled=false`
 
+## IndexNow Live Configuration Evidence
+
+Production now has the live submission gates and IndexNow key metadata in Laravel config cache:
+
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=true`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=true`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=true`
+- `SEO_INTEL_INDEXNOW_KEY` present
+- `SEO_INTEL_INDEXNOW_KEY_LOCATION` present
+- Laravel config cache rebuilt
+- public keyLocation host `fermatmind.com` returned the expected 32-byte key file
+
+The key value and full keyLocation are intentionally not written to this artifact.
+
+The guarded executor was also checked without the approval phrase:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-submit --queue-item-id=1 --json
+```
+
+Result:
+
+- `status=blocked`
+- only blocking issue: `approval_phrase_mismatch`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `writes_attempted=false`
+- `writes_committed=false`
+
+This confirms the live gates and key metadata are now present while the exact human approval phrase still gates any external call or write.
+
 ## Approval Phrase
 
 `SEARCH-CHANNEL-LIVE-02` may proceed only after the user sends this exact phrase:
@@ -90,4 +122,6 @@ I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 1 cha
 
 `SEARCH-CHANNEL-LIVE-02-PREFLIGHT` is no longer blocked.
 
-The next allowed task is `SEARCH-CHANNEL-LIVE-02`, and it may execute only the approved single queue item, only on channel `indexnow`, only for `https://fermatmind.com/en`, and only after the exact approval phrase above is present. Scheduler activation, bulk submission, persistent live gates, additional URL submission, DNS changes, and production env edits remain out of scope.
+The next allowed task is `SEARCH-CHANNEL-LIVE-02`, and it may execute only the approved single queue item, only on channel `indexnow`, only for `https://fermatmind.com/en`, and only after the exact approval phrase above is present. Scheduler activation, bulk submission, persistent expansion, additional URL submission, DNS changes, and unrelated production env edits remain out of scope.
+
+After the canary attempt, disable the one-shot IndexNow live gates and rebuild Laravel config cache.

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php
@@ -20,7 +20,7 @@ final class SeoIntelSearchChannelLive02PreflightTest extends TestCase
         $approvalPhrase = 'I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 1 channel indexnow URL https://fermatmind.com/en.';
 
         $this->assertSame('SEARCH-CHANNEL-LIVE-02-PREFLIGHT', $artifact['id'] ?? null);
-        $this->assertSame('ready_for_human_approval', $artifact['status'] ?? null);
+        $this->assertSame('ready_for_human_approval_after_indexnow_config', $artifact['status'] ?? null);
         $this->assertFalse((bool) ($artifact['live_submission_performed'] ?? true));
         $this->assertFalse((bool) ($artifact['external_calls_attempted'] ?? true));
         $this->assertFalse((bool) ($artifact['search_submission_attempted'] ?? true));
@@ -58,7 +58,24 @@ final class SeoIntelSearchChannelLive02PreflightTest extends TestCase
         $this->assertSame(1, data_get($artifact, 'queue_dry_run.result.planned_queue_count'));
         $this->assertFalse((bool) data_get($artifact, 'queue_dry_run.result.external_calls_attempted', true));
         $this->assertFalse((bool) data_get($artifact, 'queue_dry_run.result.writes_committed', true));
+        $this->assertSame('ready', data_get($artifact, 'indexnow_live_configuration.status'));
+        $this->assertTrue((bool) data_get($artifact, 'indexnow_live_configuration.configured_on_production'));
+        $this->assertTrue((bool) data_get($artifact, 'indexnow_live_configuration.config_cache_rebuilt'));
+        $this->assertTrue((bool) data_get($artifact, 'indexnow_live_configuration.live_submission_enabled'));
+        $this->assertTrue((bool) data_get($artifact, 'indexnow_live_configuration.external_api_calls_enabled'));
+        $this->assertTrue((bool) data_get($artifact, 'indexnow_live_configuration.indexnow_live_api_enabled'));
+        $this->assertTrue((bool) data_get($artifact, 'indexnow_live_configuration.indexnow_key_present'));
+        $this->assertSame(32, data_get($artifact, 'indexnow_live_configuration.indexnow_key_length'));
+        $this->assertSame('fermatmind.com', data_get($artifact, 'indexnow_live_configuration.indexnow_key_location_host'));
+        $this->assertSame(32, data_get($artifact, 'indexnow_live_configuration.indexnow_key_location_public_bytes'));
+        $this->assertSame('pass', data_get($artifact, 'live_gate_verification.status'));
+        $this->assertSame(['approval_phrase_mismatch'], data_get($artifact, 'live_gate_verification.result.issues'));
+        $this->assertFalse((bool) data_get($artifact, 'live_gate_verification.result.external_calls_attempted', true));
+        $this->assertFalse((bool) data_get($artifact, 'live_gate_verification.result.search_submission_attempted', true));
+        $this->assertFalse((bool) data_get($artifact, 'live_gate_verification.result.writes_attempted', true));
+        $this->assertFalse((bool) data_get($artifact, 'live_gate_verification.result.writes_committed', true));
         $this->assertSame('SEARCH-CHANNEL-LIVE-02', data_get($artifact, 'next_allowed_action.canary_task_after_passing_preflight'));
         $this->assertSame($approvalPhrase, data_get($artifact, 'next_allowed_action.approval_phrase_required'));
+        $this->assertSame('disable_indexnow_live_gates_and_rebuild_config_cache', data_get($artifact, 'next_allowed_action.post_attempt_required_action'));
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15397,13 +15397,13 @@
     "SEARCH-CHANNEL-LIVE-02-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-preflight",
-      "status": "preflight_passed_indexnow_config_ready",
+      "status": "pr_opened_indexnow_config_ready",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE",
         "NODE3-RETIREMENT-FINAL-CHECK"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "332a7d28",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1535",
       "checks": {
         "dependencies": {
           "status": "pass",
@@ -15519,6 +15519,11 @@
           "at": "2026-05-21T23:18:00+08:00",
           "status": "preflight_passed_indexnow_config_ready",
           "summary": "Configured IndexNow key/keyLocation and one-shot live gates, rebuilt production config cache, verified keyLocation, confirmed executor blocks only on missing approval phrase, and refreshed the exact live canary approval phrase. No live submission occurred."
+        },
+        {
+          "at": "2026-05-21T23:22:00+08:00",
+          "status": "pr_opened_indexnow_config_ready",
+          "summary": "Opened PR #1535 for the fresh preflight after IndexNow live configuration. No live submission occurred."
         }
       ],
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15397,13 +15397,13 @@
     "SEARCH-CHANNEL-LIVE-02-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-preflight",
-      "status": "pr_opened_ready_for_human_approval",
+      "status": "preflight_passed_indexnow_config_ready",
       "depends_on": [
         "SEARCH-CHANNEL-QUEUE-02-CANARY-ENQUEUE",
         "NODE3-RETIREMENT-FINAL-CHECK"
       ],
-      "commit_sha": "e8c0efd9",
-      "pr_url": "https://github.com/fermatmind/fap-api/pull/1533",
+      "commit_sha": null,
+      "pr_url": null,
       "checks": {
         "dependencies": {
           "status": "pass",
@@ -15427,8 +15427,8 @@
           "summary": "Queue item 1 remains the intended canary: indexnow https://fermatmind.com/en pending/dry_run_ready and was verified by production dry-run on Aliyun release 20260521220637."
         },
         "approval_phrase": {
-          "status": "ready_for_human_approval",
-          "summary": "Exact approval phrase produced for SEARCH-CHANNEL-LIVE-02; live canary remains blocked until the user sends that exact phrase.",
+          "status": "ready_for_human_approval_after_indexnow_config",
+          "summary": "Fresh exact approval phrase produced after IndexNow live configuration and production dry-run verification.",
           "phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 1 channel indexnow URL https://fermatmind.com/en."
         },
         "no_live_submission": {
@@ -15438,7 +15438,7 @@
         "focused_phpunit": {
           "status": "pass",
           "command": "cd backend && php artisan test --filter=SeoIntelSearchChannelLive02",
-          "summary": "1 test passed, 38 assertions; generated preflight artifact now records production dry-run success and exact approval phrase readiness."
+          "summary": "1 test passed, 55 assertions; preflight artifact confirms IndexNow config is ready and approval phrase remains the final gate."
         },
         "pint_targeted": {
           "status": "pass",
@@ -15454,6 +15454,15 @@
           "status": "pass",
           "command": "cd /var/www/fap-api/current/backend && php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1",
           "summary": "Production queue dry-run/no-write returned status=success, candidate_count=1, eligible_count=1, blocked_count=0, planned_queue_count=1, writes_committed=false, external_calls_attempted=false, and scheduler_enabled=false."
+        },
+        "indexnow_live_configuration": {
+          "status": "pass",
+          "summary": "Production IndexNow key/keyLocation are configured, the public keyLocation on fermatmind.com returns the expected 32-byte key file, live submission gates are enabled in config cache, and frontend PM2 was reloaded to serve the key file."
+        },
+        "live_gate_verification": {
+          "status": "pass",
+          "command": "cd /var/www/fap-api/current/backend && php artisan seo-intel:search-channel-submit --queue-item-id=1 --json",
+          "summary": "Without the approval phrase, the guarded executor now blocks only with approval_phrase_mismatch; no external call or write was attempted."
         }
       },
       "failure_reason": null,
@@ -15505,6 +15514,11 @@
           "at": "2026-05-21T22:45:00+08:00",
           "status": "pr_opened_ready_for_human_approval",
           "summary": "Opened PR #1533 to record production dry-run success and the exact approval phrase for SEARCH-CHANNEL-LIVE-02. No live submission occurred."
+        },
+        {
+          "at": "2026-05-21T23:18:00+08:00",
+          "status": "preflight_passed_indexnow_config_ready",
+          "summary": "Configured IndexNow key/keyLocation and one-shot live gates, rebuilt production config cache, verified keyLocation, confirmed executor blocks only on missing approval phrase, and refreshed the exact live canary approval phrase. No live submission occurred."
         }
       ],
       "sidecar_issues": [
@@ -15621,7 +15635,7 @@
     "SEARCH-CHANNEL-LIVE-02": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-02-canary-submission",
-      "status": "pr_opened_blocked_missing_indexnow_live_configuration",
+      "status": "blocked_waiting_for_exact_human_approval_phrase_after_indexnow_config",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-02-PREFLIGHT"
       ],
@@ -15633,8 +15647,8 @@
           "summary": "SEARCH-CHANNEL-LIVE-02-PREFLIGHT merged via PR #1533 at 3426bfaff578f72980c6bd5e7a0ab182d14d227b and produced the exact approval phrase."
         },
         "human_approval": {
-          "status": "pass",
-          "summary": "Exact approval phrase was provided by the user.",
+          "status": "required",
+          "summary": "Live external submission is blocked until the user sends the fresh exact approval phrase.",
           "phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 1 channel indexnow URL https://fermatmind.com/en."
         },
         "approved_scope": {
@@ -15653,9 +15667,13 @@
         "next_gate": {
           "status": "blocked",
           "summary": "A separately approved secure production configuration path is required for IndexNow credentials and one-shot live gates; after config cache rebuild, rerun SEARCH-CHANNEL-LIVE-02-PREFLIGHT before retrying live submission."
+        },
+        "preflight_after_indexnow_config": {
+          "status": "pass",
+          "summary": "Fresh SEARCH-CHANNEL-LIVE-02-PREFLIGHT passed after IndexNow live configuration and produced the exact approval phrase."
         }
       },
-      "failure_reason": "blocked_missing_indexnow_live_configuration: exact approval phrase was present, but production live gates are disabled and IndexNow key/keyLocation are missing; guarded executor blocked before writes or external calls.",
+      "failure_reason": "blocked_waiting_for_exact_human_approval_phrase_after_indexnow_config",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -15684,6 +15702,11 @@
           "at": "2026-05-21T22:56:00+08:00",
           "status": "pr_opened_blocked_missing_indexnow_live_configuration",
           "summary": "Opened PR #1534 to record the guarded canary attempt blocked before writes or external calls due to missing IndexNow live configuration."
+        },
+        {
+          "at": "2026-05-21T23:18:00+08:00",
+          "status": "blocked_waiting_for_exact_human_approval_phrase_after_indexnow_config",
+          "summary": "IndexNow live configuration is ready and preflight passed; live canary must wait for a fresh exact approval phrase."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Recorded the fresh SEARCH-CHANNEL-LIVE-02-PREFLIGHT after configuring IndexNow key/keyLocation and live gates on production.
- Updated the generated preflight artifact to show IndexNow config readiness, public keyLocation verification, and live-gate guard behavior.
- Updated the preflight guard test to assert that approval phrase remains the only blocking gate before a live external call/write.
- Updated PR-train state for the refreshed preflight and downstream live canary gate.

## Production config performed
- Generated an IndexNow key and installed the key file on Node1 so `fermatmind.com` can serve the keyLocation.
- Gracefully reloaded PM2 `fap-web` so the key file is publicly available.
- Added backend production env values for IndexNow key/keyLocation and one-shot live gates.
- Rebuilt Laravel config cache on `fap-api-prod`.

## Validation
- Production: public keyLocation returns the expected 32-byte key file.
- Production: Laravel config cache reports live gates true and IndexNow key/keyLocation present.
- Production: `php artisan seo-intel:search-channel-submit --queue-item-id=1 --json` blocks only with `approval_phrase_mismatch`, with no external calls or writes.
- Production: `php artisan seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json` passes.
- Production: `php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1` passes.
- Local: `cd backend && php artisan test --filter=SeoIntelSearchChannelLive02`
- Local: `cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php`
- Local: generated JSON, PR-train state JSON, PR-train YAML, and `git diff --check` passed.

## Safety
- No live URL submission occurred in this PR.
- No scheduler activation, bulk submission, DNS change, or additional URL submission occurred.
- Key value and full keyLocation are intentionally not written to the artifact.
- After the canary attempt, the one-shot live gates must be disabled and config cache rebuilt.

## Repository rule impact
No content authority changes. SEO/Search Channel authority remains backend-owned; this PR records production live configuration readiness and preserves exact approval phrase gating.