### PR TITLE
OPS-SEO-NATIVE-DASH-03｜Issue Queue and Search Channel detail panels

### DIFF
--- a/backend/docs/seo/generated/ops-seo-native-dashboard-panels.v1.json
+++ b/backend/docs/seo/generated/ops-seo-native-dashboard-panels.v1.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "version": "ops-seo-native-dashboard-panels.v1",
+  "task": "OPS-SEO-NATIVE-DASH-03",
+  "runtime": "ops_seo_native_dashboard",
+  "surface": "/ops/seo",
+  "implementation": "issue_queue_and_search_channel_detail_panels",
+  "read_only": true,
+  "read_only_filter_dimensions": {
+    "issue_queue": [
+      "issue_type",
+      "severity",
+      "status"
+    ],
+    "search_channel_queue": [
+      "channel",
+      "approval_state",
+      "execution_state"
+    ]
+  },
+  "issue_queue_detail_panel": {
+    "safe_columns": [
+      "canonical_path",
+      "locale",
+      "page_entity_type",
+      "issue_type",
+      "severity",
+      "source_system",
+      "source_engine",
+      "status",
+      "lifecycle_state",
+      "detected_at",
+      "updated_at"
+    ]
+  },
+  "search_channel_queue_detail_panel": {
+    "safe_columns": [
+      "canonical_path",
+      "locale",
+      "page_entity_type",
+      "source_authority",
+      "channel",
+      "eligibility_state",
+      "approval_state",
+      "execution_state",
+      "indexability_state",
+      "claim_boundary_state",
+      "private_flow",
+      "created_at",
+      "updated_at"
+    ]
+  },
+  "payload_drilldown_added": false,
+  "raw_json_displayed": false,
+  "event_payload_displayed": false,
+  "reason_codes_displayed": false,
+  "mutation_controls_added": false,
+  "approve_retry_submit_buttons_added": false,
+  "scheduler_controls_added": false,
+  "collector_controls_added": false,
+  "metabase_exposure_added": false,
+  "external_api_call_added": false,
+  "next_task": "OPS-SEO-NATIVE-DASH-04"
+}

--- a/backend/docs/seo/ops-seo-native-dashboard-panels.md
+++ b/backend/docs/seo/ops-seo-native-dashboard-panels.md
@@ -1,0 +1,63 @@
+# OPS-SEO-NATIVE-DASH-03 Issue Queue and Search Channel Detail Panels
+
+## Purpose
+
+`/ops/seo` now exposes safer native detail panels for the two operational queues that matter for SEO observability:
+
+- Issue Queue detail panel
+- Search Channel Queue detail panel
+
+These panels remain read-only and reuse normalized fields from the existing `seo_intel` read model.
+
+## Read-only Filter Dimensions
+
+Interactive Livewire filters are intentionally deferred because this PR does not modify the page class. The current PR exposes read-only filter dimensions through aggregate buckets:
+
+- Issue Queue: `issue_type`, `severity`, `status`
+- Search Channel Queue: `channel`, `approval_state`, `execution_state`
+
+## Safe Detail Columns
+
+Issue Queue detail panel:
+
+- canonical path
+- locale
+- page entity type
+- issue type
+- severity
+- source system
+- source engine
+- status
+- lifecycle state
+- detected at
+- updated at
+
+Search Channel Queue detail panel:
+
+- canonical path
+- locale
+- page entity type
+- source authority
+- channel
+- eligibility state
+- approval state
+- execution state
+- indexability state
+- claim boundary state
+- private flow
+- created at
+- updated at
+
+## Forbidden
+
+- No payload drilldown.
+- No raw JSON.
+- No `metadata_json`, `attributes_json`, `reason_codes`, or `event_payload` display.
+- No approve/retry/submit buttons.
+- No mutation controls.
+- No scheduler controls.
+- No collector controls.
+- No Metabase iframe/proxy/exposure.
+- No external search API calls.
+
+Next task: `OPS-SEO-NATIVE-DASH-04`

--- a/backend/resources/views/filament/ops/pages/seo-dashboard-access.blade.php
+++ b/backend/resources/views/filament/ops/pages/seo-dashboard-access.blade.php
@@ -71,7 +71,7 @@
 
         <x-filament-ops::ops-section
             title="Issue Queue overview"
-            description="Read-only issue aggregates and recent safe rows. Raw evidence, payloads, JSON, and PII stay hidden."
+            description="Issue Queue detail panel with read-only aggregates and recent safe rows. Aggregate buckets provide safe filter dimensions; raw evidence, payloads, JSON, and PII stay hidden."
         >
             <div class="ops-card-list">
                 @foreach ($this->issueQueueAggregateCards() as $card)
@@ -101,10 +101,14 @@
                 <x-slot name="head">
                     <tr>
                         <th>canonical path</th>
+                        <th>locale</th>
                         <th>page_entity_type</th>
                         <th>issue_type</th>
                         <th>severity</th>
+                        <th>source_system</th>
+                        <th>source_engine</th>
                         <th>status</th>
+                        <th>lifecycle_state</th>
                         <th>detected_at</th>
                         <th>updated_at</th>
                     </tr>
@@ -113,10 +117,14 @@
                 @foreach ($recentIssues as $issue)
                     <tr>
                         <td>{{ $issue['canonical_path'] ?? '-' }}</td>
+                        <td>{{ $issue['locale'] ?? '-' }}</td>
                         <td>{{ $issue['page_entity_type'] ?? '-' }}</td>
                         <td>{{ $issue['issue_type'] ?? '-' }}</td>
                         <td>{{ $issue['severity'] ?? '-' }}</td>
+                        <td>{{ $issue['source_system'] ?? '-' }}</td>
+                        <td>{{ $issue['source_engine'] ?? '-' }}</td>
                         <td>{{ $issue['status'] ?? '-' }}</td>
+                        <td>{{ $issue['lifecycle_state'] ?? '-' }}</td>
                         <td>{{ $issue['detected_at'] ?? '-' }}</td>
                         <td>{{ $issue['updated_at'] ?? '-' }}</td>
                     </tr>
@@ -126,7 +134,7 @@
 
         <x-filament-ops::ops-section
             title="Search Channel Queue overview"
-            description="Read-only channel state. This page has no approve, retry, submit, scheduler, collector, or live API controls."
+            description="Search Channel Queue detail panel with read-only channel state and safe filter dimensions. This page has no approve, retry, submit, scheduler, collector, or live API controls."
         >
             <div class="ops-card-list">
                 @foreach ($this->searchChannelQueueAggregateCards() as $card)
@@ -156,9 +164,16 @@
                 <x-slot name="head">
                     <tr>
                         <th>canonical path</th>
+                        <th>locale</th>
+                        <th>page_entity_type</th>
+                        <th>source_authority</th>
                         <th>channel</th>
+                        <th>eligibility_state</th>
                         <th>approval_state</th>
                         <th>execution_state</th>
+                        <th>indexability_state</th>
+                        <th>claim_boundary_state</th>
+                        <th>private_flow</th>
                         <th>created_at</th>
                         <th>updated_at</th>
                     </tr>
@@ -167,9 +182,16 @@
                 @foreach ($recentQueueRows as $row)
                     <tr>
                         <td>{{ $row['canonical_path'] ?? '-' }}</td>
+                        <td>{{ $row['locale'] ?? '-' }}</td>
+                        <td>{{ $row['page_entity_type'] ?? '-' }}</td>
+                        <td>{{ $row['source_authority'] ?? '-' }}</td>
                         <td>{{ $row['channel'] ?? '-' }}</td>
+                        <td>{{ $row['eligibility_state'] ?? '-' }}</td>
                         <td>{{ $row['approval_state'] ?? '-' }}</td>
                         <td>{{ $row['execution_state'] ?? '-' }}</td>
+                        <td>{{ $row['indexability_state'] ?? '-' }}</td>
+                        <td>{{ $row['claim_boundary_state'] ?? '-' }}</td>
+                        <td>{{ ($row['private_flow'] ?? false) ? 'true' : 'false' }}</td>
                         <td>{{ $row['created_at'] ?? '-' }}</td>
                         <td>{{ $row['updated_at'] ?? '-' }}</td>
                     </tr>

--- a/backend/tests/Feature/SeoIntel/SeoIntelOpsSeoNativeDashboardPanelsTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelOpsSeoNativeDashboardPanelsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelOpsSeoNativeDashboardPanelsTest extends TestCase
+{
+    #[Test]
+    public function blade_renders_issue_and_queue_detail_panels_with_safe_columns_only(): void
+    {
+        $view = strtolower((string) file_get_contents(resource_path('views/filament/ops/pages/seo-dashboard-access.blade.php')));
+
+        foreach ([
+            'issue queue detail panel',
+            'search channel queue detail panel',
+            'canonical path',
+            'locale',
+            'page_entity_type',
+            'issue_type',
+            'severity',
+            'source_system',
+            'source_engine',
+            'status',
+            'lifecycle_state',
+            'detected_at',
+            'updated_at',
+            'source_authority',
+            'channel',
+            'eligibility_state',
+            'approval_state',
+            'execution_state',
+            'indexability_state',
+            'claim_boundary_state',
+            'private_flow',
+            'event_type summary',
+        ] as $required) {
+            $this->assertStringContainsString($required, $view);
+        }
+
+        foreach ([
+            'metadata_json',
+            'attributes_json',
+            'event_payload',
+            'reason_codes',
+            '<iframe',
+            '<x-filament::button',
+            '<button',
+            'wire:click',
+            'approvequeueitem',
+            'retryqueueitem',
+            'submitqueueitem',
+            'submitsearchchannel',
+            'searchchannelqueuewriteservice',
+            'searchchannelqueuesubmission',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $view);
+        }
+    }
+
+    #[Test]
+    public function docs_and_artifact_lock_detail_panel_boundaries(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/ops-seo-native-dashboard-panels.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/ops-seo-native-dashboard-panels.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'ops-seo-native-dash-03',
+            'issue queue detail panel',
+            'search channel queue detail panel',
+            'read-only filter dimensions',
+            'no payload drilldown',
+            'no approve/retry/submit buttons',
+            'no mutation controls',
+            'no raw json',
+            'next task: `ops-seo-native-dash-04`',
+            '"next_task": "ops-seo-native-dash-04"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+
+        foreach ([
+            '"event_payload_displayed": true',
+            '"reason_codes_displayed": true',
+            '"mutation_controls_added": true',
+            '"metabase_exposure_added": true',
+            '"external_api_call_added": true',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $combined);
+        }
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15995,7 +15995,7 @@
       "depends_on": [
         "OPS-SEO-NATIVE-DASH-02"
       ],
-      "commit_sha": null,
+      "commit_sha": "0255f83cfb21460f491e4f2cff0f772727f70bff",
       "pr_url": null,
       "checks": {
         "dependency": {
@@ -16065,7 +16065,7 @@
         {
           "at": "2026-05-22T02:22:00+08:00",
           "status": "committed",
-          "summary": "Committed scoped PR3 implementation at 49d13b75eb122ad97af8cbafd7675bde294328be."
+          "summary": "Committed scoped PR3 implementation at 0255f83cfb21460f491e4f2cff0f772727f70bff."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T02:22:00+08:00",
+  "updated_at": "2026-05-22T02:28:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -4276,7 +4276,7 @@
         "no deploy"
       ],
       "commit_sha": "485949cd5b84b2b1836abefa2b639db8d724d64c",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1539",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -16066,6 +16066,11 @@
           "at": "2026-05-22T02:22:00+08:00",
           "status": "committed",
           "summary": "Committed scoped PR3 implementation at 0255f83cfb21460f491e4f2cff0f772727f70bff."
+        },
+        {
+          "at": "2026-05-22T02:28:00+08:00",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR #1539 for Issue Queue and Search Channel detail panels. GitHub checks are pending."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-21T20:30:00+08:00",
+  "updated_at": "2026-05-22T02:22:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -5314,7 +5314,7 @@
         "no fap-web change",
         "do not weaken final live acceptance"
       ],
-      "commit_sha": null,
+      "commit_sha": "49d13b75eb122ad97af8cbafd7675bde294328be",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1392",
       "checks": {
         "authorization": {
@@ -15887,12 +15887,12 @@
     "OPS-SEO-NATIVE-DASH-02": {
       "repo": "fap-api",
       "branch": "codex/ops-seo-native-dash-02-filament-ui",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "OPS-SEO-NATIVE-DASH-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "c5db09a4786b71b020abd0fa2c3ed4600c810461",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1538",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -15946,10 +15946,10 @@
           "summary": "Applied the narrowest allowlist for backend/app/Filament/Ops/Pages/SeoDashboardAccessPage.php and revalidated the runtime freeze guard, focused dashboard tests, scoped Pint, and diff checks locally."
         }
       },
-      "failure_reason": "GitHub checks verify-mbti-legacy and verify-mbti-v2 initially failed on PR #1538 because the Big Five runtime freeze classifier needed a scoped allowlist entry for SeoDashboardAccessPage.php. A scoped fix was applied and validated locally.",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "failure_reason": null,
+      "merged_at": "2026-05-22T01:56:00+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-22T00:20:00+08:00",
@@ -15980,13 +15980,18 @@
           "at": "2026-05-22T01:52:00+08:00",
           "status": "github_checks_failed_scoped_fix_local_passed",
           "summary": "Inspected PR #1538 verify-mbti failures, added the narrowest Big Five runtime freeze allowlist for SeoDashboardAccessPage.php, and reran the freeze guard, focused dashboard tests, scoped Pint, and diff checks locally."
+        },
+        {
+          "at": "2026-05-22T01:56:00+08:00",
+          "status": "merged",
+          "summary": "PR #1538 checks passed, mergeStateStatus was CLEAN, squash merge produced c5db09a4786b71b020abd0fa2c3ed4600c810461, the remote branch was deleted, and local main was synced. post_merge_cleanup.sh was not present, so cleanup was verified manually."
         }
       ]
     },
     "OPS-SEO-NATIVE-DASH-03": {
       "repo": "fap-api",
       "branch": "codex/ops-seo-native-dash-03-detail-panels",
-      "status": "registered",
+      "status": "in_progress",
       "depends_on": [
         "OPS-SEO-NATIVE-DASH-02"
       ],
@@ -15994,8 +15999,47 @@
       "pr_url": null,
       "checks": {
         "dependency": {
-          "status": "pending",
-          "summary": "Cannot start until OPS-SEO-NATIVE-DASH-02 is merged."
+          "status": "pass",
+          "summary": "OPS-SEO-NATIVE-DASH-02 is merged into origin/main as c5db09a4786b71b020abd0fa2c3ed4600c810461."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "summary": "Changed files are confined to the scoped Blade detail panels, focused panel test, docs/generated artifact, and PR-train metadata."
+        },
+        "focused_phpunit_initial": {
+          "status": "fail_fixed",
+          "command": "cd backend && php artisan test --filter=SeoIntelOpsSeoNativeDashboard",
+          "summary": "Initial panel test was too broad and treated the safety notice text 'no approve/retry/submit buttons' as a forbidden live control. The assertion was narrowed to actual button/action markers, then revalidated."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelOpsSeoNativeDashboard",
+          "summary": "10 tests passed, 170 assertions."
+        },
+        "seo_intel_suite": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "summary": "285 tests passed, 4622 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "summary": "Route list rendered successfully with 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "summary": "Pint passed across 3439 files."
+        },
+        "bigfive_runtime_freeze_guard": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff",
+          "summary": "Runtime freeze guard passed; no PR3 allowlist update was required."
+        },
+        "json_yaml_diff": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/ops-seo-native-dashboard-panels.v1.json >/dev/null; python3 -m json.tool docs/codex/pr-train-state.json >/dev/null; python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"; git diff --check; git diff --cached --check",
+          "summary": "Generated JSON, PR-train state JSON, PR-train YAML, and whitespace diff checks passed."
         }
       },
       "failure_reason": null,
@@ -16007,6 +16051,21 @@
           "at": "2026-05-22T00:20:00+08:00",
           "status": "registered",
           "summary": "Registered detail panel PR for native /ops/seo dashboard. Waiting for UI merge."
+        },
+        {
+          "at": "2026-05-22T02:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started codex/ops-seo-native-dash-03-detail-panels from latest main after confirming the Filament UI PR dependency was merged and cleaned up."
+        },
+        {
+          "at": "2026-05-22T02:20:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Implemented read-only Issue Queue and Search Channel Queue detail panels with safe display columns, docs/generated artifact, focused panel tests, and passed focused dashboard tests, full SeoIntel suite, route list, Pint, BigFive runtime freeze guard, JSON/YAML, and diff checks."
+        },
+        {
+          "at": "2026-05-22T02:22:00+08:00",
+          "status": "committed",
+          "summary": "Committed scoped PR3 implementation at 49d13b75eb122ad97af8cbafd7675bde294328be."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Expanded the native /ops/seo Issue Queue section into a read-only detail panel with safe columns for canonical path, locale, page type, issue type, severity, source system, source engine, status, lifecycle state, detected_at, and updated_at.
- Expanded the Search Channel Queue section into a read-only detail panel with safe columns for canonical path, locale, page type, source authority, channel, eligibility, approval, execution, indexability, claim boundary, private flow, created_at, and updated_at.
- Added focused static boundary tests plus docs and generated artifact for the detail-panel scope.
- Reconciled PR2 train state after its merged GitHub status.

## Why
- /ops/seo V1 needs native operator visibility into Issue Queue and Search Channel Queue state without exposing raw payloads or adding any write controls.
- This keeps the dashboard as a read-only observability surface using the existing read model from the prior PRs.

## Validation commands
- cd backend && php artisan test --filter=SeoIntelOpsSeoNativeDashboard
- cd backend && php artisan test --filter=SeoIntel
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff
- python3 -m json.tool backend/docs/seo/generated/ops-seo-native-dashboard-panels.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No interactive Livewire filters because this PR does not modify the page class; current aggregate buckets serve as read-only filter dimensions.
- No payload drilldown or raw JSON display.
- No approve, retry, submit, scheduler, collector, export, or write controls.
- No Metabase iframe/proxy/exposure.
- No production operation, deployment, migration, env edit, crawler log read, external API call, or search submission.
