### PR TITLE
docs(seo-intel): add crawler log architecture contract

### DIFF
--- a/backend/docs/seo/crawler-log-architecture-contract.md
+++ b/backend/docs/seo/crawler-log-architecture-contract.md
@@ -1,0 +1,273 @@
+# CRAWLER-LOG-00 Crawler Log Architecture Contract
+
+## Purpose
+
+Crawler Log is aggregate search bot observability. It answers which bot families accessed which safe paths, when they were seen, status distribution, whether visits concentrate on indexable URL Truth rows, and whether unknown bots, 404s, private-flow probes, or unexpected hosts appear.
+
+Crawler Log is not URL Truth, not Search Channel Queue, not CMS authority, and not an issue auto-fix system. It must not create URL Truth, decide canonical or indexability state, enqueue search submission, submit URLs, or use frontend fallback, static sitemap, static `llms.txt`, local copies, Node2 local DB, crawler logs, or external search surfaces as authority.
+
+This PR is architecture contract only. It does not read production crawler logs, add a runtime parser, add a scheduler, run collector writes, run migrations, deploy, edit env, expose Metabase, call search APIs, or submit URLs.
+
+## Source Boundary
+
+Allowed future source families after explicit approval:
+
+- nginx / OpenResty access log
+- CDN edge access log
+- ALB / SLB access log
+
+Any production source must document:
+
+- log path
+- log format
+- owner
+- retention
+- whether cookies, headers, or queries are present
+- whether private routes are present
+- maximum read lines
+- read time window
+
+Forbidden sources:
+
+- Node2 local Laravel log
+- Node2 local DB
+- business DB log
+- payment log
+- provider webhook log
+- application debug log
+- raw request payload log
+- unapproved production raw access log
+
+## Aggregate Schema
+
+Prefer the existing `seo_crawler_logs_daily` table. If a future PR proves the table is insufficient, any migration must use the `seo_intel` connection and must remain aggregate-only.
+
+Required V1 fields:
+
+- `log_date`
+- `host`
+- `surface_family`
+- `bot_family`
+- `bot_variant`
+- `bot_verification_state`
+- `route_family`
+- `page_entity_type`
+- `canonical_path`
+- `path_hash`
+- `http_status`
+- `method_bucket`
+- `query_present`
+- `query_risk_state`
+- `private_path_blocked`
+- `hit_count`
+- `first_seen_at`
+- `last_seen_at`
+- `source_log_family`
+- `privacy_transform_version`
+
+Allowed hosts are `fermatmind.com`, `www.fermatmind.com`, `api.fermatmind.com`, `ops.fermatmind.com`, and `unknown_host`.
+
+`public_web` is the SEO observation surface. `api` and `ops` are not search assets and must not become URL Truth or search candidates.
+
+## Forbidden Persistent Fields
+
+These fields must not be persisted to `seo_intel` in V1:
+
+- `ip_address`
+- `remote_addr`
+- `raw_user_agent`
+- `raw_request_uri`
+- `raw_query_string`
+- `cookie`
+- `headers`
+- `authorization`
+- `session_id`
+- `token`
+- `api_key`
+- `email`
+- `order_no`
+- `attempt_id`
+- `payment_id`
+- `provider_event_id`
+- `raw_payload`
+- `raw_log_line`
+- `event_payload`
+- `metadata_json`
+- `attributes_json`
+
+Wide JSON fields are blocked in V1 because they are too easy to misuse as raw payload storage.
+
+## Bot Normalization
+
+V1 uses user-agent claim classification only:
+
+`bot_verification_state = ua_claim_only`
+
+No DNS reverse verification is performed in V1.
+
+Bot family outputs:
+
+- `googlebot`
+- `bingbot`
+- `baiduspider`
+- `so360`
+- `sogou`
+- `shenma`
+- `yandex`
+- `duckduckbot`
+- `applebot`
+- `bytespider`
+- `petalbot`
+- `facebook_external_hit`
+- `twitterbot`
+- `linkedinbot`
+- `unknown_bot`
+- `non_bot`
+- `unknown_user_agent`
+
+Known Google variants map to `web`, `image`, `ads`, `media`, `mobile`, or `unknown`. Other crawlers use `web` or `unknown` unless a safe normalized variant is defined later.
+
+## Path Privacy Transform
+
+Every raw log line must be handled in this order:
+
+1. Parse ephemeral fields in memory.
+2. Classify bot family from user-agent in memory.
+3. Normalize method, status, and host.
+4. Strip query string completely.
+5. Classify route family.
+6. Detect private route or token risk.
+7. Map to URL Truth only when the path is safe.
+8. Drop raw IP, raw user-agent, raw request URI, cookie, header, query, and raw log line.
+9. Aggregate counters.
+10. Persist aggregate-only rows.
+
+Query handling stores only `query_present` and `query_risk_state`.
+
+Allowed query risk states:
+
+- `none`
+- `tracking_only`
+- `sensitive_key_present`
+- `unknown_query_present`
+
+Private paths and unknown paths must not store raw path text. They use `path_hash` and a blocked or unknown route family.
+
+## Private Path Denylist
+
+Any path or host matching these route prefixes must not be stored as raw `canonical_path`:
+
+- `/take`
+- `/result`
+- `/results`
+- `/order`
+- `/orders`
+- `/checkout`
+- `/pay`
+- `/payment`
+- `/share`
+- `/report-private`
+- `/report_private`
+- `/me`
+- `/account`
+- `/admin`
+- `/ops`
+- `/api`
+
+`api.fermatmind.com` and `ops.fermatmind.com` are classified as `api` and `ops` surfaces. They must not enter SEO candidates or URL Truth.
+
+## URL Truth Boundary
+
+Crawler Log may read URL Truth for safe mapping:
+
+`crawler path -> seo_urls canonical_path`
+
+Crawler Log must not:
+
+- create `seo_urls`
+- infer canonical truth
+- infer indexability truth
+- create Search Channel Queue rows
+- submit URLs
+- auto-write `seo_issue_queue`
+
+Unknown public paths may become future issue candidates only after a separate approval and sanitization step. CRAWLER-LOG-00 does not implement that step.
+
+## Fixture Plan
+
+Future parser work must use synthetic fixtures first. No production logs are allowed in CRAWLER-LOG-00.
+
+The later fixture should cover:
+
+- Googlebot visiting a Research URL with HTTP 200
+- Baiduspider visiting a test detail URL with HTTP 200
+- Bingbot visiting an unknown public path with HTTP 404
+- ordinary browser visiting home with HTTP 200
+- Googlebot visiting `/result/xxx`
+- Sogou visiting a URL with a token query
+- spoofed bot user-agent
+- static `.js` / `.css` asset
+- API host request
+- Ops host request
+
+## Command Contract
+
+A future command may be introduced as:
+
+`php artisan seo-intel:crawler-log-observe`
+
+V1 allowed modes are limited to fixture dry-run/no-write flags such as `--fixture`, `--dry-run`, `--no-write`, `--json`, and `--limit`.
+
+Forbidden flags in V1:
+
+- `--production`
+- `--tail`
+- `--schedule`
+- `--write`
+
+Required dry-run output fields:
+
+- `dry_run`
+- `writes_attempted=false`
+- `writes_committed=false`
+- `production_log_read_attempted=false`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `raw_persistence=false`
+- `parsed_line_count`
+- `aggregate_row_count`
+- `blocked_private_path_count`
+- `unknown_bot_count`
+- `bot_family_breakdown`
+- `status_code_breakdown`
+- `route_family_breakdown`
+- `privacy_transform_version`
+
+## Production Canary Boundary
+
+Production canary is not part of CRAWLER-LOG-00, CRAWLER-LOG-01, CRAWLER-LOG-02, or CRAWLER-LOG-03.
+
+Exact approval phrase required:
+
+`I explicitly approve CRAWLER-LOG-04 production canary for source <log_path> with max_lines=1000 and no raw persistence.`
+
+Production canary limits:
+
+- `max_lines <= 1000`
+- single approved log source
+- single short time window
+- no raw persistence
+- no scheduler
+- no issue queue write
+- no search submission
+- no Metabase mutation
+
+## PR Split
+
+- `CRAWLER-LOG-01` readiness scan
+- `CRAWLER-LOG-02` fixture parser MVP
+- `CRAWLER-LOG-03` aggregate dry-run/no-write
+- `CRAWLER-LOG-04` production canary preflight
+- `CRAWLER-LOG-04-CANARY` human-approved production log canary
+
+Next task: `CRAWLER-LOG-01`.

--- a/backend/docs/seo/generated/crawler-log-architecture-contract.v1.json
+++ b/backend/docs/seo/generated/crawler-log-architecture-contract.v1.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 1,
+  "version": "crawler-log-architecture-contract.v1",
+  "task": "CRAWLER-LOG-00",
+  "purpose": "aggregate_search_bot_observability_only",
+  "not_authority_for": [
+    "url_truth",
+    "search_channel_queue",
+    "cms_authority",
+    "canonical_truth",
+    "indexability_truth",
+    "issue_auto_fix"
+  ],
+  "allowed_sources": [
+    "nginx_openresty_access_log",
+    "cdn_edge_access_log",
+    "alb_slb_access_log"
+  ],
+  "source_approval_required_fields": [
+    "log_path",
+    "log_format",
+    "owner",
+    "retention",
+    "contains_cookie_header_or_query",
+    "contains_private_route",
+    "max_read_lines",
+    "read_time_window"
+  ],
+  "forbidden_sources": [
+    "node2_local_laravel_log",
+    "node2_local_db",
+    "business_db_log",
+    "payment_log",
+    "provider_webhook_log",
+    "application_debug_log",
+    "raw_request_payload_log",
+    "unapproved_production_raw_access_log"
+  ],
+  "target_table_preference": "seo_crawler_logs_daily",
+  "target_connection": "seo_intel",
+  "aggregate_schema_fields": [
+    "log_date",
+    "host",
+    "surface_family",
+    "bot_family",
+    "bot_variant",
+    "bot_verification_state",
+    "route_family",
+    "page_entity_type",
+    "canonical_path",
+    "path_hash",
+    "http_status",
+    "method_bucket",
+    "query_present",
+    "query_risk_state",
+    "private_path_blocked",
+    "hit_count",
+    "first_seen_at",
+    "last_seen_at",
+    "source_log_family",
+    "privacy_transform_version"
+  ],
+  "allowed_hosts": [
+    "fermatmind.com",
+    "www.fermatmind.com",
+    "api.fermatmind.com",
+    "ops.fermatmind.com",
+    "unknown_host"
+  ],
+  "surface_family_map": {
+    "fermatmind.com": "public_web",
+    "www.fermatmind.com": "public_web",
+    "api.fermatmind.com": "api",
+    "ops.fermatmind.com": "ops",
+    "unknown_host": "unknown"
+  },
+  "surface_family_values": [
+    "public_web",
+    "api",
+    "ops",
+    "static_asset",
+    "blocked_private",
+    "unknown"
+  ],
+  "forbidden_persistent_fields": [
+    "ip_address",
+    "remote_addr",
+    "raw_user_agent",
+    "raw_request_uri",
+    "raw_query_string",
+    "cookie",
+    "headers",
+    "authorization",
+    "session_id",
+    "token",
+    "api_key",
+    "email",
+    "order_no",
+    "attempt_id",
+    "payment_id",
+    "provider_event_id",
+    "raw_payload",
+    "raw_log_line",
+    "event_payload",
+    "metadata_json",
+    "attributes_json"
+  ],
+  "bot_verification_state": "ua_claim_only",
+  "dns_reverse_verification_in_v1": false,
+  "bot_family_map": {
+    "Googlebot": {
+      "family": "googlebot",
+      "variant": "web"
+    },
+    "Googlebot-Image": {
+      "family": "googlebot",
+      "variant": "image"
+    },
+    "Googlebot-News": {
+      "family": "googlebot",
+      "variant": "media"
+    },
+    "Googlebot-Video": {
+      "family": "googlebot",
+      "variant": "media"
+    },
+    "AdsBot-Google": {
+      "family": "googlebot",
+      "variant": "ads"
+    },
+    "Mediapartners-Google": {
+      "family": "googlebot",
+      "variant": "media"
+    },
+    "bingbot": {
+      "family": "bingbot",
+      "variant": "web"
+    },
+    "msnbot": {
+      "family": "bingbot",
+      "variant": "web"
+    },
+    "BingPreview": {
+      "family": "bingbot",
+      "variant": "web"
+    },
+    "Baiduspider": {
+      "family": "baiduspider",
+      "variant": "web"
+    },
+    "Baiduspider-image": {
+      "family": "baiduspider",
+      "variant": "image"
+    },
+    "Baiduspider-render": {
+      "family": "baiduspider",
+      "variant": "web"
+    },
+    "360Spider": {
+      "family": "so360",
+      "variant": "web"
+    },
+    "HaosouSpider": {
+      "family": "so360",
+      "variant": "web"
+    },
+    "Sogou web spider": {
+      "family": "sogou",
+      "variant": "web"
+    },
+    "Sogou Pic Spider": {
+      "family": "sogou",
+      "variant": "image"
+    },
+    "YisouSpider": {
+      "family": "shenma",
+      "variant": "web"
+    },
+    "ShenmaSpider": {
+      "family": "shenma",
+      "variant": "web"
+    },
+    "YandexBot": {
+      "family": "yandex",
+      "variant": "web"
+    },
+    "DuckDuckBot": {
+      "family": "duckduckbot",
+      "variant": "web"
+    },
+    "Applebot": {
+      "family": "applebot",
+      "variant": "web"
+    },
+    "Bytespider": {
+      "family": "bytespider",
+      "variant": "web"
+    },
+    "PetalBot": {
+      "family": "petalbot",
+      "variant": "web"
+    },
+    "facebookexternalhit": {
+      "family": "facebook_external_hit",
+      "variant": "web"
+    },
+    "Twitterbot": {
+      "family": "twitterbot",
+      "variant": "web"
+    },
+    "LinkedInBot": {
+      "family": "linkedinbot",
+      "variant": "web"
+    },
+    "unknown_bot": {
+      "family": "unknown_bot",
+      "variant": "unknown"
+    },
+    "non_bot": {
+      "family": "non_bot",
+      "variant": "unknown"
+    },
+    "unknown_user_agent": {
+      "family": "unknown_user_agent",
+      "variant": "unknown"
+    }
+  },
+  "bot_family_allowlist": [
+    "googlebot",
+    "bingbot",
+    "baiduspider",
+    "so360",
+    "sogou",
+    "shenma",
+    "yandex",
+    "duckduckbot",
+    "applebot",
+    "bytespider",
+    "petalbot",
+    "facebook_external_hit",
+    "twitterbot",
+    "linkedinbot",
+    "unknown_bot",
+    "non_bot",
+    "unknown_user_agent"
+  ],
+  "bot_variant_values": [
+    "web",
+    "image",
+    "ads",
+    "media",
+    "mobile",
+    "unknown"
+  ],
+  "route_family_map": {
+    "/": "home",
+    "/research": "research",
+    "/articles": "article",
+    "/topics": "topic",
+    "/tests": "test_hub",
+    "/tests/*": "test_detail",
+    "/career": "career",
+    "/assets": "static_asset",
+    "/api": "api",
+    "/ops": "ops"
+  },
+  "route_family_values": [
+    "home",
+    "research",
+    "article",
+    "topic",
+    "test_detail",
+    "test_hub",
+    "career",
+    "static_asset",
+    "api",
+    "ops",
+    "private_flow",
+    "unknown_public_path",
+    "blocked_private_path"
+  ],
+  "private_path_denylist": [
+    "/take",
+    "/result",
+    "/results",
+    "/order",
+    "/orders",
+    "/checkout",
+    "/pay",
+    "/payment",
+    "/share",
+    "/report-private",
+    "/report_private",
+    "/me",
+    "/account",
+    "/admin",
+    "/ops",
+    "/api"
+  ],
+  "query_risk_state_values": [
+    "none",
+    "tracking_only",
+    "sensitive_key_present",
+    "unknown_query_present"
+  ],
+  "method_bucket_values": [
+    "GET",
+    "HEAD",
+    "OTHER"
+  ],
+  "path_privacy_transform_order": [
+    "parse_ephemeral_fields_in_memory",
+    "classify_bot_from_user_agent_in_memory",
+    "normalize_method_status_host",
+    "strip_query_string_completely",
+    "classify_route_family",
+    "detect_private_route_or_token_risk",
+    "map_to_url_truth_only_when_safe",
+    "drop_raw_ip_user_agent_request_uri_cookie_header_query_and_raw_line",
+    "aggregate_counters",
+    "persist_aggregate_only"
+  ],
+  "privacy_transform_version": "crawler_log_privacy_transform_v1",
+  "future_command": "php artisan seo-intel:crawler-log-observe",
+  "future_allowed_flags": [
+    "--fixture",
+    "--dry-run",
+    "--no-write",
+    "--json",
+    "--limit"
+  ],
+  "future_forbidden_flags": [
+    "--production",
+    "--tail",
+    "--schedule",
+    "--write"
+  ],
+  "required_dry_run_output_fields": [
+    "dry_run",
+    "writes_attempted",
+    "writes_committed",
+    "production_log_read_attempted",
+    "external_calls_attempted",
+    "search_submission_attempted",
+    "raw_persistence",
+    "parsed_line_count",
+    "aggregate_row_count",
+    "blocked_private_path_count",
+    "unknown_bot_count",
+    "bot_family_breakdown",
+    "status_code_breakdown",
+    "route_family_breakdown",
+    "privacy_transform_version"
+  ],
+  "production_canary_approval_phrase": "I explicitly approve CRAWLER-LOG-04 production canary for source <log_path> with max_lines=1000 and no raw persistence.",
+  "production_canary_limits": {
+    "max_lines_lte": 1000,
+    "single_log_source": true,
+    "single_short_time_window": true,
+    "no_raw_persistence": true,
+    "no_scheduler": true,
+    "no_issue_queue_write": true,
+    "no_search_submission": true,
+    "no_metabase_mutation": true
+  },
+  "pr_split": [
+    "CRAWLER-LOG-01",
+    "CRAWLER-LOG-02",
+    "CRAWLER-LOG-03",
+    "CRAWLER-LOG-04",
+    "CRAWLER-LOG-04-CANARY"
+  ],
+  "no_raw_persistence": true,
+  "no_production_log_read": true,
+  "no_scheduler": true,
+  "no_url_truth_creation": true,
+  "no_url_truth_authority": true,
+  "no_search_channel_queue_creation": true,
+  "no_issue_queue_auto_write": true,
+  "no_search_submission": true,
+  "no_external_search_api_call": true,
+  "no_metabase_exposure": true,
+  "production_canary_requires_human_approval": true,
+  "next_task": "CRAWLER-LOG-01"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogArchitectureContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogArchitectureContractTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelCrawlerLogArchitectureContractTest extends TestCase
+{
+    #[Test]
+    public function contract_file_and_generated_artifact_exist_and_parse(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/crawler-log-architecture-contract.md'));
+        $this->assertSame('crawler-log-architecture-contract.v1', $this->artifact()['version'] ?? null);
+        $this->assertSame('CRAWLER-LOG-00', $this->artifact()['task'] ?? null);
+        $this->assertSame('aggregate_search_bot_observability_only', $this->artifact()['purpose'] ?? null);
+    }
+
+    #[Test]
+    public function forbidden_persistent_fields_include_raw_identifiers_and_payloads(): void
+    {
+        $fields = $this->artifact()['forbidden_persistent_fields'] ?? [];
+
+        foreach ([
+            'ip_address',
+            'remote_addr',
+            'raw_user_agent',
+            'raw_request_uri',
+            'raw_query_string',
+            'cookie',
+            'headers',
+            'authorization',
+            'session_id',
+            'token',
+            'api_key',
+            'email',
+            'order_no',
+            'attempt_id',
+            'payment_id',
+            'provider_event_id',
+            'raw_payload',
+            'raw_log_line',
+        ] as $field) {
+            $this->assertContains($field, $fields);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_block_raw_persistence_production_reads_and_submission(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'no_raw_persistence',
+            'no_production_log_read',
+            'no_scheduler',
+            'no_url_truth_creation',
+            'no_url_truth_authority',
+            'no_search_channel_queue_creation',
+            'no_issue_queue_auto_write',
+            'no_search_submission',
+            'no_external_search_api_call',
+            'no_metabase_exposure',
+            'production_canary_requires_human_approval',
+        ] as $flag) {
+            $this->assertTrue((bool) ($artifact[$flag] ?? false), $flag.' must be true');
+        }
+    }
+
+    #[Test]
+    public function bot_family_allowlist_and_ua_claim_only_verification_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('ua_claim_only', $artifact['bot_verification_state'] ?? null);
+        $this->assertFalse((bool) ($artifact['dns_reverse_verification_in_v1'] ?? true));
+
+        foreach ([
+            'googlebot',
+            'bingbot',
+            'baiduspider',
+            'so360',
+            'sogou',
+            'shenma',
+            'yandex',
+            'duckduckbot',
+            'applebot',
+            'bytespider',
+            'petalbot',
+            'facebook_external_hit',
+            'twitterbot',
+            'linkedinbot',
+            'unknown_bot',
+            'non_bot',
+            'unknown_user_agent',
+        ] as $family) {
+            $this->assertContains($family, $artifact['bot_family_allowlist'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function private_path_denylist_and_route_families_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            '/take',
+            '/result',
+            '/results',
+            '/order',
+            '/orders',
+            '/checkout',
+            '/pay',
+            '/payment',
+            '/share',
+            '/report-private',
+            '/report_private',
+            '/me',
+            '/account',
+            '/admin',
+            '/ops',
+            '/api',
+        ] as $path) {
+            $this->assertContains($path, $artifact['private_path_denylist'] ?? []);
+        }
+
+        foreach ([
+            'private_flow',
+            'unknown_public_path',
+            'blocked_private_path',
+            'api',
+            'ops',
+            'static_asset',
+        ] as $family) {
+            $this->assertContains($family, $artifact['route_family_values'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function url_truth_boundary_forbids_authority_drift(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'url_truth',
+            'search_channel_queue',
+            'cms_authority',
+            'canonical_truth',
+            'indexability_truth',
+        ] as $forbiddenAuthority) {
+            $this->assertContains($forbiddenAuthority, $artifact['not_authority_for'] ?? []);
+        }
+
+        $this->assertTrue((bool) ($artifact['no_url_truth_creation'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_url_truth_authority'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_search_channel_queue_creation'] ?? false));
+    }
+
+    #[Test]
+    public function production_canary_approval_phrase_and_next_task_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'I explicitly approve CRAWLER-LOG-04 production canary for source <log_path> with max_lines=1000 and no raw persistence.',
+            $artifact['production_canary_approval_phrase'] ?? null,
+        );
+        $this->assertSame('CRAWLER-LOG-01', $artifact['next_task'] ?? null);
+        $this->assertContains('CRAWLER-LOG-04-CANARY', $artifact['pr_split'] ?? []);
+    }
+
+    #[Test]
+    public function docs_lock_contract_terms_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/crawler-log-architecture-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/crawler-log-architecture-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'crawler log is aggregate search bot observability',
+            'not url truth',
+            'not search channel queue',
+            'not cms authority',
+            'no production logs are allowed in crawler-log-00',
+            'ua_claim_only',
+            'strip query string completely',
+            'private paths and unknown paths must not store raw path text',
+            'i explicitly approve crawler-log-04 production canary',
+            'next task: `crawler-log-01`',
+            '"next_task": "crawler-log-01"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/crawler-log-architecture-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T03:38:00+08:00",
+  "updated_at": "2026-05-22T03:42:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -4389,7 +4389,7 @@
         "no fap-web change"
       ],
       "commit_sha": "bb315e305714183e7c0130deacfbcf9159c95bd1",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1541",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -11508,6 +11508,11 @@
           "at": "2026-05-22T03:38:00+08:00",
           "status": "committed",
           "summary": "Committed scoped architecture contract implementation at 57927155de71a44b55f42cb1a6e0be5bfa172c04."
+        },
+        {
+          "at": "2026-05-22T03:42:00+08:00",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR #1541 for the crawler log architecture contract. GitHub checks are pending."
         }
       ],
       "branch": "codex/crawler-log-00-architecture-contract",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T03:10:00+08:00",
+  "updated_at": "2026-05-22T03:35:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -10960,6 +10960,39 @@
         },
         "github": {
           "status": "passed"
+        },
+        "crawler_log_architecture_contract_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelCrawlerLogArchitectureContract",
+          "evidence": "8 tests passed with 114 assertions."
+        },
+        "crawler_log_readiness_contract_phpunit_current": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelCrawlerLogReadinessContract",
+          "evidence": "5 tests passed with 92 assertions."
+        },
+        "seo_intel_phpunit_current": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "evidence": "301 tests passed with 4809 assertions."
+        },
+        "route_list_current": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 203 routes reported."
+        },
+        "pint_current": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "Pint completed successfully; 3441 files checked."
+        },
+        "architecture_json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/crawler-log-architecture-contract.v1.json >/dev/null"
+        },
+        "current_yaml_state_diff_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null; python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"; git diff --check; git diff --cached --check"
         }
       },
       "sidecar_issues": [],
@@ -11357,9 +11390,9 @@
     },
     "CRAWLER-LOG-00": {
       "repo": "fap-api",
-      "status": "merged",
-      "state": "merged",
-      "title": "Crawler log readiness contract",
+      "status": "in_progress",
+      "state": "in_progress",
+      "title": "Crawler log architecture contract",
       "depends_on": [
         "SEO-DASH-PROD-04B"
       ],
@@ -11375,7 +11408,7 @@
       "sidecar_allowed": true,
       "stop_on_safety_violation": true,
       "failure_reason": null,
-      "next_pr": "CLAIM-LINT-00",
+      "next_pr": "CRAWLER-LOG-01",
       "planned_at": "2026-05-19T01:02:33Z",
       "checks": {
         "registration": {
@@ -11388,7 +11421,7 @@
         },
         "scope": {
           "status": "in_progress",
-          "evidence": "Implementing only crawler log readiness contract doc, generated artifact, focused SeoIntel test, and PR train state metadata. No production log read, CDN/Nginx/OpenResty change, raw storage, scheduler, env edit, deploy, collector write, or production operation executed."
+          "evidence": "Implementing only crawler log architecture contract doc, generated artifact, focused SeoIntel test, and PR train metadata. No production log read, runtime parser, scheduler, migration, collector write, deployment, env edit, external search API call, URL submission, Metabase exposure, business DB / Tencent RDS / Node2 access, or production operation executed."
         },
         "scope_validation": {
           "status": "pass",
@@ -11460,18 +11493,30 @@
           "at": "2026-05-19T02:26:15Z",
           "status": "merged",
           "summary": "Reconciled CRAWLER-LOG-00 as merged via PR #1472. Remote branch absent and local main synced."
+        },
+        {
+          "at": "2026-05-22T03:25:00+08:00",
+          "status": "in_progress",
+          "summary": "Started supplemental CRAWLER-LOG-00 architecture contract PR from latest main using the user-provided contract. Scope is docs/generated/test/metadata only and keeps production log reads, runtime parser, scheduler, migrations, collector writes, env edits, deployments, external search APIs, URL submissions, Metabase exposure, and raw persistence blocked."
+        },
+        {
+          "at": "2026-05-22T03:35:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Added crawler log architecture contract, generated artifact, and focused SeoIntel test. Focused architecture test, existing crawler log readiness test, full SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and diff checks passed. No production log read, runtime parser, scheduler, migration, collector write, env edit, deployment, external API call, URL submission, Metabase exposure, or production operation performed."
         }
       ],
-      "branch": "codex/crawler-log-00-readiness-contract",
+      "branch": "codex/crawler-log-00-architecture-contract",
       "base": "main",
-      "pr_url": "https://github.com/fermatmind/fap-api/pull/1472",
-      "commit_sha": "56a56f73",
-      "final_status": "completed",
-      "merge_commit_sha": "4f619c18",
-      "merge_observed": true,
-      "merged_at": "2026-05-19T02:26:15Z",
-      "remote_branch_deleted": true,
-      "local_cleanup_executed": true
+      "pr_url": null,
+      "commit_sha": null,
+      "previous_pr_url": "https://github.com/fermatmind/fap-api/pull/1472",
+      "previous_merge_commit_sha": "4f619c18",
+      "final_status": null,
+      "merge_commit_sha": null,
+      "merge_observed": false,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     },
     "CLAIM-LINT-00": {
       "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T03:35:00+08:00",
+  "updated_at": "2026-05-22T03:38:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -6412,7 +6412,7 @@
         "do not weaken final live acceptance",
         "do not treat candidate-aware planning artifacts as final published authority"
       ],
-      "commit_sha": null,
+      "commit_sha": "57927155de71a44b55f42cb1a6e0be5bfa172c04",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1410",
       "checks": {
         "authorization": {
@@ -11503,6 +11503,11 @@
           "at": "2026-05-22T03:35:00+08:00",
           "status": "local_validation_passed",
           "summary": "Added crawler log architecture contract, generated artifact, and focused SeoIntel test. Focused architecture test, existing crawler log readiness test, full SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and diff checks passed. No production log read, runtime parser, scheduler, migration, collector write, env edit, deployment, external API call, URL submission, Metabase exposure, or production operation performed."
+        },
+        {
+          "at": "2026-05-22T03:38:00+08:00",
+          "status": "committed",
+          "summary": "Committed scoped architecture contract implementation at 57927155de71a44b55f42cb1a6e0be5bfa172c04."
         }
       ],
       "branch": "codex/crawler-log-00-architecture-contract",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -779,10 +779,7 @@ prs:
       - cd backend && php artisan route:list --no-ansi
       - cd backend && vendor/bin/pint --test
       - python3 -m json.tool backend/docs/seo/generated/controlled-write-enablement-plan.v1.json >/dev/null
-      - python3 - <<'PY'
-        import yaml, pathlib
-        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
-        PY
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
       - git diff --check
       - git diff --cached --check
     merge_policy:
@@ -5740,32 +5737,42 @@ prs:
     repo: fap-api
     depends_on:
       - SEO-DASH-PROD-04B
-    branch: codex/crawler-log-00-readiness-contract
+    branch: codex/crawler-log-00-architecture-contract
     base: main
-    title: "docs(seo-intel): add crawler log readiness contract"
-    name: "Crawler log readiness contract"
-    train_scope: seo_intel_crawler_log_readiness_contract
+    title: "docs(seo-intel): add crawler log architecture contract"
+    name: "Crawler log architecture contract"
+    train_scope: seo_intel_crawler_log_architecture_contract
     risk_level: low_docs_contract_no_log_read
     type: docs/contract PR
     scope:
-      - Define crawler log source approval, sanitization, and ingestion readiness gates.
-      - Keep production crawler log reads and CDN/Nginx/OpenResty changes blocked.
-      - Add generated contract artifact and focused test.
+      - Define crawler log as aggregate-only bot observability, not URL Truth, Search Channel Queue, CMS authority, or issue auto-fix.
+      - Lock allowed and forbidden sources, aggregate schema fields, forbidden persistent raw fields, bot normalization, path privacy transform, private path denylist, URL Truth boundary, fixture plan, command contract, and production canary approval.
+      - Keep production crawler log reads, runtime parser, scheduler, migrations, collector writes, deployments, env edits, Metabase exposure, external search API calls, and URL submissions blocked.
+      - Add generated architecture contract artifact and focused test.
     allowed_paths:
+      - backend/docs/seo/crawler-log-architecture-contract.md
+      - backend/docs/seo/generated/crawler-log-architecture-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogArchitectureContractTest.php
       - backend/docs/seo/crawler-log-readiness-contract.md
       - backend/docs/seo/generated/crawler-log-readiness-contract.v1.json
       - backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogReadinessContractTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
-      - Read production logs, change CDN/Nginx/OpenResty config, store raw IP/cookie/user-agent data, or enable scheduler.
-      - Run collector writes, deploy, or edit env files.
+      - Read production logs, add runtime parser, change CDN/Nginx/OpenResty config, store raw IP/cookie/user-agent/request URI/query/header data, or enable scheduler.
+      - Run collector writes, migrations, deployments, env edits, live search API calls, URL submissions, Metabase exposure, or business DB / Tencent RDS / Node2 access.
     validation:
+      - cd backend && php artisan test --filter=SeoIntelCrawlerLogArchitectureContract
       - cd backend && php artisan test --filter=SeoIntelCrawlerLogReadinessContract
       - cd backend && php artisan test --filter=SeoIntel
       - cd backend && php artisan route:list --no-ansi
       - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/crawler-log-architecture-contract.v1.json >/dev/null
       - python3 -m json.tool backend/docs/seo/generated/crawler-log-readiness-contract.v1.json >/dev/null
+      - python3 - <<'PY'
+        import yaml, pathlib
+        yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+        PY
       - git diff --check
       - git diff --cached --check
     merge_policy:
@@ -5778,7 +5785,7 @@ prs:
     metabase_deployment: false
     human_review_required: true
     production_approval_required: false
-    next_task: CLAIM-LINT-00
+    next_task: CRAWLER-LOG-01
 
   - id: CLAIM-LINT-00
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added CRAWLER-LOG-00 crawler log architecture contract docs.
- Added generated architecture artifact with source boundaries, aggregate schema, forbidden persistent fields, bot normalization, path privacy transform, private path denylist, URL Truth boundary, future command contract, production canary phrase, and PR split.
- Added focused SeoIntel contract tests.
- Updated PR train metadata for the supplemental architecture contract scope.

## Why
- Crawler Log must remain aggregate-only search bot observability and must not become URL Truth, Search Channel Queue, CMS authority, issue auto-fix, or search submission authority.
- The contract locks privacy and authority boundaries before any fixture parser or production canary work.

## Validation commands
- cd backend && php artisan test --filter=SeoIntelCrawlerLogArchitectureContract
- cd backend && php artisan test --filter=SeoIntelCrawlerLogReadinessContract
- cd backend && php artisan test --filter=SeoIntel
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/crawler-log-architecture-contract.v1.json >/dev/null
- python3 -m json.tool backend/docs/seo/generated/crawler-log-readiness-contract.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No production crawler log read.
- No runtime parser.
- No fixture parser implementation.
- No scheduler.
- No collector writes.
- No migration.
- No deployment or env edit.
- No GSC/Baidu/IndexNow/live search API call.
- No URL submission.
- No Metabase exposure.
- No business DB, Tencent RDS, or Node2 access.
- No raw IP, raw user-agent, raw request URI, query string, cookies, headers, tokens, emails, order IDs, attempt IDs, payment IDs, payloads, or raw log lines stored.
