### PR TITLE
docs(seo-intel): add crawler log readiness scan

### DIFF
--- a/backend/docs/seo/crawler-log-readiness-scan.md
+++ b/backend/docs/seo/crawler-log-readiness-scan.md
@@ -1,0 +1,219 @@
+# CRAWLER-LOG-01 Readiness Scan
+
+## Executive Summary
+
+CRAWLER-LOG-01 is a read-only repository readiness scan for crawler log observability. It does not read production crawler logs, add a runtime parser, enable scheduler jobs, run collector writes, run migrations, deploy, edit environment files, call external search APIs, expose Metabase, or submit URLs.
+
+Final readiness result: `ready_for_crawler_log_fixture_parser_mvp`.
+
+The codebase is ready to proceed to a synthetic fixture parser MVP, with one important schema caveat: the existing `seo_crawler_logs_daily` table exists under the `seo_intel` connection, but it is an earlier aggregate shape and does not fully match the CRAWLER-LOG-00 V1 architecture contract. CRAWLER-LOG-02 should stay fixture-only and no-write. Any persistent aggregate write in a later PR must first reconcile the table shape or add a scoped `seo_intel` migration.
+
+## Current Local State
+
+- Current task: `CRAWLER-LOG-01`.
+- Source branch target: `main`.
+- Previous dependency: `CRAWLER-LOG-00` architecture contract.
+- CRAWLER-LOG-00 merge commit observed in local main: `316223c6e9ece53da47bbd7523bb648a2cfb3c85`.
+- Existing architecture contract files:
+  - `backend/docs/seo/crawler-log-architecture-contract.md`
+  - `backend/docs/seo/generated/crawler-log-architecture-contract.v1.json`
+  - `backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogArchitectureContractTest.php`
+- Existing older readiness contract files:
+  - `backend/docs/seo/crawler-log-readiness-contract.md`
+  - `backend/docs/seo/generated/crawler-log-readiness-contract.v1.json`
+  - `backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogReadinessContractTest.php`
+
+## Existing Crawler Log Surface
+
+Existing crawler-log related code is present, but it is foundation-level and not the CRAWLER-LOG-00 V1 runtime:
+
+- `backend/app/Services/SeoIntel/Collectors/CrawlerLogFoundationCollector.php`
+- `backend/app/Services/SeoIntel/Collectors/ChineseCrawlerLogCollector.php`
+- `backend/app/Services/SeoIntel/Drift/CrawlerLogLineParser.php`
+- `backend/app/Services/SeoIntel/Drift/CrawlerUserAgentClassifier.php`
+- `backend/app/Services/SeoIntel/CrawlerLogLineParser.php`
+- `backend/app/Services/SeoIntel/CrawlerLogPrivacySanitizer.php`
+- `backend/app/Services/SeoIntel/CrawlerLogDailyAggregator.php`
+- `backend/app/Services/SeoIntel/ChineseCrawlerUserAgentClassifier.php`
+
+The current manual collector command is `php artisan seo-intel:collect`. No dedicated `php artisan seo-intel:crawler-log-observe` command exists yet.
+
+## Source Approval Readiness
+
+Allowed future source families remain:
+
+- nginx / OpenResty access log
+- CDN edge access log
+- ALB / SLB access log
+
+No approved production crawler log source is configured in this scan. No production log path, source owner, retention window, masking posture, max line count, or read window is approved for live access.
+
+Forbidden sources remain blocked:
+
+- Node2 local Laravel logs
+- Node2 local DB
+- business DB logs
+- payment logs
+- provider webhook logs
+- application debug logs
+- raw request payload logs
+- unapproved production raw access logs
+
+## Schema Readiness
+
+The existing migration `backend/database/migrations/seo_intel/2026_05_17_001600_create_seo_crawler_logs_daily_table.php` is scoped to:
+
+`protected $connection = 'seo_intel';`
+
+The table `seo_crawler_logs_daily` exists as an aggregate table. Current fields include:
+
+- `report_date`
+- `canonical_url_hash`
+- `path_hash`
+- `path_display_masked`
+- `locale`
+- `page_entity_type`
+- `source_engine`
+- `bot_family`
+- `user_agent_hash`
+- `method`
+- `status_code`
+- `response_time_bucket`
+- `crawl_count`
+- `robots_allowed`
+- `blocked_by_robots`
+- `private_flow_hit`
+- `noindex_hit`
+- `metadata_json`
+
+CRAWLER-LOG-00 V1 requires a stricter aggregate shape:
+
+- `log_date`
+- `host`
+- `surface_family`
+- `bot_family`
+- `bot_variant`
+- `bot_verification_state`
+- `route_family`
+- `page_entity_type`
+- `canonical_path`
+- `path_hash`
+- `http_status`
+- `method_bucket`
+- `query_present`
+- `query_risk_state`
+- `private_path_blocked`
+- `hit_count`
+- `first_seen_at`
+- `last_seen_at`
+- `source_log_family`
+- `privacy_transform_version`
+
+Schema gap: the existing table does not contain the full V1 field set and includes fields now forbidden for V1 persistence, including `user_agent_hash`, `path_display_masked`, and `metadata_json`. CRAWLER-LOG-02 can proceed as fixture-only/no-write, but CRAWLER-LOG-03 or any persistent aggregate write needs a schema reconciliation decision first.
+
+## Parser / Collector Readiness
+
+Existing foundation collectors are disabled-by-default and fixture-based:
+
+- `CrawlerLogFoundationCollector` parses one fixture line and reports `reads_production_logs=false`.
+- `ChineseCrawlerLogCollector` uses synthetic fixture lines and reports `production_log_read_attempted=false`.
+- `SeoIntelCollectorManager` forces `allow_production_log_read=false` unless global config allows it.
+- `config/seo_intel.php` has `allow_production_log_read=false` and `chinese_crawler_live_log_read_enabled=false`.
+
+Current parser gaps against CRAWLER-LOG-00 V1:
+
+- no host / `surface_family` normalization
+- no `bot_variant`
+- no `bot_verification_state=ua_claim_only` output
+- no V1 `route_family` map
+- no `query_present` / `query_risk_state`
+- private path denylist is incomplete against the V1 contract
+- unknown public paths do not consistently use V1 `path_hash` only semantics
+- current bot family names differ from V1 for several crawlers, such as `so360_spider`, `sogou_spider`, and `shenma_yisou`
+
+These gaps are appropriate for CRAWLER-LOG-02 fixture parser MVP scope.
+
+## Scheduler / Command Readiness
+
+No crawler-log scheduler entry was found. `backend/app/Console/Kernel.php` does not schedule `seo-intel:collect`, `crawler_log_foundation`, `chinese_crawler_log_foundation`, or a crawler-log observe command.
+
+The existing `seo-intel:collect` command has no `--production`, `--tail`, `--schedule`, or crawler-log `--write` mode. The CRAWLER-LOG-00 proposed command `seo-intel:crawler-log-observe` is not implemented yet.
+
+## Privacy Boundary
+
+CRAWLER-LOG-01 did not read production crawler logs and did not inspect raw production log lines.
+
+V1 must continue to forbid persistence of:
+
+- raw IP / remote address
+- raw user-agent
+- raw request URI
+- raw query string
+- cookies
+- headers
+- authorization
+- sessions
+- tokens / API keys
+- emails
+- order IDs
+- attempt IDs
+- payment IDs
+- provider event IDs
+- raw payloads
+- raw log lines
+- wide raw JSON payload fields
+
+Current foundation code avoids production log access, but the existing aggregate table and foundation collector shape are not strict enough for V1 persistence. The next runtime PR must enforce the CRAWLER-LOG-00 privacy transform before any write path is introduced.
+
+## URL Truth Boundary
+
+Crawler logs remain observation data only. They must not:
+
+- create `seo_urls`
+- decide canonical truth
+- decide indexability truth
+- create Search Channel Queue rows
+- submit URLs
+- auto-write `seo_issue_queue`
+- use frontend fallback, static sitemap, static `llms.txt`, Node2 local DB, crawler logs, or external search sources as URL authority
+
+Unknown crawler paths can only become sanitized future issue candidates after a separate approval and sanitization step.
+
+## Recommended Next PR
+
+Next task: `CRAWLER-LOG-02｜Fixture parser MVP`.
+
+Recommended scope:
+
+- add synthetic fixture file only
+- add a V1 parser/normalizer service that accepts fixture lines
+- output aggregate DTO-style rows in memory
+- prove no raw IP, raw UA, raw URI, query string, cookies, headers, tokens, private paths, or raw log lines are returned
+- prove V1 bot families, route families, surface families, query risk states, and private path denylist behavior
+- no database writes
+- no production log read
+- no scheduler
+- no external API
+
+## No-go Conditions
+
+Stop future crawler-log work if any of these appear:
+
+- production log read without explicit canary approval
+- raw IP / raw UA / raw URI / query / cookie / header persistence
+- crawler logs used as URL Truth
+- crawler logs creating Search Channel Queue rows
+- crawler logs auto-writing `seo_issue_queue`
+- scheduler activation
+- collector write mode before schema reconciliation
+- Node2 local DB or business DB access
+- Metabase exposure
+- search engine URL submission
+
+## Final Decision
+
+`ready_for_crawler_log_fixture_parser_mvp`
+
+## Next Task
+
+`CRAWLER-LOG-02｜Fixture parser MVP`

--- a/backend/docs/seo/generated/crawler-log-readiness-scan.v1.json
+++ b/backend/docs/seo/generated/crawler-log-readiness-scan.v1.json
@@ -1,0 +1,215 @@
+{
+  "schema_version": 1,
+  "version": "crawler-log-readiness-scan.v1",
+  "task": "CRAWLER-LOG-01",
+  "scan_type": "read_only_repository_readiness_scan",
+  "final_decision": "ready_for_crawler_log_fixture_parser_mvp",
+  "next_task": "CRAWLER-LOG-02",
+  "no_production_log_read": true,
+  "no_runtime_parser_added": true,
+  "no_scheduler": true,
+  "no_collector_write": true,
+  "no_production_migration": true,
+  "no_deploy": true,
+  "no_env_edit": true,
+  "no_external_search_api_call": true,
+  "no_search_submission": true,
+  "no_metabase_exposure": true,
+  "no_business_db_access": true,
+  "dependency": {
+    "task": "CRAWLER-LOG-00",
+    "status": "merged",
+    "merge_commit_sha": "316223c6e9ece53da47bbd7523bb648a2cfb3c85",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1541"
+  },
+  "existing_contracts": [
+    "backend/docs/seo/crawler-log-architecture-contract.md",
+    "backend/docs/seo/generated/crawler-log-architecture-contract.v1.json",
+    "backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogArchitectureContractTest.php",
+    "backend/docs/seo/crawler-log-readiness-contract.md",
+    "backend/docs/seo/generated/crawler-log-readiness-contract.v1.json",
+    "backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogReadinessContractTest.php"
+  ],
+  "existing_crawler_log_code": {
+    "collectors": [
+      "backend/app/Services/SeoIntel/Collectors/CrawlerLogFoundationCollector.php",
+      "backend/app/Services/SeoIntel/Collectors/ChineseCrawlerLogCollector.php"
+    ],
+    "parsers_and_helpers": [
+      "backend/app/Services/SeoIntel/Drift/CrawlerLogLineParser.php",
+      "backend/app/Services/SeoIntel/Drift/CrawlerUserAgentClassifier.php",
+      "backend/app/Services/SeoIntel/CrawlerLogLineParser.php",
+      "backend/app/Services/SeoIntel/CrawlerLogPrivacySanitizer.php",
+      "backend/app/Services/SeoIntel/CrawlerLogDailyAggregator.php",
+      "backend/app/Services/SeoIntel/ChineseCrawlerUserAgentClassifier.php"
+    ],
+    "manual_command": "php artisan seo-intel:collect",
+    "dedicated_v1_command_exists": false,
+    "dedicated_v1_command": "php artisan seo-intel:crawler-log-observe"
+  },
+  "source_approval_readiness": {
+    "approved_production_source_exists": false,
+    "allowed_future_source_families": [
+      "nginx_openresty_access_log",
+      "cdn_edge_access_log",
+      "alb_slb_access_log"
+    ],
+    "forbidden_sources": [
+      "node2_local_laravel_log",
+      "node2_local_db",
+      "business_db_log",
+      "payment_log",
+      "provider_webhook_log",
+      "application_debug_log",
+      "raw_request_payload_log",
+      "unapproved_production_raw_access_log"
+    ],
+    "required_approval_fields": [
+      "log_path",
+      "log_format",
+      "owner",
+      "retention",
+      "contains_cookie_header_or_query",
+      "contains_private_route",
+      "max_read_lines",
+      "read_time_window"
+    ]
+  },
+  "schema_readiness": {
+    "target_connection": "seo_intel",
+    "existing_table": "seo_crawler_logs_daily",
+    "existing_migration": "backend/database/migrations/seo_intel/2026_05_17_001600_create_seo_crawler_logs_daily_table.php",
+    "migration_has_seo_intel_connection": true,
+    "current_fields": [
+      "report_date",
+      "canonical_url_hash",
+      "path_hash",
+      "path_display_masked",
+      "locale",
+      "page_entity_type",
+      "source_engine",
+      "bot_family",
+      "user_agent_hash",
+      "method",
+      "status_code",
+      "response_time_bucket",
+      "crawl_count",
+      "robots_allowed",
+      "blocked_by_robots",
+      "private_flow_hit",
+      "noindex_hit",
+      "metadata_json"
+    ],
+    "v1_required_fields": [
+      "log_date",
+      "host",
+      "surface_family",
+      "bot_family",
+      "bot_variant",
+      "bot_verification_state",
+      "route_family",
+      "page_entity_type",
+      "canonical_path",
+      "path_hash",
+      "http_status",
+      "method_bucket",
+      "query_present",
+      "query_risk_state",
+      "private_path_blocked",
+      "hit_count",
+      "first_seen_at",
+      "last_seen_at",
+      "source_log_family",
+      "privacy_transform_version"
+    ],
+    "schema_gap": "existing_table_is_aggregate_but_not_v1_contract_shape",
+    "fields_requiring_v1_reconciliation_before_persistent_writes": [
+      "user_agent_hash",
+      "path_display_masked",
+      "metadata_json"
+    ],
+    "persistent_write_ready": false,
+    "fixture_no_write_ready": true
+  },
+  "parser_collector_readiness": {
+    "foundation_collectors_exist": true,
+    "foundation_collectors_fixture_only": true,
+    "production_log_read_attempted": false,
+    "current_gaps_for_v1": [
+      "host_surface_family_normalization",
+      "bot_variant",
+      "bot_verification_state",
+      "route_family_map",
+      "query_present",
+      "query_risk_state",
+      "complete_private_path_denylist",
+      "v1_bot_family_names",
+      "unknown_public_path_hash_only_semantics"
+    ]
+  },
+  "config_safety": {
+    "allow_production_log_read": false,
+    "chinese_crawler_live_log_read_enabled": false,
+    "allow_external_api_calls": false,
+    "allow_production_crawl": false,
+    "collectors_enabled_default": false,
+    "dry_run_default": true
+  },
+  "scheduler_scan": {
+    "crawler_log_scheduler_entry_found": false,
+    "seo_intel_collect_scheduled": false,
+    "crawler_log_foundation_scheduled": false,
+    "chinese_crawler_log_foundation_scheduled": false
+  },
+  "privacy_boundary": {
+    "forbidden_persistent_fields": [
+      "ip_address",
+      "remote_addr",
+      "raw_user_agent",
+      "raw_request_uri",
+      "raw_query_string",
+      "cookie",
+      "headers",
+      "authorization",
+      "session_id",
+      "token",
+      "api_key",
+      "email",
+      "order_no",
+      "attempt_id",
+      "payment_id",
+      "provider_event_id",
+      "raw_payload",
+      "raw_log_line",
+      "event_payload",
+      "metadata_json",
+      "attributes_json"
+    ],
+    "raw_persistence_allowed": false
+  },
+  "url_truth_boundary": {
+    "crawler_logs_are_url_truth": false,
+    "crawler_logs_create_seo_urls": false,
+    "crawler_logs_decide_canonical": false,
+    "crawler_logs_decide_indexability": false,
+    "crawler_logs_enqueue_search_channel": false,
+    "crawler_logs_auto_write_issue_queue": false,
+    "frontend_fallback_authority_allowed": false,
+    "static_sitemap_fallback_authority_allowed": false,
+    "static_llms_fallback_authority_allowed": false,
+    "node2_local_db_authority_allowed": false,
+    "external_search_source_authority_allowed": false
+  },
+  "recommended_next_pr_scope": [
+    "synthetic_fixture_file",
+    "v1_fixture_parser_normalizer",
+    "in_memory_aggregate_rows",
+    "bot_family_normalization",
+    "route_family_normalization",
+    "surface_family_normalization",
+    "query_risk_state",
+    "private_path_hash_only_behavior",
+    "no_database_writes",
+    "no_production_log_read"
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogReadinessScanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogReadinessScanTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelCrawlerLogReadinessScanTest extends TestCase
+{
+    #[Test]
+    public function readiness_scan_doc_and_generated_artifact_exist_and_parse(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/crawler-log-readiness-scan.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('crawler-log-readiness-scan.v1', $artifact['version'] ?? null);
+        $this->assertSame('CRAWLER-LOG-01', $artifact['task'] ?? null);
+        $this->assertSame('ready_for_crawler_log_fixture_parser_mvp', $artifact['final_decision'] ?? null);
+        $this->assertSame('CRAWLER-LOG-02', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function scan_locks_no_mutation_and_no_production_access_flags(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'no_production_log_read',
+            'no_runtime_parser_added',
+            'no_scheduler',
+            'no_collector_write',
+            'no_production_migration',
+            'no_deploy',
+            'no_env_edit',
+            'no_external_search_api_call',
+            'no_search_submission',
+            'no_metabase_exposure',
+            'no_business_db_access',
+        ] as $flag) {
+            $this->assertTrue((bool) ($artifact[$flag] ?? false), $flag.' must be true');
+        }
+    }
+
+    #[Test]
+    public function source_approval_is_required_before_any_production_log_read(): void
+    {
+        $source = $this->artifact()['source_approval_readiness'] ?? [];
+
+        $this->assertFalse((bool) ($source['approved_production_source_exists'] ?? true));
+
+        foreach ([
+            'nginx_openresty_access_log',
+            'cdn_edge_access_log',
+            'alb_slb_access_log',
+        ] as $allowedSource) {
+            $this->assertContains($allowedSource, $source['allowed_future_source_families'] ?? []);
+        }
+
+        foreach ([
+            'node2_local_laravel_log',
+            'node2_local_db',
+            'business_db_log',
+            'payment_log',
+            'provider_webhook_log',
+            'application_debug_log',
+            'raw_request_payload_log',
+            'unapproved_production_raw_access_log',
+        ] as $forbiddenSource) {
+            $this->assertContains($forbiddenSource, $source['forbidden_sources'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function schema_gap_is_recorded_before_any_persistent_write(): void
+    {
+        $schema = $this->artifact()['schema_readiness'] ?? [];
+
+        $this->assertSame('seo_intel', $schema['target_connection'] ?? null);
+        $this->assertSame('seo_crawler_logs_daily', $schema['existing_table'] ?? null);
+        $this->assertTrue((bool) ($schema['migration_has_seo_intel_connection'] ?? false));
+        $this->assertSame('existing_table_is_aggregate_but_not_v1_contract_shape', $schema['schema_gap'] ?? null);
+        $this->assertFalse((bool) ($schema['persistent_write_ready'] ?? true));
+        $this->assertTrue((bool) ($schema['fixture_no_write_ready'] ?? false));
+
+        foreach (['user_agent_hash', 'path_display_masked', 'metadata_json'] as $field) {
+            $this->assertContains($field, $schema['fields_requiring_v1_reconciliation_before_persistent_writes'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function parser_and_collector_gaps_are_scoped_to_fixture_parser_mvp(): void
+    {
+        $readiness = $this->artifact()['parser_collector_readiness'] ?? [];
+
+        $this->assertTrue((bool) ($readiness['foundation_collectors_exist'] ?? false));
+        $this->assertTrue((bool) ($readiness['foundation_collectors_fixture_only'] ?? false));
+        $this->assertFalse((bool) ($readiness['production_log_read_attempted'] ?? true));
+
+        foreach ([
+            'host_surface_family_normalization',
+            'bot_variant',
+            'bot_verification_state',
+            'route_family_map',
+            'query_present',
+            'query_risk_state',
+            'complete_private_path_denylist',
+            'v1_bot_family_names',
+            'unknown_public_path_hash_only_semantics',
+        ] as $gap) {
+            $this->assertContains($gap, $readiness['current_gaps_for_v1'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function config_and_scheduler_safety_remain_blocked(): void
+    {
+        $config = $this->artifact()['config_safety'] ?? [];
+        $scheduler = $this->artifact()['scheduler_scan'] ?? [];
+
+        foreach ([
+            'allow_production_log_read',
+            'chinese_crawler_live_log_read_enabled',
+            'allow_external_api_calls',
+            'allow_production_crawl',
+            'collectors_enabled_default',
+        ] as $flag) {
+            $this->assertFalse((bool) ($config[$flag] ?? true), $flag.' must remain false');
+        }
+
+        $this->assertTrue((bool) ($config['dry_run_default'] ?? false));
+
+        foreach ([
+            'crawler_log_scheduler_entry_found',
+            'seo_intel_collect_scheduled',
+            'crawler_log_foundation_scheduled',
+            'chinese_crawler_log_foundation_scheduled',
+        ] as $flag) {
+            $this->assertFalse((bool) ($scheduler[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function privacy_and_url_truth_boundaries_are_locked(): void
+    {
+        $artifact = $this->artifact();
+        $privacy = $artifact['privacy_boundary'] ?? [];
+        $truth = $artifact['url_truth_boundary'] ?? [];
+
+        foreach ([
+            'ip_address',
+            'remote_addr',
+            'raw_user_agent',
+            'raw_request_uri',
+            'raw_query_string',
+            'cookie',
+            'headers',
+            'token',
+            'api_key',
+            'email',
+            'order_no',
+            'attempt_id',
+            'payment_id',
+            'raw_payload',
+            'raw_log_line',
+            'metadata_json',
+        ] as $field) {
+            $this->assertContains($field, $privacy['forbidden_persistent_fields'] ?? []);
+        }
+
+        $this->assertFalse((bool) ($privacy['raw_persistence_allowed'] ?? true));
+
+        foreach ([
+            'crawler_logs_are_url_truth',
+            'crawler_logs_create_seo_urls',
+            'crawler_logs_decide_canonical',
+            'crawler_logs_decide_indexability',
+            'crawler_logs_enqueue_search_channel',
+            'crawler_logs_auto_write_issue_queue',
+            'frontend_fallback_authority_allowed',
+            'static_sitemap_fallback_authority_allowed',
+            'static_llms_fallback_authority_allowed',
+            'node2_local_db_authority_allowed',
+            'external_search_source_authority_allowed',
+        ] as $flag) {
+            $this->assertFalse((bool) ($truth[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_record_final_decision_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/crawler-log-readiness-scan.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/crawler-log-readiness-scan.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'ready_for_crawler_log_fixture_parser_mvp',
+            'crawler-log-02',
+            'existing table does not contain the full v1 field set',
+            'no production log read',
+            'fixture-only/no-write',
+            'crawler logs remain observation data only',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/crawler-log-readiness-scan.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T04:24:00+08:00",
+  "updated_at": "2026-05-22T04:28:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -12715,14 +12715,14 @@
     "CRAWLER-LOG-01": {
       "repo": "fap-api",
       "branch": "codex/crawler-log-01-readiness-scan",
-      "status": "committed",
-      "state": "committed",
+      "status": "pr_opened_github_checks_pending",
+      "state": "pr_opened_github_checks_pending",
       "title": "Crawler log readiness scan",
       "depends_on": [
         "CRAWLER-LOG-00"
       ],
-      "commit_sha": "073b43f467e067ae6da8344c0aaa660ec5ac23be",
-      "pr_url": null,
+      "commit_sha": "f52df4f34412a90ac1ff3198c69ca0b8093b9a8e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1542",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -12771,6 +12771,10 @@
         "git_diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github": {
+          "status": "pending",
+          "evidence": "Opened PR #1542; GitHub checks pending."
         }
       },
       "failure_reason": null,
@@ -12805,6 +12809,11 @@
           "at": "2026-05-22T04:24:00+08:00",
           "status": "committed",
           "summary": "Committed scoped readiness scan implementation at 073b43f467e067ae6da8344c0aaa660ec5ac23be."
+        },
+        {
+          "at": "2026-05-22T04:28:00+08:00",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1542 for CRAWLER-LOG-01. GitHub checks are pending."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T03:42:00+08:00",
+  "updated_at": "2026-05-22T04:24:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -11390,8 +11390,8 @@
     },
     "CRAWLER-LOG-00": {
       "repo": "fap-api",
-      "status": "in_progress",
-      "state": "in_progress",
+      "status": "merged",
+      "state": "merged",
       "title": "Crawler log architecture contract",
       "depends_on": [
         "SEO-DASH-PROD-04B"
@@ -11465,6 +11465,10 @@
         },
         "github": {
           "status": "passed"
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1541 was merged and origin/main contains merge commit 316223c6e9ece53da47bbd7523bb648a2cfb3c85."
         }
       },
       "sidecar_issues": [],
@@ -11513,20 +11517,25 @@
           "at": "2026-05-22T03:42:00+08:00",
           "status": "pr_opened_github_checks_pending",
           "summary": "Opened PR #1541 for the crawler log architecture contract. GitHub checks are pending."
+        },
+        {
+          "at": "2026-05-22T04:05:00+08:00",
+          "status": "merged",
+          "summary": "Reconciled supplemental CRAWLER-LOG-00 architecture contract as merged via PR #1541; origin/main contains 316223c6e9ece53da47bbd7523bb648a2cfb3c85 and local cleanup was completed before CRAWLER-LOG-01."
         }
       ],
       "branch": "codex/crawler-log-00-architecture-contract",
       "base": "main",
-      "pr_url": null,
-      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1541",
+      "commit_sha": "316223c6e9ece53da47bbd7523bb648a2cfb3c85",
       "previous_pr_url": "https://github.com/fermatmind/fap-api/pull/1472",
       "previous_merge_commit_sha": "4f619c18",
-      "final_status": null,
-      "merge_commit_sha": null,
-      "merge_observed": false,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "final_status": "crawler_log_architecture_contract_merged_ready_for_readiness_scan",
+      "merge_commit_sha": "316223c6e9ece53da47bbd7523bb648a2cfb3c85",
+      "merge_observed": true,
+      "merged_at": "2026-05-22T03:52:00+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "CLAIM-LINT-00": {
       "repo": "fap-api",
@@ -12702,6 +12711,102 @@
         }
       ],
       "next_pr": "RESEARCH-PUBLISH-02-RERUN"
+    },
+    "CRAWLER-LOG-01": {
+      "repo": "fap-api",
+      "branch": "codex/crawler-log-01-readiness-scan",
+      "status": "committed",
+      "state": "committed",
+      "title": "Crawler log readiness scan",
+      "depends_on": [
+        "CRAWLER-LOG-00"
+      ],
+      "commit_sha": "073b43f467e067ae6da8344c0aaa660ec5ac23be",
+      "pr_url": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "CRAWLER-LOG-00 is merged via PR #1541 and local main started from 316223c6e9ece53da47bbd7523bb648a2cfb3c85."
+        },
+        "scope": {
+          "status": "in_progress",
+          "evidence": "Implementing docs/generated/test/metadata only. No production log read, runtime parser, scheduler, collector write, migration, deployment, env edit, external search API call, URL submission, Metabase exposure, business DB / Tencent RDS / Node2 access, or production operation executed."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to crawler log readiness scan doc, generated artifact, focused SeoIntel test, and docs/codex PR train metadata. No production log read, runtime parser, scheduler, collector write, migration, deployment, env edit, external search API call, URL submission, Metabase exposure, business DB / Tencent RDS / Node2 access, or production operation was performed."
+        },
+        "crawler_log_readiness_scan_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelCrawlerLogReadinessScan",
+          "evidence": "8 tests passed with 109 assertions."
+        },
+        "seo_intel_phpunit": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntel",
+          "evidence": "309 tests passed with 4918 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully; 203 routes reported."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "Pint completed successfully; 3442 files checked."
+        },
+        "json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/crawler-log-readiness-scan.v1.json >/dev/null"
+        },
+        "state_json_validation": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        },
+        "yaml_validation": {
+          "status": "pass",
+          "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        },
+        "git_diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_write_execution": false,
+      "scheduler_activation": false,
+      "metabase_deployment": false,
+      "external_api_live_activation": false,
+      "crawler_log_read": false,
+      "env_edit": false,
+      "deploy": false,
+      "search_submission": false,
+      "business_db_access": false,
+      "human_review_required": true,
+      "sidecar_allowed": true,
+      "stop_on_safety_violation": true,
+      "next_pr": "CRAWLER-LOG-02",
+      "history": [
+        {
+          "at": "2026-05-22T04:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started CRAWLER-LOG-01 readiness scan from latest main. Scope is docs/generated/test/metadata only and keeps production crawler log reads, runtime parser work, scheduler, collector writes, migrations, deploys, env edits, external APIs, URL submissions, Metabase exposure, and unsafe data sources blocked."
+        },
+        {
+          "at": "2026-05-22T04:20:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Added crawler log readiness scan, generated artifact, focused SeoIntel test, and PR train metadata. Focused scan test, full SeoIntel suite, route list, Pint, JSON/YAML validation, state JSON validation, and diff check passed. No production log read, runtime parser, scheduler, collector write, migration, deployment, env edit, external API call, URL submission, Metabase exposure, or production operation performed."
+        },
+        {
+          "at": "2026-05-22T04:24:00+08:00",
+          "status": "committed",
+          "summary": "Committed scoped readiness scan implementation at 073b43f467e067ae6da8344c0aaa660ec5ac23be."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5787,6 +5787,53 @@ prs:
     production_approval_required: false
     next_task: CRAWLER-LOG-01
 
+  - id: CRAWLER-LOG-01
+    repo: fap-api
+    depends_on:
+      - CRAWLER-LOG-00
+    branch: codex/crawler-log-01-readiness-scan
+    base: main
+    title: "docs(seo-intel): add crawler log readiness scan"
+    name: "Crawler log readiness scan"
+    train_scope: seo_intel_crawler_log_readiness_scan
+    risk_level: low_docs_scan_no_log_read
+    type: docs/generated/test PR
+    scope:
+      - Perform a read-only repository readiness scan for crawler log fixture parser work.
+      - Confirm existing crawler log table, parser, collector, config, scheduler, source approval, privacy, and URL Truth boundaries.
+      - Record schema gaps and next PR scope without reading production logs, adding runtime parser code, enabling scheduler, running collector writes, running migrations, deploying, editing env, exposing Metabase, calling search APIs, or submitting URLs.
+    allowed_paths:
+      - backend/docs/seo/crawler-log-readiness-scan.md
+      - backend/docs/seo/generated/crawler-log-readiness-scan.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogReadinessScanTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Read production crawler logs, add runtime parser code, add fixture runtime files, add scheduler entries, run collector writes, run migrations, deploy, edit env, expose Metabase, call external search APIs, submit URLs, or access business DB / Tencent RDS / Node2.
+      - Store raw IP, raw user-agent, raw request URI, query string, cookies, headers, tokens, emails, order IDs, attempt IDs, payment IDs, provider payloads, raw payloads, or raw log lines.
+      - Treat crawler logs as URL Truth, Search Channel Queue, CMS authority, canonical truth, indexability truth, or issue auto-fix.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelCrawlerLogReadinessScan
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/crawler-log-readiness-scan.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: true
+    production_approval_required: false
+    next_task: CRAWLER-LOG-02
+
   - id: CLAIM-LINT-00
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed

- Added `CRAWLER-LOG-01` crawler log readiness scan documentation.
- Added generated machine-readable readiness artifact.
- Added focused SeoIntel test coverage for scan flags, source approval, schema gap, parser/collector gaps, scheduler/config safety, privacy, and URL Truth boundaries.
- Registered `CRAWLER-LOG-01` in the PR train manifest/state and reconciled the merged `CRAWLER-LOG-00` dependency.

## Why

This scan determines whether crawler log observability is ready to proceed to a synthetic fixture parser MVP without touching production logs or creating a write path. It records that the existing `seo_crawler_logs_daily` table is aggregate-only and scoped to `seo_intel`, but does not yet match the stricter CRAWLER-LOG-00 V1 schema for persistent writes.

## Validation commands

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter=SeoIntelCrawlerLogReadinessScan
php artisan test --filter=SeoIntel
php artisan route:list --no-ansi
vendor/bin/pint --test

cd /Users/rainie/Desktop/GitHub/fap-api
python3 -m json.tool backend/docs/seo/generated/crawler-log-readiness-scan.v1.json >/dev/null
python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
git diff --check
git diff --cached --check
```

## Intentionally deferred

- No production crawler log read.
- No runtime parser implementation.
- No fixture runtime file.
- No scheduler activation.
- No collector writes.
- No migrations or production schema changes.
- No deploy or env edit.
- No GSC/Baidu/IndexNow or other external search API call.
- No URL submission.
- No Metabase exposure.
- No business DB / Tencent RDS / Node2 access.

Next task: `CRAWLER-LOG-02｜Fixture parser MVP`.
