### PR TITLE
fix(deploy): keep nginx static route backups outside active config paths

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -767,13 +767,12 @@ set -euo pipefail
 tmp_site="$(mktemp)"
 tmp_script="$(mktemp)"
 tmp_snippet="$(mktemp)"
+site_backup="$(mktemp /tmp/fap-api-nginx-site-backup.XXXXXX.conf)"
+snippet_backup="$(mktemp /tmp/fap-api-nginx-snippet-backup.XXXXXX.conf)"
 site_path=__QUOTED_SITE__
 snippet_path=__QUOTED_SNIPPET__
-backup_suffix="$(date +%Y%m%d%H%M%S)"
-site_backup="$site_path.bak.fap-static.$backup_suffix"
-snippet_backup="$snippet_path.bak.fap-static.$backup_suffix"
 snippet_existed=0
-trap 'rm -f "$tmp_site" "$tmp_script" "$tmp_snippet"' EXIT
+trap 'rm -f "$tmp_site" "$tmp_script" "$tmp_snippet" "$site_backup" "$snippet_backup"' EXIT
 
 printf %s __ENCODED_SNIPPET__ | base64 -d > "$tmp_snippet"
 sudo -n test -f "$site_path"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16792,22 +16792,26 @@
     "DEPLOY-NGINX-STATIC-ROUTE-01": {
       "repo": "fap-api",
       "branch": "codex/deploy-nginx-static-route-01",
-      "status": "in_progress",
-      "state": "in_progress",
+      "status": "open",
+      "state": "open",
       "title": "Keep nginx static route backups outside active config paths",
       "depends_on": [
         "BACKEND-DEPLOY-TARGET-ALIYUN-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "1479b24c",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1547",
       "checks": {
         "dependency": {
           "status": "pass",
           "evidence": "BACKEND-DEPLOY-TARGET-ALIYUN-01 is already present in the train and the production deploy target is Aliyun ECS 139.224.130.204."
         },
         "scope": {
-          "status": "in_progress",
+          "status": "pass",
           "evidence": "Scoping only the deploy.php nginx static media route backup-placement fix plus the matching PR-train manifest/state entry. No host, workflow, runtime, or live deployment behavior changes are included."
+        },
+        "local_validation": {
+          "status": "pass",
+          "evidence": "Passed `php -l deploy.php`, the scoped `rg` backup-path check, JSON/YAML parsing, `git diff --check`, and `git diff --cached --check` before opening PR #1547."
         }
       },
       "failure_reason": null,
@@ -16826,6 +16830,11 @@
           "at": "2026-05-22T10:05:00+08:00",
           "status": "in_progress",
           "summary": "Started DEPLOY-NGINX-STATIC-ROUTE-01 after explicit user authorization to add manifest/state entries. Scope is limited to moving nginx static route temporary backups out of active nginx config directories and recording the scoped train metadata."
+        },
+        {
+          "at": "2026-05-22T10:05:00+08:00",
+          "status": "open",
+          "summary": "Opened PR #1547 for the deploy.php nginx static route backup-placement fix after scoped local validation passed."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16788,6 +16788,46 @@
           "summary": "Opened PR #1540 for permission, audit, and no-export verification. GitHub checks are pending."
         }
       ]
+    },
+    "DEPLOY-NGINX-STATIC-ROUTE-01": {
+      "repo": "fap-api",
+      "branch": "codex/deploy-nginx-static-route-01",
+      "status": "in_progress",
+      "state": "in_progress",
+      "title": "Keep nginx static route backups outside active config paths",
+      "depends_on": [
+        "BACKEND-DEPLOY-TARGET-ALIYUN-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "BACKEND-DEPLOY-TARGET-ALIYUN-01 is already present in the train and the production deploy target is Aliyun ECS 139.224.130.204."
+        },
+        "scope": {
+          "status": "in_progress",
+          "evidence": "Scoping only the deploy.php nginx static media route backup-placement fix plus the matching PR-train manifest/state entry. No host, workflow, runtime, or live deployment behavior changes are included."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "deploy": false,
+      "env_edit": false,
+      "next_pr": "CRAWLER-LOG-05",
+      "history": [
+        {
+          "at": "2026-05-22T10:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started DEPLOY-NGINX-STATIC-ROUTE-01 after explicit user authorization to add manifest/state entries. Scope is limited to moving nginx static route temporary backups out of active nginx config directories and recording the scoped train metadata."
+        }
+      ]
     }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -8076,6 +8076,45 @@ prs:
     scheduler_activation: false
     next_task: OPS-DOMAIN-MIGRATION-01
 
+  - id: DEPLOY-NGINX-STATIC-ROUTE-01
+    repo: fap-api
+    depends_on:
+      - BACKEND-DEPLOY-TARGET-ALIYUN-01
+    branch: codex/deploy-nginx-static-route-01
+    base: main
+    title: "fix(deploy): keep nginx static route backups outside active config paths"
+    name: "Keep nginx static route backups outside active config paths"
+    train_scope: deploy_nginx_static_route_backup_safety
+    risk_level: L2
+    type: deploy safety PR
+    scope:
+      - Move the temporary backup files used by `ensure:nginx-public-static-media-route` out of `/etc/nginx/sites-enabled` and related active config paths.
+      - Preserve the existing nginx static media route injection and restore behavior while preventing `nginx -t` from reading backup files as live site configs.
+      - Record the scoped PR train state for this deploy safety fix only.
+    allowed_paths:
+      - deploy.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change deploy target hosts, healthcheck URLs, queue behavior, crawler runtime behavior, production env, GitHub Actions workflow logic, or live application code.
+      - Deploy from this PR or broaden the nginx static media route feature surface beyond backup placement safety.
+    validation:
+      - php -l deploy.php
+      - rg -n "mktemp /tmp/fap-api-nginx-site-backup|mktemp /tmp/fap-api-nginx-snippet-backup|sites-enabled.*bak\\.fap-static" deploy.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: false
+    scheduler_activation: false
+    next_task: CRAWLER-LOG-05
+
   - id: OPS-DOMAIN-MIGRATION-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- moved the temporary site/snippet backup files used by `ensure:nginx-public-static-media-route` into `/tmp` via `mktemp`
- expanded the shell `trap` so those temporary backup files are cleaned up after the task exits
- added the scoped `DEPLOY-NGINX-STATIC-ROUTE-01` manifest/state entry for this PR train item

## Why
- the previous backup naming wrote a `*.bak.fap-static.*` file beside the active nginx site config under `/etc/nginx/sites-enabled`
- `nginx -t` then parsed the backup as a live site file, which can fail with duplicate server definitions and break the deploy tail
- this change preserves the existing restore behavior while removing that failure mode

## Validation commands
- `php -l deploy.php`
- `rg -n "mktemp /tmp/fap-api-nginx-site-backup|mktemp /tmp/fap-api-nginx-snippet-backup|sites-enabled.*bak\\.fap-static" deploy.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- no GitHub Actions workflow changes
- no deploy target / healthcheck / queue behavior changes
- no runtime crawler-log behavior changes
- `CRAWLER-LOG-05` follow-up remains a separate PR
