### PR TITLE
docs(seo-intel): add crawler log production canary report

### DIFF
--- a/backend/docs/seo/crawler-log-production-canary-report.md
+++ b/backend/docs/seo/crawler-log-production-canary-report.md
@@ -1,0 +1,176 @@
+# CRAWLER-LOG-05 Production Canary Report
+
+## Executive Summary
+
+CRAWLER-LOG-05 records the first human-approved crawler log production canary result as a read-only observation artifact.
+
+The canary runtime was deployed to the production backend release at commit `84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd`. The approved source was `/var/log/nginx/access.log` on `139.224.130.204`, executed from `/var/www/fap-api/current/backend`.
+
+This report does not expand crawler log collection. It does not add a scheduler, collector write, database write, issue queue write, URL Truth mutation, Search Channel Queue enqueue, or search submission.
+
+## Deployment / Runtime Confirmation
+
+- Production runtime host: `139.224.130.204`
+- Runtime shell: `/var/www/fap-api/current/backend`
+- Runtime command: `seo-intel:crawler-log-observe`
+- Deployed release SHA: `84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd`
+- Canary mode: `single_source_production_canary_dry_run`
+- Source: `/var/log/nginx/access.log`
+- Limit: `1000`
+- Required approval phrase verified: yes
+
+## Canary Execution Result
+
+The first execution as `ubuntu` failed closed because the source file was not readable by that user. That blocked attempt read zero production log lines and committed no writes.
+
+The second execution used the same approved command under `sudo -n` to read the same single source. It completed successfully as dry-run/no-write only.
+
+Sanitized successful summary:
+
+- Status: `success`
+- Parsed line count: `1000`
+- Sanitized row count: `1000`
+- Aggregate row count: `154`
+- Blocked private path count: `956`
+- Unknown bot count: `1`
+- Safe public canonical path count: `0`
+- Target table: `seo_crawler_logs_daily`
+- Target table write attempted: `false`
+- Target table write committed: `false`
+
+## Aggregate Breakdowns
+
+Bot family:
+
+- `non_bot`: `999`
+- `unknown_bot`: `1`
+
+Route family:
+
+- `blocked_private_path`: `956`
+- `static_asset`: `6`
+- `unknown_public_path`: `38`
+
+Surface family:
+
+- `blocked_private`: `956`
+- `static_asset`: `6`
+- `unknown`: `38`
+
+HTTP status:
+
+- `200`: `786`
+- `202`: `5`
+- `204`: `2`
+- `400`: `7`
+- `401`: `127`
+- `404`: `67`
+- `405`: `1`
+- `422`: `1`
+- `428`: `4`
+
+Method bucket:
+
+- `GET`: `889`
+- `HEAD`: `3`
+- `OTHER`: `108`
+
+Query risk state:
+
+- `none`: `176`
+- `unknown_query_present`: `824`
+
+## Privacy Boundary
+
+CRAWLER-LOG-05 records only aggregate summary values. It does not persist or print raw crawler log lines.
+
+Forbidden persistent and report fields remain:
+
+- raw IP / remote address
+- raw user agent
+- raw request URI
+- raw query string
+- cookies
+- headers
+- authorization values
+- session IDs
+- tokens / API keys
+- emails
+- order IDs
+- payment IDs
+- attempt IDs
+- provider event IDs
+- raw payloads
+- raw log lines
+- event payload blobs
+- metadata JSON blobs
+- attributes JSON blobs
+
+The successful canary output confirmed:
+
+- `writes_attempted=false`
+- `writes_committed=false`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `scheduler_enabled=false`
+- `collector_write_attempted=false`
+- `raw_persistence=false`
+
+## URL Truth Boundary
+
+Crawler logs remain aggregate observability only.
+
+This report does not allow crawler logs to:
+
+- create `seo_urls`
+- decide canonical truth
+- decide indexability truth
+- override CMS/backend URL Truth
+- create Search Channel Queue items
+- create issue queue rows automatically
+- submit URLs to search engines
+
+The observed `safe_public_canonical_path_count=0` means this canary did not identify any safe public canonical URL candidate in the sampled 1000 lines. It is not evidence that public crawler traffic is absent globally; it is only the result of this bounded single-source sample.
+
+## Operational Interpretation
+
+The sampled log slice was dominated by private-flow or blocked-private classification. That is useful as a privacy-boundary signal, but it is not a URL eligibility signal.
+
+The right next step is not to widen production log access. The next step is to keep the collection model aggregate-only and define an observation loop that can summarize future bounded canaries without raw persistence.
+
+## Follow-up Observation Contract
+
+Any follow-up crawler log observation task must remain:
+
+- single approved source unless a new task explicitly approves another source
+- bounded by a declared maximum line count
+- dry-run/no-write until a separate aggregate storage approval exists
+- aggregate-only
+- no raw persistence
+- no issue queue auto-write
+- no URL Truth mutation
+- no Search Channel Queue enqueue
+- no scheduler
+- no search submission
+- no Metabase exposure
+
+## What Was Not Done
+
+- No crawler log scheduler was added.
+- No collector write was run.
+- No database write was committed.
+- No issue queue row was created.
+- No URL Truth row was created or modified.
+- No Search Channel Queue row was created.
+- No GSC/Baidu/IndexNow or other search API was called.
+- No URL was submitted to a search engine.
+- No raw log line was persisted.
+- No raw IP, raw UA, raw URI, query string, cookie, token, email, order ID, payment ID, or attempt ID was stored.
+
+## Final Decision
+
+`crawler_log_production_canary_report_recorded_ready_for_aggregate_observation_design`
+
+## Next Task
+
+`CRAWLER-LOG-06｜Aggregate observation design`

--- a/backend/docs/seo/generated/crawler-log-production-canary-report.v1.json
+++ b/backend/docs/seo/generated/crawler-log-production-canary-report.v1.json
@@ -1,0 +1,145 @@
+{
+  "version": "crawler-log-production-canary-report.v1",
+  "task": "CRAWLER-LOG-05",
+  "runtime": "crawler_log_observe",
+  "report_type": "production_canary_read_only_summary",
+  "source": {
+    "host": "139.224.130.204",
+    "shell": "/var/www/fap-api/current/backend",
+    "path": "/var/log/nginx/access.log",
+    "source_log_family": "nginx_access_log",
+    "single_source_only": true
+  },
+  "deployment": {
+    "runtime_deployed": true,
+    "release_sha": "84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd",
+    "command_available": true
+  },
+  "approval": {
+    "approval_phrase_verified": true,
+    "approval_phrase_template": "I explicitly approve CRAWLER-LOG-04 production canary for source <log_path> with max_lines=1000 and no raw persistence.",
+    "approved_source_phrase": "I explicitly approve CRAWLER-LOG-04 production canary for source /var/log/nginx/access.log with max_lines=1000 and no raw persistence.",
+    "max_lines": 1000
+  },
+  "blocked_attempt": {
+    "status": "blocked",
+    "reason": "source_path_not_readable",
+    "production_log_read_attempted": false,
+    "source_line_count_read": 0,
+    "writes_attempted": false,
+    "writes_committed": false
+  },
+  "successful_canary": {
+    "status": "success",
+    "mode": "single_source_production_canary_dry_run",
+    "fixture_only": false,
+    "dry_run": true,
+    "no_write": true,
+    "writes_attempted": false,
+    "writes_committed": false,
+    "production_log_read_attempted": true,
+    "external_calls_attempted": false,
+    "search_submission_attempted": false,
+    "scheduler_enabled": false,
+    "collector_write_attempted": false,
+    "raw_persistence": false,
+    "parsed_line_count": 1000,
+    "sanitized_row_count": 1000,
+    "aggregate_row_count": 154,
+    "blocked_private_path_count": 956,
+    "unknown_bot_count": 1,
+    "safe_public_canonical_path_count": 0,
+    "target_table": "seo_crawler_logs_daily",
+    "target_table_write_attempted": false,
+    "target_table_write_committed": false,
+    "privacy_transform_version": "crawler_log_privacy_transform_v1"
+  },
+  "breakdowns": {
+    "bot_family": {
+      "non_bot": 999,
+      "unknown_bot": 1
+    },
+    "route_family": {
+      "blocked_private_path": 956,
+      "static_asset": 6,
+      "unknown_public_path": 38
+    },
+    "surface_family": {
+      "blocked_private": 956,
+      "static_asset": 6,
+      "unknown": 38
+    },
+    "http_status": {
+      "200": 786,
+      "202": 5,
+      "204": 2,
+      "400": 7,
+      "401": 127,
+      "404": 67,
+      "405": 1,
+      "422": 1,
+      "428": 4
+    },
+    "method_bucket": {
+      "GET": 889,
+      "HEAD": 3,
+      "OTHER": 108
+    },
+    "query_risk_state": {
+      "none": 176,
+      "unknown_query_present": 824
+    }
+  },
+  "privacy_boundary": {
+    "aggregate_only": true,
+    "no_raw_persistence": true,
+    "forbidden_report_fields": [
+      "ip_address",
+      "remote_addr",
+      "raw_user_agent",
+      "raw_request_uri",
+      "raw_query_string",
+      "cookie",
+      "headers",
+      "authorization",
+      "session_id",
+      "token",
+      "api_key",
+      "email",
+      "order_no",
+      "attempt_id",
+      "payment_id",
+      "provider_event_id",
+      "raw_payload",
+      "raw_log_line",
+      "event_payload",
+      "metadata_json",
+      "attributes_json"
+    ]
+  },
+  "authority_boundary": {
+    "crawler_logs_are_url_truth": false,
+    "crawler_logs_create_seo_urls": false,
+    "crawler_logs_decide_canonical": false,
+    "crawler_logs_decide_indexability": false,
+    "crawler_logs_override_cms_backend_truth": false,
+    "crawler_logs_enqueue_search_channel": false,
+    "crawler_logs_auto_write_issue_queue": false,
+    "crawler_logs_submit_urls": false
+  },
+  "follow_up_observation_contract": {
+    "do_not_expand_reading_scope": true,
+    "single_approved_source_until_separate_approval": true,
+    "bounded_max_lines_required": true,
+    "dry_run_no_write_until_separate_storage_approval": true,
+    "aggregate_only": true,
+    "no_scheduler": true,
+    "no_issue_queue_auto_write": true,
+    "no_url_truth_mutation": true,
+    "no_search_channel_queue_enqueue": true,
+    "no_search_submission": true,
+    "no_metabase_exposure": true
+  },
+  "final_decision": "crawler_log_production_canary_report_recorded_ready_for_aggregate_observation_design",
+  "next_task": "CRAWLER-LOG-06"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogProductionCanaryReportTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogProductionCanaryReportTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelCrawlerLogProductionCanaryReportTest extends TestCase
+{
+    #[Test]
+    public function production_canary_report_doc_and_generated_artifact_exist_and_parse(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/crawler-log-production-canary-report.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('crawler-log-production-canary-report.v1', $artifact['version'] ?? null);
+        $this->assertSame('CRAWLER-LOG-05', $artifact['task'] ?? null);
+        $this->assertSame('production_canary_read_only_summary', $artifact['report_type'] ?? null);
+        $this->assertSame('CRAWLER-LOG-06', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function report_records_the_successful_canary_summary_without_raw_log_details(): void
+    {
+        $artifact = $this->artifact();
+        $canary = $artifact['successful_canary'] ?? [];
+
+        $this->assertSame('success', $canary['status'] ?? null);
+        $this->assertSame('single_source_production_canary_dry_run', $canary['mode'] ?? null);
+        $this->assertTrue($canary['dry_run'] ?? false);
+        $this->assertTrue($canary['no_write'] ?? false);
+        $this->assertFalse($canary['writes_attempted'] ?? true);
+        $this->assertFalse($canary['writes_committed'] ?? true);
+        $this->assertFalse($canary['external_calls_attempted'] ?? true);
+        $this->assertFalse($canary['search_submission_attempted'] ?? true);
+        $this->assertFalse($canary['scheduler_enabled'] ?? true);
+        $this->assertFalse($canary['collector_write_attempted'] ?? true);
+        $this->assertFalse($canary['raw_persistence'] ?? true);
+
+        $this->assertSame(1000, $canary['parsed_line_count'] ?? null);
+        $this->assertSame(1000, $canary['sanitized_row_count'] ?? null);
+        $this->assertSame(154, $canary['aggregate_row_count'] ?? null);
+        $this->assertSame(956, $canary['blocked_private_path_count'] ?? null);
+        $this->assertSame(1, $canary['unknown_bot_count'] ?? null);
+        $this->assertSame(0, $canary['safe_public_canonical_path_count'] ?? null);
+    }
+
+    #[Test]
+    public function blocked_attempt_is_recorded_as_fail_closed_without_reading_or_writing(): void
+    {
+        $blocked = $this->artifact()['blocked_attempt'] ?? [];
+
+        $this->assertSame('blocked', $blocked['status'] ?? null);
+        $this->assertSame('source_path_not_readable', $blocked['reason'] ?? null);
+        $this->assertFalse($blocked['production_log_read_attempted'] ?? true);
+        $this->assertSame(0, $blocked['source_line_count_read'] ?? null);
+        $this->assertFalse($blocked['writes_attempted'] ?? true);
+        $this->assertFalse($blocked['writes_committed'] ?? true);
+    }
+
+    #[Test]
+    public function aggregate_breakdowns_are_recorded_without_raw_rows(): void
+    {
+        $artifact = $this->artifact();
+        $breakdowns = $artifact['breakdowns'] ?? [];
+
+        $this->assertSame(999, $breakdowns['bot_family']['non_bot'] ?? null);
+        $this->assertSame(1, $breakdowns['bot_family']['unknown_bot'] ?? null);
+        $this->assertSame(956, $breakdowns['route_family']['blocked_private_path'] ?? null);
+        $this->assertSame(6, $breakdowns['route_family']['static_asset'] ?? null);
+        $this->assertSame(38, $breakdowns['route_family']['unknown_public_path'] ?? null);
+        $this->assertSame(786, $breakdowns['http_status']['200'] ?? null);
+        $this->assertSame(127, $breakdowns['http_status']['401'] ?? null);
+        $this->assertSame(67, $breakdowns['http_status']['404'] ?? null);
+        $this->assertSame(824, $breakdowns['query_risk_state']['unknown_query_present'] ?? null);
+
+        $this->assertArrayNotHasKey('aggregate_rows', $artifact);
+        $this->assertArrayNotHasKey('raw_rows', $artifact);
+        $this->assertArrayNotHasKey('path_hashes', $artifact);
+    }
+
+    #[Test]
+    public function privacy_and_authority_boundaries_remain_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['privacy_boundary']['aggregate_only'] ?? false);
+        $this->assertTrue($artifact['privacy_boundary']['no_raw_persistence'] ?? false);
+
+        foreach ([
+            'ip_address',
+            'remote_addr',
+            'raw_user_agent',
+            'raw_request_uri',
+            'raw_query_string',
+            'cookie',
+            'headers',
+            'authorization',
+            'token',
+            'api_key',
+            'email',
+            'order_no',
+            'attempt_id',
+            'payment_id',
+            'raw_payload',
+            'raw_log_line',
+            'event_payload',
+            'metadata_json',
+            'attributes_json',
+        ] as $field) {
+            $this->assertContains($field, $artifact['privacy_boundary']['forbidden_report_fields'] ?? []);
+        }
+
+        foreach ([
+            'crawler_logs_are_url_truth',
+            'crawler_logs_create_seo_urls',
+            'crawler_logs_decide_canonical',
+            'crawler_logs_decide_indexability',
+            'crawler_logs_override_cms_backend_truth',
+            'crawler_logs_enqueue_search_channel',
+            'crawler_logs_auto_write_issue_queue',
+            'crawler_logs_submit_urls',
+        ] as $flag) {
+            $this->assertFalse($artifact['authority_boundary'][$flag] ?? true, $flag);
+        }
+    }
+
+    #[Test]
+    public function follow_up_observation_contract_does_not_expand_read_scope_or_add_mutation_paths(): void
+    {
+        $contract = $this->artifact()['follow_up_observation_contract'] ?? [];
+
+        foreach ([
+            'do_not_expand_reading_scope',
+            'single_approved_source_until_separate_approval',
+            'bounded_max_lines_required',
+            'dry_run_no_write_until_separate_storage_approval',
+            'aggregate_only',
+            'no_scheduler',
+            'no_issue_queue_auto_write',
+            'no_url_truth_mutation',
+            'no_search_channel_queue_enqueue',
+            'no_search_submission',
+            'no_metabase_exposure',
+        ] as $flag) {
+            $this->assertTrue($contract[$flag] ?? false, $flag);
+        }
+    }
+
+    #[Test]
+    public function docs_state_the_report_is_observation_only(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/crawler-log-production-canary-report.md')));
+
+        foreach ([
+            'read-only observation artifact',
+            'does not expand crawler log collection',
+            'no raw persistence',
+            'crawler logs remain aggregate observability only',
+            'not a url eligibility signal',
+            'not to widen production log access',
+            'no search submission',
+        ] as $requiredText) {
+            $this->assertStringContainsString($requiredText, $doc);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/crawler-log-production-canary-report.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -13228,28 +13228,32 @@
     "CRAWLER-LOG-04-CANARY": {
       "repo": "fap-api",
       "branch": "codex/crawler-log-04-canary-runtime",
-      "status": "in_progress",
-      "state": "in_progress",
+      "status": "merged",
+      "state": "merged",
       "title": "Crawler log human-approved production canary runtime",
       "depends_on": [
         "CRAWLER-LOG-04"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1546",
       "checks": {
         "dependency": {
           "status": "pass",
           "evidence": "CRAWLER-LOG-04 is merged via PR #1545 and origin/main contains 000c4798f34130d8ee4612c6008ed96e6a92730f."
         },
         "scope": {
-          "status": "in_progress",
+          "status": "pass",
           "evidence": "Implementing a fail-closed single-source crawler log canary runtime only. No scheduler, no write mode, no issue queue write, no URL Truth write, no Search Channel Queue write, no search submission, no deploy, no env edit, and no production execution are being performed in this PR."
+        },
+        "github": {
+          "status": "pass",
+          "evidence": "PR #1546 was merged and origin/main contains 84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T01:26:51Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_write_execution": false,
       "scheduler_activation": false,
       "metabase_deployment": false,
@@ -13264,12 +13268,84 @@
       "production_approval_required": true,
       "sidecar_allowed": false,
       "stop_on_safety_violation": true,
-      "next_pr": "deploy crawler-log canary runtime and execute the approved production canary",
+      "next_pr": "CRAWLER-LOG-05",
       "history": [
         {
           "at": "2026-05-22T10:05:00+08:00",
           "status": "in_progress",
           "summary": "Started CRAWLER-LOG-04-CANARY from latest main after explicit user authorization to add manifest/state entries. Scope is single-source human-approved crawler log canary runtime only; no scheduler, no writes, no issue queue mutation, no URL Truth mutation, no search submission, no deploy, and no production execution."
+        },
+        {
+          "at": "2026-05-22T10:05:00+08:00",
+          "status": "merged",
+          "summary": "Reconciled CRAWLER-LOG-04-CANARY as merged via PR #1546; origin/main contains 84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd and local cleanup had been completed before CRAWLER-LOG-05."
+        }
+      ]
+    },
+    "CRAWLER-LOG-05": {
+      "repo": "fap-api",
+      "branch": "codex/crawler-log-05-production-canary-report",
+      "status": "in_progress",
+      "state": "in_progress",
+      "title": "Crawler log production canary report and observation follow-up",
+      "depends_on": [
+        "CRAWLER-LOG-04-CANARY",
+        "DEPLOY-NGINX-STATIC-ROUTE-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "CRAWLER-LOG-04-CANARY is merged via PR #1546 and DEPLOY-NGINX-STATIC-ROUTE-01 is merged via PR #1547."
+        },
+        "scope": {
+          "status": "pass",
+          "evidence": "Adding only sanitized production canary report docs, generated artifact, focused test, and PR-train metadata. No production log read, canary execution, runtime behavior change, scheduler, write path, deployment, external API call, search submission, Metabase exposure, business DB access, Tencent RDS access, or Node2 access is being performed."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=SeoIntelCrawlerLogProductionCanaryReport",
+            "cd backend && php artisan test --filter=SeoIntel",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "python3 -m json.tool backend/docs/seo/generated/crawler-log-production-canary-report.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"",
+            "git diff --check"
+          ]
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_write_execution": false,
+      "production_log_read_execution": false,
+      "scheduler_activation": false,
+      "metabase_deployment": false,
+      "external_api_live_activation": false,
+      "crawler_log_read": false,
+      "canary_execution": false,
+      "env_edit": false,
+      "deploy": false,
+      "search_submission": false,
+      "business_db_access": false,
+      "human_review_required": true,
+      "sidecar_allowed": false,
+      "stop_on_safety_violation": true,
+      "next_pr": "CRAWLER-LOG-06",
+      "history": [
+        {
+          "at": "2026-05-22T10:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started CRAWLER-LOG-05 after user instruction. Scope is a sanitized read-only production canary report and aggregate observation follow-up contract only; no additional production crawler log read, no writes, no scheduler, no search submission, and no runtime change."
+        },
+        {
+          "at": "2026-05-22T10:25:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Local validation passed for the sanitized production canary report artifact and contract test. No production log read, canary execution, deploy, scheduler activation, write path, external search API call, or search submission was performed."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6578,8 +6578,8 @@
         "do not weaken final live acceptance",
         "do not weaken software-developers or CN proxy rollout rejection"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "fdf8f1726762550284262a44734fbecc9c0d42a7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1548",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -13346,6 +13346,11 @@
           "at": "2026-05-22T10:25:00+08:00",
           "status": "local_validation_passed",
           "summary": "Local validation passed for the sanitized production canary report artifact and contract test. No production log read, canary execution, deploy, scheduler activation, write path, external search API call, or search submission was performed."
+        },
+        {
+          "at": "2026-05-22T10:30:00+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1548 for CRAWLER-LOG-05 with commit fdf8f1726762550284262a44734fbecc9c0d42a7. Scope remains report/generated/test/metadata only."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6040,7 +6040,55 @@ prs:
     metabase_deployment: false
     human_review_required: true
     production_approval_required: true
-    next_task: deploy crawler-log canary runtime and execute the approved production canary
+    next_task: CRAWLER-LOG-05
+
+  - id: CRAWLER-LOG-05
+    repo: fap-api
+    depends_on:
+      - CRAWLER-LOG-04-CANARY
+      - DEPLOY-NGINX-STATIC-ROUTE-01
+    branch: codex/crawler-log-05-production-canary-report
+    base: main
+    title: "docs(seo-intel): add crawler log production canary report"
+    name: "Crawler log production canary report and observation follow-up"
+    train_scope: seo_intel_crawler_log_production_canary_report
+    risk_level: low_docs_generated_test_no_runtime_change
+    type: docs/generated/test PR
+    scope:
+      - Record the first human-approved production crawler log canary result as a sanitized read-only report.
+      - Preserve the aggregate-only privacy boundary and explicitly prevent raw log persistence, issue queue writes, URL Truth writes, Search Channel Queue enqueue, scheduler activation, and search submission.
+      - Define the next aggregate observation design task without expanding production log reading scope.
+    allowed_paths:
+      - backend/docs/seo/crawler-log-production-canary-report.md
+      - backend/docs/seo/generated/crawler-log-production-canary-report.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelCrawlerLogProductionCanaryReportTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Read production crawler logs, run another canary, add runtime parser behavior, add scheduler, run collector writes, run migrations, deploy, edit env, expose Metabase, call external search APIs, submit URLs, or access business DB / Tencent RDS / Node2.
+      - Store or print raw IP, raw user-agent, raw request URI, query strings, cookies, headers, tokens, emails, order IDs, attempt IDs, payment IDs, provider payloads, or raw log lines.
+      - Treat crawler logs as URL Truth, canonical truth, indexability truth, CMS authority, Search Channel Queue authority, or issue auto-remediation authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelCrawlerLogProductionCanaryReport
+      - cd backend && php artisan test --filter=SeoIntel
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/crawler-log-production-canary-report.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    production_log_read_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: true
+    next_task: CRAWLER-LOG-06
 
   - id: CLAIM-LINT-00
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added a sanitized CRAWLER-LOG-05 production canary report for the approved `/var/log/nginx/access.log` dry-run sample on `139.224.130.204`.
- Added a generated JSON artifact that records aggregate-only canary counters, privacy boundaries, URL Truth boundaries, and the next observation task.
- Added a focused contract test proving the report is aggregate-only, records no raw rows, preserves authority boundaries, and does not expand crawler log access.
- Updated PR-train manifest/state for CRAWLER-LOG-05.

## Why
The production canary result needs to be captured as a read-only audit/report artifact before any future aggregate observation design. This PR intentionally preserves the boundary that crawler logs are observability only, not URL Truth, not Search Channel Queue authority, and not a submission signal.

## Validation commands
- `cd backend && php artisan test --filter=SeoIntelCrawlerLogProductionCanaryReport`
- `cd backend && php artisan test --filter=SeoIntel`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/crawler-log-production-canary-report.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred / not done
- No production log read was executed in this PR.
- No additional canary was run.
- No runtime parser behavior changed.
- No scheduler was added or enabled.
- No collector write, issue queue write, URL Truth write, or Search Channel Queue enqueue was added.
- No GSC/Baidu/IndexNow or other search API was called.
- No URL submission was performed.
- No Metabase exposure, iframe, proxy, or mutation was added.
