### PR TITLE
docs(seo-intel): add issue severity governance contract

### DIFF
--- a/backend/docs/seo/generated/issue-severity-dedupe-mute-sla-contract.v1.json
+++ b/backend/docs/seo/generated/issue-severity-dedupe-mute-sla-contract.v1.json
@@ -1,0 +1,150 @@
+{
+  "version": "issue-severity-dedupe-mute-sla-contract.v1",
+  "task": "SEO-OBS-GOV-03",
+  "purpose": "seo_issue_queue_operational_governance_contract",
+  "severity_levels": [
+    {
+      "code": "P0",
+      "label": "critical"
+    },
+    {
+      "code": "P1",
+      "label": "high"
+    },
+    {
+      "code": "P2",
+      "label": "medium"
+    },
+    {
+      "code": "P3",
+      "label": "info"
+    }
+  ],
+  "backward_compatible_mapping": {
+    "critical": "P0",
+    "high": "P1",
+    "warning": "P2",
+    "info": "P3"
+  },
+  "required_future_fields": [
+    "dedupe_key",
+    "muted_until",
+    "mute_reason",
+    "muted_by",
+    "owner_team",
+    "sla_due_at",
+    "sla_policy",
+    "reopen_rule",
+    "reopened_at",
+    "last_seen_at",
+    "occurrence_count",
+    "closed_reason"
+  ],
+  "p0_issue_classes": [
+    "claim_unsafe_public_indexable_page",
+    "private_flow_leak_public_search_surface",
+    "search_channel_submitted_non_canonical_private_url",
+    "public_indexed_page_accidentally_noindex",
+    "wrong_canonical_on_core_public_surface"
+  ],
+  "dedupe_rule": {
+    "field": "dedupe_key",
+    "deterministic": true,
+    "allowed_inputs": [
+      "issue_type",
+      "source_system",
+      "source_engine",
+      "canonical_url_hash",
+      "entity_key",
+      "locale",
+      "page_entity_type",
+      "normalized_issue_target"
+    ],
+    "forbidden_inputs": [
+      "raw_payload",
+      "raw_crawler_log_fields",
+      "raw_request_data",
+      "query_string",
+      "email",
+      "token",
+      "cookie",
+      "order_id",
+      "payment_id",
+      "attempt_id"
+    ]
+  },
+  "mute_rule": {
+    "must_not_delete_history": true,
+    "muted_issues_remain_auditable": true,
+    "required_fields": [
+      "muted_until",
+      "mute_reason",
+      "muted_by"
+    ],
+    "p0_must_never_be_silently_muted": true
+  },
+  "sla_rule": {
+    "fields": [
+      "sla_due_at",
+      "sla_policy"
+    ],
+    "deterministic_inputs": [
+      "severity",
+      "page_family",
+      "claim_risk",
+      "source_system",
+      "owner_team"
+    ],
+    "triggers_auto_fix": false,
+    "triggers_auto_publish": false,
+    "triggers_auto_submit": false
+  },
+  "owner_team_values": [
+    "seo_ops",
+    "cms_ops",
+    "engineering",
+    "content_review",
+    "digital_pr",
+    "unknown"
+  ],
+  "reopen_rule": {
+    "must_be_explicit": true,
+    "allowed_when": [
+      "matching_dedupe_key_reappears_with_fresh_evidence",
+      "p0_class_observed_again_after_closure"
+    ],
+    "preserve_fields": [
+      "reopened_at",
+      "last_seen_at",
+      "occurrence_count"
+    ]
+  },
+  "forbidden_behaviors": [
+    "auto_fix",
+    "cms_publish",
+    "cms_unpublish",
+    "search_channel_submission",
+    "search_channel_retry",
+    "scheduler_activation",
+    "collector_writes",
+    "production_migration",
+    "raw_crawler_log_read",
+    "business_db_access",
+    "metabase_exposure"
+  ],
+  "safety_flags": {
+    "docs_only": true,
+    "generated_json_only": true,
+    "focused_tests_only": true,
+    "migration_added": false,
+    "issue_mutation_code_added": false,
+    "auto_fix_code_added": false,
+    "cms_publish_code_added": false,
+    "search_channel_mutation_added": false,
+    "scheduler_enabled": false,
+    "production_env_changed": false,
+    "fap_web_modified": false
+  },
+  "final_decision": "issue_severity_governance_contract_ready_without_migration",
+  "next_task": "SEO-OBS-GOV-04"
+}

--- a/backend/docs/seo/issue-severity-dedupe-mute-sla-contract.md
+++ b/backend/docs/seo/issue-severity-dedupe-mute-sla-contract.md
@@ -1,0 +1,124 @@
+# Issue Severity, Dedupe, Mute, and SLA Contract
+
+## Purpose
+
+SEO-OBS-GOV-03 defines how `seo_issue_queue` should evolve from a safe issue
+observation table into an operator governance surface.
+
+This PR is contract-only. It does not add a real migration, mutate issues,
+auto-fix issues, auto-publish content, mutate Search Channel Queue, submit URLs,
+enable scheduler jobs, edit production environment, or modify `fap-web`.
+
+## Severity Levels
+
+Future operational severity levels:
+
+- P0 / critical
+- P1 / high
+- P2 / medium
+- P3 / info
+
+Backward-compatible mapping from current labels:
+
+- critical -> P0
+- high -> P1
+- warning -> P2
+- info -> P3
+
+## P0 Rules
+
+P0 issues require explicit operator review and must never be silently muted.
+
+Required P0 examples:
+
+- claim-unsafe public/indexable page
+- private-flow leak into public/search surface
+- Search Channel submitted non-canonical/private URL
+- public indexed page accidentally noindex
+- canonical points to wrong URL on core public surface
+
+## Required Future Fields
+
+- dedupe_key
+- muted_until
+- mute_reason
+- muted_by
+- owner_team
+- sla_due_at
+- sla_policy
+- reopen_rule
+- reopened_at
+- last_seen_at
+- occurrence_count
+- closed_reason
+
+## Dedupe Rule
+
+`dedupe_key` must be deterministic. It should be generated from safe issue
+dimensions such as issue type, source system, source engine, canonical URL hash,
+entity key, locale, page entity type, and normalized issue target. It must not
+include raw payloads, raw crawler-log fields, raw request data, query strings,
+email, tokens, cookies, order identifiers, payment identifiers, or attempt
+identifiers.
+
+Plain-language rule: dedupe_key must be deterministic.
+
+`issue_uid` may remain a write idempotency key, but operator dedupe must be
+explicit through `dedupe_key`.
+
+## Mute Rule
+
+Mute must not delete issue history. Muted issues must remain auditable.
+`muted_until`, `mute_reason`, and `muted_by` are required for future mute
+behavior. P0 must never be silently muted.
+
+Muted issues may remain visible in `/ops/seo` behind filters and counters.
+
+## SLA Rule
+
+`sla_due_at` and `sla_policy` must be deterministic from severity, page family,
+claim risk, source system, and ownership. SLA must not trigger auto-fix,
+auto-publish, auto-submit, or Search Channel retry behavior.
+
+## Owner Rule
+
+`owner_team` should be a role/team string, not a private personal identity. The
+first expected values are:
+
+- seo_ops
+- cms_ops
+- engineering
+- content_review
+- digital_pr
+- unknown
+
+## Reopen Rule
+
+`reopen_rule` must be explicit. Reopen should happen only when a previously
+closed or muted issue reappears with a matching dedupe key and fresh evidence,
+or when a P0 class issue is observed again after closure.
+
+Reopen behavior must preserve prior history using `reopened_at`,
+`last_seen_at`, and `occurrence_count`.
+
+## Forbidden Behavior
+
+Issue severity must not trigger:
+
+- auto-fix
+- CMS publish
+- CMS unpublish
+- Search Channel submission
+- Search Channel retry
+- scheduler activation
+- collector writes
+- production migration
+- raw crawler-log read
+- business DB access
+- Metabase exposure
+
+## Final Decision
+
+`issue_severity_governance_contract_ready_without_migration`
+
+Next task: `SEO-OBS-GOV-04`

--- a/backend/tests/Feature/SeoIntel/SeoIntelIssueSeverityGovernanceContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelIssueSeverityGovernanceContractTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelIssueSeverityGovernanceContractTest extends TestCase
+{
+    #[Test]
+    public function issue_governance_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/issue-severity-dedupe-mute-sla-contract.md'));
+        $this->assertSame('issue-severity-dedupe-mute-sla-contract.v1', $this->artifact()['version'] ?? null);
+        $this->assertSame('SEO-OBS-GOV-03', $this->artifact()['task'] ?? null);
+    }
+
+    #[Test]
+    public function severity_levels_and_legacy_mapping_are_locked(): void
+    {
+        $artifact = $this->artifact();
+        $levels = collect($artifact['severity_levels'] ?? [])->pluck('label', 'code')->all();
+
+        $this->assertSame('critical', $levels['P0'] ?? null);
+        $this->assertSame('high', $levels['P1'] ?? null);
+        $this->assertSame('medium', $levels['P2'] ?? null);
+        $this->assertSame('info', $levels['P3'] ?? null);
+
+        $this->assertSame('P0', $artifact['backward_compatible_mapping']['critical'] ?? null);
+        $this->assertSame('P1', $artifact['backward_compatible_mapping']['high'] ?? null);
+        $this->assertSame('P2', $artifact['backward_compatible_mapping']['warning'] ?? null);
+        $this->assertSame('P3', $artifact['backward_compatible_mapping']['info'] ?? null);
+    }
+
+    #[Test]
+    public function required_future_fields_cover_dedupe_mute_owner_sla_reopen_and_occurrences(): void
+    {
+        $fields = $this->artifact()['required_future_fields'] ?? [];
+
+        foreach ([
+            'dedupe_key',
+            'muted_until',
+            'mute_reason',
+            'muted_by',
+            'owner_team',
+            'sla_due_at',
+            'sla_policy',
+            'reopen_rule',
+            'reopened_at',
+            'last_seen_at',
+            'occurrence_count',
+            'closed_reason',
+        ] as $field) {
+            $this->assertContains($field, $fields);
+        }
+    }
+
+    #[Test]
+    public function p0_and_mute_rules_are_strict(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'claim_unsafe_public_indexable_page',
+            'private_flow_leak_public_search_surface',
+            'search_channel_submitted_non_canonical_private_url',
+        ] as $class) {
+            $this->assertContains($class, $artifact['p0_issue_classes'] ?? []);
+        }
+
+        $this->assertTrue((bool) ($artifact['mute_rule']['must_not_delete_history'] ?? false));
+        $this->assertTrue((bool) ($artifact['mute_rule']['muted_issues_remain_auditable'] ?? false));
+        $this->assertTrue((bool) ($artifact['mute_rule']['p0_must_never_be_silently_muted'] ?? false));
+    }
+
+    #[Test]
+    public function dedupe_sla_owner_and_reopen_rules_are_safe(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('dedupe_key', $artifact['dedupe_rule']['field'] ?? null);
+        $this->assertTrue((bool) ($artifact['dedupe_rule']['deterministic'] ?? false));
+        $this->assertFalse((bool) ($artifact['sla_rule']['triggers_auto_fix'] ?? true));
+        $this->assertFalse((bool) ($artifact['sla_rule']['triggers_auto_publish'] ?? true));
+        $this->assertFalse((bool) ($artifact['sla_rule']['triggers_auto_submit'] ?? true));
+        $this->assertTrue((bool) ($artifact['reopen_rule']['must_be_explicit'] ?? false));
+
+        foreach (['seo_ops', 'cms_ops', 'engineering', 'content_review', 'digital_pr', 'unknown'] as $owner) {
+            $this->assertContains($owner, $artifact['owner_team_values'] ?? []);
+        }
+
+        foreach (['raw_payload', 'raw_crawler_log_fields', 'email', 'token', 'cookie', 'order_id', 'payment_id', 'attempt_id'] as $input) {
+            $this->assertContains($input, $artifact['dedupe_rule']['forbidden_inputs'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function severity_contract_cannot_trigger_mutating_behaviors(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'auto_fix',
+            'cms_publish',
+            'cms_unpublish',
+            'search_channel_submission',
+            'search_channel_retry',
+            'scheduler_activation',
+            'collector_writes',
+            'production_migration',
+            'raw_crawler_log_read',
+            'business_db_access',
+            'metabase_exposure',
+        ] as $behavior) {
+            $this->assertContains($behavior, $artifact['forbidden_behaviors'] ?? []);
+        }
+
+        foreach ([
+            'migration_added',
+            'issue_mutation_code_added',
+            'auto_fix_code_added',
+            'cms_publish_code_added',
+            'search_channel_mutation_added',
+            'scheduler_enabled',
+            'production_env_changed',
+            'fap_web_modified',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact['safety_flags'][$flag] ?? true), $flag.' must be false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_contract_only_boundary_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/issue-severity-dedupe-mute-sla-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/issue-severity-dedupe-mute-sla-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'does not add a real migration',
+            'mutate issues',
+            'auto-fix issues',
+            'auto-publish content',
+            'dedupe_key must be deterministic',
+            'mute must not delete issue history',
+            'muted issues must remain auditable',
+            'p0 must never be silently muted',
+            'claim-unsafe public/indexable page',
+            'private-flow leak into public/search surface',
+            'search channel submitted non-canonical/private url',
+            'issue severity must not trigger',
+            'next task: `seo-obs-gov-04`',
+            '"next_task": "seo-obs-gov-04"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/issue-severity-dedupe-mute-sla-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T13:20:23+08:00",
+  "updated_at": "2026-05-22T13:31:58+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -13947,14 +13947,14 @@
     "SEO-OBS-GOV-02": {
       "repo": "fap-api",
       "branch": "codex/seo-obs-gov-02-observation-queue-schema-contract",
-      "status": "local_validation_passed",
-      "state": "local_validation_passed",
+      "status": "merged",
+      "state": "merged",
       "title": "docs(seo-intel): add observation queue schema contract",
       "depends_on": [
         "SEO-OBS-GOV-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "f9c7f6f3a0187211211577cdd2e7be32e24a8ec2",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1557",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -13977,12 +13977,21 @@
         "scope_validation": {
           "status": "pass",
           "evidence": "Changed files are limited to PR2 observation queue schema contract docs, generated artifact, focused test, and train ledger. No real migration, writer service, scheduler, env change, production write, or fap-web change was added."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1557 merged after hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS succeeded; mergeStateStatus was CLEAN."
+        },
+        "post_merge_revalidation": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelObservationQueueSchemaContract --no-ansi",
+          "evidence": "6 tests passed, 118 assertions on merged main."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T05:28:16Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_write_execution": false,
       "production_log_read_execution": false,
       "production_migration_execution": false,
@@ -14004,21 +14013,49 @@
           "at": "2026-05-22T13:20:23+08:00",
           "status": "local_validation_passed",
           "summary": "Added observation queue schema contract docs, generated artifact, focused test, and ledger updates. No migration or runtime writer was added. Required local checks passed."
+        },
+        {
+          "at": "2026-05-22T13:31:58+08:00",
+          "status": "merged",
+          "summary": "PR #1557 was squash merged to main at f9c7f6f3a0187211211577cdd2e7be32e24a8ec2. Focused post-merge revalidation passed."
         }
       ]
     },
     "SEO-OBS-GOV-03": {
       "repo": "fap-api",
       "branch": "codex/seo-obs-gov-03-issue-severity-governance-contract",
-      "status": "pending",
-      "state": "pending",
+      "status": "local_validation_passed",
+      "state": "local_validation_passed",
       "title": "docs(seo-intel): add issue severity governance contract",
       "depends_on": [
         "SEO-OBS-GOV-02"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-OBS-GOV-02 merged as PR #1557 and origin/main contains f9c7f6f3a0187211211577cdd2e7be32e24a8ec2."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=SeoIntelIssueSeverityGovernanceContract --no-ansi",
+            "cd backend && php artisan test --filter=SeoIntel --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "python3 -m json.tool backend/docs/seo/generated/issue-severity-dedupe-mute-sla-contract.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"",
+            "git diff --check"
+          ],
+          "evidence": "All PR3 local validations passed. SeoIntel suite passed 390 tests / 6192 assertions; Pint passed 3464 files; route:list returned 203 routes."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to PR3 issue severity governance contract docs, generated artifact, focused test, and train ledger. No migrations, issue mutation code, auto-fix code, CMS publish code, Search Channel mutation, scheduler, production env, or fap-web change was added."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14039,7 +14076,13 @@
       "sidecar_allowed": true,
       "stop_on_safety_violation": true,
       "next_pr": "SEO-OBS-GOV-04",
-      "history": []
+      "history": [
+        {
+          "at": "2026-05-22T13:31:58+08:00",
+          "status": "local_validation_passed",
+          "summary": "Added issue severity/dedupe/mute/SLA contract docs, generated artifact, focused test, and ledger updates. No migration or issue mutation code was added. Required local checks passed."
+        }
+      ]
     },
     "SEO-OBS-GOV-04": {
       "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Added SEO-OBS-GOV-03 contract for seo_issue_queue severity governance.
- Defined P0/P1/P2/P3 mapping, deterministic dedupe, mute auditability, owner team, SLA, reopen, and occurrence tracking rules.
- Added generated JSON and focused tests proving severity cannot trigger auto-fix, CMS publish, Search Channel submission, scheduler, crawler-log read, production migration, business DB access, Metabase exposure, or fap-web changes.
- Updated train ledger to mark SEO-OBS-GOV-02 as merged and SEO-OBS-GOV-03 locally validated.

## Why
Issue Queue needs explicit severity, dedupe, mute, SLA, owner, and reopen contracts before any schema migration or operational dashboard work.

## Validation commands
- cd backend && php artisan test --filter=SeoIntelIssueSeverityGovernanceContract --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/issue-severity-dedupe-mute-sla-contract.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No real migration file.
- No issue mutation code.
- No auto-fix, CMS publish/unpublish, Search Channel mutation, scheduler, production env, fap-web, or production operation.

## Repository rule impact
This PR is a governance contract only. It does not change content ownership, publishing authority, runtime SEO output, sitemap, llms, CMS APIs, or frontend fallback policy.