### PR TITLE
docs(seo-intel): add entity key translation group contract

### DIFF
--- a/backend/docs/seo/entity-key-translation-group-contract.md
+++ b/backend/docs/seo/entity-key-translation-group-contract.md
@@ -1,0 +1,134 @@
+# Entity Key and Translation Group Contract
+
+## Purpose
+
+SEO-OBS-GOV-04 defines stable entity identity for locale pairing, SEO
+observation, internal links, and future locale compare.
+
+This PR is contract-only. It does not mutate CMS content, run backfill, add a
+real migration, modify `fap-web`, use frontend fallback authority, deploy, or
+edit production environment.
+
+## Required Future Key
+
+The preferred future key is `translation_group_uuid`.
+
+`entity_key` should prefer `translation_group_uuid` for all multi-locale
+entities. It should be stable across EN/ZH and any later locale.
+
+## Allowed Transitional Key
+
+`translation_group_id` is allowed only where it already exists today. It is a
+transitional key, not the long-term authority.
+translation_group_id is allowed only where it already exists today.
+
+If `translation_group_uuid` is absent:
+
+- use existing `translation_group_id` only where already supported
+- otherwise mark `legacy_unpaired`
+- slug/title similarity may be used only as a migration helper, not authority
+
+## Entity Key Format
+
+Future `entity_key` format:
+
+`translation_group_uuid:<uuid>`
+
+Transitional format:
+
+`translation_group_id:<source_table>:<translation_group_id>`
+
+Legacy unpaired format:
+
+`legacy_unpaired:<surface>:<locale>:<stable_slug_or_id>`
+
+The legacy format is for observation gaps only. It must not become permanent
+locale-pair authority.
+
+## Locale Pair Rules
+
+- Locale comparison must group by `entity_key`.
+- EN/ZH pairs require the same preferred `translation_group_uuid`.
+- If only transitional `translation_group_id` exists, mark the row as
+  `transitional_paired`.
+- If neither key exists, mark the row as `legacy_unpaired`.
+- Missing locale peers are observations, not automatic content tasks.
+
+## Surface Coverage
+
+Required surfaces:
+
+- Research reports
+- Articles
+- Topics
+- Personality pages
+- Career guides
+- Career jobs
+- Test landing/detail pages
+- Content/support pages
+
+## Surface Policy
+
+Research reports:
+
+- Future authority should be `translation_group_uuid`.
+- Current same-slug pairing may be used only as migration helper.
+
+Articles:
+
+- Existing `translation_group_id` is a transitional key.
+- Future authority should be `translation_group_uuid`.
+
+Topics:
+
+- Future authority should be `translation_group_uuid`.
+- Slug similarity is not final authority.
+
+Personality pages:
+
+- Future authority should be `translation_group_uuid` or a backend-declared
+  canonical type group.
+- Frontend route/type fallback must not define locale-pair truth.
+
+Career guides and career jobs:
+
+- Future authority should be `translation_group_uuid` or a backend-declared
+  career entity group.
+- Crawler-derived pairing is forbidden.
+
+Test landing/detail pages:
+
+- Future authority should be backend scale/catalog identity plus
+  `translation_group_uuid` where localized content diverges.
+
+Content/support pages:
+
+- Existing `translation_group_id` is transitional where already present.
+- Future authority should be `translation_group_uuid`.
+
+## Backfill Plan
+
+The future backfill must be a separate approved task. It should:
+
+1. Add schema only after human approval.
+2. Dry-run mapping by surface.
+3. Use existing `translation_group_id` where present.
+4. Mark unpaired legacy content without mutation.
+5. Use slug/title similarity only as a candidate suggestion.
+6. Require human review before any content or key mutation.
+
+## Forbidden Authority
+
+- no automatic content mutation
+- no frontend fallback pairing
+- no crawler-derived pairing
+- no title/slug similarity as final authority
+- no search engine response pairing
+- no local copy authority
+- no static sitemap/llms authority
+
+## Final Decision
+
+`entity_key_translation_group_contract_ready_without_migration`
+
+Next task: `SEO-OBS-GOV-05`

--- a/backend/docs/seo/generated/entity-key-translation-group-contract.v1.json
+++ b/backend/docs/seo/generated/entity-key-translation-group-contract.v1.json
@@ -1,0 +1,100 @@
+{
+  "version": "entity-key-translation-group-contract.v1",
+  "task": "SEO-OBS-GOV-04",
+  "purpose": "stable_entity_key_translation_group_contract",
+  "required_future_key": "translation_group_uuid",
+  "allowed_transitional_key": "translation_group_id",
+  "entity_key_preference_order": [
+    "translation_group_uuid",
+    "translation_group_id_where_already_supported",
+    "legacy_unpaired"
+  ],
+  "entity_key_formats": {
+    "preferred": "translation_group_uuid:<uuid>",
+    "transitional": "translation_group_id:<source_table>:<translation_group_id>",
+    "legacy_unpaired": "legacy_unpaired:<surface>:<locale>:<stable_slug_or_id>"
+  },
+  "locale_pair_rules": [
+    "locale_compare_groups_by_entity_key",
+    "en_zh_pairs_require_same_translation_group_uuid",
+    "translation_group_id_is_transitional_paired_only",
+    "missing_locale_peer_is_observation_not_content_task",
+    "legacy_unpaired_requires_followup_review"
+  ],
+  "surface_coverage": [
+    "research_reports",
+    "articles",
+    "topics",
+    "personality_pages",
+    "career_guides",
+    "career_jobs",
+    "test_landing_detail_pages",
+    "content_support_pages"
+  ],
+  "surface_policy": {
+    "research_reports": {
+      "future_authority": "translation_group_uuid",
+      "current_slug_pairing": "migration_helper_only"
+    },
+    "articles": {
+      "current_translation_group_id": "transitional",
+      "future_authority": "translation_group_uuid"
+    },
+    "topics": {
+      "future_authority": "translation_group_uuid",
+      "slug_similarity": "migration_helper_only"
+    },
+    "personality_pages": {
+      "future_authority": "translation_group_uuid_or_backend_canonical_type_group",
+      "frontend_fallback_authority": false
+    },
+    "career_guides": {
+      "future_authority": "translation_group_uuid_or_backend_career_entity_group",
+      "crawler_derived_pairing": false
+    },
+    "career_jobs": {
+      "future_authority": "translation_group_uuid_or_backend_career_entity_group",
+      "crawler_derived_pairing": false
+    },
+    "test_landing_detail_pages": {
+      "future_authority": "backend_scale_catalog_identity_plus_translation_group_uuid_when_needed"
+    },
+    "content_support_pages": {
+      "current_translation_group_id": "transitional",
+      "future_authority": "translation_group_uuid"
+    }
+  },
+  "backfill_plan": [
+    "schema_after_human_approval",
+    "dry_run_mapping_by_surface",
+    "use_existing_translation_group_id_where_present",
+    "mark_unpaired_legacy_content_without_mutation",
+    "slug_title_similarity_candidate_suggestion_only",
+    "human_review_before_content_or_key_mutation"
+  ],
+  "forbidden_authority": [
+    "automatic_content_mutation",
+    "frontend_fallback_pairing",
+    "crawler_derived_pairing",
+    "title_slug_similarity_as_final_authority",
+    "search_engine_response_pairing",
+    "local_copy_authority",
+    "static_sitemap_llms_authority"
+  ],
+  "safety_flags": {
+    "docs_only": true,
+    "generated_json_only": true,
+    "focused_tests_only": true,
+    "cms_content_mutation": false,
+    "backfill_execution": false,
+    "migration_added": false,
+    "fap_web_modified": false,
+    "frontend_fallback_authority": false,
+    "title_slug_similarity_final_authority": false,
+    "crawler_derived_pairing": false,
+    "production_env_changed": false,
+    "deploy": false
+  },
+  "final_decision": "entity_key_translation_group_contract_ready_without_migration",
+  "next_task": "SEO-OBS-GOV-05"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelEntityKeyTranslationGroupContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelEntityKeyTranslationGroupContractTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelEntityKeyTranslationGroupContractTest extends TestCase
+{
+    #[Test]
+    public function entity_key_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/entity-key-translation-group-contract.md'));
+        $this->assertSame('entity-key-translation-group-contract.v1', $this->artifact()['version'] ?? null);
+        $this->assertSame('SEO-OBS-GOV-04', $this->artifact()['task'] ?? null);
+        $this->assertSame('translation_group_uuid', $this->artifact()['required_future_key'] ?? null);
+    }
+
+    #[Test]
+    public function entity_key_preference_and_formats_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('translation_group_id', $artifact['allowed_transitional_key'] ?? null);
+        $this->assertSame([
+            'translation_group_uuid',
+            'translation_group_id_where_already_supported',
+            'legacy_unpaired',
+        ], $artifact['entity_key_preference_order'] ?? []);
+
+        $this->assertSame('translation_group_uuid:<uuid>', $artifact['entity_key_formats']['preferred'] ?? null);
+        $this->assertSame('translation_group_id:<source_table>:<translation_group_id>', $artifact['entity_key_formats']['transitional'] ?? null);
+        $this->assertSame('legacy_unpaired:<surface>:<locale>:<stable_slug_or_id>', $artifact['entity_key_formats']['legacy_unpaired'] ?? null);
+    }
+
+    #[Test]
+    public function locale_pair_rules_require_stable_entity_key(): void
+    {
+        foreach ([
+            'locale_compare_groups_by_entity_key',
+            'en_zh_pairs_require_same_translation_group_uuid',
+            'translation_group_id_is_transitional_paired_only',
+            'missing_locale_peer_is_observation_not_content_task',
+            'legacy_unpaired_requires_followup_review',
+        ] as $rule) {
+            $this->assertContains($rule, $this->artifact()['locale_pair_rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function all_required_surfaces_are_covered(): void
+    {
+        foreach ([
+            'research_reports',
+            'articles',
+            'topics',
+            'personality_pages',
+            'career_guides',
+            'career_jobs',
+            'test_landing_detail_pages',
+            'content_support_pages',
+        ] as $surface) {
+            $this->assertContains($surface, $this->artifact()['surface_coverage'] ?? []);
+            $this->assertArrayHasKey($surface, $this->artifact()['surface_policy'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function transitional_and_migration_helper_rules_are_explicit(): void
+    {
+        $policy = $this->artifact()['surface_policy'] ?? [];
+
+        $this->assertSame('migration_helper_only', $policy['research_reports']['current_slug_pairing'] ?? null);
+        $this->assertSame('transitional', $policy['articles']['current_translation_group_id'] ?? null);
+        $this->assertSame('migration_helper_only', $policy['topics']['slug_similarity'] ?? null);
+        $this->assertFalse((bool) ($policy['personality_pages']['frontend_fallback_authority'] ?? true));
+        $this->assertFalse((bool) ($policy['career_jobs']['crawler_derived_pairing'] ?? true));
+
+        foreach ([
+            'schema_after_human_approval',
+            'dry_run_mapping_by_surface',
+            'use_existing_translation_group_id_where_present',
+            'mark_unpaired_legacy_content_without_mutation',
+            'slug_title_similarity_candidate_suggestion_only',
+            'human_review_before_content_or_key_mutation',
+        ] as $step) {
+            $this->assertContains($step, $this->artifact()['backfill_plan'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function forbidden_authority_and_safety_flags_block_drift(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'automatic_content_mutation',
+            'frontend_fallback_pairing',
+            'crawler_derived_pairing',
+            'title_slug_similarity_as_final_authority',
+            'search_engine_response_pairing',
+            'local_copy_authority',
+            'static_sitemap_llms_authority',
+        ] as $source) {
+            $this->assertContains($source, $artifact['forbidden_authority'] ?? []);
+        }
+
+        foreach ([
+            'cms_content_mutation',
+            'backfill_execution',
+            'migration_added',
+            'fap_web_modified',
+            'frontend_fallback_authority',
+            'title_slug_similarity_final_authority',
+            'crawler_derived_pairing',
+            'production_env_changed',
+            'deploy',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact['safety_flags'][$flag] ?? true), $flag.' must be false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_mutation_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/entity-key-translation-group-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/entity-key-translation-group-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'translation_group_uuid',
+            'translation_group_id is allowed only where it already exists today',
+            'legacy_unpaired',
+            'slug/title similarity may be used only as a migration helper, not authority',
+            'no automatic content mutation',
+            'no frontend fallback pairing',
+            'no crawler-derived pairing',
+            'no title/slug similarity as final authority',
+            'next task: `seo-obs-gov-05`',
+            '"next_task": "seo-obs-gov-05"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/entity-key-translation-group-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T13:31:58+08:00",
+  "updated_at": "2026-05-22T13:45:14+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14024,14 +14024,14 @@
     "SEO-OBS-GOV-03": {
       "repo": "fap-api",
       "branch": "codex/seo-obs-gov-03-issue-severity-governance-contract",
-      "status": "local_validation_passed",
-      "state": "local_validation_passed",
+      "status": "merged",
+      "state": "merged",
       "title": "docs(seo-intel): add issue severity governance contract",
       "depends_on": [
         "SEO-OBS-GOV-02"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "cc7efe8ee340649e66650c70457526b12d616eb7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1558",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -14054,12 +14054,21 @@
         "scope_validation": {
           "status": "pass",
           "evidence": "Changed files are limited to PR3 issue severity governance contract docs, generated artifact, focused test, and train ledger. No migrations, issue mutation code, auto-fix code, CMS publish code, Search Channel mutation, scheduler, production env, or fap-web change was added."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1558 merged after hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS succeeded; mergeStateStatus was CLEAN."
+        },
+        "post_merge_revalidation": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelIssueSeverityGovernanceContract --no-ansi",
+          "evidence": "Focused post-merge revalidation passed: 7 tests / 96 assertions."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T05:39:55Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_write_execution": false,
       "production_log_read_execution": false,
       "production_migration_execution": false,
@@ -14081,21 +14090,49 @@
           "at": "2026-05-22T13:31:58+08:00",
           "status": "local_validation_passed",
           "summary": "Added issue severity/dedupe/mute/SLA contract docs, generated artifact, focused test, and ledger updates. No migration or issue mutation code was added. Required local checks passed."
+        },
+        {
+          "at": "2026-05-22T13:45:14+08:00",
+          "status": "merged",
+          "summary": "PR #1558 was squash merged to main at cc7efe8ee340649e66650c70457526b12d616eb7. Remote branch was deleted and focused post-merge revalidation passed."
         }
       ]
     },
     "SEO-OBS-GOV-04": {
       "repo": "fap-api",
       "branch": "codex/seo-obs-gov-04-entity-key-translation-group-contract",
-      "status": "pending",
-      "state": "pending",
+      "status": "local_validation_passed",
+      "state": "local_validation_passed",
       "title": "docs(seo-intel): add entity key translation group contract",
       "depends_on": [
         "SEO-OBS-GOV-03"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-OBS-GOV-03 merged as PR #1558 and origin/main contains cc7efe8ee340649e66650c70457526b12d616eb7."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=SeoIntelEntityKeyTranslationGroupContract --no-ansi",
+            "cd backend && php artisan test --filter=SeoIntel --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "python3 -m json.tool backend/docs/seo/generated/entity-key-translation-group-contract.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"",
+            "git diff --check"
+          ],
+          "evidence": "All PR4 local validations passed. Focused contract test passed 7 tests / 133 assertions; SeoIntel suite passed 397 tests / 6325 assertions; Pint passed 3465 files; route:list returned 203 routes."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to PR4 entity key and translation group contract docs, generated artifact, focused test, and train ledger. No CMS content mutation, backfill execution, migration, fap-web modification, frontend fallback authority, production env edit, or deploy was added."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14116,7 +14153,13 @@
       "sidecar_allowed": true,
       "stop_on_safety_violation": true,
       "next_pr": "SEO-OBS-GOV-05",
-      "history": []
+      "history": [
+        {
+          "at": "2026-05-22T13:45:14+08:00",
+          "status": "local_validation_passed",
+          "summary": "Added entity key / translation_group_uuid contract docs, generated artifact, focused test, and ledger updates. No migration, CMS mutation, backfill, or fap-web change was added. Required local checks passed."
+        }
+      ]
     },
     "SEO-OBS-GOV-05": {
       "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Added the entity key and translation_group_uuid governance contract.
- Added a generated v1 JSON artifact for the contract.
- Added a focused SeoIntel contract test that locks entity key preference, locale pairing rules, forbidden authority sources, and no-mutation boundaries.
- Updated the PR train ledger for PR3 merge reconciliation and PR4 local validation.

## Why
- Locale comparison and observation governance need a stable cross-locale entity key.
- translation_group_uuid is defined as the future authority, with existing translation_group_id allowed only as a transitional key.
- Legacy content without a supported key is explicitly marked legacy_unpaired instead of inferred from frontend, crawler, title, or slug data.

## Validation
- cd backend && php artisan test --filter=SeoIntelEntityKeyTranslationGroupContract --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/entity-key-translation-group-contract.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No CMS content mutation.
- No backfill execution.
- No real migration.
- No fap-web changes.
- No frontend fallback pairing.
- No production operations, deployment, env edits, Search Channel mutation, crawler log reads, or seo_intel writes.