### PR TITLE
docs(seo-intel): add ops seo observation display readiness

### DIFF
--- a/backend/docs/seo/generated/ops-seo-observation-governance-display-readiness.v1.json
+++ b/backend/docs/seo/generated/ops-seo-observation-governance-display-readiness.v1.json
@@ -1,0 +1,104 @@
+{
+  "version": "ops-seo-observation-governance-display-readiness.v1",
+  "task": "SEO-OBS-GOV-05",
+  "purpose": "Define future read-only /ops/seo panels for observation governance without UI implementation.",
+  "display_authority": {
+    "ops_seo_is_operational_view": true,
+    "ops_seo_is_truth_source": false,
+    "url_truth_source": "backend_cms_and_seo_intel_url_truth_contracts",
+    "content_truth_source": "cms_backend",
+    "metabase_exposure_allowed": false
+  },
+  "required_future_sections": [
+    "observation_queue_summary_by_event_type",
+    "observation_queue_summary_by_event_state",
+    "pending_runtime_check_count",
+    "awaiting_search_observation_count",
+    "awaiting_crawler_observation_count",
+    "needs_review_count",
+    "muted_count",
+    "issue_severity_distribution_p0_p1_p2_p3",
+    "sla_due_overdue_counters",
+    "dedupe_cluster_counters",
+    "entity_key_coverage",
+    "missing_translation_group_uuid_count",
+    "locale_pair_coverage",
+    "digital_pr_observation_only_signal_placeholders",
+    "crawler_aggregate_observation_safety_counters"
+  ],
+  "panel_contracts": {
+    "observation_queue": [
+      "event_type_distribution",
+      "event_state_distribution",
+      "priority_distribution",
+      "pending_runtime_checks",
+      "awaiting_search_engine_observation",
+      "awaiting_crawler_observation",
+      "needs_review_count",
+      "muted_count"
+    ],
+    "issue_governance": [
+      "p0_p1_p2_p3_distribution",
+      "sla_due_count",
+      "sla_overdue_count",
+      "dedupe_cluster_count",
+      "reopened_issue_count",
+      "muted_issue_count"
+    ],
+    "entity_governance": [
+      "entity_key_coverage",
+      "missing_translation_group_uuid_count",
+      "locale_pair_coverage",
+      "legacy_unpaired_count",
+      "surface_level_coverage"
+    ],
+    "observation_only_signals": [
+      "digital_pr_manual_tracking_placeholder",
+      "crawler_daily_aggregate_safety_counter",
+      "referral_observed_manual_or_safe_aggregate_only",
+      "mention_observed_manual_or_safe_aggregate_only",
+      "backlink_observed_manual_or_safe_aggregate_only"
+    ]
+  },
+  "hard_stops": [
+    "no_search_submit_button",
+    "no_approve_retry_controls",
+    "no_scheduler_controls",
+    "no_collector_controls",
+    "no_raw_sql",
+    "no_metabase_iframe_proxy",
+    "no_raw_crawler_logs",
+    "no_raw_payload_display",
+    "no_cms_write_controls_from_this_page"
+  ],
+  "forbidden_authority_sources": [
+    "frontend_fallback_authority",
+    "static_sitemap_authority",
+    "static_llms_authority",
+    "raw_crawler_logs",
+    "raw_payloads",
+    "operator_raw_sql",
+    "metabase_iframe_or_proxy",
+    "search_engine_response_as_url_truth",
+    "local_copy_authority",
+    "cms_writes_from_ops_seo"
+  ],
+  "safety_flags": {
+    "filament_ui_implemented": false,
+    "service_implemented": false,
+    "migration_added": false,
+    "action_buttons_added": false,
+    "write_controls_added": false,
+    "search_submit_button_added": false,
+    "scheduler_controls_added": false,
+    "collector_controls_added": false,
+    "raw_sql_displayed": false,
+    "metabase_exposed": false,
+    "raw_crawler_logs_displayed": false,
+    "raw_payload_displayed": false,
+    "cms_write_controls_added": false,
+    "production_env_changed": false,
+    "fap_web_modified": false
+  },
+  "next_task": "SEO-OBS-GOV-06"
+}

--- a/backend/docs/seo/ops-seo-observation-governance-display-readiness.md
+++ b/backend/docs/seo/ops-seo-observation-governance-display-readiness.md
@@ -1,0 +1,127 @@
+# /ops/seo Observation Governance Display Readiness
+
+## Purpose
+
+This contract defines future read-only `/ops/seo` display readiness for SEO
+observation governance. It is a dashboard contract only. It does not implement
+Filament UI, services, migrations, action buttons, write controls, Search
+Channel submission, crawler log readers, scheduler controls, collector controls,
+CMS write controls, Metabase exposure, or production operations.
+
+The `/ops/seo` page is an operational view, not a truth source. It may display
+safe aggregates from approved SEO Intelligence read models after future
+implementation, but it must not become URL Truth, content truth, Search Channel
+authority, crawler-log authority, search-engine authority, or Metabase proxy.
+
+## Display Authority Boundary
+
+Allowed future display sources:
+
+- sanitized SEO Intelligence observation queue summaries
+- sanitized SEO Intelligence issue severity summaries
+- sanitized SEO Intelligence entity-key coverage summaries
+- sanitized SEO Intelligence crawler aggregate observation counters
+- Digital PR observation-only placeholders without automated backlink decisions
+
+Forbidden authority sources:
+
+- frontend fallback authority
+- static sitemap authority
+- static llms authority
+- raw crawler logs
+- raw payloads
+- raw SQL from operators
+- Metabase iframe or proxy
+- search engine responses as URL Truth
+- local copy authority
+- CMS writes from `/ops/seo`
+
+## Required Future Sections
+
+Future `/ops/seo` observation governance display may include these read-only
+sections:
+
+- Observation Queue summary by event_type
+- Observation Queue summary by event_state
+- pending runtime check count
+- awaiting search observation count
+- awaiting crawler observation count
+- needs review count
+- muted count
+- Issue severity distribution P0/P1/P2/P3
+- SLA due / overdue counters
+- dedupe cluster counters
+- entity key coverage
+- missing translation_group_uuid count
+- locale pair coverage
+- Digital PR observation-only signal placeholders
+- Crawler aggregate observation safety counters
+
+## Read-only Panel Contract
+
+Observation Queue panels should show aggregate counts only:
+
+- event_type distribution
+- event_state distribution
+- priority distribution
+- pending runtime checks
+- awaiting search engine observation
+- awaiting crawler observation
+- needs_review and muted counts
+
+Issue governance panels should show operational summaries only:
+
+- P0/P1/P2/P3 distribution
+- SLA due count
+- SLA overdue count
+- dedupe cluster count
+- reopened issue count
+- muted issue count
+
+Entity governance panels should show coverage summaries only:
+
+- entity_key coverage
+- missing translation_group_uuid count
+- locale pair coverage
+- legacy_unpaired count
+- surface-level coverage by research reports, articles, topics, personality
+  pages, career guides, career jobs, test landing/detail pages, and
+  content/support pages
+
+Crawler and Digital PR panels must remain observation-only:
+
+- crawler aggregate observation safety counters may use sanitized daily
+  aggregate tables only
+- Digital PR signal placeholders may show manual tracking status only
+- backlink observed, referral observed, and mention observed must remain manual
+  or safe aggregate observations and must not trigger automated decisions
+
+## Hard Stops
+
+The future `/ops/seo` governance display must include no search submit button.
+It must include no approve/retry controls. It must include no scheduler controls.
+It must include no collector controls. It must include no raw SQL. It must
+include no Metabase iframe/proxy. It must include no raw crawler logs. It must
+include no raw payload display. It must include no CMS write controls from this
+page.
+No CMS write controls from this page.
+
+## Safety Flags
+
+This PR does not implement UI. This PR does not implement services. This PR does
+not add migrations. This PR does not add action buttons. This PR does not edit
+production env. This PR does not modify fap-web. This PR does not expose
+Metabase.
+
+## Future Implementation Notes
+
+Future implementation should be staged after the observation queue, issue
+severity, and entity key contracts have implementation approval. Any runtime
+panel must read from sanitized read models only, must avoid raw payload display,
+and must keep all mutation controls out of `/ops/seo`.
+
+## Final Decision
+
+ops_seo_observation_governance_display_readiness_contract_ready_without_ui
+
+Next task: `SEO-OBS-GOV-06`

--- a/backend/tests/Feature/SeoIntel/SeoIntelOpsSeoObservationGovernanceDisplayReadinessTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelOpsSeoObservationGovernanceDisplayReadinessTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelOpsSeoObservationGovernanceDisplayReadinessTest extends TestCase
+{
+    #[Test]
+    public function display_readiness_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/ops-seo-observation-governance-display-readiness.md'));
+        $this->assertSame('ops-seo-observation-governance-display-readiness.v1', $this->artifact()['version'] ?? null);
+        $this->assertSame('SEO-OBS-GOV-05', $this->artifact()['task'] ?? null);
+        $this->assertSame('SEO-OBS-GOV-06', $this->artifact()['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function ops_seo_display_is_read_only_and_not_authority(): void
+    {
+        $authority = $this->artifact()['display_authority'] ?? [];
+
+        $this->assertTrue((bool) ($authority['ops_seo_is_operational_view'] ?? false));
+        $this->assertFalse((bool) ($authority['ops_seo_is_truth_source'] ?? true));
+        $this->assertSame('cms_backend', $authority['content_truth_source'] ?? null);
+        $this->assertFalse((bool) ($authority['metabase_exposure_allowed'] ?? true));
+    }
+
+    #[Test]
+    public function required_future_sections_are_locked(): void
+    {
+        foreach ([
+            'observation_queue_summary_by_event_type',
+            'observation_queue_summary_by_event_state',
+            'pending_runtime_check_count',
+            'awaiting_search_observation_count',
+            'awaiting_crawler_observation_count',
+            'needs_review_count',
+            'muted_count',
+            'issue_severity_distribution_p0_p1_p2_p3',
+            'sla_due_overdue_counters',
+            'dedupe_cluster_counters',
+            'entity_key_coverage',
+            'missing_translation_group_uuid_count',
+            'locale_pair_coverage',
+            'digital_pr_observation_only_signal_placeholders',
+            'crawler_aggregate_observation_safety_counters',
+        ] as $section) {
+            $this->assertContains($section, $this->artifact()['required_future_sections'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function panel_contracts_cover_observation_issue_entity_and_safe_signals(): void
+    {
+        $panels = $this->artifact()['panel_contracts'] ?? [];
+
+        foreach ([
+            'event_type_distribution',
+            'event_state_distribution',
+            'pending_runtime_checks',
+            'awaiting_search_engine_observation',
+            'awaiting_crawler_observation',
+        ] as $item) {
+            $this->assertContains($item, $panels['observation_queue'] ?? []);
+        }
+
+        foreach ([
+            'p0_p1_p2_p3_distribution',
+            'sla_due_count',
+            'sla_overdue_count',
+            'dedupe_cluster_count',
+            'muted_issue_count',
+        ] as $item) {
+            $this->assertContains($item, $panels['issue_governance'] ?? []);
+        }
+
+        foreach ([
+            'entity_key_coverage',
+            'missing_translation_group_uuid_count',
+            'locale_pair_coverage',
+            'legacy_unpaired_count',
+        ] as $item) {
+            $this->assertContains($item, $panels['entity_governance'] ?? []);
+        }
+
+        foreach ([
+            'digital_pr_manual_tracking_placeholder',
+            'crawler_daily_aggregate_safety_counter',
+            'backlink_observed_manual_or_safe_aggregate_only',
+        ] as $item) {
+            $this->assertContains($item, $panels['observation_only_signals'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function hard_stops_block_write_controls_raw_data_and_metabase(): void
+    {
+        foreach ([
+            'no_search_submit_button',
+            'no_approve_retry_controls',
+            'no_scheduler_controls',
+            'no_collector_controls',
+            'no_raw_sql',
+            'no_metabase_iframe_proxy',
+            'no_raw_crawler_logs',
+            'no_raw_payload_display',
+            'no_cms_write_controls_from_this_page',
+        ] as $stop) {
+            $this->assertContains($stop, $this->artifact()['hard_stops'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function forbidden_authority_and_safety_flags_block_drift(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'frontend_fallback_authority',
+            'static_sitemap_authority',
+            'static_llms_authority',
+            'raw_crawler_logs',
+            'raw_payloads',
+            'operator_raw_sql',
+            'metabase_iframe_or_proxy',
+            'search_engine_response_as_url_truth',
+            'local_copy_authority',
+            'cms_writes_from_ops_seo',
+        ] as $source) {
+            $this->assertContains($source, $artifact['forbidden_authority_sources'] ?? []);
+        }
+
+        foreach ([
+            'filament_ui_implemented',
+            'service_implemented',
+            'migration_added',
+            'action_buttons_added',
+            'write_controls_added',
+            'search_submit_button_added',
+            'scheduler_controls_added',
+            'collector_controls_added',
+            'raw_sql_displayed',
+            'metabase_exposed',
+            'raw_crawler_logs_displayed',
+            'raw_payload_displayed',
+            'cms_write_controls_added',
+            'production_env_changed',
+            'fap_web_modified',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact['safety_flags'][$flag] ?? true), $flag.' must be false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_hard_stops_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/ops-seo-observation-governance-display-readiness.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/ops-seo-observation-governance-display-readiness.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'observation queue summary by event_type',
+            'issue severity distribution p0/p1/p2/p3',
+            'missing translation_group_uuid count',
+            'digital pr observation-only signal placeholders',
+            'crawler aggregate observation safety counters',
+            'no search submit button',
+            'no approve/retry controls',
+            'no scheduler controls',
+            'no collector controls',
+            'no raw sql',
+            'no metabase iframe/proxy',
+            'no raw crawler logs',
+            'no raw payload display',
+            'no cms write controls from this page',
+            'next task: `seo-obs-gov-06`',
+            '"next_task": "seo-obs-gov-06"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/ops-seo-observation-governance-display-readiness.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T13:45:14+08:00",
+  "updated_at": "2026-05-22T13:57:31+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14101,14 +14101,14 @@
     "SEO-OBS-GOV-04": {
       "repo": "fap-api",
       "branch": "codex/seo-obs-gov-04-entity-key-translation-group-contract",
-      "status": "local_validation_passed",
-      "state": "local_validation_passed",
+      "status": "merged",
+      "state": "merged",
       "title": "docs(seo-intel): add entity key translation group contract",
       "depends_on": [
         "SEO-OBS-GOV-03"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "c3ce981a94844fc65007c679cd1bcd30dcfe3ea0",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1559",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -14131,12 +14131,21 @@
         "scope_validation": {
           "status": "pass",
           "evidence": "Changed files are limited to PR4 entity key and translation group contract docs, generated artifact, focused test, and train ledger. No CMS content mutation, backfill execution, migration, fap-web modification, frontend fallback authority, production env edit, or deploy was added."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1559 merged after hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS succeeded; mergeStateStatus was CLEAN."
+        },
+        "post_merge_revalidation": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelEntityKeyTranslationGroupContract --no-ansi",
+          "evidence": "Focused post-merge revalidation passed: 7 tests / 133 assertions."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T05:53:51Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_write_execution": false,
       "production_log_read_execution": false,
       "production_migration_execution": false,
@@ -14158,21 +14167,49 @@
           "at": "2026-05-22T13:45:14+08:00",
           "status": "local_validation_passed",
           "summary": "Added entity key / translation_group_uuid contract docs, generated artifact, focused test, and ledger updates. No migration, CMS mutation, backfill, or fap-web change was added. Required local checks passed."
+        },
+        {
+          "at": "2026-05-22T13:57:31+08:00",
+          "status": "merged",
+          "summary": "PR #1559 was squash merged to main at c3ce981a94844fc65007c679cd1bcd30dcfe3ea0. Remote branch was deleted and focused post-merge revalidation passed."
         }
       ]
     },
     "SEO-OBS-GOV-05": {
       "repo": "fap-api",
       "branch": "codex/seo-obs-gov-05-ops-seo-display-readiness",
-      "status": "pending",
-      "state": "pending",
+      "status": "local_validation_passed",
+      "state": "local_validation_passed",
       "title": "docs(seo-intel): add ops seo observation display readiness",
       "depends_on": [
         "SEO-OBS-GOV-04"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-OBS-GOV-04 merged as PR #1559 and origin/main contains c3ce981a94844fc65007c679cd1bcd30dcfe3ea0."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=SeoIntelOpsSeoObservationGovernanceDisplayReadiness --no-ansi",
+            "cd backend && php artisan test --filter=SeoIntel --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "python3 -m json.tool backend/docs/seo/generated/ops-seo-observation-governance-display-readiness.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"",
+            "git diff --check"
+          ],
+          "evidence": "All PR5 local validations passed. Focused contract test passed 7 tests / 150 assertions; SeoIntel suite passed 404 tests / 6475 assertions; Pint passed 3466 files; route:list returned 203 routes."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to PR5 /ops/seo observation governance display readiness docs, generated artifact, focused test, and train ledger. No Filament UI implementation, service implementation, migration, action button, production env edit, fap-web change, or Metabase exposure was added."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14193,7 +14230,13 @@
       "sidecar_allowed": true,
       "stop_on_safety_violation": true,
       "next_pr": "SEO-OBS-GOV-06",
-      "history": []
+      "history": [
+        {
+          "at": "2026-05-22T13:57:31+08:00",
+          "status": "local_validation_passed",
+          "summary": "Added /ops/seo governance display readiness contract docs, generated artifact, focused test, and ledger updates. No UI, service, migration, write control, or Metabase exposure was added. Required local checks passed."
+        }
+      ]
     },
     "SEO-OBS-GOV-06": {
       "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Added the /ops/seo observation governance display readiness contract.
- Added a generated v1 JSON artifact for future read-only panel requirements and hard stops.
- Added a focused SeoIntel contract test that locks observation queue, issue governance, entity governance, Digital PR observation-only, and crawler aggregate safety display boundaries.
- Updated the PR train ledger for PR4 merge reconciliation and PR5 local validation.

## Why
- Future /ops/seo governance panels need a contract before UI or read-model implementation.
- The dashboard must stay read-only and must not become URL Truth, CMS authority, Search Channel controls, crawler-log authority, or a Metabase proxy.

## Validation
- cd backend && php artisan test --filter=SeoIntelOpsSeoObservationGovernanceDisplayReadiness --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/ops-seo-observation-governance-display-readiness.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No Filament UI implementation.
- No service implementation.
- No migrations.
- No action buttons, submit controls, scheduler controls, collector controls, or CMS write controls.
- No production env changes, fap-web changes, Metabase exposure, crawler log reads, Search Channel mutation, or seo_intel writes.