### PR TITLE
docs(seo-intel): close observation governance contract train

### DIFF
--- a/backend/docs/seo/generated/observation-governance-closeout.v1.json
+++ b/backend/docs/seo/generated/observation-governance-closeout.v1.json
@@ -1,0 +1,86 @@
+{
+  "version": "observation-governance-closeout.v1",
+  "task": "SEO-OBS-GOV-06",
+  "train": "SEO-OBSERVATION-GOVERNANCE-PR-TRAIN-01",
+  "completed_prs": [
+    {
+      "id": "SEO-OBS-GOV-01",
+      "title": "Observation governance architecture contract",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1556"
+    },
+    {
+      "id": "SEO-OBS-GOV-02",
+      "title": "Observation queue schema contract",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1557"
+    },
+    {
+      "id": "SEO-OBS-GOV-03",
+      "title": "Issue severity dedupe mute SLA contract",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1558"
+    },
+    {
+      "id": "SEO-OBS-GOV-04",
+      "title": "Entity key translation group contract",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1559"
+    },
+    {
+      "id": "SEO-OBS-GOV-05",
+      "title": "Ops SEO observation display readiness",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1560"
+    }
+  ],
+  "governance_results": {
+    "architecture_contract": "Observation Queue is observation only and not URL Truth, Search Channel Queue, CMS writer, raw crawler log reader, or auto-fix engine.",
+    "observation_queue_schema_contract": "Future seo_observation_queue shape is defined without a real migration or writer.",
+    "issue_severity_contract": "P0/P1/P2/P3, deterministic dedupe, mute, owner, SLA, reopen, occurrence, and closeout rules are defined without issue mutation.",
+    "entity_key_contract": "translation_group_uuid is the future stable key; translation_group_id is transitional; legacy content without key is legacy_unpaired.",
+    "ops_seo_display_readiness": "Future /ops/seo panels are read-only and explicitly exclude write controls, raw data, and Metabase exposure."
+  },
+  "safety_confirmation": {
+    "runtime_writes_introduced": false,
+    "migrations_added": false,
+    "production_migrations_executed": false,
+    "production_operations_performed": false,
+    "production_env_changed": false,
+    "scheduler_activated": false,
+    "url_submission_performed": false,
+    "production_crawler_logs_read": false,
+    "cms_content_mutated": false,
+    "seo_intel_written": false,
+    "metabase_exposed": false,
+    "fap_web_modified": false,
+    "search_channel_queue_mutated": false,
+    "collector_writes_enabled": false
+  },
+  "validation_summary": {
+    "focused_contract_tests": "passed for PR1 through PR5 and closeout",
+    "seo_intel_suite": "passed during each PR before merge",
+    "route_list": "passed during each PR before merge",
+    "pint": "passed during each PR before merge",
+    "json_validation": "passed",
+    "yaml_validation": "passed",
+    "diff_checks": "passed",
+    "github_required_checks": "passed before every merge",
+    "post_merge_revalidation": "passed after every merged PR"
+  },
+  "sidecar_issues": [
+    {
+      "title": "Unrelated local branch from earlier PR1 attempt",
+      "branch": "codex/seo-obs-gov-01-observation-governance-contract",
+      "status": "left_untouched",
+      "reason": "Branch contains unrelated deploy/SRE changes outside this train scope."
+    },
+    {
+      "title": "Future implementation train",
+      "status": "separate_approval_required",
+      "reason": "Schema, writer, issue lifecycle, entity backfill, and dashboard implementation remain outside this contract train."
+    }
+  ],
+  "final_decision": "seo_observation_governance_contract_train_completed_ready_for_content_ops_claim_link_runtime",
+  "next_task": "CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01"
+}

--- a/backend/docs/seo/observation-governance-closeout.md
+++ b/backend/docs/seo/observation-governance-closeout.md
@@ -1,0 +1,121 @@
+# Observation Governance Contract Train Closeout
+
+## Purpose
+
+This closeout records the result of the SEO Observation Governance contract
+train. It summarizes PRs `SEO-OBS-GOV-01` through `SEO-OBS-GOV-05`, confirms
+that the train remained contract-only, and sets the next implementation
+handoff.
+
+## Completed Scope
+
+The contract train completed these governance contracts:
+
+- `SEO-OBS-GOV-01`: observation governance architecture contract
+- `SEO-OBS-GOV-02`: observation queue schema contract
+- `SEO-OBS-GOV-03`: issue severity / dedupe / mute / SLA contract
+- `SEO-OBS-GOV-04`: entity key and `translation_group_uuid` contract
+- `SEO-OBS-GOV-05`: `/ops/seo` observation governance display readiness
+
+## Architecture Result
+
+The architecture contract defines Observation Queue as an observation and
+verification surface only. It is not URL Truth. It is not Search Channel Queue.
+It does not submit URLs. It does not write CMS content. It does not read raw
+crawler logs. It does not auto-fix issues.
+
+The contract connects future CMS/backend publish and metadata events, runtime
+verification, Search Channel Queue states, crawler aggregate observations,
+claim-boundary checks, issue lifecycle events, and future `/ops/seo` display
+readiness without changing runtime behavior in this train.
+
+## Observation Queue Schema Result
+
+The schema contract defines the future `seo_observation_queue` table shape,
+including event identity, event type/state, source system, canonical URL
+summary, entity/locale summary, observation target, verification states,
+dedupe, priority, scheduling, observation, closeout, and safe context hash.
+
+The schema contract explicitly forbids raw payloads, raw crawler logs, raw
+request URIs, raw user agents, IP addresses, emails, tokens, cookies,
+authorization values, payment/order identifiers, provider payloads, and raw JSON
+metadata. No real migration was added in this train.
+
+## Issue Severity Result
+
+The issue governance contract defines P0/P1/P2/P3 severity, deterministic
+dedupe, mute history, owner team, SLA due policy, explicit reopen rules,
+occurrence tracking, and closed reasons. It maps legacy `critical`, `high`,
+`warning`, and `info` labels to P0/P1/P2/P3 without mutating existing issues.
+
+The contract locks that P0 must never be silently muted, claim-unsafe
+public/indexable pages are P0, private-flow leaks are P0, Search Channel
+submission of non-canonical/private URLs is P0, and severity must not trigger
+auto-fix.
+
+## Entity Key Result
+
+The entity contract defines `translation_group_uuid` as the preferred stable key
+for multi-locale entity identity. Existing `translation_group_id` is transitional
+only where already supported. Content without a stable key is marked
+`legacy_unpaired` until approved backfill work is performed.
+
+Title/slug similarity may be used only as a migration helper, not authority.
+Frontend fallback pairing, crawler-derived pairing, search engine response
+pairing, local copy authority, and static sitemap/llms authority are forbidden.
+No CMS content mutation, backfill execution, or migration was added in this
+train.
+
+## /ops/seo Display Result
+
+The display readiness contract defines future read-only panels for:
+
+- Observation Queue summaries by event type and event state
+- pending runtime checks
+- awaiting search and crawler observations
+- needs-review and muted counts
+- P0/P1/P2/P3 issue distribution
+- SLA due and overdue counters
+- dedupe cluster counters
+- entity key and locale pair coverage
+- missing `translation_group_uuid`
+- Digital PR observation-only placeholders
+- crawler aggregate observation safety counters
+
+The display contract locks hard stops: no search submit button, no approve/retry
+controls, no scheduler controls, no collector controls, no raw SQL, no Metabase
+iframe/proxy, no raw crawler logs, no raw payload display, and no CMS write
+controls from `/ops/seo`.
+
+## Safety Confirmation
+
+This train introduced no runtime writes. This train executed no migrations. This
+train performed no production operations. This train changed no production env.
+This train activated no scheduler. This train submitted no URLs. This train read
+no production crawler logs. This train mutated no CMS content. This train wrote
+no `seo_intel` data. This train exposed no Metabase surface. This train modified
+no `fap-web` files.
+
+## Ledger Result
+
+The stale `CRAWLER-LOG-11` ledger state was reconciled in `SEO-OBS-GOV-01`.
+`SEO-OBS-GOV-01` through `SEO-OBS-GOV-05` were completed through focused
+contract tests, full `SeoIntel` test runs, route listing, Pint, JSON validation,
+YAML validation, diff checks, GitHub required checks, squash merge, and focused
+post-merge revalidation.
+
+## Sidecar Issues
+
+- The local branch `codex/seo-obs-gov-01-observation-governance-contract`
+  existed before this train with unrelated deploy/SRE changes. It was not used
+  for the train. The actual PR1 branch was
+  `codex/seo-obs-gov-01-observation-governance-contract-v2`.
+- Future schema/runtime implementation remains a separate implementation train
+  and requires explicit approval before migrations, writers, or dashboard
+  integration are added.
+
+## Final Decision
+
+seo_observation_governance_contract_train_completed_ready_for_content_ops_claim_link_runtime
+
+Next task: `CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01`

--- a/backend/tests/Feature/SeoIntel/SeoIntelObservationGovernanceCloseoutTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelObservationGovernanceCloseoutTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelObservationGovernanceCloseoutTest extends TestCase
+{
+    #[Test]
+    public function closeout_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/observation-governance-closeout.md'));
+        $this->assertSame('observation-governance-closeout.v1', $this->artifact()['version'] ?? null);
+        $this->assertSame('SEO-OBS-GOV-06', $this->artifact()['task'] ?? null);
+        $this->assertSame('SEO-OBSERVATION-GOVERNANCE-PR-TRAIN-01', $this->artifact()['train'] ?? null);
+    }
+
+    #[Test]
+    public function completed_prs_one_through_five_are_recorded(): void
+    {
+        $completed = collect($this->artifact()['completed_prs'] ?? []);
+
+        foreach ([
+            'SEO-OBS-GOV-01' => 'https://github.com/fermatmind/fap-api/pull/1556',
+            'SEO-OBS-GOV-02' => 'https://github.com/fermatmind/fap-api/pull/1557',
+            'SEO-OBS-GOV-03' => 'https://github.com/fermatmind/fap-api/pull/1558',
+            'SEO-OBS-GOV-04' => 'https://github.com/fermatmind/fap-api/pull/1559',
+            'SEO-OBS-GOV-05' => 'https://github.com/fermatmind/fap-api/pull/1560',
+        ] as $id => $url) {
+            $row = $completed->firstWhere('id', $id);
+
+            $this->assertIsArray($row, $id.' must be recorded');
+            $this->assertSame('completed_contract_only', $row['result'] ?? null);
+            $this->assertSame($url, $row['pr_url'] ?? null);
+        }
+    }
+
+    #[Test]
+    public function governance_results_cover_all_contracts(): void
+    {
+        $results = $this->artifact()['governance_results'] ?? [];
+
+        foreach ([
+            'architecture_contract',
+            'observation_queue_schema_contract',
+            'issue_severity_contract',
+            'entity_key_contract',
+            'ops_seo_display_readiness',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $results);
+            $this->assertNotSame('', $results[$key]);
+        }
+    }
+
+    #[Test]
+    public function safety_confirmation_blocks_runtime_and_production_work(): void
+    {
+        foreach ([
+            'runtime_writes_introduced',
+            'migrations_added',
+            'production_migrations_executed',
+            'production_operations_performed',
+            'production_env_changed',
+            'scheduler_activated',
+            'url_submission_performed',
+            'production_crawler_logs_read',
+            'cms_content_mutated',
+            'seo_intel_written',
+            'metabase_exposed',
+            'fap_web_modified',
+            'search_channel_queue_mutated',
+            'collector_writes_enabled',
+        ] as $flag) {
+            $this->assertFalse((bool) ($this->artifact()['safety_confirmation'][$flag] ?? true), $flag.' must be false');
+        }
+    }
+
+    #[Test]
+    public function validation_summary_and_sidecars_are_explicit(): void
+    {
+        $summary = $this->artifact()['validation_summary'] ?? [];
+
+        foreach ([
+            'focused_contract_tests',
+            'seo_intel_suite',
+            'route_list',
+            'pint',
+            'json_validation',
+            'yaml_validation',
+            'diff_checks',
+            'github_required_checks',
+            'post_merge_revalidation',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $summary);
+        }
+
+        $sidecars = collect($this->artifact()['sidecar_issues'] ?? []);
+
+        $this->assertNotNull($sidecars->firstWhere('branch', 'codex/seo-obs-gov-01-observation-governance-contract'));
+        $this->assertNotNull($sidecars->firstWhere('title', 'Future implementation train'));
+    }
+
+    #[Test]
+    public function final_decision_and_next_task_are_locked(): void
+    {
+        $this->assertSame(
+            'seo_observation_governance_contract_train_completed_ready_for_content_ops_claim_link_runtime',
+            $this->artifact()['final_decision'] ?? null
+        );
+        $this->assertSame('CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01', $this->artifact()['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function docs_lock_no_runtime_operations_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/observation-governance-closeout.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/observation-governance-closeout.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'seo-obs-gov-01',
+            'seo-obs-gov-02',
+            'seo-obs-gov-03',
+            'seo-obs-gov-04',
+            'seo-obs-gov-05',
+            'no runtime writes',
+            'no migrations',
+            'no production operations',
+            'no production env',
+            'no scheduler',
+            'no urls',
+            'no production crawler logs',
+            'no cms content',
+            'no `seo_intel` data',
+            'no metabase surface',
+            'no `fap-web` files',
+            'content-ops-claim-link-runtime-train-01',
+            '"next_task": "CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01"',
+        ] as $required) {
+            $this->assertStringContainsString(strtolower($required), $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/observation-governance-closeout.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T13:57:31+08:00",
+  "updated_at": "2026-05-22T14:08:12+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14178,14 +14178,14 @@
     "SEO-OBS-GOV-05": {
       "repo": "fap-api",
       "branch": "codex/seo-obs-gov-05-ops-seo-display-readiness",
-      "status": "local_validation_passed",
-      "state": "local_validation_passed",
+      "status": "merged",
+      "state": "merged",
       "title": "docs(seo-intel): add ops seo observation display readiness",
       "depends_on": [
         "SEO-OBS-GOV-04"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "5f5bba11f10a1ec5a9502720fb7cc47aa0293989",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1560",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -14208,12 +14208,21 @@
         "scope_validation": {
           "status": "pass",
           "evidence": "Changed files are limited to PR5 /ops/seo observation governance display readiness docs, generated artifact, focused test, and train ledger. No Filament UI implementation, service implementation, migration, action button, production env edit, fap-web change, or Metabase exposure was added."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1560 merged after hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS succeeded; mergeStateStatus was CLEAN."
+        },
+        "post_merge_revalidation": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=SeoIntelOpsSeoObservationGovernanceDisplayReadiness --no-ansi",
+          "evidence": "Focused post-merge revalidation passed: 7 tests / 150 assertions."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T06:05:10Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_write_execution": false,
       "production_log_read_execution": false,
       "production_migration_execution": false,
@@ -14235,21 +14244,49 @@
           "at": "2026-05-22T13:57:31+08:00",
           "status": "local_validation_passed",
           "summary": "Added /ops/seo governance display readiness contract docs, generated artifact, focused test, and ledger updates. No UI, service, migration, write control, or Metabase exposure was added. Required local checks passed."
+        },
+        {
+          "at": "2026-05-22T14:08:12+08:00",
+          "status": "merged",
+          "summary": "PR #1560 was squash merged to main at 5f5bba11f10a1ec5a9502720fb7cc47aa0293989. Remote branch was deleted and focused post-merge revalidation passed."
         }
       ]
     },
     "SEO-OBS-GOV-06": {
       "repo": "fap-api",
       "branch": "codex/seo-obs-gov-06-governance-closeout",
-      "status": "pending",
-      "state": "pending",
+      "status": "local_validation_passed",
+      "state": "local_validation_passed",
       "title": "docs(seo-intel): close observation governance contract train",
       "depends_on": [
         "SEO-OBS-GOV-05"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-OBS-GOV-05 merged as PR #1560 and origin/main contains 5f5bba11f10a1ec5a9502720fb7cc47aa0293989."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=SeoIntelObservationGovernanceCloseout --no-ansi",
+            "cd backend && php artisan test --filter=SeoIntel --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "python3 -m json.tool backend/docs/seo/generated/observation-governance-closeout.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"",
+            "git diff --check"
+          ],
+          "evidence": "All PR6 local validations passed. Focused closeout test passed 7 tests / 120 assertions; SeoIntel suite passed 411 tests / 6595 assertions; Pint passed 3467 files; route:list returned 203 routes."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to PR6 closeout docs, generated artifact, focused test, and train ledger. No runtime code, migrations, production operations, env edits, or fap-web changes were added."
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14270,7 +14307,13 @@
       "sidecar_allowed": true,
       "stop_on_safety_violation": true,
       "next_pr": "CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01",
-      "history": []
+      "history": [
+        {
+          "at": "2026-05-22T14:08:12+08:00",
+          "status": "local_validation_passed",
+          "summary": "Added observation governance closeout docs, generated artifact, focused test, and ledger updates. No runtime code, migration, production operation, env edit, or fap-web change was added. Required local checks passed."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {


### PR DESCRIPTION
## What changed
- Added the observation governance contract train closeout document.
- Added a generated v1 JSON closeout artifact summarizing PR1-PR5, safety confirmation, validation, sidecars, final decision, and next task.
- Added a focused SeoIntel closeout test that locks completed PRs, no-runtime/no-production boundaries, validation summary, sidecars, final decision, and next task.
- Updated the PR train ledger for PR5 merge reconciliation and PR6 local validation.

## Why
- The observation governance contract train needs an auditable closeout before the next scoped train starts.
- This records that the train remained contract-only and introduced no runtime writes, migrations, production operations, env edits, scheduler activation, URL submission, crawler log reads, CMS mutation, seo_intel writes, Metabase exposure, or fap-web changes.

## Validation
- cd backend && php artisan test --filter=SeoIntelObservationGovernanceCloseout --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/observation-governance-closeout.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No runtime implementation.
- No migrations.
- No production operations.
- No env edits.
- No fap-web changes.
- Future schema/runtime/dashboard implementation requires a separate approved train.