### PR TITLE
docs(seo-intel): add content publish rehearsal contract

### DIFF
--- a/backend/docs/seo/content-publish-rehearsal-contract.md
+++ b/backend/docs/seo/content-publish-rehearsal-contract.md
@@ -1,0 +1,155 @@
+# Content Publish Rehearsal Contract
+
+## Purpose
+
+CONTENT-OPS-02A defines a backend-owned content publish rehearsal contract for
+SEO-sensitive content operations.
+
+The rehearsal is dry-run only. It does not publish articles, does not mutate CMS
+content, does not write `seo_intel`, does not write the future Observation
+Queue, does not enqueue Search Channel Queue, does not submit URLs, does not
+change sitemap or `llms.txt`, and does not perform production writes.
+
+CMS/backend remains the content, metadata, publish-state, canonical,
+indexability, claim-boundary, and internal-link authority. `fap-web` remains a
+deterministic public runtime renderer only.
+
+## Candidate Surfaces
+
+The future rehearsal validator may evaluate these backend-owned or
+backend-declared surfaces:
+
+- articles
+- research reports
+- content pages
+- support articles
+- interpretation guides
+- topics
+- personality pages
+- career guides
+- career jobs
+- test landing/detail pages
+- homepage/landing surfaces
+
+## Required Rehearsal Checks
+
+Every supported surface must define whether each check is applicable,
+unsupported, or blocked by missing schema:
+
+- status / review_state
+- is_public / is_indexable
+- canonical_path or canonical URL readiness
+- seo_title
+- seo_description
+- robots/noindex state
+- locale
+- slug
+- references
+- CTA
+- FAQ
+- media / cover readiness where relevant
+- claim boundary
+- internal link readiness
+- Search Channel eligibility dry-run
+- Observation Queue planned event dry-run
+
+Drafts and non-public records must remain excluded from sitemap, `llms.txt`,
+Search Channel Queue, URL submissions, and indexable URL Truth handoff.
+
+## Rehearsal States
+
+The future dry-run validator should return one of:
+
+- safe
+- needs_review
+- blocked
+
+`safe` means the candidate passes known dry-run checks for the requested surface.
+`needs_review` means a human should inspect missing or cautionary fields before
+publish. `blocked` means the candidate must not be published or made eligible
+for search discovery until resolved.
+
+## Planned Observation Events
+
+CONTENT-OPS-02A does not write Observation Queue rows. It only defines planned
+events that a later implementation may report in dry-run output:
+
+- published
+- metadata_changed
+- canonical_changed
+- robots_changed
+- locale_link_changed
+- claim_boundary_changed
+- issue_detected
+
+Planned events are advisory. They are not URL Truth, not Search Channel Queue,
+not CMS writes, and not runtime verification.
+
+## Claim Lint Gate
+
+Publish rehearsal must include claim lint state before any content can be
+considered safe for manual publish review. Claim lint must not auto-rewrite
+content, auto-fix claims, auto-publish content, or create issue rows in this
+contract PR.
+
+Public/indexable claim-unsafe content must be treated as blocked in future
+runtime work.
+
+## Internal Link Readiness Gate
+
+Publish rehearsal must include internal link readiness. Internal links must be
+checked against backend/CMS authority and future entity-key governance. Frontend
+fallback, static sitemap, static `llms.txt`, crawler logs, search engine
+responses, and local copies must not become internal link authority.
+
+## Search Channel Eligibility Dry-run
+
+Search Channel eligibility may be reported as a dry-run check only. The
+rehearsal must not create, approve, retry, enqueue, or submit Search Channel
+Queue items.
+
+## Forbidden Behavior
+
+This contract forbids:
+
+- CMS content mutation
+- article publish
+- production write
+- production migration
+- sitemap mutation
+- `llms.txt` mutation
+- Observation Queue write
+- Search Channel Queue enqueue
+- URL submission
+- crawler log read
+- scheduler activation
+- collector write
+- Metabase exposure
+- fap-web modification
+- frontend fallback as authority
+- static sitemap or static `llms.txt` as authority
+- crawler logs or search engine responses as URL Truth
+- claim linter auto-rewrite
+- internal link auto-creation
+- pSEO generation
+
+## Surface Readiness Notes
+
+Articles are the most ready surface because the existing controlled article
+publish command already has dry-run preflight behavior. Research reports have
+strong methodology, disclaimer, claim-boundary, review, public, indexable, and
+canonical fields but need a reusable rehearsal implementation. Content pages,
+support articles, interpretation guides, topics, personality pages, career
+guides, career jobs, test pages, and landing surfaces need surface-specific
+field mapping before runtime enforcement.
+
+Missing `translation_group_uuid` remains a sidecar issue. Existing
+`translation_group_id` may be used only as a transitional key where it already
+exists. Title or slug similarity may help migration planning but must not become
+long-term authority.
+
+## Final Decision
+
+`content_publish_rehearsal_contract_ready`
+
+Next task: `CONTENT-OPS-02B`

--- a/backend/docs/seo/generated/content-publish-rehearsal-contract.v1.json
+++ b/backend/docs/seo/generated/content-publish-rehearsal-contract.v1.json
@@ -1,0 +1,140 @@
+{
+  "version": "content-publish-rehearsal-contract.v1",
+  "task": "CONTENT-OPS-02A",
+  "purpose": "content_publish_rehearsal_contract",
+  "mode": "dry_run_contract_only",
+  "authority_model": {
+    "cms_backend": "content_metadata_publish_canonical_indexability_claim_internal_link_truth",
+    "fap_web": "deterministic_public_runtime_renderer_only",
+    "seo_intel": "observation_only",
+    "observation_queue": "planned_events_only_in_this_pr",
+    "search_channel_queue": "eligibility_dry_run_only"
+  },
+  "candidate_surfaces": [
+    "articles",
+    "research_reports",
+    "content_pages",
+    "support_articles",
+    "interpretation_guides",
+    "topics",
+    "personality_pages",
+    "career_guides",
+    "career_jobs",
+    "test_landing_detail_pages",
+    "homepage_landing_surfaces"
+  ],
+  "required_rehearsal_checks": [
+    "status_review_state",
+    "is_public_is_indexable",
+    "canonical_path_or_url",
+    "seo_title",
+    "seo_description",
+    "robots_noindex_state",
+    "locale",
+    "slug",
+    "references",
+    "cta",
+    "faq",
+    "media_cover_readiness",
+    "claim_boundary",
+    "internal_link_readiness",
+    "search_channel_eligibility_dry_run",
+    "observation_queue_planned_event_dry_run"
+  ],
+  "rehearsal_states": [
+    "safe",
+    "needs_review",
+    "blocked"
+  ],
+  "draft_exclusions": [
+    "sitemap",
+    "llms",
+    "search_channel_queue",
+    "url_submission",
+    "indexable_url_truth_handoff"
+  ],
+  "planned_observation_event_types": [
+    "published",
+    "metadata_changed",
+    "canonical_changed",
+    "robots_changed",
+    "locale_link_changed",
+    "claim_boundary_changed",
+    "issue_detected"
+  ],
+  "required_gates": [
+    "claim_lint",
+    "internal_link_readiness",
+    "search_channel_eligibility_dry_run",
+    "observation_planning_dry_run"
+  ],
+  "forbidden_authority_sources": [
+    "frontend_fallback",
+    "static_sitemap",
+    "static_llms",
+    "crawler_logs",
+    "search_engine_responses",
+    "local_copies"
+  ],
+  "forbidden_behaviors": [
+    "cms_content_mutation",
+    "article_publish",
+    "production_write",
+    "production_migration",
+    "sitemap_mutation",
+    "llms_mutation",
+    "observation_queue_write",
+    "search_channel_queue_enqueue",
+    "url_submission",
+    "crawler_log_read",
+    "scheduler_activation",
+    "collector_write",
+    "metabase_exposure",
+    "fap_web_modification",
+    "claim_linter_auto_rewrite",
+    "internal_link_auto_creation",
+    "pseo_generation"
+  ],
+  "surface_readiness": {
+    "articles": "ready_for_reusable_rehearsal",
+    "research_reports": "needs_surface_mapping",
+    "content_pages": "needs_surface_mapping",
+    "support_articles": "needs_surface_mapping",
+    "interpretation_guides": "needs_surface_mapping",
+    "topics": "blocked_missing_universal_fields",
+    "personality_pages": "blocked_missing_universal_fields",
+    "career_guides": "needs_surface_mapping",
+    "career_jobs": "needs_surface_mapping",
+    "test_landing_detail_pages": "needs_contract_mapping",
+    "homepage_landing_surfaces": "needs_surface_mapping"
+  },
+  "sidecar_issues": [
+    "translation_group_uuid_missing_globally",
+    "translation_group_id_partial_transitional",
+    "surface_specific_field_mapping_required"
+  ],
+  "safety_flags": {
+    "docs_only": true,
+    "generated_json_only": true,
+    "focused_tests_only": true,
+    "runtime_service_added": false,
+    "migration_added": false,
+    "cms_content_mutation": false,
+    "article_published": false,
+    "production_write": false,
+    "production_migration_execution": false,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "observation_queue_write": false,
+    "search_channel_queue_enqueue": false,
+    "url_submission": false,
+    "crawler_log_read": false,
+    "scheduler_enabled": false,
+    "collector_write": false,
+    "metabase_exposure": false,
+    "fap_web_modified": false,
+    "pseo_generation": false
+  },
+  "final_decision": "content_publish_rehearsal_contract_ready",
+  "next_task": "CONTENT-OPS-02B"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelContentPublishRehearsalContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelContentPublishRehearsalContractTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelContentPublishRehearsalContractTest extends TestCase
+{
+    #[Test]
+    public function contract_file_and_generated_artifact_exist_and_parse(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/content-publish-rehearsal-contract.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('content-publish-rehearsal-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('CONTENT-OPS-02A', $artifact['task'] ?? null);
+        $this->assertSame('content_publish_rehearsal_contract', $artifact['purpose'] ?? null);
+        $this->assertSame('dry_run_contract_only', $artifact['mode'] ?? null);
+    }
+
+    #[Test]
+    public function candidate_surfaces_and_required_checks_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'articles',
+            'research_reports',
+            'content_pages',
+            'support_articles',
+            'interpretation_guides',
+            'topics',
+            'personality_pages',
+            'career_guides',
+            'career_jobs',
+            'test_landing_detail_pages',
+            'homepage_landing_surfaces',
+        ] as $surface) {
+            $this->assertContains($surface, $artifact['candidate_surfaces'] ?? []);
+        }
+
+        foreach ([
+            'status_review_state',
+            'is_public_is_indexable',
+            'canonical_path_or_url',
+            'seo_title',
+            'seo_description',
+            'robots_noindex_state',
+            'locale',
+            'slug',
+            'references',
+            'cta',
+            'faq',
+            'media_cover_readiness',
+            'claim_boundary',
+            'internal_link_readiness',
+            'search_channel_eligibility_dry_run',
+            'observation_queue_planned_event_dry_run',
+        ] as $check) {
+            $this->assertContains($check, $artifact['required_rehearsal_checks'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function rehearsal_states_draft_exclusions_and_gates_are_defined(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(['safe', 'needs_review', 'blocked'], $artifact['rehearsal_states'] ?? []);
+
+        foreach ([
+            'sitemap',
+            'llms',
+            'search_channel_queue',
+            'url_submission',
+            'indexable_url_truth_handoff',
+        ] as $exclusion) {
+            $this->assertContains($exclusion, $artifact['draft_exclusions'] ?? []);
+        }
+
+        foreach ([
+            'claim_lint',
+            'internal_link_readiness',
+            'search_channel_eligibility_dry_run',
+            'observation_planning_dry_run',
+        ] as $gate) {
+            $this->assertContains($gate, $artifact['required_gates'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function planned_observation_events_do_not_write_observation_queue(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'published',
+            'metadata_changed',
+            'canonical_changed',
+            'robots_changed',
+            'locale_link_changed',
+            'claim_boundary_changed',
+            'issue_detected',
+        ] as $eventType) {
+            $this->assertContains($eventType, $artifact['planned_observation_event_types'] ?? []);
+        }
+
+        $this->assertContains('observation_queue_write', $artifact['forbidden_behaviors'] ?? []);
+        $this->assertFalse((bool) data_get($artifact, 'safety_flags.observation_queue_write', true));
+    }
+
+    #[Test]
+    public function authority_boundaries_forbid_fallback_and_search_truth_drift(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'frontend_fallback',
+            'static_sitemap',
+            'static_llms',
+            'crawler_logs',
+            'search_engine_responses',
+            'local_copies',
+        ] as $source) {
+            $this->assertContains($source, $artifact['forbidden_authority_sources'] ?? []);
+        }
+
+        foreach ([
+            'cms_content_mutation',
+            'article_publish',
+            'production_write',
+            'sitemap_mutation',
+            'llms_mutation',
+            'search_channel_queue_enqueue',
+            'url_submission',
+            'crawler_log_read',
+            'claim_linter_auto_rewrite',
+            'internal_link_auto_creation',
+            'pseo_generation',
+        ] as $behavior) {
+            $this->assertContains($behavior, $artifact['forbidden_behaviors'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_prove_this_pr_is_contract_only(): void
+    {
+        $flags = $this->artifact()['safety_flags'] ?? [];
+
+        foreach ([
+            'docs_only',
+            'generated_json_only',
+            'focused_tests_only',
+        ] as $flag) {
+            $this->assertTrue((bool) ($flags[$flag] ?? false), $flag.' must be true');
+        }
+
+        foreach ([
+            'runtime_service_added',
+            'migration_added',
+            'cms_content_mutation',
+            'article_published',
+            'production_write',
+            'production_migration_execution',
+            'sitemap_changed',
+            'llms_changed',
+            'search_channel_queue_enqueue',
+            'url_submission',
+            'crawler_log_read',
+            'scheduler_enabled',
+            'collector_write',
+            'metabase_exposure',
+            'fap_web_modified',
+            'pseo_generation',
+        ] as $flag) {
+            $this->assertFalse((bool) ($flags[$flag] ?? true), $flag.' must be false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_dry_run_policy_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/content-publish-rehearsal-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/content-publish-rehearsal-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'dry-run only',
+            'does not publish articles',
+            'does not mutate cms',
+            'does not write `seo_intel`',
+            'does not write `seo_intel`',
+            'observation queue write',
+            'does not enqueue search channel queue',
+            'does not submit urls',
+            'sitemap mutation',
+            'llms_mutation',
+            'claim lint gate',
+            'internal link readiness gate',
+            'deterministic public runtime renderer',
+            'next task: `content-ops-02b`',
+            '"next_task": "content-ops-02b"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/content-publish-rehearsal-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T14:51:20+08:00",
+  "updated_at": "2026-05-22T14:52:09+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17883,12 +17883,12 @@
     "CONTENT-OPS-02A": {
       "repo": "fap-api",
       "branch": "codex/content-ops-02a-publish-rehearsal-contract",
-      "status": "committed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-OBS-GOV-06"
       ],
-      "commit_sha": "d226376a2f1bc12919d0871f6e5b5a7cb08ddc33",
-      "pr_url": null,
+      "commit_sha": "b1967c4e222c1688fb363157b8d77dcf99bfe0c0",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1562",
       "checks": {
         "local": {
           "php_artisan_test_filter_contract": "passed: php artisan test --filter=SeoIntelContentPublishRehearsalContract --no-ansi (7 tests, 114 assertions)",
@@ -17930,6 +17930,11 @@
           "at": "2026-05-22T14:51:20+08:00",
           "status": "committed",
           "summary": "Committed CONTENT-OPS-02A scoped contract changes at d226376a2f1bc12919d0871f6e5b5a7cb08ddc33."
+        },
+        {
+          "at": "2026-05-22T14:52:09+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1562 for CONTENT-OPS-02A and pushed branch codex/content-ops-02a-publish-rehearsal-contract."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T14:08:12+08:00",
+  "updated_at": "2026-05-22T14:51:20+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -3561,7 +3561,7 @@
       "repo": "fap-web",
       "branch": "codex/riasec-personalization-06-frontend-fail-closed",
       "title": "feat(riasec): consume backend personalization state fail-closed",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "RIASEC-PERSONALIZATION-03",
         "RIASEC-PERSONALIZATION-04"
@@ -17877,6 +17877,252 @@
           "at": "2026-05-22T10:05:00+08:00",
           "status": "open",
           "summary": "Opened PR #1547 for the deploy.php nginx static route backup-placement fix after scoped local validation passed."
+        }
+      ]
+    },
+    "CONTENT-OPS-02A": {
+      "repo": "fap-api",
+      "branch": "codex/content-ops-02a-publish-rehearsal-contract",
+      "status": "committed",
+      "depends_on": [
+        "SEO-OBS-GOV-06"
+      ],
+      "commit_sha": "d226376a2f1bc12919d0871f6e5b5a7cb08ddc33",
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_contract": "passed: php artisan test --filter=SeoIntelContentPublishRehearsalContract --no-ansi (7 tests, 114 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (418 tests, 6709 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi",
+          "pint_test": "passed: vendor/bin/pint --test",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/content-publish-rehearsal-contract.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "CONTENT-OPS-02B",
+      "history": [
+        {
+          "at": "2026-05-22T14:37:34+08:00",
+          "status": "pending",
+          "summary": "Registered content publish rehearsal contract PR after explicit user authorization to add CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01 manifest/state entries. Scope is docs/generated/test only with no runtime writes."
+        },
+        {
+          "at": "2026-05-22T14:45:00+08:00",
+          "status": "in_progress",
+          "summary": "Started CONTENT-OPS-02A on codex/content-ops-02a-publish-rehearsal-contract. Scope is limited to the publish rehearsal contract doc, generated artifact, focused SeoIntel test, and train metadata alignment."
+        },
+        {
+          "at": "2026-05-22T14:50:34+08:00",
+          "status": "local_validation_passed",
+          "summary": "CONTENT-OPS-02A local validation passed for focused contract test, full SeoIntel filter, route list, Pint, JSON/YAML parsing, and diff whitespace checks. No runtime writes, migrations, CMS mutation, Search Channel enqueue, crawler log reads, or fap-web changes were introduced."
+        },
+        {
+          "at": "2026-05-22T14:51:20+08:00",
+          "status": "committed",
+          "summary": "Committed CONTENT-OPS-02A scoped contract changes at d226376a2f1bc12919d0871f6e5b5a7cb08ddc33."
+        }
+      ]
+    },
+    "CONTENT-OPS-02B": {
+      "repo": "fap-api",
+      "branch": "codex/content-ops-02b-publish-rehearsal-dry-run",
+      "status": "pending",
+      "depends_on": [
+        "CONTENT-OPS-02A"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "INTERNAL-LINK-01A",
+      "history": [
+        {
+          "at": "2026-05-22T14:37:34+08:00",
+          "status": "pending",
+          "summary": "Registered content publish rehearsal dry-run validator PR. Scope allows backend dry-run service/command/tests only; no CMS publish, seo_intel write, Search Channel mutation, scheduler, production operation, or fap-web change."
+        }
+      ]
+    },
+    "INTERNAL-LINK-01A": {
+      "repo": "fap-api",
+      "branch": "codex/internal-link-01a-semantic-graph-contract",
+      "status": "pending",
+      "depends_on": [
+        "CONTENT-OPS-02A"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "INTERNAL-LINK-01B",
+      "history": [
+        {
+          "at": "2026-05-22T14:37:34+08:00",
+          "status": "pending",
+          "summary": "Registered semantic internal link graph contract PR. Scope is backend contract docs/generated/test only and explicitly excludes link mutation and frontend fallback authority."
+        }
+      ]
+    },
+    "INTERNAL-LINK-01B": {
+      "repo": "fap-api",
+      "branch": "codex/internal-link-01b-graph-dry-run-read-model",
+      "status": "pending",
+      "depends_on": [
+        "INTERNAL-LINK-01A",
+        "CONTENT-OPS-02B"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "CLAIM-LINT-01A",
+      "history": [
+        {
+          "at": "2026-05-22T14:37:34+08:00",
+          "status": "pending",
+          "summary": "Registered internal link graph dry-run/read-model PR. Scope allows read-only backend service/command/tests only; no CMS link writes, sitemap/crawler/search authority, or fap-web change."
+        }
+      ]
+    },
+    "CLAIM-LINT-01A": {
+      "repo": "fap-api",
+      "branch": "codex/claim-lint-01a-chinese-runtime-contract",
+      "status": "pending",
+      "depends_on": [
+        "CONTENT-OPS-02A"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "CLAIM-LINT-01B",
+      "history": [
+        {
+          "at": "2026-05-22T14:37:34+08:00",
+          "status": "pending",
+          "summary": "Registered Chinese claim linter runtime contract PR. Scope is docs/generated/test only and expands safe/needs_review/blocked plus P0-P3 severity mapping without runtime enforcement."
+        }
+      ]
+    },
+    "CLAIM-LINT-01B": {
+      "repo": "fap-api",
+      "branch": "codex/claim-lint-01b-chinese-runtime-ci",
+      "status": "pending",
+      "depends_on": [
+        "CLAIM-LINT-01A",
+        "CONTENT-OPS-02B"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "CONTENT-OPS-CLAIM-LINK-OPS-READINESS",
+      "history": [
+        {
+          "at": "2026-05-22T14:37:34+08:00",
+          "status": "pending",
+          "summary": "Registered Chinese claim linter runtime/CI PR. Scope allows backend linter service/command/tests only and forbids auto-rewrite, auto-publish, production scans, seo_intel writes, and fap-web changes."
+        }
+      ]
+    },
+    "CONTENT-OPS-CLAIM-LINK-OPS-READINESS": {
+      "repo": "fap-api",
+      "branch": "codex/content-ops-claim-link-ops-readiness",
+      "status": "pending",
+      "depends_on": [
+        "CONTENT-OPS-02B",
+        "INTERNAL-LINK-01B",
+        "CLAIM-LINT-01B"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "CONTENT-OPS-CLAIM-LINK-CLOSEOUT",
+      "history": [
+        {
+          "at": "2026-05-22T14:37:34+08:00",
+          "status": "pending",
+          "summary": "Registered /ops/seo display readiness PR for content publish rehearsal, internal link graph, and claim lint summaries. Scope is read-only readiness docs/generated/test only."
+        }
+      ]
+    },
+    "CONTENT-OPS-CLAIM-LINK-CLOSEOUT": {
+      "repo": "fap-api",
+      "branch": "codex/content-ops-claim-link-closeout",
+      "status": "pending",
+      "depends_on": [
+        "CONTENT-OPS-CLAIM-LINK-OPS-READINESS"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": null,
+      "history": [
+        {
+          "at": "2026-05-22T14:37:34+08:00",
+          "status": "pending",
+          "summary": "Registered closeout/ledger finalization PR for the content ops claim/link runtime train. Scope is closeout docs/generated/test/state only with no runtime, migration, production, CMS, Search Channel, crawler, scheduler, or fap-web changes."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9329,3 +9329,348 @@ prs:
     production_migration_execution_allowed: false
     scheduler_activation: false
     next_task: CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01
+
+  - id: CONTENT-OPS-02A
+    repo: fap-api
+    depends_on:
+      - SEO-OBS-GOV-06
+    branch: codex/content-ops-02a-publish-rehearsal-contract
+    base: main
+    title: "docs(content-ops): add content publish rehearsal contract"
+    name: "Content publish rehearsal contract"
+    train_scope: content_ops_claim_link_runtime
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define backend-owned content publish rehearsal rules for articles, Research, content pages, support, topics, personality, career, tests, and landing surfaces.
+      - Specify dry-run validation inputs for metadata, canonical, robots/indexability, references, methodology/disclaimer, claim lint, internal links, observation planning, and Search Channel eligibility.
+      - Confirm publish rehearsal does not publish, mutate CMS content, write seo_intel, enqueue Search Channel, submit URLs, or expose drafts to sitemap/llms.
+    allowed_paths:
+      - backend/docs/seo/content-publish-rehearsal-contract.md
+      - backend/docs/seo/generated/content-publish-rehearsal-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelContentPublishRehearsalContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add runtime publish services, migrations, CMS content mutation, Search Channel writes, observation queue writes, scheduler activation, production env changes, deploys, fap-web changes, sitemap changes, or llms changes.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelContentPublishRehearsalContract --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/content-publish-rehearsal-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: CONTENT-OPS-02B
+
+  - id: CONTENT-OPS-02B
+    repo: fap-api
+    depends_on:
+      - CONTENT-OPS-02A
+    branch: codex/content-ops-02b-publish-rehearsal-dry-run
+    base: main
+    title: "feat(content-ops): add content publish rehearsal dry-run validator"
+    name: "Content publish rehearsal dry-run validator"
+    train_scope: content_ops_claim_link_runtime
+    risk_level: medium_dry_run_runtime
+    type: service/command/tests
+    scope:
+      - Add a backend dry-run validator for content publish rehearsal, starting from article publish preflight extraction/reuse.
+      - Emit CI-readable rehearsal output for safe, needs_review, and blocked states without publishing or mutating content.
+      - Include planned observation and Search Channel eligibility summaries as dry-run output only.
+    allowed_paths:
+      - backend/app/Services/SeoIntel/ContentOps/**
+      - backend/app/Console/Commands/SeoIntelContentPublishRehearsalCommand.php
+      - backend/tests/Feature/SeoIntel/SeoIntelContentPublishRehearsalDryRunTest.php
+      - backend/docs/seo/content-publish-rehearsal-dry-run.md
+      - backend/docs/seo/generated/content-publish-rehearsal-dry-run.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish articles, mutate CMS content, write seo_intel, write observation queue rows, enqueue Search Channel, submit URLs, run migrations, activate scheduler, edit env, deploy, modify fap-web, sitemap, or llms.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelContentPublishRehearsalDryRun --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/content-publish-rehearsal-dry-run.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: INTERNAL-LINK-01A
+
+  - id: INTERNAL-LINK-01A
+    repo: fap-api
+    depends_on:
+      - CONTENT-OPS-02A
+    branch: codex/internal-link-01a-semantic-graph-contract
+    base: main
+    title: "docs(seo): add semantic internal link graph contract"
+    name: "Semantic internal link graph contract"
+    train_scope: content_ops_claim_link_runtime
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define backend-authoritative semantic internal link graph rules across articles, topics, Research, tests, personality, career guides, career jobs, and content pages.
+      - Define source authority, entity_key and translation-group usage, safety levels, locale pairing, missing-link reporting, and no-auto-mutation policy.
+    allowed_paths:
+      - backend/docs/seo/semantic-internal-link-graph-contract.md
+      - backend/docs/seo/generated/semantic-internal-link-graph-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSemanticInternalLinkGraphContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate links, add frontend fallback links, use crawler logs or sitemap as link authority, run migrations, write CMS content, modify fap-web, or change public runtime.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSemanticInternalLinkGraphContract --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/semantic-internal-link-graph-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: INTERNAL-LINK-01B
+
+  - id: INTERNAL-LINK-01B
+    repo: fap-api
+    depends_on:
+      - INTERNAL-LINK-01A
+      - CONTENT-OPS-02B
+    branch: codex/internal-link-01b-graph-dry-run-read-model
+    base: main
+    title: "feat(seo): add internal link graph dry-run read model"
+    name: "Internal link graph dry-run read model"
+    train_scope: content_ops_claim_link_runtime
+    risk_level: medium_read_model_only
+    type: service/command/tests
+    scope:
+      - Add a backend read-only internal link graph dry-run service and optional command.
+      - Report current links, missing opportunities, unsafe fallback links, entity-key coverage, locale-pair coverage, and claim-sensitive link risks.
+      - Keep output read-only and CI-readable without writing links or CMS content.
+    allowed_paths:
+      - backend/app/Services/SeoIntel/InternalLink/**
+      - backend/app/Console/Commands/SeoIntelInternalLinkGraphCommand.php
+      - backend/tests/Feature/SeoIntel/SeoIntelInternalLinkGraphDryRunTest.php
+      - backend/docs/seo/internal-link-graph-dry-run.md
+      - backend/docs/seo/generated/internal-link-graph-dry-run.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Write CMS links, mutate ArticleTestEdge or career pivots, modify fap-web, use sitemap/crawler/search responses as authority, enqueue Search Channel, submit URLs, run migrations, activate scheduler, edit env, or deploy.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelInternalLinkGraphDryRun --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/internal-link-graph-dry-run.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: CLAIM-LINT-01A
+
+  - id: CLAIM-LINT-01A
+    repo: fap-api
+    depends_on:
+      - CONTENT-OPS-02A
+    branch: codex/claim-lint-01a-chinese-runtime-contract
+    base: main
+    title: "docs(seo): add Chinese claim linter runtime contract"
+    name: "Chinese claim linter runtime contract"
+    train_scope: content_ops_claim_link_runtime
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define reusable Chinese claim linter runtime and CI contract for public copy, metadata, FAQ, JSON-LD, llms, articles, Research, career, and test surfaces.
+      - Expand claim phrase classes for MBTI salary/turnover, career recommendation, hiring suitability, diagnosis, IQ, Big Five, and RIASEC risks.
+      - Define safe, needs_review, and blocked output states plus P0/P1/P2/P3 issue severity mapping.
+    allowed_paths:
+      - backend/docs/seo/chinese-claim-linter-runtime-contract.md
+      - backend/docs/seo/generated/chinese-claim-linter-runtime-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelChineseClaimLinterRuntimeContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Activate runtime enforcement, mutate CMS content, rewrite copy, publish content, change fap-web, change public runtime, modify sitemap/llms, write seo_intel, or run production scans.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelChineseClaimLinterRuntimeContract --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/chinese-claim-linter-runtime-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: CLAIM-LINT-01B
+
+  - id: CLAIM-LINT-01B
+    repo: fap-api
+    depends_on:
+      - CLAIM-LINT-01A
+      - CONTENT-OPS-02B
+    branch: codex/claim-lint-01b-chinese-runtime-ci
+    base: main
+    title: "feat(seo): add Chinese claim linter runtime and CI command"
+    name: "Chinese claim linter runtime CI"
+    train_scope: content_ops_claim_link_runtime
+    risk_level: medium_ci_guard
+    type: service/command/tests
+    scope:
+      - Add a reusable backend Chinese claim linter service and CI-readable command.
+      - Scan candidate public-copy inputs and classify safe, needs_review, or blocked with severity mapping.
+      - Integrate with publish rehearsal output as a dry-run gate without auto-rewriting or publishing.
+    allowed_paths:
+      - backend/app/Services/SeoIntel/ClaimLint/**
+      - backend/app/Console/Commands/SeoIntelClaimLintCommand.php
+      - backend/tests/Feature/SeoIntel/SeoIntelChineseClaimLinterRuntimeTest.php
+      - backend/tests/Fixtures/SeoIntel/claim_lint/**
+      - backend/docs/seo/chinese-claim-linter-runtime.md
+      - backend/docs/seo/generated/chinese-claim-linter-runtime.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Auto-rewrite content, auto-publish, mutate CMS, scan private production data, write seo_intel, enqueue Search Channel, submit URLs, modify fap-web, activate scheduler, edit env, or deploy.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelChineseClaimLinterRuntime --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/chinese-claim-linter-runtime.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: CONTENT-OPS-CLAIM-LINK-OPS-READINESS
+
+  - id: CONTENT-OPS-CLAIM-LINK-OPS-READINESS
+    repo: fap-api
+    depends_on:
+      - CONTENT-OPS-02B
+      - INTERNAL-LINK-01B
+      - CLAIM-LINT-01B
+    branch: codex/content-ops-claim-link-ops-readiness
+    base: main
+    title: "docs(ops): add content ops claim link display readiness"
+    name: "Content Ops claim/link /ops/seo display readiness"
+    train_scope: content_ops_claim_link_runtime
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define future read-only /ops/seo panels for publish rehearsal, internal link graph, claim lint severity, entity-key coverage, and observation planning.
+      - Keep the page operational/read-only and forbid action buttons, write controls, submit controls, scheduler controls, collector controls, raw SQL, raw payloads, raw crawler logs, and Metabase exposure.
+    allowed_paths:
+      - backend/docs/seo/content-ops-claim-link-ops-readiness.md
+      - backend/docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelContentOpsClaimLinkOpsReadinessTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Implement Filament UI, add action buttons, write services, migrations, production env changes, fap-web changes, Metabase exposure, scheduler controls, collector controls, or Search Channel controls.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelContentOpsClaimLinkOpsReadiness --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: CONTENT-OPS-CLAIM-LINK-CLOSEOUT
+
+  - id: CONTENT-OPS-CLAIM-LINK-CLOSEOUT
+    repo: fap-api
+    depends_on:
+      - CONTENT-OPS-CLAIM-LINK-OPS-READINESS
+    branch: codex/content-ops-claim-link-closeout
+    base: main
+    title: "docs(content-ops): close content ops claim link runtime train"
+    name: "Content Ops claim/link runtime closeout"
+    train_scope: content_ops_claim_link_runtime
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Close the Content Ops / Claim Lint / Internal Link runtime train.
+      - Summarize publish rehearsal, internal link graph, Chinese claim linter, /ops/seo readiness, validation, deferred schema work, and next task recommendation.
+      - Confirm no production operations, CMS mutations, Search Channel writes, crawler log reads, scheduler activation, deploys, or fap-web changes occurred.
+    allowed_paths:
+      - backend/docs/seo/content-ops-claim-link-runtime-closeout.md
+      - backend/docs/seo/generated/content-ops-claim-link-runtime-closeout.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelContentOpsClaimLinkRuntimeCloseoutTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add runtime code, migrations, production operations, env edits, fap-web changes, CMS mutations, Search Channel mutations, collector writes, or scheduler activation.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelContentOpsClaimLinkRuntimeCloseout --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/content-ops-claim-link-runtime-closeout.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01-COMPLETE


### PR DESCRIPTION
## What changed
- Added the CONTENT-OPS-02A content publish rehearsal contract.
- Added a generated JSON contract artifact and focused SeoIntel contract test.
- Registered/aligned the CONTENT-OPS-CLAIM-LINK-RUNTIME train entries in the PR train manifest/state.

## Why
This locks the dry-run-only publish rehearsal boundary before runtime work: no CMS mutation, no article publish, no sitemap/llms mutation, no Search Channel enqueue/submission, no Observation Queue write, and no fap-web authority drift.

## Validation commands
- cd backend && php artisan test --filter=SeoIntelContentPublishRehearsalContract --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/content-publish-rehearsal-contract.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No runtime rehearsal service or command.
- No CMS publish or mutation.
- No Observation Queue writes.
- No Search Channel enqueue/submission.
- No sitemap/llms changes.
- No fap-web changes.

## Repository rule impact
Content publish rehearsal is defined as backend/CMS-authoritative and dry-run only. fap-web remains a deterministic renderer and must not become content, SEO metadata, internal link, sitemap, or llms authority.