### PR TITLE
docs(seo-intel): add semantic internal link graph contract

### DIFF
--- a/backend/docs/seo/generated/semantic-internal-link-graph-contract.v1.json
+++ b/backend/docs/seo/generated/semantic-internal-link-graph-contract.v1.json
@@ -1,0 +1,91 @@
+{
+  "version": "semantic-internal-link-graph-contract.v1",
+  "task": "INTERNAL-LINK-01A",
+  "purpose": "semantic_internal_link_graph_contract",
+  "mode": "contract_only_no_link_mutation",
+  "authority_model": {
+    "backend_cms_entity_graph": "internal_link_truth",
+    "fap_web": "deterministic_renderer_observation_only",
+    "sitemap": "observation_signal_only",
+    "llms": "observation_signal_only",
+    "crawler_logs": "observation_signal_only",
+    "gsc_ga4_referral": "opportunity_signal_only_no_auto_link"
+  },
+  "entity_key_rule": {
+    "preferred": "translation_group_uuid",
+    "transitional": "translation_group_id_where_already_supported",
+    "missing": "legacy_unpaired",
+    "migration_helper_only": "title_slug_similarity"
+  },
+  "required_link_families": [
+    "article_to_test",
+    "article_to_topic",
+    "article_to_research",
+    "article_to_related_article",
+    "topic_to_test",
+    "topic_to_article",
+    "topic_to_personality_entity",
+    "research_to_topic_test_article",
+    "test_to_article_topic_research",
+    "career_guide_to_test_topic_article",
+    "career_job_to_career_guide_test_topic",
+    "personality_page_to_test_topic_article"
+  ],
+  "future_graph_fields": [
+    "source_entity_type",
+    "source_entity_key",
+    "target_entity_type",
+    "target_entity_key",
+    "link_role",
+    "locale",
+    "authority_source",
+    "visibility_state",
+    "safety_state",
+    "created_by_system",
+    "review_state"
+  ],
+  "states": [
+    "safe",
+    "needs_review",
+    "blocked"
+  ],
+  "forbidden_authority_sources": [
+    "frontend_fallback",
+    "static_sitemap",
+    "static_llms",
+    "crawler_logs",
+    "search_engine_responses",
+    "local_copies"
+  ],
+  "forbidden_behaviors": [
+    "runtime_link_write",
+    "cms_mutation",
+    "fap_web_modification",
+    "migration_creation",
+    "crawler_derived_link_authority",
+    "sitemap_derived_graph_truth",
+    "llms_derived_graph_truth",
+    "frontend_fallback_as_graph_authority",
+    "gsc_ga4_referral_auto_link_creation",
+    "title_slug_similarity_as_permanent_key",
+    "search_channel_enqueue",
+    "url_submission",
+    "observation_queue_write",
+    "pseo_generation"
+  ],
+  "safety_flags": {
+    "docs_only": true,
+    "generated_json_only": true,
+    "focused_tests_only": true,
+    "runtime_link_writer_added": false,
+    "cms_content_mutation": false,
+    "fap_web_modified": false,
+    "migration_added": false,
+    "crawler_authority_added": false,
+    "search_submission_added": false,
+    "observation_queue_write_added": false,
+    "pseo_generation": false
+  },
+  "final_decision": "semantic_internal_link_graph_contract_ready",
+  "next_task": "INTERNAL-LINK-01B"
+}

--- a/backend/docs/seo/semantic-internal-link-graph-contract.md
+++ b/backend/docs/seo/semantic-internal-link-graph-contract.md
@@ -1,0 +1,88 @@
+# Semantic Internal Link Graph Contract
+
+## Purpose
+
+INTERNAL-LINK-01A defines the backend-owned semantic internal link graph
+contract for SEO-sensitive content operations.
+
+The graph is a contract only in this PR. It does not mutate CMS content, does not create internal links, does not modify fap-web, does not add migrations, does not write `seo_intel`, and does not use crawler logs, sitemap, `llms.txt`, GSC, GA4, referral data, or frontend fallback links as graph authority.
+
+## Authority Model
+
+Backend/CMS entity graph owns internal link truth. `fap-web` renders links from
+backend/public API contracts and may expose deterministic runtime observations,
+but static frontend links are not final authority. Sitemap-derived links,
+crawler logs, search engine responses, analytics, and referral signals may only
+suggest opportunities for human review; they cannot auto-create links.
+
+## Entity Key Rule
+
+`entity_key` should prefer `translation_group_uuid` when available. Existing
+`translation_group_id` may be transitional where already supported. Surfaces
+without a stable key must be marked `legacy_unpaired`. Title or slug similarity
+may be used only as a migration helper, not as authority.
+
+## Required Link Families
+
+- article -> test
+- article -> topic
+- article -> research
+- article -> related_article
+- topic -> test
+- topic -> article
+- topic -> personality/entity
+- research -> topic/test/article
+- test -> article/topic/research
+- career_guide -> test/topic/article
+- career_job -> career_guide/test/topic
+- personality_page -> test/topic/article
+
+## Future Graph Fields
+
+- source_entity_type
+- source_entity_key
+- target_entity_type
+- target_entity_key
+- link_role
+- locale
+- authority_source
+- visibility_state
+- safety_state
+- created_by_system
+- review_state
+
+## Safety States
+
+The future dry-run/read model should classify graph edges and opportunities as:
+
+- safe
+- needs_review
+- blocked
+
+`blocked` applies to links derived from forbidden authority sources, missing
+stable source or target identity, private/noindex/claim-unsafe surfaces, or
+links that would bypass CMS/backend review.
+
+## Forbidden Behavior
+
+This contract forbids:
+
+- runtime link writes
+- CMS mutation
+- fap-web modification
+- migration creation
+- crawler-derived link authority
+- sitemap-derived graph truth
+- `llms.txt`-derived graph truth
+- frontend fallback as graph authority
+- GSC/GA4/referral auto-link creation
+- title/slug similarity as permanent key
+- Search Channel enqueue or submission
+- Observation Queue write
+- pSEO generation
+
+## Final Decision
+
+`semantic_internal_link_graph_contract_ready`
+
+Next task: `INTERNAL-LINK-01B`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSemanticInternalLinkGraphContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSemanticInternalLinkGraphContractTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSemanticInternalLinkGraphContractTest extends TestCase
+{
+    #[Test]
+    public function contract_file_and_generated_artifact_exist_and_parse(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/semantic-internal-link-graph-contract.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('semantic-internal-link-graph-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('INTERNAL-LINK-01A', $artifact['task'] ?? null);
+        $this->assertSame('semantic_internal_link_graph_contract', $artifact['purpose'] ?? null);
+        $this->assertSame('contract_only_no_link_mutation', $artifact['mode'] ?? null);
+    }
+
+    #[Test]
+    public function required_link_families_and_fields_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'article_to_test',
+            'article_to_topic',
+            'article_to_research',
+            'article_to_related_article',
+            'topic_to_test',
+            'topic_to_article',
+            'topic_to_personality_entity',
+            'research_to_topic_test_article',
+            'test_to_article_topic_research',
+            'career_guide_to_test_topic_article',
+            'career_job_to_career_guide_test_topic',
+            'personality_page_to_test_topic_article',
+        ] as $family) {
+            $this->assertContains($family, $artifact['required_link_families'] ?? []);
+        }
+
+        foreach ([
+            'source_entity_type',
+            'source_entity_key',
+            'target_entity_type',
+            'target_entity_key',
+            'link_role',
+            'locale',
+            'authority_source',
+            'visibility_state',
+            'safety_state',
+            'created_by_system',
+            'review_state',
+        ] as $field) {
+            $this->assertContains($field, $artifact['future_graph_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function entity_key_and_authority_rules_block_fallback_truth(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('translation_group_uuid', data_get($artifact, 'entity_key_rule.preferred'));
+        $this->assertSame('translation_group_id_where_already_supported', data_get($artifact, 'entity_key_rule.transitional'));
+        $this->assertSame('legacy_unpaired', data_get($artifact, 'entity_key_rule.missing'));
+        $this->assertSame('title_slug_similarity', data_get($artifact, 'entity_key_rule.migration_helper_only'));
+
+        foreach ([
+            'frontend_fallback',
+            'static_sitemap',
+            'static_llms',
+            'crawler_logs',
+            'search_engine_responses',
+            'local_copies',
+        ] as $source) {
+            $this->assertContains($source, $artifact['forbidden_authority_sources'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function forbidden_behaviors_and_safety_flags_block_link_mutation(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'runtime_link_write',
+            'cms_mutation',
+            'fap_web_modification',
+            'migration_creation',
+            'crawler_derived_link_authority',
+            'sitemap_derived_graph_truth',
+            'llms_derived_graph_truth',
+            'frontend_fallback_as_graph_authority',
+            'gsc_ga4_referral_auto_link_creation',
+            'title_slug_similarity_as_permanent_key',
+            'search_channel_enqueue',
+            'url_submission',
+            'observation_queue_write',
+            'pseo_generation',
+        ] as $behavior) {
+            $this->assertContains($behavior, $artifact['forbidden_behaviors'] ?? []);
+        }
+
+        foreach ([
+            'docs_only',
+            'generated_json_only',
+            'focused_tests_only',
+        ] as $flag) {
+            $this->assertTrue((bool) data_get($artifact, "safety_flags.{$flag}"), $flag.' must be true');
+        }
+
+        foreach ([
+            'runtime_link_writer_added',
+            'cms_content_mutation',
+            'fap_web_modified',
+            'migration_added',
+            'crawler_authority_added',
+            'search_submission_added',
+            'observation_queue_write_added',
+            'pseo_generation',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, "safety_flags.{$flag}", true), $flag.' must be false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_contract_only_boundary_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/semantic-internal-link-graph-contract.md')));
+        $artifactJson = strtolower((string) json_encode($this->artifact(), JSON_THROW_ON_ERROR));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'backend-owned semantic internal link graph',
+            'contract only',
+            'does not mutate cms content',
+            'does not create internal links',
+            'does not modify fap-web',
+            'crawler logs',
+            'cannot auto-create links',
+            'translation_group_uuid',
+            'legacy_unpaired',
+            'title or slug similarity',
+            'next task: `internal-link-01b`',
+            '"next_task":"internal-link-01b"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/semantic-internal-link-graph-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T15:30:05+08:00",
+  "updated_at": "2026-05-22T15:31:12+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18030,12 +18030,12 @@
     "INTERNAL-LINK-01A": {
       "repo": "fap-api",
       "branch": "codex/internal-link-01a-semantic-link-graph-contract",
-      "status": "committed",
+      "status": "pr_open",
       "depends_on": [
         "CONTENT-OPS-02A"
       ],
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1564",
       "checks": {
         "local": {
           "php_artisan_test_filter_contract": "passed: php artisan test --filter=SeoIntelSemanticInternalLinkGraphContract --no-ansi (5 tests, 85 assertions)",
@@ -18077,6 +18077,11 @@
           "at": "2026-05-22T15:30:05+08:00",
           "status": "committed",
           "summary": "Committed INTERNAL-LINK-01A scoped contract changes. PR head SHA will be recorded after push/PR open; final merge SHA will be recorded after squash merge."
+        },
+        {
+          "at": "2026-05-22T15:31:12+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1564 for INTERNAL-LINK-01A and pushed branch codex/internal-link-01a-semantic-link-graph-contract."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T15:16:49+08:00",
+  "updated_at": "2026-05-22T15:30:05+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17952,11 +17952,11 @@
     "CONTENT-OPS-02B": {
       "repo": "fap-api",
       "branch": "codex/content-ops-02b-publish-rehearsal-dry-run",
-      "status": "ci_fix_local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "CONTENT-OPS-02A"
       ],
-      "commit_sha": "cbee441980261cd7c1d36fc41f640b5cd13d81a1",
+      "commit_sha": "af584594a658492572b8e1216c619b6373db2149",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1563",
       "checks": {
         "local": {
@@ -17978,13 +17978,17 @@
           "git_diff_check_after_fix": "passed: git diff --check"
         },
         "github": {
-          "pr_1563_initial": "failed: verify-mbti-legacy and verify-mbti-v2 failed because BigFiveResultPageV2CoreBodyPreview runtime freeze flagged new SeoIntel dry-run command/service paths."
+          "pr_1563_initial": "failed: verify-mbti-legacy and verify-mbti-v2 failed because BigFiveResultPageV2CoreBodyPreview runtime freeze flagged new SeoIntel dry-run command/service paths.",
+          "pr_1563_after_fix": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_dry_run_test": "passed: php artisan test --filter=SeoIntelContentPublishRehearsalDryRun --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T07:23:10Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -18015,19 +18019,35 @@
           "at": "2026-05-22T15:16:49+08:00",
           "status": "ci_fix_local_validation_passed",
           "summary": "GitHub CI initially failed on Big Five runtime freeze because CONTENT-OPS-02B intentionally added SeoIntel dry-run runtime files. Added a focused freeze classifier allowlist test for the content publish rehearsal command/service and updated manifest allowed paths. Focused dry-run, BigFive freeze, full SeoIntel, route list, Pint, JSON/YAML, and diff checks passed locally after the fix."
+        },
+        {
+          "at": "2026-05-22T15:25:13+08:00",
+          "status": "merged",
+          "summary": "PR #1563 merged via squash at af584594a658492572b8e1216c619b6373db2149 after CI freeze guard fix. Remote branch was deleted, local main synced, and post-merge dry-run test passed."
         }
       ]
     },
     "INTERNAL-LINK-01A": {
       "repo": "fap-api",
-      "branch": "codex/internal-link-01a-semantic-graph-contract",
-      "status": "pending",
+      "branch": "codex/internal-link-01a-semantic-link-graph-contract",
+      "status": "committed",
       "depends_on": [
         "CONTENT-OPS-02A"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_contract": "passed: php artisan test --filter=SeoIntelSemanticInternalLinkGraphContract --no-ansi (5 tests, 85 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (429 tests, 6871 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3472 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/semantic-internal-link-graph-contract.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18042,6 +18062,21 @@
           "at": "2026-05-22T14:37:34+08:00",
           "status": "pending",
           "summary": "Registered semantic internal link graph contract PR. Scope is backend contract docs/generated/test only and explicitly excludes link mutation and frontend fallback authority."
+        },
+        {
+          "at": "2026-05-22T15:25:13+08:00",
+          "status": "in_progress",
+          "summary": "Started INTERNAL-LINK-01A on codex/internal-link-01a-semantic-link-graph-contract. Scope is docs/generated/test only plus train metadata; no link mutation, CMS mutation, fap-web change, or migration."
+        },
+        {
+          "at": "2026-05-22T15:28:57+08:00",
+          "status": "local_validation_passed",
+          "summary": "INTERNAL-LINK-01A local validation passed for focused semantic internal link graph contract test, full SeoIntel filter, route list, Pint, JSON/YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata with no link mutation, CMS mutation, fap-web change, migration, crawler-derived authority, Search Channel enqueue, or observation write."
+        },
+        {
+          "at": "2026-05-22T15:30:05+08:00",
+          "status": "committed",
+          "summary": "Committed INTERNAL-LINK-01A scoped contract changes. PR head SHA will be recorded after push/PR open; final merge SHA will be recorded after squash merge."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9421,9 +9421,9 @@ prs:
     repo: fap-api
     depends_on:
       - CONTENT-OPS-02A
-    branch: codex/internal-link-01a-semantic-graph-contract
+    branch: codex/internal-link-01a-semantic-link-graph-contract
     base: main
-    title: "docs(seo): add semantic internal link graph contract"
+    title: "docs(seo-intel): add semantic internal link graph contract"
     name: "Semantic internal link graph contract"
     train_scope: content_ops_claim_link_runtime
     risk_level: low_contract_only


### PR DESCRIPTION
## What changed
- Added the semantic internal link graph contract for backend/CMS-owned link authority.
- Added a generated JSON contract artifact and focused SeoIntel contract test.
- Aligned train manifest/state for INTERNAL-LINK-01A.

## Why
- Locks the authority boundary before the dry-run/read-model PR.
- Defines link families, future graph fields, entity key preference, and forbidden sources such as crawler logs, sitemap-derived truth, and frontend fallback authority.

## Validation
- cd backend && php artisan test --filter=SeoIntelSemanticInternalLinkGraphContract --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/semantic-internal-link-graph-contract.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No runtime link write service.
- No CMS mutation or content changes.
- No fap-web changes.
- No migrations, Search Channel enqueue, crawler log reads, or production operations.