### PR TITLE
feat(seo-intel): add internal link graph dry-run read model

### DIFF
--- a/backend/app/Console/Commands/SeoIntelInternalLinkGraphCommand.php
+++ b/backend/app/Console/Commands/SeoIntelInternalLinkGraphCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\InternalLink\InternalLinkGraphDryRun;
+use Illuminate\Console\Command;
+
+final class SeoIntelInternalLinkGraphCommand extends Command
+{
+    protected $signature = 'seo-intel:internal-link-graph
+        {--dry-run : Required. Keep graph inspection non-mutating}
+        {--no-write : Required. Prevent all persistence}
+        {--json : Required. Output safe machine-readable JSON}';
+
+    protected $description = 'Run a non-mutating internal link graph readiness dry-run.';
+
+    public function handle(InternalLinkGraphDryRun $dryRun): int
+    {
+        if (! (bool) $this->option('dry-run') || ! (bool) $this->option('no-write') || ! (bool) $this->option('json')) {
+            $this->emit([
+                'runtime' => InternalLinkGraphDryRun::RUNTIME,
+                'status' => 'blocked',
+                'dry_run' => (bool) $this->option('dry-run'),
+                'no_write' => (bool) $this->option('no-write'),
+                'writes_attempted' => false,
+                'cms_mutation_attempted' => false,
+                'link_mutation_attempted' => false,
+                'search_channel_enqueue_attempted' => false,
+                'search_submission_attempted' => false,
+                'blockers' => [
+                    [
+                        'field' => 'command.options',
+                        'code' => 'dry_run_no_write_json_required',
+                        'message' => '--dry-run, --no-write, and --json are required.',
+                    ],
+                ],
+            ]);
+
+            return self::FAILURE;
+        }
+
+        $this->emit($dryRun->report());
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function emit(array $payload): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? 'blocked'));
+        $this->line('dry_run='.(($payload['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('no_write='.(($payload['no_write'] ?? false) ? '1' : '0'));
+        $this->line('writes_attempted='.(($payload['writes_attempted'] ?? true) ? '1' : '0'));
+    }
+}

--- a/backend/app/Services/SeoIntel/InternalLink/InternalLinkGraphDryRun.php
+++ b/backend/app/Services/SeoIntel/InternalLink/InternalLinkGraphDryRun.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\InternalLink;
+
+use App\Models\ArticleSeoMeta;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class InternalLinkGraphDryRun
+{
+    public const RUNTIME = 'internal_link_graph_dry_run';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function report(): array
+    {
+        $familyCounts = $this->emptyFamilyCounts();
+        $sourceInventory = $this->sourceInventory();
+
+        $familyCounts['article_to_test'] = $sourceInventory['cms_backend_authoritative']['article_related_test_slug']
+            + $sourceInventory['cms_backend_authoritative']['article_editorial_package_target_tests'];
+        $familyCounts['article_to_topic'] = $sourceInventory['cms_backend_authoritative']['article_editorial_package_target_topics'];
+        $familyCounts['career_guide_to_test_topic_article'] = $sourceInventory['cms_backend_authoritative']['career_guide_related_articles'];
+        $familyCounts['career_job_to_career_guide_test_topic'] = $sourceInventory['cms_backend_authoritative']['career_guide_related_jobs'];
+        $familyCounts['personality_page_to_test_topic_article'] = $sourceInventory['cms_backend_authoritative']['career_guide_related_personality_profiles'];
+
+        $missingEntityKeyCount = $this->missingEntityKeyCount();
+        $legacyUnpairedCount = $missingEntityKeyCount + $this->missingTranslationGroupUuidCount();
+        $unsafeFallbackSourceCount = array_sum($sourceInventory['unsafe_or_non_authoritative_signals']);
+        $candidateOpportunityCount = array_sum($familyCounts);
+        $warnings = $this->warnings($missingEntityKeyCount, $legacyUnpairedCount, $unsafeFallbackSourceCount);
+
+        return [
+            'runtime' => self::RUNTIME,
+            'status' => 'success',
+            'dry_run' => true,
+            'no_write' => true,
+            'writes_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'link_mutation_attempted' => false,
+            'fap_web_modification_attempted' => false,
+            'crawler_log_read_attempted' => false,
+            'crawler_log_authority_claimed' => false,
+            'sitemap_graph_truth_claimed' => false,
+            'frontend_fallback_authority_claimed' => false,
+            'search_channel_enqueue_attempted' => false,
+            'search_submission_attempted' => false,
+            'observation_queue_write_attempted' => false,
+            'source_inventory' => $sourceInventory,
+            'graph_family_counts' => $familyCounts,
+            'missing_entity_key_count' => $missingEntityKeyCount,
+            'legacy_unpaired_count' => $legacyUnpairedCount,
+            'candidate_opportunity_count' => $candidateOpportunityCount,
+            'unsafe_fallback_source_count' => $unsafeFallbackSourceCount,
+            'entity_key_policy' => [
+                'preferred' => 'translation_group_uuid',
+                'transitional' => 'translation_group_id_where_already_supported',
+                'missing' => 'legacy_unpaired',
+                'title_slug_similarity' => 'migration_helper_only_not_authority',
+            ],
+            'authority_policy' => [
+                'truth_source' => 'backend_cms_entity_graph',
+                'fap_web' => 'deterministic_renderer_observation_signal_only',
+                'sitemap' => 'observation_signal_only_not_graph_truth',
+                'crawler_logs' => 'aggregate_observation_only_never_link_authority',
+                'gsc_ga4_referral' => 'opportunity_signal_only_never_auto_create_links',
+            ],
+            'warnings' => $warnings,
+            'safety_flags' => [
+                'dry_run_only' => true,
+                'no_cms_mutation' => true,
+                'no_link_mutation' => true,
+                'no_fap_web_modification' => true,
+                'no_crawler_log_read' => true,
+                'no_crawler_derived_authority' => true,
+                'no_sitemap_derived_truth' => true,
+                'no_frontend_fallback_authority' => true,
+                'no_auto_link_creation' => true,
+                'no_search_channel_enqueue' => true,
+                'no_search_submission' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function emptyFamilyCounts(): array
+    {
+        return [
+            'article_to_test' => 0,
+            'article_to_topic' => 0,
+            'article_to_research' => 0,
+            'article_to_related_article' => 0,
+            'topic_to_test' => 0,
+            'topic_to_article' => 0,
+            'topic_to_personality_entity' => 0,
+            'research_to_topic_test_article' => 0,
+            'test_to_article_topic_research' => 0,
+            'career_guide_to_test_topic_article' => 0,
+            'career_job_to_career_guide_test_topic' => 0,
+            'personality_page_to_test_topic_article' => 0,
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    private function sourceInventory(): array
+    {
+        return [
+            'cms_backend_authoritative' => [
+                'article_related_test_slug' => $this->articleRelatedTestSlugCount(),
+                'article_editorial_package_target_tests' => $this->articleEditorialPackageListCount('target_tests'),
+                'article_editorial_package_target_topics' => $this->articleEditorialPackageListCount('target_topics'),
+                'career_guide_related_articles' => $this->tableCount('career_guide_article_map'),
+                'career_guide_related_jobs' => $this->tableCount('career_guide_job_map'),
+                'career_guide_related_personality_profiles' => $this->tableCount('career_guide_personality_map'),
+            ],
+            'deterministic_public_runtime_signals' => [
+                'fap_web_rendered_links_observed' => 0,
+            ],
+            'unsafe_or_non_authoritative_signals' => [
+                'frontend_fallback_links' => 0,
+                'sitemap_derived_links' => 0,
+                'llms_derived_links' => 0,
+                'crawler_log_derived_links' => 0,
+                'search_engine_response_derived_links' => 0,
+            ],
+        ];
+    }
+
+    private function articleRelatedTestSlugCount(): int
+    {
+        if (! Schema::hasTable('articles')) {
+            return 0;
+        }
+
+        return (int) DB::table('articles')
+            ->whereNotNull('related_test_slug')
+            ->where('related_test_slug', '!=', '')
+            ->count();
+    }
+
+    private function articleEditorialPackageListCount(string $key): int
+    {
+        if (! Schema::hasTable('article_seo_meta')) {
+            return 0;
+        }
+
+        return ArticleSeoMeta::query()
+            ->withoutGlobalScopes()
+            ->get(['schema_json'])
+            ->sum(function (ArticleSeoMeta $seoMeta) use ($key): int {
+                $items = data_get($seoMeta->schema_json, 'editorial_package_v1.'.$key, []);
+
+                return is_array($items) ? count($items) : 0;
+            });
+    }
+
+    private function missingEntityKeyCount(): int
+    {
+        if (! Schema::hasTable('articles')) {
+            return 0;
+        }
+
+        return (int) DB::table('articles')
+            ->where(static function ($query): void {
+                $query
+                    ->whereNull('translation_group_id')
+                    ->orWhere('translation_group_id', '=', '');
+            })
+            ->count();
+    }
+
+    private function missingTranslationGroupUuidCount(): int
+    {
+        $count = 0;
+
+        foreach (['articles', 'career_guides', 'career_jobs', 'personality_profiles'] as $table) {
+            if (! Schema::hasTable($table) || Schema::hasColumn($table, 'translation_group_uuid')) {
+                continue;
+            }
+
+            $count += (int) DB::table($table)->count();
+        }
+
+        return $count;
+    }
+
+    private function tableCount(string $table): int
+    {
+        if (! Schema::hasTable($table)) {
+            return 0;
+        }
+
+        return (int) DB::table($table)->count();
+    }
+
+    /**
+     * @return list<array<string, string|int>>
+     */
+    private function warnings(int $missingEntityKeyCount, int $legacyUnpairedCount, int $unsafeFallbackSourceCount): array
+    {
+        $warnings = [];
+
+        if ($missingEntityKeyCount > 0) {
+            $warnings[] = [
+                'code' => 'missing_entity_key',
+                'message' => 'Some backend CMS entities do not have a stable entity_key candidate.',
+                'count' => $missingEntityKeyCount,
+            ];
+        }
+
+        if ($legacyUnpairedCount > 0) {
+            $warnings[] = [
+                'code' => 'legacy_unpaired',
+                'message' => 'translation_group_uuid is not universally available; legacy_unpaired coverage remains transitional.',
+                'count' => $legacyUnpairedCount,
+            ];
+        }
+
+        if ($unsafeFallbackSourceCount > 0) {
+            $warnings[] = [
+                'code' => 'unsafe_fallback_source_detected',
+                'message' => 'A non-authoritative link source was observed and must not become graph truth.',
+                'count' => $unsafeFallbackSourceCount,
+            ];
+        }
+
+        return $warnings;
+    }
+}

--- a/backend/docs/seo/generated/internal-link-graph-dry-run.v1.json
+++ b/backend/docs/seo/generated/internal-link-graph-dry-run.v1.json
@@ -1,0 +1,64 @@
+{
+  "version": "internal-link-graph-dry-run.v1",
+  "task": "INTERNAL-LINK-01B",
+  "service": "App\\Services\\SeoIntel\\InternalLink\\InternalLinkGraphDryRun",
+  "command": "seo-intel:internal-link-graph --dry-run --no-write --json",
+  "runtime": "internal_link_graph_dry_run",
+  "required_output_fields": [
+    "dry_run",
+    "writes_attempted",
+    "cms_mutation_attempted",
+    "link_mutation_attempted",
+    "source_inventory",
+    "graph_family_counts",
+    "missing_entity_key_count",
+    "legacy_unpaired_count",
+    "candidate_opportunity_count",
+    "unsafe_fallback_source_count",
+    "warnings"
+  ],
+  "required_graph_families": [
+    "article_to_test",
+    "article_to_topic",
+    "article_to_research",
+    "article_to_related_article",
+    "topic_to_test",
+    "topic_to_article",
+    "topic_to_personality_entity",
+    "research_to_topic_test_article",
+    "test_to_article_topic_research",
+    "career_guide_to_test_topic_article",
+    "career_job_to_career_guide_test_topic",
+    "personality_page_to_test_topic_article"
+  ],
+  "authority_policy": {
+    "truth_source": "backend_cms_entity_graph",
+    "fap_web": "deterministic_renderer_observation_signal_only",
+    "sitemap": "observation_signal_only_not_graph_truth",
+    "llms": "observation_signal_only_not_graph_truth",
+    "crawler_logs": "aggregate_observation_only_never_link_authority",
+    "gsc_ga4_referral": "opportunity_signal_only_never_auto_create_links"
+  },
+  "entity_key_policy": {
+    "preferred": "translation_group_uuid",
+    "transitional": "translation_group_id_where_already_supported",
+    "missing": "legacy_unpaired",
+    "title_slug_similarity": "migration_helper_only_not_authority"
+  },
+  "safety_flags": {
+    "dry_run_only": true,
+    "no_cms_mutation": true,
+    "no_link_mutation": true,
+    "no_fap_web_modification": true,
+    "no_crawler_log_read": true,
+    "no_crawler_derived_authority": true,
+    "no_sitemap_derived_truth": true,
+    "no_frontend_fallback_authority": true,
+    "no_auto_link_creation": true,
+    "no_search_channel_enqueue": true,
+    "no_search_submission": true,
+    "no_observation_queue_write": true
+  },
+  "final_decision": "internal_link_graph_dry_run_ready",
+  "next_task": "CLAIM-LINT-01A"
+}

--- a/backend/docs/seo/internal-link-graph-dry-run.md
+++ b/backend/docs/seo/internal-link-graph-dry-run.md
@@ -1,0 +1,79 @@
+# Internal Link Graph Dry-run Read Model
+
+Task: `INTERNAL-LINK-01B`
+
+This PR adds a backend dry-run/read model for semantic internal link graph readiness. It reports current backend/CMS link sources, graph family coverage, entity-key gaps, legacy pairing gaps, and unsafe fallback-source counters without writing links.
+
+## Runtime Boundary
+
+The dry-run runtime is:
+
+- `App\Services\SeoIntel\InternalLink\InternalLinkGraphDryRun`
+- optional command: `php artisan seo-intel:internal-link-graph --dry-run --no-write --json`
+
+The command requires all three safety flags:
+
+- `--dry-run`
+- `--no-write`
+- `--json`
+
+## Output Contract
+
+The JSON report includes:
+
+- `dry_run=true`
+- `writes_attempted=false`
+- `cms_mutation_attempted=false`
+- `link_mutation_attempted=false`
+- `source_inventory`
+- `graph_family_counts`
+- `missing_entity_key_count`
+- `legacy_unpaired_count`
+- `candidate_opportunity_count`
+- `unsafe_fallback_source_count`
+- `warnings`
+
+## Authority Rules
+
+Backend/CMS entity graph remains internal link truth. The read model may count CMS-owned sources such as article `related_test_slug`, article editorial package target topics/tests, and career guide relation maps.
+
+The following are signals only and must not become graph truth:
+
+- fap-web rendered links
+- frontend fallback links
+- sitemap-derived links
+- `llms.txt`-derived links
+- crawler logs
+- search engine responses
+- GSC/GA4/referral data
+
+GSC, GA4, and referral data may suggest opportunities in a future manual review workflow, but this runtime does not auto-create links.
+
+## Entity Key Policy
+
+The read model follows the governance contract:
+
+- prefer `translation_group_uuid`
+- use existing `translation_group_id` only as a transitional key where already supported
+- mark missing coverage as `legacy_unpaired`
+- title/slug similarity is a migration helper only, not authority
+
+## Safety Guarantees
+
+This dry-run:
+
+- does not mutate CMS content
+- does not create internal links
+- does not modify fap-web
+- does not run migrations
+- does not read crawler logs
+- does not claim crawler logs as authority
+- does not use sitemap or `llms.txt` as graph truth
+- does not enqueue Search Channel rows
+- does not submit URLs
+- does not write Observation Queue rows
+- does not write `seo_intel`
+
+## Next Task
+
+Next task: `CLAIM-LINT-01A`

--- a/backend/tests/Feature/SeoIntel/SeoIntelInternalLinkGraphDryRunTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelInternalLinkGraphDryRunTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Services\SeoIntel\InternalLink\InternalLinkGraphDryRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Tests\TestCase;
+
+final class SeoIntelInternalLinkGraphDryRunTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function service_reports_graph_readiness_without_writes_or_link_mutation(): void
+    {
+        $article = $this->createArticleWithSeoMeta([
+            'related_test_slug' => 'mbti-personality-test',
+            'target_tests' => ['big-five-personality-test', 'enneagram-test'],
+            'target_topics' => ['personality-at-work'],
+        ]);
+
+        $before = $this->articleSnapshot($article);
+        $report = (new InternalLinkGraphDryRun)->report();
+
+        $this->assertSame('internal_link_graph_dry_run', $report['runtime']);
+        $this->assertSame('success', $report['status']);
+        $this->assertTrue($report['dry_run']);
+        $this->assertTrue($report['no_write']);
+        $this->assertFalse($report['writes_attempted']);
+        $this->assertFalse($report['cms_mutation_attempted']);
+        $this->assertFalse($report['link_mutation_attempted']);
+        $this->assertFalse($report['fap_web_modification_attempted']);
+        $this->assertFalse($report['crawler_log_read_attempted']);
+        $this->assertFalse($report['crawler_log_authority_claimed']);
+        $this->assertFalse($report['sitemap_graph_truth_claimed']);
+        $this->assertFalse($report['frontend_fallback_authority_claimed']);
+        $this->assertFalse($report['search_channel_enqueue_attempted']);
+        $this->assertFalse($report['search_submission_attempted']);
+        $this->assertFalse($report['observation_queue_write_attempted']);
+
+        $this->assertSame(1, $report['source_inventory']['cms_backend_authoritative']['article_related_test_slug']);
+        $this->assertSame(2, $report['source_inventory']['cms_backend_authoritative']['article_editorial_package_target_tests']);
+        $this->assertSame(1, $report['source_inventory']['cms_backend_authoritative']['article_editorial_package_target_topics']);
+        $this->assertSame(3, $report['graph_family_counts']['article_to_test']);
+        $this->assertSame(1, $report['graph_family_counts']['article_to_topic']);
+        $this->assertSame(4, $report['candidate_opportunity_count']);
+        $this->assertSame(0, $report['unsafe_fallback_source_count']);
+
+        $this->assertSame($before, $this->articleSnapshot($article));
+    }
+
+    #[Test]
+    public function service_marks_missing_entity_keys_as_legacy_unpaired_without_title_slug_authority(): void
+    {
+        $article = $this->createArticleWithSeoMeta();
+        DB::table('articles')
+            ->where('id', (int) $article->id)
+            ->update(['translation_group_id' => '']);
+
+        $report = (new InternalLinkGraphDryRun)->report();
+
+        $this->assertSame(1, $report['missing_entity_key_count']);
+        $this->assertGreaterThanOrEqual(1, $report['legacy_unpaired_count']);
+        $this->assertSame('translation_group_uuid', $report['entity_key_policy']['preferred']);
+        $this->assertSame('migration_helper_only_not_authority', $report['entity_key_policy']['title_slug_similarity']);
+        $this->assertContains('missing_entity_key', array_column($report['warnings'], 'code'));
+        $this->assertContains('legacy_unpaired', array_column($report['warnings'], 'code'));
+    }
+
+    #[Test]
+    public function command_requires_dry_run_no_write_and_json(): void
+    {
+        $exitCode = Artisan::call('seo-intel:internal-link-graph');
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('status=blocked', $output);
+        $this->assertStringContainsString('dry_run=0', $output);
+        $this->assertStringContainsString('no_write=0', $output);
+        $this->assertStringContainsString('writes_attempted=0', $output);
+    }
+
+    #[Test]
+    public function command_emits_json_report_without_creating_links(): void
+    {
+        $article = $this->createArticleWithSeoMeta([
+            'related_test_slug' => 'mbti-personality-test',
+        ]);
+        $before = $this->articleSnapshot($article);
+
+        $exitCode = Artisan::call('seo-intel:internal-link-graph', [
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+
+        $payload = $this->artisanJsonOutput();
+
+        $this->assertSame('internal_link_graph_dry_run', $payload['runtime']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertTrue($payload['no_write']);
+        $this->assertFalse($payload['writes_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['link_mutation_attempted']);
+        $this->assertFalse($payload['search_channel_enqueue_attempted']);
+        $this->assertFalse($payload['search_submission_attempted']);
+        $this->assertSame(1, $payload['graph_family_counts']['article_to_test']);
+
+        $this->assertSame($before, $this->articleSnapshot($article));
+    }
+
+    #[Test]
+    public function command_help_exposes_no_write_create_submit_or_scheduler_options(): void
+    {
+        Artisan::call('seo-intel:internal-link-graph --help');
+        $help = Artisan::output();
+
+        foreach ([
+            '--write',
+            '--create',
+            '--apply',
+            '--submit',
+            '--scheduler',
+            '--production',
+        ] as $forbiddenOption) {
+            $this->assertDoesNotMatchRegularExpression('/(^|\\s)'.preg_quote($forbiddenOption, '/').'(=|\\s|$)/', $help);
+        }
+
+        foreach ([
+            '--dry-run',
+            '--no-write',
+            '--json',
+        ] as $allowedOption) {
+            $this->assertStringContainsString($allowedOption, $help);
+        }
+    }
+
+    #[Test]
+    public function docs_and_generated_artifact_lock_read_only_graph_boundary(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/internal-link-graph-dry-run.md')));
+        $artifact = $this->artifact();
+        $artifactJson = strtolower((string) json_encode($artifact, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+
+        $this->assertSame('internal-link-graph-dry-run.v1', $artifact['version'] ?? null);
+        $this->assertSame('INTERNAL-LINK-01B', $artifact['task'] ?? null);
+        $this->assertSame('CLAIM-LINT-01A', $artifact['next_task'] ?? null);
+        $this->assertSame('App\\Services\\SeoIntel\\InternalLink\\InternalLinkGraphDryRun', $artifact['service'] ?? null);
+        $this->assertTrue($artifact['safety_flags']['no_cms_mutation'] ?? false);
+        $this->assertTrue($artifact['safety_flags']['no_link_mutation'] ?? false);
+        $this->assertTrue($artifact['safety_flags']['no_fap_web_modification'] ?? false);
+        $this->assertTrue($artifact['safety_flags']['no_crawler_log_read'] ?? false);
+        $this->assertTrue($artifact['safety_flags']['no_auto_link_creation'] ?? false);
+
+        foreach ([
+            'dry-run/read model',
+            'does not mutate cms content',
+            'does not create internal links',
+            'does not modify fap-web',
+            'does not read crawler logs',
+            'does not use sitemap or `llms.txt` as graph truth',
+            'does not enqueue search channel rows',
+            'does not submit urls',
+            'translation_group_uuid',
+            'migration helper only',
+            'next task: `claim-lint-01a`',
+            '"next_task":"claim-lint-01a"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $doc."\n".$artifactJson);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createArticleWithSeoMeta(array $overrides = []): Article
+    {
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => (string) ($overrides['slug'] ?? 'internal-link-draft'),
+            'locale' => (string) ($overrides['locale'] ?? 'en'),
+            'title' => 'Internal Link Draft',
+            'excerpt' => 'Internal link graph dry-run fixture.',
+            'content_md' => '# Internal Link Draft',
+            'content_html' => '<h1>Internal Link Draft</h1>',
+            'related_test_slug' => (string) ($overrides['related_test_slug'] ?? ''),
+            'status' => 'draft',
+            'lifecycle_state' => Article::LIFECYCLE_ACTIVE,
+            'is_public' => false,
+            'is_indexable' => false,
+            'translation_group_id' => (string) ($overrides['translation_group_id'] ?? 'tg-internal-link'),
+        ]);
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'seo_title' => 'Internal Link Draft',
+            'seo_description' => 'Internal link graph dry-run fixture.',
+            'canonical_url' => 'https://fermatmind.com/en/articles/internal-link-draft',
+            'robots' => 'noindex,follow',
+            'is_indexable' => false,
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'target_tests' => (array) ($overrides['target_tests'] ?? []),
+                    'target_topics' => (array) ($overrides['target_topics'] ?? []),
+                ],
+            ],
+        ]);
+
+        return $article->refresh();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function articleSnapshot(Article $article): array
+    {
+        $fresh = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+
+        return [
+            'status' => (string) $fresh->status,
+            'is_public' => (bool) $fresh->is_public,
+            'is_indexable' => (bool) $fresh->is_indexable,
+            'related_test_slug' => (string) $fresh->related_test_slug,
+            'translation_group_id' => (string) $fresh->translation_group_id,
+            'published_revision_id' => $fresh->published_revision_id,
+            'published_at' => $fresh->published_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artisanJsonOutput(): array
+    {
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path('docs/seo/generated/internal-link-graph-dry-run.v1.json')), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -600,6 +600,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_internal_link_graph_dry_run_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoIntelInternalLinkGraphCommand.php',
+            'backend/app/Services/SeoIntel/InternalLink/InternalLinkGraphDryRun.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_migration_isolation_files(): void
     {
         $changed = [
@@ -1881,6 +1891,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isInternalLinkGraphDryRunFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelOpsDashboardReadModelFile($file)) {
                 continue;
             }
@@ -2503,6 +2517,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoIntelContentPublishRehearsalCommand.php',
             'backend/app/Services/SeoIntel/ContentOps/ContentPublishRehearsalDryRun.php',
+        ], true);
+    }
+
+    private function isInternalLinkGraphDryRunFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoIntelInternalLinkGraphCommand.php',
+            'backend/app/Services/SeoIntel/InternalLink/InternalLinkGraphDryRun.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T15:45:05+08:00",
+  "updated_at": "2026-05-22T15:46:17+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18099,13 +18099,13 @@
     "INTERNAL-LINK-01B": {
       "repo": "fap-api",
       "branch": "codex/internal-link-01b-graph-dry-run-read-model",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "INTERNAL-LINK-01A",
         "CONTENT-OPS-02B"
       ],
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1565",
       "checks": {
         "local": {
           "php_artisan_test_filter_dry_run": "passed: php artisan test --filter=SeoIntelInternalLinkGraphDryRun --no-ansi (6 tests, 78 assertions)",
@@ -18144,6 +18144,11 @@
           "at": "2026-05-22T15:45:05+08:00",
           "status": "local_validation_passed",
           "summary": "INTERNAL-LINK-01B local validation passed for focused dry-run test, BigFive runtime freeze allowlist, full SeoIntel filter, route list, Pint, command help, JSON/YAML parsing, and diff whitespace checks. Runtime remains read-only/no-write with no CMS mutation, link creation, fap-web change, crawler log authority, sitemap truth, Search Channel enqueue, URL submission, or Observation Queue write."
+        },
+        {
+          "at": "2026-05-22T15:46:17+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1565 for INTERNAL-LINK-01B and pushed branch codex/internal-link-01b-graph-dry-run-read-model."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T15:31:12+08:00",
+  "updated_at": "2026-05-22T15:45:05+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18030,11 +18030,11 @@
     "INTERNAL-LINK-01A": {
       "repo": "fap-api",
       "branch": "codex/internal-link-01a-semantic-link-graph-contract",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "CONTENT-OPS-02A"
       ],
-      "commit_sha": null,
+      "commit_sha": "ec6a0c6659933e8a5af3bfc77c01de3283922cc7",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1564",
       "checks": {
         "local": {
@@ -18046,12 +18046,18 @@
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1564": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_contract_test": "passed: php artisan test --filter=SeoIntelSemanticInternalLinkGraphContract --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T07:37:00Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -18082,20 +18088,38 @@
           "at": "2026-05-22T15:31:12+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1564 for INTERNAL-LINK-01A and pushed branch codex/internal-link-01a-semantic-link-graph-contract."
+        },
+        {
+          "at": "2026-05-22T15:43:19+08:00",
+          "status": "merged",
+          "summary": "PR #1564 merged via squash at ec6a0c66d1fb7c6db731e0b3fc46dd98f8102a57. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused contract test passed."
         }
       ]
     },
     "INTERNAL-LINK-01B": {
       "repo": "fap-api",
       "branch": "codex/internal-link-01b-graph-dry-run-read-model",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "INTERNAL-LINK-01A",
         "CONTENT-OPS-02B"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_dry_run": "passed: php artisan test --filter=SeoIntelInternalLinkGraphDryRun --no-ansi (6 tests, 78 assertions)",
+          "bigfive_runtime_freeze": "passed: php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi (108 tests, 455 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (435 tests, 6949 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3475 files)",
+          "command_help": "passed: php artisan seo-intel:internal-link-graph --dry-run --no-write --json --help || true",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/internal-link-graph-dry-run.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18110,6 +18134,16 @@
           "at": "2026-05-22T14:37:34+08:00",
           "status": "pending",
           "summary": "Registered internal link graph dry-run/read-model PR. Scope allows read-only backend service/command/tests only; no CMS link writes, sitemap/crawler/search authority, or fap-web change."
+        },
+        {
+          "at": "2026-05-22T15:43:19+08:00",
+          "status": "in_progress",
+          "summary": "Started INTERNAL-LINK-01B on codex/internal-link-01b-graph-dry-run-read-model. Scope is read-only internal link graph dry-run service/command, docs/generated artifact, focused test, BigFive runtime freeze allowlist for the new SeoIntel dry-run files, and train metadata; no CMS mutation, link creation, fap-web change, crawler log authority, Search Channel enqueue, or migration."
+        },
+        {
+          "at": "2026-05-22T15:45:05+08:00",
+          "status": "local_validation_passed",
+          "summary": "INTERNAL-LINK-01B local validation passed for focused dry-run test, BigFive runtime freeze allowlist, full SeoIntel filter, route list, Pint, command help, JSON/YAML parsing, and diff whitespace checks. Runtime remains read-only/no-write with no CMS mutation, link creation, fap-web change, crawler log authority, sitemap truth, Search Channel enqueue, URL submission, or Observation Queue write."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9465,7 +9465,7 @@ prs:
       - CONTENT-OPS-02B
     branch: codex/internal-link-01b-graph-dry-run-read-model
     base: main
-    title: "feat(seo): add internal link graph dry-run read model"
+    title: "feat(seo-intel): add internal link graph dry-run read model"
     name: "Internal link graph dry-run read model"
     train_scope: content_ops_claim_link_runtime
     risk_level: medium_read_model_only
@@ -9478,6 +9478,7 @@ prs:
       - backend/app/Services/SeoIntel/InternalLink/**
       - backend/app/Console/Commands/SeoIntelInternalLinkGraphCommand.php
       - backend/tests/Feature/SeoIntel/SeoIntelInternalLinkGraphDryRunTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - backend/docs/seo/internal-link-graph-dry-run.md
       - backend/docs/seo/generated/internal-link-graph-dry-run.v1.json
       - docs/codex/pr-train.yaml


### PR DESCRIPTION
## What changed
- Added a read-only InternalLinkGraphDryRun service and safety-gated Artisan command.
- Added docs, generated JSON artifact, and focused SeoIntel tests for internal link graph readiness.
- Added a BigFive runtime freeze allowlist case for the new SeoIntel dry-run command/service so CI can distinguish this read-only SEO Ops scope from MBTI/BigFive runtime changes.
- Updated the train ledger and manifest for INTERNAL-LINK-01B.

## Why
- Provides a backend-owned internal link graph readiness read model before any future link mutation work.
- Reports CMS/backend link sources, graph family counts, entity-key gaps, legacy pairing gaps, and unsafe fallback-source counters without creating links.

## Validation
- cd backend && php artisan test --filter=SeoIntelInternalLinkGraphDryRun --no-ansi
- cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && php artisan seo-intel:internal-link-graph --dry-run --no-write --json --help || true
- python3 -m json.tool backend/docs/seo/generated/internal-link-graph-dry-run.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No CMS writes or content mutation.
- No internal link creation.
- No fap-web changes.
- No migrations, crawler log reads, Search Channel enqueue, URL submission, Observation Queue writes, or production operations.