### PR TITLE
feat(seo-intel): add Chinese claim linter runtime

### DIFF
--- a/backend/app/Console/Commands/SeoIntelClaimLintCommand.php
+++ b/backend/app/Console/Commands/SeoIntelClaimLintCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\ClaimLint\ChineseClaimLinter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class SeoIntelClaimLintCommand extends Command
+{
+    protected $signature = 'seo-intel:claim-lint
+        {--fixture : Required. Scan bundled CI fixtures only}
+        {--json : Required. Output safe machine-readable JSON}';
+
+    protected $description = 'Run the Chinese claim linter against bundled non-production fixtures.';
+
+    public function handle(ChineseClaimLinter $linter): int
+    {
+        if (! (bool) $this->option('fixture') || ! (bool) $this->option('json')) {
+            $this->emit([
+                'runtime' => ChineseClaimLinter::RUNTIME,
+                'status' => 'blocked',
+                'lint_state' => 'blocked',
+                'severity' => 'P2',
+                'fixture_mode' => (bool) $this->option('fixture'),
+                'auto_rewrite_attempted' => false,
+                'cms_mutation_attempted' => false,
+                'production_scan_attempted' => false,
+                'blockers' => [
+                    [
+                        'field' => 'command.options',
+                        'code' => 'fixture_json_required',
+                        'message' => '--fixture and --json are required.',
+                    ],
+                ],
+            ]);
+
+            return self::FAILURE;
+        }
+
+        $report = $linter->lint($this->fixtureCandidates());
+        $report['fixture_mode'] = true;
+        $report['fixture_source'] = 'backend/tests/Fixtures/SeoIntel/claim_lint';
+
+        $this->emit($report);
+
+        return ($report['lint_state'] ?? null) === 'blocked' ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fixtureCandidates(): array
+    {
+        $candidates = [];
+
+        foreach (File::glob(base_path('tests/Fixtures/SeoIntel/claim_lint/*.json')) ?: [] as $path) {
+            $decoded = json_decode((string) file_get_contents($path), true);
+
+            if (! is_array($decoded)) {
+                continue;
+            }
+
+            foreach ((array) ($decoded['cases'] ?? []) as $case) {
+                if (is_array($case)) {
+                    $candidates[] = $case;
+                }
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function emit(array $payload): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? 'blocked'));
+        $this->line('lint_state='.(string) ($payload['lint_state'] ?? 'blocked'));
+        $this->line('severity='.(string) ($payload['severity'] ?? 'P2'));
+        $this->line('auto_rewrite_attempted='.(($payload['auto_rewrite_attempted'] ?? true) ? '1' : '0'));
+        $this->line('cms_mutation_attempted='.(($payload['cms_mutation_attempted'] ?? true) ? '1' : '0'));
+        $this->line('production_scan_attempted='.(($payload['production_scan_attempted'] ?? true) ? '1' : '0'));
+    }
+}

--- a/backend/app/Services/SeoIntel/ClaimLint/ChineseClaimLinter.php
+++ b/backend/app/Services/SeoIntel/ClaimLint/ChineseClaimLinter.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\ClaimLint;
+
+final class ChineseClaimLinter
+{
+    public const RUNTIME = 'chinese_claim_linter';
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     * @return array<string, mixed>
+     */
+    public function lint(array $candidates): array
+    {
+        $results = [];
+
+        foreach ($candidates as $candidate) {
+            $results[] = $this->lintCandidate($candidate);
+        }
+
+        $lintState = $this->rollupState(array_column($results, 'lint_state'));
+        $severity = $this->rollupSeverity(array_column($results, 'severity'));
+
+        return [
+            'runtime' => self::RUNTIME,
+            'status' => $lintState === 'blocked' ? 'blocked' : 'success',
+            'lint_state' => $lintState,
+            'severity' => $severity,
+            'candidate_count' => count($results),
+            'results' => $results,
+            'matched_rules' => $this->uniqueMerged($results, 'matched_rules'),
+            'bounded_context_detected' => in_array(true, array_column($results, 'bounded_context_detected'), true),
+            'blocked_phrases' => $this->uniqueMerged($results, 'blocked_phrases'),
+            'needs_review_phrases' => $this->uniqueMerged($results, 'needs_review_phrases'),
+            'allowed_bounded_phrases' => self::allowedBoundedPhrases(),
+            'auto_rewrite_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'production_scan_attempted' => false,
+            'fap_web_modification_attempted' => false,
+            'search_channel_enqueue_attempted' => false,
+            'search_submission_attempted' => false,
+            'seo_intel_write_attempted' => false,
+            'scheduler_enabled' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    public function lintCandidate(array $candidate): array
+    {
+        $text = (string) ($candidate['text'] ?? '');
+        $surface = (string) ($candidate['surface'] ?? 'unknown');
+        $isPublic = (bool) ($candidate['is_public'] ?? false);
+        $isIndexable = (bool) ($candidate['is_indexable'] ?? false);
+        $blockedPhrases = $this->matchedPhrases($text, self::forbiddenPhrases());
+        $needsReviewPhrases = $this->matchedPhrases($text, self::needsReviewPhrases());
+        $boundedPhrases = $this->matchedPhrases($text, self::allowedBoundedPhrases());
+
+        $lintState = $blockedPhrases !== []
+            ? 'blocked'
+            : ($needsReviewPhrases !== [] ? 'needs_review' : 'safe');
+
+        return [
+            'id' => (string) ($candidate['id'] ?? 'candidate'),
+            'surface' => $surface,
+            'is_public' => $isPublic,
+            'is_indexable' => $isIndexable,
+            'lint_state' => $lintState,
+            'severity' => $this->severity($lintState, $surface, $isPublic, $isIndexable),
+            'matched_rules' => $this->matchedRules($blockedPhrases, $needsReviewPhrases, $boundedPhrases),
+            'bounded_context_detected' => $boundedPhrases !== [],
+            'blocked_phrases' => $blockedPhrases,
+            'needs_review_phrases' => $needsReviewPhrases,
+            'allowed_bounded_phrases' => $boundedPhrases,
+            'auto_rewrite_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'production_scan_attempted' => false,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function forbiddenPhrases(): array
+    {
+        return [
+            '精准职业推荐',
+            '最适合职业',
+            'AI 职业规划',
+            '岗位胜任力',
+            '招聘适配',
+            '职业成功率',
+            '薪资保证',
+            '个人离职预测',
+            'MBTI决定收入',
+            'MBTI预测离职',
+            'Big Five职业精准匹配',
+            'RIASEC推荐职业',
+            '智商真实测量',
+            '临床诊断',
+            '诊断',
+            '确诊',
+            '治疗',
+            '治愈',
+            '心理疾病判断',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedBoundedPhrases(): array
+    {
+        return [
+            '职业方向参考',
+            '兴趣信号',
+            '工作方式倾向',
+            '探索建议',
+            '非诊断',
+            '结果仅供参考',
+            '自评筛查',
+            '模型化指数',
+            '聚合层面',
+            '方向性趋势',
+            'snapshot-based support',
+            'evidence-backed explanation',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function needsReviewPhrases(): array
+    {
+        return [
+            '推荐职业',
+            '职业规划',
+            '职业匹配',
+            '胜任力',
+            '预测',
+            '测量',
+        ];
+    }
+
+    /**
+     * @param  list<string>  $phrases
+     * @return list<string>
+     */
+    private function matchedPhrases(string $text, array $phrases): array
+    {
+        $matches = [];
+
+        foreach ($phrases as $phrase) {
+            if ($phrase === '诊断' && str_contains($text, '非诊断')) {
+                continue;
+            }
+
+            if ($phrase !== '' && str_contains($text, $phrase)) {
+                $matches[] = $phrase;
+            }
+        }
+
+        return array_values(array_unique($matches));
+    }
+
+    /**
+     * @param  list<string>  $blockedPhrases
+     * @param  list<string>  $needsReviewPhrases
+     * @param  list<string>  $boundedPhrases
+     * @return list<array<string, string>>
+     */
+    private function matchedRules(array $blockedPhrases, array $needsReviewPhrases, array $boundedPhrases): array
+    {
+        $rules = [];
+
+        foreach ($blockedPhrases as $phrase) {
+            $rules[] = ['rule' => 'forbidden_or_flagged_phrase', 'phrase' => $phrase];
+        }
+
+        foreach ($needsReviewPhrases as $phrase) {
+            $rules[] = ['rule' => 'needs_review_phrase', 'phrase' => $phrase];
+        }
+
+        foreach ($boundedPhrases as $phrase) {
+            $rules[] = ['rule' => 'allowed_bounded_phrase', 'phrase' => $phrase];
+        }
+
+        return $rules;
+    }
+
+    private function severity(string $lintState, string $surface, bool $isPublic, bool $isIndexable): string
+    {
+        if ($lintState === 'blocked' && $isPublic && $isIndexable) {
+            return 'P0';
+        }
+
+        if ($lintState === 'blocked' && in_array($surface, ['seo_metadata', 'faq', 'llms', 'ai_answer', 'json_ld'], true)) {
+            return 'P1';
+        }
+
+        if ($lintState === 'blocked' || $lintState === 'needs_review') {
+            return 'P2';
+        }
+
+        return ($isPublic && $isIndexable) ? 'P3' : 'P3';
+    }
+
+    /**
+     * @param  list<string>  $states
+     */
+    private function rollupState(array $states): string
+    {
+        if (in_array('blocked', $states, true)) {
+            return 'blocked';
+        }
+
+        if (in_array('needs_review', $states, true)) {
+            return 'needs_review';
+        }
+
+        return 'safe';
+    }
+
+    /**
+     * @param  list<string>  $severities
+     */
+    private function rollupSeverity(array $severities): string
+    {
+        foreach (['P0', 'P1', 'P2', 'P3'] as $severity) {
+            if (in_array($severity, $severities, true)) {
+                return $severity;
+            }
+        }
+
+        return 'P3';
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $results
+     * @return list<mixed>
+     */
+    private function uniqueMerged(array $results, string $key): array
+    {
+        $items = [];
+
+        foreach ($results as $result) {
+            foreach ((array) ($result[$key] ?? []) as $item) {
+                $items[] = is_array($item) ? json_encode($item, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : $item;
+            }
+        }
+
+        $items = array_values(array_unique(array_filter($items, static fn ($item): bool => $item !== null && $item !== false && $item !== '')));
+
+        return array_map(static function ($item): mixed {
+            if (! is_string($item) || ! str_starts_with($item, '{')) {
+                return $item;
+            }
+
+            $decoded = json_decode($item, true);
+
+            return is_array($decoded) ? $decoded : $item;
+        }, $items);
+    }
+}

--- a/backend/docs/seo/chinese-claim-linter-runtime.md
+++ b/backend/docs/seo/chinese-claim-linter-runtime.md
@@ -1,0 +1,72 @@
+# Chinese Claim Linter Runtime
+
+Task: `CLAIM-LINT-01B`
+
+This PR adds a reusable backend Chinese claim linter and a CI-readable fixture command:
+
+- `App\Services\SeoIntel\ClaimLint\ChineseClaimLinter`
+- `php artisan seo-intel:claim-lint --fixture --json`
+
+The runtime scans candidate public-copy inputs supplied by tests or explicit fixtures. It does not scan production content by default and does not read private user data.
+
+## Output
+
+The report includes:
+
+- `status`
+- `lint_state`
+- `severity`
+- `matched_rules`
+- `bounded_context_detected`
+- `blocked_phrases`
+- `needs_review_phrases`
+- `allowed_bounded_phrases`
+- `auto_rewrite_attempted=false`
+- `cms_mutation_attempted=false`
+- `production_scan_attempted=false`
+
+## States
+
+- `safe`: no forbidden or review phrase, or bounded wording in safe context.
+- `needs_review`: caution phrase in a claim-sensitive surface.
+- `blocked`: forbidden or flagged phrase present.
+
+## Severity
+
+- `P0`: blocked public/indexable claim risk.
+- `P1`: blocked high-risk SEO metadata, FAQ, `llms`, AI answer, or JSON-LD claim risk.
+- `P2`: blocked or needs-review draft/body/content-package risk.
+- `P3`: safe or informational wording drift.
+
+## Fixture Coverage
+
+The bundled CI fixture covers:
+
+- forbidden career recommendation claim
+- bounded career direction reference
+- MBTI salary guarantee claim
+- model-index salary/turnover bounded phrasing
+- clinical diagnosis claim
+- non-diagnostic safe phrasing
+- Big Five / RIASEC overclaim
+- snapshot-based support phrasing
+
+## Safety
+
+This runtime:
+
+- does not auto-rewrite content
+- does not auto-publish
+- does not mutate CMS content
+- does not scan production content without explicit scope
+- does not modify fap-web
+- does not write `seo_intel`
+- does not enqueue Search Channel rows
+- does not submit URLs
+- does not activate scheduler
+- does not edit env
+- does not deploy
+
+## Next Task
+
+Next task: `CONTENT-OPS-CLAIM-LINK-OPS-READINESS`

--- a/backend/docs/seo/generated/chinese-claim-linter-runtime.v1.json
+++ b/backend/docs/seo/generated/chinese-claim-linter-runtime.v1.json
@@ -1,0 +1,56 @@
+{
+  "version": "chinese-claim-linter-runtime.v1",
+  "task": "CLAIM-LINT-01B",
+  "service": "App\\Services\\SeoIntel\\ClaimLint\\ChineseClaimLinter",
+  "command": "seo-intel:claim-lint --fixture --json",
+  "runtime": "chinese_claim_linter",
+  "states": [
+    "safe",
+    "needs_review",
+    "blocked"
+  ],
+  "severity_levels": [
+    "P0",
+    "P1",
+    "P2",
+    "P3"
+  ],
+  "required_output_fields": [
+    "status",
+    "lint_state",
+    "severity",
+    "matched_rules",
+    "bounded_context_detected",
+    "blocked_phrases",
+    "needs_review_phrases",
+    "allowed_bounded_phrases",
+    "auto_rewrite_attempted",
+    "cms_mutation_attempted",
+    "production_scan_attempted"
+  ],
+  "fixture_coverage": [
+    "forbidden_career_recommendation_claim",
+    "bounded_career_direction_reference",
+    "mbti_salary_guarantee_claim",
+    "model_index_salary_turnover_bounded_phrasing",
+    "clinical_diagnosis_claim",
+    "non_diagnostic_safe_phrasing",
+    "big_five_riasec_overclaim",
+    "snapshot_based_support_phrasing"
+  ],
+  "safety_flags": {
+    "auto_rewrite_enabled": false,
+    "auto_publish_enabled": false,
+    "cms_mutation_enabled": false,
+    "production_scan_enabled": false,
+    "fap_web_modified": false,
+    "seo_intel_write_enabled": false,
+    "search_channel_enqueue_enabled": false,
+    "url_submission_enabled": false,
+    "scheduler_enabled": false,
+    "env_edited": false,
+    "deployment_performed": false
+  },
+  "final_decision": "chinese_claim_linter_runtime_ready",
+  "next_task": "CONTENT-OPS-CLAIM-LINK-OPS-READINESS"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelChineseClaimLinterRuntimeTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelChineseClaimLinterRuntimeTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\ClaimLint\ChineseClaimLinter;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Tests\TestCase;
+
+final class SeoIntelChineseClaimLinterRuntimeTest extends TestCase
+{
+    #[Test]
+    public function service_blocks_forbidden_career_and_salary_claims_without_rewrite(): void
+    {
+        $report = (new ChineseClaimLinter)->lint([
+            [
+                'id' => 'career',
+                'surface' => 'career_recommendation',
+                'text' => '这套 AI 职业规划可以提供精准职业推荐，直接告诉你最适合职业。',
+                'is_public' => true,
+                'is_indexable' => true,
+            ],
+            [
+                'id' => 'salary',
+                'surface' => 'research_report',
+                'text' => 'MBTI决定收入，并可给出薪资保证。',
+                'is_public' => true,
+                'is_indexable' => true,
+            ],
+        ]);
+
+        $this->assertSame('chinese_claim_linter', $report['runtime']);
+        $this->assertSame('blocked', $report['status']);
+        $this->assertSame('blocked', $report['lint_state']);
+        $this->assertSame('P0', $report['severity']);
+        $this->assertContains('精准职业推荐', $report['blocked_phrases']);
+        $this->assertContains('最适合职业', $report['blocked_phrases']);
+        $this->assertContains('MBTI决定收入', $report['blocked_phrases']);
+        $this->assertContains('薪资保证', $report['blocked_phrases']);
+        $this->assertFalse($report['auto_rewrite_attempted']);
+        $this->assertFalse($report['cms_mutation_attempted']);
+        $this->assertFalse($report['production_scan_attempted']);
+    }
+
+    #[Test]
+    public function service_allows_bounded_non_diagnostic_and_snapshot_phrasing(): void
+    {
+        $report = (new ChineseClaimLinter)->lint([
+            [
+                'id' => 'career_reference',
+                'surface' => 'career_guide',
+                'text' => '本页仅提供职业方向参考，结合兴趣信号和工作方式倾向作为探索建议。',
+            ],
+            [
+                'id' => 'non_diagnostic',
+                'surface' => 'test_detail',
+                'text' => '结果仅供参考，属于自评筛查，非诊断。',
+            ],
+            [
+                'id' => 'snapshot',
+                'surface' => 'career_graph',
+                'text' => 'This is snapshot-based support and evidence-backed explanation for exploration only.',
+            ],
+        ]);
+
+        $this->assertSame('success', $report['status']);
+        $this->assertSame('safe', $report['lint_state']);
+        $this->assertSame('P3', $report['severity']);
+        $this->assertTrue($report['bounded_context_detected']);
+        $this->assertSame([], $report['blocked_phrases']);
+        $this->assertContains('职业方向参考', $report['allowed_bounded_phrases']);
+        $this->assertContains('snapshot-based support', $report['allowed_bounded_phrases']);
+        $this->assertContains('evidence-backed explanation', $report['allowed_bounded_phrases']);
+    }
+
+    #[Test]
+    public function service_marks_model_index_prediction_language_for_review(): void
+    {
+        $report = (new ChineseClaimLinter)->lint([
+            [
+                'id' => 'model_index',
+                'surface' => 'research_report',
+                'text' => '报告使用模型化指数展示聚合层面的薪资与离职方向性趋势，不作为个人预测。',
+                'is_public' => false,
+                'is_indexable' => false,
+            ],
+        ]);
+
+        $this->assertSame('success', $report['status']);
+        $this->assertSame('needs_review', $report['lint_state']);
+        $this->assertSame('P2', $report['severity']);
+        $this->assertContains('预测', $report['needs_review_phrases']);
+        $this->assertContains('模型化指数', $report['allowed_bounded_phrases']);
+        $this->assertContains('聚合层面', $report['allowed_bounded_phrases']);
+        $this->assertContains('方向性趋势', $report['allowed_bounded_phrases']);
+    }
+
+    #[Test]
+    public function fixture_command_emits_json_and_never_scans_production_or_mutates_content(): void
+    {
+        $exitCode = Artisan::call('seo-intel:claim-lint', [
+            '--fixture' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+
+        $payload = $this->artisanJsonOutput();
+
+        $this->assertSame('chinese_claim_linter', $payload['runtime']);
+        $this->assertTrue($payload['fixture_mode']);
+        $this->assertSame('blocked', $payload['lint_state']);
+        $this->assertSame('P0', $payload['severity']);
+        $this->assertGreaterThanOrEqual(8, $payload['candidate_count']);
+        $this->assertFalse($payload['auto_rewrite_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['production_scan_attempted']);
+        $this->assertFalse($payload['fap_web_modification_attempted']);
+        $this->assertFalse($payload['search_channel_enqueue_attempted']);
+        $this->assertFalse($payload['search_submission_attempted']);
+        $this->assertFalse($payload['seo_intel_write_attempted']);
+        $this->assertFalse($payload['scheduler_enabled']);
+    }
+
+    #[Test]
+    public function command_requires_fixture_and_json_and_exposes_no_production_write_options(): void
+    {
+        $exitCode = Artisan::call('seo-intel:claim-lint');
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('status=blocked', $output);
+        $this->assertStringContainsString('auto_rewrite_attempted=0', $output);
+        $this->assertStringContainsString('cms_mutation_attempted=0', $output);
+        $this->assertStringContainsString('production_scan_attempted=0', $output);
+
+        Artisan::call('seo-intel:claim-lint --help');
+        $help = Artisan::output();
+
+        foreach ([
+            '--rewrite',
+            '--publish',
+            '--write',
+            '--scan-production',
+            '--submit',
+            '--scheduler',
+        ] as $forbiddenOption) {
+            $this->assertDoesNotMatchRegularExpression('/(^|\\s)'.preg_quote($forbiddenOption, '/').'(=|\\s|$)/', $help);
+        }
+
+        $this->assertStringContainsString('--fixture', $help);
+        $this->assertStringContainsString('--json', $help);
+    }
+
+    #[Test]
+    public function fixture_coverage_matches_required_cases(): void
+    {
+        $fixture = $this->fixture();
+        $ids = array_column($fixture['cases'] ?? [], 'id');
+
+        foreach ([
+            'forbidden_career_recommendation_claim',
+            'bounded_career_direction_reference',
+            'mbti_salary_guarantee_claim',
+            'model_index_salary_turnover_bounded',
+            'clinical_diagnosis_claim',
+            'non_diagnostic_safe_phrasing',
+            'big_five_riasec_overclaim',
+            'snapshot_based_support_phrasing',
+        ] as $id) {
+            $this->assertContains($id, $ids);
+        }
+
+        foreach (($fixture['cases'] ?? []) as $case) {
+            $result = (new ChineseClaimLinter)->lintCandidate($case);
+
+            $this->assertSame($case['expected_lint_state'], $result['lint_state'], (string) $case['id']);
+            $this->assertSame($case['expected_severity'], $result['severity'], (string) $case['id']);
+            $this->assertFalse($result['auto_rewrite_attempted']);
+            $this->assertFalse($result['cms_mutation_attempted']);
+            $this->assertFalse($result['production_scan_attempted']);
+        }
+    }
+
+    #[Test]
+    public function docs_and_generated_artifact_lock_runtime_boundary(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/chinese-claim-linter-runtime.md')));
+        $artifact = $this->artifact();
+        $artifactJson = strtolower((string) json_encode($artifact, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+
+        $this->assertSame('chinese-claim-linter-runtime.v1', $artifact['version'] ?? null);
+        $this->assertSame('CLAIM-LINT-01B', $artifact['task'] ?? null);
+        $this->assertSame('CONTENT-OPS-CLAIM-LINK-OPS-READINESS', $artifact['next_task'] ?? null);
+        $this->assertSame('App\\Services\\SeoIntel\\ClaimLint\\ChineseClaimLinter', $artifact['service'] ?? null);
+        $this->assertFalse($artifact['safety_flags']['auto_rewrite_enabled'] ?? true);
+        $this->assertFalse($artifact['safety_flags']['cms_mutation_enabled'] ?? true);
+        $this->assertFalse($artifact['safety_flags']['production_scan_enabled'] ?? true);
+
+        foreach ([
+            'does not auto-rewrite content',
+            'does not auto-publish',
+            'does not mutate cms content',
+            'does not scan production content without explicit scope',
+            'does not modify fap-web',
+            'does not write `seo_intel`',
+            'does not enqueue search channel rows',
+            'does not submit urls',
+            'next task: `content-ops-claim-link-ops-readiness`',
+            '"next_task":"content-ops-claim-link-ops-readiness"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $doc."\n".$artifactJson);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artisanJsonOutput(): array
+    {
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fixture(): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path('tests/Fixtures/SeoIntel/claim_lint/chinese_claim_lint_cases.v1.json')), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path('docs/seo/generated/chinese-claim-linter-runtime.v1.json')), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Fixtures/SeoIntel/claim_lint/chinese_claim_lint_cases.v1.json
+++ b/backend/tests/Fixtures/SeoIntel/claim_lint/chinese_claim_lint_cases.v1.json
@@ -1,0 +1,77 @@
+{
+  "version": "chinese-claim-lint-cases.v1",
+  "cases": [
+    {
+      "id": "forbidden_career_recommendation_claim",
+      "surface": "career_recommendation",
+      "text": "这套 AI 职业规划可以提供精准职业推荐，直接告诉你最适合职业。",
+      "is_public": true,
+      "is_indexable": true,
+      "expected_lint_state": "blocked",
+      "expected_severity": "P0"
+    },
+    {
+      "id": "bounded_career_direction_reference",
+      "surface": "career_guide",
+      "text": "本页仅提供职业方向参考，结合兴趣信号和工作方式倾向作为探索建议。",
+      "is_public": false,
+      "is_indexable": false,
+      "expected_lint_state": "safe",
+      "expected_severity": "P3"
+    },
+    {
+      "id": "mbti_salary_guarantee_claim",
+      "surface": "research_report",
+      "text": "MBTI决定收入，并可给出薪资保证。",
+      "is_public": true,
+      "is_indexable": true,
+      "expected_lint_state": "blocked",
+      "expected_severity": "P0"
+    },
+    {
+      "id": "model_index_salary_turnover_bounded",
+      "surface": "research_report",
+      "text": "报告使用模型化指数展示聚合层面的薪资与离职方向性趋势，不作为个人预测。",
+      "is_public": false,
+      "is_indexable": false,
+      "expected_lint_state": "needs_review",
+      "expected_severity": "P2"
+    },
+    {
+      "id": "clinical_diagnosis_claim",
+      "surface": "test_detail",
+      "text": "本测试可用于临床诊断、确诊、治疗和治愈心理疾病判断。",
+      "is_public": true,
+      "is_indexable": true,
+      "expected_lint_state": "blocked",
+      "expected_severity": "P0"
+    },
+    {
+      "id": "non_diagnostic_safe_phrasing",
+      "surface": "test_detail",
+      "text": "结果仅供参考，属于自评筛查，非诊断。",
+      "is_public": false,
+      "is_indexable": false,
+      "expected_lint_state": "safe",
+      "expected_severity": "P3"
+    },
+    {
+      "id": "big_five_riasec_overclaim",
+      "surface": "career_graph",
+      "text": "Big Five职业精准匹配，并提供RIASEC推荐职业。",
+      "is_public": true,
+      "is_indexable": true,
+      "expected_lint_state": "blocked",
+      "expected_severity": "P0"
+    },
+    {
+      "id": "snapshot_based_support_phrasing",
+      "surface": "career_graph",
+      "text": "This is snapshot-based support and evidence-backed explanation for exploration only.",
+      "is_public": false,
+      "is_indexable": false,
+      "expected_lint_state": "safe",
+      "expected_severity": "P3"
+    }
+  ]
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -610,6 +610,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_chinese_claim_linter_runtime_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoIntelClaimLintCommand.php',
+            'backend/app/Services/SeoIntel/ClaimLint/ChineseClaimLinter.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_migration_isolation_files(): void
     {
         $changed = [
@@ -1895,6 +1905,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isChineseClaimLinterRuntimeFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelOpsDashboardReadModelFile($file)) {
                 continue;
             }
@@ -2525,6 +2539,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoIntelInternalLinkGraphCommand.php',
             'backend/app/Services/SeoIntel/InternalLink/InternalLinkGraphDryRun.php',
+        ], true);
+    }
+
+    private function isChineseClaimLinterRuntimeFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoIntelClaimLintCommand.php',
+            'backend/app/Services/SeoIntel/ClaimLint/ChineseClaimLinter.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T15:58:09+08:00",
+  "updated_at": "2026-05-22T16:11:24+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18166,11 +18166,11 @@
     "CLAIM-LINT-01A": {
       "repo": "fap-api",
       "branch": "codex/claim-lint-01a-chinese-claim-linter-contract",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "CONTENT-OPS-02A"
       ],
-      "commit_sha": null,
+      "commit_sha": "0327ae9c0b1f6ecc2bcff7d5c15589ac2a27318c",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1566",
       "checks": {
         "local": {
@@ -18182,12 +18182,18 @@
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1566": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_contract_test": "passed: php artisan test --filter=SeoIntelChineseClaimLinterRuntimeContract --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T08:04:05Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -18213,20 +18219,39 @@
           "at": "2026-05-22T15:58:09+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1566 for CLAIM-LINT-01A and pushed branch codex/claim-lint-01a-chinese-claim-linter-contract."
+        },
+        {
+          "at": "2026-05-22T16:08:57+08:00",
+          "status": "merged",
+          "summary": "PR #1566 merged via squash at 0327ae9c0b1f6ecc2bcff7d5c15589ac2a27318c. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused contract test passed."
         }
       ]
     },
     "CLAIM-LINT-01B": {
       "repo": "fap-api",
-      "branch": "codex/claim-lint-01b-chinese-runtime-ci",
-      "status": "pending",
+      "branch": "codex/claim-lint-01b-chinese-claim-linter-runtime",
+      "status": "local_validation_passed",
       "depends_on": [
         "CLAIM-LINT-01A",
         "CONTENT-OPS-02B"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_runtime": "passed: php artisan test --filter=SeoIntelChineseClaimLinterRuntime --no-ansi (13 tests, 236 assertions)",
+          "bigfive_runtime_freeze": "passed: php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi (109 tests, 456 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (448 tests, 7185 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3479 files)",
+          "command_help": "passed: php artisan seo-intel:claim-lint --fixture --json --help || true",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/chinese-claim-linter-runtime.v1.json",
+          "json_fixture": "passed: python3 -m json.tool backend/tests/Fixtures/SeoIntel/claim_lint/chinese_claim_lint_cases.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18241,6 +18266,16 @@
           "at": "2026-05-22T14:37:34+08:00",
           "status": "pending",
           "summary": "Registered Chinese claim linter runtime/CI PR. Scope allows backend linter service/command/tests only and forbids auto-rewrite, auto-publish, production scans, seo_intel writes, and fap-web changes."
+        },
+        {
+          "at": "2026-05-22T16:08:57+08:00",
+          "status": "in_progress",
+          "summary": "Started CLAIM-LINT-01B on codex/claim-lint-01b-chinese-claim-linter-runtime. Scope is Chinese claim linter service/command/fixtures/tests/docs/generated artifact, BigFive runtime freeze allowlist for the new SeoIntel runtime files, and train metadata; no CMS mutation, auto-rewrite, publish action, production scan, fap-web change, seo_intel write, Search Channel enqueue, URL submission, scheduler activation, env edit, or deploy."
+        },
+        {
+          "at": "2026-05-22T16:11:24+08:00",
+          "status": "local_validation_passed",
+          "summary": "CLAIM-LINT-01B local validation passed for focused runtime/contract tests, BigFive runtime freeze allowlist, full SeoIntel filter, route list, Pint, command help, JSON fixture/artifact/state parsing, YAML parsing, and diff whitespace checks. Runtime remains fixture/CI-readable with no CMS mutation, auto-rewrite, publish action, production scan, fap-web change, seo_intel write, Search Channel enqueue, URL submission, scheduler activation, env edit, or deploy."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T16:11:24+08:00",
+  "updated_at": "2026-05-22T16:12:46+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18230,13 +18230,13 @@
     "CLAIM-LINT-01B": {
       "repo": "fap-api",
       "branch": "codex/claim-lint-01b-chinese-claim-linter-runtime",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "CLAIM-LINT-01A",
         "CONTENT-OPS-02B"
       ],
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1567",
       "checks": {
         "local": {
           "php_artisan_test_filter_runtime": "passed: php artisan test --filter=SeoIntelChineseClaimLinterRuntime --no-ansi (13 tests, 236 assertions)",
@@ -18276,6 +18276,11 @@
           "at": "2026-05-22T16:11:24+08:00",
           "status": "local_validation_passed",
           "summary": "CLAIM-LINT-01B local validation passed for focused runtime/contract tests, BigFive runtime freeze allowlist, full SeoIntel filter, route list, Pint, command help, JSON fixture/artifact/state parsing, YAML parsing, and diff whitespace checks. Runtime remains fixture/CI-readable with no CMS mutation, auto-rewrite, publish action, production scan, fap-web change, seo_intel write, Search Channel enqueue, URL submission, scheduler activation, env edit, or deploy."
+        },
+        {
+          "at": "2026-05-22T16:12:46+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1567 for CLAIM-LINT-01B and pushed branch codex/claim-lint-01b-chinese-claim-linter-runtime."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9551,9 +9551,9 @@ prs:
     depends_on:
       - CLAIM-LINT-01A
       - CONTENT-OPS-02B
-    branch: codex/claim-lint-01b-chinese-runtime-ci
+    branch: codex/claim-lint-01b-chinese-claim-linter-runtime
     base: main
-    title: "feat(seo): add Chinese claim linter runtime and CI command"
+    title: "feat(seo-intel): add Chinese claim linter runtime"
     name: "Chinese claim linter runtime CI"
     train_scope: content_ops_claim_link_runtime
     risk_level: medium_ci_guard
@@ -9567,6 +9567,7 @@ prs:
       - backend/app/Console/Commands/SeoIntelClaimLintCommand.php
       - backend/tests/Feature/SeoIntel/SeoIntelChineseClaimLinterRuntimeTest.php
       - backend/tests/Fixtures/SeoIntel/claim_lint/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - backend/docs/seo/chinese-claim-linter-runtime.md
       - backend/docs/seo/generated/chinese-claim-linter-runtime.v1.json
       - docs/codex/pr-train.yaml


### PR DESCRIPTION
## What changed
- Added a reusable ChineseClaimLinter service with safe / needs_review / blocked classification and P0-P3 severity mapping.
- Added a fixture-only CI-readable Artisan command: php artisan seo-intel:claim-lint --fixture --json.
- Added fixture coverage for career recommendation, bounded career direction, MBTI salary guarantee, model-index salary/turnover phrasing, clinical diagnosis, non-diagnostic phrasing, Big Five/RIASEC overclaim, and snapshot-based support.
- Added runtime docs/generated artifact and focused tests.
- Added BigFive runtime freeze allowlist coverage for the new read-only SeoIntel linter command/service.

## Why
- Provides a backend-owned claim lint runtime for future publish rehearsal and CI gates without rewriting, publishing, or scanning production content.

## Validation
- cd backend && php artisan test --filter=SeoIntelChineseClaimLinterRuntime --no-ansi
- cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && php artisan seo-intel:claim-lint --fixture --json --help || true
- python3 -m json.tool backend/docs/seo/generated/chinese-claim-linter-runtime.v1.json >/dev/null
- python3 -m json.tool backend/tests/Fixtures/SeoIntel/claim_lint/chinese_claim_lint_cases.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No CMS content mutation, auto-rewrite, or publishing.
- No production content scan.
- No fap-web changes, seo_intel writes, Search Channel enqueue, URL submission, scheduler activation, env edits, or deploy.