### PR TITLE
docs(seo-intel): add content ops claim link ops readiness

### DIFF
--- a/backend/docs/seo/content-ops-claim-link-ops-readiness.md
+++ b/backend/docs/seo/content-ops-claim-link-ops-readiness.md
@@ -1,0 +1,59 @@
+# Content Ops / Claim / Link Ops Readiness
+
+Task: `CONTENT-OPS-CLAIM-LINK-OPS-READINESS`
+
+This contract defines future read-only `/ops/seo` display readiness for Content Ops, Internal Link, and Claim Lint outputs. This PR is docs/generated/test only. It does not implement Filament UI, add action buttons, add write controls, mutate CMS, create internal links, rewrite content, enqueue Search Channel rows, submit URLs, expose Metabase, run migrations, enable scheduler, run collectors, modify fap-web, or deploy.
+
+## Future /ops/seo Sections
+
+The future read-only dashboard may display:
+
+- Content publish rehearsal summary
+- planned observation event counts
+- draft blocked from sitemap / `llms.txt` / search counters
+- internal link graph coverage
+- missing entity key count
+- `legacy_unpaired` count
+- unsafe fallback link source count
+- claim lint `safe` / `needs_review` / `blocked` counts
+- P0 / P1 / P2 / P3 claim issue summary
+- content ops sidecar warnings
+
+## Read-only Inputs
+
+Allowed future inputs are read-only summaries from:
+
+- Content publish rehearsal dry-run output
+- Internal link graph dry-run output
+- Chinese claim linter fixture/CI or approved candidate-package output
+- Observation Governance planned event summaries
+- Entity key / translation group coverage summaries
+
+The dashboard must not become content, link, claim, sitemap, Search Channel, crawler, or Metabase authority.
+
+## Hard Stops
+
+The future `/ops/seo` display must include no publish button, no rewrite button, no internal link creation button, no Search Channel enqueue button, no submit URL button, no scheduler controls, no collector controls, no raw SQL, no Metabase iframe or proxy, no raw payload display, no raw crawler logs, and no CMS write controls.
+
+Hard stop checklist:
+
+- publish button
+- rewrite button
+- internal link creation button
+- Search Channel enqueue button
+- submit URL button
+- scheduler controls
+- collector controls
+- raw SQL
+- Metabase iframe or proxy
+- raw payload display
+- raw crawler logs
+- CMS write controls
+
+## Authority Boundary
+
+CMS/backend owns content, metadata, publish state, canonical, robots/noindex, and claim boundaries. The internal link graph is backend/CMS authoritative. fap-web deterministically renders public runtime but must not become fallback authority. `/ops/seo` is an operational view only.
+
+## Next Task
+
+Next task: `CONTENT-OPS-CLAIM-LINK-CLOSEOUT`

--- a/backend/docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json
+++ b/backend/docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json
@@ -1,0 +1,63 @@
+{
+  "version": "content-ops-claim-link-ops-readiness.v1",
+  "task": "CONTENT-OPS-CLAIM-LINK-OPS-READINESS",
+  "type": "docs_generated_test_only",
+  "future_sections": [
+    "content_publish_rehearsal_summary",
+    "planned_observation_event_counts",
+    "draft_blocked_from_sitemap_llms_search_counters",
+    "internal_link_graph_coverage",
+    "missing_entity_key_count",
+    "legacy_unpaired_count",
+    "unsafe_fallback_link_source_count",
+    "claim_lint_safe_needs_review_blocked_counts",
+    "claim_issue_severity_p0_p1_p2_p3_summary",
+    "content_ops_sidecar_warnings"
+  ],
+  "allowed_read_only_inputs": [
+    "content_publish_rehearsal_dry_run_output",
+    "internal_link_graph_dry_run_output",
+    "chinese_claim_linter_fixture_or_candidate_package_output",
+    "observation_governance_planned_event_summary",
+    "entity_key_translation_group_coverage_summary"
+  ],
+  "hard_stops": [
+    "no_publish_button",
+    "no_rewrite_button",
+    "no_internal_link_creation_button",
+    "no_search_channel_enqueue_button",
+    "no_submit_url_button",
+    "no_scheduler_controls",
+    "no_collector_controls",
+    "no_raw_sql",
+    "no_metabase_iframe_or_proxy",
+    "no_raw_payload_display",
+    "no_raw_crawler_logs",
+    "no_cms_write_controls"
+  ],
+  "authority_boundary": {
+    "cms_backend": "content_metadata_publish_canonical_robots_claim_truth",
+    "internal_link_graph": "backend_cms_authoritative",
+    "fap_web": "deterministic_renderer_not_fallback_authority",
+    "ops_seo": "operational_view_only",
+    "metabase": "private_not_exposed"
+  },
+  "safety_flags": {
+    "filament_ui_implemented": false,
+    "action_buttons_added": false,
+    "write_controls_added": false,
+    "cms_mutation_enabled": false,
+    "internal_link_creation_enabled": false,
+    "auto_rewrite_enabled": false,
+    "search_channel_enqueue_enabled": false,
+    "url_submission_enabled": false,
+    "metabase_exposed": false,
+    "migration_added": false,
+    "scheduler_enabled": false,
+    "collector_enabled": false,
+    "fap_web_modified": false,
+    "deployment_performed": false
+  },
+  "final_decision": "content_ops_claim_link_ops_readiness_ready",
+  "next_task": "CONTENT-OPS-CLAIM-LINK-CLOSEOUT"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelContentOpsClaimLinkOpsReadinessTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelContentOpsClaimLinkOpsReadinessTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelContentOpsClaimLinkOpsReadinessTest extends TestCase
+{
+    #[Test]
+    public function readiness_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/content-ops-claim-link-ops-readiness.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('content-ops-claim-link-ops-readiness.v1', $artifact['version'] ?? null);
+        $this->assertSame('CONTENT-OPS-CLAIM-LINK-OPS-READINESS', $artifact['task'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('CONTENT-OPS-CLAIM-LINK-CLOSEOUT', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function future_sections_cover_content_link_claim_and_sidecars(): void
+    {
+        $sections = $this->artifact()['future_sections'] ?? [];
+
+        foreach ([
+            'content_publish_rehearsal_summary',
+            'planned_observation_event_counts',
+            'draft_blocked_from_sitemap_llms_search_counters',
+            'internal_link_graph_coverage',
+            'missing_entity_key_count',
+            'legacy_unpaired_count',
+            'unsafe_fallback_link_source_count',
+            'claim_lint_safe_needs_review_blocked_counts',
+            'claim_issue_severity_p0_p1_p2_p3_summary',
+            'content_ops_sidecar_warnings',
+        ] as $section) {
+            $this->assertContains($section, $sections);
+        }
+    }
+
+    #[Test]
+    public function allowed_inputs_are_read_only_summaries(): void
+    {
+        $inputs = $this->artifact()['allowed_read_only_inputs'] ?? [];
+
+        foreach ([
+            'content_publish_rehearsal_dry_run_output',
+            'internal_link_graph_dry_run_output',
+            'chinese_claim_linter_fixture_or_candidate_package_output',
+            'observation_governance_planned_event_summary',
+            'entity_key_translation_group_coverage_summary',
+        ] as $input) {
+            $this->assertContains($input, $inputs);
+        }
+    }
+
+    #[Test]
+    public function hard_stops_block_write_actions_raw_data_and_metabase(): void
+    {
+        $stops = $this->artifact()['hard_stops'] ?? [];
+
+        foreach ([
+            'no_publish_button',
+            'no_rewrite_button',
+            'no_internal_link_creation_button',
+            'no_search_channel_enqueue_button',
+            'no_submit_url_button',
+            'no_scheduler_controls',
+            'no_collector_controls',
+            'no_raw_sql',
+            'no_metabase_iframe_or_proxy',
+            'no_raw_payload_display',
+            'no_raw_crawler_logs',
+            'no_cms_write_controls',
+        ] as $stop) {
+            $this->assertContains($stop, $stops);
+        }
+    }
+
+    #[Test]
+    public function authority_boundary_and_safety_flags_keep_ops_seo_read_only(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('content_metadata_publish_canonical_robots_claim_truth', $artifact['authority_boundary']['cms_backend'] ?? null);
+        $this->assertSame('backend_cms_authoritative', $artifact['authority_boundary']['internal_link_graph'] ?? null);
+        $this->assertSame('deterministic_renderer_not_fallback_authority', $artifact['authority_boundary']['fap_web'] ?? null);
+        $this->assertSame('operational_view_only', $artifact['authority_boundary']['ops_seo'] ?? null);
+        $this->assertSame('private_not_exposed', $artifact['authority_boundary']['metabase'] ?? null);
+
+        foreach ([
+            'filament_ui_implemented',
+            'action_buttons_added',
+            'write_controls_added',
+            'cms_mutation_enabled',
+            'internal_link_creation_enabled',
+            'auto_rewrite_enabled',
+            'search_channel_enqueue_enabled',
+            'url_submission_enabled',
+            'metabase_exposed',
+            'migration_added',
+            'scheduler_enabled',
+            'collector_enabled',
+            'fap_web_modified',
+            'deployment_performed',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact['safety_flags'][$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_display_readiness_without_ui_implementation(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/content-ops-claim-link-ops-readiness.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'docs/generated/test only',
+            'does not implement filament ui',
+            'content publish rehearsal summary',
+            'internal link graph coverage',
+            'claim lint `safe` / `needs_review` / `blocked` counts',
+            'p0 / p1 / p2 / p3 claim issue summary',
+            'no publish button',
+            'no rewrite button',
+            'no internal link creation button',
+            'no search channel enqueue button',
+            'no metabase iframe or proxy',
+            'operational view only',
+            'next task: `content-ops-claim-link-closeout`',
+            '"next_task": "content-ops-claim-link-closeout"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path('docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json')), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T16:12:46+08:00",
+  "updated_at": "2026-05-22T16:25:38+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -708,7 +708,18 @@
       ],
       "commit_sha": "32f35c17a0f29758f0f700010ac1b0c7492ffb6c",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1451",
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_ops_readiness": "passed: php artisan test --filter=SeoIntelContentOpsClaimLinkOpsReadiness --no-ansi (6 tests, 70 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (454 tests, 7255 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3480 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
@@ -18230,12 +18241,12 @@
     "CLAIM-LINT-01B": {
       "repo": "fap-api",
       "branch": "codex/claim-lint-01b-chinese-claim-linter-runtime",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "CLAIM-LINT-01A",
         "CONTENT-OPS-02B"
       ],
-      "commit_sha": null,
+      "commit_sha": "1cba31a8e37b1d00d61fcee37777ef73fd39add9",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1567",
       "checks": {
         "local": {
@@ -18250,12 +18261,18 @@
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1567": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_runtime_test": "passed: php artisan test --filter=SeoIntelChineseClaimLinterRuntime --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T08:18:58Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -18281,13 +18298,18 @@
           "at": "2026-05-22T16:12:46+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1567 for CLAIM-LINT-01B and pushed branch codex/claim-lint-01b-chinese-claim-linter-runtime."
+        },
+        {
+          "at": "2026-05-22T16:21:44+08:00",
+          "status": "merged",
+          "summary": "PR #1567 merged via squash at 1cba31a8e37b1d00d61fcee37777ef73fd39add9. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused runtime test passed."
         }
       ]
     },
     "CONTENT-OPS-CLAIM-LINK-OPS-READINESS": {
       "repo": "fap-api",
       "branch": "codex/content-ops-claim-link-ops-readiness",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "CONTENT-OPS-02B",
         "INTERNAL-LINK-01B",
@@ -18310,6 +18332,16 @@
           "at": "2026-05-22T14:37:34+08:00",
           "status": "pending",
           "summary": "Registered /ops/seo display readiness PR for content publish rehearsal, internal link graph, and claim lint summaries. Scope is read-only readiness docs/generated/test only."
+        },
+        {
+          "at": "2026-05-22T16:21:44+08:00",
+          "status": "in_progress",
+          "summary": "Started CONTENT-OPS-CLAIM-LINK-OPS-READINESS on codex/content-ops-claim-link-ops-readiness. Scope is docs/generated/test only plus train metadata; no Filament UI implementation, action buttons, write controls, migrations, production env changes, fap-web changes, Metabase exposure, scheduler controls, collector controls, or Search Channel controls."
+        },
+        {
+          "at": "2026-05-22T16:25:38+08:00",
+          "status": "local_validation_passed",
+          "summary": "CONTENT-OPS-CLAIM-LINK-OPS-READINESS local validation passed for focused readiness contract test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only, with no UI implementation, write controls, production operations, fap-web changes, Metabase exposure, scheduler controls, collector controls, or Search Channel controls."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T16:25:38+08:00",
+  "updated_at": "2026-05-22T16:27:35+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -3572,7 +3572,7 @@
       "repo": "fap-web",
       "branch": "codex/riasec-personalization-06-frontend-fail-closed",
       "title": "feat(riasec): consume backend personalization state fail-closed",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "RIASEC-PERSONALIZATION-03",
         "RIASEC-PERSONALIZATION-04"
@@ -14272,8 +14272,8 @@
       "depends_on": [
         "SEO-OBS-GOV-05"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "a29be5717ab1b0ad77dfc432a1d142370196fba5",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1568",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -18342,6 +18342,11 @@
           "at": "2026-05-22T16:25:38+08:00",
           "status": "local_validation_passed",
           "summary": "CONTENT-OPS-CLAIM-LINK-OPS-READINESS local validation passed for focused readiness contract test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only, with no UI implementation, write controls, production operations, fap-web changes, Metabase exposure, scheduler controls, collector controls, or Search Channel controls."
+        },
+        {
+          "at": "2026-05-22T16:27:35+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1568 for CONTENT-OPS-CLAIM-LINK-OPS-READINESS and pushed branch codex/content-ops-claim-link-ops-readiness."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9601,7 +9601,7 @@ prs:
       - CLAIM-LINT-01B
     branch: codex/content-ops-claim-link-ops-readiness
     base: main
-    title: "docs(ops): add content ops claim link display readiness"
+    title: "docs(seo-intel): add content ops claim link ops readiness"
     name: "Content Ops claim/link /ops/seo display readiness"
     train_scope: content_ops_claim_link_runtime
     risk_level: low_contract_only


### PR DESCRIPTION
## What changed
- Added the Content Ops / Claim / Link /ops/seo display readiness contract.
- Added the generated JSON artifact for future read-only dashboard sections, allowed inputs, hard stops, authority boundaries, and safety flags.
- Added a focused contract test and updated the PR train manifest/state ledger.

## Why
This locks the future /ops/seo governance display as read-only before any UI implementation. It keeps content publish rehearsal, internal link graph, and claim lint summaries observable without adding write controls, submit controls, Metabase exposure, CMS mutation, or production operations.

## Validation
- php artisan test --filter=SeoIntelContentOpsClaimLinkOpsReadiness --no-ansi
- php artisan test --filter=SeoIntel --no-ansi
- php artisan route:list --no-ansi
- vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- yaml.safe_load(docs/codex/pr-train.yaml)
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No Filament UI implementation.
- No action buttons or write controls.
- No migrations or runtime service changes.
- No CMS mutation, internal link creation, content rewrite, Search Channel enqueue/submission, scheduler/collector controls, production operations, fap-web changes, or Metabase exposure.
