### PR TITLE
docs(seo-intel): close content ops claim link runtime train

### DIFF
--- a/backend/docs/seo/content-ops-claim-link-runtime-closeout.md
+++ b/backend/docs/seo/content-ops-claim-link-runtime-closeout.md
@@ -1,0 +1,127 @@
+# Content Ops / Claim / Link Runtime Train Closeout
+
+## Purpose
+
+This closeout records the result of the Content Ops / Internal Link / Chinese
+Claim Lint runtime train. It summarizes `CONTENT-OPS-02A`,
+`CONTENT-OPS-02B`, `INTERNAL-LINK-01A`, `INTERNAL-LINK-01B`,
+`CLAIM-LINT-01A`, `CLAIM-LINT-01B`, and
+`CONTENT-OPS-CLAIM-LINK-OPS-READINESS`, then sets the next operational SOP
+handoff.
+
+## Completed Scope
+
+The train completed these scoped PRs:
+
+- `CONTENT-OPS-02A`: content publish rehearsal contract
+- `CONTENT-OPS-02B`: content publish rehearsal dry-run validator
+- `INTERNAL-LINK-01A`: semantic internal link graph contract
+- `INTERNAL-LINK-01B`: internal link graph dry-run read model
+- `CLAIM-LINT-01A`: Chinese claim linter runtime contract
+- `CLAIM-LINT-01B`: Chinese claim linter runtime / CI-readable command
+- `CONTENT-OPS-CLAIM-LINK-OPS-READINESS`: `/ops/seo` display readiness
+
+## Content Publish Rehearsal Result
+
+The content publish rehearsal contract locks article/content rehearsal as
+dry-run only. It confirms no CMS mutation, no article publish, no sitemap or
+`llms.txt` inclusion for drafts, no Search Channel enqueue, no production write,
+and no Observation Queue write in the contract PR.
+
+The dry-run validator adds a reusable read-only rehearsal service and command
+surface that reports content package readiness, metadata readiness, canonical
+and robots/indexability state, claim lint state, internal link readiness, Search
+Channel eligibility dry-run state, planned observation events, blockers, and
+warnings. Its output confirms `dry_run=true`, `writes_attempted=false`,
+`cms_mutation_attempted=false`, `article_publish_attempted=false`,
+`search_channel_enqueue_attempted=false`, `search_submission_attempted=false`,
+`sitemap_mutation_attempted=false`, `llms_mutation_attempted=false`, and
+`observation_queue_write_attempted=false`.
+
+## Internal Link Graph Result
+
+The semantic internal link graph contract defines backend/CMS entity graph
+authority for internal links. fap-web static links, sitemap-derived links,
+crawler logs, GSC/GA4/referral data, and title/slug similarity are observation
+or migration-helper signals only and cannot create link truth.
+
+The internal link graph dry-run read model reports source inventory, graph
+family counts, missing entity key count, `legacy_unpaired` count, candidate
+opportunity count, unsafe fallback source count, and warnings without mutating
+CMS, modifying fap-web, creating links, using crawler logs as authority, or
+using sitemap/frontend fallback as graph truth.
+
+## Chinese Claim Linter Result
+
+The Chinese claim linter contract defines backend-owned claim lint states:
+`safe`, `needs_review`, and `blocked`. It maps public/indexable claim-unsafe
+pages to P0, high-risk SEO metadata / FAQ / llms / JSON-LD risks to P1,
+draft/article body caution to P2, and informational wording drift to P3.
+
+The runtime PR adds a reusable linter service, fixture-based CI-readable
+command, and fixture coverage for forbidden career recommendation claims,
+bounded career direction references, MBTI salary guarantee claims,
+model-index salary/turnover bounded phrasing, clinical diagnosis claims,
+non-diagnostic safe phrasing, Big Five / RIASEC overclaims, and snapshot-based
+support phrasing. It does not auto-rewrite, mutate CMS content, publish content,
+scan production content, or modify fap-web.
+
+## /ops/seo Readiness Result
+
+The `/ops/seo` readiness contract defines future read-only display sections for
+content publish rehearsal summaries, planned observation event counts, draft
+blocked-from-sitemap/llms/search counters, internal link graph coverage, missing
+entity key counts, `legacy_unpaired` counts, unsafe fallback link source counts,
+claim lint `safe` / `needs_review` / `blocked` counts, P0 / P1 / P2 / P3 claim
+issue summaries, and content ops sidecar warnings.
+
+It locks hard stops: no publish button, no rewrite button, no internal link
+creation button, no Search Channel enqueue button, no submit URL button, no
+scheduler controls, no collector controls, no raw SQL, no Metabase iframe or
+proxy, no raw payload display, no raw crawler logs, and no CMS write controls.
+
+## Safety Confirmation
+
+This train introduced no CMS content mutation. This train published no
+articles. This train executed no production migrations. This train enabled no
+scheduler. This train performed no Search Channel enqueue or submission. This
+train read no production crawler logs. This train modified no fap-web files.
+This train exposed no Metabase surface. This train performed no auto-rewrite.
+This train created no internal links. This train performed no production
+deploy, production env edit, collector write, search engine API call, or
+`seo_intel` data write.
+
+Short safety lock: no CMS content mutation, no article publish, no production
+migrations, no scheduler, no Search Channel enqueue or submission, no production
+crawler logs, no fap-web files, no Metabase surface, no auto-rewrite, and no
+internal links were created.
+
+## Ledger Result
+
+PRs `CONTENT-OPS-02A` through `CONTENT-OPS-CLAIM-LINK-OPS-READINESS` were
+completed through focused tests, full `SeoIntel` test runs, route listing,
+Pint, generated JSON validation, state JSON validation, YAML validation, diff
+checks, GitHub required checks, squash merge, branch cleanup, and focused
+post-merge revalidation.
+
+This closeout reconciles the PR7 ledger state after merge and records the train
+handoff. The closeout PR itself remains docs/generated/test/state only.
+
+## Sidecar Issues
+
+- `translation_group_uuid` is still missing globally. Existing
+  `translation_group_id` remains partial and transitional until a separately
+  approved entity-key implementation/backfill train.
+- Backend deploy public smoke blocker remains separate from this train.
+- fap-web fallback authority risk remains a reference-only sidecar and was not
+  modified in this train.
+- Production `/ops` or API TLS checks may still be flaky from local network and
+  were not used as gating production operations.
+- BigFive runtime freeze allowlist was extended in scoped implementation PRs so
+  new read-only SeoIntel runtime files are classified correctly.
+
+## Final Decision
+
+content_ops_claim_link_runtime_train_completed_ready_for_seo_ops_sop
+
+Next task: `SEO-OPS-SOP-01`

--- a/backend/docs/seo/generated/content-ops-claim-link-runtime-closeout.v1.json
+++ b/backend/docs/seo/generated/content-ops-claim-link-runtime-closeout.v1.json
@@ -1,0 +1,116 @@
+{
+  "version": "content-ops-claim-link-runtime-closeout.v1",
+  "task": "CONTENT-OPS-CLAIM-LINK-CLOSEOUT",
+  "train": "CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01",
+  "completed_prs": [
+    {
+      "id": "CONTENT-OPS-02A",
+      "title": "Content publish rehearsal contract",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1562"
+    },
+    {
+      "id": "CONTENT-OPS-02B",
+      "title": "Content publish rehearsal dry-run validator",
+      "result": "completed_read_only_runtime",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1563"
+    },
+    {
+      "id": "INTERNAL-LINK-01A",
+      "title": "Semantic internal link graph contract",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1564"
+    },
+    {
+      "id": "INTERNAL-LINK-01B",
+      "title": "Internal link graph dry-run read model",
+      "result": "completed_read_only_runtime",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1565"
+    },
+    {
+      "id": "CLAIM-LINT-01A",
+      "title": "Chinese claim linter runtime contract",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1566"
+    },
+    {
+      "id": "CLAIM-LINT-01B",
+      "title": "Chinese claim linter runtime / CI",
+      "result": "completed_ci_readable_runtime",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1567"
+    },
+    {
+      "id": "CONTENT-OPS-CLAIM-LINK-OPS-READINESS",
+      "title": "/ops/seo display readiness",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1568"
+    }
+  ],
+  "results": {
+    "content_publish_rehearsal": "Contract and dry-run validator completed. Rehearsal reports readiness, blockers, warnings, claim lint state, internal link readiness, Search Channel eligibility dry-run state, and planned observation events without publishing or writing.",
+    "internal_link_graph": "Backend/CMS authority contract and dry-run read model completed. It reports source inventory, graph family counts, entity-key gaps, legacy_unpaired count, candidate opportunities, unsafe fallback sources, and warnings without creating links.",
+    "chinese_claim_linter": "Contract and runtime completed. The linter classifies safe, needs_review, and blocked candidate copy, maps severity where context is available, supports bundled fixtures, and does not auto-rewrite or mutate CMS content.",
+    "ops_seo_readiness": "Future /ops/seo read-only sections and hard stops are defined without implementing UI, action buttons, write controls, raw data display, or Metabase exposure.",
+    "ledger": "PR7 merged state is reconciled and this closeout remains docs/generated/test/state only."
+  },
+  "safety_confirmation": {
+    "cms_content_mutated": false,
+    "article_published": false,
+    "production_migrations_executed": false,
+    "scheduler_enabled": false,
+    "search_channel_enqueue_or_submission": false,
+    "production_crawler_logs_read": false,
+    "fap_web_modified": false,
+    "metabase_exposed": false,
+    "auto_rewrite_performed": false,
+    "internal_links_created": false,
+    "production_deploy_performed": false,
+    "production_env_changed": false,
+    "collector_writes_enabled": false,
+    "search_engine_api_called": false,
+    "seo_intel_written": false,
+    "cms_write_controls_added": false,
+    "ops_ui_implemented": false,
+    "migrations_added": false
+  },
+  "validation_summary": {
+    "focused_contract_and_runtime_tests": "passed during each PR before merge",
+    "seo_intel_suite": "passed during each PR before merge",
+    "route_list": "passed during each PR before merge",
+    "pint": "passed during each PR before merge",
+    "json_validation": "passed",
+    "yaml_validation": "passed",
+    "diff_checks": "passed",
+    "github_required_checks": "passed before every merge",
+    "post_merge_revalidation": "passed after every merged PR"
+  },
+  "sidecar_issues": [
+    {
+      "title": "translation_group_uuid missing globally",
+      "status": "separate_implementation_required",
+      "reason": "translation_group_id remains partial and transitional until an approved entity-key implementation/backfill train."
+    },
+    {
+      "title": "Backend deploy public smoke blocker",
+      "status": "external_sidecar",
+      "reason": "Production deploy/readiness work is separate from this train."
+    },
+    {
+      "title": "fap-web fallback authority risk",
+      "status": "left_reference_only",
+      "reason": "fap-web was not modified; frontend fallback authority remains a sidecar for future frontend/backend authority cleanup."
+    },
+    {
+      "title": "Production ops/API TLS flakiness",
+      "status": "not_gating_this_train",
+      "reason": "No production operations were part of this train."
+    },
+    {
+      "title": "BigFive runtime freeze allowlist",
+      "status": "handled_in_scoped_prs",
+      "reason": "Allowlist extensions were required only to classify new read-only SeoIntel runtime files correctly."
+    }
+  ],
+  "final_decision": "content_ops_claim_link_runtime_train_completed_ready_for_seo_ops_sop",
+  "next_task": "SEO-OPS-SOP-01"
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelContentOpsClaimLinkRuntimeCloseoutTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelContentOpsClaimLinkRuntimeCloseoutTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelContentOpsClaimLinkRuntimeCloseoutTest extends TestCase
+{
+    #[Test]
+    public function closeout_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/content-ops-claim-link-runtime-closeout.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('content-ops-claim-link-runtime-closeout.v1', $artifact['version'] ?? null);
+        $this->assertSame('CONTENT-OPS-CLAIM-LINK-CLOSEOUT', $artifact['task'] ?? null);
+        $this->assertSame('CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01', $artifact['train'] ?? null);
+    }
+
+    #[Test]
+    public function completed_train_prs_are_recorded(): void
+    {
+        $completed = collect($this->artifact()['completed_prs'] ?? []);
+
+        foreach ([
+            'CONTENT-OPS-02A' => 'https://github.com/fermatmind/fap-api/pull/1562',
+            'CONTENT-OPS-02B' => 'https://github.com/fermatmind/fap-api/pull/1563',
+            'INTERNAL-LINK-01A' => 'https://github.com/fermatmind/fap-api/pull/1564',
+            'INTERNAL-LINK-01B' => 'https://github.com/fermatmind/fap-api/pull/1565',
+            'CLAIM-LINT-01A' => 'https://github.com/fermatmind/fap-api/pull/1566',
+            'CLAIM-LINT-01B' => 'https://github.com/fermatmind/fap-api/pull/1567',
+            'CONTENT-OPS-CLAIM-LINK-OPS-READINESS' => 'https://github.com/fermatmind/fap-api/pull/1568',
+        ] as $id => $url) {
+            $row = $completed->firstWhere('id', $id);
+
+            $this->assertIsArray($row, $id.' must be recorded');
+            $this->assertSame($url, $row['pr_url'] ?? null);
+            $this->assertNotSame('', $row['result'] ?? '');
+        }
+    }
+
+    #[Test]
+    public function result_summary_covers_publish_links_claims_ops_and_ledger(): void
+    {
+        $results = $this->artifact()['results'] ?? [];
+
+        foreach ([
+            'content_publish_rehearsal',
+            'internal_link_graph',
+            'chinese_claim_linter',
+            'ops_seo_readiness',
+            'ledger',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $results);
+            $this->assertNotSame('', $results[$key]);
+        }
+    }
+
+    #[Test]
+    public function safety_confirmation_blocks_mutations_and_production_work(): void
+    {
+        foreach ([
+            'cms_content_mutated',
+            'article_published',
+            'production_migrations_executed',
+            'scheduler_enabled',
+            'search_channel_enqueue_or_submission',
+            'production_crawler_logs_read',
+            'fap_web_modified',
+            'metabase_exposed',
+            'auto_rewrite_performed',
+            'internal_links_created',
+            'production_deploy_performed',
+            'production_env_changed',
+            'collector_writes_enabled',
+            'search_engine_api_called',
+            'seo_intel_written',
+            'cms_write_controls_added',
+            'ops_ui_implemented',
+            'migrations_added',
+        ] as $flag) {
+            $this->assertFalse((bool) ($this->artifact()['safety_confirmation'][$flag] ?? true), $flag.' must be false');
+        }
+    }
+
+    #[Test]
+    public function validation_summary_and_sidecars_are_explicit(): void
+    {
+        $summary = $this->artifact()['validation_summary'] ?? [];
+
+        foreach ([
+            'focused_contract_and_runtime_tests',
+            'seo_intel_suite',
+            'route_list',
+            'pint',
+            'json_validation',
+            'yaml_validation',
+            'diff_checks',
+            'github_required_checks',
+            'post_merge_revalidation',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $summary);
+        }
+
+        $sidecars = collect($this->artifact()['sidecar_issues'] ?? []);
+
+        foreach ([
+            'translation_group_uuid missing globally',
+            'Backend deploy public smoke blocker',
+            'fap-web fallback authority risk',
+            'Production ops/API TLS flakiness',
+            'BigFive runtime freeze allowlist',
+        ] as $title) {
+            $this->assertNotNull($sidecars->firstWhere('title', $title), $title.' sidecar must be recorded');
+        }
+    }
+
+    #[Test]
+    public function final_decision_and_next_task_are_locked(): void
+    {
+        $this->assertSame(
+            'content_ops_claim_link_runtime_train_completed_ready_for_seo_ops_sop',
+            $this->artifact()['final_decision'] ?? null
+        );
+        $this->assertSame('SEO-OPS-SOP-01', $this->artifact()['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function docs_lock_no_runtime_operations_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/content-ops-claim-link-runtime-closeout.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/content-ops-claim-link-runtime-closeout.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'content-ops-02a',
+            'content-ops-02b',
+            'internal-link-01a',
+            'internal-link-01b',
+            'claim-lint-01a',
+            'claim-lint-01b',
+            'content-ops-claim-link-ops-readiness',
+            'no cms content mutation',
+            'no article publish',
+            'no production migrations',
+            'no scheduler',
+            'no search channel enqueue or submission',
+            'no production crawler logs',
+            'no fap-web files',
+            'no metabase surface',
+            'no auto-rewrite',
+            'no internal links',
+            'seo-ops-sop-01',
+            '"next_task": "SEO-OPS-SOP-01"',
+        ] as $required) {
+            $this->assertStringContainsString(strtolower($required), $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/content-ops-claim-link-runtime-closeout.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T16:27:35+08:00",
+  "updated_at": "2026-05-22T16:39:09+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -734,7 +734,18 @@
       ],
       "commit_sha": "f8d8ff9433a97acfd0ce5a7d161fac20e0283f6d",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1356",
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_closeout": "passed: php artisan test --filter=SeoIntelContentOpsClaimLinkRuntimeCloseout --no-ansi (7 tests, 138 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (461 tests, 7393 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3481 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/content-ops-claim-link-runtime-closeout.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
@@ -8224,7 +8235,7 @@
       "depends_on": [
         "REPAIR-2786-FINAL-READINESS-SOFTWARE-MANUAL-HOLD-AUTHORITY-1"
       ],
-      "status": "in_progress",
+      "status": "merged",
       "train_scope": "career_product_claim_authority",
       "risk_level": "medium",
       "title": "fix(api): align career 2786 product claim authority",
@@ -18315,13 +18326,30 @@
         "INTERNAL-LINK-01B",
         "CLAIM-LINT-01B"
       ],
-      "commit_sha": null,
-      "pr_url": null,
-      "checks": {},
+      "commit_sha": "4143c1eba91f85a80c1d4b2c8d08ae18abd2f919",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1568",
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_ops_readiness": "passed: php artisan test --filter=SeoIntelContentOpsClaimLinkOpsReadiness --no-ansi (6 tests, 70 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (454 tests, 7255 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3480 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/content-ops-claim-link-ops-readiness.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1568": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_readiness_test": "passed: php artisan test --filter=SeoIntelContentOpsClaimLinkOpsReadiness --no-ansi"
+        }
+      },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-22T08:33:52Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -18347,13 +18375,18 @@
           "at": "2026-05-22T16:27:35+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1568 for CONTENT-OPS-CLAIM-LINK-OPS-READINESS and pushed branch codex/content-ops-claim-link-ops-readiness."
+        },
+        {
+          "at": "2026-05-22T16:33:52+08:00",
+          "status": "merged",
+          "summary": "PR #1568 merged via squash at 4143c1eba91f85a80c1d4b2c8d08ae18abd2f919. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused readiness test passed."
         }
       ]
     },
     "CONTENT-OPS-CLAIM-LINK-CLOSEOUT": {
       "repo": "fap-api",
       "branch": "codex/content-ops-claim-link-closeout",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "CONTENT-OPS-CLAIM-LINK-OPS-READINESS"
       ],
@@ -18374,6 +18407,16 @@
           "at": "2026-05-22T14:37:34+08:00",
           "status": "pending",
           "summary": "Registered closeout/ledger finalization PR for the content ops claim/link runtime train. Scope is closeout docs/generated/test/state only with no runtime, migration, production, CMS, Search Channel, crawler, scheduler, or fap-web changes."
+        },
+        {
+          "at": "2026-05-22T16:38:00+08:00",
+          "status": "in_progress",
+          "summary": "Started CONTENT-OPS-CLAIM-LINK-CLOSEOUT on codex/content-ops-claim-link-closeout. Scope is closeout docs/generated/test/state only plus train ledger reconciliation; no runtime code, migrations, production operations, CMS mutation, Search Channel mutation, crawler log read, scheduler activation, Metabase exposure, or fap-web change."
+        },
+        {
+          "at": "2026-05-22T16:39:09+08:00",
+          "status": "local_validation_passed",
+          "summary": "CONTENT-OPS-CLAIM-LINK-CLOSEOUT local validation passed for focused closeout test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains closeout docs/generated/test/state only; no runtime code, migrations, production operations, CMS mutation, Search Channel mutation, crawler log read, scheduler activation, Metabase exposure, or fap-web change."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T16:39:09+08:00",
+  "updated_at": "2026-05-22T16:40:28+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -8344,7 +8344,7 @@
       "depends_on": [
         "REPAIR-CN-PROXY-NOINDEX-PUBLIC-OWNER-SURFACE-1"
       ],
-      "status": "in_progress",
+      "status": "pr_open",
       "train_scope": "career_directory_detail_pending_authority",
       "risk_level": "medium",
       "title": "fix(api): promote display-backed directory draft jobs in list authority",
@@ -16779,8 +16779,8 @@
       "depends_on": [
         "BACKEND-DEPLOY-TARGET-ALIYUN-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "a3ea1aceec6961bb511965c1d7667134702b2891",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1569",
       "checks": {
         "aliyun_tls": {
           "status": "pass",
@@ -18417,6 +18417,11 @@
           "at": "2026-05-22T16:39:09+08:00",
           "status": "local_validation_passed",
           "summary": "CONTENT-OPS-CLAIM-LINK-CLOSEOUT local validation passed for focused closeout test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains closeout docs/generated/test/state only; no runtime code, migrations, production operations, CMS mutation, Search Channel mutation, crawler log read, scheduler activation, Metabase exposure, or fap-web change."
+        },
+        {
+          "at": "2026-05-22T16:40:28+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1569 for CONTENT-OPS-CLAIM-LINK-CLOSEOUT and pushed branch codex/content-ops-claim-link-closeout."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9642,7 +9642,7 @@ prs:
       - CONTENT-OPS-CLAIM-LINK-OPS-READINESS
     branch: codex/content-ops-claim-link-closeout
     base: main
-    title: "docs(content-ops): close content ops claim link runtime train"
+    title: "docs(seo-intel): close content ops claim link runtime train"
     name: "Content Ops claim/link runtime closeout"
     train_scope: content_ops_claim_link_runtime
     risk_level: low_contract_only


### PR DESCRIPTION
## What changed
- Added the Content Ops / Claim / Link runtime train closeout document.
- Added the generated closeout JSON artifact and focused closeout contract test.
- Reconciled PR7 merged ledger state and updated the PR train manifest title for the closeout scope.

## Why
This closes the train after the publish rehearsal contract/runtime, semantic internal link graph contract/runtime, Chinese claim linter contract/runtime, and /ops/seo readiness PRs. It records validation, sidecars, safety boundaries, and the next SOP handoff.

## Validation
- php artisan test --filter=SeoIntelContentOpsClaimLinkRuntimeCloseout --no-ansi
- php artisan test --filter=SeoIntel --no-ansi
- php artisan route:list --no-ansi
- vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/content-ops-claim-link-runtime-closeout.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- yaml.safe_load(docs/codex/pr-train.yaml)
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No runtime code, migrations, production operations, CMS mutation, article publish, Search Channel enqueue/submission, crawler log read, scheduler activation, Metabase exposure, fap-web change, auto-rewrite, or internal link creation.
- translation_group_uuid implementation/backfill remains a separate sidecar.
