### PR TITLE
docs(seo-intel): add SEO Ops SOP architecture map

### DIFF
--- a/backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json
+++ b/backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json
@@ -1,0 +1,116 @@
+{
+  "version": "seo-ops-sop-architecture-authority-map.v1",
+  "task": "SEO-OPS-SOP-01A",
+  "train": "SEO-OPS-SOP-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "authority_model": {
+    "cms_backend": "truth_for_content_metadata_canonical_publish_state_claim_boundary_and_url_truth",
+    "fap_web": "deterministic_public_runtime_renderer_not_truth_source",
+    "seo_intel": "observation_only",
+    "ops_seo": "read_only_operational_view_not_truth_source",
+    "ops_seo_operations": "write_capable_cms_repair_surface_not_daily_observability",
+    "metabase": "private_read_only_not_public_surface",
+    "search_channel_queue": "distribution_of_approved_url_truth_only",
+    "crawler_log": "aggregate_observation_only_not_url_truth",
+    "observation_governance": "verification_state_tracking_only",
+    "content_publish_rehearsal": "dry_run_validation_only",
+    "internal_link_graph": "dry_run_readiness_and_opportunity_signal_only",
+    "chinese_claim_lint": "flag_or_block_only_no_auto_rewrite",
+    "digital_pr_tracking": "manual_observation_only"
+  },
+  "operator_surfaces": [
+    "/ops/seo",
+    "/ops/seo-operations",
+    "seo_intel_url_truth",
+    "seo_issue_queue",
+    "seo_search_channel_queue",
+    "seo_crawler_log_daily_aggregates",
+    "content_publish_rehearsal_dry_run",
+    "internal_link_graph_dry_run",
+    "chinese_claim_linter",
+    "digital_pr_tracking",
+    "seo_growth_mbti_00_handoff"
+  ],
+  "truth_sources": [
+    "cms_backend_content_state",
+    "cms_backend_seo_metadata",
+    "cms_backend_canonical_and_robots_state",
+    "backend_governed_url_truth",
+    "backend_payment_order_report_access_events"
+  ],
+  "observation_sources": [
+    "ops_seo_dashboard_counters",
+    "issue_queue_rows",
+    "search_channel_queue_states",
+    "crawler_aggregate_observations",
+    "approved_search_performance_feedback",
+    "digital_pr_response_referral_mention_status",
+    "claim_lint_output",
+    "internal_link_dry_run_output"
+  ],
+  "distribution_paths": [
+    "search_channel_queue_after_explicit_approval"
+  ],
+  "repair_paths": [
+    "approved_cms_backend_repair_workflows",
+    "ops_seo_operations_after_human_review"
+  ],
+  "forbidden_authority_sources": [
+    "frontend_fallback",
+    "static_sitemap",
+    "static_llms",
+    "crawler_log",
+    "search_engine_response",
+    "digital_pr_mention",
+    "local_copy"
+  ],
+  "routine_ops_forbidden": [
+    "runtime_implementation",
+    "migration",
+    "production_operation",
+    "env_edit",
+    "deployment",
+    "scheduler_activation",
+    "collector_write",
+    "crawler_log_read",
+    "search_channel_submission",
+    "cms_content_mutation",
+    "article_publish",
+    "metabase_exposure",
+    "fap_web_modification",
+    "digital_pr_send",
+    "auto_rewrite",
+    "auto_link_creation",
+    "pseo_generation",
+    "precise_recommender_overclaim"
+  ],
+  "mbti_growth_handoff": {
+    "next_phase": "SEO-GROWTH-MBTI-00",
+    "first_loop": "MBTI",
+    "do_not_scale_before_review": [
+      "Big Five",
+      "RIASEC",
+      "Career"
+    ]
+  },
+  "safety_flags": {
+    "runtime_services_added": false,
+    "migrations_added": false,
+    "production_operations_performed": false,
+    "env_edited": false,
+    "deploy_scripts_modified": false,
+    "scheduler_enabled": false,
+    "collector_writes_enabled": false,
+    "crawler_logs_read": false,
+    "search_channel_submitted": false,
+    "cms_content_mutated": false,
+    "article_published": false,
+    "metabase_exposed": false,
+    "fap_web_modified": false,
+    "digital_pr_sent": false,
+    "auto_rewrite_enabled": false,
+    "internal_links_created": false,
+    "pseo_created": false
+  },
+  "next_task": "SEO-OPS-SOP-01B"
+}

--- a/backend/docs/seo/seo-ops-sop-architecture-authority-map.md
+++ b/backend/docs/seo/seo-ops-sop-architecture-authority-map.md
@@ -1,0 +1,113 @@
+# SEO Ops SOP Architecture and Authority Map
+
+Task: SEO-OPS-SOP-01A
+
+Type: docs/generated/test only.
+
+This contract defines the final SEO Ops architecture for routine daily, weekly, and monthly operation. It does not add runtime services, migrations, production operations, scheduler behavior, Search Channel writes, crawler log reads, CMS mutations, Digital PR sends, UI implementation, or fap-web changes.
+
+## Authority Model
+
+CMS/backend is truth for content, SEO metadata, canonical paths, robots/indexability, publish state, claim boundary, and URL Truth.
+
+fap-web is a deterministic public runtime renderer. It may render CMS/API content, stale cache, or minimal shells according to existing product rules, but frontend fallback content is not truth.
+
+seo_intel observes. It stores URL Truth and operational observations, but it does not publish content, rewrite claims, create internal links, or decide CMS truth.
+
+/ops/seo is an operational read-only view. It helps operators inspect URL Truth, Issue Queue, Search Channel Queue, crawler aggregate observations, and SEO safety counters. It is not a truth source.
+
+/ops/seo-operations is a write-capable CMS repair surface behind permissions. It is not the daily read-only observability dashboard and must not be used as a routine checklist surface.
+
+Metabase remains private and read-only. It must not be exposed, iframed, proxied, or treated as a public operational surface.
+
+Search Channel Queue distributes only approved URL Truth. It is not allowed to create URL Truth or submit draft, private, noindex, non-canonical, or claim-unsafe URLs.
+
+Crawler Log observes aggregate crawler behavior only. Raw crawler logs, raw request URIs, IP addresses, user agents, and raw payloads must not become URL Truth.
+
+Observation Governance tracks verification states only. Observation Queue is not URL Truth, not Search Channel Queue, not CMS repair, and not a search submission path.
+
+Content publish rehearsal is dry-run validation. It does not publish, mutate CMS content, enqueue Search Channel, write Observation Queue, or change sitemap/llms behavior.
+
+Internal Link dry-run suggests graph readiness and opportunities. It does not create links, mutate CMS, or use crawler/search/referral signals as link authority.
+
+Chinese Claim Lint flags or blocks unsafe wording. It does not auto-rewrite, auto-publish, or mutate CMS content.
+
+Digital PR tracking is manual and observation-only. Mentions, referrals, and backlinks are signals, not URL Truth.
+
+## Operator Surface Map
+
+- Daily observability: `/ops/seo`.
+- CMS repair after human approval: `/ops/seo-operations` or approved CMS/backend workflows.
+- Search distribution after approval: Search Channel Queue commands and approved execution path.
+- Aggregate crawler review: crawler aggregate observation read model only.
+- Content validation: content publish rehearsal dry-run command/output.
+- Internal link review: internal link graph dry-run command/output.
+- Claim review: Chinese claim linter fixture/candidate output.
+- Digital PR review: local/manual tracking artifacts and approved analytics/referral summaries.
+- Growth handoff: SEO-GROWTH-MBTI-00 baseline and telemetry contract.
+
+## Routine Ops Boundaries
+
+Truth:
+
+- CMS/backend content state.
+- CMS/backend SEO metadata.
+- CMS/backend canonical and robots state.
+- Backend-governed URL Truth.
+- Backend payment/order/report access events for funnel truth.
+
+Observation:
+
+- /ops/seo dashboard counters.
+- Issue Queue rows.
+- Search Channel Queue states.
+- Crawler aggregate observations.
+- GSC/GA4/referral feedback when approved and available.
+- Digital PR response/referral/mention status.
+- Claim lint and internal link dry-run output.
+
+Distribution:
+
+- Search Channel Queue can distribute approved URL Truth only after explicit gate approval.
+
+Repair:
+
+- CMS/backend repair workflows only after human review.
+- No repair action originates from the read-only /ops/seo dashboard.
+
+## Forbidden Routine Authority Sources
+
+- frontend fallback is not truth.
+- static sitemap is not truth.
+- static llms is not truth.
+- crawler log is not truth.
+- search engine response is not truth.
+- Digital PR mention is not truth.
+- local copy is not truth.
+
+## Forbidden Routine Operations
+
+- no runtime implementation in this SOP train.
+- no migrations.
+- no production operations.
+- no env edits.
+- no deployment.
+- no scheduler activation.
+- no collector writes.
+- no crawler log reads.
+- no Search Channel submission.
+- no CMS content mutation.
+- no article publish.
+- no Metabase exposure.
+- no fap-web modification.
+- no Digital PR send.
+- no auto-rewrite.
+- no auto-link creation.
+- no pSEO generation.
+- no RIASEC, Big Five, or Career Graph precise recommender overclaiming.
+
+## MBTI Growth Loop Handoff
+
+The SOP train prepares the system for SEO-GROWTH-MBTI-00. The handoff must keep MBTI as the first governed growth loop and must not scale to Big Five, RIASEC, or Career before the MBTI baseline, telemetry, claim gate, Search Channel canary, Digital PR observation, and 7/14/28-day review are complete.
+
+Next task after this PR: `SEO-OPS-SOP-01B`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsSopArchitectureAuthorityMapTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsSopArchitectureAuthorityMapTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSeoOpsSopArchitectureAuthorityMapTest extends TestCase
+{
+    #[Test]
+    public function architecture_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-ops-sop-architecture-authority-map.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-ops-sop-architecture-authority-map.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01A', $artifact['task'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01B', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function authority_model_keeps_truth_observation_distribution_and_repair_separate(): void
+    {
+        $model = $this->artifact()['authority_model'] ?? [];
+
+        $this->assertSame('truth_for_content_metadata_canonical_publish_state_claim_boundary_and_url_truth', $model['cms_backend'] ?? null);
+        $this->assertSame('deterministic_public_runtime_renderer_not_truth_source', $model['fap_web'] ?? null);
+        $this->assertSame('observation_only', $model['seo_intel'] ?? null);
+        $this->assertSame('read_only_operational_view_not_truth_source', $model['ops_seo'] ?? null);
+        $this->assertSame('write_capable_cms_repair_surface_not_daily_observability', $model['ops_seo_operations'] ?? null);
+        $this->assertSame('private_read_only_not_public_surface', $model['metabase'] ?? null);
+        $this->assertSame('distribution_of_approved_url_truth_only', $model['search_channel_queue'] ?? null);
+        $this->assertSame('aggregate_observation_only_not_url_truth', $model['crawler_log'] ?? null);
+        $this->assertSame('manual_observation_only', $model['digital_pr_tracking'] ?? null);
+    }
+
+    #[Test]
+    public function forbidden_authority_sources_are_locked(): void
+    {
+        $sources = $this->artifact()['forbidden_authority_sources'] ?? [];
+
+        foreach ([
+            'frontend_fallback',
+            'static_sitemap',
+            'static_llms',
+            'crawler_log',
+            'search_engine_response',
+            'digital_pr_mention',
+            'local_copy',
+        ] as $source) {
+            $this->assertContains($source, $sources);
+        }
+    }
+
+    #[Test]
+    public function routine_ops_forbidden_operations_are_explicit(): void
+    {
+        $forbidden = $this->artifact()['routine_ops_forbidden'] ?? [];
+
+        foreach ([
+            'runtime_implementation',
+            'migration',
+            'production_operation',
+            'env_edit',
+            'deployment',
+            'scheduler_activation',
+            'collector_write',
+            'crawler_log_read',
+            'search_channel_submission',
+            'cms_content_mutation',
+            'article_publish',
+            'metabase_exposure',
+            'fap_web_modification',
+            'digital_pr_send',
+            'auto_rewrite',
+            'auto_link_creation',
+            'pseo_generation',
+            'precise_recommender_overclaim',
+        ] as $operation) {
+            $this->assertContains($operation, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_confirm_no_runtime_or_production_work(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_include_hard_boundaries_and_mbti_handoff(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-ops-sop-architecture-authority-map.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'cms/backend is truth',
+            'fap-web is a deterministic public runtime renderer',
+            '/ops/seo is an operational read-only view',
+            '/ops/seo-operations is a write-capable cms repair surface',
+            'metabase remains private',
+            'search channel queue distributes only approved url truth',
+            'crawler log observes aggregate crawler behavior only',
+            'frontend fallback is not truth',
+            'static sitemap is not truth',
+            'static llms is not truth',
+            'crawler log is not truth',
+            'search engine response is not truth',
+            'digital pr mention is not truth',
+            'local copy is not truth',
+            'seo-growth-mbti-00',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T17:30:30+08:00",
+  "updated_at": "2026-05-22T17:32:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18455,12 +18455,12 @@
     "SEO-OPS-SOP-01A": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01a-architecture-map",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "CONTENT-OPS-CLAIM-LINK-CLOSEOUT"
       ],
       "commit_sha": "1115a89e37a650549298a91017f392a04466b0fa",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1571",
       "checks": {
         "local": {
           "php_artisan_test_filter_architecture_authority_map": "passed: php artisan test --filter=SeoIntelSeoOpsSopArchitectureAuthorityMap --no-ansi (6 tests, 82 assertions)",
@@ -18497,6 +18497,11 @@
           "at": "2026-05-22T17:29:00+08:00",
           "status": "local_validation_passed",
           "summary": "SEO-OPS-SOP-01A local validation passed for focused architecture test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
+        },
+        {
+          "at": "2026-05-22T17:32:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1571 for SEO-OPS-SOP-01A and pushed branch codex/seo-ops-sop-01a-architecture-map."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T16:50:00+08:00",
+  "updated_at": "2026-05-22T17:30:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18449,6 +18449,189 @@
           "at": "2026-05-22T16:50:00+08:00",
           "status": "ledger_repair",
           "summary": "Corrected a closeout ledger metadata patch so OPS-DOMAIN-MIGRATION-01 keeps its pre-existing null commit/pr_url values and CONTENT-OPS-CLAIM-LINK-CLOSEOUT records PR #1569 merge state."
+        }
+      ]
+    },
+    "SEO-OPS-SOP-01A": {
+      "repo": "fap-api",
+      "branch": "codex/seo-ops-sop-01a-architecture-map",
+      "status": "local_validation_passed",
+      "depends_on": [
+        "CONTENT-OPS-CLAIM-LINK-CLOSEOUT"
+      ],
+      "commit_sha": "1115a89e37a650549298a91017f392a04466b0fa",
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_architecture_authority_map": "passed: php artisan test --filter=SeoIntelSeoOpsSopArchitectureAuthorityMap --no-ansi (6 tests, 82 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (467 tests, 7475 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3482 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-OPS-SOP-01B",
+      "history": [
+        {
+          "at": "2026-05-22T17:22:25+08:00",
+          "status": "pending",
+          "summary": "Registered SEO Ops SOP architecture and authority map PR. Scope is docs/generated/test plus train metadata only; no runtime services, migrations, production operations, fap-web changes, CMS mutations, deploys, scheduler changes, or command behavior changes."
+        },
+        {
+          "at": "2026-05-22T17:23:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-OPS-SOP-01A on codex/seo-ops-sop-01a-architecture-map. Scope is docs/generated/test plus train metadata only; no runtime services, migrations, production operations, fap-web changes, CMS mutations, deployment files, scheduler changes, or command behavior changes."
+        },
+        {
+          "at": "2026-05-22T17:29:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-OPS-SOP-01A local validation passed for focused architecture test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
+        }
+      ]
+    },
+    "SEO-OPS-SOP-01B": {
+      "repo": "fap-api",
+      "branch": "codex/seo-ops-sop-01b-daily-runbook",
+      "status": "pending",
+      "depends_on": [
+        "SEO-OPS-SOP-01A"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-OPS-SOP-01C",
+      "history": [
+        {
+          "at": "2026-05-22T17:22:25+08:00",
+          "status": "pending",
+          "summary": "Registered daily SEO Ops runbook PR. Scope is docs/generated/test plus train metadata only; no runtime services, migrations, production env changes, fap-web changes, CMS mutations, Search Channel mutations, crawler log reads, scheduler changes, or Digital PR sends."
+        }
+      ]
+    },
+    "SEO-OPS-SOP-01C": {
+      "repo": "fap-api",
+      "branch": "codex/seo-ops-sop-01c-weekly-monthly",
+      "status": "pending",
+      "depends_on": [
+        "SEO-OPS-SOP-01B"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-OPS-SOP-01D",
+      "history": [
+        {
+          "at": "2026-05-22T17:22:25+08:00",
+          "status": "pending",
+          "summary": "Registered weekly/monthly SEO Ops review runbook PR. Scope is docs/generated/test plus train metadata only; no runtime services, migrations, production operations, fap-web changes, CMS mutations, scheduler changes, queue writes, or crawler log reads."
+        }
+      ]
+    },
+    "SEO-OPS-SOP-01D": {
+      "repo": "fap-api",
+      "branch": "codex/seo-ops-sop-01d-approval-gates",
+      "status": "pending",
+      "depends_on": [
+        "SEO-OPS-SOP-01C"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-OPS-SOP-01E",
+      "history": [
+        {
+          "at": "2026-05-22T17:22:25+08:00",
+          "status": "pending",
+          "summary": "Registered SEO Ops approval gates and no-go protocols PR. Scope is docs/generated/test plus train metadata only; no gate implementation, runtime services, env edits, deploy changes, fap-web changes, or production actions."
+        }
+      ]
+    },
+    "SEO-OPS-SOP-01E": {
+      "repo": "fap-api",
+      "branch": "codex/seo-ops-sop-01e-mbti-growth-handoff",
+      "status": "pending",
+      "depends_on": [
+        "SEO-OPS-SOP-01D"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-OPS-SOP-01F",
+      "history": [
+        {
+          "at": "2026-05-22T17:22:25+08:00",
+          "status": "pending",
+          "summary": "Registered MBTI Growth Loop handoff PR. Scope is docs/generated/test plus train metadata only; no runtime services, CMS mutation, fap-web changes, Search Channel mutation, Digital PR send, pSEO, or deploy."
+        }
+      ]
+    },
+    "SEO-OPS-SOP-01F": {
+      "repo": "fap-api",
+      "branch": "codex/seo-ops-sop-01f-final-closeout",
+      "status": "pending",
+      "depends_on": [
+        "SEO-OPS-SOP-01E"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": null,
+      "history": [
+        {
+          "at": "2026-05-22T17:22:25+08:00",
+          "status": "pending",
+          "summary": "Registered final SEO Ops SOP closeout PR. Scope is closeout docs/generated/test/state only; no runtime code, migrations, production operations, fap-web changes, or CMS mutations."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9677,3 +9677,255 @@ prs:
     production_migration_execution_allowed: false
     scheduler_activation: false
     next_task: CONTENT-OPS-CLAIM-LINK-RUNTIME-TRAIN-01-COMPLETE
+
+  - id: SEO-OPS-SOP-01A
+    repo: fap-api
+    depends_on:
+      - CONTENT-OPS-CLAIM-LINK-CLOSEOUT
+    branch: codex/seo-ops-sop-01a-architecture-map
+    base: main
+    title: "docs(seo-intel): add SEO Ops SOP architecture map"
+    name: "SEO Ops SOP architecture and authority map"
+    train_scope: seo_ops_sop
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define the final SEO Ops architecture, authority map, and operator surface map.
+      - Separate truth, observation, distribution, repair, and forbidden routine operations.
+      - Lock hard boundaries for frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, and local copies.
+    allowed_paths:
+      - backend/docs/seo/seo-ops-sop-architecture-authority-map.md
+      - backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSeoOpsSopArchitectureAuthorityMapTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add runtime services, migrations, production files, fap-web changes, CMS content changes, deployment files, scheduler changes, or command behavior changes.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSeoOpsSopArchitectureAuthorityMap --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-OPS-SOP-01B
+
+  - id: SEO-OPS-SOP-01B
+    repo: fap-api
+    depends_on:
+      - SEO-OPS-SOP-01A
+    branch: codex/seo-ops-sop-01b-daily-runbook
+    base: main
+    title: "docs(seo-intel): add daily SEO Ops runbook"
+    name: "Daily SEO Ops runbook"
+    train_scope: seo_ops_sop
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define the daily SEO Ops checklist and escalation rules.
+      - Cover /ops/seo, URL Truth, Issue Queue P0/P1, Search Channel Queue states, crawler aggregate counters, Claim Lint, Internal Link gaps, Content Publish Rehearsal blockers, Digital PR HRZone state, and MBTI Growth Loop status if active.
+      - Forbid daily checklist mutations, URL submissions, raw crawler log reads, Digital PR follow-up sends, and crawler/search/referral truth drift.
+    allowed_paths:
+      - backend/docs/seo/seo-ops-daily-runbook.md
+      - backend/docs/seo/generated/seo-ops-daily-runbook.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSeoOpsDailyRunbookTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add runtime services, migrations, production env changes, fap-web changes, CMS mutations, Search Channel mutations, crawler log reads, scheduler changes, or Digital PR sends.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSeoOpsDailyRunbook --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-ops-daily-runbook.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-OPS-SOP-01C
+
+  - id: SEO-OPS-SOP-01C
+    repo: fap-api
+    depends_on:
+      - SEO-OPS-SOP-01B
+    branch: codex/seo-ops-sop-01c-weekly-monthly
+    base: main
+    title: "docs(seo-intel): add weekly and monthly SEO Ops runbook"
+    name: "Weekly and monthly SEO Ops review runbook"
+    train_scope: seo_ops_sop
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define weekly Search Channel, crawler aggregate, content rehearsal, internal link, claim lint, Research URL, Digital PR, MBTI cluster, and repair backlog review.
+      - Define monthly entity cluster, content decay, internal link coverage, claim safety, Digital PR, Search Channel audit, crawler aggregate, funnel, MBTI Growth Loop, and next entity review.
+      - Separate escalations, backlog decisions, observation-only signals, and human approval gates.
+    allowed_paths:
+      - backend/docs/seo/seo-ops-weekly-monthly-review-runbook.md
+      - backend/docs/seo/generated/seo-ops-weekly-monthly-review-runbook.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSeoOpsWeeklyMonthlyReviewRunbookTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add runtime services, migrations, production operations, fap-web changes, CMS mutations, scheduler changes, queue writes, or crawler log reads.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSeoOpsWeeklyMonthlyReviewRunbook --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-ops-weekly-monthly-review-runbook.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-OPS-SOP-01D
+
+  - id: SEO-OPS-SOP-01D
+    repo: fap-api
+    depends_on:
+      - SEO-OPS-SOP-01C
+    branch: codex/seo-ops-sop-01d-approval-gates
+    base: main
+    title: "docs(seo-intel): add SEO Ops approval gates and no-go protocols"
+    name: "SEO Ops approval gates and no-go protocols"
+    train_scope: seo_ops_sop
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define human approval gates, no-go rules, P0 triggers, and exact approval boundaries.
+      - Cover CMS publish, CMS mutation, Search Channel enqueue/live submission, search API calls, crawler log canary, scheduler, migration, deploy, Metabase, Digital PR, claim override, internal link mutation, pSEO, bulk generation, and production env edits.
+      - Lock P0 triggers for claim-unsafe public/indexable pages, private-flow leaks, submitted invalid URLs, Metabase exposure, unexpected scheduler activation, raw crawler persistence, frontend fallback authority drift, business DB leakage, and Search Channel gate drift.
+    allowed_paths:
+      - backend/docs/seo/seo-ops-approval-gates-no-go-protocols.md
+      - backend/docs/seo/generated/seo-ops-approval-gates-no-go-protocols.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSeoOpsApprovalGatesNoGoProtocolsTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Implement gates, add runtime services, edit env, change deploy files, modify fap-web, or perform production actions.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSeoOpsApprovalGatesNoGoProtocols --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-ops-approval-gates-no-go-protocols.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-OPS-SOP-01E
+
+  - id: SEO-OPS-SOP-01E
+    repo: fap-api
+    depends_on:
+      - SEO-OPS-SOP-01D
+    branch: codex/seo-ops-sop-01e-mbti-growth-handoff
+    base: main
+    title: "docs(seo-intel): add MBTI growth loop handoff"
+    name: "MBTI Growth Loop handoff and first experiment readiness"
+    train_scope: seo_ops_sop
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define SEO-GROWTH-MBTI-00 as the next phase with baseline snapshot, telemetry contract, entity map, URL Truth review, content/internal link wave, claim lint gate, Search Channel canary wave, Digital PR wave, human-only funnel review, 7/14/28-day review, and scale decision.
+      - Lock telemetry constraints for backend truth events, bot/crawler exclusion, slug-independent entity_key, brand lift proxies, and observation-only crawler/search/Digital PR data.
+      - Keep MBTI as the first experiment and forbid scaling to Big Five/RIASEC/Career, pSEO, bulk URL submission, or bulk outreach before review.
+    allowed_paths:
+      - backend/docs/seo/seo-ops-mbti-growth-loop-handoff.md
+      - backend/docs/seo/generated/seo-ops-mbti-growth-loop-handoff.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSeoOpsMbtiGrowthLoopHandoffTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add runtime services, mutate CMS content, modify fap-web, mutate Search Channel, send Digital PR, create pSEO, or deploy.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSeoOpsMbtiGrowthLoopHandoff --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-ops-mbti-growth-loop-handoff.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-OPS-SOP-01F
+
+  - id: SEO-OPS-SOP-01F
+    repo: fap-api
+    depends_on:
+      - SEO-OPS-SOP-01E
+    branch: codex/seo-ops-sop-01f-final-closeout
+    base: main
+    title: "docs(seo-intel): close final SEO Ops SOP train"
+    name: "Final SEO Ops SOP closeout and ledger finalization"
+    train_scope: seo_ops_sop
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Close out the final SEO Ops SOP train and hand off to SEO-GROWTH-MBTI-00.
+      - Summarize SEO-OPS-SOP-01A through SEO-OPS-SOP-01E, sidecars, what was not done, final decision, and next task.
+      - Confirm no runtime implementation, deployment, env edit, migration, scheduler, search submission, crawler log read, CMS publish/mutation, fap-web modification, Digital PR send, Metabase exposure, pSEO generation, auto-fix, auto-rewrite, or auto-link creation.
+    allowed_paths:
+      - backend/docs/seo/seo-ops-sop-final-closeout.md
+      - backend/docs/seo/generated/seo-ops-sop-final-closeout.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSeoOpsSopFinalCloseoutTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add runtime code, migrations, production operations, fap-web changes, or CMS mutations.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSeoOpsSopFinalCloseout --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-ops-sop-final-closeout.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-00


### PR DESCRIPTION
## What changed
- Added the SEO Ops SOP architecture and authority map contract.
- Added a generated JSON artifact for the authority model, operator surfaces, hard boundaries, and MBTI handoff.
- Added a PHPUnit contract test for the docs/artifact.
- Registered the SEO-OPS-SOP train entries in the manifest/state ledger after explicit authorization.

## Why
This starts the final Daily / Weekly / Monthly SEO Ops SOP train by locking truth, observation, distribution, repair, and forbidden authority boundaries before runbooks are added.

## Validation
- cd backend && php artisan test --filter=SeoIntelSeoOpsSopArchitectureAuthorityMap --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No runtime services, migrations, UI, deploy scripts, production operations, CMS mutations, Search Channel writes/submissions, crawler log reads, scheduler activation, Metabase exposure, fap-web changes, Digital PR sends, pSEO generation, auto-rewrite, or auto-link creation.
- Daily, weekly/monthly, approval gate, MBTI handoff, and closeout SOP details remain in later scoped PRs.