### PR TITLE
docs(seo-intel): add daily SEO Ops runbook

### DIFF
--- a/backend/docs/seo/generated/seo-ops-daily-runbook.v1.json
+++ b/backend/docs/seo/generated/seo-ops-daily-runbook.v1.json
@@ -1,0 +1,100 @@
+{
+  "version": "seo-ops-daily-runbook.v1",
+  "task": "SEO-OPS-SOP-01B",
+  "train": "SEO-OPS-SOP-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "daily_checklist": [
+    "open_ops_seo",
+    "review_overview_heartbeat",
+    "review_safety_heartbeat",
+    "check_url_truth_counts_and_forbidden_authority_counters",
+    "check_issue_queue_p0_p1_only",
+    "check_search_channel_queue_approval_execution_states",
+    "confirm_live_search_gates_closed_unless_explicitly_approved",
+    "check_crawler_aggregate_safety_counters_only",
+    "check_claim_lint_blocked_needs_review_counts",
+    "check_internal_link_missing_entity_key",
+    "check_internal_link_legacy_unpaired",
+    "check_internal_link_unsafe_fallback_sources",
+    "check_content_publish_rehearsal_blockers",
+    "check_digital_pr_hrzone_response_status",
+    "check_mbti_growth_loop_status_if_active",
+    "confirm_no_uncontrolled_scheduler_collector_write_or_search_submission"
+  ],
+  "p0_escalation_rules": [
+    "claim_unsafe_public_indexable_page",
+    "private_flow_leak_into_public_or_search_surface",
+    "non_canonical_private_draft_noindex_or_claim_unsafe_url_in_search_channel",
+    "scheduler_unexpectedly_enabled",
+    "metabase_public_exposure",
+    "raw_crawler_log_persistence",
+    "frontend_fallback_becomes_canonical_authority",
+    "business_db_data_leaks_into_seo_intel",
+    "search_channel_live_gate_left_open_after_canary"
+  ],
+  "p1_escalation_rules": [
+    "core_test_research_or_career_metadata_break",
+    "missing_canonical_on_core_page",
+    "locale_pair_missing_on_core_mbti_research_test_asset",
+    "sitemap_runtime_mismatch_on_core_public_asset",
+    "approved_search_channel_item_stuck_without_execution_result"
+  ],
+  "p2_backlog_rules": [
+    "content_publish_rehearsal_blocker_on_draft",
+    "internal_link_missing_entity_key_or_legacy_unpaired_gap",
+    "claim_lint_needs_review_on_non_public_or_draft_copy",
+    "crawler_aggregate_anomaly_without_public_leak",
+    "missing_social_metadata_or_lastmod_on_non_core_article"
+  ],
+  "p3_observation_rules": [
+    "long_tail_query_fluctuation",
+    "dormant_indexable_url",
+    "minor_metadata_drift",
+    "non_public_wording_drift",
+    "digital_pr_no_response"
+  ],
+  "daily_forbidden_actions": [
+    "cms_content_change_from_observation_dashboard",
+    "url_submission_from_daily_checklist",
+    "digital_pr_follow_up_without_exact_approval",
+    "raw_crawler_log_read",
+    "crawler_search_referral_backlink_or_mention_as_truth",
+    "metabase_exposure",
+    "scheduler_activation",
+    "collector_write",
+    "claim_auto_fix",
+    "internal_link_auto_creation",
+    "pseo_creation"
+  ],
+  "daily_output_fields": [
+    "date",
+    "operator",
+    "ops_seo_safety_status",
+    "p0_p1_issue_count_and_owner",
+    "search_channel_queue_status",
+    "crawler_aggregate_warning_count",
+    "claim_lint_blocked_needs_review_count",
+    "internal_link_gap_count",
+    "content_rehearsal_blocker_count",
+    "digital_pr_hrzone_response_status",
+    "mbti_growth_loop_status_if_active",
+    "approval_gates_confirmed_closed"
+  ],
+  "safety_flags": {
+    "runtime_services_added": false,
+    "migrations_added": false,
+    "production_env_changed": false,
+    "fap_web_modified": false,
+    "cms_mutation_enabled": false,
+    "search_channel_mutation_enabled": false,
+    "crawler_logs_read": false,
+    "scheduler_enabled": false,
+    "collector_writes_enabled": false,
+    "digital_pr_sent": false,
+    "metabase_exposed": false,
+    "auto_rewrite_enabled": false,
+    "internal_links_created": false,
+    "pseo_created": false
+  },
+  "next_task": "SEO-OPS-SOP-01C"
+}

--- a/backend/docs/seo/seo-ops-daily-runbook.md
+++ b/backend/docs/seo/seo-ops-daily-runbook.md
@@ -1,0 +1,96 @@
+# Daily SEO Ops Runbook
+
+Task: SEO-OPS-SOP-01B
+
+Type: docs/generated/test only.
+
+This runbook defines the daily SEO Ops checklist. It is an observation and escalation routine only. It does not authorize CMS mutation, Search Channel enqueue or submission, crawler log reads, scheduler activation, collector writes, Digital PR sends, production operations, migrations, UI implementation, fap-web changes, auto-rewrite, auto-link creation, or pSEO generation.
+
+## Daily Checklist
+
+1. Open `/ops/seo`.
+2. Review the overview heartbeat for URL Truth, entity, issue, Search Channel, and crawler aggregate freshness signals.
+3. Review the safety heartbeat for private-flow leaks, forbidden authority sources, and claim-unsafe public/indexable surfaces.
+4. Check URL Truth counts and forbidden-authority counters.
+5. Check Issue Queue P0/P1 only for same-day action.
+6. Check Search Channel Queue approval and execution states.
+7. Confirm live search gates are closed unless an exact human approval is active for a scoped canary.
+8. Check crawler aggregate safety counters only. Do not read raw crawler logs.
+9. Check Claim Lint `blocked` and `needs_review` counts.
+10. Check Internal Link dry-run gaps:
+    - missing entity key.
+    - legacy_unpaired.
+    - unsafe fallback sources.
+11. Check Content Publish Rehearsal blockers.
+12. Check Digital PR response status for HRZone.
+13. Check MBTI Growth Loop status if SEO-GROWTH-MBTI-00 is active.
+14. Confirm no uncontrolled scheduler, collector write, Search Channel submission, or search API call occurred.
+
+## Daily Escalation Rules
+
+P0 requires same-day human review and no automatic fix:
+
+- claim-unsafe public/indexable page.
+- private-flow leak into public/search surface.
+- non-canonical, private, draft, noindex, or claim-unsafe URL in Search Channel.
+- scheduler unexpectedly enabled.
+- Metabase public exposure.
+- raw crawler log persistence.
+- frontend fallback becoming canonical authority.
+- business DB data leaking into seo_intel.
+- Search Channel live gate left open after canary.
+
+P1 requires same-week owner review unless it blocks a core asset:
+
+- core test/research/career page metadata break.
+- missing canonical on a core page.
+- locale pair missing on core MBTI/research/test asset.
+- sitemap/runtime mismatch on core public asset.
+- approved Search Channel item stuck without execution result.
+
+P2 goes to repair backlog:
+
+- content publish rehearsal blocker on a draft.
+- Internal Link missing entity key or legacy_unpaired gap.
+- Claim Lint needs_review on non-public or draft copy.
+- crawler aggregate anomaly without public leak.
+- missing social metadata or lastmod on non-core article.
+
+P3 remains observation-only unless it trends:
+
+- long-tail query fluctuation.
+- dormant indexable URL.
+- minor metadata drift.
+- non-public wording drift.
+- Digital PR no response.
+
+## Daily Forbidden Actions
+
+- Do not change CMS content from the observation dashboard.
+- Do not submit URLs from the daily checklist.
+- Do not send Digital PR follow-up without exact approval.
+- Do not read raw crawler logs.
+- Do not treat crawler, search, referral, backlink, or mention data as truth.
+- Do not expose Metabase.
+- Do not enable scheduler or collector writes.
+- Do not auto-fix claims.
+- Do not auto-create internal links.
+- Do not create pSEO.
+
+## Daily Output
+
+The daily operator note should record:
+
+- date and operator.
+- `/ops/seo` safety status.
+- P0/P1 issue count and owner.
+- Search Channel queue status.
+- crawler aggregate warning count.
+- Claim Lint blocked/needs_review count.
+- Internal Link gap count.
+- Content rehearsal blocker count.
+- Digital PR HRZone response status.
+- MBTI Growth Loop status if active.
+- approval gates confirmed closed.
+
+Next task after this PR: `SEO-OPS-SOP-01C`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsDailyRunbookTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsDailyRunbookTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSeoOpsDailyRunbookTest extends TestCase
+{
+    #[Test]
+    public function daily_runbook_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-ops-daily-runbook.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-ops-daily-runbook.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01B', $artifact['task'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01C', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function daily_checklist_covers_required_operator_surfaces(): void
+    {
+        $checks = $this->artifact()['daily_checklist'] ?? [];
+
+        foreach ([
+            'open_ops_seo',
+            'review_overview_heartbeat',
+            'review_safety_heartbeat',
+            'check_url_truth_counts_and_forbidden_authority_counters',
+            'check_issue_queue_p0_p1_only',
+            'check_search_channel_queue_approval_execution_states',
+            'confirm_live_search_gates_closed_unless_explicitly_approved',
+            'check_crawler_aggregate_safety_counters_only',
+            'check_claim_lint_blocked_needs_review_counts',
+            'check_internal_link_missing_entity_key',
+            'check_internal_link_legacy_unpaired',
+            'check_internal_link_unsafe_fallback_sources',
+            'check_content_publish_rehearsal_blockers',
+            'check_digital_pr_hrzone_response_status',
+            'check_mbti_growth_loop_status_if_active',
+            'confirm_no_uncontrolled_scheduler_collector_write_or_search_submission',
+        ] as $check) {
+            $this->assertContains($check, $checks);
+        }
+    }
+
+    #[Test]
+    public function p0_escalation_rules_lock_same_day_human_review_cases(): void
+    {
+        $rules = $this->artifact()['p0_escalation_rules'] ?? [];
+
+        foreach ([
+            'claim_unsafe_public_indexable_page',
+            'private_flow_leak_into_public_or_search_surface',
+            'non_canonical_private_draft_noindex_or_claim_unsafe_url_in_search_channel',
+            'scheduler_unexpectedly_enabled',
+            'metabase_public_exposure',
+            'raw_crawler_log_persistence',
+            'frontend_fallback_becomes_canonical_authority',
+            'business_db_data_leaks_into_seo_intel',
+            'search_channel_live_gate_left_open_after_canary',
+        ] as $rule) {
+            $this->assertContains($rule, $rules);
+        }
+    }
+
+    #[Test]
+    public function daily_forbidden_actions_prevent_mutation_and_truth_drift(): void
+    {
+        $forbidden = $this->artifact()['daily_forbidden_actions'] ?? [];
+
+        foreach ([
+            'cms_content_change_from_observation_dashboard',
+            'url_submission_from_daily_checklist',
+            'digital_pr_follow_up_without_exact_approval',
+            'raw_crawler_log_read',
+            'crawler_search_referral_backlink_or_mention_as_truth',
+            'metabase_exposure',
+            'scheduler_activation',
+            'collector_write',
+            'claim_auto_fix',
+            'internal_link_auto_creation',
+            'pseo_creation',
+        ] as $action) {
+            $this->assertContains($action, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_confirm_daily_runbook_is_non_mutating(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_daily_sop_boundaries(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-ops-daily-runbook.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-ops-daily-runbook.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'open `/ops/seo`',
+            'issue queue p0/p1',
+            'live search gates are closed',
+            'crawler aggregate safety counters only',
+            'claim lint `blocked` and `needs_review`',
+            'missing entity key',
+            'legacy_unpaired',
+            'unsafe fallback sources',
+            'digital pr response status for hrzone',
+            'no uncontrolled scheduler',
+            'do not read raw crawler logs',
+            'do not treat crawler, search, referral, backlink, or mention data as truth',
+            'next task after this pr: `seo-ops-sop-01c`',
+            '"next_task": "seo-ops-sop-01c"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-ops-daily-runbook.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T17:41:00+08:00",
+  "updated_at": "2026-05-22T17:42:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18519,12 +18519,12 @@
     "SEO-OPS-SOP-01B": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01b-daily-runbook",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-OPS-SOP-01A"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "f814ea7e7c23caa341157d320f338559b6850794",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1572",
       "checks": {
         "local": {
           "php_artisan_test_filter_daily_runbook": "passed: php artisan test --filter=SeoIntelSeoOpsDailyRunbook --no-ansi (6 tests, 80 assertions)",
@@ -18561,6 +18561,11 @@
           "at": "2026-05-22T17:41:00+08:00",
           "status": "local_validation_passed",
           "summary": "SEO-OPS-SOP-01B local validation passed for focused daily runbook test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
+        },
+        {
+          "at": "2026-05-22T17:42:30+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1572 for SEO-OPS-SOP-01B and pushed branch codex/seo-ops-sop-01b-daily-runbook."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T17:32:00+08:00",
+  "updated_at": "2026-05-22T17:41:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18455,11 +18455,11 @@
     "SEO-OPS-SOP-01A": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01a-architecture-map",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "CONTENT-OPS-CLAIM-LINK-CLOSEOUT"
       ],
-      "commit_sha": "1115a89e37a650549298a91017f392a04466b0fa",
+      "commit_sha": "705ee466f5fa0d0a63f55fdd14835178f40af2c2",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1571",
       "checks": {
         "local": {
@@ -18471,11 +18471,17 @@
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1571": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_architecture_test": "passed: php artisan test --filter=SeoIntelSeoOpsSopArchitectureAuthorityMap --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T09:34:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -18502,19 +18508,35 @@
           "at": "2026-05-22T17:32:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1571 for SEO-OPS-SOP-01A and pushed branch codex/seo-ops-sop-01a-architecture-map."
+        },
+        {
+          "at": "2026-05-22T17:34:00+08:00",
+          "status": "merged",
+          "summary": "PR #1571 merged via squash at 705ee466f5fa0d0a63f55fdd14835178f40af2c2. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused architecture test passed. Local cleanup script was unavailable in this clone."
         }
       ]
     },
     "SEO-OPS-SOP-01B": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01b-daily-runbook",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "SEO-OPS-SOP-01A"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_daily_runbook": "passed: php artisan test --filter=SeoIntelSeoOpsDailyRunbook --no-ansi (6 tests, 80 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (473 tests, 7555 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3483 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-ops-daily-runbook.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18529,6 +18551,16 @@
           "at": "2026-05-22T17:22:25+08:00",
           "status": "pending",
           "summary": "Registered daily SEO Ops runbook PR. Scope is docs/generated/test plus train metadata only; no runtime services, migrations, production env changes, fap-web changes, CMS mutations, Search Channel mutations, crawler log reads, scheduler changes, or Digital PR sends."
+        },
+        {
+          "at": "2026-05-22T17:35:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-OPS-SOP-01B on codex/seo-ops-sop-01b-daily-runbook. Scope is docs/generated/test plus train metadata only; no runtime services, migrations, production env changes, fap-web changes, CMS mutations, Search Channel mutations, crawler log reads, scheduler changes, or Digital PR sends."
+        },
+        {
+          "at": "2026-05-22T17:41:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-OPS-SOP-01B local validation passed for focused daily runbook test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the daily SEO Ops runbook.
- Added a generated JSON artifact for the daily checklist, escalation rules, forbidden actions, and output fields.
- Added a PHPUnit contract test for the daily SOP.
- Reconciled SEO-OPS-SOP-01A merge state in the train ledger.

## Why
This turns the completed SEO system into a daily observation checklist while keeping /ops/seo read-only and preserving all mutation and approval boundaries.

## Validation
- cd backend && php artisan test --filter=SeoIntelSeoOpsDailyRunbook --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-ops-daily-runbook.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No runtime services, migrations, production env changes, fap-web changes, CMS mutations, Search Channel mutations, crawler log reads, scheduler changes, Digital PR sends, auto-rewrite, auto-link creation, or pSEO generation.
- Weekly/monthly review, approval gates, MBTI handoff, and closeout remain in later scoped PRs.