### PR TITLE
docs(seo-intel): add weekly and monthly SEO Ops runbook

### DIFF
--- a/backend/docs/seo/generated/seo-ops-weekly-monthly-review-runbook.v1.json
+++ b/backend/docs/seo/generated/seo-ops-weekly-monthly-review-runbook.v1.json
@@ -1,0 +1,92 @@
+{
+  "version": "seo-ops-weekly-monthly-review-runbook.v1",
+  "task": "SEO-OPS-SOP-01C",
+  "train": "SEO-OPS-SOP-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "weekly_review_items": [
+    "search_channel_queue_backlog",
+    "search_channel_approval_candidates",
+    "crawler_aggregate_trend_no_raw_logs",
+    "content_publish_rehearsal_blockers",
+    "internal_link_graph_coverage",
+    "chinese_claim_lint_backlog",
+    "research_url_observation",
+    "digital_pr_response_referral_mention_tracking",
+    "mbti_cluster_url_truth_and_issue_trend",
+    "approved_search_performance_feedback_if_available",
+    "repair_backlog_decisions"
+  ],
+  "weekly_escalation_rules": [
+    "p0_same_day_human_review",
+    "p1_owner_and_target_week",
+    "p2_repair_backlog",
+    "p3_observation_only_unless_repeated_or_growing"
+  ],
+  "weekly_outputs": [
+    "search_channel_backlog_summary",
+    "crawler_aggregate_observation_summary",
+    "content_rehearsal_blocker_summary",
+    "internal_link_graph_coverage_summary",
+    "claim_lint_backlog_summary",
+    "research_url_observation_summary",
+    "digital_pr_hrzone_hrec_state",
+    "mbti_cluster_risk_and_opportunity_notes",
+    "repair_backlog_decisions_and_owners"
+  ],
+  "monthly_review_items": [
+    "entity_cluster_performance",
+    "content_decay_and_repair_queue",
+    "internal_link_graph_coverage_by_entity_family",
+    "claim_safety_audit",
+    "digital_pr_outcome_and_next_wave_decision",
+    "search_channel_submission_audit",
+    "crawler_aggregate_observation_review",
+    "revenue_funnel_review_where_backend_truth_exists",
+    "mbti_growth_loop_7_14_28_day_review",
+    "next_entity_selection"
+  ],
+  "monthly_decisions": [
+    "keep_mbti_in_observation",
+    "run_another_mbti_wave",
+    "promote_entity_cluster_for_repair",
+    "consider_big_five_riasec_or_career_expansion_after_mbti_review",
+    "tighten_approval_gate"
+  ],
+  "observation_only_signals": [
+    "search_performance_feedback",
+    "crawler_aggregate_behavior",
+    "referral_traffic",
+    "digital_pr_response_mention_or_backlink_observation",
+    "frontend_runtime_observations",
+    "static_sitemap_or_llms_output"
+  ],
+  "human_approval_required_for": [
+    "cms_publish_or_content_mutation",
+    "search_channel_enqueue",
+    "search_channel_live_submission",
+    "crawler_log_production_canary",
+    "scheduler_activation",
+    "production_migration",
+    "backend_deploy",
+    "public_metabase_exposure",
+    "digital_pr_send_or_follow_up",
+    "claim_override",
+    "internal_link_mutation",
+    "pseo_generation"
+  ],
+  "safety_flags": {
+    "runtime_services_added": false,
+    "migrations_added": false,
+    "production_operations_performed": false,
+    "fap_web_modified": false,
+    "cms_mutation_enabled": false,
+    "scheduler_enabled": false,
+    "search_channel_writes_enabled": false,
+    "crawler_logs_read": false,
+    "digital_pr_sent": false,
+    "claim_auto_rewrite_enabled": false,
+    "internal_links_created": false,
+    "pseo_created": false
+  },
+  "next_task": "SEO-OPS-SOP-01D"
+}

--- a/backend/docs/seo/seo-ops-weekly-monthly-review-runbook.md
+++ b/backend/docs/seo/seo-ops-weekly-monthly-review-runbook.md
@@ -1,0 +1,95 @@
+# Weekly and Monthly SEO Ops Review Runbook
+
+Task: SEO-OPS-SOP-01C
+
+Type: docs/generated/test only.
+
+This runbook defines the weekly and monthly SEO Ops review cadence. It is a review and decision-support contract only. It does not authorize production operations, runtime services, migrations, CMS mutation, scheduler activation, Search Channel writes, crawler log reads, fap-web changes, Digital PR sends, claim auto-rewrite, internal link auto-creation, or pSEO generation.
+
+## Weekly Review
+
+Review weekly:
+
+- Search Channel Queue backlog.
+- Search Channel approval candidates.
+- crawler aggregate trend, with no raw logs.
+- content publish rehearsal blockers.
+- internal link graph coverage.
+- Chinese claim lint backlog.
+- Research URL observation.
+- Digital PR response, referral, and mention tracking.
+- MBTI cluster URL Truth and issue trend.
+- approved search performance feedback if available.
+- repair backlog decisions.
+
+Weekly escalation:
+
+- P0 remains same-day even during weekly review.
+- P1 items get owner and target week.
+- P2 items move into repair backlog.
+- P3 items remain observation-only unless repeated or growing.
+
+Weekly outputs:
+
+- Search Channel backlog summary.
+- crawler aggregate observation summary.
+- content rehearsal blocker summary.
+- internal link graph coverage summary.
+- claim lint backlog summary.
+- Research URL observation summary.
+- Digital PR HRZone/HREC state.
+- MBTI cluster risk and opportunity notes.
+- repair backlog decisions and owners.
+
+## Monthly Review
+
+Review monthly:
+
+- entity cluster performance.
+- content decay and repair queue.
+- internal link graph coverage by entity family.
+- claim safety audit.
+- Digital PR outcome and next-wave decision.
+- Search Channel submission audit.
+- crawler aggregate observation review.
+- revenue/funnel review where backend truth exists.
+- MBTI Growth Loop 7/14/28-day review.
+- next entity selection.
+
+Monthly decisions:
+
+- whether to keep MBTI in observation.
+- whether to run another MBTI content/internal-link/Search Channel/Digital PR wave.
+- whether to promote an entity cluster for repair.
+- whether the system is ready to consider Big Five, RIASEC, or Career expansion.
+- whether any approval gate needs tightening.
+
+## Observation-only Signals
+
+The following may inform review but must not become truth:
+
+- search performance feedback.
+- crawler aggregate behavior.
+- referral traffic.
+- Digital PR response, mention, or backlink observation.
+- frontend runtime observations.
+- static sitemap or llms output.
+
+## Human Approval Boundaries
+
+Weekly/monthly review may recommend, but must not execute without exact approval:
+
+- CMS publish or content mutation.
+- Search Channel enqueue.
+- Search Channel live submission.
+- crawler log production canary.
+- scheduler activation.
+- production migration.
+- backend deploy.
+- public Metabase exposure.
+- Digital PR send or follow-up.
+- claim override.
+- internal link mutation.
+- pSEO generation.
+
+Next task after this PR: `SEO-OPS-SOP-01D`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsWeeklyMonthlyReviewRunbookTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsWeeklyMonthlyReviewRunbookTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSeoOpsWeeklyMonthlyReviewRunbookTest extends TestCase
+{
+    #[Test]
+    public function weekly_monthly_runbook_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-ops-weekly-monthly-review-runbook.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-ops-weekly-monthly-review-runbook.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01C', $artifact['task'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01D', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function weekly_review_items_cover_required_system_surfaces(): void
+    {
+        $items = $this->artifact()['weekly_review_items'] ?? [];
+
+        foreach ([
+            'search_channel_queue_backlog',
+            'search_channel_approval_candidates',
+            'crawler_aggregate_trend_no_raw_logs',
+            'content_publish_rehearsal_blockers',
+            'internal_link_graph_coverage',
+            'chinese_claim_lint_backlog',
+            'research_url_observation',
+            'digital_pr_response_referral_mention_tracking',
+            'mbti_cluster_url_truth_and_issue_trend',
+            'approved_search_performance_feedback_if_available',
+            'repair_backlog_decisions',
+        ] as $item) {
+            $this->assertContains($item, $items);
+        }
+    }
+
+    #[Test]
+    public function monthly_review_items_cover_growth_and_governance(): void
+    {
+        $items = $this->artifact()['monthly_review_items'] ?? [];
+
+        foreach ([
+            'entity_cluster_performance',
+            'content_decay_and_repair_queue',
+            'internal_link_graph_coverage_by_entity_family',
+            'claim_safety_audit',
+            'digital_pr_outcome_and_next_wave_decision',
+            'search_channel_submission_audit',
+            'crawler_aggregate_observation_review',
+            'revenue_funnel_review_where_backend_truth_exists',
+            'mbti_growth_loop_7_14_28_day_review',
+            'next_entity_selection',
+        ] as $item) {
+            $this->assertContains($item, $items);
+        }
+    }
+
+    #[Test]
+    public function observation_only_signals_cannot_become_truth(): void
+    {
+        $signals = $this->artifact()['observation_only_signals'] ?? [];
+
+        foreach ([
+            'search_performance_feedback',
+            'crawler_aggregate_behavior',
+            'referral_traffic',
+            'digital_pr_response_mention_or_backlink_observation',
+            'frontend_runtime_observations',
+            'static_sitemap_or_llms_output',
+        ] as $signal) {
+            $this->assertContains($signal, $signals);
+        }
+    }
+
+    #[Test]
+    public function human_approval_boundaries_are_locked(): void
+    {
+        $gates = $this->artifact()['human_approval_required_for'] ?? [];
+
+        foreach ([
+            'cms_publish_or_content_mutation',
+            'search_channel_enqueue',
+            'search_channel_live_submission',
+            'crawler_log_production_canary',
+            'scheduler_activation',
+            'production_migration',
+            'backend_deploy',
+            'public_metabase_exposure',
+            'digital_pr_send_or_follow_up',
+            'claim_override',
+            'internal_link_mutation',
+            'pseo_generation',
+        ] as $gate) {
+            $this->assertContains($gate, $gates);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_confirm_review_runbook_is_non_mutating(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_weekly_monthly_review_boundaries(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-ops-weekly-monthly-review-runbook.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-ops-weekly-monthly-review-runbook.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'search channel queue backlog',
+            'crawler aggregate trend, with no raw logs',
+            'digital pr response, referral, and mention tracking',
+            'mbti cluster url truth and issue trend',
+            'entity cluster performance',
+            'mbti growth loop 7/14/28-day review',
+            'search performance feedback',
+            'static sitemap or llms output',
+            'cms publish or content mutation',
+            'search channel live submission',
+            'public metabase exposure',
+            'next task after this pr: `seo-ops-sop-01d`',
+            '"next_task": "seo-ops-sop-01d"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-ops-weekly-monthly-review-runbook.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T17:42:30+08:00",
+  "updated_at": "2026-05-22T17:53:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18519,11 +18519,11 @@
     "SEO-OPS-SOP-01B": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01b-daily-runbook",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-OPS-SOP-01A"
       ],
-      "commit_sha": "f814ea7e7c23caa341157d320f338559b6850794",
+      "commit_sha": "8be2df83af0cb456c73f50939e5c0ac20bd0f5b3",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1572",
       "checks": {
         "local": {
@@ -18535,11 +18535,17 @@
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1572": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_daily_runbook_test": "passed: php artisan test --filter=SeoIntelSeoOpsDailyRunbook --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T09:45:30Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -18566,19 +18572,35 @@
           "at": "2026-05-22T17:42:30+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1572 for SEO-OPS-SOP-01B and pushed branch codex/seo-ops-sop-01b-daily-runbook."
+        },
+        {
+          "at": "2026-05-22T17:45:30+08:00",
+          "status": "merged",
+          "summary": "PR #1572 merged via squash at 8be2df83af0cb456c73f50939e5c0ac20bd0f5b3. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused daily runbook test passed. Local cleanup script was unavailable in this clone."
         }
       ]
     },
     "SEO-OPS-SOP-01C": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01c-weekly-monthly",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "SEO-OPS-SOP-01B"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_weekly_monthly_runbook": "passed: php artisan test --filter=SeoIntelSeoOpsWeeklyMonthlyReviewRunbook --no-ansi (7 tests, 82 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (480 tests, 7637 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3484 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-ops-weekly-monthly-review-runbook.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18593,6 +18615,16 @@
           "at": "2026-05-22T17:22:25+08:00",
           "status": "pending",
           "summary": "Registered weekly/monthly SEO Ops review runbook PR. Scope is docs/generated/test plus train metadata only; no runtime services, migrations, production operations, fap-web changes, CMS mutations, scheduler changes, queue writes, or crawler log reads."
+        },
+        {
+          "at": "2026-05-22T17:46:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-OPS-SOP-01C on codex/seo-ops-sop-01c-weekly-monthly. Scope is docs/generated/test plus train metadata only; no runtime services, migrations, production operations, fap-web changes, CMS mutations, scheduler changes, queue writes, or crawler log reads."
+        },
+        {
+          "at": "2026-05-22T17:53:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-OPS-SOP-01C local validation passed for focused weekly/monthly runbook test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T17:53:00+08:00",
+  "updated_at": "2026-05-22T17:54:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18583,12 +18583,12 @@
     "SEO-OPS-SOP-01C": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01c-weekly-monthly",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-OPS-SOP-01B"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "124e521f8c1b3d3587c3093b7d276f9a66c7d659",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1573",
       "checks": {
         "local": {
           "php_artisan_test_filter_weekly_monthly_runbook": "passed: php artisan test --filter=SeoIntelSeoOpsWeeklyMonthlyReviewRunbook --no-ansi (7 tests, 82 assertions)",
@@ -18625,6 +18625,11 @@
           "at": "2026-05-22T17:53:00+08:00",
           "status": "local_validation_passed",
           "summary": "SEO-OPS-SOP-01C local validation passed for focused weekly/monthly runbook test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
+        },
+        {
+          "at": "2026-05-22T17:54:30+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1573 for SEO-OPS-SOP-01C and pushed branch codex/seo-ops-sop-01c-weekly-monthly."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the weekly and monthly SEO Ops review runbook.
- Added a generated JSON artifact for weekly reviews, monthly reviews, observation-only signals, and approval boundaries.
- Added a PHPUnit contract test for the review cadence.
- Reconciled SEO-OPS-SOP-01B merge state in the train ledger.

## Why
This defines the non-daily review cadence and keeps search, crawler, Digital PR, internal link, claim lint, content rehearsal, and MBTI growth signals in observation/review mode until explicit approval gates are used.

## Validation
- cd backend && php artisan test --filter=SeoIntelSeoOpsWeeklyMonthlyReviewRunbook --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-ops-weekly-monthly-review-runbook.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No runtime services, migrations, production operations, fap-web changes, CMS mutations, scheduler changes, queue writes, crawler log reads, Digital PR sends, auto-rewrite, auto-link creation, or pSEO generation.
- Approval gate templates, MBTI handoff, and closeout remain in later scoped PRs.