### PR TITLE
docs(seo-intel): add SEO Ops approval gates and no-go protocols

### DIFF
--- a/backend/docs/seo/generated/seo-ops-approval-gates-no-go-protocols.v1.json
+++ b/backend/docs/seo/generated/seo-ops-approval-gates-no-go-protocols.v1.json
@@ -1,0 +1,83 @@
+{
+  "version": "seo-ops-approval-gates-no-go-protocols.v1",
+  "task": "SEO-OPS-SOP-01D",
+  "train": "SEO-OPS-SOP-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "human_approval_required_for": [
+    "cms_publish",
+    "cms_content_mutation",
+    "search_channel_enqueue",
+    "search_channel_live_submission",
+    "gsc_baidu_indexnow_bing_360_sogou_shenma_calls",
+    "crawler_log_production_canary",
+    "scheduler_activation",
+    "production_migration",
+    "backend_deploy",
+    "public_metabase_exposure",
+    "digital_pr_send_or_follow_up",
+    "claim_override",
+    "internal_link_mutation",
+    "pseo_generation",
+    "bulk_content_generation",
+    "production_env_edit"
+  ],
+  "no_go_rules": [
+    "no_draft_private_noindex_or_claim_unsafe_url_submission",
+    "no_public_metabase_exposure",
+    "no_scheduler_without_approval",
+    "no_raw_production_crawler_log_read_without_exact_approval",
+    "no_crawler_log_as_url_truth",
+    "no_frontend_fallback_static_sitemap_static_llms_search_response_local_copy_or_digital_pr_mention_as_url_truth",
+    "no_auto_publish",
+    "no_auto_fix_cms_content",
+    "no_auto_rewrite_claims",
+    "no_auto_create_internal_links",
+    "no_bulk_digital_pr_outreach",
+    "no_paid_backlinks",
+    "no_riasec_big_five_career_graph_precise_recommender_claim",
+    "no_search_channel_retry_without_gate"
+  ],
+  "p0_triggers": [
+    "claim_unsafe_public_indexable_page",
+    "private_flow_leak_into_public_or_search_surface",
+    "submitted_private_noindex_non_canonical_draft_or_claim_unsafe_url",
+    "metabase_public_exposure",
+    "scheduler_unexpectedly_enabled",
+    "raw_crawler_logs_persisted",
+    "frontend_fallback_becomes_canonical_authority",
+    "business_db_leak_into_seo_intel",
+    "search_channel_live_gate_left_open_after_canary"
+  ],
+  "approval_phrase_templates": {
+    "search_channel_live_submission": "I approve this single Search Channel live submission for [channel] queue item [id] now.",
+    "crawler_log_production_canary": "I approve this read-only crawler log production canary for [source] with dry-run and no-write now.",
+    "backend_deploy": "I approve this backend deploy for release [sha] now.",
+    "digital_pr_send": "I approve sending the [target] canary email now.",
+    "cms_publish": "I approve publishing CMS item [type]/[id-or-slug] now.",
+    "production_migration": "I approve running production migration [migration-or-path] now.",
+    "scheduler_activation": "I approve enabling scheduler [job-name] now."
+  },
+  "gate_behavior": [
+    "approval_must_be_exact_scoped_current_and_human_provided",
+    "approval_must_name_target_channel_or_release_where_applicable",
+    "approval_must_not_be_inferred_from_prior_consent",
+    "approval_must_not_authorize_bulk_behavior_unless_explicitly_named_and_allowed",
+    "approval_does_not_bypass_claim_safety_url_truth_private_flow_canonical_robots_or_noindex_gates"
+  ],
+  "safety_flags": {
+    "gates_implemented": false,
+    "runtime_services_added": false,
+    "env_edited": false,
+    "deployment_changed": false,
+    "production_actions_performed": false,
+    "fap_web_modified": false,
+    "cms_mutation_enabled": false,
+    "search_channel_submission_enabled": false,
+    "scheduler_enabled": false,
+    "crawler_logs_read": false,
+    "digital_pr_sent": false,
+    "metabase_exposed": false,
+    "pseo_created": false
+  },
+  "next_task": "SEO-OPS-SOP-01E"
+}

--- a/backend/docs/seo/seo-ops-approval-gates-no-go-protocols.md
+++ b/backend/docs/seo/seo-ops-approval-gates-no-go-protocols.md
@@ -1,0 +1,101 @@
+# SEO Ops Approval Gates and No-go Protocols
+
+Task: SEO-OPS-SOP-01D
+
+Type: docs/generated/test only.
+
+This contract defines human approval gates, no-go rules, P0 triggers, and exact approval boundary templates. It does not implement gates, runtime services, env edits, deployment changes, production actions, fap-web changes, or CMS mutations.
+
+## Human Approval Required
+
+Exact human approval is required for:
+
+- CMS publish.
+- CMS content mutation.
+- Search Channel enqueue.
+- Search Channel live submission.
+- GSC, Baidu, IndexNow, Bing, 360, Sogou, or Shenma calls.
+- crawler log production canary.
+- scheduler activation.
+- production migration.
+- backend deploy.
+- public Metabase exposure.
+- Digital PR send or follow-up.
+- claim override.
+- internal link mutation.
+- pSEO generation.
+- bulk content generation.
+- production env edit.
+
+## No-go Rules
+
+Routine SEO Ops must not:
+
+- submit draft, private, noindex, or claim-unsafe URLs.
+- expose Metabase publicly.
+- enable scheduler without approval.
+- read raw production crawler logs without exact approval.
+- treat crawler log as URL Truth.
+- treat frontend fallback, static sitemap, static llms, search response, local copy, or Digital PR mention as URL Truth.
+- auto-publish.
+- auto-fix CMS content.
+- auto-rewrite claims.
+- auto-create internal links.
+- send bulk Digital PR outreach.
+- buy backlinks.
+- present RIASEC, Big Five, or Career Graph as precise career recommender authority.
+- retry Search Channel without gate.
+
+## P0 Triggers
+
+Escalate P0 for:
+
+- claim-unsafe public/indexable page.
+- private-flow leak into public/search surface.
+- submitted private, noindex, non-canonical, draft, or claim-unsafe URL.
+- Metabase public exposure.
+- scheduler unexpectedly enabled.
+- raw crawler logs persisted.
+- frontend fallback becomes canonical authority.
+- business DB leak into seo_intel.
+- Search Channel live gate left open after canary.
+
+## Exact Approval Phrase Templates
+
+Search Channel live submission:
+
+`I approve this single Search Channel live submission for [channel] queue item [id] now.`
+
+Crawler Log production canary:
+
+`I approve this read-only crawler log production canary for [source] with dry-run and no-write now.`
+
+Backend deploy:
+
+`I approve this backend deploy for release [sha] now.`
+
+Digital PR send:
+
+`I approve sending the [target] canary email now.`
+
+CMS publish:
+
+`I approve publishing CMS item [type]/[id-or-slug] now.`
+
+Production migration:
+
+`I approve running production migration [migration-or-path] now.`
+
+Scheduler activation:
+
+`I approve enabling scheduler [job-name] now.`
+
+## Gate Behavior
+
+- Approval must be exact, scoped, current, and human-provided.
+- Approval must name target, channel, or release where applicable.
+- Approval must not be inferred from prior consent.
+- Approval must not authorize bulk behavior unless explicitly named and allowed by the task.
+- Approval does not bypass claim safety, URL Truth, private-flow, canonical, robots, or noindex gates.
+
+Next task after this PR: `SEO-OPS-SOP-01E`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsApprovalGatesNoGoProtocolsTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsApprovalGatesNoGoProtocolsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSeoOpsApprovalGatesNoGoProtocolsTest extends TestCase
+{
+    #[Test]
+    public function approval_gate_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-ops-approval-gates-no-go-protocols.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-ops-approval-gates-no-go-protocols.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01D', $artifact['task'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01E', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function human_approval_required_actions_are_locked(): void
+    {
+        $actions = $this->artifact()['human_approval_required_for'] ?? [];
+
+        foreach ([
+            'cms_publish',
+            'cms_content_mutation',
+            'search_channel_enqueue',
+            'search_channel_live_submission',
+            'gsc_baidu_indexnow_bing_360_sogou_shenma_calls',
+            'crawler_log_production_canary',
+            'scheduler_activation',
+            'production_migration',
+            'backend_deploy',
+            'public_metabase_exposure',
+            'digital_pr_send_or_follow_up',
+            'claim_override',
+            'internal_link_mutation',
+            'pseo_generation',
+            'bulk_content_generation',
+            'production_env_edit',
+        ] as $action) {
+            $this->assertContains($action, $actions);
+        }
+    }
+
+    #[Test]
+    public function no_go_rules_block_truth_drift_and_automation(): void
+    {
+        $rules = $this->artifact()['no_go_rules'] ?? [];
+
+        foreach ([
+            'no_draft_private_noindex_or_claim_unsafe_url_submission',
+            'no_public_metabase_exposure',
+            'no_scheduler_without_approval',
+            'no_raw_production_crawler_log_read_without_exact_approval',
+            'no_crawler_log_as_url_truth',
+            'no_frontend_fallback_static_sitemap_static_llms_search_response_local_copy_or_digital_pr_mention_as_url_truth',
+            'no_auto_publish',
+            'no_auto_fix_cms_content',
+            'no_auto_rewrite_claims',
+            'no_auto_create_internal_links',
+            'no_bulk_digital_pr_outreach',
+            'no_paid_backlinks',
+            'no_riasec_big_five_career_graph_precise_recommender_claim',
+            'no_search_channel_retry_without_gate',
+        ] as $rule) {
+            $this->assertContains($rule, $rules);
+        }
+    }
+
+    #[Test]
+    public function p0_triggers_cover_claim_private_search_metabase_scheduler_and_authority_failures(): void
+    {
+        $triggers = $this->artifact()['p0_triggers'] ?? [];
+
+        foreach ([
+            'claim_unsafe_public_indexable_page',
+            'private_flow_leak_into_public_or_search_surface',
+            'submitted_private_noindex_non_canonical_draft_or_claim_unsafe_url',
+            'metabase_public_exposure',
+            'scheduler_unexpectedly_enabled',
+            'raw_crawler_logs_persisted',
+            'frontend_fallback_becomes_canonical_authority',
+            'business_db_leak_into_seo_intel',
+            'search_channel_live_gate_left_open_after_canary',
+        ] as $trigger) {
+            $this->assertContains($trigger, $triggers);
+        }
+    }
+
+    #[Test]
+    public function exact_approval_phrase_templates_are_present(): void
+    {
+        $templates = $this->artifact()['approval_phrase_templates'] ?? [];
+
+        foreach ([
+            'search_channel_live_submission',
+            'crawler_log_production_canary',
+            'backend_deploy',
+            'digital_pr_send',
+            'cms_publish',
+            'production_migration',
+            'scheduler_activation',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $templates);
+            $this->assertStringContainsString('I approve', $templates[$key]);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_confirm_no_gate_implementation_or_production_action(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_approval_and_no_go_boundaries(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-ops-approval-gates-no-go-protocols.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-ops-approval-gates-no-go-protocols.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'cms publish',
+            'search channel live submission',
+            'gsc, baidu, indexnow, bing, 360, sogou, or shenma calls',
+            'crawler log production canary',
+            'public metabase exposure',
+            'digital pr send or follow-up',
+            'claim override',
+            'internal link mutation',
+            'submit draft, private, noindex, or claim-unsafe urls',
+            'treat crawler log as url truth',
+            'auto-rewrite claims',
+            'buy backlinks',
+            'approval must be exact, scoped, current, and human-provided',
+            'next task after this pr: `seo-ops-sop-01e`',
+            '"next_task": "seo-ops-sop-01e"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-ops-approval-gates-no-go-protocols.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T17:54:30+08:00",
+  "updated_at": "2026-05-22T18:07:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18583,11 +18583,11 @@
     "SEO-OPS-SOP-01C": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01c-weekly-monthly",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-OPS-SOP-01B"
       ],
-      "commit_sha": "124e521f8c1b3d3587c3093b7d276f9a66c7d659",
+      "commit_sha": "c815888f47b0b2505849d041b5e41ad4c7a1a210",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1573",
       "checks": {
         "local": {
@@ -18599,11 +18599,17 @@
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1573": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_weekly_monthly_test": "passed: php artisan test --filter=SeoIntelSeoOpsWeeklyMonthlyReviewRunbook --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T09:58:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -18630,19 +18636,35 @@
           "at": "2026-05-22T17:54:30+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1573 for SEO-OPS-SOP-01C and pushed branch codex/seo-ops-sop-01c-weekly-monthly."
+        },
+        {
+          "at": "2026-05-22T17:58:00+08:00",
+          "status": "merged",
+          "summary": "PR #1573 merged via squash at c815888f47b0b2505849d041b5e41ad4c7a1a210. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused weekly/monthly test passed. Local cleanup script was unavailable in this clone."
         }
       ]
     },
     "SEO-OPS-SOP-01D": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01d-approval-gates",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "SEO-OPS-SOP-01C"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_approval_gates": "passed: php artisan test --filter=SeoIntelSeoOpsApprovalGatesNoGoProtocols --no-ansi (7 tests, 99 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (487 tests, 7736 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3485 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-ops-approval-gates-no-go-protocols.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18657,6 +18679,16 @@
           "at": "2026-05-22T17:22:25+08:00",
           "status": "pending",
           "summary": "Registered SEO Ops approval gates and no-go protocols PR. Scope is docs/generated/test plus train metadata only; no gate implementation, runtime services, env edits, deploy changes, fap-web changes, or production actions."
+        },
+        {
+          "at": "2026-05-22T17:59:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-OPS-SOP-01D on codex/seo-ops-sop-01d-approval-gates. Scope is docs/generated/test plus train metadata only; no gate implementation, runtime services, env edits, deploy changes, fap-web changes, or production actions."
+        },
+        {
+          "at": "2026-05-22T18:07:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-OPS-SOP-01D local validation passed for focused approval gates test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T18:07:00+08:00",
+  "updated_at": "2026-05-22T18:08:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18647,12 +18647,12 @@
     "SEO-OPS-SOP-01D": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01d-approval-gates",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-OPS-SOP-01C"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "9e967559e5ed44ddfc43b1a24db59889783238bd",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1574",
       "checks": {
         "local": {
           "php_artisan_test_filter_approval_gates": "passed: php artisan test --filter=SeoIntelSeoOpsApprovalGatesNoGoProtocols --no-ansi (7 tests, 99 assertions)",
@@ -18689,6 +18689,11 @@
           "at": "2026-05-22T18:07:00+08:00",
           "status": "local_validation_passed",
           "summary": "SEO-OPS-SOP-01D local validation passed for focused approval gates test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
+        },
+        {
+          "at": "2026-05-22T18:08:30+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1574 for SEO-OPS-SOP-01D and pushed branch codex/seo-ops-sop-01d-approval-gates."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the SEO Ops approval gates and no-go protocols contract.
- Added a generated JSON artifact for human approval gates, no-go rules, P0 triggers, exact approval phrase templates, and gate behavior.
- Added a PHPUnit contract test for approval/no-go boundaries.
- Reconciled SEO-OPS-SOP-01C merge state in the train ledger.

## Why
This locks the human approval boundaries before the MBTI growth handoff, preserving the separation between observation, review, distribution, repair, and production action.

## Validation
- cd backend && php artisan test --filter=SeoIntelSeoOpsApprovalGatesNoGoProtocols --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-ops-approval-gates-no-go-protocols.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No actual gate implementation, runtime services, env edits, deployment changes, fap-web changes, production actions, CMS mutations, Search Channel submissions, crawler log reads, scheduler activation, Digital PR sends, pSEO generation, auto-rewrite, or auto-link creation.
- MBTI Growth Loop handoff and final closeout remain in later scoped PRs.