### PR TITLE
docs(seo-intel): add MBTI growth loop handoff

### DIFF
--- a/backend/docs/seo/generated/seo-ops-mbti-growth-loop-handoff.v1.json
+++ b/backend/docs/seo/generated/seo-ops-mbti-growth-loop-handoff.v1.json
@@ -1,0 +1,76 @@
+{
+  "version": "seo-ops-mbti-growth-loop-handoff.v1",
+  "task": "SEO-OPS-SOP-01E",
+  "train": "SEO-OPS-SOP-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "next_phase": "SEO-GROWTH-MBTI-00",
+  "first_governed_growth_loop": "MBTI",
+  "required_handoff_artifacts": [
+    "baseline_snapshot_requirements",
+    "telemetry_contract_requirements",
+    "entity_map_requirements",
+    "url_truth_review",
+    "content_internal_link_wave_1",
+    "claim_lint_gate",
+    "search_channel_canary_wave",
+    "digital_pr_wave",
+    "human_only_funnel_review",
+    "7_14_28_day_review",
+    "scale_decision"
+  ],
+  "growth_loop_core_path": [
+    "search",
+    "content",
+    "test",
+    "result",
+    "report",
+    "revenue",
+    "observation",
+    "repair",
+    "next_action"
+  ],
+  "telemetry_constraints": [
+    "frontend_observation_events_are_not_backend_truth",
+    "backend_payment_order_report_access_events_are_truth",
+    "bot_and_crawler_traffic_excluded_from_product_conversion_funnel",
+    "entity_key_independent_from_url_slug",
+    "brand_lift_proxy_tracks_unlinked_mentions_and_branded_query_lift_when_data_exists",
+    "digital_pr_mention_is_not_backlink_proof",
+    "crawler_and_search_data_are_observation_only"
+  ],
+  "mbti_first_experiment_scope": [
+    "mbti_test_page",
+    "mbti_topic_hub_if_available",
+    "mbti_research_page",
+    "sixteen_type_entity_pages_where_governed",
+    "mbti_result_report_paywall_path",
+    "digital_pr_hrzone_hrec_state",
+    "search_channel_canary_state",
+    "ops_seo_review_cadence"
+  ],
+  "scale_guards": [
+    "do_not_scale_to_big_five_riasec_or_career_until_mbti_loop_reviewed",
+    "do_not_overclaim_big_five_riasec_or_career_recommender_depth",
+    "do_not_generate_pseo",
+    "do_not_bulk_submit_urls",
+    "do_not_bulk_outreach",
+    "do_not_use_riasec_big_five_or_career_graph_as_precise_career_recommender_authority"
+  ],
+  "review_windows": [
+    "7_day_review",
+    "14_day_review",
+    "28_day_review"
+  ],
+  "safety_flags": {
+    "runtime_services_added": false,
+    "cms_content_mutated": false,
+    "fap_web_modified": false,
+    "search_channel_mutated": false,
+    "digital_pr_sent": false,
+    "pseo_created": false,
+    "deploy_performed": false,
+    "scaled_beyond_mbti": false,
+    "precise_recommender_overclaim_added": false
+  },
+  "next_task": "SEO-OPS-SOP-01F"
+}

--- a/backend/docs/seo/seo-ops-mbti-growth-loop-handoff.md
+++ b/backend/docs/seo/seo-ops-mbti-growth-loop-handoff.md
@@ -1,0 +1,75 @@
+# MBTI Growth Loop Handoff
+
+Task: SEO-OPS-SOP-01E
+
+Type: docs/generated/test only.
+
+This contract defines the transition from SEO infrastructure mode to SEO-GROWTH-MBTI-00. It does not add runtime services, mutate CMS content, modify fap-web, mutate Search Channel Queue, send Digital PR, create pSEO, deploy, or scale beyond MBTI.
+
+## Next Phase
+
+Next phase: `SEO-GROWTH-MBTI-00｜Baseline Snapshot and Telemetry Contract`.
+
+The first governed growth loop is MBTI only.
+
+Do not scale to Big Five, RIASEC, or Career until the MBTI loop has completed baseline, telemetry, claim lint gate, Search Channel canary, Digital PR observation, human-only funnel review, and 7/14/28-day review.
+
+## Required Handoff Artifacts
+
+SEO-GROWTH-MBTI-00 must define:
+
+- baseline snapshot requirements.
+- telemetry contract requirements.
+- entity map requirements.
+- URL Truth review.
+- Content/Internal Link Wave 1.
+- Claim Lint gate.
+- Search Channel canary wave.
+- Digital PR wave.
+- human-only funnel review.
+- 7/14/28-day review.
+- scale decision.
+
+## MBTI Growth Loop Core Path
+
+Search -> Content -> Test -> Result -> Report -> Revenue -> Observation -> Repair -> Next Action.
+
+## Telemetry Constraints
+
+- frontend observation events are not backend truth.
+- backend payment, order, and report access events are truth.
+- bot and crawler traffic must be excluded from the product conversion funnel.
+- entity_key must be independent from URL slug.
+- brand lift proxy may track unlinked mentions and branded query lift when data exists.
+- Digital PR mention is not backlink proof.
+- crawler and search data are observation only.
+
+## MBTI First Experiment Scope
+
+The first experiment must include:
+
+- MBTI test page.
+- MBTI topic/hub if available.
+- MBTI research page.
+- 16-type entity pages where governed.
+- MBTI result/report/paywall path.
+- Digital PR HRZone/HREC state.
+- Search Channel canary state.
+- /ops/seo review cadence.
+
+## Scale Guards
+
+- do not scale to Big Five, RIASEC, or Career until MBTI loop is reviewed.
+- do not overclaim Big Five, RIASEC, or Career recommender depth.
+- do not generate pSEO.
+- do not bulk submit URLs.
+- do not bulk outreach.
+- do not use RIASEC, Big Five, or Career Graph as precise career recommender authority.
+
+## Review Windows
+
+- 7-day review: check crawl/index/referral/issue safety and no P0 regressions.
+- 14-day review: check MBTI cluster content/internal link/Search Channel/Digital PR signals.
+- 28-day review: make scale, repeat, repair, or hold decision.
+
+Next task after this PR: `SEO-OPS-SOP-01F`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsMbtiGrowthLoopHandoffTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsMbtiGrowthLoopHandoffTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSeoOpsMbtiGrowthLoopHandoffTest extends TestCase
+{
+    #[Test]
+    public function mbti_growth_handoff_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-ops-mbti-growth-loop-handoff.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-ops-mbti-growth-loop-handoff.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01E', $artifact['task'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-00', $artifact['next_phase'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01F', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function handoff_artifacts_cover_baseline_telemetry_waves_and_scale_decision(): void
+    {
+        $artifacts = $this->artifact()['required_handoff_artifacts'] ?? [];
+
+        foreach ([
+            'baseline_snapshot_requirements',
+            'telemetry_contract_requirements',
+            'entity_map_requirements',
+            'url_truth_review',
+            'content_internal_link_wave_1',
+            'claim_lint_gate',
+            'search_channel_canary_wave',
+            'digital_pr_wave',
+            'human_only_funnel_review',
+            '7_14_28_day_review',
+            'scale_decision',
+        ] as $artifact) {
+            $this->assertContains($artifact, $artifacts);
+        }
+    }
+
+    #[Test]
+    public function core_growth_loop_path_is_locked(): void
+    {
+        $this->assertSame([
+            'search',
+            'content',
+            'test',
+            'result',
+            'report',
+            'revenue',
+            'observation',
+            'repair',
+            'next_action',
+        ], $this->artifact()['growth_loop_core_path'] ?? []);
+    }
+
+    #[Test]
+    public function telemetry_constraints_preserve_backend_truth_and_observation_boundaries(): void
+    {
+        $constraints = $this->artifact()['telemetry_constraints'] ?? [];
+
+        foreach ([
+            'frontend_observation_events_are_not_backend_truth',
+            'backend_payment_order_report_access_events_are_truth',
+            'bot_and_crawler_traffic_excluded_from_product_conversion_funnel',
+            'entity_key_independent_from_url_slug',
+            'brand_lift_proxy_tracks_unlinked_mentions_and_branded_query_lift_when_data_exists',
+            'digital_pr_mention_is_not_backlink_proof',
+            'crawler_and_search_data_are_observation_only',
+        ] as $constraint) {
+            $this->assertContains($constraint, $constraints);
+        }
+    }
+
+    #[Test]
+    public function mbti_first_experiment_scope_is_explicit(): void
+    {
+        $scope = $this->artifact()['mbti_first_experiment_scope'] ?? [];
+
+        foreach ([
+            'mbti_test_page',
+            'mbti_topic_hub_if_available',
+            'mbti_research_page',
+            'sixteen_type_entity_pages_where_governed',
+            'mbti_result_report_paywall_path',
+            'digital_pr_hrzone_hrec_state',
+            'search_channel_canary_state',
+            'ops_seo_review_cadence',
+        ] as $item) {
+            $this->assertContains($item, $scope);
+        }
+    }
+
+    #[Test]
+    public function scale_guards_prevent_pseo_bulk_actions_and_recommender_overclaims(): void
+    {
+        $guards = $this->artifact()['scale_guards'] ?? [];
+
+        foreach ([
+            'do_not_scale_to_big_five_riasec_or_career_until_mbti_loop_reviewed',
+            'do_not_overclaim_big_five_riasec_or_career_recommender_depth',
+            'do_not_generate_pseo',
+            'do_not_bulk_submit_urls',
+            'do_not_bulk_outreach',
+            'do_not_use_riasec_big_five_or_career_graph_as_precise_career_recommender_authority',
+        ] as $guard) {
+            $this->assertContains($guard, $guards);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_confirm_handoff_is_non_mutating(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_mbti_handoff_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-ops-mbti-growth-loop-handoff.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-ops-mbti-growth-loop-handoff.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'seo-growth-mbti-00',
+            'the first governed growth loop is mbti only',
+            'baseline snapshot requirements',
+            'telemetry contract requirements',
+            'search -> content -> test -> result -> report -> revenue -> observation -> repair -> next action',
+            'frontend observation events are not backend truth',
+            'backend payment, order, and report access events are truth',
+            'digital pr mention is not backlink proof',
+            'mbti test page',
+            'digital pr hrzone/hrec state',
+            'do not generate pseo',
+            'do not bulk submit urls',
+            'do not bulk outreach',
+            '28-day review',
+            'next task after this pr: `seo-ops-sop-01f`',
+            '"next_task": "seo-ops-sop-01f"',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-ops-mbti-growth-loop-handoff.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T18:20:00+08:00",
+  "updated_at": "2026-05-22T18:21:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18711,12 +18711,12 @@
     "SEO-OPS-SOP-01E": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01e-mbti-growth-handoff",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-OPS-SOP-01D"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "df4716a444e3130a31df5e37eb202d904c461b4a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1575",
       "checks": {
         "local": {
           "php_artisan_test_filter_mbti_handoff": "passed: php artisan test --filter=SeoIntelSeoOpsMbtiGrowthLoopHandoff --no-ansi (8 tests, 79 assertions)",
@@ -18753,6 +18753,11 @@
           "at": "2026-05-22T18:20:00+08:00",
           "status": "local_validation_passed",
           "summary": "SEO-OPS-SOP-01E local validation passed for focused MBTI handoff test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
+        },
+        {
+          "at": "2026-05-22T18:21:30+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1575 for SEO-OPS-SOP-01E and pushed branch codex/seo-ops-sop-01e-mbti-growth-handoff."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T18:08:30+08:00",
+  "updated_at": "2026-05-22T18:20:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18647,11 +18647,11 @@
     "SEO-OPS-SOP-01D": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01d-approval-gates",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-OPS-SOP-01C"
       ],
-      "commit_sha": "9e967559e5ed44ddfc43b1a24db59889783238bd",
+      "commit_sha": "0fd84b35688d893f75a08793ca03c0a6fdb832a3",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1574",
       "checks": {
         "local": {
@@ -18663,11 +18663,17 @@
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1574": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_approval_gates_test": "passed: php artisan test --filter=SeoIntelSeoOpsApprovalGatesNoGoProtocols --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T10:12:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -18694,19 +18700,35 @@
           "at": "2026-05-22T18:08:30+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1574 for SEO-OPS-SOP-01D and pushed branch codex/seo-ops-sop-01d-approval-gates."
+        },
+        {
+          "at": "2026-05-22T18:12:00+08:00",
+          "status": "merged",
+          "summary": "PR #1574 merged via squash at 0fd84b35688d893f75a08793ca03c0a6fdb832a3. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused approval gates test passed. Local cleanup script was unavailable in this clone."
         }
       ]
     },
     "SEO-OPS-SOP-01E": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01e-mbti-growth-handoff",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "SEO-OPS-SOP-01D"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "php_artisan_test_filter_mbti_handoff": "passed: php artisan test --filter=SeoIntelSeoOpsMbtiGrowthLoopHandoff --no-ansi (8 tests, 79 assertions)",
+          "php_artisan_test_filter_seo_intel": "passed: php artisan test --filter=SeoIntel --no-ansi (495 tests, 7815 assertions)",
+          "php_artisan_route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint_test": "passed: vendor/bin/pint --test (3486 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-ops-mbti-growth-loop-handoff.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18721,6 +18743,16 @@
           "at": "2026-05-22T17:22:25+08:00",
           "status": "pending",
           "summary": "Registered MBTI Growth Loop handoff PR. Scope is docs/generated/test plus train metadata only; no runtime services, CMS mutation, fap-web changes, Search Channel mutation, Digital PR send, pSEO, or deploy."
+        },
+        {
+          "at": "2026-05-22T18:13:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-OPS-SOP-01E on codex/seo-ops-sop-01e-mbti-growth-handoff. Scope is docs/generated/test plus train metadata only; no runtime services, CMS mutation, fap-web changes, Search Channel mutation, Digital PR send, pSEO, or deploy."
+        },
+        {
+          "at": "2026-05-22T18:20:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-OPS-SOP-01E local validation passed for focused MBTI handoff test, full SeoIntel filter, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus train metadata only."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the MBTI Growth Loop handoff contract for SEO-GROWTH-MBTI-00.
- Added a generated JSON artifact for baseline, telemetry, entity map, URL Truth, content/internal link, claim lint, Search Channel, Digital PR, funnel review, 7/14/28-day review, and scale decision requirements.
- Added a PHPUnit contract test for the handoff and scale guards.
- Reconciled SEO-OPS-SOP-01D merge state in the train ledger.

## Why
This defines the transition from SEO infrastructure/SOP mode into the first governed MBTI growth loop while preventing premature Big Five/RIASEC/Career scaling, pSEO, bulk submissions, bulk outreach, and precise recommender overclaims.

## Validation
- cd backend && php artisan test --filter=SeoIntelSeoOpsMbtiGrowthLoopHandoff --no-ansi
- cd backend && php artisan test --filter=SeoIntel --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-ops-mbti-growth-loop-handoff.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No runtime services, CMS mutation, fap-web changes, Search Channel mutation, Digital PR sending, pSEO, deploy, auto-rewrite, or auto-link creation.
- Final SOP closeout remains in SEO-OPS-SOP-01F.