### PR TITLE
docs(seo-intel): close final SEO Ops SOP train

### DIFF
--- a/backend/docs/seo/generated/seo-ops-sop-final-closeout.v1.json
+++ b/backend/docs/seo/generated/seo-ops-sop-final-closeout.v1.json
@@ -1,0 +1,120 @@
+{
+  "version": "seo-ops-sop-final-closeout.v1",
+  "task": "SEO-OPS-SOP-01F",
+  "train": "SEO-OPS-SOP-PR-TRAIN-01",
+  "type": "docs_generated_test_state_only",
+  "completed_prs": [
+    {
+      "id": "SEO-OPS-SOP-01A",
+      "title": "SEO Ops SOP architecture and authority map",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1571"
+    },
+    {
+      "id": "SEO-OPS-SOP-01B",
+      "title": "Daily SEO Ops runbook",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1572"
+    },
+    {
+      "id": "SEO-OPS-SOP-01C",
+      "title": "Weekly and monthly SEO Ops review runbook",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1573"
+    },
+    {
+      "id": "SEO-OPS-SOP-01D",
+      "title": "Approval gates and no-go protocols",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1574"
+    },
+    {
+      "id": "SEO-OPS-SOP-01E",
+      "title": "MBTI Growth Loop handoff",
+      "result": "completed_contract_only",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1575"
+    }
+  ],
+  "results": {
+    "architecture_authority_map": "CMS/backend truth, fap-web deterministic runtime, seo_intel observation-only, /ops/seo read-only operational view, /ops/seo-operations repair surface, private Metabase, Search Channel distribution-only, crawler aggregate observation-only, and Digital PR observation-only boundaries are locked.",
+    "daily_ops_runbook": "Daily checklist covers /ops/seo, URL Truth counts, Issue Queue P0/P1, Search Channel Queue states, live gate closure, crawler aggregate counters, Claim Lint counts, Internal Link gaps, Content Publish Rehearsal blockers, Digital PR HRZone state, MBTI Growth Loop status, and uncontrolled scheduler/collector/submission checks.",
+    "weekly_monthly_review": "Weekly and monthly review cadence covers backlog, trends, claim and link safety, Digital PR observation, Research URL observation, MBTI cluster performance, entity selection, funnel review, and 7/14/28-day MBTI review.",
+    "approval_gates_no_go": "Human approval gates, no-go rules, P0 triggers, and exact approval phrase templates are defined without implementation.",
+    "mbti_growth_loop_handoff": "SEO-GROWTH-MBTI-00 is the next phase with MBTI as the first governed loop and scale guards against premature Big Five/RIASEC/Career expansion, pSEO, bulk submission, bulk outreach, and precise recommender overclaims.",
+    "ledger": "PR train manifest and state ledger were updated for the scoped SEO Ops SOP train."
+  },
+  "safety_confirmation": {
+    "runtime_implementation_added": false,
+    "deployment_performed": false,
+    "env_edited": false,
+    "migrations_added_or_run": false,
+    "scheduler_enabled": false,
+    "search_submission_performed": false,
+    "crawler_logs_read": false,
+    "cms_publish_or_mutation_performed": false,
+    "fap_web_modified": false,
+    "digital_pr_sent": false,
+    "metabase_exposed": false,
+    "pseo_generated": false,
+    "auto_fix_performed": false,
+    "auto_rewrite_performed": false,
+    "internal_links_created": false,
+    "collector_writes_enabled": false,
+    "production_operation_performed": false
+  },
+  "validation_summary": {
+    "focused_contract_tests": "passed during each PR before merge",
+    "seo_intel_suite": "passed during each PR before merge",
+    "route_list": "passed during each PR before merge",
+    "pint": "passed during each PR before merge",
+    "json_validation": "passed",
+    "yaml_validation": "passed",
+    "diff_checks": "passed",
+    "github_required_checks": "passed before every merge",
+    "post_merge_revalidation": "passed after every merged PR"
+  },
+  "sidecar_issues": [
+    {
+      "title": "Backend deploy public smoke blocker / local TLS flakiness",
+      "status": "external_sidecar"
+    },
+    {
+      "title": "translation_group_uuid missing globally",
+      "status": "separate_implementation_required"
+    },
+    {
+      "title": "translation_group_id partial/transitional",
+      "status": "known_sidecar"
+    },
+    {
+      "title": "seo_observation_queue contract-only",
+      "status": "future_implementation_train"
+    },
+    {
+      "title": "issue governance fields contract-only",
+      "status": "future_implementation_train"
+    },
+    {
+      "title": "fap-web fallback authority risk",
+      "status": "reference_only_sidecar"
+    },
+    {
+      "title": "HRZone Digital PR canary observing",
+      "status": "manual_observation_only"
+    },
+    {
+      "title": "stale docs/static closeout counts",
+      "status": "do_not_treat_as_live_truth"
+    },
+    {
+      "title": "ops seo operations write-capable surface",
+      "status": "not_daily_observability"
+    },
+    {
+      "title": "post merge cleanup script unavailable",
+      "status": "local_cleanup_script_missing"
+    }
+  ],
+  "final_decision": "seo_ops_sop_completed_ready_for_mbti_growth_loop_00",
+  "next_task": "SEO-GROWTH-MBTI-00｜Baseline Snapshot and Telemetry Contract"
+}

--- a/backend/docs/seo/seo-ops-sop-final-closeout.md
+++ b/backend/docs/seo/seo-ops-sop-final-closeout.md
@@ -1,0 +1,80 @@
+# SEO Ops SOP Final Closeout
+
+Task: SEO-OPS-SOP-01F
+
+Train: SEO-OPS-SOP-PR-TRAIN-01
+
+Type: docs/generated/test/state only.
+
+This closeout confirms the final Daily / Weekly / Monthly SEO Ops SOP train is complete and hands off to `SEO-GROWTH-MBTI-00｜Baseline Snapshot and Telemetry Contract`.
+
+## Completed PRs
+
+- SEO-OPS-SOP-01A: SEO Ops SOP architecture and authority map.
+- SEO-OPS-SOP-01B: Daily SEO Ops runbook.
+- SEO-OPS-SOP-01C: Weekly and monthly SEO Ops review runbook.
+- SEO-OPS-SOP-01D: Approval gates and no-go protocols.
+- SEO-OPS-SOP-01E: MBTI Growth Loop handoff.
+
+## Result Summary
+
+Architecture / authority map:
+
+CMS/backend remains truth for content, metadata, canonical, publish state, claim boundary, and URL Truth. fap-web remains deterministic runtime only. seo_intel observes only. `/ops/seo` is a read-only operational view. `/ops/seo-operations` is a write-capable CMS repair surface, not the daily observability dashboard.
+
+Daily ops runbook:
+
+The daily checklist covers `/ops/seo`, overview/safety heartbeat, URL Truth counts, Issue Queue P0/P1, Search Channel Queue states, live gate closure, crawler aggregate counters, Claim Lint counts, Internal Link gaps, Content Publish Rehearsal blockers, Digital PR HRZone state, MBTI Growth Loop status, and uncontrolled scheduler/collector/submission checks.
+
+Weekly/monthly review:
+
+The review cadence covers Search Channel backlog, crawler aggregate trends, content rehearsal blockers, internal link coverage, claim lint backlog, Research URL observation, Digital PR tracking, MBTI cluster trend, entity cluster performance, content decay, claim safety, Search Channel audit, funnel review, and 7/14/28-day MBTI Growth Loop review.
+
+Approval gates / no-go protocols:
+
+Human approval is required for CMS publish/mutation, Search Channel enqueue/live submission, search API calls, crawler log production canary, scheduler activation, production migration, backend deploy, public Metabase exposure, Digital PR send/follow-up, claim override, internal link mutation, pSEO, bulk generation, and production env edit.
+
+MBTI Growth Loop handoff:
+
+The next phase is `SEO-GROWTH-MBTI-00`. MBTI remains the first governed growth loop. Big Five, RIASEC, and Career must not scale until MBTI baseline, telemetry, claim gate, Search Channel canary, Digital PR observation, human-only funnel review, and 7/14/28-day review are complete.
+
+## Safety Confirmation
+
+- no runtime implementation.
+- no deployment.
+- no env edit.
+- no migration.
+- no scheduler.
+- no search submission.
+- no crawler log read.
+- no CMS publish or mutation.
+- no fap-web modification.
+- no Digital PR send.
+- no Metabase exposure.
+- no pSEO generation.
+- no auto-fix.
+- no auto-rewrite.
+- no auto-link creation.
+- no collector write.
+- no production operation.
+
+## Sidecar Issues
+
+- backend deploy public smoke blocker / local TLS flakiness for ops/api remains separate.
+- translation_group_uuid is still missing globally.
+- existing translation_group_id remains partial/transitional.
+- dedicated seo_observation_queue table remains contract-only.
+- issue governance fields remain contract-only.
+- fap-web fallback authority risk remains reference-only.
+- HRZone Digital PR canary remains observation-only.
+- stale docs/static closeout counts must not be treated as live operator truth.
+- `/ops/seo-operations` has write-capable CMS actions and must not be confused with read-only `/ops/seo`.
+- local cleanup script `scripts/post_merge_cleanup.sh` is unavailable in this clone; remote branches were deleted and local task branches were absent after gh merge.
+
+## Final Decision
+
+`seo_ops_sop_completed_ready_for_mbti_growth_loop_00`
+
+## Next Task
+
+`SEO-GROWTH-MBTI-00｜Baseline Snapshot and Telemetry Contract`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsSopFinalCloseoutTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSeoOpsSopFinalCloseoutTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSeoOpsSopFinalCloseoutTest extends TestCase
+{
+    #[Test]
+    public function closeout_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-ops-sop-final-closeout.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-ops-sop-final-closeout.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-01F', $artifact['task'] ?? null);
+        $this->assertSame('SEO-OPS-SOP-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_state_only', $artifact['type'] ?? null);
+    }
+
+    #[Test]
+    public function completed_prs_are_recorded_with_urls(): void
+    {
+        $completed = collect($this->artifact()['completed_prs'] ?? []);
+
+        foreach ([
+            'SEO-OPS-SOP-01A' => 'https://github.com/fermatmind/fap-api/pull/1571',
+            'SEO-OPS-SOP-01B' => 'https://github.com/fermatmind/fap-api/pull/1572',
+            'SEO-OPS-SOP-01C' => 'https://github.com/fermatmind/fap-api/pull/1573',
+            'SEO-OPS-SOP-01D' => 'https://github.com/fermatmind/fap-api/pull/1574',
+            'SEO-OPS-SOP-01E' => 'https://github.com/fermatmind/fap-api/pull/1575',
+        ] as $id => $url) {
+            $row = $completed->firstWhere('id', $id);
+
+            $this->assertIsArray($row, $id.' must be recorded');
+            $this->assertSame($url, $row['pr_url'] ?? null);
+            $this->assertNotSame('', $row['result'] ?? '');
+        }
+    }
+
+    #[Test]
+    public function results_cover_all_sop_sections(): void
+    {
+        $results = $this->artifact()['results'] ?? [];
+
+        foreach ([
+            'architecture_authority_map',
+            'daily_ops_runbook',
+            'weekly_monthly_review',
+            'approval_gates_no_go',
+            'mbti_growth_loop_handoff',
+            'ledger',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $results);
+            $this->assertNotSame('', $results[$key]);
+        }
+    }
+
+    #[Test]
+    public function safety_confirmation_blocks_runtime_and_production_work(): void
+    {
+        foreach ($this->artifact()['safety_confirmation'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function validation_summary_and_sidecars_are_explicit(): void
+    {
+        $summary = $this->artifact()['validation_summary'] ?? [];
+
+        foreach ([
+            'focused_contract_tests',
+            'seo_intel_suite',
+            'route_list',
+            'pint',
+            'json_validation',
+            'yaml_validation',
+            'diff_checks',
+            'github_required_checks',
+            'post_merge_revalidation',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $summary);
+        }
+
+        $sidecars = collect($this->artifact()['sidecar_issues'] ?? []);
+
+        foreach ([
+            'Backend deploy public smoke blocker / local TLS flakiness',
+            'translation_group_uuid missing globally',
+            'seo_observation_queue contract-only',
+            'issue governance fields contract-only',
+            'fap-web fallback authority risk',
+            'HRZone Digital PR canary observing',
+            'post merge cleanup script unavailable',
+        ] as $title) {
+            $this->assertNotNull($sidecars->firstWhere('title', $title), $title.' sidecar must be recorded');
+        }
+    }
+
+    #[Test]
+    public function final_decision_and_next_task_are_locked(): void
+    {
+        $this->assertSame(
+            'seo_ops_sop_completed_ready_for_mbti_growth_loop_00',
+            $this->artifact()['final_decision'] ?? null
+        );
+
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-00｜Baseline Snapshot and Telemetry Contract',
+            $this->artifact()['next_task'] ?? null
+        );
+    }
+
+    #[Test]
+    public function docs_lock_closeout_and_no_runtime_operations(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-ops-sop-final-closeout.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-ops-sop-final-closeout.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'seo-ops-sop-01a',
+            'seo-ops-sop-01b',
+            'seo-ops-sop-01c',
+            'seo-ops-sop-01d',
+            'seo-ops-sop-01e',
+            'no runtime implementation',
+            'no deployment',
+            'no env edit',
+            'no migration',
+            'no scheduler',
+            'no search submission',
+            'no crawler log read',
+            'no cms publish or mutation',
+            'no fap-web modification',
+            'no digital pr send',
+            'no metabase exposure',
+            'no pseo generation',
+            'seo-growth-mbti-00',
+            'seo_ops_sop_completed_ready_for_mbti_growth_loop_00',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-ops-sop-final-closeout.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T18:21:30+08:00",
+  "updated_at": "2026-05-22T18:31:04+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18711,11 +18711,11 @@
     "SEO-OPS-SOP-01E": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01e-mbti-growth-handoff",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-OPS-SOP-01D"
       ],
-      "commit_sha": "df4716a444e3130a31df5e37eb202d904c461b4a",
+      "commit_sha": "ab3878d6817d8833098edc32d2c9e09a255d69a1",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1575",
       "checks": {
         "local": {
@@ -18727,11 +18727,17 @@
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
+        },
+        "github": {
+          "pr_1575": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN"
+        },
+        "post_merge": {
+          "focused_mbti_handoff_test": "passed: php artisan test --filter=SeoIntelSeoOpsMbtiGrowthLoopHandoff --no-ansi"
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T10:24:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -18758,19 +18764,35 @@
           "at": "2026-05-22T18:21:30+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1575 for SEO-OPS-SOP-01E and pushed branch codex/seo-ops-sop-01e-mbti-growth-handoff."
+        },
+        {
+          "at": "2026-05-22T18:24:00+08:00",
+          "status": "merged",
+          "summary": "PR #1575 merged via squash at ab3878d6817d8833098edc32d2c9e09a255d69a1. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused MBTI handoff test passed. Local cleanup script was unavailable in this clone."
         }
       ]
     },
     "SEO-OPS-SOP-01F": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01f-final-closeout",
-      "status": "pending",
+      "status": "committed",
       "depends_on": [
         "SEO-OPS-SOP-01E"
       ],
-      "commit_sha": null,
+      "commit_sha": "532901be75d7035bcd077fdf425f71bab00309a1",
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "focused_final_closeout_test": "passed: php artisan test --filter=SeoIntelSeoOpsSopFinalCloseout --no-ansi (7 tests, 102 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (502 tests, 7917 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3487 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-ops-sop-final-closeout.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18785,6 +18807,23 @@
           "at": "2026-05-22T17:22:25+08:00",
           "status": "pending",
           "summary": "Registered final SEO Ops SOP closeout PR. Scope is closeout docs/generated/test/state only; no runtime code, migrations, production operations, fap-web changes, or CMS mutations."
+        },
+        {
+          "at": "2026-05-22T18:25:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-OPS-SOP-01F on codex/seo-ops-sop-01f-final-closeout. Scope is closeout docs/generated/test/state only; no runtime code, migrations, production operations, fap-web changes, or CMS mutations."
+        }
+      ],
+      "transitions": [
+        {
+          "at": "2026-05-22T18:30:24+08:00",
+          "status": "local_validation_passed",
+          "summary": "Created final SOP closeout docs, generated artifact, and contract test. Focused, SeoIntel suite, route:list, Pint, JSON/YAML, and git diff checks passed."
+        },
+        {
+          "at": "2026-05-22T18:31:04+08:00",
+          "status": "committed",
+          "summary": "Committed SEO-OPS-SOP-01F closeout scope at 532901be75d7035bcd077fdf425f71bab00309a1."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T18:31:04+08:00",
+  "updated_at": "2026-05-22T18:31:57+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18775,12 +18775,12 @@
     "SEO-OPS-SOP-01F": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-sop-01f-final-closeout",
-      "status": "committed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-OPS-SOP-01E"
       ],
-      "commit_sha": "532901be75d7035bcd077fdf425f71bab00309a1",
-      "pr_url": null,
+      "commit_sha": "2345b2014f03cc3cd0727f9ac44516c3b15119f4",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1576",
       "checks": {
         "local": {
           "focused_final_closeout_test": "passed: php artisan test --filter=SeoIntelSeoOpsSopFinalCloseout --no-ansi (7 tests, 102 assertions)",
@@ -18824,6 +18824,11 @@
           "at": "2026-05-22T18:31:04+08:00",
           "status": "committed",
           "summary": "Committed SEO-OPS-SOP-01F closeout scope at 532901be75d7035bcd077fdf425f71bab00309a1."
+        },
+        {
+          "at": "2026-05-22T18:31:57+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1576 for SEO-OPS-SOP-01F and pushed branch codex/seo-ops-sop-01f-final-closeout."
         }
       ]
     }


### PR DESCRIPTION
## What changed
- Added the final SEO Ops SOP closeout document and generated contract artifact.
- Added a focused closeout contract test covering completed SOP PRs, safety confirmations, sidecars, final decision, and next task.
- Updated the PR train ledger for SEO-OPS-SOP-01E merge reconciliation and SEO-OPS-SOP-01F local validation/commit state.

## Why
This closes the Daily / Weekly / Monthly SEO Ops SOP train and hands the system off to `SEO-GROWTH-MBTI-00｜Baseline Snapshot and Telemetry Contract` without adding runtime behavior or production operations.

## Validation
- `php artisan test --filter=SeoIntelSeoOpsSopFinalCloseout --no-ansi` (7 tests, 102 assertions)
- `php artisan test --filter=SeoIntel --no-ansi` (502 tests, 7917 assertions)
- `php artisan route:list --no-ansi` (203 routes)
- `vendor/bin/pint --test` (3487 files)
- `python3 -m json.tool backend/docs/seo/generated/seo-ops-sop-final-closeout.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No runtime services or UI implementation.
- No migrations or production operations.
- No scheduler, collector, Search Channel, crawler log, CMS, fap-web, Digital PR, Metabase, pSEO, auto-fix, auto-rewrite, or auto-link changes.
- Sidecars remain documented for the next train: deploy smoke/TLS flakiness, missing global `translation_group_uuid`, contract-only observation/issue governance fields, reference-only fap-web fallback authority risk, and HRZone observation.
