### PR TITLE
fix(deploy): detect nested nginx static routes

### DIFF
--- a/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
+++ b/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
@@ -39,6 +39,9 @@ final class DeployStorageAndDatabaseConfigTest extends TestCase
 
         $this->assertStringContainsString('static_route_action=install', $source);
         $this->assertStringContainsString('skip_existing_static_location', $source);
+        $this->assertStringContainsString('function nginxIncludePaths(string $content): array', $source);
+        $this->assertStringContainsString('glob($includePath, GLOB_NOSORT)', $source);
+        $this->assertStringContainsString('readableIncludeHasStaticLocation(string $content, array $seen = [])', $source);
         $this->assertStringContainsString('existing /static/ location found in included nginx file', $source);
         $this->assertStringContainsString('existing /static/ route detected; skipping managed snippet install', $source);
         $this->assertStringContainsString('mktemp /tmp/fap-api-nginx-site-backup.XXXXXX.conf', $source);

--- a/deploy.php
+++ b/deploy.php
@@ -809,26 +809,60 @@ function hasStaticLocation(string $content): bool
     return preg_match('/^\\s*location\\s+(?:\\^~|=|~\\*?|~)?\\s*\\/static(?:\\/|\\s|\\{)/m', $content) === 1;
 }
 
-function readableIncludeHasStaticLocation(string $content): bool
+function nginxIncludePaths(string $content): array
 {
     $includeCount = preg_match_all('/^\\s*include\\s+([^;]+);\\s*$/m', $content, $matches);
 
     if ($includeCount === false || $includeCount < 1) {
-        return false;
+        return [];
     }
+
+    $paths = [];
 
     foreach ($matches[1] as $includePath) {
         $includePath = trim((string) $includePath, " \t\n\r\0\x0B'\"");
 
-        if ($includePath === '' || $includePath[0] !== '/' || strpbrk($includePath, '*?[') !== false) {
+        if ($includePath === '' || $includePath[0] !== '/') {
             continue;
         }
 
+        if (strpbrk($includePath, '*?[') !== false) {
+            $expanded = glob($includePath, GLOB_NOSORT);
+
+            foreach (is_array($expanded) ? $expanded : [] as $path) {
+                if (is_string($path) && $path !== '') {
+                    $paths[] = $path;
+                }
+            }
+
+            continue;
+        }
+
+        $paths[] = $includePath;
+    }
+
+    return array_values(array_unique($paths));
+}
+
+function readableIncludeHasStaticLocation(string $content, array $seen = []): bool
+{
+    foreach (nginxIncludePaths($content) as $includePath) {
+        $realPath = realpath($includePath) ?: $includePath;
+
+        if (isset($seen[$realPath])) {
+            continue;
+        }
+
+        $seen[$realPath] = true;
         $included = shell_exec('sudo -n /usr/bin/cat ' . escapeshellarg($includePath));
 
         if (is_string($included) && hasStaticLocation($included)) {
             fwrite(STDERR, "existing /static/ location found in included nginx file: {$includePath}; skipping managed static snippet\n");
 
+            return true;
+        }
+
+        if (is_string($included) && readableIncludeHasStaticLocation($included, $seen)) {
             return true;
         }
     }


### PR DESCRIPTION
## What changed
- Updated the backend Deployer nginx static media route guard to expand absolute nginx include globs and recursively inspect nested included files.
- Kept the existing fail-safe behavior: if an existing `/static/` location is found, the deploy skips managed snippet installation and validates the existing config.
- Extended the SRE deploy config test to lock the glob and recursion guard behavior.

## Why
The previous deploy failed after `deploy:symlink` because `/static/` was already defined in an included runtime snippet. The guard only inspected direct non-glob includes, so it missed the existing route until `nginx -t` reported a duplicate location.

## Validation
- `php -l deploy.php`
- `php artisan test --filter=DeployStorageAndDatabaseConfigTest --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test ../deploy.php tests/Sre/DeployStorageAndDatabaseConfigTest.php`
- `git diff --check`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-ci.sqlite php artisan migrate --pretend --no-ansi`
- `bash scripts/ci_verify_mbti.sh`

Note: default `php artisan migrate --pretend --no-ansi` attempted the local MySQL default and failed with local root access denied. The same dry-run was rerun against the CI SQLite DB and passed with nothing to migrate.

## Intentionally deferred
- No production deploy retry in this PR.
- No nginx edits on production.
- No deploy lock, rollback, process kill, PM2, scheduler, collector, Search Channel, CMS, Metabase, or fap-web changes.
