### PR TITLE
fix(deploy): detect global nginx static route

### DIFF
--- a/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
+++ b/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
@@ -39,6 +39,9 @@ final class DeployStorageAndDatabaseConfigTest extends TestCase
 
         $this->assertStringContainsString('static_route_action=install', $source);
         $this->assertStringContainsString('skip_existing_static_location', $source);
+        $this->assertStringContainsString('function currentNginxConfigHasStaticLocation(): bool', $source);
+        $this->assertStringContainsString("shell_exec('sudo -n nginx -T 2>/dev/null')", $source);
+        $this->assertStringContainsString('existing /static/ location found in current nginx config', $source);
         $this->assertStringContainsString('function nginxIncludePaths(string $content): array', $source);
         $this->assertStringContainsString('glob($includePath, GLOB_NOSORT)', $source);
         $this->assertStringContainsString('readableIncludeHasStaticLocation(string $content, array $seen = [])', $source);

--- a/deploy.php
+++ b/deploy.php
@@ -809,6 +809,17 @@ function hasStaticLocation(string $content): bool
     return preg_match('/^\\s*location\\s+(?:\\^~|=|~\\*?|~)?\\s*\\/static(?:\\/|\\s|\\{)/m', $content) === 1;
 }
 
+function currentNginxConfigHasStaticLocation(): bool
+{
+    $currentConfig = shell_exec('sudo -n nginx -T 2>/dev/null');
+
+    if (! is_string($currentConfig) || $currentConfig === '') {
+        return false;
+    }
+
+    return hasStaticLocation($currentConfig);
+}
+
 function nginxIncludePaths(string $content): array
 {
     $includeCount = preg_match_all('/^\\s*include\\s+([^;]+);\\s*$/m', $content, $matches);
@@ -871,6 +882,12 @@ function readableIncludeHasStaticLocation(string $content, array $seen = []): bo
 }
 
 $content = preg_replace('/^\\s*include\\s+\\/etc\\/nginx\\/snippets\\/fap-api-public-static-media-[^;]+;\\R/m', '', $content);
+
+if (currentNginxConfigHasStaticLocation()) {
+    fwrite(STDERR, "existing /static/ location found in current nginx config; skipping managed static snippet\n");
+    echo $content;
+    exit(2);
+}
 
 if (is_string($content) && hasStaticLocation($content)) {
     fwrite(STDERR, "existing /static/ location found in nginx site; skipping managed static snippet\n");


### PR DESCRIPTION
## What changed
- Added a pre-install guard that inspects the current full nginx config with `nginx -T` before adding the managed `/static/` snippet.
- If any existing `/static/` location is already active, deploy now skips managed snippet installation and validates the existing config path.
- Extended the SRE deploy test to lock the global nginx config guard.

## Why
The previous include-chain guard did not catch production's existing `/static/` route because it is present in a runtime snippet loaded by the broader nginx config, not the deploy-managed site include chain. This caused `nginx -t` to fail with duplicate `/static/` after symlink.

## Validation
- `php -l deploy.php`
- `php artisan test --filter=DeployStorageAndDatabaseConfigTest --no-ansi`
- `vendor/bin/pint --test ../deploy.php tests/Sre/DeployStorageAndDatabaseConfigTest.php`
- `php artisan route:list --no-ansi`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-ci.sqlite php artisan migrate --pretend --no-ansi`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred
- No production deploy retry in this PR.
- No nginx edits on production.
- No deploy lock, rollback, process kill, PM2, scheduler, collector, Search Channel, CMS, Metabase, or fap-web changes.
