### PR TITLE
docs(seo-intel): add MBTI growth baseline URL Truth contract

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1.json
@@ -1,0 +1,257 @@
+{
+  "version": "seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1",
+  "task": "SEO-GROWTH-MBTI-00A",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01-PREFACE",
+  "type": "docs_generated_test_only",
+  "scan_blocker_resolved": "blocked_mbti_url_truth_unclear",
+  "baseline_asset_inventory": [
+    "mbti_test_page",
+    "mbti_research_report",
+    "mbti_topic_hub",
+    "mbti_personality_type_pages",
+    "mbti_articles",
+    "mbti_private_flows",
+    "mbti_telemetry_surfaces",
+    "mbti_search_channel_candidates",
+    "mbti_claim_sensitive_surfaces"
+  ],
+  "forbidden_authority_sources": [
+    "frontend_fallback",
+    "static_sitemap",
+    "static_llms",
+    "crawler_logs",
+    "search_engine_responses",
+    "digital_pr_mentions",
+    "local_copies"
+  ],
+  "url_truth_candidate_matrix": [
+    {
+      "family": "mbti_test_page",
+      "url": "/en/tests/mbti-personality-test-16-personality-types",
+      "locale": "en",
+      "expected_page_entity_type": "test_detail",
+      "expected_source_authorities": [
+        "scale_catalog",
+        "backend_public_surface"
+      ],
+      "status": "candidate_requiring_backend_authoritative_dry_run_confirmation"
+    },
+    {
+      "family": "mbti_test_page",
+      "url": "/zh/tests/mbti-personality-test-16-personality-types",
+      "locale": "zh",
+      "expected_page_entity_type": "test_detail",
+      "expected_source_authorities": [
+        "scale_catalog",
+        "backend_public_surface"
+      ],
+      "status": "candidate_requiring_backend_authoritative_dry_run_confirmation"
+    },
+    {
+      "family": "mbti_research_report",
+      "url": "/en/research/mbti-personality-types-salary-turnover-report",
+      "locale": "en",
+      "expected_page_entity_type": "research_report",
+      "expected_source_authorities": [
+        "backend_cms",
+        "research_reports"
+      ],
+      "status": "candidate_requiring_claim_safe_verification"
+    },
+    {
+      "family": "mbti_research_report",
+      "url": "/zh/research/mbti-personality-types-salary-turnover-report",
+      "locale": "zh",
+      "expected_page_entity_type": "research_report",
+      "expected_source_authorities": [
+        "backend_cms",
+        "research_reports"
+      ],
+      "status": "candidate_requiring_claim_safe_verification"
+    },
+    {
+      "family": "mbti_topic_hub",
+      "url": "/en/topics/mbti",
+      "locale": "en",
+      "expected_page_entity_type": "topic",
+      "expected_source_authorities": [
+        "backend_cms_topic"
+      ],
+      "status": "deferred_until_backend_cms_topic_authority_is_explicit"
+    },
+    {
+      "family": "mbti_topic_hub",
+      "url": "/zh/topics/mbti",
+      "locale": "zh",
+      "expected_page_entity_type": "topic",
+      "expected_source_authorities": [
+        "backend_cms_topic"
+      ],
+      "status": "deferred_until_backend_cms_topic_authority_is_explicit"
+    },
+    {
+      "family": "mbti_personality_type_pages",
+      "url_pattern": "/en/personality/{type}",
+      "locale": "en",
+      "expected_page_entity_type": "personality",
+      "expected_source_authorities": [
+        "backend_personality",
+        "backend_cms"
+      ],
+      "status": "deferred_until_backend_personality_cms_entity_authority_is_explicit"
+    },
+    {
+      "family": "mbti_personality_type_pages",
+      "url_pattern": "/zh/personality/{type}",
+      "locale": "zh",
+      "expected_page_entity_type": "personality",
+      "expected_source_authorities": [
+        "backend_personality",
+        "backend_cms"
+      ],
+      "status": "deferred_until_backend_personality_cms_entity_authority_is_explicit"
+    },
+    {
+      "family": "mbti_articles",
+      "url_pattern": "backend_cms_article_urls",
+      "expected_page_entity_type": "article",
+      "expected_source_authorities": [
+        "backend_cms_article"
+      ],
+      "status": "deferred_until_backend_cms_article_rows_are_verified"
+    },
+    {
+      "family": "mbti_private_flows",
+      "path_patterns": [
+        "take",
+        "result",
+        "report",
+        "paywall",
+        "order",
+        "pdf",
+        "history"
+      ],
+      "expected_status": "noindex_private_excluded_from_url_truth_and_search_channel"
+    }
+  ],
+  "entity_map_contract": {
+    "future_entity_keys": [
+      "mbti_test",
+      "mbti_topic",
+      "mbti_research_salary_turnover",
+      "mbti_result_private",
+      "mbti_paid_report_private",
+      "mbti_type_intj",
+      "mbti_type_infp",
+      "mbti_type_entj"
+    ],
+    "type_key_pattern": "mbti_type_{lowercase_type_code}",
+    "rules": [
+      "entity_key_independent_from_url_slug",
+      "translation_group_uuid_preferred_when_available",
+      "translation_group_id_transitional_only",
+      "slug_title_similarity_migration_helper_only_not_authority",
+      "frontend_fallback_cannot_create_entity_key",
+      "private_entities_not_public_url_truth_or_search_channel_candidates"
+    ]
+  },
+  "telemetry_contract": {
+    "frontend_observation_events": [
+      "landing_view",
+      "test_cta_click",
+      "test_start_click",
+      "report_preview_view",
+      "unlock_click",
+      "checkout_button_click",
+      "email_form_view"
+    ],
+    "backend_truth_events": [
+      "attempt_created",
+      "attempt_submitted",
+      "result_generated",
+      "email_captured",
+      "order_created",
+      "payment_success",
+      "benefit_granted",
+      "report_access_granted",
+      "pdf_generated"
+    ],
+    "rules": [
+      "frontend_observation_is_not_backend_truth",
+      "backend_payment_order_report_access_is_truth",
+      "bot_crawler_traffic_excluded_from_conversion_funnel_formulas",
+      "crawler_traffic_only_enters_crawler_aggregate_observation",
+      "email_not_in_public_html_search_analytics_payloads_urls_or_digital_pr_artifacts"
+    ]
+  },
+  "private_noindex_exclusion_matrix": [
+    "take_flow",
+    "result_page",
+    "report_page",
+    "paywall_checkout",
+    "order_payment_recovery",
+    "report_pdf",
+    "account_history",
+    "email_capture_recovery"
+  ],
+  "claim_gate": {
+    "required_before": [
+      "search_channel_planning",
+      "digital_pr_wave_2",
+      "content_internal_link_wave",
+      "growth_experiment_review"
+    ],
+    "forbidden_claims": [
+      "MBTI决定收入",
+      "MBTI预测离职",
+      "薪资保证",
+      "招聘适配",
+      "职业成功预测",
+      "精准职业推荐",
+      "最适合职业",
+      "诊断",
+      "确诊",
+      "治疗",
+      "治愈"
+    ],
+    "allowed_bounded_language": [
+      "模型化指数",
+      "聚合层面",
+      "方向性趋势",
+      "非诊断",
+      "结果仅供参考",
+      "职业方向参考",
+      "工作方式倾向",
+      "探索建议"
+    ],
+    "auto_rewrite_allowed": false
+  },
+  "search_channel_preconditions": [
+    "url_truth_verified",
+    "source_authority_allowed",
+    "canonical_indexable_public",
+    "claim_safe",
+    "not_private",
+    "not_draft",
+    "not_noindex",
+    "dry_run_before_enqueue",
+    "human_approval_before_live_submit",
+    "no_bulk_submit"
+  ],
+  "safety_flags": {
+    "url_truth_written": false,
+    "search_channel_enqueued": false,
+    "url_submitted": false,
+    "cms_mutated": false,
+    "seo_intel_written": false,
+    "production_operations_run": false,
+    "crawler_logs_read": false,
+    "fap_web_modified": false,
+    "digital_pr_sent": false,
+    "claims_auto_fixed": false,
+    "internal_links_auto_created": false,
+    "pseo_created": false,
+    "business_db_touched": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-PR-TRAIN-01"
+}

--- a/backend/docs/seo/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.md
+++ b/backend/docs/seo/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.md
@@ -1,0 +1,169 @@
+# MBTI Baseline URL Truth and Telemetry Contract
+
+Task: SEO-GROWTH-MBTI-00A
+
+Type: docs/generated/test only.
+
+This blocker-resolution contract resolves the `blocked_mbti_url_truth_unclear` scan outcome by defining the MBTI baseline asset inventory, URL Truth candidate matrix, entity map contract, telemetry contract, private/noindex boundary, Search Channel preconditions, and claim-gate preconditions required before the full MBTI growth train can start.
+
+This PR does not write URL Truth, enqueue Search Channel, submit URLs, mutate CMS content, read production crawler logs, write to `seo_intel`, deploy, run migrations, enable schedulers, send Digital PR outreach, auto-fix claims, auto-create internal links, create pSEO, modify fap-web, or touch business DB / Tencent RDS / Node2 DB.
+
+## Baseline Asset Inventory
+
+The MBTI growth loop baseline covers these asset families:
+
+- MBTI test page.
+- MBTI research report.
+- MBTI topic hub.
+- MBTI personality type pages.
+- MBTI articles.
+- MBTI private flows: take, result, report, paywall, order, PDF, and history.
+- MBTI telemetry surfaces.
+- MBTI Search Channel candidates.
+- MBTI claim-sensitive copy surfaces.
+
+Frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, and local copies are not authority.
+
+## URL Truth Candidate Matrix
+
+| Family | URL or path | Expected page_entity_type | Expected source authority | Status |
+| --- | --- | --- | --- | --- |
+| MBTI test page | `/en/tests/mbti-personality-test-16-personality-types` | `test_detail` | `scale_catalog` or `backend_public_surface` | candidate requiring backend-authoritative dry-run confirmation |
+| MBTI test page | `/zh/tests/mbti-personality-test-16-personality-types` | `test_detail` | `scale_catalog` or `backend_public_surface` | candidate requiring backend-authoritative dry-run confirmation |
+| MBTI research report | `/en/research/mbti-personality-types-salary-turnover-report` | `research_report` | `backend_cms` / `research_reports` | candidate requiring claim-safe verification |
+| MBTI research report | `/zh/research/mbti-personality-types-salary-turnover-report` | `research_report` | `backend_cms` / `research_reports` | candidate requiring claim-safe verification |
+| MBTI topic hub | `/en/topics/mbti` | `topic` | backend CMS topic authority | deferred until backend CMS/topic authority is explicit |
+| MBTI topic hub | `/zh/topics/mbti` | `topic` | backend CMS topic authority | deferred until backend CMS/topic authority is explicit |
+| MBTI personality type pages | `/en/personality/{type}` | `personality` | backend personality/CMS entity authority | deferred until backend personality/CMS entity authority is explicit |
+| MBTI personality type pages | `/zh/personality/{type}` | `personality` | backend personality/CMS entity authority | deferred until backend personality/CMS entity authority is explicit |
+| MBTI articles | backend CMS article URLs | `article` | backend CMS article rows | deferred until backend CMS article rows are verified |
+| Private flows | take, result, report, paywall, order, PDF, history | private/noindex | backend product truth only | excluded from URL Truth and Search Channel |
+
+## Entity Map Contract
+
+Future MBTI entity keys:
+
+- `mbti_test`.
+- `mbti_topic`.
+- `mbti_research_salary_turnover`.
+- `mbti_result_private`.
+- `mbti_paid_report_private`.
+- `mbti_type_intj`.
+- `mbti_type_infp`.
+- `mbti_type_entj`.
+- Additional MBTI type keys follow `mbti_type_{lowercase_type_code}`.
+
+Entity rules:
+
+- `entity_key` must be independent from URL slug.
+- `translation_group_uuid` is preferred when available.
+- `translation_group_id` is transitional only.
+- slug/title similarity is a migration helper only, not authority.
+- frontend fallback cannot create an entity key.
+- private result and paid report entities are product/funnel entities only; they are not public URL Truth or Search Channel candidates.
+
+## Telemetry Contract
+
+Frontend observation events:
+
+- `landing_view`.
+- `test_cta_click`.
+- `test_start_click`.
+- `report_preview_view`.
+- `unlock_click`.
+- `checkout_button_click`.
+- `email_form_view`.
+
+Backend truth events:
+
+- `attempt_created`.
+- `attempt_submitted`.
+- `result_generated`.
+- `email_captured`.
+- `order_created`.
+- `payment_success`.
+- `benefit_granted`.
+- `report_access_granted`.
+- `pdf_generated`.
+
+Telemetry rules:
+
+- frontend observation is not backend truth.
+- backend payment, order, and report access are truth.
+- bot and crawler traffic must be excluded from conversion funnel formulas.
+- crawler traffic may only enter crawler aggregate observation.
+- email must not enter public HTML, search, analytics payloads, URLs, or Digital PR artifacts.
+
+## Private and Noindex Exclusion Boundary
+
+The following MBTI paths are excluded from URL Truth, Search Channel, public growth URL lists, sitemap promotion, and Digital PR URL targets:
+
+- take flow.
+- result page.
+- report page.
+- paywall and checkout.
+- order and payment recovery paths.
+- report PDF.
+- account/history pages.
+- email capture or recovery paths.
+
+These surfaces may be used only for backend truth, entitlement, payment, report access, and human-only funnel review.
+
+## Claim Gate Boundary
+
+MBTI claim lint is required before:
+
+- Search Channel planning.
+- Digital PR Wave 2.
+- Content/Internal Link Wave 1.
+- growth experiment review.
+
+Forbidden claims:
+
+- MBTI决定收入.
+- MBTI预测离职.
+- 薪资保证.
+- 招聘适配.
+- 职业成功预测.
+- 精准职业推荐.
+- 最适合职业.
+- 诊断.
+- 确诊.
+- 治疗.
+- 治愈.
+
+Allowed bounded language:
+
+- 模型化指数.
+- 聚合层面.
+- 方向性趋势.
+- 非诊断.
+- 结果仅供参考.
+- 职业方向参考.
+- 工作方式倾向.
+- 探索建议.
+
+Claim lint may flag or block copy. It must not auto-rewrite CMS content, Digital PR copy, Search Channel candidates, or internal links.
+
+## Search Channel Preconditions
+
+MBTI Search Channel planning may proceed only when every candidate satisfies:
+
+- URL Truth verified.
+- `source_authority` allowed.
+- canonical, indexable, and public.
+- claim-safe.
+- not private.
+- not draft.
+- not noindex.
+- dry-run before enqueue.
+- human approval before live submit.
+- no bulk submit.
+
+Search response is observation only and cannot become URL Truth.
+
+## Next Task
+
+If this blocker-resolution PR completes and merges, the next task is:
+
+`SEO-GROWTH-MBTI-PR-TRAIN-01`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti00aBaselineContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti00aBaselineContractTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti00aBaselineContractTest extends TestCase
+{
+    #[Test]
+    public function baseline_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-00A', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01-PREFACE', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('blocked_mbti_url_truth_unclear', $artifact['scan_blocker_resolved'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function url_truth_candidate_matrix_locks_public_candidates_and_deferred_families(): void
+    {
+        $matrix = $this->artifact()['url_truth_candidate_matrix'] ?? [];
+
+        $this->assertCandidate($matrix, '/en/tests/mbti-personality-test-16-personality-types', 'test_detail', 'candidate_requiring_backend_authoritative_dry_run_confirmation');
+        $this->assertCandidate($matrix, '/zh/tests/mbti-personality-test-16-personality-types', 'test_detail', 'candidate_requiring_backend_authoritative_dry_run_confirmation');
+        $this->assertCandidate($matrix, '/en/research/mbti-personality-types-salary-turnover-report', 'research_report', 'candidate_requiring_claim_safe_verification');
+        $this->assertCandidate($matrix, '/zh/research/mbti-personality-types-salary-turnover-report', 'research_report', 'candidate_requiring_claim_safe_verification');
+        $this->assertCandidate($matrix, '/en/topics/mbti', 'topic', 'deferred_until_backend_cms_topic_authority_is_explicit');
+        $this->assertCandidate($matrix, '/zh/topics/mbti', 'topic', 'deferred_until_backend_cms_topic_authority_is_explicit');
+
+        $personalityPatterns = array_column($matrix, 'url_pattern');
+        $this->assertContains('/en/personality/{type}', $personalityPatterns);
+        $this->assertContains('/zh/personality/{type}', $personalityPatterns);
+        $this->assertContains('backend_cms_article_urls', $personalityPatterns);
+
+        $private = collect($matrix)->firstWhere('family', 'mbti_private_flows');
+        $this->assertSame('noindex_private_excluded_from_url_truth_and_search_channel', $private['expected_status'] ?? null);
+        $this->assertContains('take', $private['path_patterns'] ?? []);
+        $this->assertContains('result', $private['path_patterns'] ?? []);
+        $this->assertContains('report', $private['path_patterns'] ?? []);
+        $this->assertContains('paywall', $private['path_patterns'] ?? []);
+        $this->assertContains('order', $private['path_patterns'] ?? []);
+        $this->assertContains('pdf', $private['path_patterns'] ?? []);
+        $this->assertContains('history', $private['path_patterns'] ?? []);
+    }
+
+    #[Test]
+    public function entity_map_contract_keeps_keys_independent_from_fallbacks_and_slugs(): void
+    {
+        $contract = $this->artifact()['entity_map_contract'] ?? [];
+        $keys = $contract['future_entity_keys'] ?? [];
+
+        foreach ([
+            'mbti_test',
+            'mbti_topic',
+            'mbti_research_salary_turnover',
+            'mbti_result_private',
+            'mbti_paid_report_private',
+            'mbti_type_intj',
+            'mbti_type_infp',
+            'mbti_type_entj',
+        ] as $key) {
+            $this->assertContains($key, $keys);
+        }
+
+        $rules = $contract['rules'] ?? [];
+
+        foreach ([
+            'entity_key_independent_from_url_slug',
+            'translation_group_uuid_preferred_when_available',
+            'translation_group_id_transitional_only',
+            'slug_title_similarity_migration_helper_only_not_authority',
+            'frontend_fallback_cannot_create_entity_key',
+            'private_entities_not_public_url_truth_or_search_channel_candidates',
+        ] as $rule) {
+            $this->assertContains($rule, $rules);
+        }
+    }
+
+    #[Test]
+    public function telemetry_contract_splits_frontend_observation_from_backend_truth(): void
+    {
+        $contract = $this->artifact()['telemetry_contract'] ?? [];
+
+        foreach ([
+            'landing_view',
+            'test_cta_click',
+            'test_start_click',
+            'report_preview_view',
+            'unlock_click',
+            'checkout_button_click',
+            'email_form_view',
+        ] as $event) {
+            $this->assertContains($event, $contract['frontend_observation_events'] ?? []);
+        }
+
+        foreach ([
+            'attempt_created',
+            'attempt_submitted',
+            'result_generated',
+            'email_captured',
+            'order_created',
+            'payment_success',
+            'benefit_granted',
+            'report_access_granted',
+            'pdf_generated',
+        ] as $event) {
+            $this->assertContains($event, $contract['backend_truth_events'] ?? []);
+        }
+
+        foreach ([
+            'frontend_observation_is_not_backend_truth',
+            'backend_payment_order_report_access_is_truth',
+            'bot_crawler_traffic_excluded_from_conversion_funnel_formulas',
+            'crawler_traffic_only_enters_crawler_aggregate_observation',
+            'email_not_in_public_html_search_analytics_payloads_urls_or_digital_pr_artifacts',
+        ] as $rule) {
+            $this->assertContains($rule, $contract['rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function claim_gate_and_search_channel_preconditions_are_required_before_growth_actions(): void
+    {
+        $artifact = $this->artifact();
+        $claimGate = $artifact['claim_gate'] ?? [];
+
+        foreach ([
+            'search_channel_planning',
+            'digital_pr_wave_2',
+            'content_internal_link_wave',
+            'growth_experiment_review',
+        ] as $gate) {
+            $this->assertContains($gate, $claimGate['required_before'] ?? []);
+        }
+
+        foreach ([
+            'MBTI决定收入',
+            'MBTI预测离职',
+            '薪资保证',
+            '招聘适配',
+            '职业成功预测',
+            '精准职业推荐',
+            '最适合职业',
+            '诊断',
+            '确诊',
+            '治疗',
+            '治愈',
+        ] as $claim) {
+            $this->assertContains($claim, $claimGate['forbidden_claims'] ?? []);
+        }
+
+        foreach ([
+            '模型化指数',
+            '聚合层面',
+            '方向性趋势',
+            '非诊断',
+            '结果仅供参考',
+            '职业方向参考',
+            '工作方式倾向',
+            '探索建议',
+        ] as $language) {
+            $this->assertContains($language, $claimGate['allowed_bounded_language'] ?? []);
+        }
+
+        $this->assertFalse((bool) ($claimGate['auto_rewrite_allowed'] ?? true));
+
+        foreach ([
+            'url_truth_verified',
+            'source_authority_allowed',
+            'canonical_indexable_public',
+            'claim_safe',
+            'not_private',
+            'not_draft',
+            'not_noindex',
+            'dry_run_before_enqueue',
+            'human_approval_before_live_submit',
+            'no_bulk_submit',
+        ] as $precondition) {
+            $this->assertContains($precondition, $artifact['search_channel_preconditions'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_confirm_this_preface_is_non_mutating(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_next_task_and_authority_boundaries(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'seo-growth-mbti-00a',
+            'blocked_mbti_url_truth_unclear',
+            'frontend fallback',
+            'static sitemap',
+            'static llms',
+            'candidate requiring backend-authoritative dry-run confirmation',
+            'candidate requiring claim-safe verification',
+            'deferred until backend cms/topic authority is explicit',
+            'excluded from url truth and search channel',
+            'frontend observation is not backend truth',
+            'backend payment, order, and report access are truth',
+            'bot and crawler traffic must be excluded from conversion funnel formulas',
+            'email must not enter public html, search, analytics payloads, urls, or digital pr artifacts',
+            'dry-run before enqueue',
+            'human approval before live submit',
+            'no bulk submit',
+            'seo-growth-mbti-pr-train-01',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $matrix
+     */
+    private function assertCandidate(array $matrix, string $url, string $pageEntityType, string $status): void
+    {
+        $candidate = collect($matrix)->firstWhere('url', $url);
+
+        $this->assertIsArray($candidate, 'Missing URL Truth candidate '.$url);
+        $this->assertSame($pageEntityType, $candidate['expected_page_entity_type'] ?? null);
+        $this->assertSame($status, $candidate['status'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14336,6 +14336,56 @@
           "summary": "Added observation governance closeout docs, generated artifact, focused test, and ledger updates. No runtime code, migration, production operation, env edit, or fap-web change was added. Required local checks passed."
         }
       ]
+    },
+    "SEO-GROWTH-MBTI-00A": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-00a-baseline-contract",
+      "status": "committed",
+      "depends_on": [
+        "SEO-OPS-SOP-01F"
+      ],
+      "commit_sha": "4403a7bd",
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "focused_baseline_contract_test": "passed: php artisan test --filter=SeoIntelGrowthMbti00aBaselineContract --no-ansi (7 tests, 147 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (509 tests, 8064 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3488 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed before staging: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+      "history": [
+        {
+          "at": "2026-05-22T20:26:05+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-00A on codex/seo-growth-mbti-00a-baseline-contract. Scope is docs/generated/test plus authorized train metadata only; no runtime services, migrations, production operations, fap-web changes, CMS mutations, Search Channel mutation, crawler log reads, Digital PR sends, pSEO, collector writes, scheduler activation, or business DB access."
+        },
+        {
+          "at": "2026-05-22T20:33:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-GROWTH-MBTI-00A local validation passed for focused baseline contract test, full SeoIntel filter, route:list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Scope remains docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T20:34:00+08:00",
+          "status": "committed",
+          "summary": "Committed SEO-GROWTH-MBTI-00A baseline URL Truth and telemetry contract scope at 4403a7bd."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14340,12 +14340,12 @@
     "SEO-GROWTH-MBTI-00A": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-00a-baseline-contract",
-      "status": "committed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-OPS-SOP-01F"
       ],
-      "commit_sha": "4403a7bd",
-      "pr_url": null,
+      "commit_sha": "e96dd297",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1579",
       "checks": {
         "local": {
           "focused_baseline_contract_test": "passed: php artisan test --filter=SeoIntelGrowthMbti00aBaselineContract --no-ansi (7 tests, 147 assertions)",
@@ -14384,6 +14384,11 @@
           "at": "2026-05-22T20:34:00+08:00",
           "status": "committed",
           "summary": "Committed SEO-GROWTH-MBTI-00A baseline URL Truth and telemetry contract scope at 4403a7bd."
+        },
+        {
+          "at": "2026-05-22T20:38:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1579 for SEO-GROWTH-MBTI-00A and pushed branch codex/seo-growth-mbti-00a-baseline-contract."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9928,4 +9928,46 @@ prs:
     production_deploy_allowed: false
     production_migration_execution_allowed: false
     scheduler_activation: false
-    next_task: SEO-GROWTH-MBTI-00
+    next_task: SEO-GROWTH-MBTI-00A
+
+  - id: SEO-GROWTH-MBTI-00A
+    repo: fap-api
+    depends_on:
+      - SEO-OPS-SOP-01F
+    branch: codex/seo-growth-mbti-00a-baseline-contract
+    base: main
+    title: "docs(seo-intel): add MBTI growth baseline URL Truth contract"
+    name: "MBTI baseline asset inventory, URL Truth, and telemetry contract authorization"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Define and lock the MBTI baseline asset inventory, URL Truth candidate matrix, entity map contract, telemetry contract, private/noindex exclusion matrix, Search Channel preconditions, and claim-gate preconditions.
+      - Resolve the SEO-GROWTH-MBTI-SCAN-00 blocker `blocked_mbti_url_truth_unclear` without writing URL Truth, enqueueing Search Channel, submitting URLs, mutating CMS, running production operations, or modifying fap-web.
+      - Set the exact next task to SEO-GROWTH-MBTI-PR-TRAIN-01 when this blocker-resolution preface is merged.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.md
+      - backend/docs/seo/generated/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti00aBaselineContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti00aBaselineContract --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-PR-TRAIN-01


### PR DESCRIPTION
## What changed
- Added the SEO-GROWTH-MBTI-00A docs-only contract for MBTI baseline asset inventory, URL Truth candidates, entity map rules, telemetry split, private/noindex exclusions, claim-gate requirements, and Search Channel preconditions.
- Added the generated JSON artifact and focused SeoIntel contract test.
- Registered the authorized PR train manifest/state entry for SEO-GROWTH-MBTI-00A and reconciled the stale SEO-OPS-SOP-01F ledger state as already merged.

## Why
SEO-GROWTH-MBTI-SCAN-00 ended with `blocked_mbti_url_truth_unclear`. This preface resolves the blocker by locking the backend-authoritative contract before the full MBTI growth train starts, without writing URL Truth or running production operations.

## Validation commands
- `cd backend && php artisan test --filter=SeoIntelGrowthMbti00aBaselineContract --no-ansi`
- `cd backend && php artisan test --filter=SeoIntel --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-00a-baseline-url-truth-telemetry-contract.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nPY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No URL Truth writes.
- No Search Channel enqueue or live submission.
- No CMS mutation or article publication.
- No fap-web changes.
- No production DB, Tencent RDS, Node2 DB, crawler log, scheduler, deploy, or env work.
- No Digital PR sends, pSEO, claim auto-fix, or internal link auto-creation.

## Repository rule impact
This PR reinforces the existing authority boundary: backend/CMS/catalog authority must define URL Truth and entity keys; fap-web fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, and local copies remain non-authoritative observation inputs only.
