### PR TITLE
docs(seo-intel): add MBTI growth baseline telemetry contract

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1.json
@@ -1,0 +1,136 @@
+{
+  "version": "seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1",
+  "task": "SEO-GROWTH-MBTI-00",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "growth_loop": [
+    "search",
+    "content",
+    "test",
+    "result",
+    "report",
+    "revenue",
+    "observation",
+    "repair",
+    "next_action"
+  ],
+  "baseline_scope": [
+    "mbti_test_page",
+    "mbti_research_report",
+    "mbti_topic_hub",
+    "mbti_personality_type_pages",
+    "mbti_articles",
+    "mbti_take_result_report_paywall_private_flows",
+    "digital_pr_hrzone_hrec_state",
+    "search_channel_readiness_state",
+    "internal_link_readiness_state",
+    "claim_lint_readiness_state",
+    "funnel_revenue_telemetry_readiness_state"
+  ],
+  "current_candidate_urls": [
+    "/en/tests/mbti-personality-test-16-personality-types",
+    "/zh/tests/mbti-personality-test-16-personality-types",
+    "/en/research/mbti-personality-types-salary-turnover-report",
+    "/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "deferred_surfaces": [
+    "mbti_topic_hub_until_backend_cms_topic_authority_explicit",
+    "mbti_personality_type_pages_until_backend_personality_cms_authority_explicit",
+    "mbti_articles_until_backend_cms_article_rows_verified"
+  ],
+  "private_noindex_excluded": [
+    "take",
+    "result",
+    "report",
+    "paywall",
+    "order",
+    "pdf",
+    "history"
+  ],
+  "telemetry_contract": {
+    "frontend_observation_events": [
+      "landing_view",
+      "test_cta_click",
+      "test_start_click",
+      "report_preview_view",
+      "unlock_click",
+      "checkout_button_click",
+      "email_form_view"
+    ],
+    "backend_truth_events": [
+      "attempt_created",
+      "attempt_submitted",
+      "result_generated",
+      "email_captured",
+      "order_created",
+      "payment_success",
+      "benefit_granted",
+      "report_access_granted",
+      "pdf_generated"
+    ],
+    "rules": [
+      "frontend_observation_not_backend_truth",
+      "backend_payment_order_report_access_is_truth",
+      "bot_crawler_excluded_from_conversion_formulas",
+      "crawler_only_enters_crawler_aggregate_observation",
+      "email_not_in_public_html_search_analytics_payloads_urls_or_digital_pr_artifacts"
+    ]
+  },
+  "baseline_observation_inputs": [
+    "backend_authoritative_url_truth_candidates",
+    "claim_lint_states",
+    "search_channel_dry_run_eligibility_states",
+    "issue_queue_observations",
+    "crawler_aggregate_observations",
+    "ops_seo_read_only_views",
+    "digital_pr_manual_tracking_state",
+    "human_only_funnel_telemetry_contracts"
+  ],
+  "not_truth_sources": [
+    "frontend_fallback",
+    "static_sitemap",
+    "static_llms",
+    "crawler_logs",
+    "search_engine_responses",
+    "digital_pr_mentions",
+    "local_copies",
+    "ga4_gsc_referral_signals"
+  ],
+  "measurable_now": [
+    "contract_completeness",
+    "candidate_url_families",
+    "private_noindex_exclusion_boundary",
+    "telemetry_event_taxonomy",
+    "claim_gate_requirements",
+    "search_channel_preconditions",
+    "internal_link_dry_run_output_shape",
+    "digital_pr_manual_tracking_fields"
+  ],
+  "not_measurable_yet": [
+    "complete_backend_authoritative_url_truth_rows",
+    "verified_production_cms_topic_personality_article_rows",
+    "live_search_channel_outcomes",
+    "live_digital_pr_response_outcomes",
+    "complete_human_only_revenue_conversion_formulas",
+    "production_claim_lint_pass_fail_across_all_mbti_surfaces"
+  ],
+  "safety_flags": {
+    "url_truth_written": false,
+    "cms_mutated": false,
+    "search_channel_mutated": false,
+    "url_submitted": false,
+    "fap_web_modified": false,
+    "digital_pr_sent": false,
+    "production_operations_run": false,
+    "migrations_run": false,
+    "scheduler_enabled": false,
+    "crawler_logs_read": false,
+    "seo_intel_written": false,
+    "metabase_exposed": false,
+    "claims_auto_fixed": false,
+    "internal_links_auto_created": false,
+    "pseo_created": false,
+    "business_db_touched": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-01"
+}

--- a/backend/docs/seo/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.md
+++ b/backend/docs/seo/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.md
@@ -1,0 +1,136 @@
+# MBTI Baseline Snapshot and Telemetry Contract
+
+Task: SEO-GROWTH-MBTI-00
+
+Type: docs/generated/test only.
+
+This contract starts the MBTI growth planning train after SEO-GROWTH-MBTI-00A resolved the URL Truth ambiguity blocker. It defines the baseline scope, measurable surfaces, deferred surfaces, telemetry split, bot/human separation, PII boundaries, observation inputs, and non-authoritative sources for the first entity-level growth loop.
+
+Growth loop: Search -> Content -> Test -> Result -> Report -> Revenue -> Observation -> Repair -> Next Action.
+
+This PR does not write URL Truth, mutate CMS, enqueue or submit Search Channel URLs, modify fap-web, send Digital PR, run production operations, run migrations, enable schedulers, read production crawler logs, write to seo_intel, expose Metabase, auto-fix claims, auto-create internal links, create pSEO, or touch business DB / Tencent RDS / Node2 DB.
+
+## Baseline Scope
+
+The MBTI baseline covers:
+
+- MBTI test page.
+- MBTI research report.
+- MBTI topic hub.
+- MBTI personality type pages.
+- MBTI articles.
+- MBTI take/result/report/paywall/private flows.
+- Digital PR HRZone/HREC state.
+- Search Channel readiness state.
+- Internal Link readiness state.
+- Claim Lint readiness state.
+- Funnel/revenue telemetry readiness state.
+
+## Current Candidate URLs
+
+Known public candidates from the 00A contract:
+
+- `/en/tests/mbti-personality-test-16-personality-types`.
+- `/zh/tests/mbti-personality-test-16-personality-types`.
+- `/en/research/mbti-personality-types-salary-turnover-report`.
+- `/zh/research/mbti-personality-types-salary-turnover-report`.
+
+These remain candidates only. They require backend-authoritative dry-run confirmation, claim-safe verification where applicable, and later scoped approval before any Search Channel action.
+
+## Deferred Surfaces
+
+Deferred until backend authority is explicit:
+
+- `/en/topics/mbti` and `/zh/topics/mbti`.
+- `/en/personality/{type}` and `/zh/personality/{type}`.
+- MBTI article URLs.
+
+Private/noindex surfaces remain excluded:
+
+- take.
+- result.
+- report.
+- paywall.
+- order.
+- PDF.
+- history.
+
+## Telemetry Contract
+
+Frontend observation events:
+
+- `landing_view`.
+- `test_cta_click`.
+- `test_start_click`.
+- `report_preview_view`.
+- `unlock_click`.
+- `checkout_button_click`.
+- `email_form_view`.
+
+Backend truth events:
+
+- `attempt_created`.
+- `attempt_submitted`.
+- `result_generated`.
+- `email_captured`.
+- `order_created`.
+- `payment_success`.
+- `benefit_granted`.
+- `report_access_granted`.
+- `pdf_generated`.
+
+Telemetry rules:
+
+- frontend observation != backend truth.
+- backend payment/order/report access is truth.
+- bot/crawler traffic is excluded from conversion formulas.
+- crawler traffic only enters crawler aggregate observation.
+- email must not enter public HTML, search, analytics payloads, URLs, or Digital PR artifacts.
+
+## Baseline Observation Inputs
+
+Allowed observation inputs:
+
+- backend-authoritative URL Truth candidates.
+- claim lint states.
+- Search Channel dry-run eligibility states.
+- Issue Queue observations.
+- crawler aggregate observations.
+- /ops/seo read-only operational views.
+- Digital PR manual tracking state.
+- human-only funnel telemetry contracts.
+
+Not truth:
+
+- frontend fallback.
+- static sitemap.
+- static llms.
+- crawler logs.
+- search engine responses.
+- Digital PR mentions.
+- local copies.
+- GA4/GSC/referral signals.
+
+## Measurable Now
+
+- Contract completeness.
+- Candidate URL families.
+- private/noindex exclusion boundary.
+- telemetry event taxonomy.
+- claim-gate requirements.
+- Search Channel preconditions.
+- internal link dry-run output shape.
+- Digital PR manual tracking fields.
+
+## Not Measurable Yet
+
+- complete backend-authoritative URL Truth rows.
+- verified production CMS topic/personality/article rows.
+- live Search Channel outcomes.
+- live Digital PR response outcomes.
+- complete human-only revenue conversion formulas.
+- production claim lint pass/fail across all MBTI surfaces.
+
+## Next Task
+
+After this PR merges, continue with `SEO-GROWTH-MBTI-01｜Entity Map and URL Truth Review`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti00BaselineSnapshotTelemetryContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti00BaselineSnapshotTelemetryContractTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti00BaselineSnapshotTelemetryContractTest extends TestCase
+{
+    #[Test]
+    public function baseline_snapshot_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-00', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-01', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function growth_loop_and_baseline_scope_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame([
+            'search',
+            'content',
+            'test',
+            'result',
+            'report',
+            'revenue',
+            'observation',
+            'repair',
+            'next_action',
+        ], $artifact['growth_loop'] ?? []);
+
+        foreach ([
+            'mbti_test_page',
+            'mbti_research_report',
+            'mbti_topic_hub',
+            'mbti_personality_type_pages',
+            'mbti_articles',
+            'mbti_take_result_report_paywall_private_flows',
+            'digital_pr_hrzone_hrec_state',
+            'search_channel_readiness_state',
+            'internal_link_readiness_state',
+            'claim_lint_readiness_state',
+            'funnel_revenue_telemetry_readiness_state',
+        ] as $scope) {
+            $this->assertContains($scope, $artifact['baseline_scope'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function candidate_urls_deferred_surfaces_and_private_exclusions_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            '/en/tests/mbti-personality-test-16-personality-types',
+            '/zh/tests/mbti-personality-test-16-personality-types',
+            '/en/research/mbti-personality-types-salary-turnover-report',
+            '/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $url) {
+            $this->assertContains($url, $artifact['current_candidate_urls'] ?? []);
+        }
+
+        foreach ([
+            'mbti_topic_hub_until_backend_cms_topic_authority_explicit',
+            'mbti_personality_type_pages_until_backend_personality_cms_authority_explicit',
+            'mbti_articles_until_backend_cms_article_rows_verified',
+        ] as $surface) {
+            $this->assertContains($surface, $artifact['deferred_surfaces'] ?? []);
+        }
+
+        foreach (['take', 'result', 'report', 'paywall', 'order', 'pdf', 'history'] as $privateFlow) {
+            $this->assertContains($privateFlow, $artifact['private_noindex_excluded'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function telemetry_split_preserves_observation_truth_bot_and_pii_boundaries(): void
+    {
+        $telemetry = $this->artifact()['telemetry_contract'] ?? [];
+
+        foreach ([
+            'landing_view',
+            'test_cta_click',
+            'test_start_click',
+            'report_preview_view',
+            'unlock_click',
+            'checkout_button_click',
+            'email_form_view',
+        ] as $event) {
+            $this->assertContains($event, $telemetry['frontend_observation_events'] ?? []);
+        }
+
+        foreach ([
+            'attempt_created',
+            'attempt_submitted',
+            'result_generated',
+            'email_captured',
+            'order_created',
+            'payment_success',
+            'benefit_granted',
+            'report_access_granted',
+            'pdf_generated',
+        ] as $event) {
+            $this->assertContains($event, $telemetry['backend_truth_events'] ?? []);
+        }
+
+        foreach ([
+            'frontend_observation_not_backend_truth',
+            'backend_payment_order_report_access_is_truth',
+            'bot_crawler_excluded_from_conversion_formulas',
+            'crawler_only_enters_crawler_aggregate_observation',
+            'email_not_in_public_html_search_analytics_payloads_urls_or_digital_pr_artifacts',
+        ] as $rule) {
+            $this->assertContains($rule, $telemetry['rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function observation_inputs_are_allowed_without_becoming_truth_sources(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'backend_authoritative_url_truth_candidates',
+            'claim_lint_states',
+            'search_channel_dry_run_eligibility_states',
+            'issue_queue_observations',
+            'crawler_aggregate_observations',
+            'ops_seo_read_only_views',
+            'digital_pr_manual_tracking_state',
+            'human_only_funnel_telemetry_contracts',
+        ] as $input) {
+            $this->assertContains($input, $artifact['baseline_observation_inputs'] ?? []);
+        }
+
+        foreach ([
+            'frontend_fallback',
+            'static_sitemap',
+            'static_llms',
+            'crawler_logs',
+            'search_engine_responses',
+            'digital_pr_mentions',
+            'local_copies',
+            'ga4_gsc_referral_signals',
+        ] as $source) {
+            $this->assertContains($source, $artifact['not_truth_sources'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function measurable_now_and_not_yet_measurable_items_are_explicit(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'contract_completeness',
+            'candidate_url_families',
+            'private_noindex_exclusion_boundary',
+            'telemetry_event_taxonomy',
+            'claim_gate_requirements',
+            'search_channel_preconditions',
+            'internal_link_dry_run_output_shape',
+            'digital_pr_manual_tracking_fields',
+        ] as $item) {
+            $this->assertContains($item, $artifact['measurable_now'] ?? []);
+        }
+
+        foreach ([
+            'complete_backend_authoritative_url_truth_rows',
+            'verified_production_cms_topic_personality_article_rows',
+            'live_search_channel_outcomes',
+            'live_digital_pr_response_outcomes',
+            'complete_human_only_revenue_conversion_formulas',
+            'production_claim_lint_pass_fail_across_all_mbti_surfaces',
+        ] as $item) {
+            $this->assertContains($item, $artifact['not_measurable_yet'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_keep_this_contract_non_mutating(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_authority_boundaries_and_next_task(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1.json')));
+        $combined = $doc.'
+'.$artifactJson;
+
+        foreach ([
+            'frontend fallback',
+            'static sitemap',
+            'static llms',
+            'search engine responses',
+            'digital pr mentions',
+            'frontend observation != backend truth',
+            'backend payment/order/report access is truth',
+            'bot/crawler traffic is excluded from conversion formulas',
+            'email must not enter public html',
+            'seo-growth-mbti-01',
+        ] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14340,11 +14340,11 @@
     "SEO-GROWTH-MBTI-00A": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-00a-baseline-contract",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-OPS-SOP-01F"
       ],
-      "commit_sha": "e96dd297",
+      "commit_sha": "ae63f1374402f6bc9d3bfd00afd6e68cd2f6bc95",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1579",
       "checks": {
         "local": {
@@ -14358,17 +14358,19 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed before staging: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1579": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as ae63f1374402f6bc9d3bfd00afd6e68cd2f6bc95"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T12:42:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
       "scheduler_activation": false,
-      "next_pr": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+      "next_pr": "SEO-GROWTH-MBTI-00",
       "history": [
         {
           "at": "2026-05-22T20:26:05+08:00",
@@ -14389,6 +14391,301 @@
           "at": "2026-05-22T20:38:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1579 for SEO-GROWTH-MBTI-00A and pushed branch codex/seo-growth-mbti-00a-baseline-contract."
+        },
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "reconciled_merged",
+          "summary": "Reconciled SEO-GROWTH-MBTI-00A before starting SEO-GROWTH-MBTI-PR-TRAIN-01: PR #1579 is merged, origin/main contains ae63f1374402f6bc9d3bfd00afd6e68cd2f6bc95, remote branch is deleted, and local cleanup script is unavailable in this clone."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-00": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-00-baseline-telemetry",
+      "status": "local_validation_passed",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-00A"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "focused_baseline_telemetry_test": "passed: php artisan test --filter=SeoIntelGrowthMbti00BaselineSnapshotTelemetryContract --no-ansi (8 tests, 123 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (517 tests, 8187 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3489 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-01",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-00 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-00 on codex/seo-growth-mbti-00-baseline-telemetry from latest main. Scope is baseline telemetry docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T21:08:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-GROWTH-MBTI-00 local validation passed for focused baseline telemetry contract test, full SeoIntel filter, route:list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-01": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-01-entity-url-truth",
+      "status": "pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {},
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-02",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-01 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-02": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-02-content-links",
+      "status": "pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {},
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-03A",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-02 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-03A": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-03a-claim-lint",
+      "status": "pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-02"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {},
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-03B",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-03A for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-03B": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-03b-search-channel",
+      "status": "pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-03A"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {},
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-04",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-03B for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-04": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-04-digital-pr",
+      "status": "pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-03B"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {},
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-05",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-04 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-05": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-05-funnel-revenue",
+      "status": "pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-04"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {},
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-06",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-05 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-06": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-06-growth-review",
+      "status": "pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-05"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {},
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-07",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-06 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-07": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-07-playbook-closeout",
+      "status": "pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-06"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {},
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01",
+      "history": [
+        {
+          "at": "2026-05-22T21:00:00+08:00",
+          "status": "pending",
+          "summary": "Registered SEO-GROWTH-MBTI-07 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14402,12 +14402,12 @@
     "SEO-GROWTH-MBTI-00": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-00-baseline-telemetry",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-00A"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "c3fcf934",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1580",
       "checks": {
         "local": {
           "focused_baseline_telemetry_test": "passed: php artisan test --filter=SeoIntelGrowthMbti00BaselineSnapshotTelemetryContract --no-ansi (8 tests, 123 assertions)",
@@ -14446,6 +14446,11 @@
           "at": "2026-05-22T21:08:00+08:00",
           "status": "local_validation_passed",
           "summary": "SEO-GROWTH-MBTI-00 local validation passed for focused baseline telemetry contract test, full SeoIntel filter, route:list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        },
+        {
+          "at": "2026-05-22T21:10:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1580 for SEO-GROWTH-MBTI-00 and pushed branch codex/seo-growth-mbti-00-baseline-telemetry."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -9971,3 +9971,390 @@ prs:
     production_migration_execution_allowed: false
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-PR-TRAIN-01
+
+
+  - id: SEO-GROWTH-MBTI-00
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-00A
+    branch: codex/seo-growth-mbti-00-baseline-telemetry
+    base: main
+    title: "docs(seo-intel): add MBTI growth baseline telemetry contract"
+    name: "MBTI baseline snapshot and telemetry contract"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.md
+      - backend/docs/seo/generated/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti00BaselineSnapshotTelemetryContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti00BaselineSnapshotTelemetryContract --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-01
+
+
+  - id: SEO-GROWTH-MBTI-01
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-00
+    branch: codex/seo-growth-mbti-01-entity-url-truth
+    base: main
+    title: "docs(seo-intel): add MBTI entity map URL Truth review"
+    name: "MBTI entity map and URL Truth review"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-01-entity-map-url-truth-review.md
+      - backend/docs/seo/generated/seo-growth-mbti-01-entity-map-url-truth-review.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti01EntityMapUrlTruthReviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti01EntityMapUrlTruthReview --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-01-entity-map-url-truth-review.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-02
+
+
+  - id: SEO-GROWTH-MBTI-02
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-01
+    branch: codex/seo-growth-mbti-02-content-links
+    base: main
+    title: "docs(seo-intel): add MBTI content internal link wave plan"
+    name: "MBTI content and internal link Wave 1 dry-run plan"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-02-content-internal-link-wave1-plan.md
+      - backend/docs/seo/generated/seo-growth-mbti-02-content-internal-link-wave1-plan.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti02ContentInternalLinkWave1PlanTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti02ContentInternalLinkWave1Plan --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-02-content-internal-link-wave1-plan.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-03A
+
+
+  - id: SEO-GROWTH-MBTI-03A
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-02
+    branch: codex/seo-growth-mbti-03a-claim-lint
+    base: main
+    title: "docs(seo-intel): add MBTI claim lint gate"
+    name: "MBTI claim lint gate"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-03a-claim-lint-gate.md
+      - backend/docs/seo/generated/seo-growth-mbti-03a-claim-lint-gate.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti03aClaimLintGateTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti03aClaimLintGate --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-03a-claim-lint-gate.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-03B
+
+
+  - id: SEO-GROWTH-MBTI-03B
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-03A
+    branch: codex/seo-growth-mbti-03b-search-channel
+    base: main
+    title: "docs(seo-intel): add MBTI Search Channel canary plan"
+    name: "MBTI Search Channel canary wave plan"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-03b-search-channel-canary-wave-plan.md
+      - backend/docs/seo/generated/seo-growth-mbti-03b-search-channel-canary-wave-plan.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti03bSearchChannelCanaryWavePlanTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti03bSearchChannelCanaryWavePlan --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-03b-search-channel-canary-wave-plan.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-04
+
+
+  - id: SEO-GROWTH-MBTI-04
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-03B
+    branch: codex/seo-growth-mbti-04-digital-pr
+    base: main
+    title: "docs(seo-intel): add MBTI Digital PR wave two plan"
+    name: "MBTI Digital PR Wave 2 plan"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-04-digital-pr-wave2-plan.md
+      - backend/docs/seo/generated/seo-growth-mbti-04-digital-pr-wave2-plan.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti04DigitalPrWave2PlanTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti04DigitalPrWave2Plan --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-04-digital-pr-wave2-plan.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-05
+
+
+  - id: SEO-GROWTH-MBTI-05
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-04
+    branch: codex/seo-growth-mbti-05-funnel-revenue
+    base: main
+    title: "docs(seo-intel): add MBTI human-only funnel review contract"
+    name: "MBTI human-only funnel and revenue review contract"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.md
+      - backend/docs/seo/generated/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContract --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-06
+
+
+  - id: SEO-GROWTH-MBTI-06
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-05
+    branch: codex/seo-growth-mbti-06-growth-review
+    base: main
+    title: "docs(seo-intel): add MBTI growth review plan"
+    name: "MBTI 7/14/28-day growth review plan"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-06-7-14-28-day-growth-review-plan.md
+      - backend/docs/seo/generated/seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti06GrowthReviewPlanTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti06GrowthReviewPlan --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-07
+
+
+  - id: SEO-GROWTH-MBTI-07
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-06
+    branch: codex/seo-growth-mbti-07-playbook-closeout
+    base: main
+    title: "docs(seo-intel): close MBTI growth playbook train"
+    name: "MBTI scale decision and entity playbook closeout"
+    train_scope: seo_growth_mbti
+    risk_level: low_contract_only
+    type: docs/generated/test
+    scope:
+      - Keep this PR planning, contract, and readiness only; do not execute live growth actions.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+      - Keep MBTI career and recommendation language bounded; do not describe MBTI, Big Five, RIASEC, or Career Graph as precise recommender, hiring suitability, salary prediction, or career-success prediction authority.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.md
+      - backend/docs/seo/generated/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti07ScaleDecisionEntityPlaybookCloseoutTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, Search Channel Queue, crawler log readers, collectors, scheduler, Digital PR sends, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbti07ScaleDecisionEntityPlaybookCloseout --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01


### PR DESCRIPTION
## What changed
- Added the SEO-GROWTH-MBTI-00 baseline snapshot and telemetry contract.
- Locked MBTI baseline scope, candidate URLs, deferred surfaces, private/noindex exclusions, telemetry split, observation inputs, measurable/not-yet-measurable boundaries, and non-authoritative sources.
- Registered the authorized MBTI growth PR train entries and initialized train state.

## Why
SEO-GROWTH-MBTI-00A resolved the URL Truth ambiguity blocker. This PR starts the planning/readiness train by defining what the MBTI growth loop can measure safely before any live growth action.

## Validation commands
- `cd backend && php artisan test --filter=SeoIntelGrowthMbti00BaselineSnapshotTelemetryContract --no-ansi`
- `cd backend && php artisan test --filter=SeoIntel --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-00-baseline-snapshot-telemetry-contract.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nPY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No URL Truth writes.
- No Search Channel enqueue or live submission.
- No CMS mutation or publication.
- No fap-web changes.
- No production DB, crawler log, scheduler, deploy, env, Digital PR, pSEO, claim auto-fix, or internal link auto-creation.

## Repository rule impact
This PR reinforces backend/CMS/catalog authority for MBTI URL Truth and telemetry. fap-web fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, local copies, and analytics/referral signals remain non-authoritative.
