### PR TITLE
docs(seo-intel): add MBTI entity map URL Truth review

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-01-entity-map-url-truth-review.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-01-entity-map-url-truth-review.v1.json
@@ -1,0 +1,140 @@
+{
+  "version": "seo-growth-mbti-01-entity-map-url-truth-review.v1",
+  "task": "SEO-GROWTH-MBTI-01",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "url_truth_candidate_matrix": [
+    {
+      "family": "mbti_test_en",
+      "url": "/en/tests/mbti-personality-test-16-personality-types",
+      "page_entity_type": "test_detail",
+      "source_authorities": [
+        "scale_catalog",
+        "backend_public_surface"
+      ],
+      "status": "candidate_requiring_backend_authoritative_dry_run_confirmation"
+    },
+    {
+      "family": "mbti_test_zh",
+      "url": "/zh/tests/mbti-personality-test-16-personality-types",
+      "page_entity_type": "test_detail",
+      "source_authorities": [
+        "scale_catalog",
+        "backend_public_surface"
+      ],
+      "status": "candidate_requiring_backend_authoritative_dry_run_confirmation"
+    },
+    {
+      "family": "mbti_research_en",
+      "url": "/en/research/mbti-personality-types-salary-turnover-report",
+      "page_entity_type": "research_report",
+      "source_authorities": [
+        "backend_cms",
+        "research_reports"
+      ],
+      "status": "candidate_requiring_claim_safe_verification"
+    },
+    {
+      "family": "mbti_research_zh",
+      "url": "/zh/research/mbti-personality-types-salary-turnover-report",
+      "page_entity_type": "research_report",
+      "source_authorities": [
+        "backend_cms",
+        "research_reports"
+      ],
+      "status": "candidate_requiring_claim_safe_verification"
+    },
+    {
+      "family": "mbti_topic",
+      "urls": [
+        "/en/topics/mbti",
+        "/zh/topics/mbti"
+      ],
+      "page_entity_type": "topic",
+      "status": "deferred_until_backend_cms_topic_authority_explicit"
+    },
+    {
+      "family": "mbti_personality_type_pages",
+      "url_patterns": [
+        "/en/personality/{type}",
+        "/zh/personality/{type}"
+      ],
+      "page_entity_type": "personality",
+      "status": "deferred_until_backend_personality_cms_authority_explicit"
+    },
+    {
+      "family": "mbti_articles",
+      "url_pattern": "backend_cms_article_urls",
+      "page_entity_type": "article",
+      "status": "deferred_until_backend_cms_article_rows_verified"
+    },
+    {
+      "family": "private_flows",
+      "paths": [
+        "take",
+        "result",
+        "report",
+        "paywall",
+        "order",
+        "pdf",
+        "history"
+      ],
+      "status": "private_noindex_excluded_from_url_truth_and_search_channel"
+    }
+  ],
+  "entity_families": [
+    "mbti_test",
+    "mbti_topic",
+    "mbti_research_salary_turnover",
+    "mbti_result_private",
+    "mbti_paid_report_private",
+    "mbti_type_intj",
+    "mbti_type_infp",
+    "mbti_type_entj",
+    "mbti_type_{lowercase_type_code}"
+  ],
+  "entity_key_rules": [
+    "entity_key_independent_from_url_slug",
+    "translation_group_uuid_preferred_when_available",
+    "translation_group_id_transitional_only",
+    "slug_title_similarity_migration_helper_only_not_authority",
+    "frontend_fallback_cannot_create_entity_key"
+  ],
+  "allowed_source_authorities": [
+    "scale_catalog",
+    "backend_public_surface",
+    "backend_cms",
+    "research_reports",
+    "backend_cms_topic",
+    "backend_personality_cms",
+    "backend_cms_article"
+  ],
+  "forbidden_authority_sources": [
+    "frontend_fallback",
+    "static_sitemap_fallback",
+    "static_llms_fallback",
+    "crawler_log_source",
+    "search_engine_response",
+    "digital_pr_mention",
+    "local_copy",
+    "node2_business_db_tencent_rds"
+  ],
+  "private_noindex_excluded": [
+    "take",
+    "result",
+    "report",
+    "paywall",
+    "order",
+    "pdf",
+    "history"
+  ],
+  "safety_flags": {
+    "url_truth_written": false,
+    "collector_writes_run": false,
+    "production_db_read": false,
+    "search_channel_mutated": false,
+    "fap_web_modified": false,
+    "frontend_fallback_used_as_authority": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-02"
+}

--- a/backend/docs/seo/seo-growth-mbti-01-entity-map-url-truth-review.md
+++ b/backend/docs/seo/seo-growth-mbti-01-entity-map-url-truth-review.md
@@ -1,0 +1,75 @@
+# MBTI Entity Map and URL Truth Review
+
+Task: SEO-GROWTH-MBTI-01
+
+Type: docs/generated/test only.
+
+This contract defines the MBTI entity map and URL Truth review package for the growth loop. It does not write URL Truth, run collectors in write mode, read production DBs, mutate Search Channel Queue, change fap-web, or use frontend fallback/static sitemap/static llms/crawler logs/search responses/Digital PR mentions/local copies as authority.
+
+## URL Truth Candidate Matrix
+
+| Family | URL/path | page_entity_type | source_authority | Status |
+| --- | --- | --- | --- | --- |
+| MBTI test EN | `/en/tests/mbti-personality-test-16-personality-types` | `test_detail` | `scale_catalog` or `backend_public_surface` | candidate requiring backend-authoritative dry-run confirmation |
+| MBTI test ZH | `/zh/tests/mbti-personality-test-16-personality-types` | `test_detail` | `scale_catalog` or `backend_public_surface` | candidate requiring backend-authoritative dry-run confirmation |
+| MBTI research EN | `/en/research/mbti-personality-types-salary-turnover-report` | `research_report` | `backend_cms` / `research_reports` | candidate requiring claim-safe verification |
+| MBTI research ZH | `/zh/research/mbti-personality-types-salary-turnover-report` | `research_report` | `backend_cms` / `research_reports` | candidate requiring claim-safe verification |
+| MBTI topic EN/ZH | `/en/topics/mbti`, `/zh/topics/mbti` | `topic` | backend CMS topic authority | deferred until backend CMS/topic authority explicit |
+| MBTI personality pages | `/en/personality/{type}`, `/zh/personality/{type}` | `personality` | backend personality/CMS authority | deferred until backend personality/CMS authority explicit |
+| MBTI articles | backend CMS article URLs | `article` | backend CMS article rows | deferred until backend CMS article rows verified |
+| Private flows | take/result/report/paywall/order/PDF/history | private/noindex | backend product truth only | excluded from URL Truth and Search Channel |
+
+## Entity Families
+
+Public/planning entities:
+
+- `mbti_test`.
+- `mbti_topic`.
+- `mbti_research_salary_turnover`.
+- `mbti_type_intj`.
+- `mbti_type_infp`.
+- `mbti_type_entj`.
+- `mbti_type_{lowercase_type_code}`.
+
+Private/funnel entities:
+
+- `mbti_result_private`.
+- `mbti_paid_report_private`.
+
+## Entity Key Rules
+
+- `entity_key` must be independent from URL slug.
+- `translation_group_uuid` is preferred when available.
+- `translation_group_id` is transitional only.
+- slug/title similarity is migration-helper only, not authority.
+- frontend fallback cannot create entity keys.
+- crawler logs, static sitemap, static llms, search responses, local copies, and Digital PR mentions cannot create entity keys or URL Truth.
+
+## Source Authority Rules
+
+Allowed candidate source authorities:
+
+- `scale_catalog`.
+- `backend_public_surface`.
+- `backend_cms`.
+- `research_reports`.
+- backend CMS topic/personality/article authority once explicit.
+
+Forbidden source authorities:
+
+- frontend fallback.
+- static sitemap fallback.
+- static llms fallback.
+- crawler log source.
+- search engine response.
+- Digital PR mention.
+- local copy.
+- Node2 / business DB / Tencent RDS.
+
+## Private and Noindex Boundary
+
+The take, result, report, paywall, order, PDF, and history flows are private/noindex. They are product/funnel truth surfaces only and must remain excluded from public URL Truth and Search Channel planning.
+
+## Next Task
+
+After this PR merges, continue with `SEO-GROWTH-MBTI-02｜Content and Internal Link Wave 1 Dry-run Plan`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti01EntityMapUrlTruthReviewTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti01EntityMapUrlTruthReviewTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti01EntityMapUrlTruthReviewTest extends TestCase
+{
+    #[Test]
+    public function entity_map_url_truth_review_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-01-entity-map-url-truth-review.md'));
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-01-entity-map-url-truth-review.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-01', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-02', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function url_truth_matrix_classifies_candidates_deferred_surfaces_and_private_flows(): void
+    {
+        $matrix = $this->artifact()['url_truth_candidate_matrix'] ?? [];
+
+        $this->assertMatrixUrl($matrix, '/en/tests/mbti-personality-test-16-personality-types', 'test_detail', 'candidate_requiring_backend_authoritative_dry_run_confirmation');
+        $this->assertMatrixUrl($matrix, '/zh/tests/mbti-personality-test-16-personality-types', 'test_detail', 'candidate_requiring_backend_authoritative_dry_run_confirmation');
+        $this->assertMatrixUrl($matrix, '/en/research/mbti-personality-types-salary-turnover-report', 'research_report', 'candidate_requiring_claim_safe_verification');
+        $this->assertMatrixUrl($matrix, '/zh/research/mbti-personality-types-salary-turnover-report', 'research_report', 'candidate_requiring_claim_safe_verification');
+
+        $families = array_column($matrix, 'family');
+        foreach (['mbti_topic', 'mbti_personality_type_pages', 'mbti_articles', 'private_flows'] as $family) {
+            $this->assertContains($family, $families);
+        }
+
+        $private = collect($matrix)->firstWhere('family', 'private_flows');
+        $this->assertSame('private_noindex_excluded_from_url_truth_and_search_channel', $private['status'] ?? null);
+    }
+
+    #[Test]
+    public function entity_families_and_entity_key_rules_are_locked(): void
+    {
+        $artifact = $this->artifact();
+        foreach (['mbti_test', 'mbti_topic', 'mbti_research_salary_turnover', 'mbti_result_private', 'mbti_paid_report_private', 'mbti_type_intj', 'mbti_type_infp', 'mbti_type_entj', 'mbti_type_{lowercase_type_code}'] as $entity) {
+            $this->assertContains($entity, $artifact['entity_families'] ?? []);
+        }
+
+        foreach (['entity_key_independent_from_url_slug', 'translation_group_uuid_preferred_when_available', 'translation_group_id_transitional_only', 'slug_title_similarity_migration_helper_only_not_authority', 'frontend_fallback_cannot_create_entity_key'] as $rule) {
+            $this->assertContains($rule, $artifact['entity_key_rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function source_authority_rules_allow_backend_sources_and_block_observation_sources(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach (['scale_catalog', 'backend_public_surface', 'backend_cms', 'research_reports'] as $authority) {
+            $this->assertContains($authority, $artifact['allowed_source_authorities'] ?? []);
+        }
+
+        foreach (['frontend_fallback', 'static_sitemap_fallback', 'static_llms_fallback', 'crawler_log_source', 'search_engine_response', 'digital_pr_mention', 'local_copy', 'node2_business_db_tencent_rds'] as $source) {
+            $this->assertContains($source, $artifact['forbidden_authority_sources'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function private_noindex_boundary_and_safety_flags_are_non_mutating(): void
+    {
+        $artifact = $this->artifact();
+        foreach (['take', 'result', 'report', 'paywall', 'order', 'pdf', 'history'] as $path) {
+            $this->assertContains($path, $artifact['private_noindex_excluded'] ?? []);
+        }
+
+        foreach ($artifact['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_fallback_prohibition_and_next_task(): void
+    {
+        $combined = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-01-entity-map-url-truth-review.md')).'
+'.(string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-01-entity-map-url-truth-review.v1.json')));
+
+        foreach (['frontend fallback cannot create entity keys', 'static sitemap', 'static llms', 'search responses', 'digital pr mentions', 'excluded from url truth and search channel', 'seo-growth-mbti-02'] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /** @param array<int, array<string, mixed>> $matrix */
+    private function assertMatrixUrl(array $matrix, string $url, string $pageEntityType, string $status): void
+    {
+        $row = collect($matrix)->firstWhere('url', $url);
+        $this->assertIsArray($row, 'Missing URL candidate '.$url);
+        $this->assertSame($pageEntityType, $row['page_entity_type'] ?? null);
+        $this->assertSame($status, $row['status'] ?? null);
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-01-entity-map-url-truth-review.v1.json');
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14402,11 +14402,11 @@
     "SEO-GROWTH-MBTI-00": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-00-baseline-telemetry",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-00A"
       ],
-      "commit_sha": "c3fcf934",
+      "commit_sha": "d9845a401e01bd3bdd60c89a25a5778ab9fbd244",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1580",
       "checks": {
         "local": {
@@ -14420,11 +14420,16 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1580": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as d9845a401e01bd3bdd60c89a25a5778ab9fbd244"
+        },
+        "post_merge": {
+          "focused_baseline_telemetry_test": "passed: php artisan test --filter=SeoIntelGrowthMbti00BaselineSnapshotTelemetryContract --no-ansi (8 tests, 123 assertions)"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T13:03:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -14451,20 +14456,35 @@
           "at": "2026-05-22T21:10:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1580 for SEO-GROWTH-MBTI-00 and pushed branch codex/seo-growth-mbti-00-baseline-telemetry."
+        },
+        {
+          "at": "2026-05-22T21:04:00+08:00",
+          "status": "merged",
+          "summary": "PR #1580 merged via squash at d9845a401e01bd3bdd60c89a25a5778ab9fbd244. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused baseline telemetry test passed. Local cleanup script is unavailable in this clone."
         }
       ]
     },
     "SEO-GROWTH-MBTI-01": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-01-entity-url-truth",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "SEO-GROWTH-MBTI-00"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "local": {},
+        "local": {
+          "focused_entity_url_truth_test": "passed: php artisan test --filter=SeoIntelGrowthMbti01EntityMapUrlTruthReview --no-ansi (6 tests, 79 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (523 tests, 8266 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3490 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-01-entity-map-url-truth-review.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
         "github": {}
       },
       "failure_reason": null,
@@ -14481,6 +14501,16 @@
           "at": "2026-05-22T21:00:00+08:00",
           "status": "pending",
           "summary": "Registered SEO-GROWTH-MBTI-01 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T21:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-01 on codex/seo-growth-mbti-01-entity-url-truth from latest main. Scope is entity map URL Truth review docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T21:16:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-GROWTH-MBTI-01 local validation passed for focused entity URL Truth review test, full SeoIntel filter, route:list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14467,12 +14467,12 @@
     "SEO-GROWTH-MBTI-01": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-01-entity-url-truth",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-00"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "497ab62d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1581",
       "checks": {
         "local": {
           "focused_entity_url_truth_test": "passed: php artisan test --filter=SeoIntelGrowthMbti01EntityMapUrlTruthReview --no-ansi (6 tests, 79 assertions)",
@@ -14511,6 +14511,11 @@
           "at": "2026-05-22T21:16:00+08:00",
           "status": "local_validation_passed",
           "summary": "SEO-GROWTH-MBTI-01 local validation passed for focused entity URL Truth review test, full SeoIntel filter, route:list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        },
+        {
+          "at": "2026-05-22T21:18:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1581 for SEO-GROWTH-MBTI-01 and pushed branch codex/seo-growth-mbti-01-entity-url-truth."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added SEO-GROWTH-MBTI-01 entity map and URL Truth review docs/generated/test contract.
- Locked MBTI test/research candidate classifications, deferred topic/personality/article surfaces, private/noindex exclusions, entity-key rules, and source-authority boundaries.
- Reconciled SEO-GROWTH-MBTI-00 as merged in the train ledger.

## Why
The MBTI growth loop needs a slug-independent entity map and backend-authoritative URL Truth review package before content, links, claim, Search Channel, Digital PR, or funnel review planning can proceed.

## Validation commands
- `cd backend && php artisan test --filter=SeoIntelGrowthMbti01EntityMapUrlTruthReview --no-ansi`
- `cd backend && php artisan test --filter=SeoIntel --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-01-entity-map-url-truth-review.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nPY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No URL Truth writes.
- No collector writes or production DB reads.
- No Search Channel mutation.
- No fap-web changes.
- No frontend fallback/static sitemap/static llms/crawler/search/Digital PR/local copy authority.

## Repository rule impact
This PR reinforces backend/CMS/catalog URL Truth authority and keeps observation sources out of entity-key and URL Truth creation.
