### PR TITLE
docs(seo-intel): add MBTI content internal link wave plan

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-02-content-internal-link-wave1-plan.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-02-content-internal-link-wave1-plan.v1.json
@@ -1,0 +1,64 @@
+{
+  "version": "seo-growth-mbti-02-content-internal-link-wave1-plan.v1",
+  "task": "SEO-GROWTH-MBTI-02",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "candidate_wave1_assets": [
+    "mbti_test_page",
+    "mbti_research_report",
+    "mbti_topic_hub_deferred_until_backend_topic_authority_explicit",
+    "two_to_three_mbti_explanatory_articles_only_if_backend_cms_rows_exist",
+    "selected_personality_type_pages_only_after_entity_authority_confirmed"
+  ],
+  "internal_link_families": [
+    "article_to_test",
+    "article_to_topic",
+    "article_to_research",
+    "article_to_related_article",
+    "topic_to_test",
+    "topic_to_article",
+    "topic_to_personality_entity",
+    "research_to_topic_test_article",
+    "test_to_article_topic_research",
+    "personality_page_to_test_topic_article"
+  ],
+  "authority_rules": [
+    "backend_cms_entity_graph_owns_link_truth",
+    "fap_web_static_links_observation_only",
+    "sitemap_derived_links_observation_only",
+    "crawler_logs_cannot_create_links",
+    "gsc_ga4_referral_suggest_only_cannot_create_links",
+    "title_slug_similarity_migration_helper_only",
+    "entity_key_preferred",
+    "translation_group_uuid_preferred_when_available"
+  ],
+  "dry_run_outputs": [
+    "source_inventory",
+    "link_family_counts",
+    "missing_entity_key_count",
+    "legacy_unpaired_count",
+    "candidate_opportunity_count",
+    "unsafe_fallback_source_count",
+    "warnings"
+  ],
+  "forbidden_actions": [
+    "cms_writes",
+    "link_creation",
+    "article_publish",
+    "fap_web_changes",
+    "crawler_derived_authority",
+    "search_response_authority",
+    "frontend_fallback_authority",
+    "pseo",
+    "auto_link_creation"
+  ],
+  "safety_flags": {
+    "cms_mutated": false,
+    "links_created": false,
+    "articles_published": false,
+    "fap_web_modified": false,
+    "crawler_authority_used": false,
+    "auto_links_created": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-03A"
+}

--- a/backend/docs/seo/seo-growth-mbti-02-content-internal-link-wave1-plan.md
+++ b/backend/docs/seo/seo-growth-mbti-02-content-internal-link-wave1-plan.md
@@ -1,0 +1,57 @@
+# MBTI Content and Internal Link Wave 1 Dry-run Plan
+
+Task: SEO-GROWTH-MBTI-02
+
+Type: docs/generated/test only.
+
+This contract defines the MBTI Content/Internal Link Wave 1 dry-run plan. It does not create content, does not mutate CMS, does not publish articles, does not create links, does not modify fap-web, and does not use crawler/search/referral/frontend/static signals as authority.
+
+## Candidate Wave 1 Assets
+
+- MBTI test page.
+- MBTI research report.
+- MBTI topic hub, deferred until backend topic authority is explicit.
+- 2-3 MBTI explanatory articles, only if backend CMS rows exist.
+- selected personality type pages, only after entity authority is confirmed.
+
+## Internal Link Families
+
+- article -> test.
+- article -> topic.
+- article -> research.
+- article -> related article.
+- topic -> test.
+- topic -> article.
+- topic -> personality/entity.
+- research -> topic/test/article.
+- test -> article/topic/research.
+- personality page -> test/topic/article.
+
+## Authority Rules
+
+- backend/CMS entity graph owns link truth.
+- fap-web static links are observation only.
+- sitemap-derived links are observation only.
+- crawler logs cannot create links.
+- GSC/GA4/referral signals can suggest opportunities but cannot create links.
+- title/slug similarity is migration-helper only.
+- `entity_key` is preferred.
+- `translation_group_uuid` is preferred when available.
+
+## Required Dry-run Outputs
+
+- source inventory.
+- link family counts.
+- missing entity key count.
+- legacy_unpaired count.
+- candidate opportunity count.
+- unsafe fallback source count.
+- warnings.
+
+## Stop Conditions
+
+Stop if a future implementation attempts CMS writes, link creation, article publish, fap-web changes, crawler-derived authority, search-response authority, frontend fallback authority, pSEO, or auto-link creation.
+
+## Next Task
+
+After this PR merges, continue with `SEO-GROWTH-MBTI-03A｜MBTI Claim Lint Gate`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti02ContentInternalLinkWave1PlanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti02ContentInternalLinkWave1PlanTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti02ContentInternalLinkWave1PlanTest extends TestCase
+{
+    #[Test]
+    public function content_internal_link_plan_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-02-content-internal-link-wave1-plan.md'));
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-02-content-internal-link-wave1-plan.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-02', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-03A', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function candidate_wave_one_assets_are_scoped_and_deferred_where_needed(): void
+    {
+        foreach (['mbti_test_page', 'mbti_research_report', 'mbti_topic_hub_deferred_until_backend_topic_authority_explicit', 'two_to_three_mbti_explanatory_articles_only_if_backend_cms_rows_exist', 'selected_personality_type_pages_only_after_entity_authority_confirmed'] as $asset) {
+            $this->assertContains($asset, $this->artifact()['candidate_wave1_assets'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function internal_link_families_cover_required_graph_edges(): void
+    {
+        foreach (['article_to_test', 'article_to_topic', 'article_to_research', 'article_to_related_article', 'topic_to_test', 'topic_to_article', 'topic_to_personality_entity', 'research_to_topic_test_article', 'test_to_article_topic_research', 'personality_page_to_test_topic_article'] as $family) {
+            $this->assertContains($family, $this->artifact()['internal_link_families'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function authority_rules_keep_links_backend_owned_and_observation_only(): void
+    {
+        foreach (['backend_cms_entity_graph_owns_link_truth', 'fap_web_static_links_observation_only', 'sitemap_derived_links_observation_only', 'crawler_logs_cannot_create_links', 'gsc_ga4_referral_suggest_only_cannot_create_links', 'title_slug_similarity_migration_helper_only', 'entity_key_preferred', 'translation_group_uuid_preferred_when_available'] as $rule) {
+            $this->assertContains($rule, $this->artifact()['authority_rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function dry_run_outputs_are_defined_without_mutation(): void
+    {
+        foreach (['source_inventory', 'link_family_counts', 'missing_entity_key_count', 'legacy_unpaired_count', 'candidate_opportunity_count', 'unsafe_fallback_source_count', 'warnings'] as $output) {
+            $this->assertContains($output, $this->artifact()['dry_run_outputs'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function forbidden_actions_and_safety_flags_block_content_and_link_mutation(): void
+    {
+        $artifact = $this->artifact();
+        foreach (['cms_writes', 'link_creation', 'article_publish', 'fap_web_changes', 'crawler_derived_authority', 'search_response_authority', 'frontend_fallback_authority', 'pseo', 'auto_link_creation'] as $action) {
+            $this->assertContains($action, $artifact['forbidden_actions'] ?? []);
+        }
+        foreach ($artifact['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_content_creation_and_next_task(): void
+    {
+        $combined = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-02-content-internal-link-wave1-plan.md')).'
+'.(string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-02-content-internal-link-wave1-plan.v1.json')));
+        foreach (['does not create content', 'does not mutate cms', 'does not create links', 'fap-web static links are observation only', 'crawler logs cannot create links', 'seo-growth-mbti-03a'] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-02-content-internal-link-wave1-plan.v1.json');
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14467,11 +14467,11 @@
     "SEO-GROWTH-MBTI-01": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-01-entity-url-truth",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-00"
       ],
-      "commit_sha": "497ab62d",
+      "commit_sha": "fb1dbc415ce67ce3a784a6ea50329dd078268e4a",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1581",
       "checks": {
         "local": {
@@ -14485,11 +14485,16 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1581": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as fb1dbc415ce67ce3a784a6ea50329dd078268e4a"
+        },
+        "post_merge": {
+          "focused_entity_url_truth_test": "passed: php artisan test --filter=SeoIntelGrowthMbti01EntityMapUrlTruthReview --no-ansi (6 tests, 79 assertions)"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T13:20:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -14516,20 +14521,35 @@
           "at": "2026-05-22T21:18:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1581 for SEO-GROWTH-MBTI-01 and pushed branch codex/seo-growth-mbti-01-entity-url-truth."
+        },
+        {
+          "at": "2026-05-22T21:20:00+08:00",
+          "status": "merged",
+          "summary": "PR #1581 merged via squash at fb1dbc415ce67ce3a784a6ea50329dd078268e4a. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused entity URL Truth test passed. Local cleanup script is unavailable in this clone."
         }
       ]
     },
     "SEO-GROWTH-MBTI-02": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-02-content-links",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "SEO-GROWTH-MBTI-01"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "local": {},
+        "local": {
+          "focused_content_link_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti02ContentInternalLinkWave1Plan --no-ansi (7 tests, 121 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (530 tests, 8387 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3491 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-02-content-internal-link-wave1-plan.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
         "github": {}
       },
       "failure_reason": null,
@@ -14546,6 +14566,16 @@
           "at": "2026-05-22T21:00:00+08:00",
           "status": "pending",
           "summary": "Registered SEO-GROWTH-MBTI-02 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T21:21:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-02 on codex/seo-growth-mbti-02-content-links from latest main. Scope is content/internal link wave dry-run plan docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T21:27:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "SEO-GROWTH-MBTI-02 local validation passed for focused content/internal link Wave 1 plan test, full SeoIntel filter, route:list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -14532,12 +14532,12 @@
     "SEO-GROWTH-MBTI-02": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-02-content-links",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "68bcc79e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1582",
       "checks": {
         "local": {
           "focused_content_link_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti02ContentInternalLinkWave1Plan --no-ansi (7 tests, 121 assertions)",
@@ -14576,6 +14576,11 @@
           "at": "2026-05-22T21:27:00+08:00",
           "status": "local_validation_passed",
           "summary": "SEO-GROWTH-MBTI-02 local validation passed for focused content/internal link Wave 1 plan test, full SeoIntel filter, route:list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        },
+        {
+          "at": "2026-05-22T21:28:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1582 for SEO-GROWTH-MBTI-02 and pushed branch codex/seo-growth-mbti-02-content-links."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added SEO-GROWTH-MBTI-02 content/internal link Wave 1 dry-run planning contract.
- Locked candidate assets, required link families, dry-run output shape, backend/CMS graph authority, and non-mutating safety boundaries.
- Reconciled SEO-GROWTH-MBTI-01 as merged in the train ledger.

## Why
MBTI content and link planning must be dry-run only until backend/CMS entity authority and claim gates are explicit.

## Validation commands
- `cd backend && php artisan test --filter=SeoIntelGrowthMbti02ContentInternalLinkWave1Plan --no-ansi`
- `cd backend && php artisan test --filter=SeoIntel --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-02-content-internal-link-wave1-plan.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nPY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No CMS writes.
- No content creation or article publish.
- No link creation or auto-linking.
- No fap-web changes.
- No crawler/search/referral/frontend/static authority.

## Repository rule impact
This PR reinforces that backend/CMS entity graph owns link truth. fap-web static links, sitemap-derived links, crawler logs, GSC/GA4, and referral signals remain observation or opportunity inputs only.
