### PR TITLE
docs(seo-intel): add MBTI claim lint gate

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-03a-claim-lint-gate.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-03a-claim-lint-gate.v1.json
@@ -1,0 +1,79 @@
+{
+  "version": "seo-growth-mbti-03a-claim-lint-gate.v1",
+  "task": "SEO-GROWTH-MBTI-03A",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "required_before": [
+    "search_channel_planning",
+    "digital_pr_wave_2",
+    "content_internal_link_wave_1",
+    "growth_experiment_review"
+  ],
+  "surfaces": [
+    "mbti_research_salary_turnover_report",
+    "mbti_test_page_metadata_faq_jsonld",
+    "mbti_result_report_paywall_copy",
+    "mbti_topic_article_snippets",
+    "internal_link_anchor_text",
+    "digital_pr_pitch_copy_if_later_used",
+    "career_job_fit_adjacent_mbti_wording"
+  ],
+  "forbidden_claims": [
+    "MBTI决定收入",
+    "MBTI预测离职",
+    "薪资保证",
+    "个人离职预测",
+    "招聘适配",
+    "职业成功预测",
+    "精准职业推荐",
+    "最适合职业",
+    "AI 职业规划",
+    "岗位胜任力",
+    "诊断",
+    "确诊",
+    "治疗",
+    "治愈"
+  ],
+  "allowed_bounded_language": [
+    "模型化指数",
+    "聚合层面",
+    "方向性趋势",
+    "非诊断",
+    "结果仅供参考",
+    "职业方向参考",
+    "工作方式倾向",
+    "探索建议",
+    "discussion resource",
+    "modeled signal",
+    "aggregate trend",
+    "not hiring advice",
+    "not salary guarantee",
+    "not individual prediction"
+  ],
+  "states": [
+    "safe",
+    "needs_review",
+    "blocked"
+  ],
+  "severity_mapping": {
+    "P0": "claim_unsafe_public_indexable_page",
+    "P1": "high_risk_seo_metadata_faq_jsonld_llms_claim_risk",
+    "P2": "draft_article_body_needs_caution",
+    "P3": "non_public_wording_drift"
+  },
+  "gate_rules": [
+    "claim_lint_flags_or_blocks_must_not_auto_rewrite",
+    "claim_unsafe_urls_cannot_enter_search_channel_planning",
+    "claim_unsafe_pitch_copy_cannot_enter_digital_pr_wave_2",
+    "claim_unsafe_content_internal_link_candidates_cannot_enter_wave_1",
+    "no_precise_recommender_hiring_salary_or_career_success_overclaims_for_mbti_big_five_riasec_career_graph"
+  ],
+  "safety_flags": {
+    "production_content_scanned": false,
+    "auto_rewrite_enabled": false,
+    "cms_mutated": false,
+    "fap_web_modified": false,
+    "digital_pr_sent": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-03B"
+}

--- a/backend/docs/seo/seo-growth-mbti-03a-claim-lint-gate.md
+++ b/backend/docs/seo/seo-growth-mbti-03a-claim-lint-gate.md
@@ -1,0 +1,76 @@
+# MBTI Claim Lint Gate
+
+Task: SEO-GROWTH-MBTI-03A
+
+Type: docs/generated/test only.
+
+This contract defines the MBTI-specific claim lint gate before Search Channel planning, Digital PR Wave 2, Content/Internal Link Wave 1, or growth experiment review. It does not scan production content, does not mutate CMS, does not modify fap-web, does not send Digital PR, and must not auto-rewrite copy.
+
+## Required Surfaces
+
+- MBTI research salary/turnover report.
+- MBTI test page metadata/FAQ/JSON-LD.
+- MBTI result/report/paywall copy.
+- MBTI topic/article snippets.
+- internal link anchor text.
+- Digital PR pitch copy if later used.
+- career/job-fit adjacent MBTI wording.
+
+## Forbidden Claims
+
+- MBTI决定收入.
+- MBTI预测离职.
+- 薪资保证.
+- 个人离职预测.
+- 招聘适配.
+- 职业成功预测.
+- 精准职业推荐.
+- 最适合职业.
+- AI 职业规划.
+- 岗位胜任力.
+- 诊断.
+- 确诊.
+- 治疗.
+- 治愈.
+
+## Allowed Bounded Language
+
+- 模型化指数.
+- 聚合层面.
+- 方向性趋势.
+- 非诊断.
+- 结果仅供参考.
+- 职业方向参考.
+- 工作方式倾向.
+- 探索建议.
+- discussion resource.
+- modeled signal.
+- aggregate trend.
+- not hiring advice.
+- not salary guarantee.
+- not individual prediction.
+
+## States
+
+- `safe`: bounded language and no blocked phrases.
+- `needs_review`: claim-sensitive phrasing that needs human review before public/search/outreach use.
+- `blocked`: forbidden claim or high-risk overclaim.
+
+## Severity Mapping
+
+- P0: claim-unsafe public/indexable page.
+- P1: high-risk SEO metadata / FAQ / JSON-LD / llms claim risk.
+- P2: draft/article body needs caution.
+- P3: non-public wording drift.
+
+## Gate Rules
+
+- Claim lint flags or blocks copy; it must not auto-rewrite.
+- Claim unsafe URLs cannot enter Search Channel planning.
+- Claim unsafe pitch copy cannot enter Digital PR Wave 2.
+- Claim unsafe content/internal link candidates cannot enter Wave 1.
+- MBTI, Big Five, RIASEC, and Career Graph must not be framed as precise career recommendation, hiring suitability, salary prediction, or career-success prediction authority.
+
+## Next Task
+
+After this PR merges, continue with `SEO-GROWTH-MBTI-03B｜Search Channel Canary Wave Plan`.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti03aClaimLintGateTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti03aClaimLintGateTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti03aClaimLintGateTest extends TestCase
+{
+    #[Test]
+    public function claim_lint_gate_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-03a-claim-lint-gate.md'));
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-03a-claim-lint-gate.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-03A', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-03B', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function gate_is_required_before_search_digital_pr_content_and_review(): void
+    {
+        foreach (['search_channel_planning', 'digital_pr_wave_2', 'content_internal_link_wave_1', 'growth_experiment_review'] as $gate) {
+            $this->assertContains($gate, $this->artifact()['required_before'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function required_mbti_surfaces_are_covered(): void
+    {
+        foreach (['mbti_research_salary_turnover_report', 'mbti_test_page_metadata_faq_jsonld', 'mbti_result_report_paywall_copy', 'mbti_topic_article_snippets', 'internal_link_anchor_text', 'digital_pr_pitch_copy_if_later_used', 'career_job_fit_adjacent_mbti_wording'] as $surface) {
+            $this->assertContains($surface, $this->artifact()['surfaces'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function forbidden_claims_and_allowed_bounded_language_are_locked(): void
+    {
+        $artifact = $this->artifact();
+        foreach (['MBTI决定收入', 'MBTI预测离职', '薪资保证', '个人离职预测', '招聘适配', '职业成功预测', '精准职业推荐', '最适合职业', 'AI 职业规划', '岗位胜任力', '诊断', '确诊', '治疗', '治愈'] as $claim) {
+            $this->assertContains($claim, $artifact['forbidden_claims'] ?? []);
+        }
+        foreach (['模型化指数', '聚合层面', '方向性趋势', '非诊断', '结果仅供参考', '职业方向参考', '工作方式倾向', '探索建议', 'discussion resource', 'modeled signal', 'aggregate trend', 'not hiring advice', 'not salary guarantee', 'not individual prediction'] as $language) {
+            $this->assertContains($language, $artifact['allowed_bounded_language'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function states_severity_and_gate_rules_are_explicit(): void
+    {
+        $artifact = $this->artifact();
+        foreach (['safe', 'needs_review', 'blocked'] as $state) {
+            $this->assertContains($state, $artifact['states'] ?? []);
+        }
+        foreach (['P0', 'P1', 'P2', 'P3'] as $severity) {
+            $this->assertArrayHasKey($severity, $artifact['severity_mapping'] ?? []);
+        }
+        foreach (['claim_lint_flags_or_blocks_must_not_auto_rewrite', 'claim_unsafe_urls_cannot_enter_search_channel_planning', 'claim_unsafe_pitch_copy_cannot_enter_digital_pr_wave_2', 'claim_unsafe_content_internal_link_candidates_cannot_enter_wave_1', 'no_precise_recommender_hiring_salary_or_career_success_overclaims_for_mbti_big_five_riasec_career_graph'] as $rule) {
+            $this->assertContains($rule, $artifact['gate_rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_prevent_runtime_scan_rewrite_and_mutation(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_auto_rewrite_and_next_task(): void
+    {
+        $combined = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-03a-claim-lint-gate.md')).'
+'.(string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-03a-claim-lint-gate.v1.json')));
+        foreach (['must not auto-rewrite', 'does not scan production content', 'does not mutate cms', 'does not modify fap-web', 'does not send digital pr', 'seo-growth-mbti-03b'] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-03a-claim-lint-gate.v1.json');
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T18:31:57+08:00",
+  "updated_at": "2026-05-22T21:37:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14532,11 +14532,11 @@
     "SEO-GROWTH-MBTI-02": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-02-content-links",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-01"
       ],
-      "commit_sha": "68bcc79e",
+      "commit_sha": "83cc1260754b0e352200eb9c6e5a1c28fac75955",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1582",
       "checks": {
         "local": {
@@ -14550,11 +14550,16 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1582": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as 83cc1260754b0e352200eb9c6e5a1c28fac75955"
+        },
+        "post_merge": {
+          "focused_content_link_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti02ContentInternalLinkWave1Plan --no-ansi (7 tests, 121 assertions)"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T13:28:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -14581,20 +14586,35 @@
           "at": "2026-05-22T21:28:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1582 for SEO-GROWTH-MBTI-02 and pushed branch codex/seo-growth-mbti-02-content-links."
+        },
+        {
+          "at": "2026-05-22T21:28:00+08:00",
+          "status": "merged",
+          "summary": "PR #1582 merged via squash at 83cc1260754b0e352200eb9c6e5a1c28fac75955. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused content/internal link plan test passed. Local cleanup script is unavailable in this clone."
         }
       ]
     },
     "SEO-GROWTH-MBTI-03A": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-03a-claim-lint",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "SEO-GROWTH-MBTI-02"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "local": {},
+        "local": {
+          "focused_claim_lint_gate_test": "passed: php artisan test --filter=SeoIntelGrowthMbti03aClaimLintGate --no-ansi (7 tests, 98 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (537 tests, 8485 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3492 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-03a-claim-lint-gate.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
         "github": {}
       },
       "failure_reason": null,
@@ -14611,6 +14631,16 @@
           "at": "2026-05-22T21:00:00+08:00",
           "status": "pending",
           "summary": "Registered SEO-GROWTH-MBTI-03A for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T21:29:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-03A on codex/seo-growth-mbti-03a-claim-lint from latest main. Scope is MBTI claim lint gate docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T21:37:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-03A: focused claim lint gate test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T21:37:00+08:00",
+  "updated_at": "2026-05-22T21:38:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14597,12 +14597,12 @@
     "SEO-GROWTH-MBTI-03A": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-03a-claim-lint",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-02"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "53b83e10",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1583",
       "checks": {
         "local": {
           "focused_claim_lint_gate_test": "passed: php artisan test --filter=SeoIntelGrowthMbti03aClaimLintGate --no-ansi (7 tests, 98 assertions)",
@@ -14641,6 +14641,11 @@
           "at": "2026-05-22T21:37:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-03A: focused claim lint gate test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
+        },
+        {
+          "at": "2026-05-22T21:38:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1583 for SEO-GROWTH-MBTI-03A and pushed branch codex/seo-growth-mbti-03a-claim-lint."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the MBTI claim lint gate contract for SEO-GROWTH-MBTI-03A.
- Added the generated JSON contract artifact and feature tests locking forbidden claims, bounded language, gate states, severity mapping, and no-mutation safety flags.
- Updated the PR train ledger for the scoped task.

## Why
- The MBTI growth planning train needs a claim boundary before Search Channel planning, Digital PR Wave 2, Content/Internal Link Wave 1, or growth review can proceed.

## Validation
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntelGrowthMbti03aClaimLintGate --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntel --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && vendor/bin/pint --test
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-03a-claim-lint-gate.v1.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --cached --check

## Intentionally deferred
- No production content scan, CMS mutation, claim rewrite, Search Channel enqueue/submission, Digital PR send, runtime implementation, fap-web change, or crawler log read.
- Next train task remains SEO-GROWTH-MBTI-03B.