### PR TITLE
docs(seo-intel): add MBTI Search Channel canary plan

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-03b-search-channel-canary-wave-plan.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-03b-search-channel-canary-wave-plan.v1.json
@@ -1,0 +1,82 @@
+{
+  "version": "seo-growth-mbti-03b-search-channel-canary-wave-plan.v1",
+  "task": "SEO-GROWTH-MBTI-03B",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "candidate_urls_after_gates_pass": [
+    {
+      "path": "/en/tests/mbti-personality-test-16-personality-types",
+      "locale": "en",
+      "page_entity_type": "test_detail",
+      "required_gates": [
+        "url_truth_verified",
+        "claim_safe"
+      ]
+    },
+    {
+      "path": "/zh/tests/mbti-personality-test-16-personality-types",
+      "locale": "zh",
+      "page_entity_type": "test_detail",
+      "required_gates": [
+        "url_truth_verified",
+        "claim_safe"
+      ]
+    },
+    {
+      "path": "/en/research/mbti-personality-types-salary-turnover-report",
+      "locale": "en",
+      "page_entity_type": "research_report",
+      "required_gates": [
+        "url_truth_verified",
+        "claim_safe"
+      ]
+    },
+    {
+      "path": "/zh/research/mbti-personality-types-salary-turnover-report",
+      "locale": "zh",
+      "page_entity_type": "research_report",
+      "required_gates": [
+        "url_truth_verified",
+        "claim_safe"
+      ]
+    }
+  ],
+  "deferred_until_backend_authority_and_claim_gates_pass": [
+    "/en/topics/mbti",
+    "/zh/topics/mbti",
+    "mbti_personality_type_pages",
+    "mbti_article_pages"
+  ],
+  "preconditions": [
+    "url_truth_verified",
+    "allowed_source_authority",
+    "canonical",
+    "public",
+    "indexable",
+    "claim_safe",
+    "not_draft",
+    "not_noindex",
+    "not_private",
+    "dry_run_before_enqueue",
+    "human_approval_before_live_submit",
+    "one_item_canary",
+    "no_bulk_submit",
+    "live_gates_closed_after_any_approved_canary"
+  ],
+  "future_approval_template": "I approve SEO-GROWTH-MBTI-03B live Search Channel canary for exactly one URL: {url}. Keep live gates closed after this canary. No bulk submit.",
+  "authority_boundary": [
+    "search_channel_distributes_only_approved_url_truth",
+    "search_response_is_observation_not_url_truth",
+    "crawler_logs_are_observation_not_url_truth",
+    "frontend_fallback_static_sitemap_static_llms_digital_pr_mentions_and_local_copies_must_not_create_url_truth"
+  ],
+  "safety_flags": {
+    "search_channel_queue_mutated": false,
+    "live_submission_executed": false,
+    "live_gate_opened": false,
+    "external_search_api_called": false,
+    "environment_edited": false,
+    "production_operation_executed": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-04"
+}

--- a/backend/docs/seo/seo-growth-mbti-03b-search-channel-canary-wave-plan.md
+++ b/backend/docs/seo/seo-growth-mbti-03b-search-channel-canary-wave-plan.md
@@ -1,0 +1,64 @@
+# MBTI Search Channel Canary Wave Plan
+
+Task: SEO-GROWTH-MBTI-03B
+
+Train: SEO-GROWTH-MBTI-PR-TRAIN-01
+
+This is a docs / generated JSON / tests-only planning contract. It does not enqueue Search Channel Queue rows, does not submit URLs, does not open live gates, does not edit environment configuration, and does not call external search APIs.
+
+## Purpose
+
+The MBTI Search Channel canary wave may be planned only after the MBTI URL Truth and claim lint gates pass. This contract defines candidate URLs, deferred URL families, eligibility preconditions, and the exact approval template required by a future human-approved live canary task.
+
+## Candidate URLs
+
+These URLs are candidates only after URL Truth and claim gates pass:
+
+- `/en/tests/mbti-personality-test-16-personality-types`
+- `/zh/tests/mbti-personality-test-16-personality-types`
+- `/en/research/mbti-personality-types-salary-turnover-report`
+- `/zh/research/mbti-personality-types-salary-turnover-report`
+
+## Deferred URLs
+
+These surfaces remain deferred until backend authority and claim gates pass:
+
+- `/en/topics/mbti`
+- `/zh/topics/mbti`
+- MBTI personality type pages
+- MBTI article pages
+
+## Required Preconditions
+
+Every future canary candidate must satisfy all of the following:
+
+- URL Truth verified by backend-authoritative source.
+- Source authority is allowed.
+- Canonical URL is confirmed.
+- URL is public.
+- URL is indexable.
+- URL is claim-safe.
+- URL is not draft.
+- URL is not noindex.
+- URL is not private.
+- Dry-run completes before enqueue.
+- Human approval is recorded before live submit.
+- Canary is one item only.
+- Bulk submit remains forbidden.
+- Live gates are closed after any approved canary.
+
+## Approval Template
+
+Future live canary approval must use an exact, human-authored instruction scoped to one URL:
+
+`I approve SEO-GROWTH-MBTI-03B live Search Channel canary for exactly one URL: {url}. Keep live gates closed after this canary. No bulk submit.`
+
+This template is inert in this PR. It does not grant approval, enqueue a URL, submit a URL, or open a live gate.
+
+## Authority Boundary
+
+Search Channel distributes only approved URL Truth. Search engine responses, crawler logs, frontend fallback, static sitemap, static llms, Digital PR mentions, and local copies are observation only and must not become URL Truth.
+
+## Next Task
+
+SEO-GROWTH-MBTI-04

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti03bSearchChannelCanaryWavePlanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti03bSearchChannelCanaryWavePlanTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti03bSearchChannelCanaryWavePlanTest extends TestCase
+{
+    #[Test]
+    public function search_channel_canary_plan_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-03b-search-channel-canary-wave-plan.md'));
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-03b-search-channel-canary-wave-plan.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-03B', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-04', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function candidate_urls_are_limited_to_test_and_research_after_gates_pass(): void
+    {
+        $paths = array_column($this->artifact()['candidate_urls_after_gates_pass'] ?? [], 'path');
+
+        foreach ([
+            '/en/tests/mbti-personality-test-16-personality-types',
+            '/zh/tests/mbti-personality-test-16-personality-types',
+            '/en/research/mbti-personality-types-salary-turnover-report',
+            '/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $path) {
+            $this->assertContains($path, $paths);
+        }
+
+        foreach ($this->artifact()['candidate_urls_after_gates_pass'] ?? [] as $candidate) {
+            $this->assertContains('url_truth_verified', $candidate['required_gates'] ?? []);
+            $this->assertContains('claim_safe', $candidate['required_gates'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function deferred_surfaces_wait_for_backend_authority_and_claim_gates(): void
+    {
+        foreach (['/en/topics/mbti', '/zh/topics/mbti', 'mbti_personality_type_pages', 'mbti_article_pages'] as $surface) {
+            $this->assertContains($surface, $this->artifact()['deferred_until_backend_authority_and_claim_gates_pass'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function required_preconditions_block_unsafe_or_bulk_submission(): void
+    {
+        foreach (['url_truth_verified', 'allowed_source_authority', 'canonical', 'public', 'indexable', 'claim_safe', 'not_draft', 'not_noindex', 'not_private', 'dry_run_before_enqueue', 'human_approval_before_live_submit', 'one_item_canary', 'no_bulk_submit', 'live_gates_closed_after_any_approved_canary'] as $precondition) {
+            $this->assertContains($precondition, $this->artifact()['preconditions'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function approval_template_is_exact_but_inert(): void
+    {
+        $template = $this->artifact()['future_approval_template'] ?? '';
+
+        $this->assertStringContainsString('exactly one URL', $template);
+        $this->assertStringContainsString('{url}', $template);
+        $this->assertStringContainsString('No bulk submit', $template);
+    }
+
+    #[Test]
+    public function authority_boundary_rejects_observation_sources_as_truth(): void
+    {
+        foreach (['search_response_is_observation_not_url_truth', 'crawler_logs_are_observation_not_url_truth', 'frontend_fallback_static_sitemap_static_llms_digital_pr_mentions_and_local_copies_must_not_create_url_truth'] as $boundary) {
+            $this->assertContains($boundary, $this->artifact()['authority_boundary'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_prevent_queue_mutation_submission_and_external_calls(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_enqueue_no_submit_and_next_task(): void
+    {
+        $combined = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-03b-search-channel-canary-wave-plan.md')).'
+'.(string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-03b-search-channel-canary-wave-plan.v1.json')));
+
+        foreach (['does not enqueue', 'does not submit urls', 'does not open live gates', 'does not call external search apis', 'seo-growth-mbti-04'] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-03b-search-channel-canary-wave-plan.v1.json');
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T21:38:00+08:00",
+  "updated_at": "2026-05-22T21:42:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14597,11 +14597,11 @@
     "SEO-GROWTH-MBTI-03A": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-03a-claim-lint",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-02"
       ],
-      "commit_sha": "53b83e10",
+      "commit_sha": "0952412206e7e8c8611145660d01d7dfa3836190",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1583",
       "checks": {
         "local": {
@@ -14615,11 +14615,16 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1583": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as 0952412206e7e8c8611145660d01d7dfa3836190"
+        },
+        "post_merge": {
+          "focused_claim_lint_gate_test": "passed: php artisan test --filter=SeoIntelGrowthMbti03aClaimLintGate --no-ansi (7 tests, 98 assertions)"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T13:36:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -14646,20 +14651,35 @@
           "at": "2026-05-22T21:38:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1583 for SEO-GROWTH-MBTI-03A and pushed branch codex/seo-growth-mbti-03a-claim-lint."
+        },
+        {
+          "at": "2026-05-22T21:36:00+08:00",
+          "status": "merged",
+          "summary": "PR #1583 merged via squash at 0952412206e7e8c8611145660d01d7dfa3836190. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused claim lint gate test passed. Local cleanup script is unavailable in this clone."
         }
       ]
     },
     "SEO-GROWTH-MBTI-03B": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-03b-search-channel",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "SEO-GROWTH-MBTI-03A"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "local": {},
+        "local": {
+          "focused_search_channel_canary_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti03bSearchChannelCanaryWavePlan --no-ansi (8 tests, 105 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (545 tests, 8590 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3493 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-03b-search-channel-canary-wave-plan.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
         "github": {}
       },
       "failure_reason": null,
@@ -14676,6 +14696,16 @@
           "at": "2026-05-22T21:00:00+08:00",
           "status": "pending",
           "summary": "Registered SEO-GROWTH-MBTI-03B for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T21:37:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-03B on codex/seo-growth-mbti-03b-search-channel from latest main. Scope is MBTI Search Channel canary wave plan docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T21:42:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-03B: focused Search Channel canary plan test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T21:42:00+08:00",
+  "updated_at": "2026-05-22T21:43:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14662,12 +14662,12 @@
     "SEO-GROWTH-MBTI-03B": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-03b-search-channel",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-03A"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "96be1e8f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1584",
       "checks": {
         "local": {
           "focused_search_channel_canary_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti03bSearchChannelCanaryWavePlan --no-ansi (8 tests, 105 assertions)",
@@ -14706,6 +14706,11 @@
           "at": "2026-05-22T21:42:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-03B: focused Search Channel canary plan test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
+        },
+        {
+          "at": "2026-05-22T21:43:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1584 for SEO-GROWTH-MBTI-03B and pushed branch codex/seo-growth-mbti-03b-search-channel."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the MBTI Search Channel canary wave planning contract for SEO-GROWTH-MBTI-03B.
- Added a generated JSON artifact and feature tests locking candidate URLs, deferred surfaces, eligibility preconditions, authority boundaries, and safety flags.
- Reconciled SEO-GROWTH-MBTI-03A as merged in the PR train ledger and started the 03B ledger entry.

## Why
- The MBTI growth planning train needs Search Channel eligibility rules before any future human-approved canary can be considered.

## Validation
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntelGrowthMbti03bSearchChannelCanaryWavePlan --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntel --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && vendor/bin/pint --test
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-03b-search-channel-canary-wave-plan.v1.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --cached --check

## Intentionally deferred
- No Search Channel Queue mutation, live submission, environment edit, external API call, production operation, CMS mutation, or fap-web change.
- Future live canary still requires exact human approval and one-URL scope.