### PR TITLE
docs(seo-intel): add MBTI Digital PR wave two plan

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-04-digital-pr-wave2-plan.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-04-digital-pr-wave2-plan.v1.json
@@ -1,0 +1,63 @@
+{
+  "version": "seo-growth-mbti-04-digital-pr-wave2-plan.v1",
+  "task": "SEO-GROWTH-MBTI-04",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "current_state": {
+    "hrzone": "observing_after_first_canary_path_no_automated_follow_up_in_this_pr",
+    "hrec": "draft_status_reference_only_until_future_human_task_confirms_readiness"
+  },
+  "candidate_target_categories": [
+    "hr_and_people_analytics_publications",
+    "workplace_psychology_and_career_education_publications",
+    "research_newsletter_editors",
+    "university_career_or_employability_blogs_with_explicit_submission_paths",
+    "known_founder_or_editorial_relationships"
+  ],
+  "tracking_fields": [
+    "target_name",
+    "target_url",
+    "language",
+    "channel",
+    "sent_at",
+    "human_sender",
+    "response_status",
+    "follow_up_due_at",
+    "follow_up_sent_at",
+    "mention_url",
+    "mention_type",
+    "backlink_url",
+    "referral_source",
+    "referral_sessions",
+    "brand_lift_proxy",
+    "notes"
+  ],
+  "outreach_rules": [
+    "human_only_sends",
+    "no_bulk_outreach",
+    "no_private_email_scraping",
+    "no_paid_backlinks",
+    "no_transactional_backlink_request",
+    "one_follow_up_max_after_5_to_7_days",
+    "pitch_must_preserve_mbti_salary_turnover_claim_boundary"
+  ],
+  "observation_rules": [
+    "digital_pr_mention_is_observation_only",
+    "digital_pr_does_not_create_url_truth",
+    "referral_does_not_prove_backlink",
+    "unlinked_brand_mention_can_be_brand_lift_proxy_only",
+    "backlink_and_referral_fields_remain_observational_and_manually_reviewed"
+  ],
+  "safety_flags": {
+    "emails_sent": false,
+    "dms_sent": false,
+    "contact_info_scraped": false,
+    "links_purchased": false,
+    "transactional_backlink_requested": false,
+    "local_pr_tracking_files_edited": false,
+    "cms_mutated": false,
+    "fap_web_modified": false,
+    "search_channel_mutated": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-05"
+}

--- a/backend/docs/seo/seo-growth-mbti-04-digital-pr-wave2-plan.md
+++ b/backend/docs/seo/seo-growth-mbti-04-digital-pr-wave2-plan.md
@@ -1,0 +1,67 @@
+# MBTI Digital PR Wave 2 Plan
+
+Task: SEO-GROWTH-MBTI-04
+
+Train: SEO-GROWTH-MBTI-PR-TRAIN-01
+
+This is a docs / generated JSON / tests-only planning contract. It does not send emails, does not send DMs, does not scrape contact information, does not buy links, and does not request transactional backlinks.
+
+## Purpose
+
+MBTI Digital PR Wave 2 can proceed only as human-operated outreach with manual observation. Mentions, referrals, and backlinks are observation signals only. They do not create URL Truth, Search Channel approval, or content authority.
+
+## Current State
+
+- HRZone: observing after first canary path; no automated follow-up in this PR.
+- HREC: draft/status remains reference-only unless a future human task confirms readiness.
+
+## Candidate Target Categories
+
+- HR and people analytics publications.
+- Workplace psychology and career education publications.
+- Research newsletter editors.
+- University career or employability blogs where submission is explicitly allowed.
+- Founder or editorial relationships already known to the team.
+
+## Tracking Fields
+
+Every future manual tracking row must include:
+
+- `target_name`
+- `target_url`
+- `language`
+- `channel`
+- `sent_at`
+- `human_sender`
+- `response_status`
+- `follow_up_due_at`
+- `follow_up_sent_at`
+- `mention_url`
+- `mention_type`
+- `backlink_url`
+- `referral_source`
+- `referral_sessions`
+- `brand_lift_proxy`
+- `notes`
+
+## Outreach Rules
+
+- Human-only sends.
+- No bulk outreach.
+- No private email scraping.
+- No paid backlinks.
+- No transactional backlink request.
+- One follow-up maximum after 5-7 days.
+- Pitch copy must preserve the MBTI salary/turnover claim boundary.
+
+## Observation Rules
+
+- Digital PR mention is observation only.
+- Digital PR does not create URL Truth.
+- Referral does not prove backlink.
+- Unlinked brand mention can be recorded as brand-lift proxy only.
+- Backlink and referral fields must remain observational and manually reviewed.
+
+## Next Task
+
+SEO-GROWTH-MBTI-05

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti04DigitalPrWave2PlanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti04DigitalPrWave2PlanTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti04DigitalPrWave2PlanTest extends TestCase
+{
+    #[Test]
+    public function digital_pr_wave_two_plan_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-04-digital-pr-wave2-plan.md'));
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-04-digital-pr-wave2-plan.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-04', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-05', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function hrzone_hrec_and_target_categories_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertArrayHasKey('hrzone', $artifact['current_state'] ?? []);
+        $this->assertArrayHasKey('hrec', $artifact['current_state'] ?? []);
+
+        foreach (['hr_and_people_analytics_publications', 'workplace_psychology_and_career_education_publications', 'research_newsletter_editors'] as $category) {
+            $this->assertContains($category, $artifact['candidate_target_categories'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function required_tracking_fields_are_present(): void
+    {
+        foreach (['target_name', 'target_url', 'language', 'channel', 'sent_at', 'human_sender', 'response_status', 'follow_up_due_at', 'follow_up_sent_at', 'mention_url', 'mention_type', 'backlink_url', 'referral_source', 'referral_sessions', 'brand_lift_proxy', 'notes'] as $field) {
+            $this->assertContains($field, $this->artifact()['tracking_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function outreach_rules_prevent_bulk_paid_or_scraped_outreach(): void
+    {
+        foreach (['human_only_sends', 'no_bulk_outreach', 'no_private_email_scraping', 'no_paid_backlinks', 'no_transactional_backlink_request', 'one_follow_up_max_after_5_to_7_days', 'pitch_must_preserve_mbti_salary_turnover_claim_boundary'] as $rule) {
+            $this->assertContains($rule, $this->artifact()['outreach_rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function observation_rules_do_not_create_truth(): void
+    {
+        foreach (['digital_pr_mention_is_observation_only', 'digital_pr_does_not_create_url_truth', 'referral_does_not_prove_backlink', 'unlinked_brand_mention_can_be_brand_lift_proxy_only'] as $rule) {
+            $this->assertContains($rule, $this->artifact()['observation_rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_prevent_sends_scraping_link_buying_and_mutations(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_sends_no_scraping_no_backlink_requests_and_next_task(): void
+    {
+        $combined = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-04-digital-pr-wave2-plan.md')).'
+'.(string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-04-digital-pr-wave2-plan.v1.json')));
+
+        foreach (['does not send emails', 'does not send dms', 'does not scrape contact information', 'does not buy links', 'does not request transactional backlinks', 'seo-growth-mbti-05'] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-04-digital-pr-wave2-plan.v1.json');
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T21:43:00+08:00",
+  "updated_at": "2026-05-22T21:52:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14662,11 +14662,11 @@
     "SEO-GROWTH-MBTI-03B": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-03b-search-channel",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-03A"
       ],
-      "commit_sha": "96be1e8f",
+      "commit_sha": "431defa1d3d3b9e55eb05455bc5ab89cb26a1832",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1584",
       "checks": {
         "local": {
@@ -14680,11 +14680,16 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1584": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as 431defa1d3d3b9e55eb05455bc5ab89cb26a1832"
+        },
+        "post_merge": {
+          "focused_search_channel_canary_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti03bSearchChannelCanaryWavePlan --no-ansi (8 tests, 105 assertions)"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T13:47:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -14711,20 +14716,35 @@
           "at": "2026-05-22T21:43:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1584 for SEO-GROWTH-MBTI-03B and pushed branch codex/seo-growth-mbti-03b-search-channel."
+        },
+        {
+          "at": "2026-05-22T21:47:00+08:00",
+          "status": "merged",
+          "summary": "PR #1584 merged via squash at 431defa1d3d3b9e55eb05455bc5ab89cb26a1832. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused Search Channel canary plan test passed. Local cleanup script is unavailable in this clone."
         }
       ]
     },
     "SEO-GROWTH-MBTI-04": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-04-digital-pr",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "SEO-GROWTH-MBTI-03B"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "local": {},
+        "local": {
+          "focused_digital_pr_wave2_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti04DigitalPrWave2Plan --no-ansi (7 tests, 113 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (552 tests, 8703 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3494 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-04-digital-pr-wave2-plan.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
         "github": {}
       },
       "failure_reason": null,
@@ -14741,6 +14761,16 @@
           "at": "2026-05-22T21:00:00+08:00",
           "status": "pending",
           "summary": "Registered SEO-GROWTH-MBTI-04 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T21:48:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-04 on codex/seo-growth-mbti-04-digital-pr from latest main. Scope is MBTI Digital PR Wave 2 plan docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T21:52:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-04: focused Digital PR Wave 2 plan test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T21:52:00+08:00",
+  "updated_at": "2026-05-22T21:53:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14727,12 +14727,12 @@
     "SEO-GROWTH-MBTI-04": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-04-digital-pr",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-03B"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "e4db284e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1585",
       "checks": {
         "local": {
           "focused_digital_pr_wave2_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti04DigitalPrWave2Plan --no-ansi (7 tests, 113 assertions)",
@@ -14771,6 +14771,11 @@
           "at": "2026-05-22T21:52:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-04: focused Digital PR Wave 2 plan test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
+        },
+        {
+          "at": "2026-05-22T21:53:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1585 for SEO-GROWTH-MBTI-04 and pushed branch codex/seo-growth-mbti-04-digital-pr."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the MBTI Digital PR Wave 2 planning contract for SEO-GROWTH-MBTI-04.
- Added generated JSON and feature tests locking HRZone/HREC state, target categories, tracking fields, outreach rules, observation-only rules, and safety flags.
- Reconciled SEO-GROWTH-MBTI-03B as merged in the train ledger and started the 04 entry.

## Why
- The MBTI growth planning train needs a manual, observation-only Digital PR plan before any future human-approved outreach task.

## Validation
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntelGrowthMbti04DigitalPrWave2Plan --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntel --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && vendor/bin/pint --test
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-04-digital-pr-wave2-plan.v1.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --cached --check

## Intentionally deferred
- No emails, DMs, scraping, paid links, transactional backlink requests, local PR tracking edits, CMS mutations, fap-web changes, or Search Channel mutations.
- Any future outreach remains human-only with one follow-up maximum after 5-7 days.