### PR TITLE
docs(seo-intel): add MBTI human-only funnel review contract

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1.json
@@ -1,0 +1,82 @@
+{
+  "version": "seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1",
+  "task": "SEO-GROWTH-MBTI-05",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "frontend_observation_events": [
+    "landing_view",
+    "test_cta_click",
+    "test_start_click",
+    "report_preview_view",
+    "unlock_click",
+    "checkout_button_click",
+    "email_form_view"
+  ],
+  "backend_truth_events": [
+    "attempt_created",
+    "attempt_submitted",
+    "result_generated",
+    "email_captured",
+    "order_created",
+    "payment_success",
+    "benefit_granted",
+    "report_access_granted",
+    "pdf_generated"
+  ],
+  "rules": [
+    "conversion_formulas_use_human_only_traffic",
+    "known_bot_suspected_bot_and_crawler_excluded",
+    "internal_and_qa_traffic_excluded_where_identifiable",
+    "crawler_traffic_only_enters_crawler_aggregate_observation",
+    "backend_payment_success_is_revenue_truth",
+    "backend_report_access_granted_is_access_truth",
+    "frontend_unlock_click_is_observation_only",
+    "email_is_pii_and_must_not_enter_public_html_search_analytics_url_or_digital_pr",
+    "revenue_review_must_not_query_business_db_in_this_pr"
+  ],
+  "funnel_metrics": [
+    "human_landing_views",
+    "human_test_starts",
+    "human_submitted_attempts",
+    "human_generated_results",
+    "human_report_previews",
+    "human_unlock_clicks_observation_only",
+    "human_orders_created",
+    "human_payment_successes",
+    "human_benefits_granted",
+    "human_report_access_grants",
+    "human_pdf_generations"
+  ],
+  "dedupe_concepts": [
+    "attempt_id",
+    "order_id",
+    "email_hash",
+    "report_id",
+    "session_id",
+    "date_grain"
+  ],
+  "source_of_truth_table_families_contract_only": [
+    "attempts",
+    "results",
+    "email_captures",
+    "orders",
+    "payments",
+    "benefits",
+    "report_access",
+    "pdf_generation"
+  ],
+  "gaps_and_sidecars": [
+    "bot_human_separation_partially_proven",
+    "gsc_ga4_referral_inputs_are_not_revenue_truth",
+    "frontend_events_remain_observation_until_backend_truth_joins_are_explicit"
+  ],
+  "safety_flags": {
+    "production_db_read": false,
+    "business_db_accessed": false,
+    "analytics_mutated": false,
+    "pii_exposed": false,
+    "fap_web_modified": false,
+    "runtime_implemented": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-06"
+}

--- a/backend/docs/seo/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.md
+++ b/backend/docs/seo/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.md
@@ -1,0 +1,79 @@
+# MBTI Human-only Funnel and Revenue Review Contract
+
+Task: SEO-GROWTH-MBTI-05
+
+Train: SEO-GROWTH-MBTI-PR-TRAIN-01
+
+This is a docs / generated JSON / tests-only contract. It does not query production databases, does not touch the business DB, does not mutate analytics, does not expose PII, does not modify fap-web, and does not implement runtime telemetry.
+
+## Purpose
+
+The MBTI growth loop must separate frontend observation from backend truth before any revenue review. Conversion formulas are human-only. Known bots, suspected bots, crawlers, and identifiable internal/QA traffic are excluded from funnel and revenue formulas.
+
+## Frontend Observation Events
+
+- `landing_view`
+- `test_cta_click`
+- `test_start_click`
+- `report_preview_view`
+- `unlock_click`
+- `checkout_button_click`
+- `email_form_view`
+
+Frontend observation is not backend truth.
+
+## Backend Truth Events
+
+- `attempt_created`
+- `attempt_submitted`
+- `result_generated`
+- `email_captured`
+- `order_created`
+- `payment_success`
+- `benefit_granted`
+- `report_access_granted`
+- `pdf_generated`
+
+Backend `payment_success` is revenue truth. Backend `report_access_granted` is report access truth.
+
+## Required Rules
+
+- Conversion formulas use human-only traffic.
+- `known_bot`, `suspected_bot`, and `crawler` traffic are excluded.
+- Internal and QA traffic are excluded where identifiable.
+- Crawler traffic belongs only in crawler aggregate observation.
+- Frontend `unlock_click` is observation only.
+- Email is PII and must not enter public HTML, search surfaces, analytics URLs, or Digital PR artifacts.
+- Revenue review must not query the business DB in this PR.
+
+## Funnel Metrics
+
+- Human landing views.
+- Human test starts.
+- Human submitted attempts.
+- Human generated results.
+- Human report previews.
+- Human unlock clicks as observation only.
+- Human orders created.
+- Human payment successes.
+- Human benefits granted.
+- Human report access grants.
+- Human PDF generations.
+
+## Dedupe Concepts
+
+Contract-level dedupe keys may use attempt, order, email hash, report, session, and date grain. Raw email must not be exposed to public, search, Digital PR, or analytics URL surfaces.
+
+## Source-of-truth Table Families
+
+Future implementation may reference attempt, result, email capture, order, payment, benefit, report access, and PDF generation table families at a contract level only. This PR performs no production query.
+
+## Gaps and Sidecars
+
+- Bot/human separation is partially proven and must be verified before formulas are operational.
+- GSC/GA4/referral inputs are not revenue truth.
+- Frontend events remain observation until backend truth joins are explicit.
+
+## Next Task
+
+SEO-GROWTH-MBTI-06

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContractTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContractTest extends TestCase
+{
+    #[Test]
+    public function funnel_revenue_contract_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.md'));
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-05', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-06', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function frontend_observation_and_backend_truth_events_are_separated(): void
+    {
+        $artifact = $this->artifact();
+        foreach (['landing_view', 'test_cta_click', 'test_start_click', 'report_preview_view', 'unlock_click', 'checkout_button_click', 'email_form_view'] as $event) {
+            $this->assertContains($event, $artifact['frontend_observation_events'] ?? []);
+        }
+        foreach (['attempt_created', 'attempt_submitted', 'result_generated', 'email_captured', 'order_created', 'payment_success', 'benefit_granted', 'report_access_granted', 'pdf_generated'] as $event) {
+            $this->assertContains($event, $artifact['backend_truth_events'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function human_only_bot_exclusion_and_pii_rules_are_locked(): void
+    {
+        foreach (['conversion_formulas_use_human_only_traffic', 'known_bot_suspected_bot_and_crawler_excluded', 'internal_and_qa_traffic_excluded_where_identifiable', 'crawler_traffic_only_enters_crawler_aggregate_observation', 'email_is_pii_and_must_not_enter_public_html_search_analytics_url_or_digital_pr'] as $rule) {
+            $this->assertContains($rule, $this->artifact()['rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function backend_payment_and_report_access_are_truth(): void
+    {
+        foreach (['backend_payment_success_is_revenue_truth', 'backend_report_access_granted_is_access_truth', 'frontend_unlock_click_is_observation_only'] as $rule) {
+            $this->assertContains($rule, $this->artifact()['rules'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function funnel_metrics_dedupe_and_table_families_are_contract_only(): void
+    {
+        $artifact = $this->artifact();
+        foreach (['human_landing_views', 'human_test_starts', 'human_payment_successes', 'human_report_access_grants'] as $metric) {
+            $this->assertContains($metric, $artifact['funnel_metrics'] ?? []);
+        }
+        foreach (['attempt_id', 'order_id', 'email_hash', 'report_id', 'session_id', 'date_grain'] as $key) {
+            $this->assertContains($key, $artifact['dedupe_concepts'] ?? []);
+        }
+        foreach (['attempts', 'orders', 'payments', 'benefits', 'report_access'] as $family) {
+            $this->assertContains($family, $artifact['source_of_truth_table_families_contract_only'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_prevent_production_queries_pii_and_runtime_work(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_business_db_no_pii_no_runtime_and_next_task(): void
+    {
+        $combined = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.md')).'
+'.(string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1.json')));
+
+        foreach (['does not query production databases', 'does not touch the business db', 'does not expose pii', 'does not implement runtime telemetry', 'seo-growth-mbti-06'] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1.json');
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T22:00:00+08:00",
+  "updated_at": "2026-05-22T22:01:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14792,12 +14792,12 @@
     "SEO-GROWTH-MBTI-05": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-05-funnel-revenue",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-04"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "eaeada30",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1586",
       "checks": {
         "local": {
           "focused_human_only_funnel_revenue_review_contract_test": "passed: php artisan test --filter=SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContract --no-ansi (7 tests, 80 assertions)",
@@ -14836,6 +14836,11 @@
           "at": "2026-05-22T22:00:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-05: focused funnel revenue contract test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
+        },
+        {
+          "at": "2026-05-22T22:01:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1586 for SEO-GROWTH-MBTI-05 and pushed branch codex/seo-growth-mbti-05-funnel-revenue."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T21:53:00+08:00",
+  "updated_at": "2026-05-22T22:00:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14727,11 +14727,11 @@
     "SEO-GROWTH-MBTI-04": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-04-digital-pr",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-03B"
       ],
-      "commit_sha": "e4db284e",
+      "commit_sha": "3c7c0c3ec8ea5f9d2ea2a8c8f8959ae57e2b879e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1585",
       "checks": {
         "local": {
@@ -14745,11 +14745,16 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1585": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as 3c7c0c3ec8ea5f9d2ea2a8c8f8959ae57e2b879e"
+        },
+        "post_merge": {
+          "focused_digital_pr_wave2_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti04DigitalPrWave2Plan --no-ansi (7 tests, 113 assertions)"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T13:56:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -14776,20 +14781,35 @@
           "at": "2026-05-22T21:53:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1585 for SEO-GROWTH-MBTI-04 and pushed branch codex/seo-growth-mbti-04-digital-pr."
+        },
+        {
+          "at": "2026-05-22T21:56:00+08:00",
+          "status": "merged",
+          "summary": "PR #1585 merged via squash at 3c7c0c3ec8ea5f9d2ea2a8c8f8959ae57e2b879e. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused Digital PR Wave 2 plan test passed. Local cleanup script is unavailable in this clone."
         }
       ]
     },
     "SEO-GROWTH-MBTI-05": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-05-funnel-revenue",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "SEO-GROWTH-MBTI-04"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "local": {},
+        "local": {
+          "focused_human_only_funnel_revenue_review_contract_test": "passed: php artisan test --filter=SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContract --no-ansi (7 tests, 80 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (559 tests, 8783 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3495 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
         "github": {}
       },
       "failure_reason": null,
@@ -14806,6 +14826,16 @@
           "at": "2026-05-22T21:00:00+08:00",
           "status": "pending",
           "summary": "Registered SEO-GROWTH-MBTI-05 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T21:57:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-05 on codex/seo-growth-mbti-05-funnel-revenue from latest main. Scope is MBTI human-only funnel and revenue review contract docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T22:00:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-05: focused funnel revenue contract test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the MBTI human-only funnel and revenue review contract for SEO-GROWTH-MBTI-05.
- Added generated JSON and feature tests locking frontend observation events, backend truth events, human-only formulas, bot/crawler exclusion, PII boundaries, dedupe concepts, and contract-only table families.
- Reconciled SEO-GROWTH-MBTI-04 as merged in the train ledger and started the 05 entry.

## Why
- The MBTI growth planning train needs revenue and funnel measurement boundaries before any human-approved growth execution can use conversion or revenue signals.

## Validation
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContract --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntel --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && vendor/bin/pint --test
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-05-human-only-funnel-revenue-review-contract.v1.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --cached --check

## Intentionally deferred
- No production DB read, business DB access, analytics mutation, PII exposure, fap-web change, or runtime implementation.
- Future revenue review still requires human-only traffic separation and backend truth joins.