### PR TITLE
docs(seo-intel): add MBTI growth review plan

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1.json
@@ -1,0 +1,73 @@
+{
+  "version": "seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1",
+  "task": "SEO-GROWTH-MBTI-06",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_only",
+  "review_windows": {
+    "T+1": [
+      "public_url_status",
+      "url_truth_candidate_matrix",
+      "claim_lint_pass_fail",
+      "search_channel_dry_run_eligibility",
+      "funnel_event_contract_completeness",
+      "issue_queue_p0_p1_check"
+    ],
+    "T+7": [
+      "ops_seo_deltas",
+      "issue_queue_observations",
+      "crawler_aggregate_trends",
+      "search_channel_pending_approved_dry_run_states",
+      "digital_pr_human_send_status",
+      "early_internal_link_coverage"
+    ],
+    "T+14": [
+      "human_only_test_starts_results_unlocks_orders",
+      "claim_lint_regressions",
+      "internal_link_graph_coverage",
+      "referral_mention_observations",
+      "brand_lift_proxy_if_data_exists"
+    ],
+    "T+28": [
+      "revenue_and_report_access_deltas",
+      "entity_page_family_performance",
+      "repair_backlog_completion",
+      "scale_no_scale_decision",
+      "next_entity_candidate"
+    ]
+  },
+  "decision_outcomes": [
+    "scale",
+    "adjust",
+    "pause",
+    "rollback",
+    "replicate",
+    "insufficient_data"
+  ],
+  "required_safety_checks_before_scale": [
+    "no_claim_unsafe_public_pages",
+    "no_private_flow_leaks",
+    "no_forbidden_authority_url_truth",
+    "no_uncontrolled_search_channel_live_gates",
+    "no_bulk_outreach",
+    "no_pseo"
+  ],
+  "allowed_inputs": [
+    "ops_seo_read_only_view",
+    "url_truth",
+    "issue_queue",
+    "search_channel_queue_state",
+    "crawler_aggregate_observation",
+    "digital_pr_manual_tracking",
+    "human_only_funnel_telemetry",
+    "claim_lint",
+    "internal_link_graph_dry_run"
+  ],
+  "safety_flags": {
+    "live_review_executed": false,
+    "production_query_executed": false,
+    "search_channel_mutated": false,
+    "digital_pr_sent": false,
+    "cms_mutated": false
+  },
+  "next_task": "SEO-GROWTH-MBTI-07"
+}

--- a/backend/docs/seo/seo-growth-mbti-06-7-14-28-day-growth-review-plan.md
+++ b/backend/docs/seo/seo-growth-mbti-06-7-14-28-day-growth-review-plan.md
@@ -1,0 +1,67 @@
+# MBTI 7/14/28-day Growth Review Plan
+
+Task: SEO-GROWTH-MBTI-06
+
+Train: SEO-GROWTH-MBTI-PR-TRAIN-01
+
+This is a docs / generated JSON / tests-only plan. It does not execute a live review, does not query production systems, does not mutate Search Channel, does not send Digital PR, and does not mutate CMS.
+
+## Purpose
+
+The MBTI growth loop needs fixed review windows before any scale decision. Each review window combines only approved observation inputs and backend-authoritative truth inputs, while preserving URL Truth, claim, Search Channel, Digital PR, and funnel boundaries.
+
+## T+1 Review
+
+- Public URL status.
+- URL Truth candidate matrix.
+- Claim lint pass/fail.
+- Search Channel dry-run eligibility.
+- Funnel event contract completeness.
+- Issue Queue P0/P1 check.
+
+## T+7 Review
+
+- `/ops/seo` deltas.
+- Issue Queue observations.
+- Crawler aggregate trends.
+- Search Channel pending, approved, and dry-run states.
+- Digital PR human-send status.
+- Early internal link coverage.
+
+## T+14 Review
+
+- Human-only test starts, results, unlocks, and orders.
+- Claim lint regressions.
+- Internal link graph coverage.
+- Referral and mention observations.
+- Brand lift proxy if data exists.
+
+## T+28 Review
+
+- Revenue and report access deltas.
+- Entity/page family performance.
+- Repair backlog completion.
+- Scale/no-scale decision.
+- Next entity candidate.
+
+## Decision Outcomes
+
+- `scale`
+- `adjust`
+- `pause`
+- `rollback`
+- `replicate`
+- `insufficient_data`
+
+## Required Safety Checks Before Scale
+
+- No claim-unsafe public pages.
+- No private-flow leaks.
+- No forbidden-authority URL Truth.
+- No uncontrolled Search Channel live gates.
+- No bulk outreach.
+- No pSEO.
+
+## Next Task
+
+SEO-GROWTH-MBTI-07

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti06GrowthReviewPlanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti06GrowthReviewPlanTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti06GrowthReviewPlanTest extends TestCase
+{
+    #[Test]
+    public function growth_review_plan_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-06-7-14-28-day-growth-review-plan.md'));
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-06', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_only', $artifact['type'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-07', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function t_plus_one_review_inputs_are_locked(): void
+    {
+        foreach (['public_url_status', 'url_truth_candidate_matrix', 'claim_lint_pass_fail', 'search_channel_dry_run_eligibility', 'funnel_event_contract_completeness', 'issue_queue_p0_p1_check'] as $input) {
+            $this->assertContains($input, $this->artifact()['review_windows']['T+1'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function t_plus_seven_fourteen_and_twenty_eight_windows_are_locked(): void
+    {
+        $windows = $this->artifact()['review_windows'] ?? [];
+
+        foreach (['ops_seo_deltas', 'crawler_aggregate_trends', 'digital_pr_human_send_status'] as $input) {
+            $this->assertContains($input, $windows['T+7'] ?? []);
+        }
+        foreach (['human_only_test_starts_results_unlocks_orders', 'claim_lint_regressions', 'brand_lift_proxy_if_data_exists'] as $input) {
+            $this->assertContains($input, $windows['T+14'] ?? []);
+        }
+        foreach (['revenue_and_report_access_deltas', 'scale_no_scale_decision', 'next_entity_candidate'] as $input) {
+            $this->assertContains($input, $windows['T+28'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function decision_outcomes_and_allowed_inputs_are_explicit(): void
+    {
+        foreach (['scale', 'adjust', 'pause', 'rollback', 'replicate', 'insufficient_data'] as $outcome) {
+            $this->assertContains($outcome, $this->artifact()['decision_outcomes'] ?? []);
+        }
+        foreach (['ops_seo_read_only_view', 'url_truth', 'issue_queue', 'crawler_aggregate_observation', 'human_only_funnel_telemetry', 'claim_lint', 'internal_link_graph_dry_run'] as $input) {
+            $this->assertContains($input, $this->artifact()['allowed_inputs'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function scale_safety_checks_block_unsafe_growth(): void
+    {
+        foreach (['no_claim_unsafe_public_pages', 'no_private_flow_leaks', 'no_forbidden_authority_url_truth', 'no_uncontrolled_search_channel_live_gates', 'no_bulk_outreach', 'no_pseo'] as $check) {
+            $this->assertContains($check, $this->artifact()['required_safety_checks_before_scale'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function safety_flags_prevent_live_review_and_mutation(): void
+    {
+        foreach ($this->artifact()['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_live_review_no_queries_no_mutation_and_next_task(): void
+    {
+        $combined = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-06-7-14-28-day-growth-review-plan.md')).'
+'.(string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1.json')));
+
+        foreach (['does not execute a live review', 'does not query production systems', 'does not mutate search channel', 'does not send digital pr', 'does not mutate cms', 'seo-growth-mbti-07'] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1.json');
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T22:11:00+08:00",
+  "updated_at": "2026-05-22T22:12:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14857,12 +14857,12 @@
     "SEO-GROWTH-MBTI-06": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-06-growth-review",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-05"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "7e7abbd9",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1587",
       "checks": {
         "local": {
           "focused_growth_review_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti06GrowthReviewPlan --no-ansi (7 tests, 107 assertions)",
@@ -14901,6 +14901,11 @@
           "at": "2026-05-22T22:11:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-06: focused growth review plan test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
+        },
+        {
+          "at": "2026-05-22T22:12:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1587 for SEO-GROWTH-MBTI-06 and pushed branch codex/seo-growth-mbti-06-growth-review."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T22:01:00+08:00",
+  "updated_at": "2026-05-22T22:11:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14792,11 +14792,11 @@
     "SEO-GROWTH-MBTI-05": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-05-funnel-revenue",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-04"
       ],
-      "commit_sha": "eaeada30",
+      "commit_sha": "2a3207e840f18a8e6a79ca62d6123ddd113db19e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1586",
       "checks": {
         "local": {
@@ -14810,11 +14810,16 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1586": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as 2a3207e840f18a8e6a79ca62d6123ddd113db19e"
+        },
+        "post_merge": {
+          "focused_human_only_funnel_revenue_review_contract_test": "passed: php artisan test --filter=SeoIntelGrowthMbti05HumanOnlyFunnelRevenueReviewContract --no-ansi (7 tests, 80 assertions)"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T14:06:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -14841,20 +14846,35 @@
           "at": "2026-05-22T22:01:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1586 for SEO-GROWTH-MBTI-05 and pushed branch codex/seo-growth-mbti-05-funnel-revenue."
+        },
+        {
+          "at": "2026-05-22T22:06:00+08:00",
+          "status": "merged",
+          "summary": "PR #1586 merged via squash at 2a3207e840f18a8e6a79ca62d6123ddd113db19e. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused funnel revenue contract test passed. Local cleanup script is unavailable in this clone."
         }
       ]
     },
     "SEO-GROWTH-MBTI-06": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-06-growth-review",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "SEO-GROWTH-MBTI-05"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "local": {},
+        "local": {
+          "focused_growth_review_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti06GrowthReviewPlan --no-ansi (7 tests, 107 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (566 tests, 8890 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3496 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
         "github": {}
       },
       "failure_reason": null,
@@ -14871,6 +14891,16 @@
           "at": "2026-05-22T21:00:00+08:00",
           "status": "pending",
           "summary": "Registered SEO-GROWTH-MBTI-06 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T22:07:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-06 on codex/seo-growth-mbti-06-growth-review from latest main. Scope is MBTI 7/14/28-day growth review plan docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T22:11:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-06: focused growth review plan test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the MBTI 7/14/28-day growth review plan for SEO-GROWTH-MBTI-06.
- Added generated JSON and feature tests locking T+1, T+7, T+14, and T+28 review inputs, decision outcomes, allowed inputs, scale safety checks, and no-mutation safety flags.
- Reconciled SEO-GROWTH-MBTI-05 as merged in the train ledger and started the 06 entry.

## Why
- The MBTI growth planning train needs fixed review windows and scale/no-scale criteria before any human-approved growth execution.

## Validation
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntelGrowthMbti06GrowthReviewPlan --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntel --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && vendor/bin/pint --test
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-06-7-14-28-day-growth-review-plan.v1.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --cached --check

## Intentionally deferred
- No live review execution, production queries, Search Channel mutation, Digital PR sending, or CMS mutation.
- Future scale decision still requires the locked review windows and safety checks.