### PR TITLE
docs(seo-intel): close MBTI growth playbook train

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1.json
@@ -1,0 +1,99 @@
+{
+  "version": "seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1",
+  "task": "SEO-GROWTH-MBTI-07",
+  "train": "SEO-GROWTH-MBTI-PR-TRAIN-01",
+  "type": "docs_generated_test_ledger_only",
+  "completed_train_items": [
+    "SEO-GROWTH-MBTI-00",
+    "SEO-GROWTH-MBTI-01",
+    "SEO-GROWTH-MBTI-02",
+    "SEO-GROWTH-MBTI-03A",
+    "SEO-GROWTH-MBTI-03B",
+    "SEO-GROWTH-MBTI-04",
+    "SEO-GROWTH-MBTI-05",
+    "SEO-GROWTH-MBTI-06"
+  ],
+  "entity_playbook_template": [
+    "entity_key_rules",
+    "url_truth_rules",
+    "content_internal_link_rules",
+    "claim_lint_rules",
+    "search_channel_rules",
+    "digital_pr_rules",
+    "funnel_telemetry_rules",
+    "bot_human_separation",
+    "brand_lift_proxy",
+    "ops_seo_review_cadence",
+    "repair_action_rules",
+    "replication_checklist"
+  ],
+  "scale_no_scale_criteria": [
+    "mbti_review_window_produces_clear_scale_decision",
+    "no_claim_unsafe_public_page",
+    "no_private_flow_leak",
+    "no_forbidden_authority_url_truth",
+    "no_uncontrolled_search_channel_live_gate",
+    "no_bulk_outreach",
+    "no_pseo",
+    "human_only_funnel_and_backend_revenue_truth_separated_from_frontend_observation"
+  ],
+  "replication_order": [
+    "MBTI",
+    "Big Five",
+    "Enneagram",
+    "RIASEC",
+    "Career Guides",
+    "Research Hub",
+    "Topic Clusters",
+    "Multi-language"
+  ],
+  "hard_boundaries": [
+    "do_not_replicate_until_mbti_review_window_produces_clear_scale_decision",
+    "do_not_overclaim_big_five_riasec_career_or_mbti_as_precise_recommender",
+    "do_not_describe_personality_or_career_systems_as_hiring_suitability_salary_prediction_or_career_success_prediction",
+    "do_not_bulk_submit_urls",
+    "do_not_bulk_outreach",
+    "do_not_generate_pseo",
+    "do_not_auto_publish",
+    "do_not_auto_link"
+  ],
+  "sidecar_issues": [
+    "translation_group_uuid_missing_globally",
+    "translation_group_id_transitional_partial",
+    "backend_deploy_public_smoke_local_tls_sidecar",
+    "fap_web_fallback_authority_risk",
+    "gsc_ga4_referral_data_not_fully_implemented_growth_inputs",
+    "bot_human_funnel_separation_partially_proven",
+    "public_runtime_source_ambiguity_for_some_topic_personality_article_rows",
+    "search_channel_live_gates_must_remain_closed_except_exact_approved_live_canary",
+    "claim_linter_has_fixtures_but_no_verified_production_mbti_surface_scan",
+    "ops_seo_operations_write_capable_outside_this_train",
+    "post_merge_cleanup_script_absent_manual_cleanup_used"
+  ],
+  "not_done": [
+    "live_growth_actions",
+    "content_publish",
+    "search_channel_enqueue",
+    "url_submission",
+    "digital_pr_send",
+    "cms_mutation",
+    "url_truth_write",
+    "internal_link_creation",
+    "production_db_query",
+    "pii_exposure",
+    "deployment",
+    "migration_execution",
+    "fap_web_modification"
+  ],
+  "safety_flags": {
+    "runtime_implemented": false,
+    "migration_executed": false,
+    "production_operation_executed": false,
+    "cms_mutated": false,
+    "fap_web_modified": false,
+    "search_channel_mutated": false,
+    "digital_pr_sent": false
+  },
+  "final_decision": "seo_growth_mbti_planning_completed_ready_for_first_human_approved_growth_action",
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01"
+}

--- a/backend/docs/seo/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.md
+++ b/backend/docs/seo/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.md
@@ -1,0 +1,92 @@
+# MBTI Scale Decision and Entity Playbook Closeout
+
+Task: SEO-GROWTH-MBTI-07
+
+Train: SEO-GROWTH-MBTI-PR-TRAIN-01
+
+This is a docs / generated JSON / tests / train-ledger closeout. It does not implement runtime code, does not run migrations, does not perform production operations, does not mutate CMS, does not modify fap-web, does not mutate Search Channel, and does not send Digital PR.
+
+## Train Summary
+
+- SEO-GROWTH-MBTI-00: baseline snapshot and telemetry contract.
+- SEO-GROWTH-MBTI-01: entity map and URL Truth review.
+- SEO-GROWTH-MBTI-02: content and internal link Wave 1 dry-run plan.
+- SEO-GROWTH-MBTI-03A: MBTI claim lint gate.
+- SEO-GROWTH-MBTI-03B: Search Channel canary wave plan.
+- SEO-GROWTH-MBTI-04: Digital PR Wave 2 plan.
+- SEO-GROWTH-MBTI-05: human-only funnel and revenue review contract.
+- SEO-GROWTH-MBTI-06: 7/14/28-day growth review plan.
+
+## Entity Playbook Template
+
+Every future entity growth loop must define:
+
+- Entity key rules.
+- URL Truth rules.
+- Content and internal link rules.
+- Claim lint rules.
+- Search Channel rules.
+- Digital PR rules.
+- Funnel telemetry rules.
+- Bot/human separation.
+- Brand lift proxy.
+- `/ops/seo` review cadence.
+- Repair action rules.
+- Replication checklist.
+
+## Scale / No-scale Criteria
+
+Scale only when the 7/14/28-day review window produces a clear scale decision and all safety checks pass:
+
+- No claim-unsafe public page.
+- No private-flow leak.
+- No forbidden-authority URL Truth.
+- No uncontrolled Search Channel live gate.
+- No bulk outreach.
+- No pSEO.
+- Human-only funnel and backend revenue truth are separated from frontend observation.
+
+## Replication Order
+
+1. MBTI.
+2. Big Five.
+3. Enneagram.
+4. RIASEC.
+5. Career Guides.
+6. Research Hub.
+7. Topic Clusters.
+8. Multi-language.
+
+Do not replicate until the MBTI review window produces a clear scale decision.
+
+## Hard Boundaries
+
+- Do not overclaim Big Five, RIASEC, Career, or MBTI as precise recommender authority.
+- Do not describe personality/career systems as precise hiring suitability, salary prediction, or career-success prediction.
+- Do not bulk submit URLs.
+- Do not bulk outreach.
+- Do not generate pSEO.
+- Do not auto-publish.
+- Do not auto-link.
+
+## Sidecar Issues
+
+- `translation_group_uuid` missing globally.
+- `translation_group_id` remains transitional and partial.
+- Backend deploy public smoke / local TLS remains a sidecar.
+- fap-web fallback authority risk remains outside this train.
+- GSC/GA4/referral data are not fully implemented growth inputs.
+- Bot/human funnel separation remains partially proven.
+- Public runtime source ambiguity exists for some topic/personality/article rows.
+- Search Channel live gates must remain closed except exact approved live canary.
+- Claim linter has fixtures but no verified production MBTI surface scan.
+- `/ops/seo-operations` is write-capable and outside this train.
+- `scripts/post_merge_cleanup.sh` is absent in this clone; manual cleanup verification was used.
+
+## What Was Not Done
+
+This train did not execute live growth actions, publish content, enqueue Search Channel URLs, submit URLs, send Digital PR, mutate CMS, write URL Truth, create internal links, query production databases, expose PII, deploy, run migrations, or modify fap-web.
+
+## Next Execution Task
+
+SEO-GROWTH-MBTI-ACTION-01

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti07ScaleDecisionEntityPlaybookCloseoutTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbti07ScaleDecisionEntityPlaybookCloseoutTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbti07ScaleDecisionEntityPlaybookCloseoutTest extends TestCase
+{
+    #[Test]
+    public function closeout_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.md'));
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-07', $artifact['task'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-PR-TRAIN-01', $artifact['train'] ?? null);
+        $this->assertSame('docs_generated_test_ledger_only', $artifact['type'] ?? null);
+    }
+
+    #[Test]
+    public function completed_train_items_are_recorded(): void
+    {
+        foreach (['SEO-GROWTH-MBTI-00', 'SEO-GROWTH-MBTI-01', 'SEO-GROWTH-MBTI-02', 'SEO-GROWTH-MBTI-03A', 'SEO-GROWTH-MBTI-03B', 'SEO-GROWTH-MBTI-04', 'SEO-GROWTH-MBTI-05', 'SEO-GROWTH-MBTI-06'] as $item) {
+            $this->assertContains($item, $this->artifact()['completed_train_items'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function entity_playbook_template_covers_required_rule_families(): void
+    {
+        foreach (['entity_key_rules', 'url_truth_rules', 'content_internal_link_rules', 'claim_lint_rules', 'search_channel_rules', 'digital_pr_rules', 'funnel_telemetry_rules', 'bot_human_separation', 'brand_lift_proxy', 'ops_seo_review_cadence', 'repair_action_rules', 'replication_checklist'] as $rule) {
+            $this->assertContains($rule, $this->artifact()['entity_playbook_template'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function scale_criteria_and_replication_order_are_locked(): void
+    {
+        foreach (['mbti_review_window_produces_clear_scale_decision', 'no_claim_unsafe_public_page', 'no_private_flow_leak', 'no_forbidden_authority_url_truth', 'no_uncontrolled_search_channel_live_gate', 'no_bulk_outreach', 'no_pseo'] as $criteria) {
+            $this->assertContains($criteria, $this->artifact()['scale_no_scale_criteria'] ?? []);
+        }
+
+        $this->assertSame(['MBTI', 'Big Five', 'Enneagram', 'RIASEC', 'Career Guides', 'Research Hub', 'Topic Clusters', 'Multi-language'], $this->artifact()['replication_order'] ?? []);
+    }
+
+    #[Test]
+    public function hard_boundaries_prevent_overclaiming_bulk_actions_and_automation(): void
+    {
+        foreach (['do_not_replicate_until_mbti_review_window_produces_clear_scale_decision', 'do_not_overclaim_big_five_riasec_career_or_mbti_as_precise_recommender', 'do_not_bulk_submit_urls', 'do_not_bulk_outreach', 'do_not_generate_pseo', 'do_not_auto_publish', 'do_not_auto_link'] as $boundary) {
+            $this->assertContains($boundary, $this->artifact()['hard_boundaries'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function sidecars_not_done_and_safety_flags_are_explicit(): void
+    {
+        $artifact = $this->artifact();
+        foreach (['translation_group_uuid_missing_globally', 'fap_web_fallback_authority_risk', 'bot_human_funnel_separation_partially_proven', 'search_channel_live_gates_must_remain_closed_except_exact_approved_live_canary'] as $sidecar) {
+            $this->assertContains($sidecar, $artifact['sidecar_issues'] ?? []);
+        }
+        foreach (['live_growth_actions', 'content_publish', 'search_channel_enqueue', 'url_submission', 'digital_pr_send', 'cms_mutation', 'url_truth_write', 'internal_link_creation', 'fap_web_modification'] as $notDone) {
+            $this->assertContains($notDone, $artifact['not_done'] ?? []);
+        }
+        foreach ($artifact['safety_flags'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function final_decision_and_next_task_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo_growth_mbti_planning_completed_ready_for_first_human_approved_growth_action', $artifact['final_decision'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-ACTION-01', $artifact['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function docs_lock_no_runtime_or_growth_execution(): void
+    {
+        $combined = strtolower((string) file_get_contents(base_path('docs/seo/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.md')).'
+'.(string) file_get_contents(base_path('docs/seo/generated/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1.json')));
+
+        foreach (['does not implement runtime code', 'does not run migrations', 'does not perform production operations', 'does not mutate cms', 'does not modify fap-web', 'does not mutate search channel', 'does not send digital pr', 'seo-growth-mbti-action-01'] as $required) {
+            $this->assertStringContainsString($required, $combined);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1.json');
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T22:22:00+08:00",
+  "updated_at": "2026-05-22T22:23:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14922,12 +14922,12 @@
     "SEO-GROWTH-MBTI-07": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-07-playbook-closeout",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-06"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "0eecd854",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1588",
       "checks": {
         "local": {
           "focused_scale_decision_entity_playbook_closeout_test": "passed: php artisan test --filter=SeoIntelGrowthMbti07ScaleDecisionEntityPlaybookCloseout --no-ansi (8 tests, 146 assertions)",
@@ -14966,6 +14966,11 @@
           "at": "2026-05-22T22:22:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-07: focused scale decision/entity playbook closeout test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
+        },
+        {
+          "at": "2026-05-22T22:23:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1588 for SEO-GROWTH-MBTI-07 and pushed branch codex/seo-growth-mbti-07-playbook-closeout."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-22T22:12:00+08:00",
+  "updated_at": "2026-05-22T22:22:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -14857,11 +14857,11 @@
     "SEO-GROWTH-MBTI-06": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-06-growth-review",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-05"
       ],
-      "commit_sha": "7e7abbd9",
+      "commit_sha": "4db6c1bac5e7165af22970a7156bd4b75ce507f5",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1587",
       "checks": {
         "local": {
@@ -14875,11 +14875,16 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "pr_1587": "passed: hygiene, Semgrep, verify-mbti-legacy, verify-mbti-v2; mergeStateStatus CLEAN; merged as 4db6c1bac5e7165af22970a7156bd4b75ce507f5. Cancelled superseded Code Scanning run was rerun successfully on latest head."
+        },
+        "post_merge": {
+          "focused_growth_review_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbti06GrowthReviewPlan --no-ansi (7 tests, 107 assertions)"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-22T14:17:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -14906,20 +14911,35 @@
           "at": "2026-05-22T22:12:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1587 for SEO-GROWTH-MBTI-06 and pushed branch codex/seo-growth-mbti-06-growth-review."
+        },
+        {
+          "at": "2026-05-22T22:17:00+08:00",
+          "status": "merged",
+          "summary": "PR #1587 merged via squash at 4db6c1bac5e7165af22970a7156bd4b75ce507f5 after rerunning a cancelled latest-head Code Scanning workflow. Remote branch was deleted, local main synced to origin/main, local task branch absent, and post-merge focused growth review plan test passed. Local cleanup script is unavailable in this clone."
         }
       ]
     },
     "SEO-GROWTH-MBTI-07": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-07-playbook-closeout",
-      "status": "pending",
+      "status": "in_progress",
       "depends_on": [
         "SEO-GROWTH-MBTI-06"
       ],
       "commit_sha": null,
       "pr_url": null,
       "checks": {
-        "local": {},
+        "local": {
+          "focused_scale_decision_entity_playbook_closeout_test": "passed: php artisan test --filter=SeoIntelGrowthMbti07ScaleDecisionEntityPlaybookCloseout --no-ansi (8 tests, 146 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (574 tests, 9036 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3497 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
         "github": {}
       },
       "failure_reason": null,
@@ -14936,6 +14956,16 @@
           "at": "2026-05-22T21:00:00+08:00",
           "status": "pending",
           "summary": "Registered SEO-GROWTH-MBTI-07 for SEO-GROWTH-MBTI-PR-TRAIN-01. Scope is docs/generated/test plus authorized train metadata only; no runtime, CMS, Search Channel, fap-web, Digital PR, production, crawler log, pSEO, claim rewrite, internal link creation, or business DB work."
+        },
+        {
+          "at": "2026-05-22T22:18:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-07 on codex/seo-growth-mbti-07-playbook-closeout from latest main. Scope is MBTI scale decision/entity playbook closeout docs/generated/test plus authorized train metadata only."
+        },
+        {
+          "at": "2026-05-22T22:22:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-07: focused scale decision/entity playbook closeout test, full SeoIntel suite, route list, Pint, JSON/YAML parsing, and diff checks."
         }
       ]
     }


### PR DESCRIPTION
## What changed
- Added the MBTI scale decision and entity playbook closeout for SEO-GROWTH-MBTI-07.
- Added generated JSON and feature tests locking completed train items, entity playbook template, scale/no-scale criteria, replication order, hard boundaries, sidecars, not-done list, safety flags, final decision, and next task.
- Reconciled SEO-GROWTH-MBTI-06 as merged in the train ledger and started the 07 closeout entry.

## Why
- The MBTI growth planning train needs a final closeout artifact and replication playbook before any human-approved growth action begins.

## Validation
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntelGrowthMbti07ScaleDecisionEntityPlaybookCloseout --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntel --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && vendor/bin/pint --test
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-07-scale-decision-entity-playbook-closeout.v1.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --cached --check

## Intentionally deferred
- No runtime implementation, migrations, production operations, CMS mutation, fap-web changes, Search Channel mutation, Digital PR send, URL Truth write, content publish, pSEO, or internal link creation.
- Next execution remains SEO-GROWTH-MBTI-ACTION-01 and requires human-approved growth action scope.