### PR TITLE
fix(deploy): keep static media route target-scoped

### DIFF
--- a/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
+++ b/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
@@ -39,12 +39,13 @@ final class DeployStorageAndDatabaseConfigTest extends TestCase
 
         $this->assertStringContainsString('static_route_action=install', $source);
         $this->assertStringContainsString('skip_existing_static_location', $source);
-        $this->assertStringContainsString('function currentNginxConfigHasStaticLocation(): bool', $source);
-        $this->assertStringContainsString("shell_exec('sudo -n nginx -T 2>/dev/null')", $source);
-        $this->assertStringContainsString('existing /static/ location found in current nginx config', $source);
+        $this->assertStringNotContainsString('function currentNginxConfigHasStaticLocation(): bool', $source);
+        $this->assertStringNotContainsString("shell_exec('sudo -n nginx -T 2>/dev/null')", $source);
+        $this->assertStringNotContainsString('existing /static/ location found in current nginx config', $source);
         $this->assertStringContainsString('function nginxIncludePaths(string $content): array', $source);
         $this->assertStringContainsString('glob($includePath, GLOB_NOSORT)', $source);
         $this->assertStringContainsString('readableIncludeHasStaticLocation(string $content, array $seen = [])', $source);
+        $this->assertStringContainsString('existing /static/ location found in nginx site', $source);
         $this->assertStringContainsString('existing /static/ location found in included nginx file', $source);
         $this->assertStringContainsString('existing /static/ route detected; skipping managed snippet install', $source);
         $this->assertStringContainsString('mktemp /tmp/fap-api-nginx-site-backup.XXXXXX.conf', $source);

--- a/deploy.php
+++ b/deploy.php
@@ -809,17 +809,6 @@ function hasStaticLocation(string $content): bool
     return preg_match('/^\\s*location\\s+(?:\\^~|=|~\\*?|~)?\\s*\\/static(?:\\/|\\s|\\{)/m', $content) === 1;
 }
 
-function currentNginxConfigHasStaticLocation(): bool
-{
-    $currentConfig = shell_exec('sudo -n nginx -T 2>/dev/null');
-
-    if (! is_string($currentConfig) || $currentConfig === '') {
-        return false;
-    }
-
-    return hasStaticLocation($currentConfig);
-}
-
 function nginxIncludePaths(string $content): array
 {
     $includeCount = preg_match_all('/^\\s*include\\s+([^;]+);\\s*$/m', $content, $matches);
@@ -882,12 +871,6 @@ function readableIncludeHasStaticLocation(string $content, array $seen = []): bo
 }
 
 $content = preg_replace('/^\\s*include\\s+\\/etc\\/nginx\\/snippets\\/fap-api-public-static-media-[^;]+;\\R/m', '', $content);
-
-if (currentNginxConfigHasStaticLocation()) {
-    fwrite(STDERR, "existing /static/ location found in current nginx config; skipping managed static snippet\n");
-    echo $content;
-    exit(2);
-}
 
 if (is_string($content) && hasStaticLocation($content)) {
     fwrite(STDERR, "existing /static/ location found in nginx site; skipping managed static snippet\n");


### PR DESCRIPTION
## What changed
- Removed the broad global `nginx -T` `/static/` detection from the deploy static media route installer.
- Kept duplicate-route skip behavior scoped to the target nginx site file and its readable include files.
- Updated the SRE guard test so unrelated global nginx `/static/` routes cannot suppress the managed fap-api static media snippet.

## Why
The staging Deploy Application rerun reached `healthcheck:public-static-media-assets` and failed with a 404 for committed static media. The deploy task had skipped installing the managed `/static/` snippet because it detected a `/static/` location somewhere in the full nginx config, even though that route did not serve the staging fap-api static asset.

## Validation
- `php -l deploy.php`
- `cd backend && php artisan test --filter=DeployStorageAndDatabaseConfigTest --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production deploy.
- No staging deploy rerun from this branch.
- No remote lock mutation or manual unlock.
- No fap-web changes.
