### PR TITLE
fix(deploy): resolve relative nginx includes

### DIFF
--- a/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
+++ b/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
@@ -43,6 +43,7 @@ final class DeployStorageAndDatabaseConfigTest extends TestCase
         $this->assertStringNotContainsString("shell_exec('sudo -n nginx -T 2>/dev/null')", $source);
         $this->assertStringNotContainsString('existing /static/ location found in current nginx config', $source);
         $this->assertStringContainsString('function nginxIncludePaths(string $content): array', $source);
+        $this->assertStringContainsString("\$includePath = '/etc/nginx/'.ltrim(\$includePath, '/');", $source);
         $this->assertStringContainsString('glob($includePath, GLOB_NOSORT)', $source);
         $this->assertStringContainsString('readableIncludeHasStaticLocation(string $content, array $seen = [])', $source);
         $this->assertStringContainsString('existing /static/ location found in nginx site', $source);

--- a/deploy.php
+++ b/deploy.php
@@ -822,8 +822,12 @@ function nginxIncludePaths(string $content): array
     foreach ($matches[1] as $includePath) {
         $includePath = trim((string) $includePath, " \t\n\r\0\x0B'\"");
 
-        if ($includePath === '' || $includePath[0] !== '/') {
+        if ($includePath === '') {
             continue;
+        }
+
+        if ($includePath[0] !== '/') {
+            $includePath = '/etc/nginx/'.ltrim($includePath, '/');
         }
 
         if (strpbrk($includePath, '*?[') !== false) {


### PR DESCRIPTION
## What changed
- Resolve relative nginx include paths against `/etc/nginx/` before checking included files for an existing `/static/` location.
- Keep the existing target-scoped duplicate `/static/` guard and add SRE test coverage for relative include resolution.

## Why
Production deploy for `6c20eb5` reached `deploy:symlink` but failed during `ensure:nginx-public-static-media-route`: production nginx had an existing `/static/` location inside a relative include (`snippets/...`). The deploy script skipped non-absolute include paths, missed that existing route, attempted to install another `/static/` route, and nginx correctly rejected the duplicate.

## Validation
- `php -l deploy.php`
- `cd backend && php artisan test --filter=DeployStorageAndDatabaseConfigTest --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production deploy from this PR.
- No rollback.
- No unlock.
- No fap-web changes.
