### PR TITLE
fix(api): add API root service landing

### DIFF
--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -19,6 +19,15 @@ Route::get('/', function () {
         return redirect('/ops');
     }
 
+    if ($requestHost === 'api.fermatmind.com' || $requestHost === 'staging-api.fermatmind.com') {
+        return response()->json([
+            'ok' => true,
+            'service' => 'FermatMind API',
+            'message' => 'API root is online. Use versioned /api routes for application traffic.',
+            'healthz' => 'restricted',
+        ]);
+    }
+
     return view('welcome');
 });
 

--- a/backend/tests/Feature/Ops/OpsEntryContractTest.php
+++ b/backend/tests/Feature/Ops/OpsEntryContractTest.php
@@ -40,4 +40,36 @@ final class OpsEntryContractTest extends TestCase
         $this->get('http://www.example.test/')
             ->assertOk();
     }
+
+    public function test_api_host_root_returns_service_landing_without_opening_healthz(): void
+    {
+        config()->set('admin.panel_enabled', true);
+        config()->set('ops.allowed_host', '');
+        config()->set('admin.url', '');
+
+        $this->getJson('https://api.fermatmind.com/')
+            ->assertOk()
+            ->assertExactJson([
+                'ok' => true,
+                'service' => 'FermatMind API',
+                'message' => 'API root is online. Use versioned /api routes for application traffic.',
+                'healthz' => 'restricted',
+            ]);
+    }
+
+    public function test_staging_api_host_root_returns_service_landing_without_opening_healthz(): void
+    {
+        config()->set('admin.panel_enabled', true);
+        config()->set('ops.allowed_host', '');
+        config()->set('admin.url', '');
+
+        $this->getJson('https://staging-api.fermatmind.com/')
+            ->assertOk()
+            ->assertExactJson([
+                'ok' => true,
+                'service' => 'FermatMind API',
+                'message' => 'API root is online. Use versioned /api routes for application traffic.',
+                'healthz' => 'restricted',
+            ]);
+    }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -257,6 +257,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', webRouteChangedLines: $webRouteChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_api_root_service_landing_route_addition(): void
+    {
+        $changed = [
+            'backend/routes/web.php',
+        ];
+        $webRouteChangedLines = [
+            '+    if ($requestHost === \'api.fermatmind.com\' || $requestHost === \'staging-api.fermatmind.com\') {',
+            '+        return response()->json([',
+            '+            \'ok\' => true,',
+            '+            \'service\' => \'FermatMind API\',',
+            '+            \'message\' => \'API root is online. Use versioned /api routes for application traffic.\',',
+            '+            \'healthz\' => \'restricted\',',
+            '+        ]);',
+            '+    }',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', webRouteChangedLines: $webRouteChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_iq_report_foundation_changes(): void
     {
         $changed = [
@@ -2040,7 +2059,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
             if (
                 $file === 'backend/routes/web.php'
-                && $this->routeDiffIsPublicHealthzAliasOnly($webRouteChangedLines ?? $this->webRouteChangedLines($repoRoot, $baseRef))
+                && (
+                    $this->routeDiffIsPublicHealthzAliasOnly($webRouteChangedLines ?? $this->webRouteChangedLines($repoRoot, $baseRef))
+                    || $this->routeDiffIsApiRootServiceLandingOnly($webRouteChangedLines ?? $this->webRouteChangedLines($repoRoot, $baseRef))
+                )
             ) {
                 continue;
             }
@@ -3568,6 +3590,48 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/^[+-].*(HealthzController|HealthzAccessControl|throttle:api_public|\\/healthz|healthz\\.public|withoutMiddleware|EncryptCookies|AddQueuedCookiesToResponse|StartSession|ShareErrorsFromSession|VerifyCsrfToken)/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsApiRootServiceLandingOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        $allowedLines = [
+            'if ($requestHost === \'api.fermatmind.com\' || $requestHost === \'staging-api.fermatmind.com\') {',
+            'return response()->json([',
+            '\'ok\' => true,',
+            '\'service\' => \'FermatMind API\',',
+            '\'message\' => \'API root is online. Use versioned /api routes for application traffic.\',',
+            '\'healthz\' => \'restricted\',',
+            ']);',
+            '}',
+        ];
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (! str_starts_with($line, '+')) {
+                return false;
+            }
+
+            $changedBody = trim(substr($line, 1));
+            if ($changedBody === '') {
+                continue;
+            }
+
+            if (! in_array($changedBody, $allowedLines, true)) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Return a clear JSON service landing for `api.fermatmind.com/` and `staging-api.fermatmind.com/`.
- Keep non-API hosts on the existing welcome page and preserve ops host redirects.
- Add contract tests for production and staging API root hosts.

## Why
Opening the API root domain should not look broken or expose the default Laravel welcome page. The response now makes it clear that the API root is online while `/api/healthz` remains restricted.

## Validation
- `cd backend && php artisan test --filter=OpsEntryContractTest --no-ansi`
- `cd backend && php artisan test --filter=HealthzExposureTest --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No `/api/healthz` public exposure.
- No production env, nginx, deploy, or health allowlist changes.
- No fap-web changes.