### PR TITLE
docs(seo-intel): record MBTI Search Channel enqueue

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-search-channel-enqueue.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-search-channel-enqueue.v1.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-search-channel-enqueue.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B",
+  "final_decision": "mbti_action_01b_blocked_no_supported_enqueue_command",
+  "approval_phrase_verified": true,
+  "approval_phrase": "I explicitly approve Search Channel enqueue for the EN MBTI test URL https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types via indexnow now. Do not perform live search submission.",
+  "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "enqueue_attempted": false,
+  "enqueue_committed": false,
+  "queue_item_id": null,
+  "duplicate_detected": false,
+  "live_submission_attempted": false,
+  "external_api_call_attempted": false,
+  "search_submission_attempted": false,
+  "bulk_enqueue_attempted": false,
+  "cms_mutation_attempted": false,
+  "url_truth_write_attempted": false,
+  "sitemap_mutation_attempted": false,
+  "llms_mutation_attempted": false,
+  "candidates_forbidden_or_deferred": [
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "status": "not_enqueued",
+      "reason": "ZH MBTI test URL was outside this one-URL approval and was missing from exact production seo_urls evidence in the readiness scan."
+    },
+    {
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "channel": "indexnow",
+      "status": "not_enqueued",
+      "reason": "Research URLs were forbidden for this task and production URL Truth used www host while public canonical was apex."
+    },
+    {
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "channel": "indexnow",
+      "status": "not_enqueued",
+      "reason": "Research URLs were forbidden for this task and production URL Truth used www host while public canonical was apex."
+    }
+  ],
+  "production_preflight_summary": {
+    "release_path": "/var/www/fap-api/releases/prod-20260523-2ad5fc44",
+    "command_available": true,
+    "help_options": [
+      "--dry-run",
+      "--no-write",
+      "--json",
+      "--channel",
+      "--page-type",
+      "--limit"
+    ],
+    "single_url_selector_supported": false,
+    "dry_run": {
+      "command": "php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=20",
+      "status": "success",
+      "candidate_count": 9,
+      "eligible_count": 9,
+      "blocked_count": 0,
+      "planned_queue_count": 9,
+      "issues": [],
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "search_submission_attempted": false,
+      "crawler_log_read_attempted": false
+    },
+    "exact_candidate": {
+      "planned_match_count": 1,
+      "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "locale": "en",
+      "page_entity_type": "test_detail",
+      "source_authority": "scale_catalog",
+      "indexability_state": "indexable",
+      "claim_boundary_state": "claim_safe",
+      "private_flow": false,
+      "reason_codes": [],
+      "existing_queue_items": 0
+    },
+    "live_gates": {
+      "queue_write_enabled": false,
+      "live_submission_enabled": false,
+      "external_api_calls_enabled": false
+    }
+  },
+  "post_enqueue_verification": {
+    "performed": false,
+    "reason": "No enqueue was attempted because the official command does not support bounded single-URL enqueue.",
+    "queue_item_count_for_url_channel": 0,
+    "no_duplicate_created": true,
+    "no_live_submission_occurred": true,
+    "no_external_call_occurred": true
+  },
+  "sidecars": [
+    "official_search_channel_queue_command_lacks_single_url_selector",
+    "zh_mbti_test_url_truth_missing_from_exact_production_seo_urls_scan",
+    "research_url_truth_www_host_differs_from_public_apex_canonical",
+    "primary_worktree_had_unrelated_dirty_ops_ui_branch_changes_so_task_used_isolated_worktree"
+  ],
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-01｜Search Channel single-URL enqueue command support"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-search-channel-enqueue.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-search-channel-enqueue.md
@@ -1,0 +1,60 @@
+# SEO-GROWTH-MBTI-ACTION-01B Search Channel Enqueue Report
+
+Task: SEO-GROWTH-MBTI-ACTION-01B
+
+Final decision: `mbti_action_01b_blocked_no_supported_enqueue_command`
+
+## Executive Summary
+
+The human approval phrase was present and verified for a bounded Search Channel Queue enqueue of the EN MBTI test URL through the `indexnow` channel.
+
+Production read-only preflight passed: the Search Channel Queue command exists, no-write dry-run returned candidates with no issues, and the exact EN MBTI test URL appeared as an eligible `indexnow` planned item from backend-authoritative URL Truth.
+
+No enqueue was performed because the official `seo-intel:search-channel-queue` command does not support selecting a single canonical URL. Its supported options are limited to `--dry-run`, `--no-write`, `--json`, `--channel`, `--page-type`, and `--limit`. Running it without dry-run would enqueue multiple eligible rows, which violates the one-URL bound for this task.
+
+## Approval Verification
+
+Verified phrase:
+
+`I explicitly approve Search Channel enqueue for the EN MBTI test URL https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types via indexnow now. Do not perform live search submission.`
+
+Approval status: verified.
+
+## Production Preflight
+
+- Current production release path: `/var/www/fap-api/releases/prod-20260523-2ad5fc44`
+- Command availability: `seo-intel:search-channel-queue` exists.
+- No-write dry-run command: `php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=20`
+- Dry-run result: `candidate_count=9`, `eligible_count=9`, `planned_queue_count=9`, `issues=[]`
+- Exact EN MBTI test URL planned match: 1
+- Existing queue items for exact EN MBTI test URL and `indexnow`: 0
+- Live gates: queue write disabled, live submission disabled, external API calls disabled.
+
+## Enqueue Result
+
+No queue row was created.
+
+Reason: the official command has no supported single-URL selector. The task explicitly forbids invented flags, manual DB writes, alternative write paths, bulk enqueue, and live submission.
+
+## Deferred / Forbidden URLs
+
+- ZH MBTI test URL was not enqueued.
+- EN MBTI Research URL was not enqueued.
+- ZH MBTI Research URL was not enqueued.
+- Research URLs remain deferred because production URL Truth currently stores the research rows with `www.fermatmind.com` while public canonical is apex `fermatmind.com`.
+- ZH MBTI test remains deferred because the exact URL was not present in production `seo_urls` during the prior readiness scan.
+
+## Safety Confirmation
+
+- No live IndexNow submission occurred.
+- No external search API call occurred.
+- No GSC, Baidu, Bing, 360, Sogou, or Shenma call occurred.
+- No CMS mutation occurred.
+- No URL Truth write occurred.
+- No sitemap or llms mutation occurred.
+- No crawler log read occurred.
+- No Digital PR send occurred.
+
+## Next Task
+
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-01｜Search Channel single-URL enqueue command support`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bSearchChannelEnqueueTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bSearchChannelEnqueueTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bSearchChannelEnqueueTest extends TestCase
+{
+    #[Test]
+    public function generated_artifact_exists_and_parses(): void
+    {
+        $this->assertFileExists(base_path('docs/seo/seo-growth-mbti-action-01b-search-channel-enqueue.md'));
+
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-action-01b-search-channel-enqueue.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-ACTION-01B', $artifact['task'] ?? null);
+    }
+
+    #[Test]
+    public function approval_url_and_channel_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['approval_phrase_verified'] ?? false);
+        $this->assertSame('https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types', $artifact['url'] ?? null);
+        $this->assertSame('indexnow', $artifact['channel'] ?? null);
+    }
+
+    #[Test]
+    public function safety_flags_confirm_no_bulk_enqueue_submission_or_mutation(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'bulk_enqueue_attempted',
+            'live_submission_attempted',
+            'external_api_call_attempted',
+            'search_submission_attempted',
+            'cms_mutation_attempted',
+            'url_truth_write_attempted',
+            'sitemap_mutation_attempted',
+            'llms_mutation_attempted',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function deferred_candidates_include_zh_mbti_and_research_urls(): void
+    {
+        $urls = array_column($this->artifact()['candidates_forbidden_or_deferred'] ?? [], 'url');
+
+        foreach ([
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $url) {
+            $this->assertContains($url, $urls);
+        }
+    }
+
+    #[Test]
+    public function final_decision_and_next_task_are_present(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertIsString($artifact['final_decision'] ?? null);
+        $this->assertNotSame('', $artifact['final_decision'] ?? '');
+        $this->assertIsString($artifact['next_task'] ?? null);
+        $this->assertNotSame('', $artifact['next_task'] ?? '');
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-search-channel-enqueue.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6136,7 +6136,7 @@
       "repo": "fap-api",
       "branch": "codex/repair-progressive-readiness-occupation-aware-selection-1",
       "title": "fix(api): make progressive readiness selection occupation-aware",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "REPAIR-PROGRESSIVE-READINESS-SELECTION-1"
       ],
@@ -15040,8 +15040,8 @@
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01A"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "01bb56638674c358f8f42343f82a1347ce84d66d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1594",
       "checks": {
         "production_preflight": {
           "release_path": "/var/www/fap-api/releases/prod-20260523-2ad5fc44",
@@ -15081,6 +15081,11 @@
           "at": "2026-05-23T09:34:32+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-ACTION-01B blocked-operation report: focused test, full SeoIntel suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Production enqueue remains blocked because the official command has no single-URL selector."
+        },
+        {
+          "at": "2026-05-23T09:40:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1594 for SEO-GROWTH-MBTI-ACTION-01B with blocked-operation report. No production queue row was created and no live submission occurred."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2135,7 +2135,7 @@
       "branch": "fix/career-2786-full-audit-report-audit13",
       "title": "feat(api): add career 2786 full audit artifact report",
       "name": "Career 2786 Full Audit Artifact Report",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "AUDIT-12"
       ],
@@ -9992,7 +9992,7 @@
       "depends_on": [
         "SEO-DASH-PROD-00"
       ],
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "train_scope": "production_seo_intel_db_user_migration_runbook",
       "risk_level": "low_docs_contract_no_execution",
       "title": "docs(seo-intel): add production DB migration runbook",
@@ -14981,7 +14981,7 @@
       "depends_on": [
         "SEO-GROWTH-MBTI-07"
       ],
-      "commit_sha": "bb7288ac984e567d0f39fa7e8365b3363203734c",
+      "commit_sha": "2ad5fc44989848896e1aa79abf6d0fd224865385",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1592",
       "checks": {
         "local": {
@@ -14997,9 +14997,9 @@
         "github": {}
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T00:21:01Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -15025,6 +15025,62 @@
           "at": "2026-05-23T08:22:00+08:00",
           "status": "committed",
           "summary": "Committed SEO-GROWTH-MBTI-ACTION-01A preflight package scope at 23e176c9dba4ac718ac0370706b02399f9387bfc."
+        },
+        {
+          "at": "2026-05-23T09:25:47+08:00",
+          "status": "merged",
+          "summary": "Reconciled SEO-GROWTH-MBTI-ACTION-01A ledger: GitHub PR #1592 is merged and origin/main contains merge commit 2ad5fc44989848896e1aa79abf6d0fd224865385."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-enqueue",
+      "status": "in_progress",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01A"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_preflight": {
+          "release_path": "/var/www/fap-api/releases/prod-20260523-2ad5fc44",
+          "search_channel_queue_help": "passed: official command exists but supports only --dry-run, --no-write, --json, --channel, --page-type, and --limit",
+          "search_channel_queue_dry_run": "passed: candidate_count=9, eligible_count=9, planned_queue_count=9, issues=[]",
+          "exact_candidate_read_only": "passed: exact EN MBTI test URL planned once for indexnow, no existing queue item, live gates closed",
+          "enqueue": "not_attempted: official command lacks bounded single-URL selector"
+        },
+        "local": {
+          "focused_enqueue_report_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bSearchChannelEnqueue --no-ansi (5 tests, 31 assertions)",
+          "seo_intel_suite": "passed: php artisan test --filter=SeoIntel --no-ansi (586 tests, 9112 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3499 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-search-channel-enqueue.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        },
+        "github": {}
+      },
+      "failure_reason": "Blocked before production write because the official Search Channel Queue command does not support bounded single-URL enqueue.",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-FIX-01",
+      "history": [
+        {
+          "at": "2026-05-23T09:25:47+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-ACTION-01B in an isolated worktree because the primary worktree had unrelated dirty ops UI branch changes. Production read-only preflight passed and exact EN MBTI test URL was eligible, but no enqueue was attempted because the official command has no single-URL selector."
+        },
+        {
+          "at": "2026-05-23T09:34:32+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-ACTION-01B blocked-operation report: focused test, full SeoIntel suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. Production enqueue remains blocked because the official command has no single-URL selector."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10400,3 +10400,46 @@ prs:
     production_migration_execution_allowed: false
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX
+
+  - id: SEO-GROWTH-MBTI-ACTION-01B
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01A
+    branch: codex/seo-growth-mbti-action-01b-enqueue
+    base: main
+    title: "docs(seo-intel): record MBTI Search Channel enqueue"
+    name: "Human-approved MBTI Search Channel enqueue"
+    train_scope: seo_growth_mbti_action
+    risk_level: bounded_production_operation_report
+    type: production_operation_report_docs_generated_test
+    scope:
+      - Perform only the human-approved bounded Search Channel Queue enqueue for the EN MBTI test URL and indexnow channel if the official command supports single-URL enqueue.
+      - If the official command does not support bounded single-URL enqueue, do not write production and record the blocked result in docs/generated/test.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-search-channel-enqueue.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-search-channel-enqueue.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bSearchChannelEnqueueTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, URL Truth, seo_urls, seo_url_entities, crawler log readers, collectors, scheduler, Digital PR sends, Outlook drafts, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+      - Submit URLs, call live IndexNow, call GSC/Baidu/Bing/360/Sogou/Shenma, or enqueue any ZH MBTI or Research URL.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bSearchChannelEnqueue --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-search-channel-enqueue.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-01


### PR DESCRIPTION
## What changed
- Added the SEO-GROWTH-MBTI-ACTION-01B blocked-operation report for the human-approved EN MBTI Search Channel enqueue attempt.
- Added generated JSON evidence and a focused contract test locking the exact URL, channel, approval phrase, safety flags, and deferred candidates.
- Registered the 01B manifest/state entry and recorded production preflight evidence.

## Why
Production read-only preflight confirmed the EN MBTI test URL is eligible, but the official `seo-intel:search-channel-queue` command does not support a bounded single-URL enqueue selector. The task forbids invented flags, manual DB writes, bulk enqueue, and live submission, so no queue row was created.

## Validation
- `php artisan test --filter=SeoIntelGrowthMbtiAction01bSearchChannelEnqueue --no-ansi`
- `php artisan test --filter=SeoIntel --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-search-channel-enqueue.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No Search Channel Queue row was created.
- No live IndexNow or external search submission was attempted.
- ZH MBTI and EN/ZH Research URLs were not enqueued.
- Next task: `SEO-GROWTH-MBTI-ACTION-01B-FIX-01｜Search Channel single-URL enqueue command support`.

## Repository rule impact
No content ownership, runtime authority, publish workflow, sitemap/llms generation, or frontend fallback behavior changed. This PR is docs/generated/test plus PR-train metadata only.