### PR TITLE
feat(seo-intel): add single URL Search Channel enqueue support

### DIFF
--- a/backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
+++ b/backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
@@ -13,8 +13,10 @@ final class SeoIntelSearchChannelQueueCommand extends Command
     protected $signature = 'seo-intel:search-channel-queue
         {--dry-run : Plan queue candidates without writing}
         {--no-write : Prevent writes even when the write gate is enabled}
+        {--enqueue : Explicitly request queue row creation through the existing write gate}
         {--json : Output safe machine-readable JSON}
         {--channel= : Restrict planning to one supported channel}
+        {--canonical-url= : Restrict planning to one persisted canonical URL}
         {--page-type= : Restrict planning to one page entity type}
         {--limit=20 : Maximum URL Truth rows to inspect}';
 
@@ -24,47 +26,96 @@ final class SeoIntelSearchChannelQueueCommand extends Command
     {
         $dryRun = (bool) $this->option('dry-run');
         $noWrite = (bool) $this->option('no-write');
+        $enqueue = (bool) $this->option('enqueue');
         $limit = max(1, min((int) $this->option('limit'), 500));
         $channel = $this->nullableOption('channel');
+        $canonicalUrl = $this->nullableOption('canonical-url');
         $pageType = $this->nullableOption('page-type');
 
-        $plan = $planner->plan($channel, $pageType, $limit);
+        $plan = $planner->plan($channel, $pageType, $limit, $canonicalUrl);
         $plannedItems = $plan['planned_items'];
         $writeGateEnabled = (bool) config('seo_intel.search_channel_queue.write_enabled', false);
-        $writeRequested = ! $dryRun && ! $noWrite;
+        $writeRequested = $enqueue || (! $dryRun && ! $noWrite);
         $writesAttempted = false;
         $writesCommitted = false;
+        $enqueueAttempted = false;
+        $enqueueCommitted = false;
         $writeResult = [
             'batch_ids' => [],
             'written_items' => 0,
         ];
         $status = 'success';
         $issues = [];
+        $duplicateDetected = (bool) ($plan['duplicate_detected'] ?? false);
 
-        if ($writeRequested && ! $writeGateEnabled) {
+        if ($canonicalUrl !== null && $plan['source_unavailable_reason'] === null && (int) $plan['candidate_count'] === 0) {
+            $issues[] = 'canonical_url_not_found';
+        }
+
+        if ($canonicalUrl !== null && $plan['source_unavailable_reason'] === null && (int) $plan['candidate_count'] > 0 && (int) $plan['eligible_count'] === 0) {
+            $issues[] = 'canonical_url_not_eligible';
+        }
+
+        if ($canonicalUrl !== null && $duplicateDetected) {
+            $issues[] = 'existing_active_queue_item';
+        }
+
+        $canonicalFilterBlocked = $canonicalUrl !== null
+            && $plan['source_unavailable_reason'] === null
+            && $issues !== [];
+
+        if ($writeRequested && $canonicalUrl !== null && $channel === null) {
+            $issues[] = 'canonical_url_requires_channel';
+        }
+
+        if ($writeRequested && $channel !== null && ($plan['selected_channels'] ?? []) === []) {
+            $issues[] = 'channel_not_allowed';
+        }
+
+        if ($canonicalFilterBlocked) {
+            $status = 'blocked';
+        }
+
+        if ($writeRequested && $issues !== []) {
             $writesAttempted = true;
+            $enqueueAttempted = true;
+            $status = 'blocked';
+        } elseif ($writeRequested && ! $writeGateEnabled) {
+            $writesAttempted = true;
+            $enqueueAttempted = true;
             $status = 'blocked';
             $issues[] = 'write_gate_disabled';
         } elseif ($writeRequested && $plannedItems !== []) {
             $writesAttempted = true;
+            $enqueueAttempted = true;
             $writeResult = $writer->write($plannedItems);
             $writesCommitted = ((int) $writeResult['written_items']) > 0;
+            $enqueueCommitted = $writesCommitted;
         }
 
         if ($plan['source_unavailable_reason'] !== null) {
             $issues[] = $plan['source_unavailable_reason'];
         }
 
+        $issues = array_values(array_unique($issues));
+
         $payload = [
             'runtime' => 'search_channel_queue',
             'status' => $status,
             'dry_run' => $dryRun,
             'no_write' => $noWrite,
+            'canonical_url_filter' => $canonicalUrl,
             'writes_attempted' => $writesAttempted,
             'writes_committed' => $writesCommitted,
+            'enqueue_attempted' => $enqueueAttempted,
+            'enqueue_committed' => $enqueueCommitted,
+            'duplicate_detected' => $duplicateDetected,
             'external_calls_attempted' => false,
             'search_submission_attempted' => false,
+            'live_submission_attempted' => false,
             'crawler_log_read_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'url_truth_write_attempted' => false,
             'candidate_count' => $plan['candidate_count'],
             'eligible_count' => $plan['eligible_count'],
             'blocked_count' => $plan['blocked_count'],
@@ -72,6 +123,7 @@ final class SeoIntelSearchChannelQueueCommand extends Command
             'channel_breakdown' => $plan['channel_breakdown'],
             'page_type_breakdown' => $plan['page_type_breakdown'],
             'reason_code_breakdown' => $plan['reason_code_breakdown'],
+            'selected_candidate' => $plan['selected_candidate'],
             'target_tables' => config('seo_intel.search_channel_queue.target_tables', []),
             'protected_legacy_tables_not_written' => config('seo_intel.search_channel_queue.protected_legacy_tables', []),
             'write_gate_env' => 'SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED',

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\SeoIntel\SearchChannelQueue;
 
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
 final class SearchChannelQueueIdempotency
 {
     public function key(string $canonicalUrl, string $locale, string $channel): string
@@ -13,5 +16,37 @@ final class SearchChannelQueueIdempotency
             strtolower(trim($locale)),
             strtolower(trim($channel)),
         ]));
+    }
+
+    /**
+     * @return array{id:int, approval_state:string, execution_state:string}|null
+     */
+    public function existingQueueItem(string $canonicalUrl, string $locale, string $channel): ?array
+    {
+        $connectionName = (string) config('seo_intel.connection', 'seo_intel');
+
+        try {
+            if (! Schema::connection($connectionName)->hasTable('seo_search_channel_queue_items')) {
+                return null;
+            }
+
+            $row = DB::connection($connectionName)
+                ->table('seo_search_channel_queue_items')
+                ->where('idempotency_key', $this->key($canonicalUrl, $locale, $channel))
+                ->select(['id', 'approval_state', 'execution_state'])
+                ->first();
+
+            if ($row === null) {
+                return null;
+            }
+
+            return [
+                'id' => (int) $row->id,
+                'approval_state' => (string) $row->approval_state,
+                'execution_state' => (string) $row->execution_state,
+            ];
+        } catch (\Throwable) {
+            return null;
+        }
     }
 }

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php
@@ -18,7 +18,7 @@ final class SearchChannelQueuePlanner
     /**
      * @return array<string, mixed>
      */
-    public function plan(?string $channel = null, ?string $pageType = null, int $limit = 20): array
+    public function plan(?string $channel = null, ?string $pageType = null, int $limit = 20, ?string $canonicalUrl = null): array
     {
         $sourceUnavailableReason = null;
         $rows = [];
@@ -40,6 +40,10 @@ final class SearchChannelQueuePlanner
                     $query->where('page_entity_type', $pageType);
                 }
 
+                if ($canonicalUrl !== null && $canonicalUrl !== '') {
+                    $query->where('canonical_url', $canonicalUrl);
+                }
+
                 $rows = $query->get()
                     ->map(fn (object $row): array => (array) $row)
                     ->all();
@@ -55,6 +59,8 @@ final class SearchChannelQueuePlanner
         $pageTypeBreakdown = [];
         $reasonCodeBreakdown = [];
         $selectedChannels = $this->channels->channels($channel);
+        $matchedCandidates = [];
+        $duplicateDetected = false;
 
         if ($selectedChannels === [] && $channel !== null && $channel !== '') {
             $reasonCodeBreakdown['channel_not_allowed'] = 1;
@@ -64,6 +70,7 @@ final class SearchChannelQueuePlanner
             $result = $this->eligibility->evaluate($row);
             $pageEntityType = (string) ($row['page_entity_type'] ?? 'unknown');
             $pageTypeBreakdown[$pageEntityType] = ($pageTypeBreakdown[$pageEntityType] ?? 0) + 1;
+            $matchedCandidates[] = $this->matchedCandidate($row, $result);
 
             if (! $result->eligible) {
                 $blocked[] = [
@@ -84,6 +91,30 @@ final class SearchChannelQueuePlanner
             $eligibleUrlCount++;
 
             foreach ($selectedChannels as $selectedChannel) {
+                $duplicate = $this->idempotency->existingQueueItem(
+                    canonicalUrl: (string) ($row['canonical_url'] ?? ''),
+                    locale: (string) ($row['locale'] ?? ''),
+                    channel: $selectedChannel,
+                );
+
+                if ($duplicate !== null) {
+                    $duplicateDetected = true;
+                    $blocked[] = [
+                        'canonical_url_hash' => hash('sha256', (string) ($row['canonical_url'] ?? '')),
+                        'locale' => (string) ($row['locale'] ?? ''),
+                        'page_entity_type' => $pageEntityType,
+                        'channel' => $selectedChannel,
+                        'eligibility_state' => 'blocked',
+                        'reason_codes' => ['existing_active_queue_item'],
+                        'duplicate_queue_item_id' => $duplicate['id'],
+                        'duplicate_approval_state' => $duplicate['approval_state'],
+                        'duplicate_execution_state' => $duplicate['execution_state'],
+                    ];
+                    $reasonCodeBreakdown['existing_active_queue_item'] = ($reasonCodeBreakdown['existing_active_queue_item'] ?? 0) + 1;
+
+                    continue;
+                }
+
                 $channelBreakdown[$selectedChannel] = ($channelBreakdown[$selectedChannel] ?? 0) + 1;
                 $planned[] = $this->plannedItem($row, $result, $selectedChannel);
             }
@@ -104,6 +135,9 @@ final class SearchChannelQueuePlanner
             'channel_breakdown' => $channelBreakdown,
             'page_type_breakdown' => $pageTypeBreakdown,
             'reason_code_breakdown' => $reasonCodeBreakdown,
+            'selected_channels' => $selectedChannels,
+            'duplicate_detected' => $duplicateDetected,
+            'selected_candidate' => count($matchedCandidates) === 1 ? $matchedCandidates[0] : null,
         ];
     }
 
@@ -170,5 +204,24 @@ final class SearchChannelQueuePlanner
         }
 
         return str_contains($source, '.') ? explode('.', $source, 2)[0] : $source;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function matchedCandidate(array $row, SearchChannelQueueEligibilityResult $result): array
+    {
+        return [
+            'canonical_url' => (string) ($row['canonical_url'] ?? ''),
+            'locale' => (string) ($row['locale'] ?? ''),
+            'page_entity_type' => (string) ($row['page_entity_type'] ?? ''),
+            'source_authority' => (string) ($row['source_authority'] ?? ''),
+            'indexability_state' => (string) ($row['indexability_state'] ?? ''),
+            'claim_boundary_state' => $result->claimBoundaryState,
+            'private_flow' => (bool) ($row['is_private_flow'] ?? false),
+            'eligibility_state' => $result->eligibilityState,
+            'reason_codes' => $result->reasonCodes,
+        ];
     }
 }

--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-01",
+  "final_decision": "mbti_action_01b_fix_01_merged_ready_for_backend_deploy_readiness",
+  "command": "seo-intel:search-channel-queue",
+  "added_options": [
+    "--canonical-url",
+    "--enqueue"
+  ],
+  "single_url_selector_enabled": true,
+  "persisted_url_truth_required": true,
+  "sitemap_authority_allowed": false,
+  "llms_authority_allowed": false,
+  "frontend_fallback_authority_allowed": false,
+  "live_submission_allowed": false,
+  "external_api_call_allowed": false,
+  "bulk_enqueue_allowed": false,
+  "duplicate_protection_required": true,
+  "write_gate_required": true,
+  "deferred_urls": [
+    "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-R2"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.md
@@ -1,0 +1,96 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-01 Single URL Search Channel Enqueue Command
+
+Task: `SEO-GROWTH-MBTI-ACTION-01B-FIX-01`
+
+## Why this fix was needed
+
+`SEO-GROWTH-MBTI-ACTION-01B` proved that the EN MBTI test URL was already an eligible persisted `seo_urls` candidate for `indexnow`, but the official `seo-intel:search-channel-queue` command could only plan or write broad candidate sets. It had no supported way to target exactly one canonical URL through the official queue path.
+
+This fix adds a bounded single-URL selector so a later human-approved production task can enqueue exactly one persisted URL without manual DB writes, without bulk queue creation, and without any live search submission.
+
+## Added command support
+
+The official command now supports:
+
+- `--canonical-url=<absolute canonical URL>`
+- `--enqueue`
+
+Example safe dry-run:
+
+```bash
+php artisan seo-intel:search-channel-queue \
+  --dry-run \
+  --no-write \
+  --json \
+  --channel=indexnow \
+  --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types
+```
+
+Example later bounded enqueue path after deploy and human approval:
+
+```bash
+php artisan seo-intel:search-channel-queue \
+  --enqueue \
+  --json \
+  --channel=indexnow \
+  --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types
+```
+
+## Authority boundary
+
+The single-URL selector is backed only by persisted `seo_intel.seo_urls`.
+
+Required authority:
+
+- persisted URL Truth row in `seo_urls`
+- approved `source_authority`
+- supported `page_entity_type`
+- public, canonical, indexable, non-private, non-draft, non-noindex, claim-safe state
+
+Forbidden authority sources:
+
+- sitemap
+- `llms.txt`
+- frontend fallback
+- crawler logs
+- search engine responses
+- Digital PR mentions
+- local copies
+
+If the exact canonical URL is absent from persisted `seo_urls`, the command fails closed.
+
+## Safety behavior
+
+- No live submission is added or changed.
+- No external API call is added or changed.
+- No URL Truth writer is added or changed.
+- No sitemap or `llms.txt` behavior is changed.
+- No `fap-web` behavior is changed.
+- No bulk enqueue is allowed through the single-URL path when `--canonical-url` is used for a write without an explicit channel.
+- Existing queue idempotency remains required.
+- Existing active queue item protection remains required.
+
+## Duplicate and idempotency behavior
+
+When `--canonical-url` and `--channel` resolve to an existing queue item idempotency key:
+
+- the command reports duplicate detection
+- no second queue item is created
+- no manual DB write path is used
+- no live submission is attempted
+
+## Deferred URLs
+
+The following remain deferred and are not changed by this PR:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+ZH MBTI remains deferred because it is still missing from the exact production `seo_urls` evidence. Research URLs remain deferred because prior production readiness found URL Truth host mismatch versus public apex canonical.
+
+## Next task
+
+After backend deploy readiness and deploy of this command support:
+
+`SEO-GROWTH-MBTI-ACTION-01B-R2`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+            'seo_intel.search_channel_queue.write_enabled' => false,
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function command_signature_exposes_canonical_url_and_enqueue(): void
+    {
+        $command = app(\App\Console\Commands\SeoIntelSearchChannelQueueCommand::class);
+
+        $synopsis = $command->getDefinition()->getSynopsis();
+
+        $this->assertStringContainsString('--canonical-url [CANONICAL-URL]', $synopsis);
+        $this->assertStringContainsString('--enqueue', $synopsis);
+    }
+
+    #[Test]
+    public function dry_run_with_eligible_persisted_url_returns_exactly_one_selected_candidate(): void
+    {
+        $url = 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types';
+        $this->seedSeoUrl([
+            'canonical_url' => $url,
+            'page_entity_type' => 'test_detail',
+            'entity_id_or_slug' => 'mbti-personality-test-16-personality-types',
+            'source_authority' => 'scale_catalog',
+            'metadata_json' => ['claim_safe' => true, 'source_table' => 'backend_authority_canary_contract'],
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--channel' => 'indexnow',
+            '--canonical-url' => $url,
+            '--limit' => 20,
+        ]);
+
+        $this->assertSame('success', $output['status'] ?? null);
+        $this->assertSame($url, $output['canonical_url_filter'] ?? null);
+        $this->assertSame(1, $output['candidate_count'] ?? null);
+        $this->assertSame(1, $output['eligible_count'] ?? null);
+        $this->assertSame(1, $output['planned_queue_count'] ?? null);
+        $this->assertSame($url, data_get($output, 'selected_candidate.canonical_url'));
+        $this->assertSame('eligible', data_get($output, 'selected_candidate.eligibility_state'));
+        $this->assertFalse((bool) ($output['duplicate_detected'] ?? true));
+        $this->assertFalse((bool) ($output['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['external_calls_attempted'] ?? true));
+    }
+
+    #[Test]
+    public function dry_run_with_absent_url_returns_zero_candidates_and_safe_issue(): void
+    {
+        $exitCode = Artisan::call('seo-intel:search-channel-queue', [
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--channel' => 'indexnow',
+            '--canonical-url' => 'https://fermatmind.com/en/tests/missing-mbti-url',
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertSame(0, $output['candidate_count'] ?? null);
+        $this->assertContains('canonical_url_not_found', $output['issues'] ?? []);
+    }
+
+    #[Test]
+    public function dry_run_with_forbidden_source_authority_does_not_mark_ready(): void
+    {
+        $url = 'https://fermatmind.com/en/tests/frontend-fallback';
+        $this->seedSeoUrl([
+            'canonical_url' => $url,
+            'page_entity_type' => 'test_detail',
+            'entity_id_or_slug' => 'frontend-fallback',
+            'source_authority' => 'frontend_fallback',
+            'metadata_json' => ['claim_safe' => true, 'frontend_fallback' => true],
+        ]);
+
+        $exitCode = Artisan::call('seo-intel:search-channel-queue', [
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--channel' => 'indexnow',
+            '--canonical-url' => $url,
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertSame(0, $output['planned_queue_count'] ?? null);
+        $this->assertContains('canonical_url_not_eligible', $output['issues'] ?? []);
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.source_authority_forbidden'));
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.frontend_fallback_source'));
+    }
+
+    #[Test]
+    public function dry_run_with_private_or_noindex_candidate_does_not_mark_ready(): void
+    {
+        $url = 'https://fermatmind.com/en/tests/private-mbti';
+        $this->seedSeoUrl([
+            'canonical_url' => $url,
+            'page_entity_type' => 'test_detail',
+            'entity_id_or_slug' => 'private-mbti',
+            'source_authority' => 'scale_catalog',
+            'indexability_state' => 'noindex',
+            'is_private_flow' => true,
+            'metadata_json' => ['claim_safe' => true, 'private_flow' => true, 'noindex' => true],
+        ]);
+
+        $exitCode = Artisan::call('seo-intel:search-channel-queue', [
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--channel' => 'indexnow',
+            '--canonical-url' => $url,
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertContains('canonical_url_not_eligible', $output['issues'] ?? []);
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.private_flow'));
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.noindex'));
+    }
+
+    #[Test]
+    public function dry_run_with_canonical_url_uses_persisted_rows_only(): void
+    {
+        $output = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--channel' => 'indexnow',
+            '--canonical-url' => 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+        ], expectSuccess: false);
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertSame(0, $output['candidate_count'] ?? null);
+        $this->assertContains('canonical_url_not_found', $output['issues'] ?? []);
+        $this->assertFalse((bool) ($output['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['live_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['url_truth_write_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['cms_mutation_attempted'] ?? true));
+    }
+
+    #[Test]
+    public function enqueue_path_is_blocked_when_write_gate_disabled(): void
+    {
+        $url = 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types';
+        $this->seedSeoUrl([
+            'canonical_url' => $url,
+            'page_entity_type' => 'test_detail',
+            'entity_id_or_slug' => 'mbti-personality-test-16-personality-types',
+            'source_authority' => 'scale_catalog',
+            'metadata_json' => ['claim_safe' => true, 'source_table' => 'backend_authority_canary_contract'],
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--enqueue' => true,
+            '--json' => true,
+            '--channel' => 'indexnow',
+            '--canonical-url' => $url,
+        ], expectSuccess: false);
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertTrue((bool) ($output['enqueue_attempted'] ?? false));
+        $this->assertFalse((bool) ($output['enqueue_committed'] ?? true));
+        $this->assertContains('write_gate_disabled', $output['issues'] ?? []);
+    }
+
+    #[Test]
+    public function duplicate_active_queue_item_is_not_recreated(): void
+    {
+        config(['seo_intel.search_channel_queue.write_enabled' => true]);
+
+        $url = 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types';
+        $locale = 'en';
+        $channel = 'indexnow';
+        $this->seedSeoUrl([
+            'canonical_url' => $url,
+            'locale' => $locale,
+            'page_entity_type' => 'test_detail',
+            'entity_id_or_slug' => 'mbti-personality-test-16-personality-types',
+            'source_authority' => 'scale_catalog',
+            'metadata_json' => ['claim_safe' => true, 'source_table' => 'backend_authority_canary_contract'],
+        ]);
+
+        DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insert([
+            'batch_id' => null,
+            'canonical_url' => $url,
+            'locale' => $locale,
+            'page_entity_type' => 'test_detail',
+            'entity_type' => 'test_detail',
+            'entity_id' => 'mbti-personality-test-16-personality-types',
+            'source_authority' => 'scale_catalog',
+            'source_table' => 'backend_authority_canary_contract',
+            'channel' => $channel,
+            'eligibility_state' => 'eligible',
+            'approval_state' => 'pending',
+            'execution_state' => 'dry_run_ready',
+            'indexability_state' => 'indexable',
+            'claim_boundary_state' => 'claim_safe',
+            'private_flow' => false,
+            'reason_codes' => json_encode([], JSON_THROW_ON_ERROR),
+            'lastmod' => now()->subMinute(),
+            'content_hash' => null,
+            'url_hash' => hash('sha256', $url),
+            'idempotency_key' => hash('sha256', implode('|', [$url, $locale, $channel])),
+            'approved_by' => null,
+            'approved_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--enqueue' => true,
+            '--json' => true,
+            '--channel' => $channel,
+            '--canonical-url' => $url,
+        ], expectSuccess: false);
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertTrue((bool) ($output['duplicate_detected'] ?? false));
+        $this->assertFalse((bool) ($output['enqueue_committed'] ?? true));
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_batches')->count());
+    }
+
+    #[Test]
+    public function generated_artifact_exists_and_locks_authority_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1.json');
+        $this->assertFileExists($path);
+
+        $artifact = json_decode((string) file_get_contents($path), true);
+
+        $this->assertSame('seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1', $artifact['schema_version'] ?? null);
+        $this->assertTrue((bool) ($artifact['single_url_selector_enabled'] ?? false));
+        $this->assertTrue((bool) ($artifact['persisted_url_truth_required'] ?? false));
+        $this->assertFalse((bool) ($artifact['sitemap_authority_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['llms_authority_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['frontend_fallback_authority_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['live_submission_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['external_api_call_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['bulk_enqueue_allowed'] ?? true));
+        $this->assertTrue((bool) ($artifact['duplicate_protection_required'] ?? false));
+        $this->assertTrue((bool) ($artifact['write_gate_required'] ?? false));
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    private function runQueueCommand(array $arguments, bool $expectSuccess = true): array
+    {
+        $exitCode = Artisan::call('seo-intel:search-channel-queue', $arguments);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertIsArray($output);
+        $this->assertSame($expectSuccess ? 0 : 1, $exitCode, Artisan::output());
+
+        return $output;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedSeoUrl(array $overrides = []): void
+    {
+        $canonicalUrl = (string) ($overrides['canonical_url'] ?? 'https://www.fermatmind.com/en/research/safe-research-report');
+        $metadata = $overrides['metadata_json'] ?? ['claim_safe' => true, 'source_table' => 'research_reports'];
+
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'canonical_url' => $canonicalUrl,
+            'locale' => $overrides['locale'] ?? 'en',
+            'page_entity_type' => $overrides['page_entity_type'] ?? 'research_report',
+            'entity_id_or_slug' => $overrides['entity_id_or_slug'] ?? 'safe-research-report',
+            'cluster' => $overrides['cluster'] ?? 'research',
+            'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
+            'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
+            'lastmod_at' => now()->subHour(),
+            'lastmod_source' => $overrides['lastmod_source'] ?? 'research_reports.updated_at',
+            'is_private_flow' => (bool) ($overrides['is_private_flow'] ?? false),
+            'first_seen_at' => now()->subDay(),
+            'last_seen_at' => now(),
+            'metadata_json' => json_encode($metadata, JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 64)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_batches', function ($table): void {
+            $table->id();
+            $table->string('channel', 64);
+            $table->string('status', 64)->default('draft');
+            $table->unsignedInteger('item_count')->default(0);
+            $table->json('dry_run_report')->nullable();
+            $table->text('approval_note')->nullable();
+            $table->string('created_by', 128)->nullable();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_events', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('queue_item_id')->nullable();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->string('event_type', 96);
+            $table->json('event_payload')->nullable();
+            $table->string('actor_type', 64)->default('system');
+            $table->string('actor_id', 128)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15088,6 +15088,54 @@
           "summary": "Opened PR #1594 for SEO-GROWTH-MBTI-ACTION-01B with blocked-operation report. No production queue row was created and no live submission occurred."
         }
       ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-01": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-01",
+      "status": "in_progress",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "focused_single_url_command_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommand --no-ansi (9 tests, 64 assertions)",
+          "search_channel_queue_suite": "passed: php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi (22 tests, 200 assertions)",
+          "seo_intel_suite": "preexisting_main_blocker: php artisan test --filter=SeoIntel --no-ansi failed on 4 /ops/seo UI assertions that also fail on clean origin/main (SeoIntelOpsSeoCrawlerObservationUiTest, SeoIntelOpsSeoNativeDashboardAccessBoundaryTest x2, SeoIntelOpsSeoNativeDashboardPanelsTest).",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3500 files)",
+          "command_help": "passed: php artisan seo-intel:search-channel-queue --help exposes --canonical-url and --enqueue",
+          "local_no_write_dry_run": "passed_with_source_unavailable: php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types --limit=20 returned status=success issues=[seo_urls_source_unavailable] with no writes or external calls",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "scope_diff": "passed: changed files remain inside the allowed scope for SEO-GROWTH-MBTI-ACTION-01B-FIX-01"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "BACKEND-DEPLOY-READINESS",
+      "history": [
+        {
+          "at": "2026-05-23T10:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-ACTION-01B-FIX-01 on codex/seo-growth-mbti-action-01b-fix-01 from clean main. Scope is limited to Search Channel Queue single-URL command support, focused docs/generated/test, and authorized PR-train metadata only."
+        },
+        {
+          "at": "2026-05-23T10:14:34+08:00",
+          "status": "local_checks_sidecar_blocker_documented",
+          "summary": "Scoped validation passed for the single-URL Search Channel command change, route list, Pint, JSON/YAML parsing, and dry-run help checks. Full SeoIntel suite still has 4 pre-existing /ops/seo UI assertion failures that reproduce on clean origin/main and are outside this PR scope."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -10095,7 +10095,7 @@
       "depends_on": [
         "SEO-DASH-PROD-01B-STAGE1-BLOCKED"
       ],
-      "status": "in_progress",
+      "status": "pr_open",
       "train_scope": "seo_intel_migration_isolation",
       "risk_level": "medium_migration_scope_no_production_execution",
       "title": "fix(seo-intel): isolate seo_intel migrations",
@@ -15096,8 +15096,8 @@
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "4e15fdf38ac25eeada0b78a4f68f9bdaaf1950ac",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1595",
       "checks": {
         "local": {
           "focused_single_url_command_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommand --no-ansi (9 tests, 64 assertions)",
@@ -15134,6 +15134,11 @@
           "at": "2026-05-23T10:14:34+08:00",
           "status": "local_checks_sidecar_blocker_documented",
           "summary": "Scoped validation passed for the single-URL Search Channel command change, route list, Pint, JSON/YAML parsing, and dry-run help checks. Full SeoIntel suite still has 4 pre-existing /ops/seo UI assertion failures that reproduce on clean origin/main and are outside this PR scope."
+        },
+        {
+          "at": "2026-05-23T10:16:24+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1595 for SEO-GROWTH-MBTI-ACTION-01B-FIX-01 with the single-URL queue selector change and documented pre-existing /ops/seo UI sidecars from origin/main."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10443,3 +10443,52 @@ prs:
     production_migration_execution_allowed: false
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-01
+
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-01
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B
+    branch: codex/seo-growth-mbti-action-01b-fix-01
+    base: main
+    title: "feat(seo-intel): add single URL Search Channel enqueue support"
+    name: "Search Channel single-URL enqueue command support"
+    train_scope: seo_growth_mbti_action
+    risk_level: scoped_runtime_command
+    type: implementation_docs_generated_test
+    scope:
+      - Add official `--canonical-url` filtering support to `seo-intel:search-channel-queue` against persisted `seo_urls` rows only.
+      - Preserve existing eligibility gates, write gate, idempotency, and no-live-submission boundary.
+      - Add focused tests and docs for single-URL dry-run and bounded enqueue support without performing any production enqueue.
+    allowed_paths:
+      - backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
+      - backend/app/Services/SeoIntel/SearchChannelQueue/**
+      - backend/config/seo_intel.php
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, migrations, production env/deploy files, CMS content, sitemap/llms generation, live submit executor behavior, URL Truth collectors, crawler log readers, Digital PR files, manual DB scripts, or business DB / Tencent RDS / Node2 DB.
+      - Perform production enqueue, live submission, external search API calls, collector writes, scheduler activation, or CMS mutation.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommand --no-ansi
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && php artisan seo-intel:search-channel-queue --help
+      - cd backend && php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types --limit=20
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: BACKEND-DEPLOY-READINESS


### PR DESCRIPTION
## What changed
- Added `--canonical-url` support to `seo-intel:search-channel-queue`, backed only by persisted `seo_intel.seo_urls` rows.
- Added optional `--enqueue` support that still goes through the existing queue write gate and does not change live submission behavior.
- Added duplicate detection for single-URL queue attempts so an existing queue item for the same canonical URL/channel is fail-closed instead of silently broadening or manually rewriting state.
- Added focused docs, generated JSON, and a feature test covering eligible, absent, forbidden, private/noindex, duplicate, and write-gate-disabled cases.
- Registered the authorized PR-train manifest/state entry for `SEO-GROWTH-MBTI-ACTION-01B-FIX-01`.

## Why
`SEO-GROWTH-MBTI-ACTION-01B` proved that the EN MBTI test URL was already eligible in persisted URL Truth, but the official queue command had no supported single-URL selector. This PR adds the smallest safe official path so a later human-approved enqueue can target exactly one URL without bulk queue creation, manual DB writes, or live submission.

## Validation
- `php artisan test --filter=SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommand --no-ansi`
- `php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi`
- `php artisan test --filter=SeoIntel --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `php artisan seo-intel:search-channel-queue --help`
- `php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types --limit=20`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-01-single-url-enqueue-command.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY`
- `git diff --check`
- `git diff --cached --check`

## Sidecar
- `php artisan test --filter=SeoIntel --no-ansi` still reports 4 pre-existing `/ops/seo` UI assertion failures that reproduce on a clean `origin/main` worktree and are outside this PR scope: `SeoIntelOpsSeoCrawlerObservationUiTest`, `SeoIntelOpsSeoNativeDashboardAccessBoundaryTest` (2 assertions), and `SeoIntelOpsSeoNativeDashboardPanelsTest`.

## Intentionally deferred
- No production enqueue was executed.
- No live IndexNow or other search submission was executed.
- No URL Truth collector, live submission executor, sitemap, `llms.txt`, CMS content, or `fap-web` behavior was changed.
- ZH MBTI and EN/ZH Research URLs remain deferred.
- Next task remains `BACKEND-DEPLOY-READINESS`.

## Repository rule impact
This PR does not change CMS authority, SEO/GEO enumeration sources, sitemap/llms generation, frontend fallback policy, or deploy readiness rules. It extends the backend Search Channel Queue command only, preserving persisted URL Truth as the authority.