### PR TITLE
docs(seo-intel): record MBTI Search Channel single URL enqueue

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-search-channel-enqueue.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-search-channel-enqueue.v1.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-R2",
+  "final_decision": "mbti_action_01b_r2_blocked_write_gate_closed",
+  "approval_phrase_verified": true,
+  "production_release": "search-channel-single-url-20260523-d6a599a8",
+  "deployed_sha": "d6a599a8dad0e0cc8fb6aba0c2ac2a216f7ebddc",
+  "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "dry_run_passed": true,
+  "enqueue_attempted": false,
+  "enqueue_committed": false,
+  "queue_item_id": null,
+  "duplicate_detected": false,
+  "live_submission_attempted": false,
+  "external_api_call_attempted": false,
+  "search_submission_attempted": false,
+  "bulk_enqueue_attempted": false,
+  "cms_mutation_attempted": false,
+  "url_truth_write_attempted": false,
+  "sitemap_mutation_attempted": false,
+  "llms_mutation_attempted": false,
+  "deferred_urls": [
+    "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "post_enqueue_verification": {
+    "queue_item_created": false,
+    "queue_item_count_delta": 0,
+    "duplicate_detected": false,
+    "live_gates_closed": true,
+    "status": "blocked_before_write"
+  },
+  "sidecars": [
+    "write_gate_env=SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED",
+    "write_gate_enabled=false",
+    "api_public_health_endpoints_still_return_404_sidecar"
+  ],
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-r2-search-channel-enqueue.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-r2-search-channel-enqueue.md
@@ -1,0 +1,87 @@
+# SEO-GROWTH-MBTI-ACTION-01B-R2 Search Channel Enqueue
+
+## Purpose
+
+Record the human-approved single-URL Search Channel enqueue attempt for the EN MBTI test URL after the single-URL command support from PR #1595 reached production.
+
+This task remained bounded:
+
+- one canonical URL only
+- one channel only (`indexnow`)
+- no live submission
+- no external search API calls
+- no URL Truth writes
+- no CMS mutation
+- no sitemap or `llms.txt` mutation
+
+## Approved target
+
+- URL: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- channel: `indexnow`
+
+Deferred and forbidden for this task:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+## Production preflight
+
+Production release at execution time:
+
+- release: `search-channel-single-url-20260523-d6a599a8`
+- deployed SHA: `d6a599a8dad0e0cc8fb6aba0c2ac2a216f7ebddc`
+- release contains PR #1595
+
+Command help confirmed official support for:
+
+- `--canonical-url`
+- `--enqueue`
+
+Dry-run/no-write preflight:
+
+```bash
+php artisan seo-intel:search-channel-queue \
+  --dry-run \
+  --no-write \
+  --json \
+  --channel=indexnow \
+  --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types
+```
+
+Observed dry-run result:
+
+- `status=success`
+- `candidate_count=1`
+- `eligible_count=1`
+- `planned_queue_count=1`
+- `duplicate_detected=false`
+- selected candidate exactly matched the EN MBTI canonical URL
+- `page_entity_type=test_detail`
+- `source_authority=scale_catalog`
+- `claim_boundary_state=claim_safe`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `live_submission_attempted=false`
+- `writes_attempted=false`
+
+## Blocker
+
+The official command reported:
+
+- `write_gate_env=SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED`
+- `write_gate_enabled=false`
+
+Because the queue write gate was closed in production, this task did not run the bounded enqueue command. No attempt was made to bypass the gate. No manual DB write, bulk enqueue, or live submit path was used.
+
+## Outcome
+
+Final decision:
+
+- `mbti_action_01b_r2_blocked_write_gate_closed`
+
+No queue row was created during this task.
+
+## Next task
+
+- `SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueueTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueueTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueueTest extends TestCase
+{
+    public function test_generated_artifact_exists_and_locks_blocked_gate_result(): void
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-r2-search-channel-enqueue.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertTrue($payload['approval_phrase_verified']);
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $payload['url']
+        );
+        $this->assertSame('indexnow', $payload['channel']);
+        $this->assertFalse($payload['bulk_enqueue_attempted']);
+        $this->assertFalse($payload['live_submission_attempted']);
+        $this->assertFalse($payload['external_api_call_attempted']);
+        $this->assertFalse($payload['search_submission_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['url_truth_write_attempted']);
+        $this->assertFalse($payload['sitemap_mutation_attempted']);
+        $this->assertFalse($payload['llms_mutation_attempted']);
+        $this->assertContains(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $payload['deferred_urls']
+        );
+        $this->assertContains(
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            $payload['deferred_urls']
+        );
+        $this->assertContains(
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+            $payload['deferred_urls']
+        );
+        $this->assertArrayHasKey('final_decision', $payload);
+        $this->assertArrayHasKey('next_task', $payload);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15145,12 +15145,12 @@
     "SEO-GROWTH-MBTI-ACTION-01B-R2": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-r2-enqueue",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-FIX-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "da965d08d62bb46a61bc24c6a61cf2cde5334fdb",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1596",
       "checks": {
         "production_preflight": {
           "release": "search-channel-single-url-20260523-d6a599a8",
@@ -15191,6 +15191,11 @@
           "at": "2026-05-23T10:50:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-ACTION-01B-R2 blocked-operation report: focused test, Search Channel Queue suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. No production queue write was attempted because the write gate is closed."
+        },
+        {
+          "at": "2026-05-23T10:57:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1596 for SEO-GROWTH-MBTI-ACTION-01B-R2 with the blocked gate report. Production preflight passed for the exact EN MBTI test URL, but no queue write was attempted because SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED remained false."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15141,6 +15141,58 @@
           "summary": "Opened PR #1595 for SEO-GROWTH-MBTI-ACTION-01B-FIX-01 with the single-URL queue selector change and documented pre-existing /ops/seo UI sidecars from origin/main."
         }
       ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-R2": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-r2-enqueue",
+      "status": "in_progress",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-FIX-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_preflight": {
+          "release": "search-channel-single-url-20260523-d6a599a8",
+          "deployed_sha": "d6a599a8dad0e0cc8fb6aba0c2ac2a216f7ebddc",
+          "command_help": "passed: production command help exposes --canonical-url and --enqueue",
+          "dry_run": "passed: exact EN MBTI canonical URL selected once for indexnow with candidate_count=1 eligible_count=1 planned_queue_count=1 duplicate_detected=false and no writes or external calls",
+          "write_gate": "blocked: write_gate_env=SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED write_gate_enabled=false",
+          "enqueue": "not_attempted: production write gate closed so no bounded enqueue command was executed"
+        },
+        "local": {
+          "focused_enqueue_report_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueue --no-ansi (1 test, 17 assertions)",
+          "search_channel_queue_suite": "passed: php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi (22 tests, 200 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3501 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-search-channel-enqueue.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        },
+        "github": {}
+      },
+      "failure_reason": "Blocked before production write because the official production Search Channel Queue write gate is closed.",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT",
+      "history": [
+        {
+          "at": "2026-05-23T10:44:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-ACTION-01B-R2 on codex/seo-growth-mbti-action-01b-r2-enqueue after deploying PR #1595. Production preflight confirmed the exact EN MBTI test URL is still eligible for indexnow but the Search Channel queue write gate remains closed."
+        },
+        {
+          "at": "2026-05-23T10:50:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-ACTION-01B-R2 blocked-operation report: focused test, Search Channel Queue suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks. No production queue write was attempted because the write gate is closed."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10492,3 +10492,46 @@ prs:
     production_migration_execution_allowed: false
     scheduler_activation: false
     next_task: BACKEND-DEPLOY-READINESS
+
+  - id: SEO-GROWTH-MBTI-ACTION-01B-R2
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-FIX-01
+    branch: codex/seo-growth-mbti-action-01b-r2-enqueue
+    base: main
+    title: "docs(seo-intel): record MBTI Search Channel single URL enqueue"
+    name: "Human-approved single-URL Search Channel enqueue"
+    train_scope: seo_growth_mbti_action
+    risk_level: bounded_production_operation_report
+    type: production_operation_report_docs_generated_test
+    scope:
+      - Perform production preflight for the exact EN MBTI canonical URL through the official single-URL Search Channel command support deployed in PR #1595.
+      - If the production write gate remains closed, do not enqueue and record the blocked result in docs/generated/test.
+      - Preserve backend/CMS/catalog authority and forbid frontend fallback, static sitemap, static llms, crawler logs, search responses, Digital PR mentions, or local copies as URL Truth.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-r2-search-channel-enqueue.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-search-channel-enqueue.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueueTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, URL Truth, seo_urls, seo_url_entities, crawler log readers, collectors, scheduler, Digital PR sends, Outlook drafts, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+      - Submit URLs, call live IndexNow, call GSC/Baidu/Bing/360/Sogou/Shenma, or enqueue any ZH MBTI or Research URL.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueue --no-ansi
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-search-channel-enqueue.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT


### PR DESCRIPTION
## What changed
- recorded the production preflight for the exact EN MBTI test URL after PR #1595 was deployed
- documented that the official single-URL command selected one eligible candidate in dry-run
- recorded the blocked result because the production Search Channel queue write gate remained closed
- added focused docs/generated/test coverage and PR-train manifest/state entries for SEO-GROWTH-MBTI-ACTION-01B-R2

## Why
- the single-URL enqueue path needed a bounded production follow-up after backend deploy
- production preflight was required before any queue write
- the task had to fail closed if the write gate was disabled instead of bypassing the existing queue guard

## Validation
- cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueue --no-ansi
- cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-search-channel-enqueue.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- no production enqueue because `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED` remained false
- no live IndexNow submission
- no ZH MBTI enqueue
- no EN/ZH Research enqueue
- next task: `SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT`
