### PR TITLE
docs(seo-intel): add MBTI Search Channel queue gate preflight

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-gate-preflight.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-gate-preflight.v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT",
+  "final_decision": "mbti_action_01b_r2_gate_preflight_ready_for_one_shot_enqueue_approval",
+  "target_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "queue_write_gate_env": "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED",
+  "queue_write_gate_current_state": false,
+  "live_submission_gate_current_state": false,
+  "external_api_gate_current_state": false,
+  "indexnow_live_api_gate_current_state": false,
+  "dry_run_passed": true,
+  "duplicate_detected": false,
+  "allowed_gate_change": [
+    {
+      "env": "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED",
+      "temporary_value": true,
+      "scope": "one enqueue only"
+    }
+  ],
+  "forbidden_gate_changes": [
+    "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED",
+    "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED",
+    "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED"
+  ],
+  "exact_future_approval_phrase": "I explicitly approve opening Search Channel queue write gate for one enqueue of https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types via indexnow, then immediately closing the queue write gate. Do not perform live submission.",
+  "no_gate_change_performed": true,
+  "no_enqueue": true,
+  "no_submission": true,
+  "no_external_api_call": true,
+  "no_cms_mutation": true,
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-R3"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-r2-gate-preflight.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-r2-gate-preflight.md
@@ -1,0 +1,160 @@
+# SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT
+
+## Purpose
+
+Prepare the one-shot Search Channel queue write gate plan for the EN MBTI test URL. This task was read-only: it did not edit production env, open any gate, enqueue a queue item, submit to IndexNow, or write SEO Intel data.
+
+## Target
+
+- URL: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- channel: `indexnow`
+
+## Production read-only checks
+
+Production release:
+
+- release: `search-channel-single-url-20260523-d6a599a8`
+- deployed SHA: `d6a599a8dad0e0cc8fb6aba0c2ac2a216f7ebddc`
+
+Command help confirmed support for:
+
+- `--canonical-url`
+- `--enqueue`
+
+Dry-run command:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-queue \
+  --dry-run \
+  --no-write \
+  --json \
+  --channel=indexnow \
+  --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types
+```
+
+Dry-run result:
+
+- `status=success`
+- `candidate_count=1`
+- `eligible_count=1`
+- `planned_queue_count=1`
+- `duplicate_detected=false`
+- `selected_candidate.canonical_url` matched the target URL
+- `selected_candidate.page_entity_type=test_detail`
+- `selected_candidate.source_authority=scale_catalog`
+- `selected_candidate.claim_boundary_state=claim_safe`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `live_submission_attempted=false`
+
+## Gate state
+
+Current masked env/config state:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED`: missing / config false
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED`: present masked / config false
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED`: present masked / config false
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED`: present masked / config false
+
+Live gates are closed.
+
+## Duplicate check
+
+Read-only duplicate check:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan tinker --execute='echo json_encode([
+    "active_duplicate_count" => DB::connection((string) config("seo_intel.connection", "seo_intel"))
+        ->table("seo_search_channel_queue_items")
+        ->where("canonical_url", "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types")
+        ->where("channel", "indexnow")
+        ->count(),
+], JSON_UNESCAPED_SLASHES);'
+```
+
+Observed result:
+
+- `active_duplicate_count=0`
+
+## One-shot gate plan
+
+The later approved operation should temporarily open only:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=true`
+
+It must keep closed:
+
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false`
+
+Future enqueue command:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-queue \
+  --enqueue \
+  --json \
+  --channel=indexnow \
+  --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types
+```
+
+Future queue item verification command:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan tinker --execute='echo json_encode([
+    "queue_item_count" => DB::connection((string) config("seo_intel.connection", "seo_intel"))
+        ->table("seo_search_channel_queue_items")
+        ->where("canonical_url", "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types")
+        ->where("channel", "indexnow")
+        ->count(),
+], JSON_UNESCAPED_SLASHES);'
+```
+
+Future duplicate verification command:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-queue \
+  --dry-run \
+  --no-write \
+  --json \
+  --channel=indexnow \
+  --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types
+```
+
+After enqueue, this should report `duplicate_detected=true` or equivalent existing-item evidence. It must not create a second queue item.
+
+Future no-live-submission verification command:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan tinker --execute='echo json_encode([
+    "live_submission_gate" => (bool) config("seo_intel.search_channel_queue.live_submission.enabled", false),
+    "external_api_gate" => (bool) config("seo_intel.search_channel_queue.live_submission.external_api_calls_enabled", false),
+    "indexnow_live_api_gate" => (bool) config("seo_intel.indexnow_live_api_enabled", false),
+], JSON_UNESCAPED_SLASHES);'
+```
+
+Gate close step for the later approved task:
+
+1. Set `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false` or remove the temporary env value through the approved production env update mechanism.
+2. Rebuild Laravel config cache for the current backend release.
+3. Re-run config verification and confirm `queue_write_gate=false`.
+
+## Future approval phrase
+
+```text
+I explicitly approve opening Search Channel queue write gate for one enqueue of https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types via indexnow, then immediately closing the queue write gate. Do not perform live submission.
+```
+
+## Decision
+
+`mbti_action_01b_r2_gate_preflight_ready_for_one_shot_enqueue_approval`
+
+## Next task
+
+`SEO-GROWTH-MBTI-ACTION-01B-R3｜One-shot queue gate open, enqueue, gate close`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR2GatePreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR2GatePreflightTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bR2GatePreflightTest extends TestCase
+{
+    public function test_generated_artifact_exists_and_locks_gate_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-r2-gate-preflight.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $payload['target_url']
+        );
+        $this->assertSame('indexnow', $payload['channel']);
+        $this->assertSame('SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED', $payload['queue_write_gate_env']);
+        $this->assertTrue($payload['no_gate_change_performed']);
+        $this->assertTrue($payload['no_enqueue']);
+        $this->assertTrue($payload['no_submission']);
+        $this->assertTrue($payload['no_external_api_call']);
+        $this->assertFalse($payload['live_submission_gate_current_state']);
+        $this->assertFalse($payload['external_api_gate_current_state']);
+        $this->assertFalse($payload['indexnow_live_api_gate_current_state']);
+        $this->assertContains(
+            'SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED',
+            $payload['forbidden_gate_changes']
+        );
+        $this->assertContains(
+            'SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED',
+            $payload['forbidden_gate_changes']
+        );
+        $this->assertContains(
+            'SEO_INTEL_INDEXNOW_LIVE_API_ENABLED',
+            $payload['forbidden_gate_changes']
+        );
+        $this->assertNotEmpty($payload['exact_future_approval_phrase']);
+        $this->assertArrayHasKey('next_task', $payload);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15203,12 +15203,12 @@
     "SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-r2-gate-preflight",
-      "status": "in_progress",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-R2"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "8a6b82b2e9a535792f7f76e39f894c82d61ff0b0",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1599",
       "checks": {
         "production_read_only": {
           "release": "search-channel-single-url-20260523-d6a599a8",
@@ -15249,6 +15249,11 @@
           "at": "2026-05-23T11:13:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT: focused test, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        },
+        {
+          "at": "2026-05-23T11:34:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1599 for SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT. No production env edit, queue gate change, enqueue, live submission, or external API call was performed."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15199,6 +15199,58 @@
           "summary": "Opened PR #1596 for SEO-GROWTH-MBTI-ACTION-01B-R2 with the blocked gate report. Production preflight passed for the exact EN MBTI test URL, but no queue write was attempted because SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED remained false."
         }
       ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-r2-gate-preflight",
+      "status": "in_progress",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-R2"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_read_only": {
+          "release": "search-channel-single-url-20260523-d6a599a8",
+          "deployed_sha": "d6a599a8dad0e0cc8fb6aba0c2ac2a216f7ebddc",
+          "command_help": "passed: production command help exposes --canonical-url and --enqueue",
+          "dry_run": "passed: exact EN MBTI canonical URL selected once for indexnow with candidate_count=1 eligible_count=1 planned_queue_count=1 duplicate_detected=false and no writes or external calls",
+          "masked_env_presence": "passed: queue write gate env missing; live submission, external API, and IndexNow live API gate env entries present but masked",
+          "config_gates": "passed: queue_write_gate=false, live_submission_gate=false, external_api_gate=false, indexnow_live_api_gate=false",
+          "duplicate_check": "passed: active_duplicate_count=0"
+        },
+        "local": {
+          "focused_gate_preflight_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bR2GatePreflight --no-ansi (1 test, 16 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3502 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-gate-preflight.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-R3",
+      "history": [
+        {
+          "at": "2026-05-23T11:07:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT on codex/seo-growth-mbti-action-01b-r2-gate-preflight. Production read-only checks confirmed the exact EN MBTI URL remains eligible, no duplicate queue item exists, the queue write gate is closed, and all live/external submission gates are closed."
+        },
+        {
+          "at": "2026-05-23T11:13:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT: focused test, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10536,6 +10536,48 @@ prs:
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-R2
+    branch: codex/seo-growth-mbti-action-01b-r2-gate-preflight
+    base: main
+    title: "docs(seo-intel): add MBTI Search Channel queue gate preflight"
+    name: "Preflight one-shot Search Channel queue write gate"
+    train_scope: seo_growth_mbti_action
+    risk_level: read_only_production_gate_preflight
+    type: docs_generated_test
+    scope:
+      - Record read-only production gate state for the exact EN MBTI indexnow enqueue target.
+      - Define the one-shot gate plan that temporarily opens only the Search Channel queue write gate while keeping all live submission and external API gates closed.
+      - Preserve no-enqueue, no-submission, no-env-edit, and no-production-write boundaries for this task.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-r2-gate-preflight.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-gate-preflight.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR2GatePreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, production env/deploy files, fap-web, CMS content, URL Truth, seo_urls, seo_url_entities, crawler log readers, collectors, scheduler, Digital PR sends, Outlook drafts, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+      - Open the queue write gate, enqueue Search Channel items, submit URLs, call live IndexNow, call GSC/Baidu/Bing/360/Sogou/Shenma, or modify production env.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bR2GatePreflight --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-gate-preflight.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-R3
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- recorded read-only production gate preflight for the EN MBTI Search Channel enqueue target
- documented current queue/live/external gate states and duplicate status
- added the one-shot gate operation plan and exact future approval phrase
- added focused generated JSON/test coverage and PR-train manifest/state entries

## Why
- SEO-GROWTH-MBTI-ACTION-01B-R2 proved the URL is eligible but blocked because the queue write gate is closed
- the next operation needs a precise gate plan that opens only queue writes and keeps all live submission paths closed

## Validation
- cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bR2GatePreflight --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r2-gate-preflight.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- no production env edit
- no gate open
- no Search Channel enqueue
- no live submission or external search API call
- next task: `SEO-GROWTH-MBTI-ACTION-01B-R3`
