### PR TITLE
docs(seo-intel): record MBTI one-shot Search Channel enqueue

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-r3-one-shot-enqueue.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-r3-one-shot-enqueue.v1.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-R3",
+  "final_decision": "mbti_action_01b_r3_enqueue_completed_ready_for_post_enqueue_review",
+  "approval_phrase_verified": true,
+  "target_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "queue_write_gate_opened": true,
+  "queue_write_gate_closed": true,
+  "enqueue_attempted": true,
+  "enqueue_committed": true,
+  "queue_item_id": 2,
+  "duplicate_detected": false,
+  "live_submission_attempted": false,
+  "external_api_call_attempted": false,
+  "search_submission_attempted": false,
+  "bulk_enqueue_attempted": false,
+  "cms_mutation_attempted": false,
+  "url_truth_write_attempted": false,
+  "sitemap_mutation_attempted": false,
+  "llms_mutation_attempted": false,
+  "deferred_urls": [
+    "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "post_enqueue_verification": {
+    "production_release": "search-channel-single-url-20260523-d6a599a8",
+    "deployed_sha": "d6a599a8dad0e0cc8fb6aba0c2ac2a216f7ebddc",
+    "queue_item_count": 1,
+    "queue_item_id": 2,
+    "batch_id": 2,
+    "approval_state": "pending",
+    "execution_state": "dry_run_ready",
+    "batch_status": "dry_run",
+    "live_submission_gate_closed": true,
+    "external_api_gate_closed": true,
+    "indexnow_live_api_gate_closed": true,
+    "no_live_submission_occurred": true,
+    "no_external_api_call_occurred": true
+  },
+  "sidecars": [
+    {
+      "key": "config_cache_gate_resolution",
+      "status": "observed",
+      "summary": "Gate verification succeeded through cached Laravel config after editing /var/www/fap-api/shared/backend/.env; runtime getenv remained absent, so operational verification should rely on config values."
+    }
+  ],
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-r3-one-shot-enqueue.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-r3-one-shot-enqueue.md
@@ -1,0 +1,163 @@
+# SEO-GROWTH-MBTI-ACTION-01B-R3
+
+## Purpose
+
+Perform one human-approved Search Channel Queue enqueue for the EN MBTI test URL, then immediately close the queue write gate again. This task did not submit the URL to IndexNow, did not call external search APIs, did not modify CMS content, and did not write URL Truth.
+
+## Approval verification
+
+The required approval phrase was present for this task:
+
+```text
+I explicitly approve opening Search Channel queue write gate for one enqueue of https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types via indexnow, then immediately closing the queue write gate. Do not perform live submission.
+```
+
+## Target
+
+- URL: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- channel: `indexnow`
+
+Deferred and forbidden URLs:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+## Pre-action gate state
+
+Production release in use:
+
+- release: `search-channel-single-url-20260523-d6a599a8`
+- deployed SHA evidence source: release name and previous deployed command support validation for PR `#1595`
+
+Before action, production config gates were:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false`
+
+## Dry-run verification
+
+Dry-run command:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-queue \
+  --dry-run \
+  --no-write \
+  --json \
+  --channel=indexnow \
+  --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types
+```
+
+Observed dry-run result:
+
+- `status=success`
+- `candidate_count=1`
+- `eligible_count=1`
+- `planned_queue_count=1`
+- `duplicate_detected=false`
+- `selected_candidate.canonical_url` matched the target URL
+- `selected_candidate.page_entity_type=test_detail`
+- `selected_candidate.source_authority=scale_catalog`
+- `selected_candidate.claim_boundary_state=claim_safe`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `live_submission_attempted=false`
+
+Pre-action duplicate check:
+
+- `active_duplicate_count=0`
+- no existing queue item for the exact URL/channel pair
+
+## Enqueue result
+
+Operational env path resolved to:
+
+- `/var/www/fap-api/shared/backend/.env`
+
+One-shot gate open step:
+
+- temporarily set `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=true`
+- rebuilt Laravel config cache for the current release
+- verified `queue_write_gate=true`
+- kept live submission, external API, and IndexNow live API gates at `false`
+
+Bounded enqueue command:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-queue \
+  --enqueue \
+  --json \
+  --channel=indexnow \
+  --canonical-url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types
+```
+
+Observed enqueue result:
+
+- `status=success`
+- `enqueue_attempted=true`
+- `enqueue_committed=true`
+- `writes_committed=true`
+- `written_items=1`
+- `batch_ids=[2]`
+- `duplicate_detected=false`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `live_submission_attempted=false`
+
+## Gate closure verification
+
+Immediately after enqueue:
+
+- restored `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- rebuilt Laravel config cache for the current release
+
+Post-close gate verification:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false`
+
+## Post-enqueue verification
+
+Queue item verification result:
+
+- `queue_item_count=1`
+- `queue_item_id=2`
+- `batch_id=2`
+- `approval_state=pending`
+- `execution_state=dry_run_ready`
+- `channel=indexnow`
+- `canonical_url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+
+Batch verification result:
+
+- `batch_id=2`
+- `channel=indexnow`
+- `status=dry_run`
+- `item_count=1`
+- `created_by=seo-intel:search-channel-queue`
+
+This task created one Search Channel Queue item only. It did not perform live submission and did not call any external search API.
+
+## Safety boundaries preserved
+
+- ZH MBTI test URL was not enqueued.
+- EN/ZH Research URLs were not enqueued.
+- No live IndexNow submission occurred.
+- No external search API call occurred.
+- No CMS mutation occurred.
+- No URL Truth, `seo_urls`, or `seo_url_entities` write occurred.
+- No sitemap or `llms.txt` mutation occurred.
+
+## Decision
+
+`mbti_action_01b_r3_enqueue_completed_ready_for_post_enqueue_review`
+
+## Next task
+
+`SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR3OneShotEnqueueTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR3OneShotEnqueueTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bR3OneShotEnqueueTest extends TestCase
+{
+    public function test_generated_artifact_exists_and_locks_one_shot_enqueue_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-r3-one-shot-enqueue.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertTrue($payload['approval_phrase_verified']);
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $payload['target_url']
+        );
+        $this->assertSame('indexnow', $payload['channel']);
+        $this->assertTrue($payload['queue_write_gate_opened']);
+        $this->assertTrue($payload['queue_write_gate_closed']);
+        $this->assertFalse($payload['bulk_enqueue_attempted']);
+        $this->assertFalse($payload['live_submission_attempted']);
+        $this->assertFalse($payload['external_api_call_attempted']);
+        $this->assertFalse($payload['search_submission_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['url_truth_write_attempted']);
+        $this->assertFalse($payload['sitemap_mutation_attempted']);
+        $this->assertFalse($payload['llms_mutation_attempted']);
+        $this->assertContains(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $payload['deferred_urls']
+        );
+        $this->assertContains(
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            $payload['deferred_urls']
+        );
+        $this->assertContains(
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+            $payload['deferred_urls']
+        );
+        $this->assertNotEmpty($payload['final_decision']);
+        $this->assertArrayHasKey('next_task', $payload);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15268,12 +15268,12 @@
     "SEO-GROWTH-MBTI-ACTION-01B-R3": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-r3-enqueue",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "b7facfe25a0076fc34045c7fdde670f3e87e0cfe",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1602",
       "checks": {
         "production_operation": {
           "approval_phrase": "passed: exact one-shot queue gate open, enqueue, and gate close approval phrase present in the task prompt",
@@ -15322,6 +15322,11 @@
           "at": "2026-05-23T12:20:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEO-GROWTH-MBTI-ACTION-01B-R3: focused one-shot enqueue test, Search Channel Queue suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        },
+        {
+          "at": "2026-05-23T12:24:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1602 for SEO-GROWTH-MBTI-ACTION-01B-R3 from codex/seo-growth-mbti-action-01b-r3-enqueue after moving the scoped local commit off main and onto the correct task branch before push. The production operation remained bounded to one queue item, the queue write gate was closed again, and no live submission or external API call occurred."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15203,11 +15203,11 @@
     "SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-r2-gate-preflight",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-R2"
       ],
-      "commit_sha": "8a6b82b2e9a535792f7f76e39f894c82d61ff0b0",
+      "commit_sha": "25d3833b53cb6e54b71bac226f1797ead11d1ff9",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1599",
       "checks": {
         "production_read_only": {
@@ -15228,12 +15228,15 @@
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
         },
-        "github": {}
+        "github": {
+          "status": "passed",
+          "pr": "passed: PR #1599 merged after hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS succeeded"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T03:38:43Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -15254,6 +15257,71 @@
           "at": "2026-05-23T11:34:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1599 for SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT. No production env edit, queue gate change, enqueue, live submission, or external API call was performed."
+        },
+        {
+          "at": "2026-05-23T11:38:43+08:00",
+          "status": "merged",
+          "summary": "Merged PR #1599 for SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT with merge commit 25d3833b53cb6e54b71bac226f1797ead11d1ff9. origin/main contains the merge commit, the remote branch was deleted, and local main was synced with focused revalidation passing."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-R3": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-r3-enqueue",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_operation": {
+          "approval_phrase": "passed: exact one-shot queue gate open, enqueue, and gate close approval phrase present in the task prompt",
+          "pre_action_gates": "passed: queue_write_gate=false, live_submission_gate=false, external_api_gate=false, indexnow_live_api_gate=false",
+          "dry_run": "passed: exact EN MBTI canonical URL selected once for indexnow with candidate_count=1 eligible_count=1 planned_queue_count=1 duplicate_detected=false and no writes or external calls",
+          "pre_duplicate_check": "passed: active_duplicate_count=0 and no existing queue item before write",
+          "gate_open": "passed: SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED temporarily enabled through /var/www/fap-api/shared/backend/.env and applied with php artisan config:cache while live and external API gates remained closed",
+          "enqueue": "passed: one queue item written for the exact EN MBTI test URL with batch_id=2 queue_item_id=2 channel=indexnow approval_state=pending execution_state=dry_run_ready",
+          "gate_close": "passed: SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED restored to false and php artisan config:cache rerun immediately after enqueue",
+          "post_enqueue_verification": "passed: queue_item_count=1, batch_status=dry_run, no duplicate active item, no live submission, and no external API call"
+        },
+        "local": {
+          "focused_r3_enqueue_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bR3OneShotEnqueue --no-ansi (1 test, 19 assertions)",
+          "search_channel_queue_suite": "passed: php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi (22 tests, 200 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3503 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r3-one-shot-enqueue.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW",
+      "history": [
+        {
+          "at": "2026-05-23T12:17:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-ACTION-01B-R3 on codex/seo-growth-mbti-action-01b-r3-enqueue from latest main after reconciling that SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT had already merged on GitHub."
+        },
+        {
+          "at": "2026-05-23T12:18:36+08:00",
+          "status": "production_operation_completed",
+          "summary": "Completed the one-shot production operation for SEO-GROWTH-MBTI-ACTION-01B-R3: opened only the Search Channel queue write gate, enqueued the exact EN MBTI test URL via indexnow with queue_item_id=2 and batch_id=2, then immediately closed the gate while all live submission and external API gates remained false."
+        },
+        {
+          "at": "2026-05-23T12:20:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEO-GROWTH-MBTI-ACTION-01B-R3: focused one-shot enqueue test, Search Channel Queue suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10578,6 +10578,49 @@ prs:
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-01B-R3
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-R3
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-R2-GATE-PREFLIGHT
+    branch: codex/seo-growth-mbti-action-01b-r3-enqueue
+    base: main
+    title: "docs(seo-intel): record MBTI one-shot Search Channel enqueue"
+    name: "One-shot Search Channel queue gate open, enqueue, gate close"
+    train_scope: seo_growth_mbti_action
+    risk_level: bounded_production_queue_write
+    type: docs_generated_test
+    scope:
+      - Perform one human-approved Search Channel Queue enqueue for the exact EN MBTI test URL via indexnow using the official single-URL command path.
+      - Temporarily open only the Search Channel queue write gate, then immediately close it again while keeping live submission and external API gates closed.
+      - Record the enqueue result, gate closure verification, and deferred URL boundaries without modifying CMS, URL Truth, sitemap, llms, or fap-web.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-r3-one-shot-enqueue.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-r3-one-shot-enqueue.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bR3OneShotEnqueueTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, deploy files, fap-web, CMS content, URL Truth, seo_urls, seo_url_entities, crawler log readers, collectors, scheduler, Digital PR sends, Outlook drafts, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+      - Enqueue any URL other than the exact EN MBTI test URL, perform live submission, call external search APIs, bulk enqueue, mutate sitemap or llms, or leave the queue write gate open after the one-shot operation.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bR3OneShotEnqueue --no-ansi
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r3-one-shot-enqueue.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- recorded the one-shot EN MBTI Search Channel queue enqueue result
- added the generated JSON artifact and focused test for the bounded production operation
- added the R3 manifest entry and reconciled the R2 gate preflight ledger state to merged

## Why
- preserve a repo-tracked audit record for the approved one-shot queue write
- lock that the operation opened only the queue write gate, created exactly one queue item, and closed the gate again without live submission

## Validation
- cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bR3OneShotEnqueue --no-ansi
- cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-r3-one-shot-enqueue.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path("docs/codex/pr-train.yaml").read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- ZH MBTI test enqueue
- EN/ZH research URL enqueue
- any live IndexNow submission or external search API call
- any CMS, URL Truth, sitemap, llms, or fap-web change