### PR TITLE
docs(seo-intel): record MBTI live submission preflight

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-mbti-01-preflight.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-mbti-01-preflight.v1.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "v1",
+  "task": "SEARCH-CHANNEL-LIVE-MBTI-01",
+  "final_decision": "ready_for_human_approved_live_submission",
+  "queue_item_id": 2,
+  "batch_id": 2,
+  "target_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "approval_state": "pending",
+  "execution_state": "dry_run_ready",
+  "source_authority": "scale_catalog",
+  "page_entity_type": "test_detail",
+  "duplicate_active_queue_item": false,
+  "queue_write_gate_state": false,
+  "live_submission_gate_state": false,
+  "external_api_gate_state": false,
+  "indexnow_live_api_gate_state": false,
+  "indexnow_key_present": true,
+  "indexnow_key_location_present": true,
+  "indexnow_key_location_publicly_verified": true,
+  "submit_dry_run_passed": true,
+  "live_submission_attempted": false,
+  "external_api_call_attempted": false,
+  "search_submission_attempted": false,
+  "enqueue_attempted": false,
+  "cms_mutation_attempted": false,
+  "url_truth_write_attempted": false,
+  "exact_future_approval_phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 2 channel indexnow URL https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types.",
+  "required_gates_to_open": [
+    "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED",
+    "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED",
+    "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED"
+  ],
+  "required_gates_to_close_after_submission": [
+    "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED",
+    "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED",
+    "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED"
+  ],
+  "required_gates_to_remain_closed": [
+    "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED"
+  ],
+  "no_go_conditions": [
+    "queue_item_missing",
+    "queue_item_field_mismatch",
+    "approval_state_not_pending",
+    "execution_state_not_dry_run_ready",
+    "duplicate_count_gt_1",
+    "live_gate_unexpectedly_open",
+    "indexnow_key_missing",
+    "indexnow_key_location_missing",
+    "indexnow_key_location_public_mismatch",
+    "submit_dry_run_failed",
+    "external_call_attempted_in_dry_run",
+    "item_not_indexable_or_not_claim_safe"
+  ]
+}

--- a/backend/docs/seo/search-channel-live-mbti-01-preflight.md
+++ b/backend/docs/seo/search-channel-live-mbti-01-preflight.md
@@ -1,0 +1,141 @@
+# SEARCH-CHANNEL-LIVE-MBTI-01
+
+## Purpose
+
+Perform a read-only live submission preflight for EN MBTI Search Channel queue item `2`.
+
+This task did not open any live gate, did not call IndexNow, did not call any external search API, did not enqueue any URL, and did not mutate CMS, URL Truth, or production env.
+
+## Target queue item
+
+- `queue_item_id=2`
+- `batch_id=2`
+- `canonical_url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- `channel=indexnow`
+- `approval_state=pending`
+- `execution_state=dry_run_ready`
+- `source_authority=scale_catalog`
+- `page_entity_type=test_detail`
+
+## Queue item verification
+
+Production read-only checks confirmed:
+
+- queue item `2` exists
+- `batch_id=2`
+- URL and channel match the intended EN MBTI test candidate
+- `indexability_state=indexable`
+- `claim_boundary_state=claim_safe`
+- `private_flow=false`
+- batch `2` exists with `status=dry_run` and `item_count=1`
+
+## Duplicate verification
+
+Exact idempotency-key review showed:
+
+- `duplicate_count=1`
+- the only matching row is queue item `2`
+
+This means there is no duplicate active queue row beyond the expected planned item.
+
+## Gate verification
+
+Production config remained closed:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false`
+
+## IndexNow key readiness
+
+Production config contains IndexNow live submission metadata:
+
+- IndexNow key present
+- key length `32`
+- keyLocation present
+- keyLocation host `fermatmind.com`
+
+Public keyLocation verification succeeded:
+
+- URL: `https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt`
+- HTTP `200`
+- content type `text/plain; charset=UTF-8`
+- body length `32`
+- public file SHA-256 matched the configured IndexNow key SHA-256
+
+The raw key value is intentionally not recorded here.
+
+## Submit dry-run verification
+
+Read-only submit dry-run command:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan seo-intel:search-channel-submit --queue-item-id=2 --dry-run --json
+```
+
+Observed result:
+
+- `status=success`
+- `queue_item_id=2`
+- `channel=indexnow`
+- `canonical_url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- `execution_state=dry_run_ready`
+- `external_calls_attempted=false`
+- `search_submission_attempted=false`
+- `writes_attempted=false`
+- `writes_committed=false`
+
+## Exact future approval phrase
+
+The current executor requires this exact phrase:
+
+```text
+I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 2 channel indexnow URL https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types.
+```
+
+This phrase is taken from the current production executor contract and must match exactly for a future live submission task.
+
+## Required gates to open
+
+Only for the later human-approved live submission task:
+
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=true`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=true`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=true`
+
+Queue write must remain closed:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+
+## Required gates to close after submission
+
+Immediately after the one-shot live submission:
+
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false`
+
+Queue write stays closed throughout:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+
+## No-go conditions
+
+Do not proceed with live submission if any of the following becomes true:
+
+- queue item `2` is missing
+- queue item `2` URL, channel, source authority, or page entity type no longer matches the approved candidate
+- `approval_state` is not `pending`
+- `execution_state` is not `dry_run_ready`
+- duplicate count is greater than `1`
+- any live gate is already unexpectedly open before the approved operation
+- IndexNow key or keyLocation is missing
+- public keyLocation no longer matches the configured key
+- submit dry-run fails or attempts any external call
+- queue item becomes non-indexable, private, claim-unsafe, or host-disallowed
+
+## Decision
+
+`ready_for_human_approved_live_submission`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti01PreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti01PreflightTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLiveMbti01PreflightTest extends TestCase
+{
+    public function test_generated_artifact_exists_and_locks_live_preflight_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/search-channel-live-mbti-01-preflight.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(2, $payload['queue_item_id']);
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $payload['target_url']
+        );
+        $this->assertSame('indexnow', $payload['channel']);
+        $this->assertSame('pending', $payload['approval_state']);
+        $this->assertSame('dry_run_ready', $payload['execution_state']);
+        $this->assertSame('scale_catalog', $payload['source_authority']);
+        $this->assertSame('test_detail', $payload['page_entity_type']);
+        $this->assertFalse($payload['duplicate_active_queue_item']);
+        $this->assertFalse($payload['queue_write_gate_state']);
+        $this->assertFalse($payload['live_submission_gate_state']);
+        $this->assertFalse($payload['external_api_gate_state']);
+        $this->assertFalse($payload['indexnow_live_api_gate_state']);
+        $this->assertTrue($payload['indexnow_key_present']);
+        $this->assertTrue($payload['indexnow_key_location_present']);
+        $this->assertTrue($payload['indexnow_key_location_publicly_verified']);
+        $this->assertTrue($payload['submit_dry_run_passed']);
+        $this->assertFalse($payload['live_submission_attempted']);
+        $this->assertFalse($payload['external_api_call_attempted']);
+        $this->assertFalse($payload['search_submission_attempted']);
+        $this->assertFalse($payload['enqueue_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['url_truth_write_attempted']);
+        $this->assertNotEmpty($payload['exact_future_approval_phrase']);
+        $this->assertSame('ready_for_human_approved_live_submission', $payload['final_decision']);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6194,7 +6194,7 @@
       "repo": "fap-api",
       "branch": "codex/repair-progressive-runtime-candidate-pool-selection-1",
       "title": "fix(api): consume progressive delta slugs in runtime candidate pool",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1"
       ],
@@ -6348,7 +6348,7 @@
         "do not treat candidate-aware planning artifacts as final published authority"
       ],
       "commit_sha": "66800c324532fff8eb20ebd0c5a5bfdf9098dd61",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1605",
       "checks": {
         "authorization": {
           "status": "pass",
@@ -14940,7 +14940,10 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "status": "pending",
+          "pr": "pending: PR #1605 opened for SEARCH-CHANNEL-LIVE-MBTI-01 and awaiting required GitHub checks"
+        }
       },
       "failure_reason": null,
       "merged_at": null,
@@ -15454,6 +15457,11 @@
           "at": "2026-05-23T13:05:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEARCH-CHANNEL-LIVE-MBTI-01: focused live preflight test, Search Channel Queue suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        },
+        {
+          "at": "2026-05-23T13:10:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1605 for SEARCH-CHANNEL-LIVE-MBTI-01 from codex/search-channel-live-mbti-01-preflight. The task remains production read-only: no live gate changes, no live submission, no enqueue, no CMS mutation, and no external search API call."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15037,7 +15037,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-enqueue",
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01A"
       ],
@@ -15341,11 +15341,11 @@
     "SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-post-enqueue-review",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-R3"
       ],
-      "commit_sha": "c6f5bd2bd3f0e9d204e24ef0d889653c4db3c32f",
+      "commit_sha": "25a43e669cfe12f0a72ec5db64fb739a46a185a6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1604",
       "checks": {
         "production_read_only": {
@@ -15367,12 +15367,15 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "status": "passed",
+          "pr": "passed: PR #1604 merged after hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep sarif, and Semgrep OSS succeeded"
+        }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T04:45:59Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -15393,6 +15396,64 @@
           "at": "2026-05-23T12:39:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1604 for SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW from codex/seo-growth-mbti-action-01b-post-enqueue-review. The task remained read-only against production: no gate change, no enqueue, no submission, and no CMS mutation."
+        },
+        {
+          "at": "2026-05-23T12:45:59+08:00",
+          "status": "merged",
+          "summary": "Merged PR #1604 for SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW with merge commit 25a43e669cfe12f0a72ec5db64fb739a46a185a6. origin/main contains the merge commit, the remote branch was deleted, local main was synced, and focused revalidation passed."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-LIVE-MBTI-01": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-mbti-01-preflight",
+      "status": "in_progress",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_read_only": {
+          "queue_item_verification": "passed: queue_item_id=2 exists with batch_id=2 canonical_url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types channel=indexnow approval_state=pending execution_state=dry_run_ready source_authority=scale_catalog page_entity_type=test_detail indexability_state=indexable claim_boundary_state=claim_safe private_flow=false",
+          "duplicate_verification": "passed: duplicate_count=1 and the only matching idempotency-key row is queue_item_id=2",
+          "batch_verification": "passed: batch_id=2 exists with channel=indexnow status=dry_run item_count=1 created_by=seo-intel:search-channel-queue",
+          "gate_verification": "passed: queue_write_gate=false, live_submission_gate=false, external_api_gate=false, indexnow_live_api_gate=false",
+          "indexnow_key_verification": "passed: key present, key length 32, keyLocation present, public keyLocation returned 200 text/plain and matched the configured key SHA-256 without exposing the raw key",
+          "submit_dry_run": "passed: php artisan seo-intel:search-channel-submit --queue-item-id=2 --dry-run --json returned success with no external calls, no search submission, and no writes"
+        },
+        "local": {
+          "focused_live_preflight_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveMbti01Preflight --no-ansi (1 test, 25 assertions)",
+          "search_channel_queue_suite": "passed: php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi (22 tests, 200 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3507 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-01-preflight.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "human_approved_live_submission_for_queue_item_2",
+      "history": [
+        {
+          "at": "2026-05-23T12:50:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEARCH-CHANNEL-LIVE-MBTI-01 on codex/search-channel-live-mbti-01-preflight from latest main. Production read-only checks confirmed queue item 2 is still the intended EN MBTI indexnow candidate, all live gates remain closed, the submit dry-run passes without external calls, and the public keyLocation matches the configured IndexNow key."
+        },
+        {
+          "at": "2026-05-23T13:05:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEARCH-CHANNEL-LIVE-MBTI-01: focused live preflight test, Search Channel Queue suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10664,6 +10664,49 @@ prs:
     scheduler_activation: false
     next_task: SEARCH-CHANNEL-LIVE-MBTI-01
 
+  - id: SEARCH-CHANNEL-LIVE-MBTI-01
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW
+    branch: codex/search-channel-live-mbti-01-preflight
+    base: main
+    title: "docs(seo-intel): record MBTI live submission preflight"
+    name: "Live submission preflight for queue item 2"
+    train_scope: seo_growth_mbti_action
+    risk_level: read_only_production_live_preflight
+    type: docs_generated_test
+    scope:
+      - Verify queue item 2 remains the exact approved EN MBTI indexnow candidate and stays in pending dry_run_ready state.
+      - Confirm queue write, live submission, external API, and IndexNow live API gates are closed before any human-approved live submission.
+      - Verify IndexNow key metadata is present and the public keyLocation matches the configured key without performing a live submission.
+    allowed_paths:
+      - backend/docs/seo/search-channel-live-mbti-01-preflight.md
+      - backend/docs/seo/generated/search-channel-live-mbti-01-preflight.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti01PreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, deploy files, fap-web, CMS content, URL Truth, seo_urls, seo_url_entities, crawler log readers, collectors, scheduler, Digital PR sends, Outlook drafts, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+      - Open any live gate, submit any URL, call IndexNow or any external search API, enqueue any item, mutate production env, or infer runtime truth from frontend fallback, static sitemap, static llms, crawler logs, or search engine responses.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLiveMbti01Preflight --no-ansi
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-01-preflight.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: human_approved_live_submission_for_queue_item_2
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- added a read-only MBTI live submission preflight report for Search Channel queue item 2
- added the generated JSON artifact that locks the verified queue item, gate, and IndexNow keyLocation evidence
- added a focused feature test for the preflight artifact
- updated the PR train manifest/state, including reconciliation that the prior post-enqueue review PR is already merged

## Why
- we need a production-safe preflight package before any human-approved live submission
- this locks the exact queue item state, confirms all live gates remain closed, and verifies the submit dry-run path without external calls

## Validation commands
- `cd backend && php artisan test --filter=SeoIntelSearchChannelLiveMbti01Preflight --no-ansi`
- `cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-01-preflight.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- no live submission
- no live gate changes
- no enqueue changes
- no env edits or deploy
- no CMS or URL Truth mutation
