### PR TITLE
docs(seo-intel): record MBTI IndexNow live submission

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-mbti-02.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-mbti-02.v1.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "v1",
+  "task": "SEARCH-CHANNEL-LIVE-MBTI-02",
+  "final_decision": "search_channel_live_mbti_02_completed_ready_for_24h_review",
+  "approval_phrase_verified": true,
+  "queue_item_id": 2,
+  "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "live_submission_attempted": true,
+  "live_submission_committed": true,
+  "external_api_call_attempted": true,
+  "response_status": "accepted",
+  "response_code": 200,
+  "queue_item_state_after": {
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "approved_by": "codex"
+  },
+  "live_gates_opened": true,
+  "live_gates_closed": true,
+  "queue_write_gate_state": false,
+  "duplicate_detected": false,
+  "only_queue_item_2_submitted": true,
+  "no_bulk_submission": true,
+  "cms_mutation_attempted": false,
+  "url_truth_write_attempted": false,
+  "sitemap_mutation_attempted": false,
+  "llms_mutation_attempted": false,
+  "deferred_urls": [
+    "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "sidecars": [],
+  "next_task": "SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW"
+}

--- a/backend/docs/seo/search-channel-live-mbti-02.md
+++ b/backend/docs/seo/search-channel-live-mbti-02.md
@@ -1,0 +1,88 @@
+# SEARCH-CHANNEL-LIVE-MBTI-02
+
+## Scope
+- Human-approved one-shot IndexNow live submission for existing Search Channel queue item `2`.
+- Production action was limited to `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types` on channel `indexnow`.
+- No enqueue, no collector write, no CMS mutation, no URL Truth write, no bulk submission, and no non-IndexNow search API calls.
+
+## Approval Verification
+- Exact approval phrase verified before any live gate change:
+  - `I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 2 channel indexnow URL https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types.`
+
+## Pre-submit Verification
+- Queue item `2` existed and still matched:
+  - `channel=indexnow`
+  - `approval_state=pending`
+  - `execution_state=dry_run_ready`
+  - `source_authority=scale_catalog`
+  - `page_entity_type=test_detail`
+  - `eligibility_state=eligible`
+  - `indexability_state=indexable`
+  - `claim_boundary_state=claim_safe`
+  - `private_flow=false`
+- No duplicate active queue item existed for the same idempotency key:
+  - `duplicate_count=1`
+  - only matching row was queue item `2`
+- All gates were closed before submission:
+  - `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+  - `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+  - `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+  - `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false`
+- Official dry-run submit command still passed with no external call and no write:
+  - `php artisan seo-intel:search-channel-submit --queue-item-id=2 --dry-run --json`
+
+## Gate Open / Close Result
+- Opened only:
+  - `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=true`
+  - `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=true`
+  - `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=true`
+- Kept closed throughout:
+  - `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- Applied gate changes through the shared backend `.env` and `php artisan config:cache`.
+- Closed the three live gates immediately after submission and re-cached config.
+- Verified after close:
+  - `queue_write_gate=false`
+  - `live_submission_gate=false`
+  - `external_api_gate=false`
+  - `indexnow_live_api_gate=false`
+
+## Live Submission Result
+- Official command used:
+  - `php artisan seo-intel:search-channel-submit --queue-item-id=2 --approval-phrase="<exact phrase>" --actor=codex --json`
+- Result:
+  - `status=success`
+  - `submission_status=accepted`
+  - `http_status=200`
+  - `external_calls_attempted=true`
+  - `search_submission_attempted=true`
+  - `writes_committed=true`
+  - `execution_state=submitted`
+
+## Post-submit Queue Verification
+- Queue item `2` after submission:
+  - `approval_state=approved`
+  - `execution_state=submitted`
+  - `approved_by=codex`
+- Queue item `2` live event trail increased from `0` to `2`:
+  - `live_submission_approved`
+  - `live_submission_response`
+- `live_submission_response` payload recorded:
+  - `endpoint_host=api.indexnow.org`
+  - `http_status=200`
+  - `submission_status=accepted`
+  - `exception_class=null`
+- Other queue-item live event count remained unchanged:
+  - before `2`
+  - after `2`
+- That bounded delta confirms only queue item `2` was submitted in this operation.
+
+## Deferred / Forbidden URLs
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+## Final Decision
+- `search_channel_live_mbti_02_completed_ready_for_24h_review`
+
+## Next Task
+- `SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti02Test.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti02Test.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLiveMbti02Test extends TestCase
+{
+    public function test_generated_artifact_exists_and_locks_live_submission_result(): void
+    {
+        $path = base_path('docs/seo/generated/search-channel-live-mbti-02.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(2, $payload['queue_item_id']);
+        $this->assertSame('https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types', $payload['url']);
+        $this->assertSame('indexnow', $payload['channel']);
+        $this->assertTrue($payload['approval_phrase_verified']);
+        $this->assertTrue($payload['no_bulk_submission']);
+        $this->assertFalse($payload['queue_write_gate_state']);
+        $this->assertTrue($payload['live_gates_closed']);
+        $this->assertTrue($payload['only_queue_item_2_submitted']);
+        $this->assertContains('https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types', $payload['deferred_urls']);
+        $this->assertContains('https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report', $payload['deferred_urls']);
+        $this->assertContains('https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report', $payload['deferred_urls']);
+        $this->assertNotEmpty($payload['final_decision'] ?? null);
+        $this->assertNotEmpty($payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15096,7 +15096,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-01": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-fix-01",
-      "status": "in_progress",
+      "status": "local_checks_passed",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B"
       ],
@@ -15462,6 +15462,66 @@
           "at": "2026-05-23T13:10:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1605 for SEARCH-CHANNEL-LIVE-MBTI-01 from codex/search-channel-live-mbti-01-preflight. The task remains production read-only: no live gate changes, no live submission, no enqueue, no CMS mutation, and no external search API call."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-LIVE-MBTI-02": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-mbti-02",
+      "status": "in_progress",
+      "depends_on": [
+        "SEARCH-CHANNEL-LIVE-MBTI-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_operation": {
+          "approval_phrase": "passed: exact SEARCH-CHANNEL-LIVE-02 approval phrase present before any live gate change",
+          "pre_submit_verification": "passed: queue_item_id=2 still matched the EN MBTI indexnow candidate with approval_state=pending execution_state=dry_run_ready source_authority=scale_catalog page_entity_type=test_detail eligibility_state=eligible indexability_state=indexable claim_boundary_state=claim_safe private_flow=false",
+          "duplicate_verification": "passed: duplicate_count=1 and the only matching idempotency-key row was queue_item_id=2",
+          "dry_run_verification": "passed: php artisan seo-intel:search-channel-submit --queue-item-id=2 --dry-run --json returned success with no external call and no writes",
+          "gate_open": "passed: SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED, SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED, and SEO_INTEL_INDEXNOW_LIVE_API_ENABLED were temporarily enabled while SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED remained false",
+          "live_submission": "passed: php artisan seo-intel:search-channel-submit --queue-item-id=2 --approval-phrase=<exact phrase> --actor=codex --json returned status=success submission_status=accepted http_status=200 execution_state=submitted",
+          "gate_close": "passed: all three live gates were restored to false immediately after submission and queue write remained false",
+          "post_submit_verification": "passed: queue item 2 moved to approval_state=approved execution_state=submitted, item2 live event count increased from 0 to 2, other queue-item live event count remained unchanged at 2, and only queue item 2 was submitted"
+        },
+        "local": {
+          "focused_live_submission_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveMbti02 --no-ansi (1 test, 14 assertions)",
+          "search_channel_queue_suite": "passed: php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi (22 tests, 200 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3508 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-02.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": true,
+      "scheduler_activation": false,
+      "next_pr": "SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW",
+      "history": [
+        {
+          "at": "2026-05-23T13:15:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEARCH-CHANNEL-LIVE-MBTI-02 on codex/search-channel-live-mbti-02 from latest main. Production pre-submit verification confirmed queue item 2 remained the approved EN MBTI indexnow candidate, no duplicate active item existed, and the official dry-run submit command still passed with no external call."
+        },
+        {
+          "at": "2026-05-23T13:18:45+08:00",
+          "status": "production_operation_completed",
+          "summary": "Completed the one-shot live submission for SEARCH-CHANNEL-LIVE-MBTI-02: opened only the three approved live submission gates, kept queue write disabled, submitted queue item 2 through the official command, received IndexNow HTTP 200 accepted, and immediately closed all live gates again."
+        },
+        {
+          "at": "2026-05-23T13:24:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local validation passed for SEARCH-CHANNEL-LIVE-MBTI-02: focused live submission test, Search Channel Queue suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6325,7 +6325,7 @@
       "branch": "fix/career-runtime-projection-lookup-latest-selection-1",
       "title": "fix(api): select newest career runtime projection artifact",
       "name": "Fix latest materialized Career runtime projection lookup selection",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1"
       ],
@@ -9510,7 +9510,7 @@
         }
       },
       "failure_reason": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1606",
       "commit_sha": "2ef32aa4ff65c1a58c360ab4f07123dca957f56e",
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -14998,7 +14998,10 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {}
+        "github": {
+          "status": "pending",
+          "pr": "pending: PR #1606 opened for SEARCH-CHANNEL-LIVE-MBTI-02 and awaiting required GitHub checks"
+        }
       },
       "failure_reason": null,
       "merged_at": "2026-05-23T00:21:01Z",
@@ -15522,6 +15525,11 @@
           "at": "2026-05-23T13:24:00+08:00",
           "status": "local_checks_passed",
           "summary": "Local validation passed for SEARCH-CHANNEL-LIVE-MBTI-02: focused live submission test, Search Channel Queue suite, route list, Pint, generated JSON/state parsing, YAML parsing, and diff whitespace checks."
+        },
+        {
+          "at": "2026-05-23T13:28:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1606 for SEARCH-CHANNEL-LIVE-MBTI-02 from codex/search-channel-live-mbti-02. The production operation stayed bounded to queue item 2 only; queue write remained disabled, and all three live gates were closed again immediately after submission."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10707,6 +10707,49 @@ prs:
     scheduler_activation: false
     next_task: human_approved_live_submission_for_queue_item_2
 
+  - id: SEARCH-CHANNEL-LIVE-MBTI-02
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-LIVE-MBTI-01
+    branch: codex/search-channel-live-mbti-02
+    base: main
+    title: "docs(seo-intel): record MBTI IndexNow live submission"
+    name: "Human-approved one-shot IndexNow live submission for queue item 2"
+    train_scope: search_channel_live_mbti
+    risk_level: bounded_production_live_submission
+    type: docs_generated_test
+    scope:
+      - Submit only existing Search Channel queue item 2 for the EN MBTI test URL through the official live submission command.
+      - Open only the three approved live submission gates for the duration of the one-shot submission and keep queue write closed throughout.
+      - Record the exact response, queue state transition, and proof that no other queue item was submitted.
+    allowed_paths:
+      - backend/docs/seo/search-channel-live-mbti-02.md
+      - backend/docs/seo/generated/search-channel-live-mbti-02.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti02Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime services, migrations, deploy files, fap-web, CMS content, URL Truth, seo_urls, seo_url_entities, crawler log readers, collectors, scheduler, Digital PR sends, Outlook drafts, pSEO, frontend fallback authority, static sitemap authority, static llms authority, claim auto-rewrite, internal link auto-creation, or business DB / Tencent RDS / Node2 DB.
+      - Submit any URL other than queue item 2, enqueue any item, bulk submit, modify queue write gate, or call GSC, Baidu, Bing, 360, Sogou, or Shenma.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLiveMbti02 --no-ansi
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-02.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- recorded the one-shot human-approved IndexNow live submission for queue item 2
- added the generated JSON artifact locking the exact response, gate behavior, and post-submit queue state
- added a focused feature test for the live submission artifact
- updated the PR train manifest/state for SEARCH-CHANNEL-LIVE-MBTI-02

## Why
- we needed a bounded production record for the approved live submission of the EN MBTI test URL
- this locks the exact queue item, exact live gate behavior, and proof that no other queue item was submitted

## Validation commands
- `cd backend && php artisan test --filter=SeoIntelSearchChannelLiveMbti02 --no-ansi`
- `cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-02.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- no enqueue change
- no queue write gate enablement
- no bulk submission
- no ZH MBTI submission
- no research URL submission
- no CMS or URL Truth mutation
