### PR TITLE
fix(ci): eliminate CiScaleImpact Semgrep findings

### DIFF
--- a/backend/app/Console/Commands/CiScaleImpact.php
+++ b/backend/app/Console/Commands/CiScaleImpact.php
@@ -161,15 +161,28 @@ final class CiScaleImpact extends Command
             return null;
         }
 
-        $directory = dirname($target);
+        $directory = realpath(dirname($target));
+        if (! is_string($directory) || $directory === '') {
+            return null;
+        }
+
+        $resolvedTarget = $directory.DIRECTORY_SEPARATOR.basename($target);
+        if ($resolvedTarget !== $target) {
+            return null;
+        }
+
+        // nosemgrep: php.lang.security.injection.tainted-filename.tainted-filename
+        // The directory comes from realpath(dirname($target)) and the final target must round-trip exactly.
         if (! is_dir($directory) || ! is_writable($directory)) {
             return null;
         }
 
-        if (file_exists($target) && (! is_file($target) || ! is_writable($target))) {
+        // nosemgrep: php.lang.security.injection.tainted-filename.tainted-filename
+        // $resolvedTarget is constrained to a local canonical directory plus basename(target), with no scheme.
+        if (file_exists($resolvedTarget) && (! is_file($resolvedTarget) || ! is_writable($resolvedTarget))) {
             return null;
         }
 
-        return $target;
+        return $resolvedTarget;
     }
 }

--- a/backend/tests/Unit/Ci/CiScaleImpactGithubOutputTest.php
+++ b/backend/tests/Unit/Ci/CiScaleImpactGithubOutputTest.php
@@ -89,6 +89,26 @@ final class CiScaleImpactGithubOutputTest extends TestCase
         @unlink($targetFile);
     }
 
+    public function test_github_output_rejects_non_canonical_paths_that_escape_directory(): void
+    {
+        $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'ci_scale_impact_'.bin2hex(random_bytes(4));
+        mkdir($tempDir, 0777, true);
+        mkdir($tempDir.DIRECTORY_SEPARATOR.'nested', 0777, true);
+
+        $targetFile = $tempDir.DIRECTORY_SEPARATOR.'nested'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'escaped_output.txt';
+
+        $_SERVER['GITHUB_OUTPUT'] = $targetFile;
+        unset($_ENV['GITHUB_OUTPUT']);
+
+        $this->writeGithubOutput([
+            'run_big5_ocean_gate' => true,
+            'scale_scope' => 'full_regression',
+            'reason' => 'reject_non_canonical_target',
+        ]);
+
+        $this->assertFileDoesNotExist($tempDir.DIRECTORY_SEPARATOR.'escaped_output.txt');
+    }
+
     /**
      * @param  array<string,mixed>  $payload
      */

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15754,15 +15754,15 @@
     "next_pr": "OPS-CI-CODESCAN-WEB-01"
   },
   "OPS-CI-CODESCAN-API-02": {
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/ops-ci-codescan-api-02",
     "base": "main",
     "title": "fix(ci): eliminate CiScaleImpact Semgrep findings",
     "depends_on": [],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "a194a0bb1d0cf83e130cce205cb9410cb48d725b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1607",
     "checks": {
       "local": {
         "php_artisan_test_filter_ci_scale_impact_github_output": "passed",
@@ -15773,7 +15773,10 @@
         "git_diff_check": "passed",
         "git_diff_cached_check": "passed"
       },
-      "github": {}
+      "github": {
+        "status": "pending",
+        "pr": "pending: PR #1607 opened for OPS-CI-CODESCAN-API-02 and awaiting required GitHub checks"
+      }
     },
     "failure_reason": null,
     "merged_at": null,
@@ -15790,6 +15793,11 @@
         "at": "2026-05-23T13:46:00+08:00",
         "status": "local_checks_passed",
         "summary": "Local validation passed for OPS-CI-CODESCAN-API-02: CiScaleImpactGithubOutput unit test, route list, Pint, manifest/state parse checks, and git diff whitespace checks."
+      },
+      {
+        "at": "2026-05-23T13:49:00+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1607 for OPS-CI-CODESCAN-API-02 from codex/ops-ci-codescan-api-02. Scope is limited to CiScaleImpact local output path canonicalization, focused test coverage, and PR train metadata."
       }
     ],
     "next_pr": null

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15753,6 +15753,47 @@
     ],
     "next_pr": "OPS-CI-CODESCAN-WEB-01"
   },
+  "OPS-CI-CODESCAN-API-02": {
+    "status": "local_checks_passed",
+    "repo": "fap-api",
+    "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+    "branch": "codex/ops-ci-codescan-api-02",
+    "base": "main",
+    "title": "fix(ci): eliminate CiScaleImpact Semgrep findings",
+    "depends_on": [],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "local": {
+        "php_artisan_test_filter_ci_scale_impact_github_output": "passed",
+        "php_artisan_route_list": "passed",
+        "vendor_bin_pint_test": "passed",
+        "json_validation": "passed",
+        "yaml_validation": "passed",
+        "git_diff_check": "passed",
+        "git_diff_cached_check": "passed"
+      },
+      "github": {}
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "history": [
+      {
+        "at": "2026-05-23T13:40:00+08:00",
+        "status": "in_progress",
+        "summary": "Started OPS-CI-CODESCAN-API-02 on codex/ops-ci-codescan-api-02 from latest main. Scope is limited to CiScaleImpact GitHub output path validation, its focused unit test, and PR train metadata so the repeated Semgrep tainted-filename findings can be eliminated without changing runtime behavior."
+      },
+      {
+        "at": "2026-05-23T13:46:00+08:00",
+        "status": "local_checks_passed",
+        "summary": "Local validation passed for OPS-CI-CODESCAN-API-02: CiScaleImpactGithubOutput unit test, route list, Pint, manifest/state parse checks, and git diff whitespace checks."
+      }
+    ],
+    "next_pr": null
+  },
   "OPS-RUNBOOK-HEALTHZ-01": {
     "status": "merged",
     "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6520,6 +6520,48 @@ prs:
     production_approval_required: false
     next_task: OPS-CI-CODESCAN-WEB-01
 
+  - id: OPS-CI-CODESCAN-API-02
+    repo: fap-api
+    depends_on: []
+    branch: codex/ops-ci-codescan-api-02
+    base: main
+    title: "fix(ci): eliminate CiScaleImpact Semgrep findings"
+    name: "Eliminate CiScaleImpact Semgrep findings"
+    train_scope: ops_ci_codescan_api
+    risk_level: L1
+    type: ci/runtime-safety PR
+    scope:
+      - Refactor CiScaleImpact GITHUB_OUTPUT target resolution so local canonical paths are enforced before write.
+      - Eliminate the repeated Semgrep tainted-filename findings on the validated local CI output path checks.
+      - Preserve command behavior for valid local GitHub Actions output files.
+    allowed_paths:
+      - backend/app/Console/Commands/CiScaleImpact.php
+      - backend/tests/Unit/Ci/CiScaleImpactGithubOutputTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change backend runtime routes, controllers, migrations, deploy scripts, production env, or non-CI command behavior beyond the validated local path guard.
+      - Deploy production, mutate servers, or alter unrelated security workflows.
+    validation:
+      - cd backend && php artisan test --filter=CiScaleImpactGithubOutput --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: false
+    production_approval_required: false
+    next_task: null
+
   - id: OPS-RUNBOOK-HEALTHZ-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- hardened `CiScaleImpact` GitHub output target resolution by canonicalizing the parent directory and requiring the final target path to round-trip exactly
- added targeted `nosemgrep` annotations at the two validated local-path guard sites that Semgrep was still flagging
- extended the focused unit test to cover non-canonical path rejection
- registered the scoped PR-train item and ledger state

## Why
- GitHub code scanning had five repeated `php.lang.security.injection.tainted-filename.tainted-filename` findings against `CiScaleImpact.php`
- this PR keeps the command behavior for valid local `GITHUB_OUTPUT` files while making the guard logic clearer to static analysis and blocking `..` path escapes

## Validation commands
- `cd backend && php artisan test --filter=CiScaleImpactGithubOutput --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- no runtime route, controller, migration, or deploy changes
- no changes to the broader Semgrep workflow configuration
- no dismissal of historical GitHub alerts in the UI from this PR
