### PR TITLE
fix(seo-intel): align MBTI URL Truth candidates to apex

### DIFF
--- a/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
+++ b/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
@@ -86,27 +86,29 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
 
             $updatedAt = $this->parseUpdatedAt($row['updated_at'] ?? null);
 
-            $records[] = new UrlTruthInventoryRecord(
-                canonicalUrl: $this->canonicalUrl('/en/tests/'.$slug),
-                locale: 'en',
-                pageEntityType: 'test_detail',
-                entityIdOrSlug: $slug,
-                sourceAuthority: 'scale_catalog',
-                indexabilityState: 'indexable',
-                lastmodAt: $updatedAt,
-                lastmodSource: 'scales_registry.updated_at',
-                cluster: 'tests',
-                entitySource: 'scales_registry',
-                authorityStatus: 'observed',
-                sourceUpdatedAt: $updatedAt,
-                metadata: [
-                    'source_table_hash' => hash('sha256', 'scales_registry'),
-                    'scale_code_hash' => hash('sha256', (string) ($row['code'] ?? $slug)),
-                ],
-                attributes: [
-                    'source_authority' => 'scale_catalog',
-                ],
-            );
+            foreach ($this->publicScaleCatalogLocales($row) as $locale) {
+                $records[] = new UrlTruthInventoryRecord(
+                    canonicalUrl: $this->canonicalUrl('/'.$this->publicLocaleSegment($locale).'/tests/'.$slug),
+                    locale: $locale,
+                    pageEntityType: 'test_detail',
+                    entityIdOrSlug: $slug,
+                    sourceAuthority: 'scale_catalog',
+                    indexabilityState: 'indexable',
+                    lastmodAt: $updatedAt,
+                    lastmodSource: 'scales_registry.updated_at',
+                    cluster: 'tests',
+                    entitySource: 'scales_registry',
+                    authorityStatus: 'observed',
+                    sourceUpdatedAt: $updatedAt,
+                    metadata: [
+                        'source_table_hash' => hash('sha256', 'scales_registry'),
+                        'scale_code_hash' => hash('sha256', (string) ($row['code'] ?? $slug)),
+                    ],
+                    attributes: [
+                        'source_authority' => 'scale_catalog',
+                    ],
+                );
+            }
         }
 
         $this->scaleCatalogAvailable = $records !== [];
@@ -303,12 +305,86 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
 
     private function canonicalUrl(string $path): string
     {
-        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', 'https://fermatmind.com')), '/');
+        $baseUrl = rtrim((string) config('seo_intel.public_canonical_host', 'https://fermatmind.com'), '/');
         if ($baseUrl === '') {
             $baseUrl = 'https://fermatmind.com';
         }
 
         return $baseUrl.'/'.ltrim($path, '/');
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function publicScaleCatalogLocales(array $row): array
+    {
+        $locales = [];
+
+        foreach (['en', 'zh-CN'] as $locale) {
+            if ($this->hasCatalogMetadata($row, $locale)) {
+                $locales[] = $locale;
+            }
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function hasCatalogMetadata(array $row, string $locale): bool
+    {
+        $contentI18n = $this->toArray($row['content_i18n_json'] ?? null);
+        $language = $this->localeLanguage($locale);
+        $localizedCatalog = $this->toArray($this->toArray($contentI18n[$language] ?? null)['catalog'] ?? null);
+        $fallbackCatalog = $this->toArray($this->toArray($contentI18n['en'] ?? null)['catalog'] ?? null);
+
+        return $this->positiveInt($localizedCatalog['questions_count'] ?? $fallbackCatalog['questions_count'] ?? null) > 0
+            && $this->positiveInt($localizedCatalog['time_minutes'] ?? $fallbackCatalog['time_minutes'] ?? null) > 0;
+    }
+
+    private function publicLocaleSegment(string $locale): string
+    {
+        return $this->localeLanguage($locale) === 'zh' ? 'zh' : 'en';
+    }
+
+    private function localeLanguage(string $locale): string
+    {
+        $locale = strtolower(trim($locale));
+        if ($locale === '') {
+            return 'en';
+        }
+
+        $parts = explode('-', $locale);
+
+        return strtolower((string) ($parts[0] ?? 'en'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && trim($value) !== '') {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+
+    private function positiveInt(mixed $value): int
+    {
+        $int = (int) $value;
+
+        return $int > 0 ? $int : 0;
     }
 
     private function parseUpdatedAt(mixed $value): ?Carbon

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -3,6 +3,7 @@
 return [
     'enabled' => env('SEO_INTEL_ENABLED', false),
     'connection' => env('SEO_INTEL_DB_CONNECTION', 'seo_intel'),
+    'public_canonical_host' => env('SEO_INTEL_PUBLIC_CANONICAL_HOST', 'https://fermatmind.com'),
     'write_enabled' => env('SEO_INTEL_WRITE_ENABLED', false),
     'collectors_enabled' => env('SEO_INTEL_COLLECTORS_ENABLED', false),
     'dry_run_default' => env('SEO_INTEL_DRY_RUN_DEFAULT', true),

--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-fix-02-url-truth-alignment.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02",
+  "final_decision": "mbti_action_01b_fix_02_merged_ready_for_backend_deploy_readiness",
+  "fixes": [
+    "align_backend_url_truth_public_canonical_host_to_apex",
+    "emit_zh_mbti_test_detail_candidate",
+    "emit_research_report_candidates_on_apex_host"
+  ],
+  "canonical_host": "https://fermatmind.com",
+  "zh_mbti_test_emission_enabled": true,
+  "research_apex_canonical_enabled": true,
+  "sitemap_authority_allowed": false,
+  "llms_authority_allowed": false,
+  "frontend_fallback_authority_allowed": false,
+  "production_write_performed": false,
+  "enqueue_performed": false,
+  "live_submission_performed": false,
+  "expected_candidates": [
+    "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "deferred_followups": [
+    "backend deploy/readiness",
+    "bounded production URL Truth dry-run",
+    "bounded production URL Truth write/preflight only with later approval",
+    "sitemap exposure policy review",
+    "later ZH/Search Channel enqueue after persisted rows verified"
+  ],
+  "next_task": "BACKEND-DEPLOY-READINESS"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.md
@@ -1,0 +1,101 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-02 URL Truth Alignment
+
+Task: `SEO-GROWTH-MBTI-ACTION-01B-FIX-02`
+
+## Why this fix was needed
+
+The MBTI/Search Channel scan found two backend-owned URL Truth defects:
+
+- `BackendAuthorityUrlTruthSource::scaleCatalogCandidates()` emitted only EN `test_detail` candidates and never emitted the ZH MBTI public URL.
+- absolute public canonical URLs were derived from `app.frontend_url`, which allowed production URL Truth to persist `https://www.fermatmind.com/...` while public runtime canonical had already converged to apex `https://fermatmind.com/...`.
+
+This PR fixes URL Truth source generation only. It does not write production rows, enqueue Search Channel items, submit URLs, or change sitemap/`llms.txt`.
+
+## What changed
+
+### Canonical host alignment
+
+URL Truth public canonical URLs now resolve from:
+
+- `seo_intel.public_canonical_host`
+
+Default:
+
+- `https://fermatmind.com`
+
+This keeps backend URL Truth deterministic and apex-aligned without relying on request host, `fap-web`, sitemap, or `llms.txt`.
+
+### ZH MBTI test emission
+
+Scale catalog candidates now emit localized public `test_detail` URLs for supported public locales:
+
+- `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+Locale handling remains backend-safe:
+
+- backend locale `zh-CN` maps to public path segment `/zh/`
+- unsupported locale segments are not emitted
+- private flows such as `/take`, `/result`, `/order`, and paywalled/report-private routes are not emitted
+
+### Research apex alignment
+
+Research URL Truth candidates now emit apex canonical URLs:
+
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+The source authority and entity classification remain unchanged:
+
+- `page_entity_type = research_report`
+- `source_authority = backend_cms`
+- `entity_source = research_reports`
+
+Unsafe routes remain excluded:
+
+- stale `turnover-rate-report`
+- `/articles/*`
+- `/reports/*`
+- `www` host variants
+
+## Authority boundary
+
+Allowed authority:
+
+- backend CMS / backend public surface / scale catalog
+
+Forbidden authority:
+
+- frontend fallback
+- static sitemap
+- static `llms.txt`
+- crawler logs
+- search engine responses
+- Digital PR mentions
+- local copies
+
+This PR does not:
+
+- write production URL Truth rows
+- enqueue Search Channel
+- perform live submission
+- modify `fap-web`
+
+## Expected candidates after deploy and bounded production preflight
+
+- `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+## Deferred follow-ups
+
+- backend deploy/readiness
+- bounded production URL Truth dry-run
+- bounded production URL Truth write/preflight only with later approval
+- sitemap exposure policy review
+- later ZH/Search Channel enqueue after persisted rows are verified
+
+## Next task
+
+`BACKEND-DEPLOY-READINESS`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignmentTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignmentTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ResearchReport;
+use App\Services\Scale\ScaleRegistry;
+use App\Services\SeoIntel\Sources\BackendAuthorityUrlTruthSource;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function mbti_and_research_candidates_align_to_apex_and_emit_zh_public_paths(): void
+    {
+        config([
+            'app.frontend_url' => 'https://www.fermatmind.com',
+            'seo_intel.public_canonical_host' => 'https://fermatmind.com',
+        ]);
+
+        $this->app->instance(ScaleRegistry::class, $this->mockScaleRegistry());
+
+        $this->createResearchReport([
+            'slug' => 'mbti-personality-types-salary-turnover-report',
+            'locale' => 'en',
+            'canonical_path' => '/en/research/mbti-personality-types-salary-turnover-report',
+        ]);
+        $this->createResearchReport([
+            'slug' => 'mbti-personality-types-salary-turnover-report',
+            'locale' => 'zh-CN',
+            'canonical_path' => '/zh/research/mbti-personality-types-salary-turnover-report',
+        ]);
+        $this->createResearchReport([
+            'slug' => 'mbti-personality-types-salary-turnover-rate-report',
+            'locale' => 'en',
+            'canonical_path' => '/en/research/mbti-personality-types-salary-turnover-rate-report',
+        ]);
+        $this->createResearchReport([
+            'slug' => 'article-fallback-report',
+            'locale' => 'en',
+            'canonical_path' => '/en/articles/article-fallback-report',
+        ]);
+        $this->createResearchReport([
+            'slug' => 'reports-fallback-report',
+            'locale' => 'zh-CN',
+            'canonical_path' => '/zh/reports/reports-fallback-report',
+        ]);
+
+        $source = new BackendAuthorityUrlTruthSource;
+        $records = $source->candidates();
+        $canonicalUrls = array_map(static fn ($record): string => $record->canonicalUrl, $records);
+
+        $this->assertContains('https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types', $canonicalUrls);
+        $this->assertContains('https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types', $canonicalUrls);
+        $this->assertContains('https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report', $canonicalUrls);
+        $this->assertContains('https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report', $canonicalUrls);
+        $this->assertNotContains('https://www.fermatmind.com/en/tests/mbti-personality-test-16-personality-types', $canonicalUrls);
+        $this->assertNotContains('https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types', $canonicalUrls);
+        $this->assertFalse(collect($canonicalUrls)->contains(static fn (string $url): bool => str_contains($url, 'https://www.fermatmind.com')));
+        $this->assertFalse(collect($canonicalUrls)->contains(static fn (string $url): bool => str_contains($url, 'turnover-rate-report')));
+        $this->assertFalse(collect($canonicalUrls)->contains(static fn (string $url): bool => str_contains($url, '/articles/')));
+        $this->assertFalse(collect($canonicalUrls)->contains(static fn (string $url): bool => str_contains($url, '/reports/')));
+        $this->assertFalse(collect($canonicalUrls)->contains(static fn (string $url): bool => str_contains($url, '/zh-CN/')));
+        $this->assertFalse(collect($canonicalUrls)->contains(static fn (string $url): bool => str_contains($url, '/take')));
+
+        $zhMbti = collect($records)->first(
+            static fn ($record): bool => $record->canonicalUrl === 'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types'
+        );
+        $enResearch = collect($records)->first(
+            static fn ($record): bool => $record->canonicalUrl === 'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report'
+        );
+        $zhResearch = collect($records)->first(
+            static fn ($record): bool => $record->canonicalUrl === 'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report'
+        );
+
+        $this->assertNotNull($zhMbti);
+        $this->assertSame('zh-CN', $zhMbti->locale);
+        $this->assertSame('test_detail', $zhMbti->pageEntityType);
+        $this->assertSame('scale_catalog', $zhMbti->sourceAuthority);
+        $this->assertSame('indexable', $zhMbti->indexabilityState);
+        $this->assertFalse($zhMbti->isPrivateFlow);
+
+        $this->assertNotNull($enResearch);
+        $this->assertSame('research_report', $enResearch->pageEntityType);
+        $this->assertSame('backend_cms', $enResearch->sourceAuthority);
+        $this->assertSame('research_reports', $enResearch->entitySource);
+        $this->assertFalse($enResearch->isPrivateFlow);
+
+        $this->assertNotNull($zhResearch);
+        $this->assertSame('zh-CN', $zhResearch->locale);
+        $this->assertSame('research_report', $zhResearch->pageEntityType);
+        $this->assertSame('backend_cms', $zhResearch->sourceAuthority);
+
+        $this->assertContains('test_detail', config('seo_intel.url_truth_inventory.allowed_page_entity_types', []));
+        $this->assertContains('research_report', config('seo_intel.url_truth_inventory.allowed_page_entity_types', []));
+        $this->assertContains('scale_catalog', config('seo_intel.url_truth_inventory.allowed_source_authorities', []));
+        $this->assertContains('backend_cms', config('seo_intel.url_truth_inventory.allowed_source_authorities', []));
+
+        $metadata = $source->metadata();
+        $this->assertFalse((bool) ($metadata['frontend_fallback_data_source'] ?? true));
+        $this->assertFalse((bool) ($metadata['static_llms_fallback_graph_truth'] ?? true));
+    }
+
+    private function mockScaleRegistry(): ScaleRegistry
+    {
+        $registry = \Mockery::mock(ScaleRegistry::class);
+        $registry->shouldReceive('listActivePublic')->once()->with(0)->andReturn([
+            [
+                'code' => 'MBTI',
+                'primary_slug' => 'mbti-personality-test-16-personality-types',
+                'updated_at' => now()->toISOString(),
+                'content_i18n_json' => [
+                    'en' => [
+                        'catalog' => [
+                            'questions_count' => 93,
+                            'time_minutes' => 12,
+                        ],
+                    ],
+                    'zh' => [
+                        'catalog' => [
+                            'questions_count' => 93,
+                            'time_minutes' => 12,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        return $registry;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createResearchReport(array $overrides = []): ResearchReport
+    {
+        $slug = (string) ($overrides['slug'] ?? 'safe-research-report');
+        $locale = (string) ($overrides['locale'] ?? 'en');
+        $localeSegment = $locale === 'zh-CN' ? 'zh' : $locale;
+
+        return ResearchReport::query()->create($overrides + [
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => 'Safe Research Report',
+            'executive_summary' => 'Directional research summary.',
+            'body_md' => 'Research body.',
+            'research_type' => 'salary_turnover',
+            'methodology' => 'Modeled index methodology.',
+            'sample_disclaimer' => 'Exploratory, non-diagnostic, not hiring advice.',
+            'claim_boundary' => 'No salary guarantee or individual prediction.',
+            'author_name' => 'FermatMind Research',
+            'reviewer_name' => 'FermatMind Review',
+            'references' => [['title' => 'Reference', 'url' => 'https://example.com/reference']],
+            'downloadable_asset_placeholder' => 'Dataset schema blocked for first publish.',
+            'status' => ResearchReport::STATUS_PUBLISHED,
+            'review_state' => ResearchReport::REVIEW_APPROVED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'last_reviewed_at' => now()->subDay(),
+            'published_at' => now()->subHour(),
+            'seo_title' => 'Safe Research Report',
+            'seo_description' => 'Safe Research Report description.',
+            'canonical_path' => '/'.$localeSegment.'/research/'.$slug,
+        ]);
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelResearchUrlTruthObservationTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelResearchUrlTruthObservationTest.php
@@ -19,7 +19,10 @@ final class SeoIntelResearchUrlTruthObservationTest extends TestCase
     #[Test]
     public function published_claim_safe_research_report_emits_url_truth_candidate(): void
     {
-        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+        config([
+            'app.frontend_url' => 'https://www.fermatmind.com',
+            'seo_intel.public_canonical_host' => 'https://fermatmind.com',
+        ]);
 
         $this->createResearchReport([
             'slug' => 'mbti-personality-types-salary-turnover-report',
@@ -37,7 +40,7 @@ final class SeoIntelResearchUrlTruthObservationTest extends TestCase
 
         $record = $records[0];
 
-        $this->assertSame('https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report', $record->canonicalUrl);
+        $this->assertSame('https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report', $record->canonicalUrl);
         $this->assertSame('en', $record->locale);
         $this->assertSame('research_report', $record->pageEntityType);
         $this->assertSame('mbti-personality-types-salary-turnover-report', $record->entityIdOrSlug);
@@ -59,7 +62,10 @@ final class SeoIntelResearchUrlTruthObservationTest extends TestCase
     #[Test]
     public function research_url_truth_skips_draft_private_noindex_unapproved_and_unsafe_routes(): void
     {
-        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+        config([
+            'app.frontend_url' => 'https://www.fermatmind.com',
+            'seo_intel.public_canonical_host' => 'https://fermatmind.com',
+        ]);
 
         $this->createResearchReport([
             'slug' => 'valid-research-report',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-23T12:32:05+08:00",
+  "updated_at": "2026-05-23T15:01:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15530,6 +15530,53 @@
           "at": "2026-05-23T13:28:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1606 for SEARCH-CHANNEL-LIVE-MBTI-02 from codex/search-channel-live-mbti-02. The production operation stayed bounded to queue item 2 only; queue write remained disabled, and all three live gates were closed again immediately after submission."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-02": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-02",
+      "status": "local_checks_sidecar_blocker_documented",
+      "depends_on": [
+        "SEARCH-CHANNEL-LIVE-MBTI-02"
+      ],
+      "commit_sha": "4cd92c44e38be9296318462f2456c396fcc3d453",
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "focused_url_truth_alignment_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignment --no-ansi (1 test, 34 assertions)",
+          "seo_intel_suite": "preexisting_main_blocker: php artisan test --filter=SeoIntel --no-ansi failed on 4 /ops/seo UI assertions that also fail on clean origin/main (SeoIntelOpsSeoCrawlerObservationUiTest, SeoIntelOpsSeoNativeDashboardAccessBoundaryTest x2, SeoIntelOpsSeoNativeDashboardPanelsTest).",
+          "url_truth_dry_run_test_detail": "passed_with_local_source_unavailable: php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=test_detail --limit=50 returned status=success planned_url_count=3 with no writes or external calls",
+          "url_truth_dry_run_research_report": "passed_with_local_source_unavailable: php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=research_report --limit=50 returned status=success planned_url_count=0 because local research source is unavailable",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3509 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "BACKEND-DEPLOY-READINESS",
+      "history": [
+        {
+          "at": "2026-05-23T14:35:00+08:00",
+          "status": "in_progress",
+          "summary": "Started SEO-GROWTH-MBTI-ACTION-01B-FIX-02 on codex/seo-growth-mbti-action-01b-fix-02 from latest clean main. Scope is limited to backend URL Truth host alignment, ZH MBTI test-detail emission, focused docs/generated/tests, and authorized PR-train metadata only."
+        },
+        {
+          "at": "2026-05-23T14:58:00+08:00",
+          "status": "local_checks_sidecar_blocker_documented",
+          "summary": "Scoped validation passed for URL Truth apex alignment, route list, Pint, JSON/YAML parsing, and no-write collector dry-runs. Full SeoIntel suite still has 4 pre-existing /ops/seo UI assertion failures that reproduce on clean origin/main and are outside this PR scope."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-23T15:01:00+08:00",
+  "updated_at": "2026-05-23T18:01:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15536,12 +15536,12 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-fix-02",
-      "status": "local_checks_sidecar_blocker_documented",
+      "status": "pr_open",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-MBTI-02"
       ],
-      "commit_sha": "4cd92c44e38be9296318462f2456c396fcc3d453",
-      "pr_url": null,
+      "commit_sha": "b0fe3875ae2d1db4fe80a11c6333071d5ffbdf2d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1608",
       "checks": {
         "local": {
           "focused_url_truth_alignment_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignment --no-ansi (1 test, 34 assertions)",
@@ -15577,6 +15577,11 @@
           "at": "2026-05-23T14:58:00+08:00",
           "status": "local_checks_sidecar_blocker_documented",
           "summary": "Scoped validation passed for URL Truth apex alignment, route list, Pint, JSON/YAML parsing, and no-write collector dry-runs. Full SeoIntel suite still has 4 pre-existing /ops/seo UI assertion failures that reproduce on clean origin/main and are outside this PR scope."
+        },
+        {
+          "at": "2026-05-23T18:01:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1608 for SEO-GROWTH-MBTI-ACTION-01B-FIX-02 from codex/seo-growth-mbti-action-01b-fix-02. The PR is limited to backend URL Truth host alignment, ZH MBTI test-detail emission, focused docs/generated/tests, and authorized PR-train metadata only."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10792,6 +10792,54 @@ prs:
     scheduler_activation: false
     next_task: SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-LIVE-MBTI-02
+    branch: codex/seo-growth-mbti-action-01b-fix-02
+    base: main
+    title: "fix(seo-intel): align MBTI URL Truth candidates to apex"
+    name: "ZH MBTI URL Truth and Research canonical alignment"
+    train_scope: seo_growth_mbti_action
+    risk_level: scoped_backend_url_truth_alignment
+    type: implementation_docs_generated_test
+    scope:
+      - Align backend URL Truth public canonical host generation to apex `https://fermatmind.com` for owned public FermatMind pages.
+      - Emit ZH MBTI `test_detail` URL Truth candidates with `/zh/` public path while preserving approved source authority, page type, and private-flow exclusions.
+      - Emit EN/ZH research report URL Truth candidates on apex host without changing sitemap, `llms.txt`, Search Channel enqueue, or production persisted rows.
+    allowed_paths:
+      - backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
+      - backend/config/seo_intel.php
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignmentTest.php
+      - backend/tests/Feature/SeoIntel/SeoIntelResearchUrlTruthObservationTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, migrations, production env/deploy files, CMS content, sitemap/llms generators, Search Channel enqueue/submit code, live executor behavior, crawler log readers, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform production URL Truth writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, or CMS mutation.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignment --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=test_detail --limit=50
+      - cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=research_report --limit=50
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: BACKEND-DEPLOY-READINESS
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- aligned backend URL Truth public canonical host generation to apex `https://fermatmind.com`
- emitted localized ZH MBTI `test_detail` candidates alongside EN candidates from the backend scale catalog source
- aligned EN/ZH research report URL Truth candidates to apex host while preserving `backend_cms` / `research_reports` authority
- added focused docs/generated artifact and URL Truth alignment tests
- updated PR-train manifest/state for `SEO-GROWTH-MBTI-ACTION-01B-FIX-02`

## Why
Production URL Truth previously missed the exact ZH MBTI public test URL and persisted EN/ZH research URLs on `www.fermatmind.com` while public runtime canonical had converged to apex. Search Channel readiness depends on persisted backend-authoritative canonical rows, so the source generator had to be corrected at the backend URL Truth layer.

## Validation
- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignment --no-ansi`
- `cd backend && php artisan test --filter=SeoIntelResearchUrlTruthObservation --no-ansi`
- `cd backend && php artisan test --filter=SeoIntel --no-ansi`
- `cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=test_detail --limit=50`
- `cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=research_report --limit=50`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-url-truth-alignment.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- production deploy/readiness
- bounded production URL Truth dry-run/write preflight
- sitemap / `llms.txt` exposure review
- any Search Channel enqueue or live submission

## Sidecar
- `php artisan test --filter=SeoIntel --no-ansi` still has 4 pre-existing `/ops/seo` UI assertion failures that reproduce on clean `origin/main` and are outside this PR scope:
  - `SeoIntelOpsSeoCrawlerObservationUiTest`
  - `SeoIntelOpsSeoNativeDashboardAccessBoundaryTest` (2 assertions)
  - `SeoIntelOpsSeoNativeDashboardPanelsTest`
