### PR TITLE
fix(ops): submit global search form

### DIFF
--- a/backend/resources/views/filament/ops/pages/global-search-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/global-search-page.blade.php
@@ -15,25 +15,29 @@
             :title="__('ops.custom_pages.global_search.title')"
             :description="__('ops.custom_pages.global_search.description')"
         >
-            <x-filament-ops::ops-toolbar>
-                <div class="ops-control-stack">
-                    <label class="ops-control-label" for="ops-global-search-input">{{ __('ops.custom_pages.global_search.search_label') }}</label>
-                    <input
-                        id="ops-global-search-input"
-                        type="text"
-                        wire:model.defer="query"
-                        placeholder="{{ __('ops.custom_pages.global_search.placeholder') }}"
-                        class="ops-input"
-                    />
-                    <p class="ops-control-hint">{{ __('ops.custom_pages.global_search.hint') }}</p>
-                </div>
+            <form id="ops-global-search-form" wire:submit.prevent="runSearch" class="contents">
+                <x-filament-ops::ops-toolbar>
+                    <div class="ops-control-stack">
+                        <label class="ops-control-label" for="ops-global-search-input">{{ __('ops.custom_pages.global_search.search_label') }}</label>
+                        <input
+                            id="ops-global-search-input"
+                            name="query"
+                            type="text"
+                            wire:model="query"
+                            placeholder="{{ __('ops.custom_pages.global_search.placeholder') }}"
+                            class="ops-input"
+                            autocomplete="off"
+                        />
+                        <p class="ops-control-hint">{{ __('ops.custom_pages.global_search.hint') }}</p>
+                    </div>
 
-                <x-slot name="actions">
-                    <x-filament::button color="primary" wire:click="runSearch">
-                        {{ __('ops.custom_pages.common.actions.search') }}
-                    </x-filament::button>
-                </x-slot>
-            </x-filament-ops::ops-toolbar>
+                    <x-slot name="actions">
+                        <x-filament::button color="primary" type="submit" wire:target="runSearch">
+                            {{ __('ops.custom_pages.common.actions.search') }}
+                        </x-filament::button>
+                    </x-slot>
+                </x-filament-ops::ops-toolbar>
+            </form>
         </x-filament-ops::ops-section>
 
         <x-filament-ops::ops-section

--- a/backend/tests/Feature/Ops/OpsAccessBoundaryTest.php
+++ b/backend/tests/Feature/Ops/OpsAccessBoundaryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Ops;
 
 use App\Filament\Ops\Pages\DeliveryTools;
+use App\Filament\Ops\Pages\GlobalSearchPage;
 use App\Filament\Ops\Pages\SecureLink;
 use App\Models\AdminApproval;
 use App\Support\OrgContext;
@@ -120,6 +121,36 @@ final class OpsAccessBoundaryTest extends TestCase
         ])->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->get('/ops/select-org')
             ->assertForbidden();
+    }
+
+    public function test_global_search_uses_real_submit_form_and_returns_matches(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_GLOBAL_SEARCH,
+            PermissionNames::ADMIN_MENU_SUPPORT,
+        ]);
+        $selectedOrg = $this->createOrganization('Global Search Submit Org');
+        $chain = $this->seedCommerceOpsChain((int) $selectedOrg->id, 'ord_global_search_submit_001');
+
+        $session = $this->opsSession($admin, $selectedOrg);
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/global-search')
+            ->assertOk()
+            ->assertSee('id="ops-global-search-form"', false)
+            ->assertSee('wire:submit.prevent="runSearch"', false)
+            ->assertSee('type="submit"', false);
+
+        session($session);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->bindOpsOrgContext((int) $selectedOrg->id);
+
+        Livewire::test(GlobalSearchPage::class)
+            ->set('query', $chain['order_no'])
+            ->call('runSearch')
+            ->assertSet('items.0.label', $chain['order_no'])
+            ->assertSet('items.0.type', 'order');
     }
 
     public function test_delivery_tools_request_requires_elevated_action_permission(): void


### PR DESCRIPTION
## What changed
- Converted `/ops/global-search` from a standalone `wire:click` action to a real Livewire submit form.
- The query input now uses the current Livewire model binding and supports normal submit behavior.
- Added regression coverage that the page renders a submit form and that searching by order number returns a result.

## Why
The page could remain in the initial empty state because the search control was not wired as a real form submission.

## Validation
- `./vendor/bin/pint tests/Feature/Ops/OpsAccessBoundaryTest.php`
- `php -l tests/Feature/Ops/OpsAccessBoundaryTest.php && php -l app/Filament/Ops/Pages/GlobalSearchPage.php`
- `php artisan test tests/Feature/Ops/OpsAccessBoundaryTest.php --filter='global_search|order_and_attempt_explorer_pages_require_org_context'`
- `php artisan test tests/Feature/Ops/OpsCustomPagesI18nContractTest.php --filter='global search|custom_ops_pages_render'`
- `FAP_ADMIN_PANEL_ENABLED=true php artisan route:list --path=ops/global-search --no-ansi`
- `git diff --check`

## Deferred
- Production deploy is not included; the live Ops page will change after backend deployment.