### PR TITLE
fix(ops): localize personality list UI

### DIFF
--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource.php
@@ -66,6 +66,16 @@ class PersonalityProfileResource extends Resource
         return __('ops.nav.personality');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('ops.resources.personality_profiles.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('ops.resources.personality_profiles.plural');
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([
@@ -364,7 +374,7 @@ class PersonalityProfileResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('title')
-                    ->label('Profile')
+                    ->label(__('ops.resources.personality_profiles.table.profile'))
                     ->html()
                     ->searchable(['title', 'slug', 'type_code'])
                     ->sortable()
@@ -388,51 +398,54 @@ class PersonalityProfileResource extends Resource
                     ->description(fn (PersonalityProfile $record): string => PersonalityWorkspace::visibilityMeta($record))
                     ->color(fn (string $state): string => StatusBadge::color($state)),
                 Tables\Columns\TextColumn::make('is_public')
-                    ->label('Visibility')
+                    ->label(__('ops.table.visibility'))
                     ->badge()
-                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Public', 'Private'))
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, __('ops.status.public'), __('ops.status.private')))
                     ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('is_indexable')
-                    ->label('Indexing')
+                    ->label(__('ops.resources.personality_profiles.table.indexing'))
                     ->badge()
-                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Indexable', 'Noindex'))
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, __('ops.status.indexable'), __('ops.status.noindex')))
                     ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('published_at')
-                    ->label('Published')
+                    ->label(__('ops.resources.personality_profiles.table.published'))
                     ->dateTime()
                     ->sortable()
-                    ->placeholder('Not published'),
+                    ->placeholder(__('ops.status.not_published')),
                 Tables\Columns\TextColumn::make('updated_at')
-                    ->label('Updated')
+                    ->label(__('ops.table.updated'))
                     ->since()
                     ->sortable(),
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('type_code')
-                    ->label('Type')
+                    ->label(__('ops.resources.personality_profiles.filters.type'))
                     ->options(self::typeOptions()),
                 Tables\Filters\SelectFilter::make('locale')
+                    ->label(__('ops.table.locale'))
                     ->options(self::localeOptions()),
                 Tables\Filters\SelectFilter::make('status')
+                    ->label(__('ops.table.status'))
                     ->options(self::statusOptions()),
                 Tables\Filters\SelectFilter::make('schema_version')
+                    ->label(__('ops.resources.personality_profiles.filters.schema_version'))
                     ->options([
                         PersonalityProfile::SCHEMA_VERSION_V1 => PersonalityProfile::SCHEMA_VERSION_V1,
                         PersonalityProfile::SCHEMA_VERSION_V2 => PersonalityProfile::SCHEMA_VERSION_V2,
                     ]),
                 TernaryFilter::make('is_public')
-                    ->label('Public'),
+                    ->label(__('ops.table.public')),
                 TernaryFilter::make('is_indexable')
-                    ->label('Indexable'),
+                    ->label(__('ops.table.indexable')),
             ])
-            ->searchPlaceholder('Search type, title, or slug')
+            ->searchPlaceholder(__('ops.resources.personality_profiles.search_placeholder'))
             ->defaultSort('updated_at', 'desc')
             ->recordUrl(fn (PersonalityProfile $record): string => static::getUrl('edit', ['record' => $record]))
             ->actions([
                 Tables\Actions\EditAction::make()
-                    ->label('Edit')
+                    ->label(__('ops.resources.articles.actions.edit'))
                     ->icon('heroicon-o-pencil-square')
                     ->color('gray'),
             ])
@@ -462,8 +475,8 @@ class PersonalityProfileResource extends Resource
     private static function statusOptions(): array
     {
         return [
-            'draft' => 'draft',
-            'published' => 'published',
+            'draft' => __('ops.status.draft'),
+            'published' => __('ops.status.published'),
         ];
     }
 

--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php
@@ -519,19 +519,19 @@ final class PersonalityWorkspace
         return new HtmlString((string) view('filament.ops.personality.partials.editorial-cues', [
             'facts' => array_values(array_filter([
                 [
-                    'label' => 'Published',
+                    'label' => __('ops.resources.personality_profiles.table.published'),
                     'value' => self::formatTimestamp($get('published_at') ?? $record?->published_at),
                 ],
                 [
-                    'label' => 'Scheduled',
+                    'label' => __('ops.status.scheduled'),
                     'value' => self::formatTimestamp($get('scheduled_at') ?? $record?->scheduled_at),
                 ],
                 [
-                    'label' => 'Planned public URL',
+                    'label' => __('ops.resources.personality_profiles.fields.planned_public_url'),
                     'value' => $plannedUrl,
                 ],
                 [
-                    'label' => 'Revisions',
+                    'label' => __('ops.table.revision'),
                     'value' => $record instanceof PersonalityProfile ? (string) self::revisionCount($record) : null,
                 ],
             ], static fn (array $fact): bool => filled($fact['value'] ?? null))),
@@ -541,11 +541,11 @@ final class PersonalityWorkspace
                     'state' => $status,
                 ],
                 [
-                    'label' => $isPublic ? 'Public' : 'Private',
+                    'label' => $isPublic ? __('ops.status.public') : __('ops.status.private'),
                     'state' => $isPublic ? 'public' : 'inactive',
                 ],
                 [
-                    'label' => $isIndexable ? 'Indexable' : 'Noindex',
+                    'label' => $isIndexable ? __('ops.status.indexable') : __('ops.status.noindex'),
                     'state' => $isIndexable ? 'indexable' : 'noindex',
                 ],
             ],
@@ -594,8 +594,8 @@ final class PersonalityWorkspace
     public static function visibilityMeta(PersonalityProfile $record): string
     {
         return implode(' · ', [
-            StatusBadge::booleanLabel($record->is_public, 'Public', 'Private'),
-            StatusBadge::booleanLabel($record->is_indexable, 'Indexable', 'Noindex'),
+            StatusBadge::booleanLabel($record->is_public, __('ops.status.public'), __('ops.status.private')),
+            StatusBadge::booleanLabel($record->is_indexable, __('ops.status.indexable'), __('ops.status.noindex')),
         ]);
     }
 

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -2111,12 +2111,26 @@ return [
             ],
         ],
         'personality_profiles' => [
+            'label' => 'Personality Profile',
             'plural' => 'Personality Profiles',
             'list_subheading' => 'Global MBTI content workspace for structured personality profiles. Not tenant-specific.',
             'create_title' => 'Create Personality Profile',
             'create_subheading' => 'Build a structured MBTI profile in the main workspace, then finish publish and SEO cues in the side rail.',
             'edit_title' => 'Edit Personality Profile',
             'edit_subheading' => 'Maintain the structured MBTI profile without leaving the editorial workspace.',
+            'search_placeholder' => 'Search type, title, or slug',
+            'table' => [
+                'profile' => 'Profile',
+                'indexing' => 'Indexing',
+                'published' => 'Published',
+            ],
+            'filters' => [
+                'type' => 'Type',
+                'schema_version' => 'Schema version',
+            ],
+            'fields' => [
+                'planned_public_url' => 'Planned public URL',
+            ],
             'actions' => [
                 'create' => 'Create Personality Profile',
                 'all' => 'All Personality Profiles',

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -2111,12 +2111,26 @@ return [
             ],
         ],
         'personality_profiles' => [
+            'label' => '人格档案',
             'plural' => '人格档案',
             'list_subheading' => '结构化人格档案的全局 MBTI 内容工作区，不按租户隔离。',
             'create_title' => '创建人格档案',
             'create_subheading' => '在主工作区创建结构化 MBTI 人格档案，并在侧栏完成发布与 SEO 信息。',
             'edit_title' => '编辑人格档案',
             'edit_subheading' => '在编辑工作区维护结构化 MBTI 人格档案。',
+            'search_placeholder' => '搜索类型、标题或 slug',
+            'table' => [
+                'profile' => '人格档案',
+                'indexing' => '索引状态',
+                'published' => '发布时间',
+            ],
+            'filters' => [
+                'type' => '人格类型',
+                'schema_version' => '结构版本',
+            ],
+            'fields' => [
+                'planned_public_url' => '计划公开 URL',
+            ],
             'actions' => [
                 'create' => '创建人格档案',
                 'all' => '全部人格档案',

--- a/backend/tests/Feature/Ops/OpsCmsResourceI18nTest.php
+++ b/backend/tests/Feature/Ops/OpsCmsResourceI18nTest.php
@@ -10,12 +10,14 @@ use App\Filament\Ops\Resources\ArticleTagResource;
 use App\Filament\Ops\Resources\InterpretationGuideResource;
 use App\Filament\Ops\Resources\LandingSurfaceResource;
 use App\Filament\Ops\Resources\MediaAssetResource;
+use App\Filament\Ops\Resources\PersonalityProfileResource;
 use App\Filament\Ops\Resources\SupportArticleResource;
 use App\Http\Middleware\SetOpsLocale;
 use App\Models\AdminUser;
 use App\Models\LandingSurface;
 use App\Models\Organization;
 use App\Models\Permission;
+use App\Models\PersonalityProfile;
 use App\Models\Role;
 use App\Support\Rbac\PermissionNames;
 use Filament\Facades\Filament;
@@ -197,6 +199,49 @@ final class OpsCmsResourceI18nTest extends TestCase
             ['Approvals', 'Requested by', 'Approved by'],
             null,
         ];
+
+    }
+
+    public function test_personality_resource_list_uses_chinese_table_and_filter_copy(): void
+    {
+        app()->setLocale('zh_CN');
+
+        $this->assertSame('人格内容', PersonalityProfileResource::getNavigationLabel());
+        $this->assertSame('人格档案', PersonalityProfileResource::getModelLabel());
+        $this->assertSame('人格档案', PersonalityProfileResource::getPluralModelLabel());
+
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $org = $this->createOrganization();
+        PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'title' => 'INTJ 建筑师',
+            'status' => 'draft',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $html = $this->withSession($this->opsSession($admin, $org, 'zh_CN'))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/personality?locale=zh-CN')
+            ->assertOk()
+            ->content();
+
+        foreach (['人格档案', '搜索类型、标题或 slug', '可见性', '可索引', '未发布'] as $phrase) {
+            $this->assertStringContainsString($phrase, $html);
+        }
+
+        foreach (['Personality Profiles', 'Search type, title, or slug', 'Visibility', 'Indexable', 'Not published'] as $phrase) {
+            $this->assertStringNotContainsString($phrase, $html);
+        }
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -658,6 +658,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_personality_ops_ui_files(): void
+    {
+        $changed = [
+            'backend/app/Filament/Ops/Resources/PersonalityProfileResource.php',
+            'backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_migration_isolation_files(): void
     {
         $changed = [
@@ -1963,6 +1973,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isPersonalityOpsUiFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelMigrationIsolationFile($file)) {
                 continue;
             }
@@ -2629,6 +2643,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isContentOverviewOpsUiFile(string $file): bool
     {
         return $file === 'backend/app/Filament/Ops/Pages/ContentOverviewPage.php';
+    }
+
+    private function isPersonalityOpsUiFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Filament/Ops/Resources/PersonalityProfileResource.php',
+            'backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php',
+        ], true);
     }
 
     private function isSeoIntelMigrationIsolationFile(string $file): bool


### PR DESCRIPTION
## What changed
- Localized the Ops personality resource model labels, table headers, filters, search placeholder, edit action, and publish/indexability status copy.
- Localized personality list status metadata produced by the workspace helper.
- Added regression coverage for Chinese `/ops/personality` list copy so common English UI labels do not leak into the Chinese surface.
- Documented the Personality Ops resource files as UI-only for the BigFive runtime freeze classifier.

## Why
PR #1609 only covered content-search layout polish and remains scoped to that surface. The personality resource still had hardcoded English list UI copy, so the Chinese Ops page could not reflect the selected locale.

## Validation
- `./vendor/bin/pint app/Filament/Ops/Resources/PersonalityProfileResource.php app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php tests/Feature/Ops/OpsCmsResourceI18nTest.php`
- `./vendor/bin/pint tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php -l app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php && php -l app/Filament/Ops/Resources/PersonalityProfileResource.php && php -l tests/Feature/Ops/OpsCmsResourceI18nTest.php && php -l lang/zh_CN/ops.php && php -l lang/en/ops.php`
- `php -l tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Feature/Ops/OpsCmsResourceI18nTest.php --filter='personality_resource_list|targeted_ops_resources'`
- `php artisan test tests/Feature/Ops/PersonalityWorkspaceTest.php`
- `php artisan test tests/Feature/Ops/OpsCmsListPolishTest.php --filter='content_lists|asset_taxonomy'`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|personality_ops_ui_files|content_overview_ops_ui_file|content_growth_attribution_ops_ui_files'`
- `git diff --check`

## Deferred
- Production visibility requires backend deploy after merge.
- #1609 remains a separate content-search UI PR and is not included here.