### PR TITLE
PR-API-SEC-02 docs(security): redact production infrastructure details

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -50,10 +50,10 @@ Truth Source: `backend/composer.json` / `backend/package.json` / `backend/config
 以 `backend/.env.example` 为模板，生产必须由密钥系统注入。
 
 Deployer SSH 约定：
-- 默认 production 走阿里云 ECS `DEPLOY_HOST_PROD=139.224.130.204`、`DEPLOY_USER_PROD=ubuntu`
-- `122.152.221.126` 是退役中的腾讯云 Node3，不允许作为 production deploy target
-- GitHub Actions production deploy 使用 release layout：`DEPLOY_PATH_PROD=/var/www/fap-api`
-- 阿里云 host bootstrap 后，nginx / Supervisor / cron 应指向 `/var/www/fap-api/current/backend`；迁移期可让 `current` 临时指向手工 runtime，首次标准 Deployer release 会替换该 symlink
+- 默认 production 使用受控 `DEPLOY_HOST_PROD` 和 `DEPLOY_USER_PROD`，具体主机和账号只保存在部署配置/密钥系统中。
+- 退役腾讯云 Node3 不允许作为 production deploy target；具体地址不写入仓库文档。
+- GitHub Actions production deploy 使用受控 release layout；具体 release root 以部署配置为准。
+- host bootstrap 后，nginx / Supervisor / cron 应指向受控 current release backend；首次标准 Deployer release 会替换临时 symlink。
 - 若本机存在 `~/.ssh/fap_prod` 或 `~/.ssh/fap_api_gha`，`deploy.php` 会自动将其作为 production `IdentityFile`
 - staging 若本机存在 `~/.ssh/fap_actions_staging`，会自动作为 staging `IdentityFile`
 - 如需显式覆盖，使用：

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T21:36:27+08:00",
+  "updated_at": "2026-05-23T21:43:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5036,10 +5036,10 @@
     "PR-API-SEC-02": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-api-sec-02-redact-prod-infra-docs",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "7b95b8a5",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1617",
       "title": "docs(security): redact production infrastructure details",
       "checks": {
         "local": [
@@ -5075,7 +5075,13 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "github_checks",
+            "status": "pending",
+            "details": "PR #1617 opened; awaiting GitHub check completion."
+          }
+        ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
@@ -5097,6 +5103,11 @@
           "at": "2026-05-23T21:36:27+08:00",
           "status": "local_checks_passed",
           "summary": "Redacted exact production origins, SSH targets, IndexNow key locations, canary infrastructure details, and generated artifacts while preserving non-sensitive operational guidance; focused security guardrail, route list, JSON, Pint, and diff checks passed."
+        },
+        {
+          "at": "2026-05-23T21:43:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened GitHub PR https://github.com/fermatmind/fap-api/pull/1617 for PR-API-SEC-02 after local checks and scope validation passed."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T21:20:46+08:00",
+  "updated_at": "2026-05-23T21:36:27+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3785,7 +3785,7 @@
             "result": "25 modifiers, 12 synergies, 30 facets, 23 precision rules, 40 action rules, 8 coverage profiles"
           },
           {
-            "command": "rg -n \"Profile Summary|Domain Deep Dive|Norms Comparison|Methodology and Access|A compact overview|Focused read|Near-term actions|assertiveness|你天生注定|你永远都会|你只能这样活|你太玻璃心|你有问题|你不正常\" backend/content_assets/big5/v1/expanded || true",
+            "command": "rg -n \"Profile Summary|Domain Deep Dive|Norms Comparison|Methodology and Access|A compact overview|Focused read|Near-term actions|assertiveness|\u4f60\u5929\u751f\u6ce8\u5b9a|\u4f60\u6c38\u8fdc\u90fd\u4f1a|\u4f60\u53ea\u80fd\u8fd9\u6837\u6d3b|\u4f60\u592a\u73bb\u7483\u5fc3|\u4f60\u6709\u95ee\u9898|\u4f60\u4e0d\u6b63\u5e38\" backend/content_assets/big5/v1/expanded || true",
             "status": "passed",
             "result": "no matches in expanded assets"
           },
@@ -4377,7 +4377,7 @@
             "status": "passed"
           },
           {
-            "command": "php artisan career:align-selected-authority-crosswalks --file=/Users/rainie/Desktop/第八版_d5a_8_repaired.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
+            "command": "php artisan career:align-selected-authority-crosswalks --file=/Users/rainie/Desktop/\u7b2c\u516b\u7248_d5a_8_repaired.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
             "status": "passed_local_db_unavailable_plan",
             "details": "Local authority DB is unavailable; dry-run completed read-only from the D5a repaired workbook, validated all 8 selected slugs, reported would_create_occupation_count=8 and would_create_crosswalk_count=16, and wrote no DB rows."
           },
@@ -4438,9 +4438,9 @@
             "status": "passed"
           },
           {
-            "command": "php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/第九版.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
+            "command": "php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/\u7b2c\u4e5d\u7248.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
             "status": "failed_workbook_contract_outside_scope",
-            "details": "Draft PR exception: unsupported slug error is gone; all 8 D5 slugs were requested, validated, and generated payload summaries, but 第九版.xlsx still fails workbook contract validation for CTA/source labels, CN job-posting sample terms, and biomedical Product substring. This PR is not mergeable until the workbook source passes or the manifest acceptance is updated."
+            "details": "Draft PR exception: unsupported slug error is gone; all 8 D5 slugs were requested, validated, and generated payload summaries, but \u7b2c\u4e5d\u7248.xlsx still fails workbook contract validation for CTA/source labels, CN job-posting sample terms, and biomedical Product substring. This PR is not mergeable until the workbook source passes or the manifest acceptance is updated."
           },
           {
             "command": "git diff --check && git diff --cached --check",
@@ -4476,17 +4476,17 @@
         {
           "at": "2026-05-03T18:33:57Z",
           "status": "failed_local_check",
-          "summary": "Updated D5c1 validation source to 第九版.xlsx. Scoped code checks passed and unsupported slug errors are gone, but real workbook dry-run fails due workbook contract blockers outside allowlist scope."
+          "summary": "Updated D5c1 validation source to \u7b2c\u4e5d\u7248.xlsx. Scoped code checks passed and unsupported slug errors are gone, but real workbook dry-run fails due workbook contract blockers outside allowlist scope."
         },
         {
           "at": "2026-05-03T18:36:47Z",
           "status": "draft_exception_ready",
-          "summary": "Review pass: scope limited to allowlist/tests/train metadata. Open draft PR under documented exception because 第九版 workbook dry-run fails only on data contract blockers outside this PR."
+          "summary": "Review pass: scope limited to allowlist/tests/train metadata. Open draft PR under documented exception because \u7b2c\u4e5d\u7248 workbook dry-run fails only on data contract blockers outside this PR."
         },
         {
           "at": "2026-05-03T18:38:31Z",
           "status": "draft_open_workbook_blocked",
-          "summary": "Opened draft PR #1114. GitHub checks are pending; mergeStateStatus is UNSTABLE because the PR is draft/pending and the real 第九版 workbook dry-run remains blocked by workbook contract data."
+          "summary": "Opened draft PR #1114. GitHub checks are pending; mergeStateStatus is UNSTABLE because the PR is draft/pending and the real \u7b2c\u4e5d\u7248 workbook dry-run remains blocked by workbook contract data."
         },
         {
           "at": "2026-05-03T18:40:10Z",
@@ -4674,12 +4674,12 @@
         {
           "at": "2026-05-04T05:20:00Z",
           "status": "in_progress",
-          "summary": "Initialized PR-D6 ledger entry for the read-only 第九版 full display workbook intake validator after D5e live validation passed."
+          "summary": "Initialized PR-D6 ledger entry for the read-only \u7b2c\u4e5d\u7248 full display workbook intake validator after D5e live validation passed."
         },
         {
           "at": "2026-05-04T05:45:00Z",
           "status": "scope_extended",
-          "summary": "Extended PR-D6 scope to include a read-only Strategic Architecture Gap Scan for protocol sections §1 through §5 without implementing architecture modules or changing release gates."
+          "summary": "Extended PR-D6 scope to include a read-only Strategic Architecture Gap Scan for protocol sections \u00a71 through \u00a75 without implementing architecture modules or changing release gates."
         },
         {
           "at": "2026-05-04T06:05:00Z",
@@ -4877,9 +4877,9 @@
     "PR-API-SEC-01": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "ci_fix_local_checks_passed",
+      "status": "merged",
       "branch": "codex/pr-api-sec-01-research-cms-trusted-org",
-      "commit_sha": "206cf1bba7909c9b4785922338c630f24850cc0b",
+      "commit_sha": "9456fdfda688623b621ca24fdcacee995ac33c59",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1616",
       "title": "fix(security): bind research CMS endpoints to trusted org context",
       "checks": {
@@ -4928,56 +4928,58 @@
           {
             "command": "vendor/bin/pint --test app/Http/Controllers/API/V0_5/Cms/ResearchReportController.php app/Http/Middleware/ResolveOrgContext.php tests/Feature/Research/ResearchAssetBackendMvpTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
             "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Research/ResearchAssetBackendMvpTest.php",
+            "status": "passed",
+            "details": "Post-merge revalidation passed: 5 tests, 55 assertions."
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|research_cms_trusted_org_hardening'",
+            "status": "passed",
+            "details": "Post-merge revalidation passed: 2 tests, 5 assertions."
           }
         ],
         "github": [
           {
             "name": "hygiene",
-            "status": "passed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/26333130980/job/77522390325"
+            "status": "passed"
           },
           {
             "name": "hygiene",
-            "status": "passed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/26333130187/job/77522385973"
+            "status": "passed"
           },
           {
             "name": "semgrep sarif",
-            "status": "passed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/26333130972/job/77522402720"
+            "status": "passed"
           },
           {
             "name": "Semgrep OSS",
-            "status": "passed",
-            "details_url": "https://github.com/fermatmind/fap-api/runs/77522460675"
+            "status": "passed"
           },
           {
             "name": "verify-mbti-legacy",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/26333130980/job/77522420876"
+            "status": "failed_then_passed"
           },
           {
             "name": "verify-mbti-legacy",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/26333130187/job/77522414773"
+            "status": "failed_then_passed"
           },
           {
             "name": "verify-mbti-v2",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/26333130980/job/77522420878"
+            "status": "failed_then_passed"
           },
           {
             "name": "verify-mbti-v2",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/26333130187/job/77522414779"
+            "status": "failed_then_passed"
           }
         ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T13:27:24Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-23T00:00:00+08:00",
@@ -5013,19 +5015,66 @@
           "at": "2026-05-23T21:20:46+08:00",
           "status": "ci_fix_local_checks_passed",
           "summary": "Diagnosed GitHub verify-mbti failures as current PR CI classifier coverage gap; added scoped Research CMS trusted-org hardening classifier test and full local ci_verify_mbti plus manifest checks passed."
+        },
+        {
+          "at": "2026-05-23T21:27:24+08:00",
+          "status": "github_checks_green",
+          "summary": "GitHub checks for PR #1616 reran green after the scoped CI classifier fix was pushed."
+        },
+        {
+          "at": "2026-05-23T21:27:24+08:00",
+          "status": "merged",
+          "summary": "PR #1616 merged into main with merge commit 9456fdfda688623b621ca24fdcacee995ac33c59; remote branch was deleted."
+        },
+        {
+          "at": "2026-05-23T21:31:00+08:00",
+          "status": "post_merge_revalidated",
+          "summary": "Ran post_merge_cleanup.sh for codex/pr-api-sec-01-research-cms-trusted-org and revalidated the focused Research CMS and freeze-classifier tests on updated main."
         }
       ]
     },
     "PR-API-SEC-02": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
+      "status": "local_checks_passed",
       "branch": "codex/pr-api-sec-02-redact-prod-infra-docs",
       "commit_sha": "",
       "pr_url": "",
       "title": "docs(security): redact production infrastructure details",
       "checks": {
-        "local": [],
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Security/SecurityGuardrailsTest.php",
+            "status": "passed",
+            "details": "16 tests, 69 assertions; includes production infrastructure disclosure guardrail."
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/seo/generated/crawler-log-production-canary-preflight.v1.json >/dev/null && python3 -m json.tool backend/docs/seo/generated/crawler-log-production-canary-runtime.v1.json >/dev/null && python3 -m json.tool backend/docs/seo/generated/crawler-log-production-canary-report.v1.json >/dev/null && python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-preflight.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "rg -n '139\\.224\\.130\\.204|122\\.152\\.221\\.126|/var/log/nginx/access\\.log|/var/www/fap-api/current/backend|https://fermatmind\\.com/[a-f0-9]{32}\\.txt|rm-uf6u2498t7nk2faya\\.rwlb\\.rds\\.aliyuncs\\.com' README_DEPLOY.md docs/04-ops/backend-deploy-target-aliyun-01.md backend/docs/seo/crawler-log-production-canary-preflight.md backend/docs/seo/crawler-log-production-canary-report.md backend/docs/seo/crawler-log-production-canary-runtime.md backend/docs/seo/search-channel-live-02-preflight.md backend/docs/seo/search-channel-live-mbti-01-preflight.md backend/docs/seo/generated/crawler-log-production-canary-preflight.v1.json backend/docs/seo/generated/crawler-log-production-canary-report.v1.json backend/docs/seo/generated/crawler-log-production-canary-runtime.v1.json backend/docs/seo/generated/search-channel-live-02-preflight.v1.json",
+            "status": "passed",
+            "details": "No scoped sensitive-production-infrastructure pattern matches remained in changed docs/generated artifacts."
+          },
+          {
+            "command": "vendor/bin/pint --test tests/Unit/Security/SecurityGuardrailsTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list --no-ansi",
+            "status": "passed",
+            "details": "203 routes listed; no route/runtime changes in scope."
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
         "github": []
       },
       "failure_reason": "",
@@ -5038,6 +5087,16 @@
           "at": "2026-05-23T00:00:00+08:00",
           "status": "planned",
           "summary": "PR-API-SEC-02 planned after explicit user authorization for the first-wave security train."
+        },
+        {
+          "at": "2026-05-23T21:36:27+08:00",
+          "status": "in_progress",
+          "summary": "Started PR-API-SEC-02 from updated main after PR-API-SEC-01 merged; scope is limited to production infrastructure documentation redaction plus focused guardrail coverage."
+        },
+        {
+          "at": "2026-05-23T21:36:27+08:00",
+          "status": "local_checks_passed",
+          "summary": "Redacted exact production origins, SSH targets, IndexNow key locations, canary infrastructure details, and generated artifacts while preserving non-sensitive operational guidance; focused security guardrail, route list, JSON, Pint, and diff checks passed."
         }
       ]
     },

--- a/backend/docs/seo/crawler-log-production-canary-preflight.md
+++ b/backend/docs/seo/crawler-log-production-canary-preflight.md
@@ -12,7 +12,7 @@ The crawler-log observe command now supports two safe modes:
 
 ```bash
 php artisan seo-intel:crawler-log-observe --fixture --dry-run --no-write --json --limit=20
-php artisan seo-intel:crawler-log-observe --source=/var/log/nginx/access.log --approval-phrase="I explicitly approve CRAWLER-LOG-04 production canary for source /var/log/nginx/access.log with max_lines=1000 and no raw persistence." --dry-run --no-write --json --limit=1000
+php artisan seo-intel:crawler-log-observe --source=<approved-log-path> --approval-phrase="I explicitly approve CRAWLER-LOG-04 production canary for source <approved-log-path> with max_lines=1000 and no raw persistence." --dry-run --no-write --json --limit=1000
 ```
 
 Current command posture:

--- a/backend/docs/seo/crawler-log-production-canary-report.md
+++ b/backend/docs/seo/crawler-log-production-canary-report.md
@@ -4,18 +4,18 @@
 
 CRAWLER-LOG-05 records the first human-approved crawler log production canary result as a read-only observation artifact.
 
-The canary runtime was deployed to the production backend release at commit `84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd`. The approved source was `/var/log/nginx/access.log` on `139.224.130.204`, executed from `/var/www/fap-api/current/backend`.
+The canary runtime was deployed to the production backend release at commit `84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd`. The approved source, host, and execution shell are redacted from repository docs and recorded in approved ops inventory.
 
 This report does not expand crawler log collection. It does not add a scheduler, collector write, database write, issue queue write, URL Truth mutation, Search Channel Queue enqueue, or search submission.
 
 ## Deployment / Runtime Confirmation
 
-- Production runtime host: `139.224.130.204`
-- Runtime shell: `/var/www/fap-api/current/backend`
+- Production runtime host: redacted from repository docs
+- Runtime shell: redacted from repository docs
 - Runtime command: `seo-intel:crawler-log-observe`
 - Deployed release SHA: `84d48b2cfc15ac48a7999e2b0af56c1b4a3626bd`
 - Canary mode: `single_source_production_canary_dry_run`
-- Source: `/var/log/nginx/access.log`
+- Source: redacted from repository docs
 - Limit: `1000`
 - Required approval phrase verified: yes
 

--- a/backend/docs/seo/crawler-log-production-canary-runtime.md
+++ b/backend/docs/seo/crawler-log-production-canary-runtime.md
@@ -22,8 +22,8 @@ Crawler log canary output remains observability-only. It is not URL Truth, not S
 ```bash
 cd backend
 php artisan seo-intel:crawler-log-observe \
-  --source=/var/log/nginx/access.log \
-  --approval-phrase="I explicitly approve CRAWLER-LOG-04 production canary for source /var/log/nginx/access.log with max_lines=1000 and no raw persistence." \
+  --source=<approved-log-path> \
+  --approval-phrase="I explicitly approve CRAWLER-LOG-04 production canary for source <approved-log-path> with max_lines=1000 and no raw persistence." \
   --dry-run \
   --no-write \
   --json \
@@ -86,8 +86,8 @@ The absolute source path is used transiently for approval verification and file 
 
 Current approved production execution context observed during preflight:
 
-- host: `139.224.130.204`
-- release shell: `/var/www/fap-api/current/backend`
-- source: `/var/log/nginx/access.log`
+- host: redacted from repository docs; recorded in approved ops inventory
+- release shell: redacted from repository docs; recorded in approved ops inventory
+- source: redacted from repository docs; recorded in approved ops inventory
 
 This document defines runtime only. It does not deploy the runtime and does not perform a production log read by itself.

--- a/backend/docs/seo/generated/crawler-log-production-canary-preflight.v1.json
+++ b/backend/docs/seo/generated/crawler-log-production-canary-preflight.v1.json
@@ -5,7 +5,7 @@
   "mode": "production_canary_preflight_no_log_read",
   "runtime": "crawler_log_observe",
   "current_fixture_command": "php artisan seo-intel:crawler-log-observe --fixture --dry-run --no-write --json --limit=20",
-  "current_single_source_canary_command": "php artisan seo-intel:crawler-log-observe --source=/var/log/nginx/access.log --approval-phrase=\"I explicitly approve CRAWLER-LOG-04 production canary for source /var/log/nginx/access.log with max_lines=1000 and no raw persistence.\" --dry-run --no-write --json --limit=1000",
+  "current_single_source_canary_command": "php artisan seo-intel:crawler-log-observe --source=<approved-log-path> --approval-phrase=\"I explicitly approve CRAWLER-LOG-04 production canary for source <approved-log-path> with max_lines=1000 and no raw persistence.\" --dry-run --no-write --json --limit=1000",
   "current_command_fixture_only": false,
   "no_production_log_read": true,
   "no_canary_execution": true,

--- a/backend/docs/seo/generated/crawler-log-production-canary-report.v1.json
+++ b/backend/docs/seo/generated/crawler-log-production-canary-report.v1.json
@@ -4,9 +4,9 @@
   "runtime": "crawler_log_observe",
   "report_type": "production_canary_read_only_summary",
   "source": {
-    "host": "139.224.130.204",
-    "shell": "/var/www/fap-api/current/backend",
-    "path": "/var/log/nginx/access.log",
+    "host": "<redacted-approved-production-host>",
+    "shell": "<redacted-production-release-shell>",
+    "path": "<redacted-approved-log-path>",
     "source_log_family": "nginx_access_log",
     "single_source_only": true
   },
@@ -18,7 +18,7 @@
   "approval": {
     "approval_phrase_verified": true,
     "approval_phrase_template": "I explicitly approve CRAWLER-LOG-04 production canary for source <log_path> with max_lines=1000 and no raw persistence.",
-    "approved_source_phrase": "I explicitly approve CRAWLER-LOG-04 production canary for source /var/log/nginx/access.log with max_lines=1000 and no raw persistence.",
+    "approved_source_phrase": "I explicitly approve CRAWLER-LOG-04 production canary for source <approved-log-path> with max_lines=1000 and no raw persistence.",
     "max_lines": 1000
   },
   "blocked_attempt": {

--- a/backend/docs/seo/generated/crawler-log-production-canary-runtime.v1.json
+++ b/backend/docs/seo/generated/crawler-log-production-canary-runtime.v1.json
@@ -4,7 +4,7 @@
   "runtime": "crawler_log_observe",
   "mode": "single_source_production_canary_dry_run",
   "single_source_only": true,
-  "command": "php artisan seo-intel:crawler-log-observe --source=/var/log/nginx/access.log --approval-phrase=\"I explicitly approve CRAWLER-LOG-04 production canary for source /var/log/nginx/access.log with max_lines=1000 and no raw persistence.\" --dry-run --no-write --json --limit=1000",
+  "command": "php artisan seo-intel:crawler-log-observe --source=<approved-log-path> --approval-phrase=\"I explicitly approve CRAWLER-LOG-04 production canary for source <approved-log-path> with max_lines=1000 and no raw persistence.\" --dry-run --no-write --json --limit=1000",
   "required_flags": [
     "--source",
     "--approval-phrase",
@@ -23,9 +23,9 @@
   "max_line_limit": 1000,
   "approval_phrase_template": "I explicitly approve CRAWLER-LOG-04 production canary for source <log_path> with max_lines=1000 and no raw persistence.",
   "source_execution_surface": {
-    "host": "139.224.130.204",
-    "release_shell": "/var/www/fap-api/current/backend",
-    "approved_source": "/var/log/nginx/access.log"
+    "host": "<redacted-approved-production-host>",
+    "release_shell": "<redacted-production-release-shell>",
+    "approved_source": "<redacted-approved-log-path>"
   },
   "output_fields": [
     "runtime",

--- a/backend/docs/seo/generated/search-channel-live-02-preflight.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-02-preflight.v1.json
@@ -31,8 +31,8 @@
     "production_deploy_contains_executor_merge": true
   },
   "production_runtime": {
-    "target_host": "139.224.130.204",
-    "target_path": "/var/www/fap-api/current/backend",
+    "target_host": "<redacted-approved-production-host>",
+    "target_path": "<redacted-production-release-shell>",
     "required_deploy_sha": "af8a050bfed88631cfc687775402548848ba87a1",
     "last_successful_production_deploy_run_id": 26174360293,
     "last_successful_production_deploy_completed_at": "2026-05-20T16:17:20Z",
@@ -40,7 +40,7 @@
     "production_executor_presence_verified": true,
     "remote_read_only_command_verified": true,
     "local_ssh_attempt": {
-      "target": "fap-api-prod",
+      "target": "<redacted-ssh-target>",
       "result": "success"
     },
     "current_release": "20260521220637",
@@ -65,7 +65,7 @@
     "claim_boundary_state": "claim_safe",
     "private_flow": false,
     "verification_state": "fresh_production_dry_run_verified",
-    "verification_source": "Production read-only executor dry-run on Aliyun release 20260521220637 at SHA 35d1f33b038df4eac330475d072f25fbbfd66364."
+    "verification_source": "Production read-only executor dry-run on the approved release; concrete host and release shell are redacted from repository docs."
   },
   "fresh_dry_run": {
     "status": "success",
@@ -243,11 +243,11 @@
     "indexnow_live_api_enabled": true,
     "indexnow_key_present": true,
     "indexnow_key_length": 32,
-    "indexnow_key_sha256": "e9a3eca3e7c107d6e0ac63c1fdba24068d970aecb4bdf18ed69735e8b77cf143",
-    "indexnow_key_location_host": "fermatmind.com",
+    "indexnow_key_sha256": "<redacted-indexnow-key-sha256>",
+    "indexnow_key_location_host": "<redacted-indexnow-key-location-host>",
     "indexnow_key_location_public_bytes": 32,
-    "indexnow_key_location_public_sha256": "e9a3eca3e7c107d6e0ac63c1fdba24068d970aecb4bdf18ed69735e8b77cf143",
-    "frontend_pm2_reloaded_for_key_file": true
+    "indexnow_key_location_public_sha256": "<redacted-indexnow-key-location-sha256>",
+    "frontend_pm2_reloaded_for_key_file": "<redacted-operational-detail>"
   },
   "live_gate_verification": {
     "status": "pass",

--- a/backend/docs/seo/search-channel-live-02-preflight.md
+++ b/backend/docs/seo/search-channel-live-02-preflight.md
@@ -7,7 +7,7 @@ Date: 2026-05-21
 
 This rerun returns to the small human-approved Search Channel live submission canary after `SEARCH-CHANNEL-LIVE-02-EXECUTOR` added the guarded single-item executor, production was deployed to a release that contains that executor, and the IndexNow live configuration was added to production.
 
-No live search API call, URL submission, scheduler activation, DNS change, or additional queue write was performed in this preflight task. The production env/config cache was updated only to add the IndexNow key/keyLocation and one-shot live gates needed for the next approved canary attempt.
+No live search API call, URL submission, scheduler activation, DNS change, or additional queue write was performed in this preflight task. The production config cache was updated only for the approved one-shot live gates; concrete IndexNow key and keyLocation details are kept outside repository docs.
 
 ## Executor Evidence
 
@@ -38,7 +38,7 @@ The production dry-run confirmed the intended canary candidate:
 The guarded live submission executor was run in dry-run mode only:
 
 ```bash
-cd /var/www/fap-api/current/backend
+cd <production-backend-release-dir>
 php artisan seo-intel:search-channel-submit --queue-item-id=1 --dry-run --json
 ```
 
@@ -59,7 +59,7 @@ Result:
 The queue planner was also run in no-write dry-run mode:
 
 ```bash
-cd /var/www/fap-api/current/backend
+cd <production-backend-release-dir>
 php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=1
 ```
 
@@ -88,14 +88,14 @@ Production now has the live submission gates and IndexNow key metadata in Larave
 - `SEO_INTEL_INDEXNOW_KEY` present
 - `SEO_INTEL_INDEXNOW_KEY_LOCATION` present
 - Laravel config cache rebuilt
-- public keyLocation host `fermatmind.com` returned the expected 32-byte key file
+- public keyLocation on the approved host returned the expected 32-byte key file
 
-The key value and full keyLocation are intentionally not written to this artifact.
+The key value, full keyLocation, key hash, and concrete host are intentionally not written to this artifact.
 
 The guarded executor was also checked without the approval phrase:
 
 ```bash
-cd /var/www/fap-api/current/backend
+cd <production-backend-release-dir>
 php artisan seo-intel:search-channel-submit --queue-item-id=1 --json
 ```
 

--- a/backend/docs/seo/search-channel-live-mbti-01-preflight.md
+++ b/backend/docs/seo/search-channel-live-mbti-01-preflight.md
@@ -54,24 +54,24 @@ Production config contains IndexNow live submission metadata:
 - IndexNow key present
 - key length `32`
 - keyLocation present
-- keyLocation host `fermatmind.com`
+- keyLocation host redacted from repository docs
 
 Public keyLocation verification succeeded:
 
-- URL: `https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt`
+- URL: `<redacted-indexnow-key-location>`
 - HTTP `200`
 - content type `text/plain; charset=UTF-8`
 - body length `32`
 - public file SHA-256 matched the configured IndexNow key SHA-256
 
-The raw key value is intentionally not recorded here.
+The raw key value, full keyLocation, concrete host, and key hash are intentionally not recorded here.
 
 ## Submit dry-run verification
 
 Read-only submit dry-run command:
 
 ```bash
-cd /var/www/fap-api/current/backend
+cd <production-backend-release-dir>
 php artisan seo-intel:search-channel-submit --queue-item-id=2 --dry-run --json
 ```
 

--- a/backend/tests/Unit/Security/SecurityGuardrailsTest.php
+++ b/backend/tests/Unit/Security/SecurityGuardrailsTest.php
@@ -379,6 +379,55 @@ final class SecurityGuardrailsTest extends TestCase
         $this->assertDoesNotMatchRegularExpression('/[\'"]reason[\'"]\s*=>/', $source);
     }
 
+    public function test_security_docs_do_not_disclose_exact_production_infrastructure_details(): void
+    {
+        $repoRoot = dirname(base_path());
+        $paths = [
+            'README_DEPLOY.md',
+            'docs/04-ops/backend-deploy-target-aliyun-01.md',
+            'backend/docs/seo/crawler-log-production-canary-preflight.md',
+            'backend/docs/seo/crawler-log-production-canary-report.md',
+            'backend/docs/seo/crawler-log-production-canary-runtime.md',
+            'backend/docs/seo/search-channel-live-02-preflight.md',
+            'backend/docs/seo/search-channel-live-mbti-01-preflight.md',
+            'backend/docs/seo/generated/crawler-log-production-canary-preflight.v1.json',
+            'backend/docs/seo/generated/crawler-log-production-canary-report.v1.json',
+            'backend/docs/seo/generated/crawler-log-production-canary-runtime.v1.json',
+            'backend/docs/seo/generated/search-channel-live-02-preflight.v1.json',
+        ];
+
+        $patterns = [
+            'production_ip' => '/\b(?:139\.224\.130\.204|122\.152\.221\.126)\b/',
+            'production_webhook_url' => '/http:\/\/122\.152\.221\.126:9000\/hooks\/deploy-fap-api/',
+            'production_log_path' => '/\/var\/log\/nginx\/access\.log/',
+            'production_release_shell' => '/\/var\/www\/fap-api\/current\/backend/',
+            'indexnow_key_location_url' => '/https:\/\/fermatmind\.com\/[a-f0-9]{32}\.txt/',
+            'indexnow_key_hash' => '/indexnow_key_(?:location_public_)?sha256"\s*:\s*"[a-f0-9]{64}"/',
+            'rds_endpoint' => '/rm-uf6u2498t7nk2faya\.rwlb\.rds\.aliyuncs\.com/',
+        ];
+
+        $violations = [];
+
+        foreach ($paths as $relativePath) {
+            $source = file_get_contents($repoRoot.'/'.$relativePath);
+            $this->assertIsString($source, $relativePath);
+
+            foreach ($patterns as $label => $pattern) {
+                if (preg_match($pattern, $source) !== 1) {
+                    continue;
+                }
+
+                $violations[] = "{$relativePath}:{$label}";
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $violations,
+            "Security docs must use placeholders for exact production infrastructure details.\n".implode("\n", $violations)
+        );
+    }
+
     public function test_v03_auth_guest_route_wiring_and_middleware_contract(): void
     {
         $source = file_get_contents(base_path('routes/api.php'));

--- a/docs/04-ops/backend-deploy-target-aliyun-01.md
+++ b/docs/04-ops/backend-deploy-target-aliyun-01.md
@@ -8,25 +8,25 @@ Last updated: 2026-05-21
 
 Production backend deploy target is Aliyun ECS `fap-api-prod-ali-01`:
 
-- Public IP: `139.224.130.204`
-- Runtime host user: `ubuntu`
-- Standard deploy root: `/var/www/fap-api`
+- Public IP: redacted from repository docs; use deploy config / approved ops inventory.
+- Runtime host user: redacted from repository docs; use deploy config / approved ops inventory.
+- Standard deploy root: redacted from repository docs; use deploy config / approved ops inventory.
 - Public API host: `api.fermatmind.com`
 - Ops host: `ops.fermatmind.com`
 
-Tencent Node3 `122.152.221.126` is retired as a production deploy target. Deploy automation must fail closed instead of deploying new production releases to Node3.
+Tencent Node3 is retired as a production deploy target. Deploy automation must fail closed instead of deploying new production releases to Node3.
 
 ## Runtime Bootstrap
 
 The emergency migration runtime was mounted behind the standard deploy path so future releases have one stable target:
 
-- `/var/www/fap-api/current -> /opt/fap-api`
-- `/var/www/fap-api/releases`
-- `/var/www/fap-api/shared/backend/.env`
-- `/var/www/fap-api/shared/backend/storage`
-- `/var/www/fap-api/shared/content_packages`
+- current release symlink
+- managed release directory
+- shared backend env file
+- shared backend storage
+- shared content packages
 
-Nginx, Supervisor, and cron point to `/var/www/fap-api/current/backend`. The first standard Deployer release may replace the temporary `current` symlink with a managed release symlink.
+Nginx, Supervisor, and cron point to the managed current release backend. The first standard Deployer release may replace the temporary `current` symlink with a managed release symlink.
 
 Node3 queue workers and Laravel scheduler were stopped after `api.fermatmind.com` and `ops.fermatmind.com` resolved to Aliyun. Node3 nginx was left running temporarily only for stale DNS-cache tail traffic.
 
@@ -36,7 +36,7 @@ Node3 queue workers and Laravel scheduler were stopped after `api.fermatmind.com
 
 - Cert path: `/etc/letsencrypt/live/ops.fermatmind.com/fullchain.pem`
 - Renewal authenticator: `webroot`
-- Webroot: `/var/www/fap-api/current/backend/public`
+- Webroot: managed current release public directory
 - Nginx reload hook: `/etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh`
 - Certbot timer: enabled and active
 
@@ -44,7 +44,7 @@ Node3 queue workers and Laravel scheduler were stopped after `api.fermatmind.com
 
 ## Retired Node3 Deploy Webhook
 
-The old GitHub push webhook that targeted `http://122.152.221.126:9000/hooks/deploy-fap-api` has been disabled in GitHub. Node3 `webhook.service` is stopped and disabled, and Node3 has a host firewall reject rule for TCP/9000.
+The old GitHub push webhook for the retired Node3 deploy endpoint has been disabled in GitHub. Node3 `webhook.service` is stopped and disabled, and Node3 has a host firewall reject rule for TCP/9000.
 
 Production deployment should use the GitHub Actions/Deployer SSH path to Aliyun, not the old Node3 webhook.
 
@@ -52,7 +52,7 @@ Production deployment should use the GitHub Actions/Deployer SSH path to Aliyun,
 
 `NODE3-RETIREMENT-FINAL-CHECK` completed on 2026-05-21:
 
-- Cloudflare and Google public DNS resolve `api.fermatmind.com` and `ops.fermatmind.com` to Aliyun `139.224.130.204`.
+- Cloudflare and Google public DNS resolve `api.fermatmind.com` and `ops.fermatmind.com` to the approved Aliyun backend target.
 - Aliyun Host-forced smoke checks returned 200 for the public API questions endpoint and Ops login.
 - The old GitHub deploy webhook for Node3 TCP/9000 is inactive.
 - Node3 `webhook.service` is inactive and disabled.
@@ -66,15 +66,15 @@ Conclusion: Node3 can expire without affecting the current production API/Ops/qu
 ## Acceptance Checks
 
 ```bash
-rg -n '122\.152\.221\.126|DEPLOY_HOST_PROD' deploy.php .github/workflows/deploy.yml README_DEPLOY.md
+rg -n 'DEPLOY_HOST_PROD|retired Tencent Node3' deploy.php .github/workflows/deploy.yml README_DEPLOY.md
 php -l deploy.php
 certbot renew --dry-run --cert-name ops.fermatmind.com --no-random-sleep-on-renew
 ```
 
 Expected result:
 
-- Production defaults resolve to `139.224.130.204`.
-- The workflow refuses `DEPLOY_HOST_PROD=122.152.221.126`.
+- Production defaults resolve to the approved Aliyun backend target.
+- The workflow refuses the retired Node3 deploy target.
 - Production health and auth smoke use `https://api.fermatmind.com`.
 - Production Deployer host defaults use `api.fermatmind.com` as the backend healthcheck host.
 - `ops.fermatmind.com` certificate renewal succeeds without DNSPod manual TXT records.


### PR DESCRIPTION
## What changed
- Redacted exact production origins, SSH targets, deploy paths, IndexNow key locations, and production canary execution details from scoped ops/SEO docs and generated artifacts.
- Preserved non-sensitive operational guidance with placeholders that point operators back to approved secret/config/inventory sources.
- Added a focused security guardrail test so these docs do not re-disclose the same concrete infrastructure details.
- Reconciled PR-API-SEC-01 ledger state after its CI fix, merge, branch cleanup, and post-merge revalidation.

## Why
The security finding showed production infrastructure details and generated artifacts were preserving sensitive operational values. This PR keeps the docs useful while removing exact hosts, paths, keys, and targets.

## Validation commands
- `php artisan test tests/Unit/Security/SecurityGuardrailsTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test tests/Unit/Security/SecurityGuardrailsTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan route:list --no-ansi`
- `git diff --check`
- `git diff --cached --check`
- Targeted generated-artifact JSON validation for the four changed `backend/docs/seo/generated/*.json` files
- Targeted sensitive-pattern search across changed docs/generated artifacts

## Intentionally deferred
- No runtime code, routes, migrations, deploy config, public APIs, fap-web changes, or production infrastructure changes.
- No broad rewrite of unrelated operational docs outside this finding scope.

## Repository rule impact
Documentation-only security redaction. It does not change content authority, publishing workflow, API contracts, SEO generation behavior, sitemap/llms enumeration, or frontend fallback behavior.
