### PR TITLE
PR-API-SEC-04 fix(security): enforce source article approval in Translation Ops

### DIFF
--- a/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+++ b/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
@@ -673,6 +673,9 @@ final class ArticleTranslationWorkflowService
         if ($source->published_at instanceof \DateTimeInterface && $source->published_at > now()) {
             $blockers[] = 'source article publish date is future';
         }
+        if (($this->sourceEditorialReviewState($source)['state'] ?? null) !== EditorialReviewAudit::STATE_APPROVED) {
+            $blockers[] = 'source article editorial approval missing';
+        }
 
         $publishedRevision = $source->publishedRevision;
         if (! $publishedRevision instanceof ArticleTranslationRevision) {
@@ -687,6 +690,14 @@ final class ArticleTranslationWorkflowService
         }
 
         return $blockers;
+    }
+
+    /**
+     * @return array{state:string,label:string,reviewed_at:string,owner_admin_user_id:int|null,owner_label:string,reviewer_admin_user_id:int|null,reviewer_label:string}|null
+     */
+    private function sourceEditorialReviewState(Article $source): ?array
+    {
+        return EditorialReviewAudit::latestState('article', $source);
     }
 
     private function referencesPreserved(Article $source, ArticleTranslationRevision $targetRevision): bool

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T22:30:00+08:00",
+  "updated_at": "2026-05-23T22:33:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5302,10 +5302,10 @@
     "PR-API-SEC-04": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-api-sec-04-translation-source-approval",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "9ad96647",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1619",
       "title": "fix(security): enforce source article approval in Translation Ops",
       "checks": {
         "local": [
@@ -5333,7 +5333,13 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "github_checks",
+            "status": "pending",
+            "details": "PR #1619 opened; awaiting GitHub check completion."
+          }
+        ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
@@ -5355,6 +5361,11 @@
           "at": "2026-05-23T22:30:00+08:00",
           "status": "local_checks_passed",
           "summary": "Required source articles to retain current editorial approval before translation draft, resync, preflight, or publish actions; focused Ops tests, Pint, JSON, route list, and diff checks passed."
+        },
+        {
+          "at": "2026-05-23T22:33:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened GitHub PR https://github.com/fermatmind/fap-api/pull/1619 for PR-API-SEC-04 after local checks and scope validation passed."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T22:18:00+08:00",
+  "updated_at": "2026-05-23T22:30:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5161,9 +5161,9 @@
     "PR-API-SEC-03": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "ci_fix_local_checks_passed",
+      "status": "merged",
       "branch": "codex/pr-api-sec-03-pin-semgrep-ci",
-      "commit_sha": "41feebfb",
+      "commit_sha": "7c4f1081fde6aa8890625e21fe829c04d0f6a0d6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1618",
       "title": "ci(security): pin privileged Semgrep install",
       "checks": {
@@ -5203,6 +5203,11 @@
             "command": "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/codeql.yml\")'",
             "status": "passed",
             "details": "CI fix rerun."
+          },
+          {
+            "command": "php artisan test tests/Unit/Security/SecurityGuardrailsTest.php && ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/codeql.yml\")'",
+            "status": "passed",
+            "details": "Post-merge revalidation passed: SecurityGuardrailsTest 17 tests, 77 assertions; workflow YAML parsed."
           }
         ],
         "github": [
@@ -5216,24 +5221,36 @@
           },
           {
             "name": "semgrep sarif",
-            "status": "failed_then_fixed_pending_rerun",
-            "details": "Pinned Semgrep 1.136.0 installed, but latest setuptools 82 removed pkg_resources required by Semgrep/opentelemetry; CI failed during semgrep --version. Fix pins setuptools 80.9.0 alongside Semgrep."
+            "status": "failed_then_passed",
+            "details": "Initial pinned Semgrep run failed on setuptools 82/pkg_resources removal; rerun passed after pinning setuptools 80.9.0."
+          },
+          {
+            "name": "Semgrep OSS",
+            "status": "passed"
           },
           {
             "name": "verify-mbti-legacy",
-            "status": "pending"
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-legacy",
+            "status": "passed"
           },
           {
             "name": "verify-mbti-v2",
-            "status": "pending"
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-v2",
+            "status": "passed"
           }
         ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T14:01:22Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-23T00:00:00+08:00",
@@ -5264,19 +5281,58 @@
           "at": "2026-05-23T22:18:00+08:00",
           "status": "ci_fix_local_checks_passed",
           "summary": "Pinned setuptools 80.9.0 alongside Semgrep 1.136.0 and extended workflow guardrail coverage; focused test, JSON, and workflow YAML parse checks passed locally."
+        },
+        {
+          "at": "2026-05-23T22:00:21+08:00",
+          "status": "github_checks_green",
+          "summary": "GitHub checks for PR #1618 completed successfully after the scoped Semgrep installer fix: hygiene, Semgrep OSS, semgrep sarif, verify-mbti-legacy, and verify-mbti-v2 all passed."
+        },
+        {
+          "at": "2026-05-23T22:01:22+08:00",
+          "status": "merged",
+          "summary": "PR #1618 squash-merged into main with merge commit 7c4f1081fde6aa8890625e21fe829c04d0f6a0d6; remote branch was deleted."
+        },
+        {
+          "at": "2026-05-23T22:03:00+08:00",
+          "status": "post_merge_revalidated",
+          "summary": "Ran post_merge_cleanup.sh for codex/pr-api-sec-03-pin-semgrep-ci and revalidated SecurityGuardrailsTest plus Code Scanning workflow YAML parse on updated main."
         }
       ]
     },
     "PR-API-SEC-04": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
+      "status": "local_checks_passed",
       "branch": "codex/pr-api-sec-04-translation-source-approval",
       "commit_sha": "",
       "pr_url": "",
       "title": "fix(security): enforce source article approval in Translation Ops",
       "checks": {
-        "local": [],
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Ops app/Services/Cms tests/Feature/Ops docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed",
+            "details": "147 files checked."
+          },
+          {
+            "command": "php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php",
+            "status": "passed",
+            "details": "35 tests, 337 assertions."
+          },
+          {
+            "command": "php artisan route:list --no-ansi",
+            "status": "passed",
+            "details": "203 routes listed."
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
         "github": []
       },
       "failure_reason": "",
@@ -5289,6 +5345,16 @@
           "at": "2026-05-23T00:00:00+08:00",
           "status": "planned",
           "summary": "PR-API-SEC-04 planned after explicit user authorization for the first-wave security train."
+        },
+        {
+          "at": "2026-05-23T22:30:00+08:00",
+          "status": "in_progress",
+          "summary": "Started PR-API-SEC-04 from updated main after PR-API-SEC-03 merged; scope is limited to Translation Ops source article approval guards and focused Ops regression tests."
+        },
+        {
+          "at": "2026-05-23T22:30:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Required source articles to retain current editorial approval before translation draft, resync, preflight, or publish actions; focused Ops tests, Pint, JSON, route list, and diff checks passed."
         }
       ]
     },

--- a/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
@@ -6,11 +6,13 @@ namespace Tests\Feature\Ops;
 
 use App\Contracts\Cms\ArticleMachineTranslationProvider;
 use App\Filament\Ops\Pages\ArticleTranslationOpsPage;
+use App\Filament\Ops\Support\EditorialReviewAudit;
 use App\Models\AdminUser;
 use App\Models\Article;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
 use App\Models\AuditLog;
+use App\Models\EditorialReview;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
@@ -387,6 +389,34 @@ final class ArticleTranslationOpsPageTest extends TestCase
             ->count());
     }
 
+    public function test_translation_workflow_blocks_unapproved_source_before_machine_translation(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $provider = new FakeArticleMachineTranslationProvider;
+        $this->app->instance(ArticleMachineTranslationProvider::class, $provider);
+
+        $source = $this->createSourceOnlyGroup('unapproved-source-translation-fixture');
+        $this->setArticleReviewState($source, EditorialReviewAudit::STATE_IN_REVIEW);
+
+        try {
+            app(ArticleTranslationWorkflowService::class)->createMachineDraft($source->fresh(['workingRevision', 'publishedRevision']), 'en', (int) $admin->id);
+            $this->fail('Expected source approval guard to block the machine translation draft.');
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->assertContains('source article editorial approval missing', $exception->blockers);
+        }
+
+        $this->assertSame(0, $provider->calls);
+        $this->assertSame(0, Article::query()
+            ->withoutGlobalScopes()
+            ->where('translation_group_id', (string) $source->translation_group_id)
+            ->where('locale', 'en')
+            ->count());
+    }
+
     public function test_translation_ops_page_create_draft_action_uses_workflow_service(): void
     {
         $admin = $this->createAdminWithPermissions([
@@ -619,6 +649,33 @@ final class ArticleTranslationOpsPageTest extends TestCase
         $this->assertNull($translation->published_revision_id);
     }
 
+    public function test_translation_preflight_blocks_target_when_source_approval_is_not_current(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $group = $this->createPublishedTranslationGroup('source-approval-preflight-fixture');
+        $this->setArticleReviewState($group['source'], EditorialReviewAudit::STATE_CHANGES_REQUESTED);
+
+        $preflight = app(ArticleTranslationWorkflowService::class)->preflight(
+            $group['translation']->fresh(['workingRevision', 'sourceCanonical.workingRevision'])
+        );
+
+        $this->assertFalse($preflight['ok']);
+        $this->assertContains('source article editorial approval missing', $preflight['blockers']);
+
+        try {
+            app(ArticleTranslationWorkflowService::class)->publishTranslation($group['translation']);
+            $this->fail('Expected publish preflight to block an unapproved source article.');
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->assertSame('Translation publish preflight failed.', $exception->getMessage());
+            $this->assertContains('source article editorial approval missing', $exception->blockers);
+        }
+    }
+
     public function test_translation_workflow_promotes_approves_and_publishes_with_guardrails(): void
     {
         $admin = $this->createAdminWithPermissions([
@@ -788,7 +845,26 @@ final class ArticleTranslationOpsPageTest extends TestCase
             'is_indexable' => true,
         ]);
 
+        $this->setArticleReviewState($source, EditorialReviewAudit::STATE_APPROVED);
+
         return $source->fresh(['workingRevision', 'publishedRevision', 'seoMeta']);
+    }
+
+    private function setArticleReviewState(Article $article, string $state): void
+    {
+        EditorialReview::withoutGlobalScopes()->updateOrCreate(
+            [
+                'content_type' => 'article',
+                'content_id' => (int) $article->id,
+            ],
+            [
+                'org_id' => (int) $article->org_id,
+                'workflow_state' => $state,
+                'reviewed_by_admin_user_id' => null,
+                'reviewed_at' => $state === EditorialReviewAudit::STATE_APPROVED ? now() : null,
+                'last_transition_at' => now(),
+            ],
+        );
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added a source article editorial approval guard to Article Translation workflow scope checks.
- Translation draft, resync, target preflight, approval, and publish paths now require the source article to still have current `approved` EditorialReview state.
- Added focused Ops tests for unapproved source draft blocking and target preflight/publish blocking.
- Reconciled PR-API-SEC-03 ledger state after its CI fix, merge, branch cleanup, and post-merge revalidation.

## Why
Translation Ops already required source publication/public state, but it did not verify the trusted editorial approval state. A stale or unapproved source could therefore feed translation actions after publication fields were present.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Ops app/Services/Cms tests/Feature/Ops docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php`
- `php artisan route:list --no-ansi`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No content publication, article body edits, public article API changes, fap-web changes, or unrelated CMS surface changes.
- No changes to support-article sibling translation flows.

## Repository rule impact
Backend CMS authority hardening only. It preserves CMS/backend authority for translation workflows and does not change public content ownership, sitemap/llms enumeration, or frontend fallback behavior.
