### PR TITLE
PR-API-SEC-05 fix(career): bound public jobs list database work

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -95,15 +95,7 @@ final class CareerJobDisplaySurfaceBuilder
             return null;
         }
 
-        $asset = $occupation->displayAssets()
-            ->where('canonical_slug', $canonicalSlug)
-            ->where('surface_version', self::SURFACE_VERSION)
-            ->where('asset_version', self::ASSET_VERSION)
-            ->where('template_version', self::TEMPLATE_VERSION)
-            ->where('status', self::READY_STATUS)
-            ->where('asset_type', self::ASSET_TYPE)
-            ->orderByDesc('updated_at')
-            ->first();
+        $asset = $this->readyDisplayAsset($occupation, $canonicalSlug);
 
         if (! $asset instanceof CareerJobDisplayAsset) {
             return null;
@@ -158,6 +150,33 @@ final class CareerJobDisplaySurfaceBuilder
             'structured_data_from_visible_content' => $structuredData,
             'implementation_contract' => $implementationContract,
         ];
+    }
+
+    private function readyDisplayAsset(Occupation $occupation, string $canonicalSlug): ?CareerJobDisplayAsset
+    {
+        if ($occupation->relationLoaded('displayAssets')) {
+            $asset = $occupation->displayAssets
+                ->filter(static fn (CareerJobDisplayAsset $candidate): bool => (string) $candidate->canonical_slug === $canonicalSlug
+                    && (string) $candidate->surface_version === self::SURFACE_VERSION
+                    && (string) $candidate->asset_version === self::ASSET_VERSION
+                    && (string) $candidate->template_version === self::TEMPLATE_VERSION
+                    && (string) $candidate->status === self::READY_STATUS
+                    && (string) $candidate->asset_type === self::ASSET_TYPE)
+                ->sortByDesc('updated_at')
+                ->first();
+
+            return $asset instanceof CareerJobDisplayAsset ? $asset : null;
+        }
+
+        return $occupation->displayAssets()
+            ->where('canonical_slug', $canonicalSlug)
+            ->where('surface_version', self::SURFACE_VERSION)
+            ->where('asset_version', self::ASSET_VERSION)
+            ->where('template_version', self::TEMPLATE_VERSION)
+            ->where('status', self::READY_STATUS)
+            ->where('asset_type', self::ASSET_TYPE)
+            ->orderByDesc('updated_at')
+            ->first();
     }
 
     private function isManualHoldSlug(string $slug): bool

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -209,6 +209,7 @@ final class CareerJobListBundleBuilder
         $excluded = array_flip(array_filter($excludedSlugs));
 
         return Occupation::query()
+            ->with(['crosswalks', 'displayAssets'])
             ->where('crosswalk_mode', self::DIRECTORY_DRAFT_CROSSWALK_MODE)
             ->orderBy('canonical_title_en')
             ->orderBy('canonical_slug')
@@ -875,15 +876,24 @@ final class CareerJobListBundleBuilder
 
     private function validDisplayAssetBackedAsset(Occupation $occupation, string $subjectSlug): ?CareerJobDisplayAsset
     {
-        $assets = CareerJobDisplayAsset::query()
-            ->where('occupation_id', $occupation->id)
-            ->where('canonical_slug', $subjectSlug)
-            ->where('surface_version', self::DISPLAY_SURFACE_VERSION)
-            ->where('asset_version', self::DISPLAY_ASSET_VERSION)
-            ->where('template_version', self::DISPLAY_ASSET_VERSION)
-            ->where('status', self::DISPLAY_READY_STATUS)
-            ->where('asset_type', self::DISPLAY_ASSET_TYPE)
-            ->get();
+        $assets = $occupation->relationLoaded('displayAssets')
+            ? $occupation->displayAssets
+                ->where('canonical_slug', $subjectSlug)
+                ->where('surface_version', self::DISPLAY_SURFACE_VERSION)
+                ->where('asset_version', self::DISPLAY_ASSET_VERSION)
+                ->where('template_version', self::DISPLAY_ASSET_VERSION)
+                ->where('status', self::DISPLAY_READY_STATUS)
+                ->where('asset_type', self::DISPLAY_ASSET_TYPE)
+                ->values()
+            : CareerJobDisplayAsset::query()
+                ->where('occupation_id', $occupation->id)
+                ->where('canonical_slug', $subjectSlug)
+                ->where('surface_version', self::DISPLAY_SURFACE_VERSION)
+                ->where('asset_version', self::DISPLAY_ASSET_VERSION)
+                ->where('template_version', self::DISPLAY_ASSET_VERSION)
+                ->where('status', self::DISPLAY_READY_STATUS)
+                ->where('asset_type', self::DISPLAY_ASSET_TYPE)
+                ->get();
 
         if ($assets->count() !== 1) {
             return null;

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T22:33:00+08:00",
+  "updated_at": "2026-05-23T22:52:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5302,9 +5302,9 @@
     "PR-API-SEC-04": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/pr-api-sec-04-translation-source-approval",
-      "commit_sha": "9ad96647",
+      "commit_sha": "5d4e0294c725d04a4c31b6d38e60babac1a241fa",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1619",
       "title": "fix(security): enforce source article approval in Translation Ops",
       "checks": {
@@ -5331,21 +5331,53 @@
           {
             "command": "git diff --check && git diff --cached --check",
             "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php",
+            "status": "passed",
+            "details": "Post-merge revalidation passed: 35 tests, 337 assertions."
           }
         ],
         "github": [
           {
-            "name": "github_checks",
-            "status": "pending",
-            "details": "PR #1619 opened; awaiting GitHub check completion."
+            "name": "hygiene",
+            "status": "passed"
+          },
+          {
+            "name": "hygiene",
+            "status": "passed"
+          },
+          {
+            "name": "semgrep sarif",
+            "status": "passed"
+          },
+          {
+            "name": "Semgrep OSS",
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-legacy",
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-legacy",
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-v2",
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-v2",
+            "status": "passed"
           }
         ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T14:15:38Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-23T00:00:00+08:00",
@@ -5366,19 +5398,63 @@
           "at": "2026-05-23T22:33:00+08:00",
           "status": "pr_open",
           "summary": "Opened GitHub PR https://github.com/fermatmind/fap-api/pull/1619 for PR-API-SEC-04 after local checks and scope validation passed."
+        },
+        {
+          "at": "2026-05-23T22:14:27+08:00",
+          "status": "github_checks_green",
+          "summary": "GitHub checks for PR #1619 completed successfully: hygiene, Semgrep OSS, semgrep sarif, verify-mbti-legacy, and verify-mbti-v2 all passed."
+        },
+        {
+          "at": "2026-05-23T22:15:38+08:00",
+          "status": "merged",
+          "summary": "PR #1619 squash-merged into main with merge commit 5d4e0294c725d04a4c31b6d38e60babac1a241fa; remote branch was deleted."
+        },
+        {
+          "at": "2026-05-23T22:17:00+08:00",
+          "status": "post_merge_revalidated",
+          "summary": "Ran post_merge_cleanup.sh for codex/pr-api-sec-04-translation-source-approval and revalidated focused Translation Ops tests on updated main."
         }
       ]
     },
     "PR-API-SEC-05": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
+      "status": "local_checks_passed",
       "branch": "codex/pr-api-sec-05-public-jobs-list-db-budget",
       "commit_sha": "",
       "pr_url": "",
       "title": "fix(career): bound public jobs list database work",
       "checks": {
-        "local": [],
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles tests/Feature/Career tests/Unit/Services/Career docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed",
+            "details": "157 files checked."
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php",
+            "status": "passed",
+            "details": "36 tests, 1035 assertions."
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerJobListApiTest.php",
+            "status": "passed",
+            "details": "8 tests, 121 assertions; includes directory draft query-budget regression."
+          },
+          {
+            "command": "php artisan route:list --path=career --no-ansi",
+            "status": "passed",
+            "details": "43 career routes listed."
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
         "github": []
       },
       "failure_reason": "",
@@ -5391,6 +5467,16 @@
           "at": "2026-05-23T00:00:00+08:00",
           "status": "planned",
           "summary": "PR-API-SEC-05 planned after explicit user authorization for the first-wave security train."
+        },
+        {
+          "at": "2026-05-23T22:52:00+08:00",
+          "status": "in_progress",
+          "summary": "Started PR-API-SEC-05 from updated main after PR-API-SEC-04 merged; scope is limited to public career jobs list DB budget hardening and focused regression tests."
+        },
+        {
+          "at": "2026-05-23T22:52:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Eager-loaded directory draft crosswalk/display asset data and reused preloaded display assets in surface validation to avoid per-draft query amplification; focused performance and display-surface checks passed."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T22:52:00+08:00",
+  "updated_at": "2026-05-23T23:02:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5419,10 +5419,10 @@
     "PR-API-SEC-05": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-api-sec-05-public-jobs-list-db-budget",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "1b32dd2f768b392e2d0c2b3e540c9b61b216ff61",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1620",
       "title": "fix(career): bound public jobs list database work",
       "checks": {
         "local": [
@@ -5477,6 +5477,11 @@
           "at": "2026-05-23T22:52:00+08:00",
           "status": "local_checks_passed",
           "summary": "Eager-loaded directory draft crosswalk/display asset data and reused preloaded display assets in surface validation to avoid per-draft query amplification; focused performance and display-surface checks passed."
+        },
+        {
+          "at": "2026-05-23T23:02:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1620 from codex/pr-api-sec-05-public-jobs-list-db-budget after push."
         }
       ]
     },

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -14,6 +14,7 @@ use App\Models\OccupationCrosswalk;
 use App\Models\OccupationFamily;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\Fixtures\Career\CareerFoundationFixture;
 use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
@@ -212,6 +213,46 @@ final class CareerJobListApiTest extends TestCase
             ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1');
     }
 
+    public function test_directory_draft_display_asset_list_work_stays_bounded(): void
+    {
+        $slugs = [];
+        for ($i = 1; $i <= 8; $i++) {
+            $slug = "bounded-directory-draft-{$i}";
+            $slugs[] = $slug;
+            $occupation = $this->createDirectoryDraftOccupation([
+                'canonical_slug' => $slug,
+                'canonical_title_en' => "Bounded Directory Draft {$i}",
+                'canonical_title_zh' => "有界目录草稿 {$i}",
+                'search_h1_zh' => "有界目录草稿 {$i}",
+                'truth_market' => 'US',
+                'display_market' => 'zh-CN',
+            ]);
+            $this->addDisplayAssetBackedCrosswalks($occupation, sprintf('29-%04d', 1200 + $i), sprintf('29-%04d.00', 1200 + $i));
+            $this->createDisplayAsset($occupation->refresh());
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                detailRouteEnabled: array_fill_keys($slugs, true),
+                robotsIndexable: array_fill_keys($slugs, true),
+                releaseGatePass: array_fill_keys($slugs, true),
+            ),
+        );
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $this->getJson('/api/v0.5/career/jobs')
+            ->assertOk()
+            ->assertJsonCount(8, 'items');
+
+        $queryCount = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        $this->assertLessThanOrEqual(20, $queryCount, "Directory draft list should not query per draft; saw {$queryCount} queries.");
+    }
+
     public function test_directory_draft_with_runtime_published_detail_shell_is_listed_as_detail_ready(): void
     {
         $this->app->instance(
@@ -375,7 +416,7 @@ final class CareerJobListApiTest extends TestCase
     private function createDirectoryDraftOccupation(array $overrides = []): Occupation
     {
         $family = OccupationFamily::query()->create([
-            'canonical_slug' => 'directory-draft-family',
+            'canonical_slug' => 'directory-draft-family-'.($overrides['canonical_slug'] ?? 'default'),
             'title_en' => 'Directory Draft Family',
             'title_zh' => '目录草稿职业族',
         ]);


### PR DESCRIPTION
## What changed
- Eager-load directory draft career job crosswalks and display assets in the public jobs list builder.
- Reuse preloaded display assets in list and display-surface builders to avoid per-draft database amplification.
- Added a focused feature regression that asserts directory draft display-asset list work remains bounded.
- Updated the PR train ledger for PR-API-SEC-05.

## Why
The public career jobs list could amplify database work when many directory draft occupations had display-asset-backed payloads. This keeps the public route shape intact while bounding relation lookups inside the declared career jobs list scope.

## Validation commands
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- vendor/bin/pint --test app/Services/Career/Bundles tests/Feature/Career tests/Unit/Services/Career docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
- php artisan test tests/Feature/Career/CareerJobListApiTest.php
- php artisan route:list --path=career --no-ansi
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No public career route shape changes.
- No canonical career content, sitemap, llms, fap-web, migrations, or production data changes.

## Repository rule impact
No content ownership or publishing workflow changes. Career content remains backend/CMS/public API authoritative; this PR only hardens backend product-code query behavior.