### PR TITLE
PR-API-SEC-06 fix(security): enforce CN proxy public-route release gate

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerCnProxyPublicOwnerSurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerCnProxyPublicOwnerSurfaceBuilder.php
@@ -120,10 +120,26 @@ final class CareerCnProxyPublicOwnerSurfaceBuilder
             && (int) ($plan['occupations_delta'] ?? 0) === 0
             && (int) ($plan['occupation_crosswalks_delta'] ?? 0) === 0
             && (int) ($plan['career_job_display_assets_delta'] ?? 0) === 0
+            && $this->planAllowsPublicRouteExposure($plan)
             && ($plan['CN_proxy_can_masquerade_as_US_canonical_job'] ?? true) === false
             && ($plan['US_canonical_job_schema_returned'] ?? true) === false
             && ($plan['noindex_default'] ?? null) === true
             && ($plan['blockers'] ?? []) === [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     */
+    private function planAllowsPublicRouteExposure(array $plan): bool
+    {
+        $publicRows = (int) ($plan['public_cn_proxy_page_rows'] ?? 0);
+
+        return $publicRows > 0
+            && ($plan['route_owner_enabled'] ?? null) === true
+            && ($plan['public_route_allowed'] ?? null) === true
+            && (int) ($plan['public_pages_exposed'] ?? -1) === $publicRows
+            && ($plan['release_gate_approved'] ?? null) === true
+            && ($plan['release_gate_approval_required'] ?? null) === false;
     }
 
     /**

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T23:15:00+08:00",
+  "updated_at": "2026-05-23T23:20:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5524,10 +5524,10 @@
     "PR-API-SEC-06": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_scope_validation_passed",
+      "status": "pr_open",
       "branch": "codex/pr-api-sec-06-cn-proxy-release-gate",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "b01b92d533f99c593bd24973222c405e23aaa950",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1621",
       "title": "fix(security): enforce CN proxy public-route release gate",
       "checks": {
         "local": [
@@ -5597,6 +5597,11 @@
           "at": "2026-05-23T23:15:00+08:00",
           "status": "local_scope_validation_passed",
           "summary": "Enforced explicit CN proxy public-route release gate in the surface builder; focused CN proxy/job-detail tests, Pint, route list, JSON validation, and diff checks passed. Broad SeoIntel/Career manifest suite failures were recorded as external sidecar SIDE-PR-API-SEC-06-01."
+        },
+        {
+          "at": "2026-05-23T23:20:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1621 from codex/pr-api-sec-06-cn-proxy-release-gate after push."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T23:02:00+08:00",
+  "updated_at": "2026-05-23T23:15:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1070,7 +1070,7 @@
     "PR-B13": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/pr-b13-clean-environment-determinism",
       "commit_sha": "11a8af51a0c363ff7acb910bf0f65a28bf53eab2",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/853",
@@ -5421,7 +5421,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open",
       "branch": "codex/pr-api-sec-05-public-jobs-list-db-budget",
-      "commit_sha": "1b32dd2f768b392e2d0c2b3e540c9b61b216ff61",
+      "commit_sha": "9e22b229fe04972c4c18a9f9f190514fb24ac055",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1620",
       "title": "fix(career): bound public jobs list database work",
       "checks": {
@@ -5455,13 +5455,34 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "Code Scanning / semgrep sarif",
+            "status": "passed",
+            "details": "GitHub check completed successfully on PR #1620."
+          },
+          {
+            "name": "CI / hygiene",
+            "status": "passed",
+            "details": "GitHub push and pull_request hygiene checks completed successfully on PR #1620."
+          },
+          {
+            "name": "CI / verify-mbti-legacy",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-legacy checks completed successfully on PR #1620."
+          },
+          {
+            "name": "CI / verify-mbti-v2",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-v2 checks completed successfully on PR #1620."
+          }
+        ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T22:33:04+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-23T00:00:00+08:00",
@@ -5482,22 +5503,81 @@
           "at": "2026-05-23T23:02:00+08:00",
           "status": "pr_open",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1620 from codex/pr-api-sec-05-public-jobs-list-db-budget after push."
+        },
+        {
+          "at": "2026-05-23T23:05:00+08:00",
+          "status": "github_checks_passed",
+          "summary": "GitHub Code Scanning and CI checks passed on PR #1620 for commit 99e2b93972710c3897afc3a0d93659678f16a8ff."
+        },
+        {
+          "at": "2026-05-23T23:05:00+08:00",
+          "status": "merged",
+          "summary": "Squash merged PR #1620; merge commit 9e22b229fe04972c4c18a9f9f190514fb24ac055. Remote branch was deleted and local post-merge cleanup executed."
+        },
+        {
+          "at": "2026-05-23T23:05:00+08:00",
+          "status": "post_merge_revalidated",
+          "summary": "Post-merge focused career display surface tests passed: 36 tests, 1035 assertions; CareerJobListApiTest passed: 8 tests, 121 assertions."
         }
       ]
     },
     "PR-API-SEC-06": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
+      "status": "local_scope_validation_passed",
       "branch": "codex/pr-api-sec-06-cn-proxy-release-gate",
       "commit_sha": "",
       "pr_url": "",
       "title": "fix(security): enforce CN proxy public-route release gate",
       "checks": {
-        "local": [],
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app tests/Feature docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed",
+            "details": "2700 files checked after formatting the scoped CN proxy feature test."
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerCnProxyPublicOwnerApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php",
+            "status": "passed",
+            "details": "15 tests, 148 assertions."
+          },
+          {
+            "command": "php artisan test tests/Feature/SeoIntel tests/Feature/Career",
+            "status": "failed_external_sidecar",
+            "details": "24 failed, 707 passed. Failures are outside the PR-API-SEC-06 changed files and include SeoIntel artifact/UI copy baselines plus unrelated Career fixture baselines; recorded as SIDE-PR-API-SEC-06-01 per user override protocol."
+          },
+          {
+            "command": "php artisan route:list --no-ansi",
+            "status": "passed",
+            "details": "203 routes listed; no route shape changes."
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
         "github": []
       },
       "failure_reason": "",
+      "sidecar_issues": [
+        {
+          "id": "SIDE-PR-API-SEC-06-01",
+          "status": "open",
+          "type": "external_local_suite_baseline",
+          "command": "php artisan test tests/Feature/SeoIntel tests/Feature/Career",
+          "summary": "Broad manifest suite has existing/out-of-scope failures unrelated to CN proxy public-route release gate hardening.",
+          "evidence": [
+            "PR-API-SEC-06 changed files are limited to CareerCnProxyPublicOwnerSurfaceBuilder, CareerCnProxyPublicOwnerApiTest, and PR train state.",
+            "Focused CN proxy and career job detail tests passed: 15 tests, 148 assertions.",
+            "Broad suite failures include SeoIntel artifact/UI text baselines, IndexNow host redaction fixture, Career dataset/member fixture counts, family/first-wave/search fixture baselines, and first-wave publish-ready fixture baselines."
+          ],
+          "policy": "User-authorized /goal protocol allows continuing when the blocker is not introduced by the current PR and scope validation is green; external blockers are recorded as sidecar issues."
+        }
+      ],
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,
@@ -5507,6 +5587,16 @@
           "at": "2026-05-23T00:00:00+08:00",
           "status": "planned",
           "summary": "PR-API-SEC-06 planned after explicit user authorization for the first-wave security train."
+        },
+        {
+          "at": "2026-05-23T23:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started PR-API-SEC-06 from updated main after PR-API-SEC-05 merged; scope is limited to backend CN proxy public-route release gate hardening and focused policy tests."
+        },
+        {
+          "at": "2026-05-23T23:15:00+08:00",
+          "status": "local_scope_validation_passed",
+          "summary": "Enforced explicit CN proxy public-route release gate in the surface builder; focused CN proxy/job-detail tests, Pint, route list, JSON validation, and diff checks passed. Broad SeoIntel/Career manifest suite failures were recorded as external sidecar SIDE-PR-API-SEC-06-01."
         }
       ]
     },

--- a/backend/tests/Feature/Career/CareerCnProxyPublicOwnerApiTest.php
+++ b/backend/tests/Feature/Career/CareerCnProxyPublicOwnerApiTest.php
@@ -59,6 +59,19 @@ final class CareerCnProxyPublicOwnerApiTest extends TestCase
             ->assertNotFound();
     }
 
+    public function test_it_fails_closed_until_public_route_release_gate_is_approved(): void
+    {
+        [$planPath, $manifestPath] = $this->writeReviewedPublicOwnerArtifacts(publicRouteAllowed: false);
+        config()->set('fap.career.cn_proxy_public_owner_plan_path', $planPath);
+        config()->set('fap.career.cn_proxy_trust_manifest_path', $manifestPath);
+
+        $this->getJson('/api/v0.5/career/cn-proxy/cn-1-01-00-01')
+            ->assertNotFound();
+
+        $this->getJson('/api/v0.5/career/jobs/cn-1-01-00-01?locale=zh-CN')
+            ->assertNotFound();
+    }
+
     public function test_it_rejects_manifest_that_attempts_indexable_cn_proxy_publication(): void
     {
         [$planPath, $manifestPath] = $this->writeReviewedPublicOwnerArtifacts(indexable: true);
@@ -72,8 +85,11 @@ final class CareerCnProxyPublicOwnerApiTest extends TestCase
     /**
      * @return array{0: string, 1?: string}
      */
-    private function writeReviewedPublicOwnerArtifacts(bool $writeManifest = true, bool $indexable = false): array
-    {
+    private function writeReviewedPublicOwnerArtifacts(
+        bool $writeManifest = true,
+        bool $indexable = false,
+        bool $publicRouteAllowed = true,
+    ): array {
         $dir = storage_path('framework/testing/cn-proxy-public-owner');
         File::ensureDirectoryExists($dir);
 
@@ -135,6 +151,11 @@ final class CareerCnProxyPublicOwnerApiTest extends TestCase
             'reviewed_trust_manifest_rows' => 1663,
             'reviewed_trust_manifest_complete' => true,
             'public_owner_plan_ready' => true,
+            'route_owner_enabled' => $publicRouteAllowed,
+            'public_pages_exposed' => $publicRouteAllowed ? 1663 : 0,
+            'public_route_allowed' => $publicRouteAllowed,
+            'release_gate_approved' => $publicRouteAllowed,
+            'release_gate_approval_required' => ! $publicRouteAllowed,
             'guarded_public_owner_state' => 'reviewed_noindex_public_cn_proxy_page_ready_for_separate_owner_train',
             'public_cn_proxy_page_rows' => 1663,
             'indexable_CN_proxy_rows' => 0,


### PR DESCRIPTION
## What changed
- Added an explicit public-route release gate to `CareerCnProxyPublicOwnerSurfaceBuilder`.
- CN proxy public-owner surfaces now require route ownership, public-route allowance, exposed row count alignment, release gate approval, and no remaining approval requirement before either `/career/cn-proxy/{slug}` or `/career/jobs/{slug}` fallback can expose the artifact.
- Added focused feature coverage proving the direct CN proxy route and job detail fallback fail closed when the reviewed artifact is not release-gate approved.
- Reconciled PR-API-SEC-05 as merged in the PR train ledger and recorded PR-API-SEC-06 state.

## Why
Reviewed/noindex/trust-manifest evidence alone should not expose CN proxy public routes. The validator-produced artifact can be ready for a separate owner train while still declaring `public_route_allowed=false`; the runtime route must honor that boundary.

## Validation commands
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- vendor/bin/pint --test app tests/Feature docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- php artisan test tests/Feature/Career/CareerCnProxyPublicOwnerApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php
- php artisan route:list --no-ansi
- git diff --check
- git diff --cached --check

## Sidecar issue
- `SIDE-PR-API-SEC-06-01`: `php artisan test tests/Feature/SeoIntel tests/Feature/Career` currently fails on external/out-of-scope baselines: SeoIntel artifact/UI copy, IndexNow host redaction fixture, Career dataset/member fixture counts, family/first-wave/search fixtures, and first-wave publish-ready fixtures. PR6 changed files are limited to CN proxy runtime gate, focused CN proxy tests, and PR train state; scoped tests are green. Recorded per the user-approved /goal protocol.

## Intentionally deferred
- No fap-web changes.
- No route shape changes.
- No sitemap, llms, production content, production data, migrations, or unrelated career/article workflow changes.

## Repository rule impact
No content ownership or publishing workflow change. This keeps CN proxy public-owner content backend-authoritative and prevents runtime exposure until backend release-gate fields explicitly allow it.