### PR TITLE
PR-API-SEC-07 fix(security): validate research URL truth tenant paths

### DIFF
--- a/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
+++ b/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
@@ -181,8 +181,11 @@ final class UrlTruthHandoffArtifact
     {
         $issues = [];
         $url = (string) ($candidate['canonical_url'] ?? '');
+        $scheme = Str::lower((string) parse_url($url, PHP_URL_SCHEME));
+        $host = Str::lower((string) parse_url($url, PHP_URL_HOST));
         $path = (string) (parse_url($url, PHP_URL_PATH) ?: '');
         $pathLocale = Str::before(Str::after($path, '/'), '/');
+        $pathSlug = Str::after($path, '/research/');
         $locale = (string) ($candidate['locale'] ?? '');
 
         if (($candidate['page_entity_type'] ?? null) !== self::PAGE_ENTITY_TYPE) {
@@ -217,6 +220,19 @@ final class UrlTruthHandoffArtifact
             $issues[] = 'candidate_route_not_research:'.$index;
         }
 
+        if ($scheme !== 'https' || ! in_array($host, $this->trustedTenantHosts(), true)) {
+            $issues[] = 'candidate_untrusted_tenant_host:'.$index;
+        }
+
+        if ($pathSlug === '' || ($candidate['entity_id_or_slug'] ?? null) !== $pathSlug) {
+            $issues[] = 'candidate_research_path_slug_mismatch:'.$index;
+        }
+
+        $canonicalPathHash = data_get($candidate, 'metadata.canonical_path_hash');
+        if ($canonicalPathHash !== null && $canonicalPathHash !== hash('sha256', $path)) {
+            $issues[] = 'candidate_canonical_path_hash_mismatch:'.$index;
+        }
+
         foreach (['/articles', '/reports', 'turnover-rate-report'] as $fragment) {
             if (str_contains($path, $fragment)) {
                 $issues[] = 'candidate_forbidden_route_fragment:'.$fragment.':'.$index;
@@ -248,6 +264,23 @@ final class UrlTruthHandoffArtifact
         }
 
         return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function trustedTenantHosts(): array
+    {
+        $hosts = ['fermatmind.com', 'www.fermatmind.com'];
+
+        foreach (['seo_intel.public_canonical_host', 'app.frontend_url'] as $configKey) {
+            $host = parse_url((string) config($configKey), PHP_URL_HOST);
+            if (is_string($host) && trim($host) !== '') {
+                $hosts[] = Str::lower(trim($host));
+            }
+        }
+
+        return array_values(array_unique($hosts));
     }
 
     /**

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T23:20:00+08:00",
+  "updated_at": "2026-05-23T23:40:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1164,7 +1164,7 @@
     "PR-B17": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/pr-b17-career-transition-preview-attribution-daily-extension",
       "commit_sha": "0025ed318a6b077b1d059b58d6fcce718605b60e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/859",
@@ -5526,7 +5526,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open",
       "branch": "codex/pr-api-sec-06-cn-proxy-release-gate",
-      "commit_sha": "b01b92d533f99c593bd24973222c405e23aaa950",
+      "commit_sha": "285e14f9041aabb8c2a56930ac23bc8a9c16a427",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1621",
       "title": "fix(security): enforce CN proxy public-route release gate",
       "checks": {
@@ -5560,7 +5560,28 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "Code Scanning / semgrep sarif",
+            "status": "passed",
+            "details": "GitHub check completed successfully on PR #1621."
+          },
+          {
+            "name": "CI / hygiene",
+            "status": "passed",
+            "details": "GitHub push and pull_request hygiene checks completed successfully on PR #1621."
+          },
+          {
+            "name": "CI / verify-mbti-legacy",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-legacy checks completed successfully on PR #1621."
+          },
+          {
+            "name": "CI / verify-mbti-v2",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-v2 checks completed successfully on PR #1621."
+          }
+        ]
       },
       "failure_reason": "",
       "sidecar_issues": [
@@ -5579,9 +5600,9 @@
         }
       ],
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T22:52:19+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-23T00:00:00+08:00",
@@ -5602,19 +5623,58 @@
           "at": "2026-05-23T23:20:00+08:00",
           "status": "pr_open",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1621 from codex/pr-api-sec-06-cn-proxy-release-gate after push."
+        },
+        {
+          "at": "2026-05-23T23:30:00+08:00",
+          "status": "github_checks_passed",
+          "summary": "GitHub Code Scanning and CI checks passed on PR #1621 for commit 746196d2dcc64a0f953fe8eac0d092c2ef03a0cd."
+        },
+        {
+          "at": "2026-05-23T23:30:00+08:00",
+          "status": "merged",
+          "summary": "Squash merged PR #1621; merge commit 285e14f9041aabb8c2a56930ac23bc8a9c16a427. Remote branch was deleted and local post-merge cleanup executed."
+        },
+        {
+          "at": "2026-05-23T23:30:00+08:00",
+          "status": "post_merge_revalidated",
+          "summary": "Post-merge focused CN proxy and career job detail tests passed: 15 tests, 148 assertions."
         }
       ]
     },
     "PR-API-SEC-07": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
+      "status": "local_checks_passed",
       "branch": "codex/pr-api-sec-07-research-url-truth-paths",
       "commit_sha": "",
       "pr_url": "",
       "title": "fix(security): validate research URL truth tenant paths",
       "checks": {
-        "local": [],
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/SeoIntel app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php tests/Feature/SeoIntel docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed",
+            "details": "174 files checked."
+          },
+          {
+            "command": "php artisan test tests/Feature/SeoIntel/SeoIntelResearchUrlTruthObservationTest.php tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php",
+            "status": "passed",
+            "details": "9 tests, 115 assertions."
+          },
+          {
+            "command": "php artisan route:list --no-ansi",
+            "status": "passed",
+            "details": "203 routes listed; no route shape changes."
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
         "github": []
       },
       "failure_reason": "",
@@ -5627,6 +5687,16 @@
           "at": "2026-05-23T00:00:00+08:00",
           "status": "planned",
           "summary": "PR-API-SEC-07 planned after explicit user authorization for the first-wave security train."
+        },
+        {
+          "at": "2026-05-23T23:30:00+08:00",
+          "status": "in_progress",
+          "summary": "Started PR-API-SEC-07 from updated main after PR-API-SEC-06 merged; scope is limited to backend research URL truth tenant path validation and focused URL truth artifact tests."
+        },
+        {
+          "at": "2026-05-23T23:40:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Added URL truth handoff import validation for trusted tenant hosts, research path slug alignment, and canonical path hash consistency. PR7 Pint, focused tests, route list, JSON validation, and diff checks passed."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T23:40:00+08:00",
+  "updated_at": "2026-05-23T23:45:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5644,10 +5644,10 @@
     "PR-API-SEC-07": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-api-sec-07-research-url-truth-paths",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "9052b10aef8647f6ebf8264ecef4b223d4cce773",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1622",
       "title": "fix(security): validate research URL truth tenant paths",
       "checks": {
         "local": [
@@ -5697,6 +5697,11 @@
           "at": "2026-05-23T23:40:00+08:00",
           "status": "local_checks_passed",
           "summary": "Added URL truth handoff import validation for trusted tenant hosts, research path slug alignment, and canonical path hash consistency. PR7 Pint, focused tests, route list, JSON validation, and diff checks passed."
+        },
+        {
+          "at": "2026-05-23T23:45:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1622 from codex/pr-api-sec-07-research-url-truth-paths after push."
         }
       ]
     },

--- a/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
@@ -100,6 +100,41 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
     }
 
     #[Test]
+    public function import_validation_rejects_cross_tenant_or_mismatched_research_paths(): void
+    {
+        $artifact = new UrlTruthHandoffArtifact;
+        $payload = $artifact->fromRecords([
+            $this->validRecord(canonicalUrl: 'https://evil.example/en/research/mbti-personality-types-salary-turnover-report'),
+            $this->validRecord(
+                canonicalUrl: 'https://www.fermatmind.com/en/research/other-report',
+                entityIdOrSlug: 'mbti-personality-types-salary-turnover-report',
+            ),
+            $this->validRecord(metadata: [
+                'canonical_path_hash' => hash('sha256', '/en/articles/mbti-personality-types-salary-turnover-report'),
+                'source_table_hash' => hash('sha256', 'research_reports'),
+            ]),
+        ]);
+
+        $path = sys_get_temp_dir().'/tenant-research-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+        $artifact->writeJson($path, $payload);
+
+        $exitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 20,
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertContains('candidate_untrusted_tenant_host:0', $output['issues'] ?? []);
+        $this->assertContains('candidate_research_path_slug_mismatch:1', $output['issues'] ?? []);
+        $this->assertContains('candidate_canonical_path_hash_mismatch:2', $output['issues'] ?? []);
+        $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+    }
+
+    #[Test]
     public function bounded_import_write_requires_sha_confirmation_and_targets_only_url_truth_tables(): void
     {
         $this->prepareSeoIntelSqliteConnection();
@@ -168,13 +203,19 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
         $this->assertSame('RESEARCH-PUBLISH-02-RERUN', $artifact['next_task'] ?? null);
     }
 
-    private function validRecord(): UrlTruthInventoryRecord
-    {
+    /**
+     * @param  array<string, mixed>|null  $metadata
+     */
+    private function validRecord(
+        string $canonicalUrl = 'https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+        string $entityIdOrSlug = 'mbti-personality-types-salary-turnover-report',
+        ?array $metadata = null,
+    ): UrlTruthInventoryRecord {
         return new UrlTruthInventoryRecord(
-            canonicalUrl: 'https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            canonicalUrl: $canonicalUrl,
             locale: 'en',
             pageEntityType: 'research_report',
-            entityIdOrSlug: 'mbti-personality-types-salary-turnover-report',
+            entityIdOrSlug: $entityIdOrSlug,
             sourceAuthority: 'backend_cms',
             indexabilityState: 'indexable',
             lastmodAt: now()->subHour(),
@@ -184,7 +225,7 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
             authorityStatus: 'published_approved',
             sourceUpdatedAt: now()->subHour(),
             isPrivateFlow: false,
-            metadata: [
+            metadata: $metadata ?? [
                 'canonical_path_hash' => hash('sha256', '/en/research/mbti-personality-types-salary-turnover-report'),
                 'source_table_hash' => hash('sha256', 'research_reports'),
             ],


### PR DESCRIPTION
## What changed
- Hardened `UrlTruthHandoffArtifact` import validation for research URL truth candidates.
- Import now rejects candidates whose canonical URL is not on a trusted FermatMind tenant host, whose `/research/{slug}` path does not match `entity_id_or_slug`, or whose `metadata.canonical_path_hash` does not match the canonical path.
- Added focused two-stage handoff coverage for cross-tenant host, slug mismatch, and path hash mismatch rejection.
- Reconciled PR-API-SEC-06 as merged in the PR train ledger and recorded PR-API-SEC-07 state.

## Why
A handoff artifact can be marked `backend_cms` while carrying a same-shaped research path from an untrusted host or a mismatched entity/path pair. URL truth ingestion should accept only trusted tenant CMS research paths with self-consistent path evidence.

## Validation commands
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- vendor/bin/pint --test app/Services/SeoIntel app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php tests/Feature/SeoIntel docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- php artisan test tests/Feature/SeoIntel/SeoIntelResearchUrlTruthObservationTest.php tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
- php artisan route:list --no-ansi
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No public research route behavior changes.
- No fap-web changes.
- No sitemap, llms, migrations, production data, or search submission changes.

## Repository rule impact
No content ownership or publishing workflow change. Research URL truth remains backend/CMS authoritative; this PR only validates handoff artifact consistency before URL truth ingestion.