### PR TITLE
PR-API-SEC-08 fix(security): redact identifiers in drift issue queues

### DIFF
--- a/backend/app/Services/SeoIntel/SeoIssueSanitizer.php
+++ b/backend/app/Services/SeoIntel/SeoIssueSanitizer.php
@@ -112,7 +112,7 @@ final class SeoIssueSanitizer
             return null;
         }
 
-        $path = $parts['path'] ?? '/';
+        $path = $this->maskSensitivePath((string) ($parts['path'] ?? '/'));
 
         return ($parts['scheme'] ?? 'https').'://'.($parts['host'] ?? '').$path;
     }
@@ -132,9 +132,35 @@ final class SeoIssueSanitizer
     {
         $text = preg_replace('/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i', '[redacted]', $text) ?? $text;
         $text = preg_replace('/\b(?:order|attempt|payment|provider)[-_ ]?[A-Z0-9]{6,}\b/i', '[redacted]', $text) ?? $text;
+        $text = preg_replace('#/(attempts?|results?|orders?|payments?|shares?|reports?)/[A-Za-z0-9_-]{6,}#i', '/$1/:redacted', $text) ?? $text;
+        $text = preg_replace('/\b[A-F0-9]{16,}\b/i', '[redacted]', $text) ?? $text;
         $text = preg_replace('/\b(?:token|secret|api[_-]?key)=?[^,\s]+/i', '[redacted]', $text) ?? $text;
 
         return $text;
+    }
+
+    private function maskSensitivePath(string $path): string
+    {
+        $segments = explode('/', $path);
+        $privateParents = ['attempt', 'attempts', 'result', 'results', 'order', 'orders', 'payment', 'payments', 'share', 'shares', 'report', 'reports'];
+
+        foreach ($segments as $index => $segment) {
+            $previous = strtolower($segments[$index - 1] ?? '');
+            if (
+                in_array($previous, $privateParents, true)
+                && preg_match('/^[A-Za-z0-9_-]{6,}$/', $segment) === 1
+            ) {
+                $segments[$index] = ':redacted';
+
+                continue;
+            }
+
+            if (preg_match('/^[A-F0-9]{16,}$/i', $segment) === 1) {
+                $segments[$index] = ':redacted';
+            }
+        }
+
+        return implode('/', $segments);
     }
 
     private function issueUid(string $issueType, array $issue, ?string $canonicalUrl): string

--- a/backend/app/Services/SeoIntel/UrlTruthDriftIssueCandidateSource.php
+++ b/backend/app/Services/SeoIntel/UrlTruthDriftIssueCandidateSource.php
@@ -98,7 +98,7 @@ final class UrlTruthDriftIssueCandidateSource
         $canonicalUrlHash = $this->stringOrNull($row->canonical_url_hash ?? null);
         $locale = $this->stringOrNull($row->locale ?? null);
         $pageEntityType = $this->stringOrNull($row->page_entity_type ?? null);
-        $entityIdOrSlug = $this->stringOrNull($row->entity_id_or_slug ?? null);
+        $entityIdOrSlug = $this->safeIdentifier($this->stringOrNull($row->entity_id_or_slug ?? null));
         $cluster = $this->stringOrNull($row->cluster ?? null);
         $sourceAuthority = (string) ($row->source_authority ?? '');
         $sourceAuthorityAllowed = in_array($sourceAuthority, $this->allowedSourceAuthorities(), true);
@@ -358,6 +358,19 @@ final class UrlTruthDriftIssueCandidateSource
         $normalized = trim((string) $value);
 
         return $normalized === '' ? null : $normalized;
+    }
+
+    private function safeIdentifier(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $masked = preg_replace('/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i', '[redacted]', $value) ?? $value;
+        $masked = preg_replace('/\b(?:order|attempt|payment|provider)[-_ ]?[A-Z0-9]{6,}\b/i', '[redacted]', $masked) ?? $masked;
+        $masked = preg_replace('/\b[A-F0-9]{16,}\b/i', '[redacted]', $masked) ?? $masked;
+
+        return $masked === '' ? null : $masked;
     }
 
     /**

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T23:45:00+08:00",
+  "updated_at": "2026-05-23T23:56:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1402,7 +1402,7 @@
     "PR-B18": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/pr-b18-career-transition-path-taxonomy-typed-payload-hardening",
       "commit_sha": "ea7193830652f08805388e2c5bc782235e3462b5",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/860",
@@ -5646,7 +5646,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open",
       "branch": "codex/pr-api-sec-07-research-url-truth-paths",
-      "commit_sha": "9052b10aef8647f6ebf8264ecef4b223d4cce773",
+      "commit_sha": "ac50710ef7c5e4270bb2b0ad53bcca6d49c393dc",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1622",
       "title": "fix(security): validate research URL truth tenant paths",
       "checks": {
@@ -5675,13 +5675,34 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "Code Scanning / semgrep sarif",
+            "status": "passed",
+            "details": "GitHub check completed successfully on PR #1622."
+          },
+          {
+            "name": "CI / hygiene",
+            "status": "passed",
+            "details": "GitHub push and pull_request hygiene checks completed successfully on PR #1622."
+          },
+          {
+            "name": "CI / verify-mbti-legacy",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-legacy checks completed successfully on PR #1622."
+          },
+          {
+            "name": "CI / verify-mbti-v2",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-v2 checks completed successfully on PR #1622."
+          }
+        ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T23:07:01+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-23T00:00:00+08:00",
@@ -5702,22 +5723,77 @@
           "at": "2026-05-23T23:45:00+08:00",
           "status": "pr_open",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1622 from codex/pr-api-sec-07-research-url-truth-paths after push."
+        },
+        {
+          "at": "2026-05-23T23:55:00+08:00",
+          "status": "github_checks_passed",
+          "summary": "GitHub Code Scanning and CI checks passed on PR #1622 for commit f0cce0eb889311c45281c2a4c7720fd0f0115369."
+        },
+        {
+          "at": "2026-05-23T23:55:00+08:00",
+          "status": "merged",
+          "summary": "Squash merged PR #1622; merge commit ac50710ef7c5e4270bb2b0ad53bcca6d49c393dc. Remote branch was deleted and local post-merge cleanup executed."
+        },
+        {
+          "at": "2026-05-23T23:55:00+08:00",
+          "status": "post_merge_revalidated",
+          "summary": "Post-merge focused research URL truth tests passed: 9 tests, 115 assertions."
         }
       ]
     },
     "PR-API-SEC-08": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
+      "status": "local_scope_validation_passed",
       "branch": "codex/pr-api-sec-08-issue-queue-pii-sanitizer",
       "commit_sha": "",
       "pr_url": "",
       "title": "fix(security): redact identifiers in drift issue queues",
       "checks": {
-        "local": [],
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/SeoIntel app/Console/Commands tests/Feature/SeoIntel docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed",
+            "details": "386 files passed style validation."
+          },
+          {
+            "command": "php artisan test tests/Feature/SeoIntel/SeoIntelCmsIssueQueueSummaryTest.php tests/Feature/SeoIntel/SeoIntelDriftCollectorFoundationTest.php",
+            "status": "passed",
+            "details": "25 tests, 369 assertions."
+          },
+          {
+            "command": "php artisan test tests/Feature/SeoIntel",
+            "status": "failed_external_sidecar",
+            "details": "6 failed, 599 passed, 9217 assertions. Failures are existing/out-of-scope SeoIntel artifact/UI baseline failures and are recorded as SIDE-PR-API-SEC-08-01."
+          },
+          {
+            "command": "php artisan route:list --no-ansi",
+            "status": "passed",
+            "details": "203 routes listed."
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
         "github": []
       },
       "failure_reason": "",
+      "sidecar_issues": [
+        {
+          "id": "SIDE-PR-API-SEC-08-01",
+          "type": "external_local_suite_baseline",
+          "status": "open",
+          "command": "php artisan test tests/Feature/SeoIntel",
+          "summary": "Broad SeoIntel manifest suite has existing/out-of-scope artifact and UI baseline failures unrelated to drift/issue queue PII sanitizer hardening.",
+          "evidence": "Focused PR-API-SEC-08 sanitizer tests passed 25 tests and 369 assertions. The broad suite failures are in crawler log canary runtime docs, ops SEO dashboard UI text baselines, and IndexNow preflight redaction fixture, while changed files remain limited to SeoIssueSanitizer, UrlTruthDriftIssueCandidateSource, focused SeoIntel tests, and the PR train ledger.",
+          "created_at": "2026-05-23T23:56:00+08:00"
+        }
+      ],
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,
@@ -5727,6 +5803,16 @@
           "at": "2026-05-23T00:00:00+08:00",
           "status": "planned",
           "summary": "PR-API-SEC-08 planned after explicit user authorization for the first-wave security train."
+        },
+        {
+          "at": "2026-05-23T23:55:00+08:00",
+          "status": "in_progress",
+          "summary": "Started PR-API-SEC-08 from updated main after PR-API-SEC-07 merged; scope is limited to backend drift canary and issue queue PII sanitization hardening with focused sanitizer tests."
+        },
+        {
+          "at": "2026-05-23T23:56:00+08:00",
+          "status": "local_scope_validation_passed",
+          "summary": "Focused PR-API-SEC-08 sanitizer tests, Pint, route listing, JSON validation, and diff checks passed. Broad tests/Feature/SeoIntel has 6 existing/out-of-scope failures recorded as SIDE-PR-API-SEC-08-01 under the user-approved sidecar protocol."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5744,10 +5744,10 @@
     "PR-API-SEC-08": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_scope_validation_passed",
+      "status": "pr_open",
       "branch": "codex/pr-api-sec-08-issue-queue-pii-sanitizer",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "bd2c1f03e78b886958ba421dd01da7955906cd83",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1623",
       "title": "fix(security): redact identifiers in drift issue queues",
       "checks": {
         "local": [
@@ -5778,9 +5778,24 @@
           {
             "command": "git diff --check",
             "status": "passed"
+          },
+          {
+            "command": "git diff --cached --check",
+            "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "Code Scanning / semgrep sarif",
+            "status": "pending",
+            "details": "GitHub check is in progress on PR #1623."
+          },
+          {
+            "name": "CI / hygiene",
+            "status": "pending",
+            "details": "GitHub push and pull_request hygiene checks are in progress on PR #1623."
+          }
+        ]
       },
       "failure_reason": "",
       "sidecar_issues": [
@@ -5813,6 +5828,11 @@
           "at": "2026-05-23T23:56:00+08:00",
           "status": "local_scope_validation_passed",
           "summary": "Focused PR-API-SEC-08 sanitizer tests, Pint, route listing, JSON validation, and diff checks passed. Broad tests/Feature/SeoIntel has 6 existing/out-of-scope failures recorded as SIDE-PR-API-SEC-08-01 under the user-approved sidecar protocol."
+        },
+        {
+          "at": "2026-05-23T23:56:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1623 from codex/pr-api-sec-08-issue-queue-pii-sanitizer after push; initial GitHub checks are pending."
         }
       ]
     },

--- a/backend/tests/Feature/SeoIntel/SeoIntelCmsIssueQueueSummaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelCmsIssueQueueSummaryTest.php
@@ -153,6 +153,34 @@ final class SeoIntelCmsIssueQueueSummaryTest extends TestCase
     }
 
     #[Test]
+    public function sanitizer_redacts_private_identifiers_embedded_in_paths(): void
+    {
+        $sanitized = (new SeoIssueSanitizer)->sanitize([
+            'issue_type' => 'crawler_private_hit',
+            'severity' => 'high',
+            'source_system' => 'fixture',
+            'canonical_url' => 'https://fermatmind.com/zh/result/ATTEMPTABC123456/report/ORDERABC123456?token=secret',
+            'summary' => 'Private path /zh/result/ATTEMPTABC123456/report/ORDERABC123456 should not persist.',
+            'recommendation' => 'Review /share/PROVIDERABC123456 manually.',
+            'metadata_json' => [
+                'path_display_masked' => '/zh/result/ATTEMPTABC123456/report/ORDERABC123456',
+                'nested' => [
+                    'share_path' => '/share/PROVIDERABC123456',
+                ],
+            ],
+        ]);
+
+        $encoded = json_encode($sanitized, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('https://fermatmind.com/zh/result/:redacted/report/:redacted', $sanitized['canonical_url']);
+        $this->assertStringContainsString(':redacted', $encoded);
+
+        foreach (['ATTEMPTABC123456', 'ORDERABC123456', 'PROVIDERABC123456', 'token=secret'] as $forbiddenValue) {
+            $this->assertStringNotContainsString($forbiddenValue, $encoded);
+        }
+    }
+
+    #[Test]
     public function producer_and_summary_service_are_sanitized_and_do_not_mutate_cms(): void
     {
         $producer = new SeoIssueQueueProducer;

--- a/backend/tests/Feature/SeoIntel/SeoIntelDriftCollectorFoundationTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelDriftCollectorFoundationTest.php
@@ -162,6 +162,51 @@ final class SeoIntelDriftCollectorFoundationTest extends TestCase
     }
 
     #[Test]
+    public function drift_foundation_redacts_private_entity_identifiers_before_issue_queue_write(): void
+    {
+        $this->prepareSeoIntelSqliteConnection();
+        $now = now();
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/result/ATTEMPTABC123456'),
+            'canonical_url' => 'https://fermatmind.com/zh/result/ATTEMPTABC123456',
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'result',
+            'entity_id_or_slug' => 'ATTEMPTABC123456',
+            'cluster' => 'private_flow',
+            'source_authority' => 'backend_public_surface',
+            'indexability_state' => 'indexable',
+            'lastmod_at' => null,
+            'lastmod_source' => null,
+            'is_private_flow' => true,
+            'first_seen_at' => $now,
+            'last_seen_at' => $now,
+            'metadata_json' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        config([
+            'seo_intel.enabled' => true,
+            'seo_intel.collectors_enabled' => true,
+            'seo_intel.write_enabled' => true,
+            'seo_intel.drift_foundation.issue_queue_target_enabled' => true,
+        ]);
+
+        $result = (new SeoIntelCollectorManager)->collect('drift_foundation', [
+            'dry_run' => false,
+            'no_write' => false,
+            'canary' => true,
+        ]);
+        $row = (array) DB::connection('seo_intel')->table('seo_issue_queue')->first();
+        $encoded = json_encode($row, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('success', $result->status);
+        $this->assertTrue($result->writesCommitted);
+        $this->assertSame('[redacted]', $row['entity_id_or_slug'] ?? null);
+        $this->assertStringNotContainsString('ATTEMPTABC123456', $encoded);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/result/ATTEMPTABC123456', $encoded);
+    }
+
+    #[Test]
     public function drift_foundation_rejects_forbidden_source_authority_without_using_node2_source(): void
     {
         $this->prepareSeoIntelSqliteConnection();


### PR DESCRIPTION
## What changed
- Hardened SeoIntel issue sanitizer URL/text redaction for private identifiers embedded in result, attempt, order, payment, share, and report paths.
- Redacted private drift entity identifiers before issue queue candidates are persisted or exported.
- Added focused coverage for issue queue summary sanitization and drift collector persistence sanitization.
- Updated the PR train ledger with PR-API-SEC-08 validation state and sidecar tracking.

## Why
This keeps backend drift canary and issue queue records from storing or exporting private identifiers while preserving the existing queue processing behavior outside redaction.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/SeoIntel app/Console/Commands tests/Feature/SeoIntel docs/codex/pr-train.yaml docs/codex/pr-train-state.json` — 386 files
- `php artisan test tests/Feature/SeoIntel/SeoIntelCmsIssueQueueSummaryTest.php tests/Feature/SeoIntel/SeoIntelDriftCollectorFoundationTest.php` — 25 tests, 369 assertions
- `php artisan route:list --no-ansi` — 203 routes
- `git diff --check`
- `git diff --cached --check`

## Sidecar issue
- `SIDE-PR-API-SEC-08-01`: `php artisan test tests/Feature/SeoIntel` has 6 existing/out-of-scope artifact/UI baseline failures unrelated to this sanitizer scope. Focused scope validation is green.

## Intentionally deferred
- No changes to public APIs, routes, migrations, fap-web, production queue semantics outside redaction, or unrelated SeoIntel dashboard/artifact baselines.

## Repository rule impact
- Backend remains authoritative for SeoIntel issue queue persistence/export sanitization.
- No content authority, CMS ownership, public SEO enumeration, or frontend fallback behavior changes.
