### PR TITLE
PR-API-SEC-09 fix(security): harden docs heredoc guard parsing

### DIFF
--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-23T23:56:00+08:00",
+  "updated_at": "2026-05-23T23:58:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5744,9 +5744,9 @@
     "PR-API-SEC-08": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/pr-api-sec-08-issue-queue-pii-sanitizer",
-      "commit_sha": "bd2c1f03e78b886958ba421dd01da7955906cd83",
+      "commit_sha": "052980ee164d440e77a138c207386678b4e9c675",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1623",
       "title": "fix(security): redact identifiers in drift issue queues",
       "checks": {
@@ -5787,13 +5787,28 @@
         "github": [
           {
             "name": "Code Scanning / semgrep sarif",
-            "status": "pending",
-            "details": "GitHub check is in progress on PR #1623."
+            "status": "passed",
+            "details": "GitHub check completed successfully on PR #1623."
           },
           {
             "name": "CI / hygiene",
-            "status": "pending",
-            "details": "GitHub push and pull_request hygiene checks are in progress on PR #1623."
+            "status": "passed",
+            "details": "GitHub push and pull_request hygiene checks completed successfully on PR #1623."
+          },
+          {
+            "name": "CI / verify-mbti-legacy",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-legacy checks completed successfully on PR #1623."
+          },
+          {
+            "name": "CI / verify-mbti-v2",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-v2 checks completed successfully on PR #1623."
+          },
+          {
+            "name": "Semgrep OSS",
+            "status": "passed",
+            "details": "GitHub Semgrep OSS check completed successfully on PR #1623."
           }
         ]
       },
@@ -5810,9 +5825,9 @@
         }
       ],
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T23:24:04+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-23T00:00:00+08:00",
@@ -5833,19 +5848,63 @@
           "at": "2026-05-23T23:56:00+08:00",
           "status": "pr_open",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1623 from codex/pr-api-sec-08-issue-queue-pii-sanitizer after push; initial GitHub checks are pending."
+        },
+        {
+          "at": "2026-05-23T23:57:00+08:00",
+          "status": "github_checks_passed",
+          "summary": "GitHub Code Scanning and CI checks passed on PR #1623 for commit 72939234d06fc752da72a3e37e94e7f98de967e3."
+        },
+        {
+          "at": "2026-05-23T23:57:00+08:00",
+          "status": "merged",
+          "summary": "Squash merged PR #1623; merge commit 052980ee164d440e77a138c207386678b4e9c675. Remote branch was deleted and local post-merge cleanup executed."
+        },
+        {
+          "at": "2026-05-23T23:57:00+08:00",
+          "status": "post_merge_revalidated",
+          "summary": "Post-merge focused issue queue sanitizer tests passed: 25 tests, 369 assertions."
         }
       ]
     },
     "PR-API-SEC-09": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
+      "status": "local_checks_passed",
       "branch": "codex/pr-api-sec-09-docs-heredoc-guard",
       "commit_sha": "",
       "pr_url": "",
       "title": "fix(security): harden docs heredoc guard parsing",
       "checks": {
-        "local": [],
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app tests docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed",
+            "details": "3118 files passed style validation."
+          },
+          {
+            "command": "php artisan test tests/Feature/ReleasePackScriptContractTest.php tests/Unit/Security/SecurityGuardrailsTest.php",
+            "status": "passed",
+            "details": "26 tests, 105 assertions."
+          },
+          {
+            "command": "php artisan test tests/Unit/Security/SecurityGuardrailsTest.php",
+            "status": "passed",
+            "details": "17 tests, 77 assertions."
+          },
+          {
+            "command": "php artisan route:list --no-ansi",
+            "status": "passed",
+            "details": "203 routes listed."
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
         "github": []
       },
       "failure_reason": "",
@@ -5858,6 +5917,16 @@
           "at": "2026-05-23T00:00:00+08:00",
           "status": "planned",
           "summary": "PR-API-SEC-09 planned after explicit user authorization for the first-wave security train."
+        },
+        {
+          "at": "2026-05-23T23:57:00+08:00",
+          "status": "in_progress",
+          "summary": "Started PR-API-SEC-09 from updated main after PR-API-SEC-08 merged; scope is limited to backend docs heredoc guard whitespace bypass hardening and focused parser/guard tests."
+        },
+        {
+          "at": "2026-05-23T23:58:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Hardened docs heredoc guard whitespace parsing and added focused ReleasePack guard coverage; JSON, Pint, SecurityGuardrails, route list, and diff checks passed."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5869,10 +5869,10 @@
     "PR-API-SEC-09": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-api-sec-09-docs-heredoc-guard",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "5f5a9217455d727907e46c8f1e28f1c4aa965840",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1624",
       "title": "fix(security): harden docs heredoc guard parsing",
       "checks": {
         "local": [
@@ -5903,9 +5903,24 @@
           {
             "command": "git diff --check",
             "status": "passed"
+          },
+          {
+            "command": "git diff --cached --check",
+            "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "Code Scanning / semgrep sarif",
+            "status": "pending",
+            "details": "GitHub check is in progress on PR #1624."
+          },
+          {
+            "name": "CI / hygiene",
+            "status": "pending",
+            "details": "GitHub push and pull_request hygiene checks are in progress on PR #1624."
+          }
+        ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
@@ -5927,6 +5942,11 @@
           "at": "2026-05-23T23:58:00+08:00",
           "status": "local_checks_passed",
           "summary": "Hardened docs heredoc guard whitespace parsing and added focused ReleasePack guard coverage; JSON, Pint, SecurityGuardrails, route list, and diff checks passed."
+        },
+        {
+          "at": "2026-05-23T23:58:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened https://github.com/fermatmind/fap-api/pull/1624 from codex/pr-api-sec-09-docs-heredoc-guard after push; initial GitHub checks are pending."
         }
       ]
     }

--- a/backend/tests/Feature/ReleasePackScriptContractTest.php
+++ b/backend/tests/Feature/ReleasePackScriptContractTest.php
@@ -119,6 +119,23 @@ final class ReleasePackScriptContractTest extends TestCase
         $this->assertStringContainsString('unquoted_heredoc_eof', $output);
     }
 
+    public function test_docs_shell_safety_guard_rejects_unquoted_heredoc_with_whitespace(): void
+    {
+        [$exitCode, $output] = $this->runDocsShellSafetyGuard(
+            "```bash\n".
+            "cat > /tmp/ledger.md << EOF\n".
+            "Markdown with backticks can be expanded by the shell.\n".
+            "EOF\n".
+            "cat > /tmp/indented.md <<- EOF\n".
+            "Indented heredoc bodies can still expand variables.\n".
+            "EOF\n".
+            "```\n"
+        );
+
+        $this->assertNotSame(0, $exitCode, $output);
+        $this->assertStringContainsString('unquoted_heredoc_eof', $output);
+    }
+
     public function test_docs_shell_safety_guard_rejects_content_releases_tree_delete_example(): void
     {
         [$exitCode, $output] = $this->runDocsShellSafetyGuard(

--- a/scripts/security/assert_docs_shell_safety.sh
+++ b/scripts/security/assert_docs_shell_safety.sh
@@ -61,7 +61,7 @@ check_line() {
   local printable
   printable="$(rel "$file")"
 
-  if [[ "$line" =~ (^|[^\<])\<\<-?EOF([^A-Za-z0-9_]|$) ]]; then
+  if [[ "$line" =~ (^|[^\<])\<\<-?[[:space:]]*EOF([^A-Za-z0-9_]|$) ]]; then
     fail "$printable" "$line_no" "unquoted_heredoc_eof"
   fi
 


### PR DESCRIPTION
## What changed
- Hardened the docs shell safety guard so unquoted `EOF` heredocs with whitespace after `<<` or `<<-` are rejected.
- Preserved quoted heredoc delimiters and here-string avoidance behavior.
- Added focused release-pack guard coverage for whitespace heredoc variants.
- Reconciled PR-API-SEC-08 merge/cleanup state in the PR train ledger and recorded PR-API-SEC-09 local validation.

## Why
Whitespace between the heredoc operator and delimiter should not bypass protected docs-shell guardrails.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app tests docs/codex/pr-train.yaml docs/codex/pr-train-state.json` — 3118 files
- `php artisan test tests/Feature/ReleasePackScriptContractTest.php tests/Unit/Security/SecurityGuardrailsTest.php` — 26 tests, 105 assertions
- `php artisan test tests/Unit/Security/SecurityGuardrailsTest.php` — 17 tests, 77 assertions
- `php artisan route:list --no-ansi` — 203 routes
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No runtime application behavior, routes, migrations, public APIs, fap-web, production content, or unrelated docs shell safety rules changed.

## Repository rule impact
- Backend/security guardrail behavior only.
- No content authority, CMS ownership, public SEO enumeration, or frontend fallback behavior changes.
