### PR TITLE
fix(storage): harden archive and restore path containment

### DIFF
--- a/backend/app/Console/Commands/StorageRehydrateExactRelease.php
+++ b/backend/app/Console/Commands/StorageRehydrateExactRelease.php
@@ -139,10 +139,10 @@ final class StorageRehydrateExactRelease extends Command
         }
 
         if (str_starts_with($targetRootOption, DIRECTORY_SEPARATOR)) {
-            return $this->normalizePath($targetRootOption);
+            return $this->canonicalizeTargetRoot($targetRootOption);
         }
 
-        return $this->normalizePath(storage_path('app/private/'.ltrim($targetRootOption, '/\\')));
+        return $this->canonicalizeTargetRoot(storage_path('app/private/'.ltrim($targetRootOption, '/\\')));
     }
 
     private function ensureSafeTargetRoot(string $targetRoot): void
@@ -156,7 +156,7 @@ final class StorageRehydrateExactRelease extends Command
         ];
 
         foreach ($forbiddenRoots as $forbiddenRoot) {
-            $forbiddenRoot = $this->normalizePath($forbiddenRoot);
+            $forbiddenRoot = $this->canonicalizeTargetRoot($forbiddenRoot);
             if ($targetRoot === $forbiddenRoot || str_starts_with($targetRoot.'/', $forbiddenRoot.'/') || str_starts_with($forbiddenRoot.'/', $targetRoot.'/')) {
                 throw new \RuntimeException('unsafe target root for rehydrate runs: '.$targetRoot);
             }
@@ -252,5 +252,53 @@ final class StorageRehydrateExactRelease extends Command
     private function normalizePath(string $path): string
     {
         return str_replace('\\', '/', rtrim(trim($path), '/\\'));
+    }
+
+    private function canonicalizeTargetRoot(string $path): string
+    {
+        $path = $this->normalizePath($path);
+        if ($path === '') {
+            throw new \RuntimeException('rehydrate target root is required.');
+        }
+
+        if (preg_match('/^[A-Za-z]:[\/\\\\]/', $path) === 1) {
+            throw new \RuntimeException('windows drive roots are not supported for rehydrate target root.');
+        }
+
+        $segments = [];
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+
+            if ($segment === '..') {
+                array_pop($segments);
+
+                continue;
+            }
+
+            $segments[] = $segment;
+        }
+
+        $normalized = (str_starts_with($path, '/') ? '/' : '').implode('/', $segments);
+        if ($normalized === '') {
+            $normalized = '/';
+        }
+
+        $existing = $normalized;
+        $suffix = [];
+        while ($existing !== '' && $existing !== '/' && ! is_dir($existing)) {
+            array_unshift($suffix, basename($existing));
+            $existing = dirname($existing);
+        }
+
+        if (is_dir($existing)) {
+            $realExisting = realpath($existing);
+            if (is_string($realExisting) && $realExisting !== '') {
+                $normalized = $this->normalizePath($realExisting.(count($suffix) > 0 ? '/'.implode('/', $suffix) : ''));
+            }
+        }
+
+        return $normalized;
     }
 }

--- a/backend/app/Services/Storage/QuarantinedRootPurgeService.php
+++ b/backend/app/Services/Storage/QuarantinedRootPurgeService.php
@@ -86,6 +86,11 @@ final class QuarantinedRootPurgeService
     {
         $resolvedPlan = $this->resolveExecutablePlan($plan, $expectedItemRoot);
         $itemRoot = $this->normalizeRoot((string) ($resolvedPlan['item_root'] ?? ''));
+        $canonicalItemRoot = $this->canonicalExistingDirectory($itemRoot);
+        if ($canonicalItemRoot === null || ! $this->isUnderPrefix($canonicalItemRoot, $this->quarantineRootBase())) {
+            throw new \RuntimeException('purge item root must be under the quarantine root base.');
+        }
+
         $runId = now()->format('Ymd_His').'_'.substr(bin2hex(random_bytes(4)), 0, 8);
         $runBase = $this->purgeRootBase().DIRECTORY_SEPARATOR.$runId;
         $itemReceiptDir = $runBase.DIRECTORY_SEPARATOR.'items'.DIRECTORY_SEPARATOR.hash('sha256', $itemRoot);
@@ -121,12 +126,12 @@ final class QuarantinedRootPurgeService
         );
 
         try {
-            if (! is_dir($itemRoot)) {
+            if (! is_dir($canonicalItemRoot)) {
                 throw new \RuntimeException('quarantine item root does not exist.');
             }
 
-            File::deleteDirectory($itemRoot);
-            if (is_dir($itemRoot)) {
+            File::deleteDirectory($canonicalItemRoot);
+            if (is_dir($canonicalItemRoot)) {
                 throw new \RuntimeException('failed to delete quarantine item root.');
             }
 
@@ -206,8 +211,10 @@ final class QuarantinedRootPurgeService
             throw new \RuntimeException('purge plan disk is required.');
         }
 
-        $planItemRoot = $this->normalizeRoot((string) ($plan['item_root'] ?? ''));
-        $requestedItemRoot = $expectedItemRoot !== null ? $this->normalizeRoot($expectedItemRoot) : $planItemRoot;
+        $planItemRootRaw = $this->normalizeRoot((string) ($plan['item_root'] ?? ''));
+        $planItemRoot = $this->canonicalExistingDirectory($planItemRootRaw) ?? $planItemRootRaw;
+        $requestedItemRootRaw = $expectedItemRoot !== null ? $this->normalizeRoot($expectedItemRoot) : $planItemRootRaw;
+        $requestedItemRoot = $this->canonicalExistingDirectory($requestedItemRootRaw) ?? $requestedItemRootRaw;
         if ($requestedItemRoot === '') {
             throw new \RuntimeException('purge item root is required.');
         }
@@ -222,7 +229,6 @@ final class QuarantinedRootPurgeService
         }
 
         $comparisons = [
-            'item_root',
             'exact_manifest_id',
             'exact_identity_hash',
             'source_kind',
@@ -233,7 +239,7 @@ final class QuarantinedRootPurgeService
         ];
         foreach ($comparisons as $field) {
             if (($plan[$field] ?? null) !== ($freshPlan[$field] ?? null)) {
-                throw new \RuntimeException('plan_candidate_mismatch');
+                throw new \RuntimeException('plan_candidate_mismatch: '.$field);
             }
         }
 
@@ -249,6 +255,7 @@ final class QuarantinedRootPurgeService
             throw new \RuntimeException('purge item root is required.');
         }
 
+        $itemRoot = $this->canonicalExistingDirectory($itemRoot) ?? $itemRoot;
         if (! $this->isUnderPrefix($itemRoot, $this->quarantineRootBase())) {
             throw new \RuntimeException('purge item root must be under the quarantine root base.');
         }
@@ -480,13 +487,28 @@ final class QuarantinedRootPurgeService
 
     private function isUnderPrefix(string $path, string $prefix): bool
     {
-        $path = $this->normalizeRoot($path);
-        $prefix = $this->normalizeRoot($prefix);
+        $path = $this->canonicalExistingDirectory($path) ?? $this->normalizeRoot($path);
+        $prefix = $this->canonicalExistingDirectory($prefix) ?? $this->normalizeRoot($prefix);
         if ($path === '' || $prefix === '') {
             return false;
         }
 
         return $path === $prefix || str_starts_with($path.'/', $prefix.'/');
+    }
+
+    private function canonicalExistingDirectory(string $path): ?string
+    {
+        $path = $this->normalizeRoot($path);
+        if ($path === '') {
+            return null;
+        }
+
+        $realPath = realpath($path);
+        if (! is_string($realPath) || $realPath === '' || ! is_dir($realPath)) {
+            return null;
+        }
+
+        return $this->normalizeRoot($realPath);
     }
 
     private function normalizeRoot(string $root): string

--- a/backend/app/Services/Storage/ReportArtifactsArchiveService.php
+++ b/backend/app/Services/Storage/ReportArtifactsArchiveService.php
@@ -419,6 +419,20 @@ final class ReportArtifactsArchiveService
             ];
         }
 
+        $resolvedSource = $this->resolveCandidateSource($sourcePath, $relativePath, $targetObjectKey);
+        if (isset($resolvedSource['error'])) {
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => $resolvedSource['error'],
+            ];
+        }
+
+        $absoluteSourcePath = $resolvedSource['absolute_source_path'];
+        $relativePath = $resolvedSource['relative_path'];
+        $targetObjectKey = $resolvedSource['target_object_key'];
+        $baseResult['relative_path'] = $relativePath;
+        $baseResult['target_object_key'] = $targetObjectKey;
+
         if (! is_file($absoluteSourcePath)) {
             return $baseResult + [
                 'status' => 'failed',
@@ -493,6 +507,84 @@ final class ReportArtifactsArchiveService
             'verified_at' => now()->toIso8601String(),
             'target_bytes' => $targetBytesAfterUpload,
         ];
+    }
+
+    /**
+     * @return array{absolute_source_path:string,relative_path:string,target_object_key:string}|array{error:string}
+     */
+    private function resolveCandidateSource(string $sourcePath, string $relativePath, string $targetObjectKey): array
+    {
+        try {
+            $relativePath = $this->normalizeCandidateRelativePath($relativePath);
+            $sourcePath = $this->normalizeCandidateRelativePath($sourcePath);
+            $targetObjectKey = $this->normalizeCandidateRelativePath($targetObjectKey);
+        } catch (\RuntimeException) {
+            return ['error' => 'CANDIDATE_PATH_INVALID'];
+        }
+
+        if ($this->canonicalContextForRelativePath($relativePath) === null) {
+            return ['error' => 'CANDIDATE_RELATIVE_PATH_NOT_CANONICAL'];
+        }
+
+        if ($sourcePath !== 'artifacts/'.$relativePath) {
+            return ['error' => 'CANDIDATE_SOURCE_PATH_MISMATCH'];
+        }
+
+        if ($targetObjectKey !== self::TARGET_PREFIX.'/'.$relativePath) {
+            return ['error' => 'CANDIDATE_TARGET_KEY_MISMATCH'];
+        }
+
+        $artifactsRoot = realpath(storage_path('app/private/artifacts'));
+        if (! is_string($artifactsRoot) || $artifactsRoot === '') {
+            return ['error' => 'ARTIFACTS_ROOT_MISSING_AT_EXECUTE'];
+        }
+
+        $artifactsRoot = str_replace('\\', '/', rtrim($artifactsRoot, '/'));
+        $absoluteSourcePath = storage_path('app/private/'.$sourcePath);
+        $realSourcePath = realpath($absoluteSourcePath);
+        if (is_string($realSourcePath) && $realSourcePath !== '') {
+            $realSourcePath = str_replace('\\', '/', rtrim($realSourcePath, '/'));
+            if (! $this->isPathUnderDirectory($realSourcePath, $artifactsRoot)) {
+                return ['error' => 'SOURCE_PATH_OUTSIDE_ARTIFACTS'];
+            }
+
+            $absoluteSourcePath = $realSourcePath;
+        }
+
+        return [
+            'absolute_source_path' => $absoluteSourcePath,
+            'relative_path' => $relativePath,
+            'target_object_key' => $targetObjectKey,
+        ];
+    }
+
+    private function normalizeCandidateRelativePath(string $path): string
+    {
+        $path = str_replace('\\', '/', trim($path));
+        if ($path === '' || str_starts_with($path, '/') || preg_match('/^[A-Za-z]:[\/\\\\]/', $path) === 1) {
+            throw new \RuntimeException('candidate path must be relative.');
+        }
+
+        $segments = array_values(array_filter(explode('/', $path), static fn (string $segment): bool => $segment !== ''));
+        if ($segments === []) {
+            throw new \RuntimeException('candidate path cannot be empty.');
+        }
+
+        foreach ($segments as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new \RuntimeException('candidate path contains traversal.');
+            }
+        }
+
+        return implode('/', $segments);
+    }
+
+    private function isPathUnderDirectory(string $path, string $directory): bool
+    {
+        $path = str_replace('\\', '/', rtrim($path, '/'));
+        $directory = str_replace('\\', '/', rtrim($directory, '/'));
+
+        return $path === $directory || str_starts_with($path.'/', $directory.'/');
     }
 
     private function sizeForDiskPath(string $disk, string $path): ?int

--- a/backend/tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php
@@ -308,6 +308,56 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         $this->assertStringContainsString('requested_limit=', $output);
     }
 
+    public function test_command_execute_rejects_traversal_source_paths_from_plan(): void
+    {
+        File::put(storage_path('app/private/.env'), 'APP_KEY=leaked');
+
+        $planPath = storage_path('app/private/report_artifact_archive_plans/traversal-plan.json');
+        File::ensureDirectoryExists(dirname($planPath));
+        File::put($planPath, json_encode([
+            'schema' => 'storage_archive_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'disk' => 's3',
+            'target_disk' => 's3',
+            'summary' => [
+                'candidate_count' => 1,
+                'candidate_bytes' => 14,
+                'kind_counts' => ['report_json' => 1],
+            ],
+            'candidates' => [[
+                'kind' => 'report_json',
+                'source_path' => '../.env',
+                'relative_path' => 'reports/MBTI/traversal/report.json',
+                'target_disk' => 's3',
+                'target_object_key' => 'report_artifacts_archive/reports/MBTI/traversal/report.json',
+                'bytes' => 14,
+                'sha256' => hash('sha256', 'APP_KEY=leaked'),
+                'scale_code' => 'MBTI',
+                'attempt_id' => 'traversal',
+            ]],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+
+        $this->assertSame(1, Artisan::call('storage:archive-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=partial_failure', $output);
+        $this->assertStringContainsString('failed_count=1', $output);
+        preg_match('/^run_path=(.+)$/m', $output, $matches);
+        $runPath = trim((string) ($matches[1] ?? ''));
+        $this->assertFileExists($runPath);
+
+        $run = json_decode((string) File::get($runPath), true);
+        $this->assertIsArray($run);
+        $this->assertSame('CANDIDATE_PATH_INVALID', data_get($run, 'results.0.reason'));
+        Storage::disk('s3')->assertMissing('report_artifacts_archive/reports/MBTI/traversal/report.json');
+    }
+
     public function test_command_execute_surfaces_scoped_plan_metadata_for_auditability(): void
     {
         $this->seedCanonicalReportArtifact('scoped-plan-attempt');

--- a/backend/tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php
+++ b/backend/tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php
@@ -149,6 +149,21 @@ final class StoragePurgeQuarantinedRootCommandTest extends TestCase
         $planPath = $this->extractOutputValue($output, 'plan');
         $this->assertFileExists($planPath);
         $this->assertDirectoryExists($fixture['item_root']);
+
+        $outsideRoot = storage_path('app/private/outside-purge-target');
+        File::ensureDirectoryExists($outsideRoot);
+        $traversalRoot = storage_path('app/private/quarantine/release_roots/../../outside-purge-target');
+
+        $this->assertSame(1, Artisan::call('storage:purge-quarantined-root', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--item-root' => $traversalRoot,
+        ]));
+
+        $traversalOutput = Artisan::output();
+        $this->assertStringContainsString('status=blocked', $traversalOutput);
+        $this->assertStringContainsString('purge item root must be under the quarantine root base.', $traversalOutput);
+        $this->assertDirectoryExists($outsideRoot);
     }
 
     public function test_command_fails_when_plan_is_tampered_or_item_root_mismatches(): void

--- a/backend/tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php
@@ -164,6 +164,16 @@ final class StorageRehydrateExactReleaseCommandTest extends TestCase
         $output = Artisan::output();
         $this->assertStringContainsString('unsafe target root for rehydrate runs', $output);
         $this->assertDirectoryDoesNotExist(storage_path('app/private/rehydrate_plans'));
+
+        $this->assertSame(1, Artisan::call('storage:rehydrate-exact-release', [
+            '--dry-run' => true,
+            '--exact-manifest-id' => (string) $fixture['exact_manifest_id'],
+            '--disk' => 's3',
+            '--target-root' => '../private/content_releases',
+        ]));
+
+        $traversalOutput = Artisan::output();
+        $this->assertStringContainsString('unsafe target root for rehydrate runs', $traversalOutput);
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -327,6 +327,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_storage_path_safety_hardening_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/StorageRehydrateExactRelease.php',
+            'backend/app/Services/Storage/QuarantinedRootPurgeService.php',
+            'backend/app/Services/Storage/ReportArtifactsArchiveService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_content_release_revalidate_automation_files(): void
     {
         $changed = [
@@ -1864,6 +1875,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isStoragePathSafetyHardeningFile($file)) {
+                continue;
+            }
+
             if ($this->isCiScaleImpactCommandFile($file)) {
                 continue;
             }
@@ -2354,6 +2369,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isStorageReleaseRootsAuditCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/StorageReleaseRootsAudit.php';
+    }
+
+    private function isStoragePathSafetyHardeningFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/StorageRehydrateExactRelease.php',
+            'backend/app/Services/Storage/QuarantinedRootPurgeService.php',
+            'backend/app/Services/Storage/ReportArtifactsArchiveService.php',
+        ], true);
     }
 
     private function isCiScaleImpactCommandFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-23T18:01:00+08:00",
+  "updated_at": "2026-05-24T00:00:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15584,6 +15584,420 @@
           "summary": "Opened PR #1608 for SEO-GROWTH-MBTI-ACTION-01B-FIX-02 from codex/seo-growth-mbti-action-01b-fix-02. The PR is limited to backend URL Truth host alignment, ZH MBTI test-detail emission, focused docs/generated/tests, and authorized PR-train metadata only."
         }
       ]
+    },
+    "OPS-SECURITY-STORAGE-PATH-SAFETY-01": {
+      "repo": "fap-api",
+      "branch": "codex/ops-security-storage-path-safety-01",
+      "status": "github_checks_failed_scoped_fix_local_passed",
+      "depends_on": [],
+      "findings": [
+        66,
+        68,
+        69
+      ],
+      "commit_sha": "ddd73cfea622d10414a4b24817c2c6559111d260",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1625",
+      "checks": {
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files confined to storage path safety services/commands/tests and PR train metadata."
+        },
+        "storage_feature_suite": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Feature/Storage --filter Storage --no-ansi",
+          "evidence": "182 tests passed, 3128 assertions."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Storage/ReportArtifactsArchiveService.php app/Console/Commands/StoragePurgeQuarantinedRoot.php app/Services/Storage/QuarantinedRootPurgeService.php app/Console/Commands/StorageRehydrateExactRelease.php tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "evidence": "8 files passed Pint after the scoped runtime-freeze fix."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "203 routes listed."
+        },
+        "manifest_yaml": {
+          "status": "pass",
+          "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        },
+        "state_json": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "github_verify_mbti_initial": {
+          "status": "failed",
+          "evidence": "PR #1625 verify-mbti-legacy and verify-mbti-v2 failed on BigFive runtime freeze because the guard flagged the scoped storage hardening files as unrelated runtime drift.",
+          "files_flagged": [
+            "backend/app/Console/Commands/StorageRehydrateExactRelease.php",
+            "backend/app/Services/Storage/QuarantinedRootPurgeService.php",
+            "backend/app/Services/Storage/ReportArtifactsArchiveService.php"
+          ]
+        },
+        "bigfive_runtime_freeze": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --no-ansi",
+          "evidence": "115 tests passed, 462 assertions after adding the narrow storage path-safety hardening classifier allowance."
+        },
+        "ci_verify_mbti": {
+          "status": "pass",
+          "command": "cd backend && bash scripts/ci_verify_mbti.sh",
+          "evidence": "Local verify-mbti gate completed successfully after the scoped runtime-freeze fix."
+        }
+      },
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-05-24T01:05:00+08:00",
+          "status": "github_checks_failed_scoped_fix_local_passed",
+          "summary": "Inspected PR #1625 GitHub check failures, added the narrowest BigFive runtime-freeze allowance for the scoped storage path-safety hardening files, and reran the full BigFive freeze file, full storage feature suite, scoped Pint, and ci_verify_mbti locally."
+        }
+      ]
+    },
+    "OPS-SECURITY-MBTI-RELATIONSHIP-AUTH-01": {
+      "repo": "fap-api",
+      "branch": "codex/ops-security-mbti-relationship-auth-01",
+      "status": "pending",
+      "depends_on": [
+        "OPS-SECURITY-STORAGE-PATH-SAFETY-01"
+      ],
+      "findings": [
+        67
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "ATTEMPT-SUBMISSION-RELIABILITY-01": {
+      "repo": "fap-api",
+      "branch": "codex/attempt-submission-reliability-01",
+      "status": "pending",
+      "depends_on": [
+        "OPS-SECURITY-MBTI-RELATIONSHIP-AUTH-01"
+      ],
+      "findings": [
+        61,
+        62
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "COMMERCE-TENANT-REPAIR-01": {
+      "repo": "fap-api",
+      "branch": "codex/commerce-tenant-repair-01",
+      "status": "pending",
+      "depends_on": [
+        "ATTEMPT-SUBMISSION-RELIABILITY-01"
+      ],
+      "findings": [
+        63
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "DB-MIGRATION-PORTABILITY-01": {
+      "repo": "fap-api",
+      "branch": "codex/db-migration-portability-01",
+      "status": "pending",
+      "depends_on": [
+        "COMMERCE-TENANT-REPAIR-01"
+      ],
+      "findings": [
+        54,
+        64,
+        65
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "SEO-OPS-SAFETY-ARTIFACTS-01": {
+      "repo": "fap-api",
+      "branch": "codex/seo-ops-safety-artifacts-01",
+      "status": "pending",
+      "depends_on": [
+        "DB-MIGRATION-PORTABILITY-01"
+      ],
+      "findings": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "SEO-INDEXABILITY-TRUTH-01": {
+      "repo": "fap-api",
+      "branch": "codex/seo-indexability-truth-01",
+      "status": "pending",
+      "depends_on": [
+        "SEO-OPS-SAFETY-ARTIFACTS-01"
+      ],
+      "findings": [
+        6,
+        20,
+        25,
+        44,
+        49
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "RIASEC-CONTRACT-QUALITY-01": {
+      "repo": "fap-api",
+      "branch": "codex/riasec-contract-quality-01",
+      "status": "pending",
+      "depends_on": [
+        "SEO-INDEXABILITY-TRUTH-01"
+      ],
+      "findings": [
+        5,
+        17,
+        21,
+        26
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "BIGFIVE-RUNTIME-GUARDS-01": {
+      "repo": "fap-api",
+      "branch": "codex/bigfive-runtime-guards-01",
+      "status": "pending",
+      "depends_on": [
+        "RIASEC-CONTRACT-QUALITY-01"
+      ],
+      "findings": [
+        34,
+        35,
+        36
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "CAREER-POLICY-CLAIM-GUARDS-01": {
+      "repo": "fap-api",
+      "branch": "codex/career-policy-claim-guards-01",
+      "status": "pending",
+      "depends_on": [
+        "BIGFIVE-RUNTIME-GUARDS-01"
+      ],
+      "findings": [
+        8,
+        9,
+        13,
+        33,
+        41,
+        42,
+        43,
+        58
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "CAREER-READINESS-AUDITORS-01": {
+      "repo": "fap-api",
+      "branch": "codex/career-readiness-auditors-01",
+      "status": "pending",
+      "depends_on": [
+        "CAREER-POLICY-CLAIM-GUARDS-01"
+      ],
+      "findings": [
+        7,
+        10,
+        11,
+        14,
+        18,
+        19,
+        23,
+        24,
+        27,
+        30
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "CAREER-RELEASE-GATES-01": {
+      "repo": "fap-api",
+      "branch": "codex/career-release-gates-01",
+      "status": "pending",
+      "depends_on": [
+        "CAREER-READINESS-AUDITORS-01"
+      ],
+      "findings": [
+        12,
+        16,
+        22,
+        28,
+        31,
+        32
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "CAREER-ROLLOUT-MATERIALIZATION-01": {
+      "repo": "fap-api",
+      "branch": "codex/career-rollout-materialization-01",
+      "status": "pending",
+      "depends_on": [
+        "CAREER-RELEASE-GATES-01"
+      ],
+      "findings": [
+        29,
+        55,
+        56,
+        57
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "CAREER-EXPORT-CLI-ROBUSTNESS-01": {
+      "repo": "fap-api",
+      "branch": "codex/career-export-cli-robustness-01",
+      "status": "pending",
+      "depends_on": [
+        "CAREER-ROLLOUT-MATERIALIZATION-01"
+      ],
+      "findings": [
+        15,
+        37,
+        38,
+        39,
+        40,
+        50,
+        51,
+        52,
+        53
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "CMS-ARTICLE-REPORT-CORRECTNESS-01": {
+      "repo": "fap-api",
+      "branch": "codex/cms-article-report-correctness-01",
+      "status": "pending",
+      "depends_on": [
+        "CAREER-EXPORT-CLI-ROBUSTNESS-01"
+      ],
+      "findings": [
+        46,
+        47,
+        48
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PERSONALITY-ENNEAGRAM-COMPAT-01": {
+      "repo": "fap-api",
+      "branch": "codex/personality-enneagram-compat-01",
+      "status": "pending",
+      "depends_on": [
+        "CMS-ARTICLE-REPORT-CORRECTNESS-01"
+      ],
+      "findings": [
+        45,
+        59,
+        60,
+        70
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11051,3 +11051,227 @@ prs:
     production_migration_execution_allowed: false
     scheduler_activation: false
     next_task: null
+
+  - id: OPS-SECURITY-STORAGE-PATH-SAFETY-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/ops-security-storage-path-safety-01
+    base: main
+    title: "fix(storage): harden archive and restore path containment"
+    train_scope: codex_security_findings_20260523
+    risk_level: high_security_boundary
+    findings: [66, 68, 69]
+    scope:
+      - Harden storage archive, purge, and rehydrate path containment against traversal and unsafe roots.
+    allowed_paths:
+      - backend/app/Services/Storage/ReportArtifactsArchiveService.php
+      - backend/app/Console/Commands/StoragePurgeQuarantinedRoot.php
+      - backend/app/Services/Storage/QuarantinedRootPurgeService.php
+      - backend/app/Console/Commands/StorageRehydrateExactRelease.php
+      - backend/tests/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test tests/Feature/Storage --filter Storage --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Storage/ReportArtifactsArchiveService.php app/Console/Commands/StoragePurgeQuarantinedRoot.php app/Services/Storage/QuarantinedRootPurgeService.php app/Console/Commands/StorageRehydrateExactRelease.php tests
+      - cd backend && php artisan route:list --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: OPS-SECURITY-MBTI-RELATIONSHIP-AUTH-01
+    repo: fap-api
+    depends_on: [OPS-SECURITY-STORAGE-PATH-SAFETY-01]
+    branch: codex/ops-security-mbti-relationship-auth-01
+    base: main
+    title: "fix(mbti): require identity for private relationship listing"
+    train_scope: codex_security_findings_20260523
+    risk_level: high_auth_boundary
+    findings: [67]
+    allowed_paths: [backend/app/Services/V0_3/MbtiCompareInviteService.php, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter MbtiCompare --no-ansi, cd backend && vendor/bin/pint --test app/Services/V0_3/MbtiCompareInviteService.php tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: ATTEMPT-SUBMISSION-RELIABILITY-01
+    repo: fap-api
+    depends_on: [OPS-SECURITY-MBTI-RELATIONSHIP-AUTH-01]
+    branch: codex/attempt-submission-reliability-01
+    base: main
+    title: "fix(attempts): preserve retries and durable ack identity"
+    train_scope: codex_security_findings_20260523
+    risk_level: high_product_reliability
+    findings: [61, 62]
+    allowed_paths: [backend/app/Services/Attempts/AttemptSubmissionService.php, backend/app/Jobs/ProcessAttemptSubmissionJob.php, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter AttemptSubmission --no-ansi, cd backend && vendor/bin/pint --test app/Services/Attempts/AttemptSubmissionService.php app/Jobs/ProcessAttemptSubmissionJob.php tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: COMMERCE-TENANT-REPAIR-01
+    repo: fap-api
+    depends_on: [ATTEMPT-SUBMISSION-RELIABILITY-01]
+    branch: codex/commerce-tenant-repair-01
+    base: main
+    title: "fix(commerce): repair tenant-scoped post-commit failures"
+    train_scope: codex_security_findings_20260523
+    risk_level: high_revenue_reliability
+    findings: [63]
+    allowed_paths: [backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php, backend/app/Console/Commands/CommerceRepairPostCommitFailed.php, backend/app/Console/Kernel.php, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter CommerceRepairPostCommitFailed --no-ansi, cd backend && vendor/bin/pint --test app/Services/Commerce/Webhook/WebhookEntitlementService.php app/Console/Commands/CommerceRepairPostCommitFailed.php app/Console/Kernel.php tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: DB-MIGRATION-PORTABILITY-01
+    repo: fap-api
+    depends_on: [COMMERCE-TENANT-REPAIR-01]
+    branch: codex/db-migration-portability-01
+    base: main
+    title: "fix(db): make MariaDB migration index guards portable"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_deploy_reliability
+    findings: [54, 64, 65]
+    allowed_paths: [backend/app/Support/Database/SchemaIndex.php, backend/config/database.php, backend/database/migrations/**, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter SchemaIndex --no-ansi, "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force", cd backend && vendor/bin/pint --test app/Support/Database/SchemaIndex.php config/database.php database/migrations tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: SEO-OPS-SAFETY-ARTIFACTS-01
+    repo: fap-api
+    depends_on: [DB-MIGRATION-PORTABILITY-01]
+    branch: codex/seo-ops-safety-artifacts-01
+    base: main
+    title: "fix(seo-intel): align no-write and artifact safety contracts"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_ops_safety
+    findings: [1, 2, 3, 4]
+    allowed_paths: [backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php, backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php, backend/app/Services/SeoIntel/**, backend/docs/seo/**, backend/tests/Feature/SeoIntel/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test tests/Feature/SeoIntel --no-ansi, cd backend && vendor/bin/pint --test app/Console/Commands/SeoIntelSearchChannelQueueCommand.php app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php app/Services/SeoIntel tests/Feature/SeoIntel, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: SEO-INDEXABILITY-TRUTH-01
+    repo: fap-api
+    depends_on: [SEO-OPS-SAFETY-ARTIFACTS-01]
+    branch: codex/seo-indexability-truth-01
+    base: main
+    title: "fix(seo): enforce indexability truth across robots and sitemap"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_seo_correctness
+    findings: [6, 20, 25, 44, 49]
+    allowed_paths: [backend/app/Services/SEO/**, backend/app/Services/SeoIntel/**, backend/app/Domain/Career/Audit/**, backend/app/Services/Cms/CareerJobSeoService.php, backend/app/Http/Controllers/API/V0_5/Career/**, backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php, backend/app/Console/Commands/CareerAuditCanonicalEligibility.php, backend/tests/**, backend/docs/career/audits/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter CareerSeo --no-ansi, cd backend && php artisan test --filter Sitemap --no-ansi, cd backend && vendor/bin/pint --test app tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: RIASEC-CONTRACT-QUALITY-01
+    repo: fap-api
+    depends_on: [SEO-INDEXABILITY-TRUTH-01]
+    branch: codex/riasec-contract-quality-01
+    base: main
+    title: "fix(riasec): enforce slot quality and compare contracts"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_contract_correctness
+    findings: [5, 17, 21, 26]
+    allowed_paths: [backend/app/Services/Riasec/**, backend/app/Services/V0_3/Me/MeAttemptsService.php, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter Riasec --no-ansi, cd backend && vendor/bin/pint --test app/Services/Riasec app/Services/V0_3/Me/MeAttemptsService.php tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: BIGFIVE-RUNTIME-GUARDS-01
+    repo: fap-api
+    depends_on: [RIASEC-CONTRACT-QUALITY-01]
+    branch: codex/bigfive-runtime-guards-01
+    base: main
+    title: "fix(big-five): harden norm capture and projection routing"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_result_correctness
+    findings: [34, 35, 36]
+    allowed_paths: [backend/app/Services/BigFive/**, backend/database/migrations/2026_05_06_132700_create_big_five_norm_observations_table.php, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter BigFive --no-ansi, cd backend && vendor/bin/pint --test app/Services/BigFive database/migrations/2026_05_06_132700_create_big_five_norm_observations_table.php tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: CAREER-POLICY-CLAIM-GUARDS-01
+    repo: fap-api
+    depends_on: [BIGFIVE-RUNTIME-GUARDS-01]
+    branch: codex/career-policy-claim-guards-01
+    base: main
+    title: "fix(career): tighten policy claim and trust guards"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_content_governance
+    findings: [8, 9, 13, 33, 41, 42, 43, 58]
+    allowed_paths: [backend/app/Console/Commands/Career*Policy*.php, backend/app/Console/Commands/CareerValidateDisplayBatch.php, backend/app/Services/Career/**, backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php, backend/app/Domain/Career/Scoring/**, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter Career --no-ansi, cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career app/Services/Cms/EditorialPackage app/Domain/Career tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: CAREER-READINESS-AUDITORS-01
+    repo: fap-api
+    depends_on: [CAREER-POLICY-CLAIM-GUARDS-01]
+    branch: codex/career-readiness-auditors-01
+    base: main
+    title: "fix(career): make readiness auditors fail closed"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_release_correctness
+    findings: [7, 10, 11, 14, 18, 19, 23, 24, 27, 30]
+    allowed_paths: [backend/app/Domain/Career/Audit/**, backend/app/Domain/Career/Publish/**, backend/app/Console/Commands/StorageReleaseRootsAudit.php, backend/docs/career/audits/**, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter Career --no-ansi, cd backend && vendor/bin/pint --test app/Domain/Career app/Console/Commands/StorageReleaseRootsAudit.php tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: CAREER-RELEASE-GATES-01
+    repo: fap-api
+    depends_on: [CAREER-READINESS-AUDITORS-01]
+    branch: codex/career-release-gates-01
+    base: main
+    title: "fix(career): enforce release gates and blocked states"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_release_safety
+    findings: [12, 16, 22, 28, 31, 32]
+    allowed_paths: [backend/app/Domain/Career/**, backend/app/Console/Commands/Career*.php, backend/app/Console/Commands/ReleaseVerifyPublicContent.php, backend/tests/**, deploy.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter Career --no-ansi, cd backend && vendor/bin/pint --test app/Domain/Career app/Console/Commands tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: CAREER-ROLLOUT-MATERIALIZATION-01
+    repo: fap-api
+    depends_on: [CAREER-RELEASE-GATES-01]
+    branch: codex/career-rollout-materialization-01
+    base: main
+    title: "fix(career): preserve rollout governance during materialization"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_data_integrity
+    findings: [29, 55, 56, 57]
+    allowed_paths: [backend/app/Domain/Career/Publish/**, backend/app/Domain/Career/Expansion/**, backend/app/Services/Career/**, backend/routes/api.php, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter Career --no-ansi, cd backend && php artisan route:list --path=career --no-ansi, cd backend && vendor/bin/pint --test app/Domain/Career app/Services/Career routes/api.php tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: CAREER-EXPORT-CLI-ROBUSTNESS-01
+    repo: fap-api
+    depends_on: [CAREER-ROLLOUT-MATERIALIZATION-01]
+    branch: codex/career-export-cli-robustness-01
+    base: main
+    title: "fix(career): harden export and dry-run CLI contracts"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_ops_correctness
+    findings: [15, 37, 38, 39, 40, 50, 51, 52, 53]
+    allowed_paths: [backend/app/Console/Commands/Career*.php, backend/app/Services/Career/**, backend/tests/**, backend/docs/codex/pr-train-state.json, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter Career --no-ansi, cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: CMS-ARTICLE-REPORT-CORRECTNESS-01
+    repo: fap-api
+    depends_on: [CAREER-EXPORT-CLI-ROBUSTNESS-01]
+    branch: codex/cms-article-report-correctness-01
+    base: main
+    title: "fix(cms): stabilize article SEO and report snapshot saves"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_ops_correctness
+    findings: [46, 47, 48]
+    allowed_paths: [backend/app/Filament/Ops/Resources/ArticleResource**, backend/app/Filament/Ops/Resources/ReportSnapshotResource**, backend/app/Models/Article.php, backend/app/Models/ReportSnapshot.php, backend/app/Models/Scopes/TenantScope.php, backend/database/migrations/2026_03_05_154121_create_article_seo_meta_table.php, backend/database/migrations/2026_04_23_040000_consolidate_article_translation_canonical_owners.php, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter Article --no-ansi, cd backend && php artisan test --filter ReportSnapshot --no-ansi, cd backend && vendor/bin/pint --test app/Filament/Ops/Resources/ArticleResource.php app/Filament/Ops/Resources/ArticleResource app/Filament/Ops/Resources/ReportSnapshotResource.php app/Filament/Ops/Resources/ReportSnapshotResource app/Models tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+
+  - id: PERSONALITY-ENNEAGRAM-COMPAT-01
+    repo: fap-api
+    depends_on: [CMS-ARTICLE-REPORT-CORRECTNESS-01]
+    branch: codex/personality-enneagram-compat-01
+    base: main
+    title: "fix(personality): preserve clone slots and experiment compatibility"
+    train_scope: codex_security_findings_20260523
+    risk_level: medium_product_correctness
+    findings: [45, 59, 60, 70]
+    allowed_paths: [backend/app/Services/Enneagram/**, backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php, backend/app/Services/PublicSurface/AnswerSurfaceContractService.php, backend/app/PersonalityCms/**, backend/app/Services/Cms/PersonalityDesktopCloneContentService.php, backend/app/Services/Experiments/ExperimentAssigner.php, backend/database/migrations/**, backend/tests/**, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json]
+    validation: [cd backend && php artisan test --filter Personality --no-ansi, cd backend && php artisan test --filter Enneagram --no-ansi, cd backend && php artisan test --filter ExperimentAssigner --no-ansi, cd backend && vendor/bin/pint --test app/Services/Enneagram app/Http/Controllers/API/V0_5/Cms/PersonalityController.php app/Services/PublicSurface app/PersonalityCms app/Services/Cms/PersonalityDesktopCloneContentService.php app/Services/Experiments/ExperimentAssigner.php tests, git diff --check, git diff --cached --check]
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }


### PR DESCRIPTION
## What changed
- Registered the 16-item Codex security findings PR train and initialized state entries.
- Hardened report artifact archive execution so plan-supplied source paths, relative paths, and target keys must match canonical artifact shapes before any local file is opened.
- Hardened quarantined root purge so deletion uses a canonical real path under the quarantine base while preserving existing plan/result path output contracts.
- Hardened exact release rehydrate target roots by canonicalizing traversal and symlink-sensitive prefixes before forbidden-root checks.
- Added regression coverage for archive source traversal, purge item-root traversal, and rehydrate target-root traversal.

## Why
Codex security findings #66, #68, and #69 identified plan/CLI path traversal risks that could exfiltrate local files, delete arbitrary directories, or write rehydrated files under forbidden storage roots if an unsafe plan or target root were accepted.

## Validation
- `cd backend && php artisan test tests/Feature/Storage --filter Storage --no-ansi` → 182 tests passed, 3128 assertions
- `cd backend && vendor/bin/pint --test app/Services/Storage/ReportArtifactsArchiveService.php app/Console/Commands/StoragePurgeQuarantinedRoot.php app/Services/Storage/QuarantinedRootPurgeService.php app/Console/Commands/StorageRehydrateExactRelease.php tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php`
- `cd backend && php artisan route:list --no-ansi`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- Findings #67 and #61-#65 are assigned to the next PRs in the train.
- No storage schema, bucket config, CMS data, queue, payment, or fap-web changes are included.
