### PR TITLE
fix(seo-intel): align no-write and artifact safety contracts

### DIFF
--- a/backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
+++ b/backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
@@ -35,7 +35,7 @@ final class SeoIntelSearchChannelQueueCommand extends Command
         $plan = $planner->plan($channel, $pageType, $limit, $canonicalUrl);
         $plannedItems = $plan['planned_items'];
         $writeGateEnabled = (bool) config('seo_intel.search_channel_queue.write_enabled', false);
-        $writeRequested = $enqueue || (! $dryRun && ! $noWrite);
+        $writeRequested = ! $dryRun && ! $noWrite;
         $writesAttempted = false;
         $writesCommitted = false;
         $enqueueAttempted = false;
@@ -60,6 +60,12 @@ final class SeoIntelSearchChannelQueueCommand extends Command
             $issues[] = 'existing_active_queue_item';
         }
 
+        $enqueueConflictBlocked = $enqueue && ($dryRun || $noWrite);
+
+        if ($enqueueConflictBlocked) {
+            $issues[] = 'enqueue_conflicts_with_dry_run_or_no_write';
+        }
+
         $canonicalFilterBlocked = $canonicalUrl !== null
             && $plan['source_unavailable_reason'] === null
             && $issues !== [];
@@ -72,7 +78,7 @@ final class SeoIntelSearchChannelQueueCommand extends Command
             $issues[] = 'channel_not_allowed';
         }
 
-        if ($canonicalFilterBlocked) {
+        if ($canonicalFilterBlocked || $enqueueConflictBlocked) {
             $status = 'blocked';
         }
 

--- a/backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
+++ b/backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
@@ -61,6 +61,17 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
 
     private function export(UrlTruthHandoffArtifact $artifact, string $path, int $limit): int
     {
+        $pathSafetyIssue = $artifact->artifactPathSafetyIssue($path, forWrite: true);
+        if ($pathSafetyIssue !== null) {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'export',
+                'issues' => [$pathSafetyIssue],
+                'dry_run' => true,
+                'writes_committed' => false,
+            ]);
+        }
+
         $source = new BackendAuthorityUrlTruthSource;
         $records = array_values(array_filter(
             $source->candidates(),
@@ -108,6 +119,18 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
 
     private function import(UrlTruthHandoffArtifact $artifact, string $path, int $limit, bool $dryRun, bool $write): int
     {
+        $pathSafetyIssue = $artifact->artifactPathSafetyIssue($path, forWrite: false);
+        if ($pathSafetyIssue !== null) {
+            return $this->finish([
+                'status' => 'blocked',
+                'mode' => 'import',
+                'issues' => [$pathSafetyIssue],
+                'dry_run' => true,
+                'writes_committed' => false,
+                'target_tables' => ['seo_urls', 'seo_url_entities'],
+            ]);
+        }
+
         if (! is_file($path)) {
             return $this->finish([
                 'status' => 'blocked',

--- a/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
+++ b/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
@@ -6,6 +6,7 @@ namespace App\Services\SeoIntel;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 final class UrlTruthHandoffArtifact
 {
@@ -121,9 +122,9 @@ final class UrlTruthHandoffArtifact
 
     public function writeJson(string $path, array $artifact): void
     {
-        $directory = dirname($path);
-        if (! is_dir($directory)) {
-            mkdir($directory, 0755, true);
+        $issue = $this->artifactPathSafetyIssue($path, forWrite: true);
+        if ($issue !== null) {
+            throw new InvalidArgumentException($issue);
         }
 
         file_put_contents($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL);
@@ -134,6 +135,11 @@ final class UrlTruthHandoffArtifact
      */
     public function readJson(string $path): array
     {
+        $issue = $this->artifactPathSafetyIssue($path, forWrite: false);
+        if ($issue !== null) {
+            throw new InvalidArgumentException($issue);
+        }
+
         $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
 
         return is_array($decoded) ? $decoded : [];
@@ -141,7 +147,69 @@ final class UrlTruthHandoffArtifact
 
     public function sha256(string $path): string
     {
+        $issue = $this->artifactPathSafetyIssue($path, forWrite: false);
+        if ($issue !== null) {
+            throw new InvalidArgumentException($issue);
+        }
+
         return hash_file('sha256', $path) ?: '';
+    }
+
+    public function artifactPathSafetyIssue(string $path, bool $forWrite): ?string
+    {
+        $path = trim($path);
+
+        if ($path === '') {
+            return 'artifact_path_empty';
+        }
+
+        if (str_contains($path, "\0")) {
+            return 'artifact_path_invalid';
+        }
+
+        if (parse_url($path, PHP_URL_SCHEME) !== null) {
+            return 'artifact_path_stream_wrapper_forbidden';
+        }
+
+        if (! str_starts_with($path, DIRECTORY_SEPARATOR)) {
+            return 'artifact_path_must_be_absolute';
+        }
+
+        if (Str::lower(pathinfo($path, PATHINFO_EXTENSION)) !== 'json') {
+            return 'artifact_path_must_be_json';
+        }
+
+        $basename = basename($path);
+        if ($basename === '' || $basename === '.' || $basename === '..') {
+            return 'artifact_path_invalid';
+        }
+
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            return 'artifact_directory_missing';
+        }
+
+        if (is_link($directory)) {
+            return 'artifact_directory_symlink_forbidden';
+        }
+
+        if ($forWrite) {
+            if (file_exists($path) || is_link($path)) {
+                return 'artifact_path_already_exists';
+            }
+
+            return null;
+        }
+
+        if (! is_file($path) || is_link($path)) {
+            return 'artifact_path_not_regular_file';
+        }
+
+        if (filesize($path) > 1024 * 1024) {
+            return 'artifact_file_too_large';
+        }
+
+        return null;
     }
 
     /**

--- a/backend/docs/seo/generated/seo-intel-two-stage-url-truth-handoff.v1.json
+++ b/backend/docs/seo/generated/seo-intel-two-stage-url-truth-handoff.v1.json
@@ -20,6 +20,16 @@
       "seo_url_entities"
     ]
   },
+  "artifact_path_safety": {
+    "absolute_path_required": true,
+    "json_extension_required": true,
+    "stream_wrappers_allowed": false,
+    "directory_must_exist": true,
+    "directory_symlink_allowed": false,
+    "export_overwrite_allowed": false,
+    "import_regular_file_required": true,
+    "max_import_bytes": 1048576
+  },
   "allowed_candidates": {
     "page_entity_type": "research_report",
     "source_authority": "backend_cms",

--- a/backend/docs/seo/seo-intel-two-stage-url-truth-handoff.md
+++ b/backend/docs/seo/seo-intel-two-stage-url-truth-handoff.md
@@ -29,6 +29,8 @@ php artisan seo-intel:url-truth-handoff \
 
 The export is candidate-only. It does not write to `seo_intel`, does not call external search APIs, does not read crawler logs, and does not submit URLs.
 
+The artifact path must be an absolute `.json` path in an existing non-symlink directory. Export refuses to overwrite an existing file or symlink.
+
 ## Runner-side Validation
 
 The Aliyun runner validates the artifact with:
@@ -53,6 +55,8 @@ Validation is fail-closed. The artifact is accepted only when every candidate is
 - routed under `/en/research/{slug}` or `/zh/research/{slug}`
 
 Validation rejects `/articles`, `/reports`, stale `turnover-rate-report` slugs, draft/private/noindex/claim-unsafe candidates, and sensitive metadata keys.
+
+Import validates artifact path safety before reading. It accepts only regular `.json` files under an existing non-symlink directory and rejects stream wrappers, relative paths, missing files, symlinks, and oversized artifacts.
 
 ## Runner-side Bounded Write
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
@@ -167,6 +167,50 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
     }
 
     #[Test]
+    public function no_write_overrides_explicit_enqueue_even_when_write_gate_is_enabled(): void
+    {
+        config(['seo_intel.search_channel_queue.write_enabled' => true]);
+        $this->seedSeoUrl();
+
+        $exitCode = Artisan::call('seo-intel:search-channel-queue', [
+            '--enqueue' => true,
+            '--no-write' => true,
+            '--json' => true,
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertContains('enqueue_conflicts_with_dry_run_or_no_write', $output['issues'] ?? []);
+        $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_batches')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+    }
+
+    #[Test]
+    public function dry_run_overrides_explicit_enqueue_even_when_write_gate_is_enabled(): void
+    {
+        config(['seo_intel.search_channel_queue.write_enabled' => true]);
+        $this->seedSeoUrl();
+
+        $exitCode = Artisan::call('seo-intel:search-channel-queue', [
+            '--enqueue' => true,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertContains('enqueue_conflicts_with_dry_run_or_no_write', $output['issues'] ?? []);
+        $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_batches')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+    }
+
+    #[Test]
     public function enqueue_requires_explicit_env_gate(): void
     {
         $this->seedSeoUrl();

--- a/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
@@ -69,6 +69,70 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
     }
 
     #[Test]
+    public function export_rejects_unsafe_or_existing_artifact_paths(): void
+    {
+        $relativeExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--export' => '../research-url-truth-handoff.json',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+        $relativeOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $relativeExitCode);
+        $this->assertSame('blocked', $relativeOutput['status'] ?? null);
+        $this->assertContains('artifact_path_must_be_absolute', $relativeOutput['issues'] ?? []);
+
+        $existingPath = sys_get_temp_dir().'/existing-research-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+        file_put_contents($existingPath, '{}');
+
+        $existingExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--export' => $existingPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+        $existingOutput = json_decode(trim(Artisan::output()), true);
+
+        @unlink($existingPath);
+
+        $this->assertSame(1, $existingExitCode);
+        $this->assertSame('blocked', $existingOutput['status'] ?? null);
+        $this->assertContains('artifact_path_already_exists', $existingOutput['issues'] ?? []);
+    }
+
+    #[Test]
+    public function import_rejects_non_json_or_missing_artifact_paths_before_reading(): void
+    {
+        $textPath = sys_get_temp_dir().'/research-url-truth-handoff-'.bin2hex(random_bytes(4)).'.txt';
+        file_put_contents($textPath, '{}');
+
+        $textExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $textPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+        $textOutput = json_decode(trim(Artisan::output()), true);
+
+        @unlink($textPath);
+
+        $this->assertSame(1, $textExitCode);
+        $this->assertSame('blocked', $textOutput['status'] ?? null);
+        $this->assertContains('artifact_path_must_be_json', $textOutput['issues'] ?? []);
+
+        $missingPath = sys_get_temp_dir().'/missing-research-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+
+        $missingExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $missingPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+        $missingOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $missingExitCode);
+        $this->assertSame('blocked', $missingOutput['status'] ?? null);
+        $this->assertContains('artifact_path_not_regular_file', $missingOutput['issues'] ?? []);
+    }
+
+    #[Test]
     public function import_validation_rejects_non_research_article_or_claim_unsafe_candidates(): void
     {
         $artifact = new UrlTruthHandoffArtifact;
@@ -198,6 +262,10 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
         $this->assertFalse((bool) ($artifact['tencent_prod_direct_write_to_aliyun_rds_allowed'] ?? true));
         $this->assertTrue((bool) ($artifact['no_cross_cloud_private_networking_required'] ?? false));
         $this->assertTrue((bool) ($artifact['no_search_submission'] ?? false));
+        $this->assertTrue((bool) data_get($artifact, 'artifact_path_safety.absolute_path_required'));
+        $this->assertTrue((bool) data_get($artifact, 'artifact_path_safety.json_extension_required'));
+        $this->assertFalse((bool) data_get($artifact, 'artifact_path_safety.stream_wrappers_allowed', true));
+        $this->assertFalse((bool) data_get($artifact, 'artifact_path_safety.export_overwrite_allowed', true));
         $this->assertContains('/articles', data_get($artifact, 'forbidden.route_fragments', []));
         $this->assertContains('seo_issue_queue', data_get($artifact, 'forbidden.tables', []));
         $this->assertSame('RESEARCH-PUBLISH-02-RERUN', $artifact['next_task'] ?? null);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15891,14 +15891,14 @@
     "COMMERCE-TENANT-REPAIR-01": {
       "repo": "fap-api",
       "branch": "codex/commerce-tenant-repair-01",
-      "status": "github_checks_failed_scoped_fix_local_passed",
+      "status": "merged",
       "depends_on": [
         "ATTEMPT-SUBMISSION-RELIABILITY-01"
       ],
       "findings": [
         63
       ],
-      "commit_sha": "43269b5cd9d6ba9a6c038d9bf6d4bac66feef750",
+      "commit_sha": "fd0fb1f4c1109d2a806085cd0debcad98f38ab33",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1628",
       "checks": {
         "dependency_reconciliation": {
@@ -15942,12 +15942,16 @@
           "status": "pass",
           "command": "bash backend/scripts/ci_verify_mbti.sh",
           "evidence": "Local MBTI verification completed successfully after the scoped runtime freeze allowlist. Generated BigFive compiled artifacts were restored before staging."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "GitHub PR #1628 is MERGED at fd0fb1f4c1109d2a806085cd0debcad98f38ab33; remote branch is absent."
         }
       },
       "sidecar_issues": [],
-      "failure_reason": "Initial GitHub verify-mbti jobs failed on scoped CommerceRepairPostCommitFailed.php runtime freeze classification; local scoped fix and backend/scripts/ci_verify_mbti.sh now pass, pending amended push and GitHub rerun.",
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "failure_reason": null,
+      "merged_at": "2026-05-23T18:54:35Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "updated_at": "2026-05-24T02:40:27+08:00",
       "events": [
@@ -15965,13 +15969,19 @@
           "at": "2026-05-24T02:40:27+08:00",
           "status": "github_checks_failed_scoped_fix_local_passed",
           "summary": "Added a narrow runtime freeze classifier regression/allowlist for CommerceRepairPostCommitFailed.php, reran targeted freeze tests and backend/scripts/ci_verify_mbti.sh successfully, and restored generated BigFive compiled files before staging."
+        },
+        {
+          "at": "2026-05-24T03:35:00+08:00",
+          "status": "ledger_reconciled_merged",
+          "summary": "Reconciled PR #1628 as merged; origin/main contains fd0fb1f4c1109d2a806085cd0debcad98f38ab33 and the remote branch is absent."
         }
-      ]
+      ],
+      "local_cleanup_note": "Reconciled from GitHub while preparing SEO-OPS-SAFETY-ARTIFACTS-01; no scripts/post_merge_cleanup.sh exists in this clone, and local task branch was absent."
     },
     "DB-MIGRATION-PORTABILITY-01": {
       "repo": "fap-api",
       "branch": "codex/db-migration-portability-01",
-      "status": "pending",
+      "status": "merged",
       "depends_on": [
         "COMMERCE-TENANT-REPAIR-01"
       ],
@@ -15980,19 +15990,32 @@
         64,
         65
       ],
-      "commit_sha": null,
-      "pr_url": null,
-      "checks": {},
+      "commit_sha": "47f18f4f4806f734f08f8677f8d15a36da6c3198",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1629",
+      "checks": {
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "GitHub PR #1629 is MERGED at 47f18f4f4806f734f08f8677f8d15a36da6c3198; remote branch is absent."
+        }
+      },
       "sidecar_issues": [],
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "merged_at": "2026-05-23T19:21:05Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-05-24T03:35:00+08:00",
+          "status": "ledger_reconciled_merged",
+          "summary": "Reconciled PR #1629 as merged; origin/main contains 47f18f4f4806f734f08f8677f8d15a36da6c3198 and the remote branch is absent."
+        }
+      ],
+      "local_cleanup_note": "Reconciled from GitHub while preparing SEO-OPS-SAFETY-ARTIFACTS-01; no scripts/post_merge_cleanup.sh exists in this clone, and local task branch was absent."
     },
     "SEO-OPS-SAFETY-ARTIFACTS-01": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-safety-artifacts-01",
-      "status": "pending",
+      "status": "local_checks_passed_with_external_sidecar",
       "depends_on": [
         "DB-MIGRATION-PORTABILITY-01"
       ],
@@ -16004,12 +16027,56 @@
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
-      "sidecar_issues": [],
+      "checks": {
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to SEO search-channel queue safety, two-stage URL truth handoff artifact safety, SEO docs/generated artifact, focused SeoIntel tests, and PR train state metadata."
+        },
+        "search_channel_queue_runtime": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php --no-ansi",
+          "evidence": "19 tests passed, 118 assertions."
+        },
+        "two_stage_url_truth_handoff": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php --no-ansi",
+          "evidence": "7 tests passed, 71 assertions."
+        },
+        "seo_intel_feature_suite": {
+          "status": "failed_external_sidecar_reproduced_on_main",
+          "command": "cd backend && php artisan test tests/Feature/SeoIntel --no-ansi",
+          "evidence": "Current branch full SeoIntel feature suite failed in existing crawler log/UI/live02 preflight assertions; the representative failures reproduced on origin/main detached worktree at 47f18f4f, so they are not introduced by this scoped PR."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Console/Commands/SeoIntelSearchChannelQueueCommand.php app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php app/Services/SeoIntel tests/Feature/SeoIntel",
+          "evidence": "173 files passed Pint."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [
+        {
+          "id": "SEO-INTEL-FEATURE-SUITE-BASELINE-20260524",
+          "status": "external_blocker_reproduced_on_main",
+          "summary": "Full tests/Feature/SeoIntel currently fails on origin/main in crawler log artifact text, SEO Ops crawler observation UI text, native dashboard Chinese/English assertion drift, issue queue detail panel text, and IndexNow keyLocation host redaction. These failures are outside SEO-OPS-SAFETY-ARTIFACTS-01 scope and were reproduced on origin/main before PR creation.",
+          "reproduced_on": "origin/main@47f18f4f4806f734f08f8677f8d15a36da6c3198",
+          "reproduced_at": "2026-05-24T03:35:00+08:00"
+        }
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-05-24T03:35:00+08:00",
+          "status": "local_checks_passed_with_external_sidecar",
+          "summary": "Scoped Search Channel queue no-write/enqueue conflict tests, two-stage URL truth handoff artifact safety tests, Pint, and diff check passed. Full SeoIntel feature-suite failures were reproduced on origin/main and recorded as an external sidecar under the user-approved continuation protocol."
+        }
+      ]
     },
     "SEO-INDEXABILITY-TRUTH-01": {
       "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16015,7 +16015,7 @@
     "SEO-OPS-SAFETY-ARTIFACTS-01": {
       "repo": "fap-api",
       "branch": "codex/seo-ops-safety-artifacts-01",
-      "status": "local_checks_passed_with_external_sidecar",
+      "status": "pr_open",
       "depends_on": [
         "DB-MIGRATION-PORTABILITY-01"
       ],
@@ -16025,8 +16025,8 @@
         3,
         4
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "69700814",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1630",
       "checks": {
         "scope_validation": {
           "status": "pass",
@@ -16075,6 +16075,11 @@
           "at": "2026-05-24T03:35:00+08:00",
           "status": "local_checks_passed_with_external_sidecar",
           "summary": "Scoped Search Channel queue no-write/enqueue conflict tests, two-stage URL truth handoff artifact safety tests, Pint, and diff check passed. Full SeoIntel feature-suite failures were reproduced on origin/main and recorded as an external sidecar under the user-approved continuation protocol."
+        },
+        {
+          "at": "2026-05-24T03:40:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1630 for SEO-OPS-SAFETY-ARTIFACTS-01 after scoped local checks passed and the full SeoIntel Feature-suite failure was recorded as an external sidecar reproduced on origin/main."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Make `--dry-run` and `--no-write` override explicit Search Channel Queue `--enqueue` requests and block contradictory write intent.
- Add URL Truth handoff artifact path validation before export/import/read/hash operations.
- Document the artifact path safety contract and update the generated handoff artifact.
- Add focused Feature tests for no-write enqueue conflicts and handoff artifact path rejection.
- Reconcile prior PR-train ledger entries needed for dependency continuity and record an external sidecar for existing SeoIntel Feature-suite failures reproduced on `origin/main`.

## Why
Codex security findings require the SEO Intel command surface to preserve no-write semantics and avoid unsafe artifact paths before any bounded handoff work can proceed.

## Validation commands
- `cd backend && php artisan test tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php --no-ansi`
- `cd backend && php artisan test tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoIntelSearchChannelQueueCommand.php app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php app/Services/SeoIntel tests/Feature/SeoIntel`
- `git diff --check`
- `git diff --cached --check`

## External sidecar
`cd backend && php artisan test tests/Feature/SeoIntel --no-ansi` still has existing failures outside this PR scope. Representative failures were reproduced on `origin/main@47f18f4f4806f734f08f8677f8d15a36da6c3198`: crawler log artifact text, SEO Ops crawler observation UI text, native dashboard locale/text drift, issue queue detail panel text, and IndexNow keyLocation host redaction. Per the user-approved protocol, this is recorded as a sidecar and not fixed in this PR.

## Intentionally deferred
- SEO Ops UI/text drift and IndexNow preflight redaction assertions.
- Any production scheduler, queue worker, external API, Search Channel submission, env, DNS, or deployment change.
