### PR TITLE
fix(riasec): enforce slot quality and compare contracts

### DIFF
--- a/backend/app/Services/Riasec/RiasecCompareGuardService.php
+++ b/backend/app/Services/Riasec/RiasecCompareGuardService.php
@@ -39,8 +39,10 @@ final class RiasecCompareGuardService
         $groupB = (string) ($basisB['compare_compatibility_group'] ?? '');
         $formA = (string) ($basisA['form_code'] ?? '');
         $formB = (string) ($basisB['form_code'] ?? '');
+        $scoreSpaceA = (string) ($basisA['score_space_version'] ?? '');
+        $scoreSpaceB = (string) ($basisB['score_space_version'] ?? '');
 
-        if ($groupA !== '' && $groupA === $groupB && $formA !== '' && $formA === $formB) {
+        if ($groupA !== '' && $groupA === $groupB && $formA !== '' && $formA === $formB && $scoreSpaceA !== '' && $scoreSpaceA === $scoreSpaceB) {
             return $this->contract($basisA, $basisB, true, 'same_compare_compatibility_group', 'riasec.compare.allowed_same_form');
         }
 

--- a/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
+++ b/backend/app/Services/Riasec/RiasecContentRegistrySlotContract.php
@@ -247,6 +247,15 @@ final class RiasecContentRegistrySlotContract
         '职业成功',
     ];
 
+    /** @var list<string> */
+    private const ALLOWED_FORM_CODES = ['riasec_60', 'riasec_140'];
+
+    /** @var list<string> */
+    private const ALLOWED_PROFILE_SHAPES = ['clear_code', 'blended_code', 'broad_profile', 'near_tie', 'low_clarity', 'low_quality'];
+
+    /** @var list<string> */
+    private const ALLOWED_QUALITY_STATES = ['normal', 'caution', 'low_quality', 'retake_recommended', 'minimal_quality_boundary_60q'];
+
     /**
      * @return array<string,mixed>
      */
@@ -325,6 +334,21 @@ final class RiasecContentRegistrySlotContract
                 $errors[] = $field.'_must_be_non_empty_array';
             }
         }
+        $errors = array_merge($errors, $this->unsupportedArrayValueErrors(
+            'applicable_form_codes',
+            $slot['applicable_form_codes'] ?? null,
+            self::ALLOWED_FORM_CODES,
+        ));
+        $errors = array_merge($errors, $this->unsupportedArrayValueErrors(
+            'applicable_profile_shapes',
+            $slot['applicable_profile_shapes'] ?? null,
+            self::ALLOWED_PROFILE_SHAPES,
+        ));
+        $errors = array_merge($errors, $this->unsupportedArrayValueErrors(
+            'applicable_quality_states',
+            $slot['applicable_quality_states'] ?? null,
+            self::ALLOWED_QUALITY_STATES,
+        ));
         if (! is_array($slot['applicable_codes'] ?? null) && ! is_array($slot['applicable_dimensions'] ?? null)) {
             $errors[] = 'missing_applicable_codes_or_dimensions';
         }
@@ -346,11 +370,7 @@ final class RiasecContentRegistrySlotContract
             }
         }
 
-        foreach (self::FORBIDDEN_FIELDS as $field) {
-            if (array_key_exists($field, $slot)) {
-                $errors[] = 'forbidden_field_'.$field;
-            }
-        }
+        $errors = array_merge($errors, $this->forbiddenFieldErrors($slot));
         $errors = array_merge($errors, $this->forbiddenPhraseErrors($slot));
 
         return [
@@ -465,6 +485,28 @@ final class RiasecContentRegistrySlotContract
         return ['omit_module', 'minimal_backend_empty_state', 'reject_payload'];
     }
 
+    /**
+     * @param  list<string>  $allowed
+     * @return list<string>
+     */
+    private function unsupportedArrayValueErrors(string $field, mixed $value, array $allowed): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($value as $item) {
+            $normalized = trim((string) $item);
+            if ($normalized === '' || ! in_array($normalized, $allowed, true)) {
+                $errors[] = 'unsupported_'.$field.'_value';
+                break;
+            }
+        }
+
+        return $errors;
+    }
+
     private function isBlank(mixed $value): bool
     {
         if ($value === null) {
@@ -490,7 +532,7 @@ final class RiasecContentRegistrySlotContract
         $strings = $this->payloadStrings($payload);
         foreach (self::FORBIDDEN_PHRASES as $phrase) {
             foreach ($strings as $text) {
-                if (str_contains($text, $phrase) && ! $this->isBoundaryOrNegatedHit($text, $phrase)) {
+                if ($this->textContainsPhrase($text, $phrase) && ! $this->isBoundaryOrNegatedHit($text, $phrase)) {
                     $errors[] = 'forbidden_claim_phrase_'.$this->errorToken($phrase);
                     break;
                 }
@@ -518,11 +560,41 @@ final class RiasecContentRegistrySlotContract
         return $strings;
     }
 
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    private function forbiddenFieldErrors(array $payload): array
+    {
+        $errors = [];
+        foreach ($payload as $key => $value) {
+            $field = (string) $key;
+            if (in_array($field, self::FORBIDDEN_FIELDS, true)) {
+                $errors[] = 'forbidden_field_'.$field;
+            }
+            if (is_array($value)) {
+                array_push($errors, ...$this->forbiddenFieldErrors($value));
+            }
+        }
+
+        return $errors;
+    }
+
+    private function textContainsPhrase(string $text, string $phrase): bool
+    {
+        if ($phrase === 'Matches') {
+            return preg_match('/\bmatches\b/i', $text) === 1;
+        }
+
+        return stripos($text, $phrase) !== false;
+    }
+
     private function isBoundaryOrNegatedHit(string $text, string $phrase): bool
     {
         $offset = 0;
-        while (($position = strpos($text, $phrase, $offset)) !== false) {
+        while (($position = stripos($text, $phrase, $offset)) !== false) {
             $context = substr($text, max(0, $position - 48), strlen($phrase) + 96);
+            $context = strtolower($context);
             $hasBoundaryMarker = false;
             foreach (['不是', '不能', '不得', '不输出', '不允许', '禁止', '不作为', '不把', '不代表', '不会', '不用于', '不默认', '不要', 'not ', 'does not', 'do not', 'forbidden'] as $marker) {
                 if (str_contains($context, $marker)) {

--- a/backend/app/Services/Riasec/RiasecQualityRuleContract.php
+++ b/backend/app/Services/Riasec/RiasecQualityRuleContract.php
@@ -131,7 +131,7 @@ final class RiasecQualityRuleContract
      */
     private function boolSignal(array $payload, string $key): bool
     {
-        return filter_var($payload[$key] ?? false, FILTER_VALIDATE_BOOL);
+        return filter_var($payload[$key] ?? data_get($payload, 'quality.'.$key, false), FILTER_VALIDATE_BOOL);
     }
 
     /**

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -651,7 +651,6 @@ class MeAttemptsService
                 $payload['previous_attempt_id'] = $previousId;
                 $payload['previous_top_code'] = (string) ($previousScore['top_code'] ?? '');
                 $payload['previous_primary_type'] = (string) ($previousScore['primary_type'] ?? '');
-                $payload['top_code_changed'] = $payload['previous_top_code'] !== $payload['current_top_code'];
                 $payload['previous_compare_policy_v1'] = $this->riasecCompareGuardService->summarizeAttempt(
                     $previous,
                     $resultByAttemptId[$previousId] ?? null
@@ -662,6 +661,9 @@ class MeAttemptsService
                     $previous,
                     $resultByAttemptId[$previousId] ?? null
                 );
+                if ((bool) data_get($payload, 'compare_guard_v1.can_compare', false)) {
+                    $payload['top_code_changed'] = $payload['previous_top_code'] !== $payload['current_top_code'];
+                }
             }
         }
 

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -478,6 +478,7 @@ final class RiasecAssessmentFlowTest extends TestCase
         $history->assertJsonPath('history_compare.compare_guard_v1.can_compare', false);
         $history->assertJsonPath('history_compare.compare_guard_v1.reason', 'cross_form_score_space_mismatch');
         $history->assertJsonPath('history_compare.compare_guard_v1.raw_score_delta_allowed', false);
+        $this->assertNull($history->json('history_compare.top_code_changed'));
         $history->assertJsonPath('history_compare.current_compare_policy_v1.score_space_version', 'riasec_140_likert5_activity_context_space.v1');
         $history->assertJsonPath('history_compare.previous_compare_policy_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
         $this->assertNull($history->json('history_compare.raw_scores_delta'));

--- a/backend/tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php
@@ -49,6 +49,28 @@ final class RiasecCompareGuardContractTest extends TestCase
         $this->assertArrayNotHasKey('domains_delta', $guard);
     }
 
+    public function test_compare_guard_blocks_same_form_when_score_space_versions_differ(): void
+    {
+        $service = new RiasecCompareGuardService(new RiasecMeasurementContract);
+
+        $guard = $service->evaluate(
+            $this->attempt('attempt_a', 'riasec_60', 60),
+            $this->makeResult('attempt_a', 'riasec_60', 'riasec_60_likert5_activity_sum_space.v1'),
+            $this->attempt('attempt_b', 'riasec_60', 60),
+            $this->makeResult(
+                'attempt_b',
+                'riasec_60',
+                'riasec_60_legacy_or_untrusted_space.v0',
+                'RIASEC:riasec_60:riasec_60_likert5_activity_sum_space.v1'
+            )
+        );
+
+        $this->assertFalse($guard['can_compare']);
+        $this->assertSame('cross_form_score_space_mismatch', $guard['reason']);
+        $this->assertSame('riasec.compare.blocked_cross_form', $guard['copy_key']);
+        $this->assertFalse($guard['raw_score_delta_allowed']);
+    }
+
     public function test_measurement_contract_keeps_claim_boundary_and_140q_contextual_label(): void
     {
         $contract = (new RiasecMeasurementContract)->forFormCode('riasec_140', 140);
@@ -80,15 +102,23 @@ final class RiasecCompareGuardContractTest extends TestCase
         return $attempt;
     }
 
-    private function makeResult(string $attemptId, string $formCode, string $scoreSpaceVersion): Result
+    private function makeResult(string $attemptId, string $formCode, string $scoreSpaceVersion, ?string $compareGroup = null): Result
     {
         $result = new Result;
         $result->attempt_id = $attemptId;
         $result->scale_code = 'RIASEC';
+        $contract = (new RiasecMeasurementContract)->forFormCode($formCode);
+        data_set($contract, 'form.score_space_version', $scoreSpaceVersion);
+        data_set(
+            $contract,
+            'compare_policy.compare_compatibility_group',
+            $compareGroup ?? (new RiasecMeasurementContract)->compareCompatibilityGroup($formCode, $scoreSpaceVersion)
+        );
+
         $result->result_json = [
             'form_code' => $formCode,
             'top_code' => 'RIA',
-            'measurement_contract_v1' => (new RiasecMeasurementContract)->forFormCode($formCode),
+            'measurement_contract_v1' => $contract,
             'score_space_version' => $scoreSpaceVersion,
         ];
 

--- a/backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecContentRegistrySlotContractTest.php
@@ -108,6 +108,47 @@ final class RiasecContentRegistrySlotContractTest extends TestCase
         $this->assertContains('forbidden_claim_phrase_140q_more_accurate', $result['errors']);
     }
 
+    public function test_validator_rejects_nested_forbidden_fields_and_invalid_applicability(): void
+    {
+        $slot = $this->validSlot([
+            'slot_key' => 'pair_blend_copy',
+            'slot_group' => 'pair_blend_copy',
+            'applicable_codes' => ['IA'],
+            'applicable_form_codes' => ['riasec_60', 'legacy_36'],
+            'applicable_profile_shapes' => ['clear_code', 'career_match_shape'],
+            'applicable_quality_states' => ['normal', 'excellent'],
+            'metadata' => [
+                'source_url' => 'https://example.test/unreviewed-source',
+                'scoring' => [
+                    'percentile' => 98,
+                ],
+            ],
+        ]);
+
+        $result = (new RiasecContentRegistrySlotContract)->validate($slot);
+
+        $this->assertFalse($result['ok']);
+        $this->assertContains('unsupported_applicable_form_codes_value', $result['errors']);
+        $this->assertContains('unsupported_applicable_profile_shapes_value', $result['errors']);
+        $this->assertContains('unsupported_applicable_quality_states_value', $result['errors']);
+        $this->assertContains('forbidden_field_source_url', $result['errors']);
+        $this->assertContains('forbidden_field_percentile', $result['errors']);
+    }
+
+    public function test_validator_rejects_forbidden_claim_phrases_case_insensitively(): void
+    {
+        $result = (new RiasecContentRegistrySlotContract)->validate($this->validSlot([
+            'slot_key' => 'pair_blend_copy',
+            'slot_group' => 'pair_blend_copy',
+            'applicable_codes' => ['IA'],
+            'body' => 'This says the result offers Career Match and SUCCESS PROBABILITY claims.',
+        ]));
+
+        $this->assertFalse($result['ok']);
+        $this->assertContains('forbidden_claim_phrase_career_match', $result['errors']);
+        $this->assertContains('forbidden_claim_phrase_success_probability', $result['errors']);
+    }
+
     public function test_validator_allows_negated_boundary_mentions_without_allowing_positive_claims(): void
     {
         $contract = new RiasecContentRegistrySlotContract;
@@ -173,10 +214,13 @@ final class RiasecContentRegistrySlotContractTest extends TestCase
             'forbidden_claims' => ['career_outcome_claims_forbidden'],
             'required_boundaries' => [
                 'interest_evidence_only',
+                'not_personality_identity',
                 'not_career_recommendation',
                 'not_job_fit',
                 'not_success_prediction',
                 'not_ability_or_skill_measure',
+                'examples_not_matches',
+                'not_hiring_or_screening_use',
                 'no_60q_140q_raw_delta',
                 '140q_contextual_not_more_accurate',
                 'feedback_does_not_mutate_measured_result',

--- a/backend/tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php
@@ -74,6 +74,22 @@ final class RiasecQualityRuleContractTest extends TestCase
         $this->assertNoForbiddenClaims($state);
     }
 
+    public function test_nested_quality_boolean_signals_are_respected(): void
+    {
+        $state = (new RiasecQualityRuleContract)->build([
+            'form_code' => 'riasec_140',
+            'answer_count' => 140,
+            'quality' => [
+                'too_fast' => true,
+            ],
+        ]);
+
+        $this->assertSame('caution', $state['quality_state']);
+        $this->assertTrue($state['too_fast']);
+        $this->assertSame('cautious_reading', $state['reading_strength']);
+        $this->assertNoForbiddenClaims($state);
+    }
+
     public function test_140q_two_attention_flags_route_to_low_quality_and_hide_140q_upsell(): void
     {
         $state = (new RiasecQualityRuleContract)->build([

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3538,7 +3538,7 @@
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-05-content-registry-readiness",
       "title": "feat(riasec): add content registry readiness contract",
-      "status": "github_checks_failed_scoped_fix_local_passed",
+      "status": "merged",
       "depends_on": [
         "RIASEC-PERSONALIZATION-04"
       ],
@@ -16096,7 +16096,7 @@
     "SEO-INDEXABILITY-TRUTH-01": {
       "repo": "fap-api",
       "branch": "codex/seo-indexability-truth-01",
-      "status": "github_checks_failed_scoped_fix_local_passed",
+      "status": "merged",
       "depends_on": [
         "SEO-OPS-SAFETY-ARTIFACTS-01"
       ],
@@ -16107,7 +16107,7 @@
         44,
         49
       ],
-      "commit_sha": "ad923f24fb14c86cece0664ca90d28e26ed8ac6d",
+      "commit_sha": "d6f3e4ae4909196d17b2e441fe0188de274e84e7",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1631",
       "checks": {
         "scope_validation": {
@@ -16146,9 +16146,9 @@
       },
       "sidecar_issues": [],
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T20:23:03Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "events": [
         {
           "at": "2026-05-24T04:01:40+08:00",
@@ -16164,13 +16164,18 @@
           "at": "2026-05-24T04:20:00+08:00",
           "status": "github_checks_failed_scoped_fix_local_passed",
           "summary": "GitHub verify-mbti-legacy and verify-mbti-v2 failed because the BigFive runtime-freeze classifier did not yet allow the CMS CareerJob public surface controller touched by this PR. Added a narrow classifier allowance and reran the full BigFiveResultPageV2CoreBodyPreviewTest file successfully."
+        },
+        {
+          "at": "2026-05-24T04:23:03+08:00",
+          "status": "merged",
+          "summary": "PR #1631 required GitHub checks passed, then the PR was squash-merged into origin/main as d6f3e4ae4909196d17b2e441fe0188de274e84e7. Remote branch deletion and local cleanup were verified."
         }
       ]
     },
     "RIASEC-CONTRACT-QUALITY-01": {
       "repo": "fap-api",
       "branch": "codex/riasec-contract-quality-01",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "SEO-INDEXABILITY-TRUTH-01"
       ],
@@ -16182,12 +16187,47 @@
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "SEO-INDEXABILITY-TRUTH-01 is merged into origin/main as d6f3e4ae4909196d17b2e441fe0188de274e84e7."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to RIASEC services, MeAttemptsService RIASEC history summary, RIASEC tests, and PR train state metadata."
+        },
+        "riasec": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter Riasec --no-ansi",
+          "evidence": "136 tests passed, 92689 assertions."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Riasec app/Services/V0_3/Me/MeAttemptsService.php tests",
+          "evidence": "1272 files passed Pint."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
       "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-05-24T04:24:00+08:00",
+          "status": "in_progress",
+          "summary": "Started from latest main after SEO-INDEXABILITY-TRUTH-01 merged and created branch codex/riasec-contract-quality-01."
+        },
+        {
+          "at": "2026-05-24T04:35:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Hardened RIASEC slot validation for nested forbidden fields and case-insensitive forbidden claims, enforced nested quality boolean signals, blocked same-form compare when score-space versions differ, and suppressed top_code_changed on non-comparable cross-form history. Focused RIASEC tests, Pint, and diff check passed."
+        }
+      ]
     },
     "BIGFIVE-RUNTIME-GUARDS-01": {
       "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6863,7 +6863,7 @@
       "branch": "codex/repair-2786-final-readiness-public-owner-partition-authority-1",
       "title": "fix(api): account reviewed public owner partition in 2786 readiness",
       "name": "Account reviewed CN proxy public-owner partition in final 2786 readiness",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "2786-CN-PROXY-PUBLIC-OWNER-PLAN-1"
       ],
@@ -10163,7 +10163,7 @@
         }
       },
       "failure_reason": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1632",
       "commit_sha": "33c0faf7b9522f7df6b6e76efef86f5959039bbf",
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -16226,6 +16226,11 @@
           "at": "2026-05-24T04:35:00+08:00",
           "status": "local_validation_passed",
           "summary": "Hardened RIASEC slot validation for nested forbidden fields and case-insensitive forbidden claims, enforced nested quality boolean signals, blocked same-form compare when score-space versions differ, and suppressed top_code_changed on non-comparable cross-form history. Focused RIASEC tests, Pint, and diff check passed."
+        },
+        {
+          "at": "2026-05-24T04:38:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1632 for RIASEC contract quality hardening after scoped local validation passed."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -10164,7 +10164,7 @@
       },
       "failure_reason": null,
       "pr_url": null,
-      "commit_sha": null,
+      "commit_sha": "33c0faf7b9522f7df6b6e76efef86f5959039bbf",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,


### PR DESCRIPTION
## What changed
- Hardened RIASEC content slot validation for nested forbidden fields, invalid applicability values, and case-insensitive forbidden claim phrases.
- Enforced RIASEC quality signals from nested quality payloads.
- Tightened compare guard so same-form comparisons still require identical score-space versions.
- Suppressed RIASEC history top-code change flags when the compare guard blocks cross-form comparison.
- Reconciled prior SEO indexability train state and recorded this PR local validation.

## Why
Codex security findings 5, 17, 21, and 26 require RIASEC contracts to fail closed around unsafe slot metadata, quality signals, and cross-form/score-space comparison semantics.

## Validation
- cd backend && php artisan test --filter Riasec --no-ansi
- cd backend && vendor/bin/pint --test app/Services/Riasec app/Services/V0_3/Me/MeAttemptsService.php tests
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No scoring math changes.
- No public copy/content asset changes.
- No frontend changes.
- No production data, queue, telemetry, or CMS mutation.