### PR TITLE
fix(big-five): harden norm capture and projection routing

### DIFF
--- a/backend/app/Services/BigFive/Norms/BigFiveNormObservationCaptureWriter.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormObservationCaptureWriter.php
@@ -12,6 +12,25 @@ final class BigFiveNormObservationCaptureWriter
 {
     public const SCHEMA_VERSION = 'big5_norm_observation.v0.1';
 
+    private const SCALE_CODE = 'BIG5_OCEAN';
+
+    private const DOMAIN_SCORE_KEYS = ['O', 'C', 'E', 'A', 'N'];
+
+    private const FACET_SCORE_KEYS = [
+        'N1', 'E1', 'O1', 'A1', 'C1',
+        'N2', 'E2', 'O2', 'A2', 'C2',
+        'N3', 'E3', 'O3', 'A3', 'C3',
+        'N4', 'E4', 'O4', 'A4', 'C4',
+        'N5', 'E5', 'O5', 'A5', 'C5',
+        'N6', 'E6', 'O6', 'A6', 'C6',
+    ];
+
+    private const SUPPORTED_FORM_CODES = ['big5_120', 'big5_90'];
+
+    private const EXCLUDED_ATTEMPT_SOURCES = ['fixture', 'staging', 'internal'];
+
+    private const EXCLUDED_QUALITY_FLAGS = ['ATTENTION_CHECK_FAILED', 'SPEEDING', 'STRAIGHTLINING'];
+
     /**
      * @param  array<string,mixed>  $scoreResult
      * @param  array<string,mixed>  $context
@@ -64,11 +83,21 @@ final class BigFiveNormObservationCaptureWriter
             }
         }
 
+        if (strtoupper(trim((string) ($context['scale_code'] ?? self::SCALE_CODE))) !== self::SCALE_CODE) {
+            return BigFiveNormCaptureDecision::reject('unsupported_scale_code');
+        }
+
+        $formCode = strtolower(trim((string) ($context['form_code'] ?? '')));
+        if (! in_array($formCode, self::SUPPORTED_FORM_CODES, true)) {
+            return BigFiveNormCaptureDecision::reject('unsupported_form_code');
+        }
+
         if (($context['norm_eligibility_status'] ?? null) !== 'eligible' || ($context['norm_excluded'] ?? true) !== false) {
             return BigFiveNormCaptureDecision::reject('invalid_eligibility');
         }
 
-        if (in_array((string) ($context['attempt_source'] ?? 'real'), ['fixture', 'staging', 'internal'], true)) {
+        $attemptSource = strtolower(trim((string) ($context['attempt_source'] ?? 'real')));
+        if (in_array($attemptSource, self::EXCLUDED_ATTEMPT_SOURCES, true)) {
             return BigFiveNormCaptureDecision::reject('source_excluded');
         }
 
@@ -77,17 +106,22 @@ final class BigFiveNormObservationCaptureWriter
             return BigFiveNormCaptureDecision::reject('quality_level_excluded');
         }
 
-        $qualityFlags = $this->stringList((array) ($context['quality_flags'] ?? []));
-        if (array_intersect($qualityFlags, ['ATTENTION_CHECK_FAILED', 'SPEEDING', 'STRAIGHTLINING']) !== []) {
+        $qualityFlags = array_map(
+            static fn (string $flag): string => strtoupper($flag),
+            $this->stringList((array) ($context['quality_flags'] ?? []))
+        );
+        if (array_intersect($qualityFlags, self::EXCLUDED_QUALITY_FLAGS) !== []) {
             return BigFiveNormCaptureDecision::reject('quality_flags_excluded');
         }
 
-        if (! $this->hasScoreVector($scoreResult, 'raw_domain_scores')) {
-            return BigFiveNormCaptureDecision::reject('missing_raw_domain_scores');
+        $domainScoreError = $this->scoreVectorError($scoreResult, 'raw_domain_scores', self::DOMAIN_SCORE_KEYS);
+        if ($domainScoreError !== null) {
+            return BigFiveNormCaptureDecision::reject($domainScoreError);
         }
 
-        if (! $this->hasScoreVector($scoreResult, 'raw_facet_scores')) {
-            return BigFiveNormCaptureDecision::reject('missing_raw_facet_scores');
+        $facetScoreError = $this->scoreVectorError($scoreResult, 'raw_facet_scores', self::FACET_SCORE_KEYS);
+        if ($facetScoreError !== null) {
+            return BigFiveNormCaptureDecision::reject($facetScoreError);
         }
 
         return BigFiveNormCaptureDecision::allow();
@@ -110,8 +144,8 @@ final class BigFiveNormObservationCaptureWriter
             'observation_idempotency_key' => (string) $context['observation_idempotency_key'],
             'observation_source' => (string) ($context['observation_source'] ?? 'norm_capture_writer'),
             'environment' => $this->optionalString($context, 'environment'),
-            'scale_code' => (string) ($context['scale_code'] ?? 'BIG5_OCEAN'),
-            'form_code' => $this->optionalString($context, 'form_code'),
+            'scale_code' => self::SCALE_CODE,
+            'form_code' => strtolower((string) $context['form_code']),
             'content_version' => (string) $context['content_version'],
             'score_version' => (string) $context['score_version'],
             'norm_version_at_scoring' => $this->optionalString($context, 'norm_version_at_scoring'),
@@ -136,11 +170,38 @@ final class BigFiveNormObservationCaptureWriter
     /**
      * @param  array<string,mixed>  $scoreResult
      */
-    private function hasScoreVector(array $scoreResult, string $key): bool
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @param  list<string>  $expectedKeys
+     */
+    private function scoreVectorError(array $scoreResult, string $key, array $expectedKeys): ?string
     {
         $value = $scoreResult[$key] ?? null;
+        if (! is_array($value) || $value === []) {
+            return 'missing_'.$key;
+        }
 
-        return is_array($value) && $value !== [];
+        $actualKeys = array_map('strval', array_keys($value));
+        sort($actualKeys);
+        $sortedExpectedKeys = $expectedKeys;
+        sort($sortedExpectedKeys);
+
+        if ($actualKeys !== $sortedExpectedKeys) {
+            return 'incomplete_'.$key;
+        }
+
+        foreach ($expectedKeys as $expectedKey) {
+            $score = $value[$expectedKey] ?? null;
+            if (! is_int($score) && ! is_float($score) && ! (is_string($score) && is_numeric($score))) {
+                return 'invalid_'.$key;
+            }
+
+            if (! is_finite((float) $score)) {
+                return 'invalid_'.$key;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2ProjectionRouteInputAdapter.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2ProjectionRouteInputAdapter.php
@@ -10,6 +10,17 @@ final class BigFiveV2ProjectionRouteInputAdapter
 {
     private const DOMAIN_ORDER = ['O', 'C', 'E', 'A', 'N'];
 
+    private const PROJECTION_SCHEMA_VERSION = 'big5.public_projection.v1';
+
+    private const FACET_ORDER = [
+        'N1', 'E1', 'O1', 'A1', 'C1',
+        'N2', 'E2', 'O2', 'A2', 'C2',
+        'N3', 'E3', 'O3', 'A3', 'C3',
+        'N4', 'E4', 'O4', 'A4', 'C4',
+        'N5', 'E5', 'O5', 'A5', 'C5',
+        'N6', 'E6', 'O6', 'A6', 'C6',
+    ];
+
     /**
      * @var list<string>
      */
@@ -32,9 +43,14 @@ final class BigFiveV2ProjectionRouteInputAdapter
             return null;
         }
 
+        $facetSignals = $this->facetSignalsFromPercentileMap((array) data_get($scoreResult, 'scores_0_100.facets_percentile', []));
+        if ($this->errors !== []) {
+            return null;
+        }
+
         return $this->buildRouteInput(
             $domainPercentiles,
-            $this->facetSignalsFromPercentileMap((array) data_get($scoreResult, 'scores_0_100.facets_percentile', [])),
+            $facetSignals,
             (array) ($scoreResult['quality'] ?? []),
             (array) ($scoreResult['norms'] ?? []),
         );
@@ -49,6 +65,13 @@ final class BigFiveV2ProjectionRouteInputAdapter
         $meta = (array) ($projection['_meta'] ?? []);
         if (($meta['redacted'] ?? false) === true || ($meta['locked'] ?? false) === true) {
             $this->errors[] = 'projection is locked or redacted';
+
+            return null;
+        }
+
+        $schemaVersion = (string) ($projection['schema_version'] ?? $meta['schema_version'] ?? '');
+        if ($schemaVersion !== self::PROJECTION_SCHEMA_VERSION) {
+            $this->errors[] = 'projection.schema_version unsupported';
 
             return null;
         }
@@ -77,9 +100,14 @@ final class BigFiveV2ProjectionRouteInputAdapter
             $domainPercentiles[$key] = $trait['percentile'];
         }
 
+        $facetSignals = $this->facetSignalsFromProjection((array) ($projection['facet_vector'] ?? []));
+        if ($facetSignals === null) {
+            return null;
+        }
+
         return $this->buildRouteInput(
             $domainPercentiles,
-            $this->facetSignalsFromProjection((array) ($projection['facet_vector'] ?? [])),
+            $facetSignals,
             (array) ($projection['quality'] ?? []),
             (array) ($projection['norms'] ?? []),
         );
@@ -175,9 +203,19 @@ final class BigFiveV2ProjectionRouteInputAdapter
             if ($facetKey === '') {
                 continue;
             }
+            if (! in_array($facetKey, self::FACET_ORDER, true)) {
+                $this->errors[] = "score_result.scores_0_100.facets_percentile.{$facetKey} unsupported";
+
+                return [];
+            }
+            if (! $this->validPercentile($percentile)) {
+                $this->errors[] = "score_result.scores_0_100.facets_percentile.{$facetKey} invalid";
+
+                return [];
+            }
             $signals[] = [
                 'key' => $facetKey,
-                'percentile' => is_numeric($percentile) ? (int) $percentile : null,
+                'percentile' => (int) $percentile,
             ];
         }
 
@@ -185,9 +223,9 @@ final class BigFiveV2ProjectionRouteInputAdapter
     }
 
     /**
-     * @return list<array<string,mixed>>
+     * @return list<array<string,mixed>>|null
      */
-    private function facetSignalsFromProjection(array $facetVector): array
+    private function facetSignalsFromProjection(array $facetVector): ?array
     {
         $signals = [];
         foreach ($facetVector as $facet) {
@@ -198,13 +236,34 @@ final class BigFiveV2ProjectionRouteInputAdapter
             if ($key === '') {
                 continue;
             }
+            if (! in_array($key, self::FACET_ORDER, true)) {
+                $this->errors[] = "projection.facet_vector.{$key} unsupported";
+
+                return null;
+            }
+            if (! array_key_exists('percentile', $facet) || ! $this->validPercentile($facet['percentile'])) {
+                $this->errors[] = "projection.facet_vector.{$key}.percentile invalid";
+
+                return null;
+            }
             $signals[] = [
                 'key' => $key,
-                'percentile' => array_key_exists('percentile', $facet) && is_numeric($facet['percentile']) ? (int) $facet['percentile'] : null,
+                'percentile' => (int) $facet['percentile'],
                 'bucket' => isset($facet['bucket']) ? (string) $facet['bucket'] : null,
             ];
         }
 
         return $signals;
+    }
+
+    private function validPercentile(mixed $percentile): bool
+    {
+        if (! is_int($percentile) && ! (is_float($percentile) && floor($percentile) === $percentile) && ! (is_string($percentile) && preg_match('/^\d+$/', $percentile) === 1)) {
+            return false;
+        }
+
+        $value = (int) $percentile;
+
+        return $value >= 0 && $value <= 100;
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/NormCaptureTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/NormCaptureTest.php
@@ -47,7 +47,7 @@ final class NormCaptureTest extends TestCase
         $writer = $this->writer();
         $first = $writer->capture($this->scoreResult(), $this->context());
         $second = $writer->capture($this->scoreResult([
-            'raw_domain_scores' => ['O' => 1],
+            'raw_domain_scores' => ['O' => 1, 'C' => 2, 'E' => 3, 'A' => 4, 'N' => 5],
         ]), $this->context());
 
         $this->assertTrue($first->captured);
@@ -66,10 +66,18 @@ final class NormCaptureTest extends TestCase
             'missing_score_version' => [$this->scoreResult(), ['score_version' => '']],
             'invalid_eligibility' => [$this->scoreResult(), ['norm_eligibility_status' => 'excluded']],
             'source_excluded' => [$this->scoreResult(), ['attempt_source' => 'fixture']],
+            'source_excluded_case_insensitive' => [$this->scoreResult(), ['attempt_source' => 'Staging']],
             'low_quality' => [$this->scoreResult(), ['quality_level' => 'C']],
             'quality_flag_excluded' => [$this->scoreResult(), ['quality_flags' => ['SPEEDING']]],
+            'quality_flag_excluded_case_insensitive' => [$this->scoreResult(), ['quality_flags' => ['attention_check_failed']]],
+            'unsupported_scale_code' => [$this->scoreResult(), ['scale_code' => 'RIASEC']],
+            'unsupported_form_code' => [$this->scoreResult(), ['form_code' => 'big5_legacy']],
             'missing_raw_domain_scores' => [$this->scoreResult(['raw_domain_scores' => []]), []],
             'missing_raw_facet_scores' => [$this->scoreResult(['raw_facet_scores' => []]), []],
+            'incomplete_raw_domain_scores' => [$this->scoreResult(['raw_domain_scores' => ['O' => 71, 'C' => 64, 'E' => 58, 'A' => 69]]), []],
+            'incomplete_raw_facet_scores' => [$this->scoreResult(['raw_facet_scores' => ['O1' => 15]]), []],
+            'invalid_raw_domain_scores' => [$this->scoreResult(['raw_domain_scores' => ['O' => 71, 'C' => 64, 'E' => 58, 'A' => 69, 'N' => 'NaN']]), []],
+            'invalid_raw_facet_scores' => [$this->scoreResult(['raw_facet_scores' => array_replace($this->facetScores(), ['C6' => null])]), []],
         ];
 
         foreach ($cases as $case => [$scoreResult, $overrides]) {
@@ -110,8 +118,23 @@ final class NormCaptureTest extends TestCase
     {
         return array_replace([
             'raw_domain_scores' => ['O' => 71, 'C' => 64, 'E' => 58, 'A' => 69, 'N' => 31],
-            'raw_facet_scores' => ['O1' => 15, 'C1' => 13, 'E1' => 12, 'A1' => 14, 'N1' => 7],
+            'raw_facet_scores' => $this->facetScores(),
         ], $overrides);
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    private function facetScores(): array
+    {
+        return [
+            'N1' => 7, 'E1' => 12, 'O1' => 15, 'A1' => 14, 'C1' => 13,
+            'N2' => 8, 'E2' => 11, 'O2' => 16, 'A2' => 13, 'C2' => 14,
+            'N3' => 9, 'E3' => 10, 'O3' => 17, 'A3' => 12, 'C3' => 15,
+            'N4' => 10, 'E4' => 9, 'O4' => 18, 'A4' => 11, 'C4' => 16,
+            'N5' => 11, 'E5' => 8, 'O5' => 19, 'A5' => 10, 'C5' => 17,
+            'N6' => 12, 'E6' => 7, 'O6' => 20, 'A6' => 9, 'C6' => 18,
+        ];
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/RoutingTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/RoutingTest.php
@@ -109,9 +109,7 @@ final class RoutingTest extends TestCase
     public function test_full_projection_percentiles_can_build_route_input_without_trait_bands(): void
     {
         $routeInput = (new BigFiveV2ProjectionRouteInputAdapter)->fromProjection([
-            '_meta' => [
-                'schema_version' => 'big5.public_projection.v1',
-            ],
+            'schema_version' => 'big5.public_projection.v1',
             'trait_bands' => [
                 'O' => 'mid',
                 'C' => 'low',
@@ -136,6 +134,58 @@ final class RoutingTest extends TestCase
         $this->assertNotNull($routeInput);
         $this->assertSame('O3_C2_E2_A3_N4', $routeInput->combinationKey);
         $this->assertSame([['key' => 'N1', 'percentile' => 82, 'bucket' => 'high']], $routeInput->facetRouteSignals);
+    }
+
+    public function test_projection_with_unsupported_schema_fails_closed(): void
+    {
+        $adapter = new BigFiveV2ProjectionRouteInputAdapter;
+
+        $this->assertNull($adapter->fromProjection(array_replace($this->projection(), [
+            'schema_version' => 'legacy.public_projection.v1',
+        ])));
+        $this->assertContains('projection.schema_version unsupported', $adapter->errors());
+    }
+
+    public function test_projection_with_invalid_facet_signal_fails_closed(): void
+    {
+        $adapter = new BigFiveV2ProjectionRouteInputAdapter;
+
+        $this->assertNull($adapter->fromProjection(array_replace($this->projection(), [
+            'facet_vector' => [
+                ['key' => 'X1', 'percentile' => 82, 'bucket' => 'high'],
+            ],
+        ])));
+        $this->assertContains('projection.facet_vector.X1 unsupported', $adapter->errors());
+
+        $adapter = new BigFiveV2ProjectionRouteInputAdapter;
+
+        $this->assertNull($adapter->fromProjection(array_replace($this->projection(), [
+            'facet_vector' => [
+                ['key' => 'N1', 'percentile' => 101, 'bucket' => 'high'],
+            ],
+        ])));
+        $this->assertContains('projection.facet_vector.N1.percentile invalid', $adapter->errors());
+    }
+
+    public function test_score_result_with_invalid_facet_signal_fails_closed(): void
+    {
+        $adapter = new BigFiveV2ProjectionRouteInputAdapter;
+
+        $this->assertNull($adapter->fromScoreResult(array_replace_recursive($this->scoreResult([
+            'O' => 59,
+            'C' => 32,
+            'E' => 20,
+            'A' => 55,
+            'N' => 68,
+        ]), [
+            'scores_0_100' => [
+                'facets_percentile' => [
+                    'N1' => 82,
+                    'C1' => 101,
+                ],
+            ],
+        ])));
+        $this->assertContains('score_result.scores_0_100.facets_percentile.C1 invalid', $adapter->errors());
     }
 
     public function test_degraded_quality_and_missing_norms_carry_suppression_hints(): void
@@ -205,6 +255,28 @@ final class RoutingTest extends TestCase
             ],
             'quality' => $quality,
             'norms' => $norms,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function projection(): array
+    {
+        return [
+            'schema_version' => 'big5.public_projection.v1',
+            'trait_vector' => [
+                ['key' => 'O', 'percentile' => 59, 'band' => 'mid'],
+                ['key' => 'C', 'percentile' => 32, 'band' => 'low'],
+                ['key' => 'E', 'percentile' => 20, 'band' => 'low'],
+                ['key' => 'A', 'percentile' => 55, 'band' => 'mid'],
+                ['key' => 'N', 'percentile' => 68, 'band' => 'high'],
+            ],
+            'facet_vector' => [
+                ['key' => 'N1', 'percentile' => 82, 'bucket' => 'high'],
+            ],
+            'quality' => ['level' => 'A'],
+            'norms' => ['status' => 'CALIBRATED'],
         ];
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T05:11:00+08:00",
+  "updated_at": "2026-05-24T05:14:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -16246,7 +16246,7 @@
     "BIGFIVE-RUNTIME-GUARDS-01": {
       "repo": "fap-api",
       "branch": "codex/bigfive-runtime-guards-01",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "RIASEC-CONTRACT-QUALITY-01"
       ],
@@ -16255,8 +16255,8 @@
         35,
         36
       ],
-      "commit_sha": "e5c21649",
-      "pr_url": null,
+      "commit_sha": "3edb152d1d3b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1633",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -16301,6 +16301,11 @@
           "at": "2026-05-24T05:08:00+08:00",
           "status": "local_validation_passed",
           "summary": "Hardened Big Five norm capture against unsupported scale/form, case-insensitive excluded sources/quality flags, incomplete score vectors, and invalid score values; hardened projection routing against unsupported schema and invalid facet route signals. Focused tests, full BigFive filter, Pint, and diff check passed."
+        },
+        {
+          "at": "2026-05-24T05:14:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1633 after scoped local validation passed."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T03:15:15+08:00",
+  "updated_at": "2026-05-24T05:11:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -16175,7 +16175,7 @@
     "RIASEC-CONTRACT-QUALITY-01": {
       "repo": "fap-api",
       "branch": "codex/riasec-contract-quality-01",
-      "status": "local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "SEO-INDEXABILITY-TRUTH-01"
       ],
@@ -16185,8 +16185,8 @@
         21,
         26
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "ceef6619d3b28276f76f8e0ce5194c03a2762df2",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1632",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -16209,13 +16209,17 @@
         "diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github": {
+          "status": "pass",
+          "evidence": "GitHub PR #1632 is MERGED and origin/main contains merge commit ceef6619d3b28276f76f8e0ce5194c03a2762df2."
         }
       },
       "sidecar_issues": [],
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T20:44:54Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "events": [
         {
           "at": "2026-05-24T04:24:00+08:00",
@@ -16231,13 +16235,18 @@
           "at": "2026-05-24T04:38:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1632 for RIASEC contract quality hardening after scoped local validation passed."
+        },
+        {
+          "at": "2026-05-24T05:08:00+08:00",
+          "status": "merged",
+          "summary": "Reconciled ledger after PR #1632 was squash-merged; origin/main contains ceef6619d3b28276f76f8e0ce5194c03a2762df2 and remote branch is absent."
         }
       ]
     },
     "BIGFIVE-RUNTIME-GUARDS-01": {
       "repo": "fap-api",
       "branch": "codex/bigfive-runtime-guards-01",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "RIASEC-CONTRACT-QUALITY-01"
       ],
@@ -16246,14 +16255,54 @@
         35,
         36
       ],
-      "commit_sha": null,
+      "commit_sha": "e5c21649",
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "RIASEC-CONTRACT-QUALITY-01 is merged into main as ceef6619d3b28276f76f8e0ce5194c03a2762df2."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Big Five services, Big Five tests, and PR train state metadata; generated content pack test artifacts were removed from the worktree."
+        },
+        "focused_bigfive_runtime": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/NormCaptureTest.php tests/Unit/Services/BigFive/ResultPageV2/RoutingTest.php tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php --no-ansi",
+          "evidence": "20 tests passed, 138 assertions."
+        },
+        "bigfive": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter BigFive --no-ansi",
+          "evidence": "755 tests passed, 60849 assertions."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/BigFive database/migrations/2026_05_06_132700_create_big_five_norm_observations_table.php tests",
+          "evidence": "1349 files passed Pint."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
       "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-05-24T04:46:00+08:00",
+          "status": "in_progress",
+          "summary": "Started from latest main after RIASEC-CONTRACT-QUALITY-01 merged and created branch codex/bigfive-runtime-guards-01."
+        },
+        {
+          "at": "2026-05-24T05:08:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Hardened Big Five norm capture against unsupported scale/form, case-insensitive excluded sources/quality flags, incomplete score vectors, and invalid score values; hardened projection routing against unsupported schema and invalid facet route signals. Focused tests, full BigFive filter, Pint, and diff check passed."
+        }
+      ]
     },
     "CAREER-POLICY-CLAIM-GUARDS-01": {
       "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Hardened Big Five norm observation capture against unsupported scale/form values, case-insensitive excluded sources and quality flags, incomplete score vectors, and invalid raw score values.
- Hardened Big Five V2 projection routing to accept only the public projection schema and reject unsupported or invalid facet route signals.
- Added focused coverage for norm capture and routing fail-closed behavior, and reconciled the prior RIASEC PR train state.

## Why
This addresses `BIGFIVE-RUNTIME-GUARDS-01` findings 34, 35, and 36 by preventing runtime routing or norm capture from trusting partial, malformed, or wrong-schema payloads.

## Validation
- `cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/NormCaptureTest.php tests/Unit/Services/BigFive/ResultPageV2/RoutingTest.php tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php --no-ansi`
- `cd backend && php artisan test --filter BigFive --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/BigFive database/migrations/2026_05_06_132700_create_big_five_norm_observations_table.php tests`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No changes to Big Five public projection copy or report content packs.
- No changes to production runtime flags or rollout policy.
