### PR TITLE
fix(career): tighten policy claim and trust guards

### DIFF
--- a/backend/app/Domain/Career/Scoring/ClaimPermissionsCompiler.php
+++ b/backend/app/Domain/Career/Scoring/ClaimPermissionsCompiler.php
@@ -33,18 +33,21 @@ final class ClaimPermissionsCompiler
 
         $allowSalaryComparison = ! isset($blocked['salary_comparison'])
             && ! $indexBlocked
+            && $this->hasTrustedSourceEvidence($context)
             && ($context['median_pay_usd_annual'] ?? null) !== null
             && ! ((bool) ($context['cross_market_mismatch'] ?? false) && ! (bool) ($context['allow_pay_direct_inheritance'] ?? false));
 
         $allowAiStrategy = ! isset($blocked['ai_strategy'])
             && ! $indexBlocked
             && $aiScore instanceof CareerScoreResult
-            && $aiScore->integrityState !== IntegrityState::BLOCKED;
+            && $this->claimStateAllowsPublicGuidance($aiScore)
+            && $this->hasTrustedSourceEvidence($context);
 
         $allowTransitionRecommendation = ! isset($blocked['transition_recommendation'])
             && ! $indexBlocked
             && $mobilityScore instanceof CareerScoreResult
-            && $mobilityScore->integrityState !== IntegrityState::BLOCKED
+            && $this->claimStateAllowsPublicGuidance($mobilityScore)
+            && $this->crosswalkConfidenceAllowsTransition($context)
             && $mobilityScore->value >= 40;
 
         $allowCrossMarketPayCopy = ! isset($blocked['cross_market_pay_copy'])
@@ -80,5 +83,47 @@ final class ClaimPermissionsCompiler
             'allow_cross_market_pay_copy' => $allowCrossMarketPayCopy,
             'reason_codes' => array_values(array_unique($reasonCodes)),
         ];
+    }
+
+    private function claimStateAllowsPublicGuidance(CareerScoreResult $result): bool
+    {
+        return in_array($result->integrityState, [IntegrityState::FULL, IntegrityState::PROVISIONAL], true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function hasTrustedSourceEvidence(array $context): bool
+    {
+        if (! array_key_exists('trust_manifest', $context)
+            && ! array_key_exists('truth_manifest', $context)
+            && ! array_key_exists('source_trace_evidence', $context)
+            && ! array_key_exists('source_fields_used_count', $context)
+        ) {
+            return true;
+        }
+
+        $sourceTraceEvidence = $context['source_trace_evidence'] ?? null;
+        $sourceFieldsUsedCount = $context['source_fields_used_count'] ?? null;
+
+        return ($context['trust_manifest'] ?? $context['truth_manifest'] ?? false) === true
+            && is_numeric($sourceTraceEvidence)
+            && (float) $sourceTraceEvidence >= 0.65
+            && is_numeric($sourceFieldsUsedCount)
+            && (int) $sourceFieldsUsedCount > 0;
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function crosswalkConfidenceAllowsTransition(array $context): bool
+    {
+        if (! array_key_exists('crosswalk_confidence', $context) || $context['crosswalk_confidence'] === null) {
+            return true;
+        }
+
+        $crosswalkConfidence = $context['crosswalk_confidence'] ?? null;
+
+        return is_numeric($crosswalkConfidence) && (float) $crosswalkConfidence >= 0.7;
     }
 }

--- a/backend/app/Domain/Career/Scoring/ClaimReasonCode.php
+++ b/backend/app/Domain/Career/Scoring/ClaimReasonCode.php
@@ -29,4 +29,10 @@ final class ClaimReasonCode
     public const MISSING_MEDIAN_PAY = 'missing_median_pay';
 
     public const CROSS_MARKET_MISMATCH = 'cross_market_mismatch';
+
+    public const MISSING_TRUST_MANIFEST = 'missing_trust_manifest';
+
+    public const MISSING_SOURCE_TRACE_EVIDENCE = 'missing_source_trace_evidence';
+
+    public const LOW_CROSSWALK_CONFIDENCE = 'low_crosswalk_confidence';
 }

--- a/backend/app/Domain/Career/Scoring/WarningMatrix.php
+++ b/backend/app/Domain/Career/Scoring/WarningMatrix.php
@@ -30,6 +30,31 @@ final class WarningMatrix
         $indexState = (string) ($context['index_state'] ?? '');
         $indexEligible = (bool) ($context['index_eligible'] ?? false);
 
+        if (! $this->hasTrustManifest($context)) {
+            $redFlags[] = ClaimReasonCode::MISSING_TRUST_MANIFEST;
+            $blockedClaims[] = 'strong_claim';
+            $blockedClaims[] = 'salary_comparison';
+            $blockedClaims[] = 'ai_strategy';
+            $blockedClaims[] = 'transition_recommendation';
+            $blockedClaims[] = 'cross_market_pay_copy';
+        }
+
+        if (! $this->hasSourceTraceEvidence($context)) {
+            $redFlags[] = ClaimReasonCode::MISSING_SOURCE_TRACE_EVIDENCE;
+            $blockedClaims[] = 'strong_claim';
+            $blockedClaims[] = 'salary_comparison';
+            $blockedClaims[] = 'ai_strategy';
+            $blockedClaims[] = 'transition_recommendation';
+            $blockedClaims[] = 'cross_market_pay_copy';
+        }
+
+        $crosswalkConfidence = $context['crosswalk_confidence'] ?? null;
+        if (is_numeric($crosswalkConfidence) && (float) $crosswalkConfidence < 0.7) {
+            $amberFlags[] = ClaimReasonCode::LOW_CROSSWALK_CONFIDENCE;
+            $blockedClaims[] = 'strong_claim';
+            $blockedClaims[] = 'transition_recommendation';
+        }
+
         if (($context['median_pay_usd_annual'] ?? null) === null) {
             $redFlags[] = ClaimReasonCode::MISSING_MEDIAN_PAY;
             $blockedClaims[] = 'salary_comparison';
@@ -92,5 +117,39 @@ final class WarningMatrix
             'amber_flags' => array_values(array_unique($amberFlags)),
             'blocked_claims' => array_values(array_unique($blockedClaims)),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function hasSourceTraceEvidence(array $context): bool
+    {
+        if (! array_key_exists('source_trace_evidence', $context)
+            && ! array_key_exists('source_fields_used_count', $context)
+        ) {
+            return true;
+        }
+
+        $sourceTraceEvidence = $context['source_trace_evidence'] ?? null;
+        $sourceFieldsUsedCount = $context['source_fields_used_count'] ?? null;
+
+        return is_numeric($sourceTraceEvidence)
+            && (float) $sourceTraceEvidence >= 0.65
+            && is_numeric($sourceFieldsUsedCount)
+            && (int) $sourceFieldsUsedCount > 0;
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function hasTrustManifest(array $context): bool
+    {
+        if (! array_key_exists('trust_manifest', $context)
+            && ! array_key_exists('truth_manifest', $context)
+        ) {
+            return true;
+        }
+
+        return ($context['trust_manifest'] ?? $context['truth_manifest'] ?? false) === true;
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -322,7 +322,7 @@ final class CareerJobDisplaySurfaceBuilder
         $allowSalaryComparison = $salaryBasis === 'official';
         $allowMarketSignal = in_array($marketBasis, ['official', 'sample'], true);
         $allowLocalProxyWage = false;
-        $allowStrongClaim = in_array($crosswalkBasis, ['direct', 'trust_inheritance'], true);
+        $allowStrongClaim = $crosswalkBasis === 'direct';
 
         $blockedClaims = [];
         $warnings = [];
@@ -456,14 +456,6 @@ final class CareerJobDisplaySurfaceBuilder
         $occupation->loadMissing('crosswalks');
 
         $mode = strtolower((string) $occupation->crosswalk_mode);
-        if (in_array($mode, ['exact', 'direct', 'direct_match'], true)) {
-            return 'direct';
-        }
-
-        if ($mode === 'trust_inheritance') {
-            return 'trust_inheritance';
-        }
-
         if (in_array($mode, ['functional_equivalent', 'functional_proxy', 'local_heavy_interpretation', 'family_proxy', 'cn_boundary_only'], true)) {
             return 'proxy';
         }
@@ -479,11 +471,20 @@ final class CareerJobDisplaySurfaceBuilder
             $system = strtolower((string) $crosswalk->source_system);
             $mappingType = strtolower((string) $crosswalk->mapping_type);
             $isDirect = in_array($mappingType, ['exact', 'direct', 'direct_match'], true);
-            $hasUsSoc = $hasUsSoc || ($system === 'us_soc' && $isDirect);
-            $hasOnet = $hasOnet || ($system === 'onet_soc_2019' && $isDirect);
+            $hasTrustedConfidence = $crosswalk->confidence_score !== null && (float) $crosswalk->confidence_score >= 0.8;
+            $hasUsSoc = $hasUsSoc || ($system === 'us_soc' && $isDirect && $hasTrustedConfidence);
+            $hasOnet = $hasOnet || ($system === 'onet_soc_2019' && $isDirect && $hasTrustedConfidence);
         }
 
-        return $hasUsSoc && $hasOnet ? 'direct' : 'missing';
+        if ($hasUsSoc && $hasOnet && in_array($mode, ['exact', 'direct', 'direct_match'], true)) {
+            return 'direct';
+        }
+
+        if ($mode === 'trust_inheritance') {
+            return 'trust_inheritance';
+        }
+
+        return 'missing';
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1573,6 +1573,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_policy_claim_guard_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Scoring/ClaimPermissionsCompiler.php',
+            'backend/app/Domain/Career/Scoring/ClaimReasonCode.php',
+            'backend/app/Domain/Career/Scoring/WarningMatrix.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_runtime_projection_consumer_changes(): void
     {
         $changed = [
@@ -2135,6 +2146,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isCareerDisplaySurfaceFile($file)) {
+                continue;
+            }
+
+            if ($this->isCareerPolicyClaimGuardFile($file)) {
                 continue;
             }
 
@@ -3196,6 +3211,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php',
             'backend/app/Http/Resources/Career/CareerJobDetailResource.php',
             'backend/app/Services/Cms/CareerJobSeoService.php',
+        ], true);
+    }
+
+    private function isCareerPolicyClaimGuardFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Scoring/ClaimPermissionsCompiler.php',
+            'backend/app/Domain/Career/Scoring/ClaimReasonCode.php',
+            'backend/app/Domain/Career/Scoring/WarningMatrix.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
@@ -457,6 +457,36 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         $this->assertContains('strong_claim_crosswalk_not_direct', $surface['claim_permissions']['blocked_claims']);
     }
 
+    public function test_it_blocks_strong_claims_for_trust_inheritance_crosswalks(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $occupation->update(['crosswalk_mode' => 'trust_inheritance']);
+        $this->createDisplayAsset($occupation);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertSame('provisional', $surface['claim_permissions']['integrity_state']);
+        $this->assertFalse($surface['claim_permissions']['allow_strong_claim']);
+        $this->assertSame('trust_inheritance', $surface['claim_permissions']['evidence_basis']['crosswalk']);
+        $this->assertContains('strong_claim_crosswalk_not_direct', $surface['claim_permissions']['blocked_claims']);
+    }
+
+    public function test_it_blocks_strong_claims_when_direct_mode_lacks_trusted_dual_crosswalks(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $occupation->crosswalks()
+            ->where('source_system', 'onet_soc_2019')
+            ->update(['confidence_score' => 0.5]);
+        $this->createDisplayAsset($occupation->refresh());
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertSame('provisional', $surface['claim_permissions']['integrity_state']);
+        $this->assertFalse($surface['claim_permissions']['allow_strong_claim']);
+        $this->assertSame('missing', $surface['claim_permissions']['evidence_basis']['crosswalk']);
+        $this->assertContains('strong_claim_crosswalk_not_direct', $surface['claim_permissions']['blocked_claims']);
+    }
+
     public function test_it_includes_sources_and_implementation_contract(): void
     {
         $occupation = $this->createOccupation('actors');

--- a/backend/tests/Unit/Services/Career/ClaimPermissionsCompilerTest.php
+++ b/backend/tests/Unit/Services/Career/ClaimPermissionsCompilerTest.php
@@ -65,4 +65,53 @@ final class ClaimPermissionsCompilerTest extends CareerScoringTestCase
         $this->assertTrue($permissions['allow_ai_strategy']);
         $this->assertContains('index_state_restricted', $permissions['reason_codes']);
     }
+
+    public function test_it_blocks_guidance_claims_without_trusted_source_evidence(): void
+    {
+        $permissions = (new ClaimPermissionsCompiler)->compile(
+            [
+                'fit_score' => new CareerScoreResult(81, IntegrityState::FULL, [], 90, 'fit', [], [], 1.0),
+                'strain_score' => new CareerScoreResult(36, IntegrityState::FULL, [], 90, 'strain', [], [], 1.0),
+                'ai_survival_score' => new CareerScoreResult(64, IntegrityState::FULL, [], 88, 'ai', [], [], 1.0),
+                'mobility_score' => new CareerScoreResult(69, IntegrityState::FULL, [], 88, 'mobility', [], [], 1.0),
+                'confidence_score' => new CareerScoreResult(79, IntegrityState::FULL, [], 88, 'confidence', [], [], 1.0),
+            ],
+            [
+                'red_flags' => ['missing_source_trace_evidence'],
+                'amber_flags' => [],
+                'blocked_claims' => ['salary_comparison', 'ai_strategy', 'transition_recommendation'],
+            ],
+            $this->sampleContext([
+                'source_trace_evidence' => null,
+                'source_fields_used_count' => 0,
+            ]),
+        );
+
+        $this->assertFalse($permissions['allow_salary_comparison']);
+        $this->assertFalse($permissions['allow_ai_strategy']);
+        $this->assertFalse($permissions['allow_transition_recommendation']);
+        $this->assertContains('missing_source_trace_evidence', $permissions['reason_codes']);
+    }
+
+    public function test_it_blocks_restricted_ai_and_transition_guidance_even_when_scores_are_numeric(): void
+    {
+        $permissions = (new ClaimPermissionsCompiler)->compile(
+            [
+                'fit_score' => new CareerScoreResult(81, IntegrityState::FULL, [], 90, 'fit', [], [], 1.0),
+                'strain_score' => new CareerScoreResult(36, IntegrityState::FULL, [], 90, 'strain', [], [], 1.0),
+                'ai_survival_score' => new CareerScoreResult(64, IntegrityState::RESTRICTED, [], 68, 'ai', [], [], 0.7),
+                'mobility_score' => new CareerScoreResult(69, IntegrityState::RESTRICTED, [], 68, 'mobility', [], [], 0.7),
+                'confidence_score' => new CareerScoreResult(79, IntegrityState::FULL, [], 88, 'confidence', [], [], 1.0),
+            ],
+            [
+                'red_flags' => [],
+                'amber_flags' => ['ai_survival_score.restricted', 'mobility_score.restricted'],
+                'blocked_claims' => [],
+            ],
+            $this->sampleContext(),
+        );
+
+        $this->assertFalse($permissions['allow_ai_strategy']);
+        $this->assertFalse($permissions['allow_transition_recommendation']);
+    }
 }

--- a/backend/tests/Unit/Services/Career/WarningMatrixTest.php
+++ b/backend/tests/Unit/Services/Career/WarningMatrixTest.php
@@ -59,4 +59,50 @@ final class WarningMatrixTest extends CareerScoringTestCase
         $this->assertContains('ai_strategy', $warnings['blocked_claims']);
         $this->assertContains('transition_recommendation', $warnings['blocked_claims']);
     }
+
+    public function test_it_blocks_claims_when_trust_or_source_evidence_is_missing(): void
+    {
+        $warnings = app(WarningMatrix::class)->build(
+            $this->sampleContext([
+                'trust_manifest' => false,
+                'truth_manifest' => false,
+                'source_trace_evidence' => null,
+                'source_fields_used_count' => 0,
+            ]),
+            [
+                'fit_score' => new CareerScoreResult(80, IntegrityState::FULL, [], 88, 'fit', [], [], 1.0),
+                'strain_score' => new CareerScoreResult(32, IntegrityState::FULL, [], 88, 'strain', [], [], 1.0),
+                'ai_survival_score' => new CareerScoreResult(61, IntegrityState::FULL, [], 88, 'ai', [], [], 1.0),
+                'mobility_score' => new CareerScoreResult(66, IntegrityState::FULL, [], 88, 'mobility', [], [], 1.0),
+                'confidence_score' => new CareerScoreResult(77, IntegrityState::FULL, [], 88, 'confidence', [], [], 1.0),
+            ]
+        );
+
+        $this->assertContains('missing_trust_manifest', $warnings['red_flags']);
+        $this->assertContains('missing_source_trace_evidence', $warnings['red_flags']);
+        $this->assertContains('strong_claim', $warnings['blocked_claims']);
+        $this->assertContains('salary_comparison', $warnings['blocked_claims']);
+        $this->assertContains('ai_strategy', $warnings['blocked_claims']);
+        $this->assertContains('transition_recommendation', $warnings['blocked_claims']);
+    }
+
+    public function test_it_blocks_strong_and_transition_claims_when_crosswalk_confidence_is_low(): void
+    {
+        $warnings = app(WarningMatrix::class)->build(
+            $this->sampleContext([
+                'crosswalk_confidence' => 0.42,
+            ]),
+            [
+                'fit_score' => new CareerScoreResult(80, IntegrityState::FULL, [], 88, 'fit', [], [], 1.0),
+                'strain_score' => new CareerScoreResult(32, IntegrityState::FULL, [], 88, 'strain', [], [], 1.0),
+                'ai_survival_score' => new CareerScoreResult(61, IntegrityState::FULL, [], 88, 'ai', [], [], 1.0),
+                'mobility_score' => new CareerScoreResult(66, IntegrityState::FULL, [], 88, 'mobility', [], [], 1.0),
+                'confidence_score' => new CareerScoreResult(77, IntegrityState::FULL, [], 88, 'confidence', [], [], 1.0),
+            ]
+        );
+
+        $this->assertContains('low_crosswalk_confidence', $warnings['amber_flags']);
+        $this->assertContains('strong_claim', $warnings['blocked_claims']);
+        $this->assertContains('transition_recommendation', $warnings['blocked_claims']);
+    }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T05:57:54+08:00",
+  "updated_at": "2026-05-24T06:04:26+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -21548,11 +21548,11 @@
       ]
     },
     "CAREER-POLICY-CLAIM-GUARDS-01": {
-      "status": "github_checks_failed_scoped_fix_local_passed",
+      "status": "github_checks_passed_ready_to_merge",
       "checks": {
         "github_required_checks": {
-          "status": "failed_scoped_fix_local_passed_pending_rerun",
-          "evidence": "PR #1634 verify-mbti-legacy and verify-mbti-v2 failed because BigFive runtime freeze classifier treated Career scoring claim guard files as MBTI-impacting runtime changes.",
+          "status": "pass",
+          "evidence": "PR #1634 checks passed after scoped BigFive runtime freeze classifier fix: hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2.",
           "failed_checks": [
             "verify-mbti-legacy",
             "verify-mbti-v2"
@@ -21571,6 +21571,11 @@
           "at": "2026-05-24T05:57:54+08:00",
           "status": "github_checks_failed_scoped_fix_local_passed",
           "summary": "GitHub verify-mbti checks failed on the BigFive runtime freeze classifier. Added a scoped tests-only classifier exemption for Career policy claim guard files; focused BigFive test, scoped Career tests, Pint, and diff check passed locally."
+        },
+        {
+          "at": "2026-05-24T06:04:26+08:00",
+          "status": "github_checks_passed_ready_to_merge",
+          "summary": "PR #1634 required GitHub checks passed after the scoped classifier fix."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16246,7 +16246,7 @@
     "BIGFIVE-RUNTIME-GUARDS-01": {
       "repo": "fap-api",
       "branch": "codex/bigfive-runtime-guards-01",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "RIASEC-CONTRACT-QUALITY-01"
       ],
@@ -16255,7 +16255,7 @@
         35,
         36
       ],
-      "commit_sha": "3edb152d1d3b",
+      "commit_sha": "bd4816a8253c1307f3cca47e1479e98959aec3a6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1633",
       "checks": {
         "dependency": {
@@ -16284,13 +16284,17 @@
         "diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github": {
+          "status": "pass",
+          "evidence": "GitHub PR #1633 is MERGED and origin/main contains merge commit bd4816a8253c1307f3cca47e1479e98959aec3a6; remote task branch is absent."
         }
       },
       "sidecar_issues": [],
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T21:07:40Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "events": [
         {
           "at": "2026-05-24T04:46:00+08:00",
@@ -16306,13 +16310,18 @@
           "at": "2026-05-24T05:14:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1633 after scoped local validation passed."
+        },
+        {
+          "at": "2026-05-24T05:45:16+08:00",
+          "status": "merged",
+          "summary": "Reconciled PR #1633 as merged; remote branch absent and local task branch already cleaned."
         }
       ]
     },
     "CAREER-POLICY-CLAIM-GUARDS-01": {
       "repo": "fap-api",
       "branch": "codex/career-policy-claim-guards-01",
-      "status": "pending",
+      "status": "local_validation_passed_with_external_sidecar",
       "depends_on": [
         "BIGFIVE-RUNTIME-GUARDS-01"
       ],
@@ -16328,12 +16337,57 @@
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
-      "sidecar_issues": [],
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "BIGFIVE-RUNTIME-GUARDS-01 is merged into main as bd4816a8253c1307f3cca47e1479e98959aec3a6."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Career scoring guards, Career display-surface claim basis, related unit tests, and PR train state metadata."
+        },
+        "focused_career_policy_claim_guards": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Services/Career/ClaimPermissionsCompilerTest.php tests/Unit/Services/Career/WarningMatrixTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi",
+          "evidence": "52 tests passed, 1109 assertions."
+        },
+        "career_filter": {
+          "status": "external_failure_sidecar",
+          "command": "cd backend && php artisan test --filter Career --no-ansi",
+          "evidence": "Current branch: 47 failed, 1289 passed, 52229 assertions. origin/main baseline: 47 failed, 1283 passed, 52206 assertions. Failure family is pre-existing Career runtime projection/test-suite blockage, not introduced by this PR."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career app/Services/Cms/EditorialPackage app/Domain/Career tests",
+          "evidence": "1740 files passed Pint."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [
+        {
+          "id": "CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01",
+          "severity": "external_blocker",
+          "status": "open",
+          "evidence": "Both origin/main and codex/career-policy-claim-guards-01 fail cd backend && php artisan test --filter Career --no-ansi with 47 failures in Career runtime projection, family hub/search/readiness, and display asset public route expectations.",
+          "external_to_current_pr": true,
+          "current_pr_introduced": false,
+          "train_continuation_allowed": true
+        }
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-05-24T05:45:16+08:00",
+          "status": "local_validation_passed_with_external_sidecar",
+          "summary": "Scoped Career policy/claim guard tests, Pint, and diff check passed. Full Career filter remains red with the same 47-failure baseline on origin/main, recorded as external sidecar CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01."
+        }
+      ]
     },
     "CAREER-READINESS-AUDITORS-01": {
       "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16321,7 +16321,7 @@
     "CAREER-POLICY-CLAIM-GUARDS-01": {
       "repo": "fap-api",
       "branch": "codex/career-policy-claim-guards-01",
-      "status": "local_validation_passed_with_external_sidecar",
+      "status": "pr_open",
       "depends_on": [
         "BIGFIVE-RUNTIME-GUARDS-01"
       ],
@@ -16335,8 +16335,8 @@
         43,
         58
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "2b67c2fa",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1634",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -16386,6 +16386,11 @@
           "at": "2026-05-24T05:45:16+08:00",
           "status": "local_validation_passed_with_external_sidecar",
           "summary": "Scoped Career policy/claim guard tests, Pint, and diff check passed. Full Career filter remains red with the same 47-failure baseline on origin/main, recorded as external sidecar CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01."
+        },
+        {
+          "at": "2026-05-24T05:50:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1634 after scoped validation passed and external Career full-filter baseline sidecar was recorded."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T05:14:00+08:00",
+  "updated_at": "2026-05-24T05:57:54+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -21544,6 +21544,33 @@
           "at": "2026-05-24T03:15:15+08:00",
           "status": "ci_fix_pushed_pending_checks",
           "summary": "Fixed verify-mbti failure with narrow DB migration portability allowlist; local targeted tests and pint pass."
+        }
+      ]
+    },
+    "CAREER-POLICY-CLAIM-GUARDS-01": {
+      "status": "github_checks_failed_scoped_fix_local_passed",
+      "checks": {
+        "github_required_checks": {
+          "status": "failed_scoped_fix_local_passed_pending_rerun",
+          "evidence": "PR #1634 verify-mbti-legacy and verify-mbti-v2 failed because BigFive runtime freeze classifier treated Career scoring claim guard files as MBTI-impacting runtime changes.",
+          "failed_checks": [
+            "verify-mbti-legacy",
+            "verify-mbti-v2"
+          ],
+          "scoped_fix": "Added BigFive runtime freeze classifier coverage for Career policy claim guard files under backend/tests/**.",
+          "local_validation": [
+            "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter \"runtime_freeze_classifier_ignores_career_policy_claim_guard_changes|runtime_paths_have_no_uncommitted_diff\" --no-ansi",
+            "cd backend && php artisan test tests/Unit/Services/Career/ClaimPermissionsCompilerTest.php tests/Unit/Services/Career/WarningMatrixTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi",
+            "cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career app/Services/Cms/EditorialPackage app/Domain/Career tests",
+            "git diff --check"
+          ]
+        }
+      },
+      "events": [
+        {
+          "at": "2026-05-24T05:57:54+08:00",
+          "status": "github_checks_failed_scoped_fix_local_passed",
+          "summary": "GitHub verify-mbti checks failed on the BigFive runtime freeze classifier. Added a scoped tests-only classifier exemption for Career policy claim guard files; focused BigFive test, scoped Career tests, Pint, and diff check passed locally."
         }
       ]
     }


### PR DESCRIPTION
## What changed
- Added explicit Career claim reason codes for missing trust manifest, missing source trace evidence, and low crosswalk confidence.
- Tightened Career claim permission compilation so salary, AI strategy, transition guidance, and strong claims require appropriate trusted evidence/state.
- Hardened display-surface claim basis so trust inheritance and insufficient direct crosswalk evidence do not emit strong claim permission.
- Reconciled PR-train state for the merged Big Five predecessor and recorded the current Career full-filter baseline failure as an external sidecar.

## Why
Codex security findings 8, 9, 13, 33, 41, 42, 43, and 58 require fail-closed handling around Career policy claims, trust/source evidence, and direct-vs-inherited crosswalk basis.

## Validation
- `cd backend && php artisan test tests/Unit/Services/Career/ClaimPermissionsCompilerTest.php tests/Unit/Services/Career/WarningMatrixTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi` -> 52 passed, 1109 assertions
- `cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career app/Services/Cms/EditorialPackage app/Domain/Career tests` -> 1740 files passed
- `git diff --check`
- `git diff --cached --check`

## Sidecar / Deferred
- `cd backend && php artisan test --filter Career --no-ansi` remains red with a pre-existing baseline failure: current branch 47 failed / 1289 passed, `origin/main` 47 failed / 1283 passed. Recorded as `CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01`; not introduced by this PR.
