### PR TITLE
fix(career): make readiness auditors fail closed

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerBatchLiveAcceptanceV2Auditor.php
+++ b/backend/app/Domain/Career/Audit/CareerBatchLiveAcceptanceV2Auditor.php
@@ -63,9 +63,9 @@ final class CareerBatchLiveAcceptanceV2Auditor
                     $surfaceStatus = CareerCanonicalEligibilityStatus::UNVERIFIED;
                     $rowIssues[] = $this->issue(CareerBatchLiveAcceptanceV2Issue::SURFACE_UNVERIFIED, $slug, $locale, [['surface' => 'live_html']]);
                 } elseif ($surfaceRow !== null && (
-                    ($surfaceRow['surface_match'] ?? true) !== true
-                    || ($surfaceRow['canonical_self'] ?? true) !== true
-                    || ($surfaceRow['robots_indexable'] ?? true) !== true
+                    ($surfaceRow['surface_match'] ?? null) !== true
+                    || ($surfaceRow['canonical_self'] ?? null) !== true
+                    || ($surfaceRow['robots_indexable'] ?? null) !== true
                 )) {
                     $surfaceStatus = CareerCanonicalEligibilityStatus::BLOCKED;
                     $rowIssues[] = $this->issue(CareerBatchLiveAcceptanceV2Issue::SURFACE_MISMATCH, $slug, $locale, [$surfaceRow]);

--- a/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityCheckProtocol.php
+++ b/backend/app/Domain/Career/Audit/CareerCanonicalEligibilityCheckProtocol.php
@@ -47,9 +47,7 @@ final class CareerCanonicalEligibilityCheckProtocol
 
     public static function isImmediateStop(string $state): bool
     {
-        self::assertValidState($state);
-
-        return false;
+        return self::assertValidState($state) === self::STATE_FAILED;
     }
 
     public static function trainContinueForState(string $state): string

--- a/backend/app/Domain/Career/Audit/CareerSurfaceReadinessAuditor.php
+++ b/backend/app/Domain/Career/Audit/CareerSurfaceReadinessAuditor.php
@@ -196,9 +196,20 @@ final class CareerSurfaceReadinessAuditor
      */
     private function surfaceLayerStatus(array $issues, array $evidence, bool $unverified): CareerCanonicalEligibilityLayerStatus
     {
+        $hardIssues = array_filter(
+            $issues,
+            static fn (CareerSurfaceReadinessIssue $issue): bool => ! in_array($issue->reason, [
+                CareerSurfaceReadinessIssue::SURFACE_VERIFIER_MISSING,
+                CareerSurfaceReadinessIssue::VALIDATOR_CONTEXT_MISSING,
+            ], true)
+        );
+        $unverifiedOnly = $unverified && $issues !== [] && $hardIssues === [];
+
         return new CareerCanonicalEligibilityLayerStatus(
             layer: CareerCanonicalEligibilityLayer::SURFACE,
-            status: $issues === [] ? CareerCanonicalEligibilityStatus::PASS : ($unverified ? CareerCanonicalEligibilityStatus::UNVERIFIED : CareerCanonicalEligibilityStatus::BLOCKED),
+            status: $issues === []
+                ? CareerCanonicalEligibilityStatus::PASS
+                : ($unverifiedOnly ? CareerCanonicalEligibilityStatus::UNVERIFIED : CareerCanonicalEligibilityStatus::BLOCKED),
             reasons: array_values(array_unique(array_map(
                 static fn (CareerSurfaceReadinessIssue $issue): string => $issue->reason,
                 $issues

--- a/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerService.php
+++ b/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerService.php
@@ -194,23 +194,22 @@ final class CareerFullReleaseLedgerService
             );
         }
 
+        $additionalTrackedSlugs = [];
         if ($trustedRolloutAuthority && $additionalSlugs !== []) {
-            $additionalIndexStates = $this->loadIndexStateBySlug($additionalSlugs);
+            $additionalTrackedSlugs = array_values(array_diff(array_keys($explicitBatchSlugs), array_keys($trackedMembers)));
+            $additionalIndexStates = $this->loadIndexStateBySlug($additionalTrackedSlugs);
 
-            foreach ($additionalSlugs as $slug) {
-                if (isset($trackedMembers[$slug])) {
-                    continue;
-                }
-
+            foreach ($additionalTrackedSlugs as $slug) {
                 $indexRow = $additionalIndexStates[$slug] ?? null;
                 $hasIndexState = $indexRow !== null;
-                $indexEligible = $hasIndexState ? (bool) ($indexRow['index_eligible'] ?? false) : true;
+                $indexEligible = $hasIndexState ? (bool) ($indexRow['index_eligible'] ?? false) : false;
                 $publicIndexState = $hasIndexState
                     ? $this->normalizePublicIndexState((string) ($indexRow['public_index_state'] ?? ''), $indexEligible)
-                    : IndexStateValue::INDEXABLE;
+                    : IndexStateValue::NOINDEX;
                 $releaseCohort = in_array($publicIndexState, [IndexStateValue::INDEXABLE, 'indexable'], true)
                     ? 'public_detail_indexable'
                     : 'public_detail_conservative';
+                $blockerReasons = $hasIndexState ? [] : ['explicit_batch_index_state_missing'];
 
                 $releaseCounts[$releaseCohort]++;
 
@@ -224,9 +223,10 @@ final class CareerFullReleaseLedgerService
                     publicIndexState: $publicIndexState,
                     indexEligible: $indexEligible,
                     releaseCohort: $releaseCohort,
-                    blockerReasons: [],
+                    blockerReasons: $blockerReasons,
                     evidenceRefs: [
                         'tracking_source' => ['kind' => 'canonical_rollout_batch_executor', 'scope' => self::SCOPE],
+                        'index_state' => ['present' => $hasIndexState],
                     ],
                 );
             }
@@ -238,7 +238,7 @@ final class CareerFullReleaseLedgerService
         ));
 
         $expectedTotal = (int) data_get($batchMembers, 'coverage.expected_total_occupations', 0);
-        $trackedTotal = count($trackedMembers) + count($additionalSlugs);
+        $trackedTotal = count($trackedMembers) + count($additionalTrackedSlugs);
         $missing = $expectedTotal > 0 ? max(0, $expectedTotal - $trackedTotal) : 0;
 
         return new CareerFullReleaseLedger(

--- a/backend/tests/Unit/Domain/Career/Audit/CareerCanonicalEligibilityAuditSchemaTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerCanonicalEligibilityAuditSchemaTest.php
@@ -240,13 +240,13 @@ JSON,
         );
     }
 
-    public function test_failed_check_state_requires_inspect_fix_loop_not_immediate_stop(): void
+    public function test_failed_check_state_requires_inspect_fix_loop_and_immediate_stop(): void
     {
         $this->assertSame(
             CareerCanonicalEligibilityCheckProtocol::ACTION_INSPECT_FAILURE,
             CareerCanonicalEligibilityCheckProtocol::actionForState(CareerCanonicalEligibilityCheckProtocol::STATE_FAILED)
         );
-        $this->assertFalse(CareerCanonicalEligibilityCheckProtocol::isImmediateStop(CareerCanonicalEligibilityCheckProtocol::STATE_FAILED));
+        $this->assertTrue(CareerCanonicalEligibilityCheckProtocol::isImmediateStop(CareerCanonicalEligibilityCheckProtocol::STATE_FAILED));
     }
 
     public function test_current_pr_introduced_failure_requires_may_continue_train_false(): void

--- a/backend/tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
@@ -141,6 +141,45 @@ final class CareerFullReleaseLedgerServiceTest extends TestCase
         $this->assertArrayNotHasKey('explicit_rollout_batch', (array) ($member['evidence_refs'] ?? []));
     }
 
+    public function test_trusted_rollout_batch_does_not_double_count_existing_tracked_slugs(): void
+    {
+        $service = app(CareerFullReleaseLedgerService::class);
+        $baseLedger = $service->build()->toArray();
+        $baseMember = collect((array) ($baseLedger['members'] ?? []))->first();
+
+        $this->assertIsArray($baseMember);
+        $slug = (string) $baseMember['canonical_slug'];
+
+        $ledger = $service->build([$slug, $slug], trustedRolloutAuthority: true)->toArray();
+
+        $this->assertSame(
+            (int) data_get($baseLedger, 'counts.tracking_counts.tracked_total_occupations'),
+            (int) data_get($ledger, 'counts.tracking_counts.tracked_total_occupations')
+        );
+        $this->assertCount(1, array_values(array_filter(
+            (array) ($ledger['members'] ?? []),
+            static fn (array $member): bool => ($member['canonical_slug'] ?? null) === $slug,
+        )));
+    }
+
+    public function test_trusted_rollout_batch_additional_slug_without_index_state_fails_closed(): void
+    {
+        $ledger = app(CareerFullReleaseLedgerService::class)
+            ->build(['codex-untracked-career'], trustedRolloutAuthority: true)
+            ->toArray();
+
+        $member = collect((array) ($ledger['members'] ?? []))->firstWhere('canonical_slug', 'codex-untracked-career');
+
+        $this->assertIsArray($member);
+        $this->assertSame('career_rollout_batch_additional', $member['member_kind'] ?? null);
+        $this->assertSame('noindex', $member['current_index_state'] ?? null);
+        $this->assertSame('noindex', $member['public_index_state'] ?? null);
+        $this->assertFalse((bool) ($member['index_eligible'] ?? true));
+        $this->assertSame('public_detail_conservative', $member['release_cohort'] ?? null);
+        $this->assertContains('explicit_batch_index_state_missing', $member['blocker_reasons'] ?? []);
+        $this->assertFalse((bool) data_get($member, 'evidence_refs.index_state.present', true));
+    }
+
     public function test_explicit_rollout_batch_candidate_state_projects_as_conservative_candidate_for_tracked_members(): void
     {
         $service = app(CareerFullReleaseLedgerService::class);

--- a/backend/tests/Unit/Services/Career/CareerReadinessAuditorsFailClosedTest.php
+++ b/backend/tests/Unit/Services/Career/CareerReadinessAuditorsFailClosedTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Audit\CareerBatchLiveAcceptanceV2Auditor;
+use App\Domain\Career\Audit\CareerBatchLiveAcceptanceV2Issue;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityCheckProtocol;
+use App\Domain\Career\Audit\CareerCanonicalEligibilityStatus;
+use App\Domain\Career\Audit\CareerSurfaceReadinessAuditor;
+use App\Domain\Career\Audit\CareerSurfaceReadinessIssue;
+use Tests\TestCase;
+
+final class CareerReadinessAuditorsFailClosedTest extends TestCase
+{
+    public function test_failed_check_state_is_an_immediate_stop(): void
+    {
+        $this->assertFalse(CareerCanonicalEligibilityCheckProtocol::isImmediateStop(CareerCanonicalEligibilityCheckProtocol::STATE_PENDING));
+        $this->assertFalse(CareerCanonicalEligibilityCheckProtocol::isImmediateStop(CareerCanonicalEligibilityCheckProtocol::STATE_GREEN));
+        $this->assertTrue(CareerCanonicalEligibilityCheckProtocol::isImmediateStop(CareerCanonicalEligibilityCheckProtocol::STATE_FAILED));
+    }
+
+    public function test_surface_readiness_keeps_api_hard_failures_blocked_when_live_html_is_unverified(): void
+    {
+        $result = (new CareerSurfaceReadinessAuditor)->auditSlugs(
+            slugs: ['software-developers'],
+            locales: ['en'],
+            apiArtifact: [[
+                'canonical_slug' => 'software-developers',
+                'locale' => 'en',
+                'api_canonical_path' => '/en/career/jobs/wrong',
+                'api_indexable' => true,
+            ]],
+            includeLiveHtml: true,
+            baseUrl: null,
+        )->toArray();
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result['status']);
+        $this->assertSame(1, $result['blocked_rows']);
+        $this->assertSame(0, $result['unverified_rows']);
+        $this->assertContains(CareerSurfaceReadinessIssue::API_CANONICAL_NOT_SELF, array_keys($result['by_reason']));
+        $this->assertContains(CareerSurfaceReadinessIssue::VALIDATOR_CONTEXT_MISSING, array_keys($result['by_reason']));
+    }
+
+    public function test_surface_readiness_stays_unverified_when_only_live_html_context_is_missing(): void
+    {
+        $result = (new CareerSurfaceReadinessAuditor)->auditSlugs(
+            slugs: ['software-developers'],
+            locales: ['en'],
+            apiArtifact: [[
+                'canonical_slug' => 'software-developers',
+                'locale' => 'en',
+                'api_canonical_path' => '/en/career/jobs/software-developers',
+                'api_indexable' => true,
+            ]],
+            includeLiveHtml: true,
+            baseUrl: null,
+        )->toArray();
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::UNVERIFIED, $result['status']);
+        $this->assertSame(0, $result['blocked_rows']);
+        $this->assertSame(1, $result['unverified_rows']);
+        $this->assertSame([CareerSurfaceReadinessIssue::VALIDATOR_CONTEXT_MISSING => 1], $result['by_reason']);
+    }
+
+    public function test_batch_live_acceptance_requires_explicit_surface_truth_fields(): void
+    {
+        $result = (new CareerBatchLiveAcceptanceV2Auditor)->audit(
+            batchId: 'batch-001',
+            slugs: ['software-developers'],
+            locales: ['en'],
+            projection: ['items' => [[
+                'canonical_slug' => 'software-developers',
+                'locale' => 'en',
+                'release_gate_pass' => true,
+            ]]],
+            truth: ['items' => [[
+                'canonical_slug' => 'software-developers',
+                'locale' => 'en',
+                'release_gate_pass' => true,
+            ]]],
+            surfaces: ['items' => [[
+                'canonical_slug' => 'software-developers',
+                'locale' => 'en',
+                'surface_match' => true,
+                'canonical_self' => true,
+            ]]],
+        )->toArray();
+
+        $this->assertSame(CareerCanonicalEligibilityStatus::BLOCKED, $result['status']);
+        $this->assertFalse($result['accepted']);
+        $this->assertSame([CareerBatchLiveAcceptanceV2Issue::SURFACE_MISMATCH => 1], $result['by_reason']);
+        $this->assertSame('fail', $result['surfaces']['surface_equality']);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T06:04:26+08:00",
+  "updated_at": "2026-05-24T06:21:29+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -16321,7 +16321,7 @@
     "CAREER-POLICY-CLAIM-GUARDS-01": {
       "repo": "fap-api",
       "branch": "codex/career-policy-claim-guards-01",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "BIGFIVE-RUNTIME-GUARDS-01"
       ],
@@ -16335,7 +16335,7 @@
         43,
         58
       ],
-      "commit_sha": "2b67c2fa",
+      "commit_sha": "f80d91e2cdaa03f2c11551a5958157438b4f65c1",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1634",
       "checks": {
         "dependency": {
@@ -16364,6 +16364,10 @@
         "diff_check": {
           "status": "pass",
           "command": "git diff --check"
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1634 merged as f80d91e2cdaa03f2c11551a5958157438b4f65c1 after required checks passed. Remote branch deleted; local branch absent after merge checkout."
         }
       },
       "sidecar_issues": [
@@ -16378,9 +16382,9 @@
         }
       ],
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-23T22:10:30Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "events": [
         {
           "at": "2026-05-24T05:45:16+08:00",
@@ -16391,13 +16395,18 @@
           "at": "2026-05-24T05:50:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1634 after scoped validation passed and external Career full-filter baseline sidecar was recorded."
+        },
+        {
+          "at": "2026-05-24T06:21:29+08:00",
+          "status": "merged_reconciled",
+          "summary": "Reconciled PR #1634 merge into origin/main at f80d91e2cdaa03f2c11551a5958157438b4f65c1 and removed accidental duplicate prs ledger entry."
         }
       ]
     },
     "CAREER-READINESS-AUDITORS-01": {
       "repo": "fap-api",
       "branch": "codex/career-readiness-auditors-01",
-      "status": "pending",
+      "status": "local_validation_passed_with_external_sidecar",
       "depends_on": [
         "CAREER-POLICY-CLAIM-GUARDS-01"
       ],
@@ -16415,12 +16424,72 @@
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
-      "sidecar_issues": [],
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "CAREER-POLICY-CLAIM-GUARDS-01 is merged into main as f80d91e2cdaa03f2c11551a5958157438b4f65c1."
+        },
+        "focused_tests": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Domain/Career/Audit/CareerCanonicalEligibilityAuditSchemaTest.php tests/Unit/Services/Career/CareerReadinessAuditorsFailClosedTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php --no-ansi",
+          "evidence": "33 passed, 195 assertions."
+        },
+        "career_filter": {
+          "status": "external_failure_sidecar",
+          "command": "cd backend && php artisan test --filter Career --no-ansi",
+          "evidence": "47 failed, 1296 passed, 52257 assertions; matches known origin/main Career runtime projection baseline and is not introduced by this scoped auditor fail-closed PR.",
+          "sidecar_issue": "CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Domain/Career app/Console/Commands/StorageReleaseRootsAudit.php tests",
+          "evidence": "PASS, 1472 files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check",
+          "evidence": "No whitespace errors."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "command": "(git diff --name-only; git ls-files --others --exclude-standard) | sort",
+          "evidence": "Changed files are limited to Career audit/publish code, matching Career tests, and PR-train state metadata."
+        },
+        "cached_diff_check": {
+          "status": "pass",
+          "command": "git diff --cached --check",
+          "evidence": "No staged whitespace errors."
+        }
+      },
+      "sidecar_issues": [
+        "CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01"
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-05-24T06:21:29+08:00",
+          "status": "in_progress",
+          "summary": "Started scoped fail-closed fixes for career readiness auditors from latest main."
+        },
+        {
+          "at": "2026-05-24T06:32:40+08:00",
+          "status": "local_validation_passed_with_external_sidecar",
+          "summary": "Focused auditor tests and Pint passed; full Career filter remains on known 47-failure external baseline sidecar."
+        },
+        {
+          "at": "2026-05-24T06:33:23+08:00",
+          "status": "scope_validation_passed",
+          "summary": "Changed file list stays within CAREER-READINESS-AUDITORS-01 allowed paths."
+        },
+        {
+          "at": "2026-05-24T06:33:48+08:00",
+          "status": "local_checks_recorded",
+          "summary": "Recorded focused tests, external Career baseline sidecar, Pint, scope, and diff checks."
+        }
+      ]
     },
     "CAREER-RELEASE-GATES-01": {
       "repo": "fap-api",
@@ -21544,38 +21613,6 @@
           "at": "2026-05-24T03:15:15+08:00",
           "status": "ci_fix_pushed_pending_checks",
           "summary": "Fixed verify-mbti failure with narrow DB migration portability allowlist; local targeted tests and pint pass."
-        }
-      ]
-    },
-    "CAREER-POLICY-CLAIM-GUARDS-01": {
-      "status": "github_checks_passed_ready_to_merge",
-      "checks": {
-        "github_required_checks": {
-          "status": "pass",
-          "evidence": "PR #1634 checks passed after scoped BigFive runtime freeze classifier fix: hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2.",
-          "failed_checks": [
-            "verify-mbti-legacy",
-            "verify-mbti-v2"
-          ],
-          "scoped_fix": "Added BigFive runtime freeze classifier coverage for Career policy claim guard files under backend/tests/**.",
-          "local_validation": [
-            "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter \"runtime_freeze_classifier_ignores_career_policy_claim_guard_changes|runtime_paths_have_no_uncommitted_diff\" --no-ansi",
-            "cd backend && php artisan test tests/Unit/Services/Career/ClaimPermissionsCompilerTest.php tests/Unit/Services/Career/WarningMatrixTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --no-ansi",
-            "cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career app/Services/Cms/EditorialPackage app/Domain/Career tests",
-            "git diff --check"
-          ]
-        }
-      },
-      "events": [
-        {
-          "at": "2026-05-24T05:57:54+08:00",
-          "status": "github_checks_failed_scoped_fix_local_passed",
-          "summary": "GitHub verify-mbti checks failed on the BigFive runtime freeze classifier. Added a scoped tests-only classifier exemption for Career policy claim guard files; focused BigFive test, scoped Career tests, Pint, and diff check passed locally."
-        },
-        {
-          "at": "2026-05-24T06:04:26+08:00",
-          "status": "github_checks_passed_ready_to_merge",
-          "summary": "PR #1634 required GitHub checks passed after the scoped classifier fix."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16406,7 +16406,7 @@
     "CAREER-READINESS-AUDITORS-01": {
       "repo": "fap-api",
       "branch": "codex/career-readiness-auditors-01",
-      "status": "local_validation_passed_with_external_sidecar",
+      "status": "pr_open_checks_pending",
       "depends_on": [
         "CAREER-POLICY-CLAIM-GUARDS-01"
       ],
@@ -16422,8 +16422,8 @@
         27,
         30
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "6093126accce779846b30e2e2a771960c4bc28af",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1635",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -16459,6 +16459,10 @@
           "status": "pass",
           "command": "git diff --cached --check",
           "evidence": "No staged whitespace errors."
+        },
+        "github": {
+          "status": "pending",
+          "evidence": "PR #1635 opened; GitHub checks pending."
         }
       },
       "sidecar_issues": [
@@ -16488,6 +16492,11 @@
           "at": "2026-05-24T06:33:48+08:00",
           "status": "local_checks_recorded",
           "summary": "Recorded focused tests, external Career baseline sidecar, Pint, scope, and diff checks."
+        },
+        {
+          "at": "2026-05-24T06:35:20+08:00",
+          "status": "pr_open_checks_pending",
+          "summary": "Opened PR #1635 and started GitHub check polling."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Make career canonical eligibility failed checks immediate-stop conditions.
- Fail closed when readiness surface checks report hard API/live issues, while preserving `UNVERIFIED` for live-HTML-only missing context.
- Require explicit live acceptance surface truth fields instead of defaulting missing evidence to passing.
- Prevent trusted rollout ledger inputs from double-counting already tracked slugs and treat missing index-state as blocked/noindex.
- Reconcile the prior Career policy PR ledger entry and record the known external Career runtime projection test-suite sidecar.

## Why
Codex security findings 7, 10, 11, 14, 18, 19, 23, 24, 27, and 30 require readiness auditors and release ledger paths to reject ambiguous or missing evidence instead of allowing optimistic pass-through behavior.

## Validation
- `cd backend && php artisan test tests/Unit/Domain/Career/Audit/CareerCanonicalEligibilityAuditSchemaTest.php tests/Unit/Services/Career/CareerReadinessAuditorsFailClosedTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php --no-ansi` -> 33 passed, 195 assertions
- `cd backend && php artisan test --filter Career --no-ansi` -> external baseline sidecar, 47 failed / 1296 passed / 52257 assertions, matching known `CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01`
- `cd backend && vendor/bin/pint --test app/Domain/Career app/Console/Commands/StorageReleaseRootsAudit.php tests` -> PASS, 1472 files
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- `CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01`: pre-existing Career runtime projection failures observed on `origin/main`; not introduced by this PR.
