### PR TITLE
CAREER-EXPORT-CLI-ROBUSTNESS-01: harden export and dry-run CLI contracts

### DIFF
--- a/backend/app/Console/Commands/CareerAlignActorsAuthorityOccupation.php
+++ b/backend/app/Console/Commands/CareerAlignActorsAuthorityOccupation.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 use App\Models\Occupation;
 use App\Models\OccupationCrosswalk;
 use App\Models\OccupationFamily;
+use App\Services\Career\CareerCliArtifactPathGuard;
 use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
@@ -327,10 +328,7 @@ final class CareerAlignActorsAuthorityOccupation extends Command
     {
         $report['decision'] = $success ? ($report['decision'] === 'fail' ? 'pass' : $report['decision']) : 'fail';
 
-        $outputPath = trim((string) ($this->option('output') ?? ''));
-        if ($outputPath !== '') {
-            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
-        }
+        CareerCliArtifactPathGuard::writeJsonOutput($this->option('output'), $report);
 
         if ((bool) $this->option('json')) {
             $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/backend/app/Console/Commands/CareerAlignCareerAuthorityBatch.php
+++ b/backend/app/Console/Commands/CareerAlignCareerAuthorityBatch.php
@@ -8,6 +8,7 @@ use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationCrosswalk;
 use App\Models\OccupationFamily;
+use App\Services\Career\CareerCliArtifactPathGuard;
 use App\Services\Career\Import\CareerSelectedDisplayAssetMapper;
 use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;
@@ -948,10 +949,7 @@ final class CareerAlignCareerAuthorityBatch extends Command
             $report['writes_database'] = $success && $writeCount > 0;
         }
 
-        $outputPath = trim((string) ($this->option('output') ?? ''));
-        if ($outputPath !== '') {
-            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
-        }
+        CareerCliArtifactPathGuard::writeJsonOutput($this->option('output'), $report);
 
         if ((bool) $this->option('json')) {
             $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/backend/app/Console/Commands/CareerAlignD8AuthorityCrosswalks.php
+++ b/backend/app/Console/Commands/CareerAlignD8AuthorityCrosswalks.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 use App\Models\Occupation;
 use App\Models\OccupationCrosswalk;
 use App\Models\OccupationFamily;
+use App\Services\Career\CareerCliArtifactPathGuard;
 use App\Support\Xlsx\XlsxCellReference;
 use DOMDocument;
 use DOMElement;
@@ -634,10 +635,7 @@ final class CareerAlignD8AuthorityCrosswalks extends Command
             $report['writes_database'] = $success && (($report['created_occupation_count'] ?? 0) + ($report['created_crosswalk_count'] ?? 0)) > 0;
         }
 
-        $outputPath = trim((string) ($this->option('output') ?? ''));
-        if ($outputPath !== '') {
-            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
-        }
+        CareerCliArtifactPathGuard::writeJsonOutput($this->option('output'), $report);
 
         if ((bool) $this->option('json')) {
             $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/backend/app/Console/Commands/CareerAlignSelectedAuthorityCrosswalks.php
+++ b/backend/app/Console/Commands/CareerAlignSelectedAuthorityCrosswalks.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 use App\Models\Occupation;
 use App\Models\OccupationCrosswalk;
 use App\Models\OccupationFamily;
+use App\Services\Career\CareerCliArtifactPathGuard;
 use App\Support\Xlsx\XlsxCellReference;
 use DOMDocument;
 use DOMElement;
@@ -614,10 +615,7 @@ final class CareerAlignSelectedAuthorityCrosswalks extends Command
             $report['writes_database'] = $success && (($report['created_occupation_count'] ?? 0) + ($report['created_crosswalk_count'] ?? 0)) > 0;
         }
 
-        $outputPath = trim((string) ($this->option('output') ?? ''));
-        if ($outputPath !== '') {
-            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
-        }
+        CareerCliArtifactPathGuard::writeJsonOutput($this->option('output'), $report);
 
         if ((bool) $this->option('json')) {
             $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/backend/app/Console/Commands/CareerImportActorsDisplayAsset.php
+++ b/backend/app/Console/Commands/CareerImportActorsDisplayAsset.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
+use App\Services\Career\CareerCliArtifactPathGuard;
 use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
@@ -381,10 +382,7 @@ final class CareerImportActorsDisplayAsset extends Command
     {
         $report['decision'] = $success ? ($report['decision'] === 'fail' ? 'pass' : $report['decision']) : 'fail';
 
-        $outputPath = trim((string) ($this->option('output') ?? ''));
-        if ($outputPath !== '') {
-            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
-        }
+        CareerCliArtifactPathGuard::writeJsonOutput($this->option('output'), $report);
 
         if ((bool) $this->option('json')) {
             $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationCrosswalk;
+use App\Services\Career\CareerCliArtifactPathGuard;
 use App\Services\Career\Import\CareerSelectedDisplayAssetMapper;
 use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;
@@ -714,10 +715,7 @@ final class CareerImportSelectedDisplayAssets extends Command
         }
 
         $outputReport = $this->outputReport($report);
-        $outputPath = trim((string) ($this->option('output') ?? ''));
-        if ($outputPath !== '') {
-            file_put_contents($outputPath, json_encode($outputReport, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
-        }
+        CareerCliArtifactPathGuard::writeJsonOutput($this->option('output'), $outputReport);
 
         if ((bool) $this->option('json')) {
             $this->line(json_encode($outputReport, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php
+++ b/backend/app/Console/Commands/CareerPrepareCanonicalRuntimeCandidates.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 use App\Domain\Career\IndexStateValue;
 use App\Models\IndexState;
 use App\Models\Occupation;
+use App\Services\Career\CareerCliArtifactPathGuard;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -837,10 +838,7 @@ final class CareerPrepareCanonicalRuntimeCandidates extends Command
             return self::FAILURE;
         }
 
-        $outputPath = trim((string) ($this->option('output') ?? ''));
-        if ($outputPath !== '') {
-            file_put_contents($outputPath, $encoded.PHP_EOL);
-        }
+        CareerCliArtifactPathGuard::writeTextOutput($this->option('output'), $encoded.PHP_EOL);
 
         if ((bool) $this->option('json')) {
             $this->line($encoded);

--- a/backend/app/Console/Commands/CareerValidateAssetImport.php
+++ b/backend/app/Console/Commands/CareerValidateAssetImport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Services\Career\CareerCliArtifactPathGuard;
 use App\Services\Career\Import\CareerAssetImportValidator;
 use App\Support\Xlsx\XlsxCellReference;
 use DOMDocument;
@@ -37,13 +38,7 @@ final class CareerValidateAssetImport extends Command
                 throw new RuntimeException('Unable to encode validation report.');
             }
 
-            $output = trim((string) ($this->option('output') ?? ''));
-            if ($output !== '') {
-                $written = file_put_contents($output, $json.PHP_EOL);
-                if ($written === false) {
-                    throw new RuntimeException('Unable to write report output: '.$output);
-                }
-            }
+            CareerCliArtifactPathGuard::writeTextOutput($this->option('output'), $json.PHP_EOL);
 
             if ((bool) $this->option('json')) {
                 $this->line($json);

--- a/backend/app/Console/Commands/CareerValidateReleaseGate.php
+++ b/backend/app/Console/Commands/CareerValidateReleaseGate.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Services\Career\CareerCliArtifactPathGuard;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
@@ -526,13 +527,7 @@ final class CareerValidateReleaseGate extends Command
             throw new RuntimeException('Unable to encode validation report.');
         }
 
-        $output = trim((string) ($this->option('output') ?? ''));
-        if ($output !== '') {
-            $written = file_put_contents($output, $json.PHP_EOL);
-            if ($written === false) {
-                throw new RuntimeException('Unable to write report output: '.$output);
-            }
-        }
+        CareerCliArtifactPathGuard::writeTextOutput($this->option('output'), $json.PHP_EOL);
 
         if ((bool) $this->option('json')) {
             $this->output->write($json.PHP_EOL, false, OutputInterface::OUTPUT_RAW);

--- a/backend/app/Services/Career/CareerCliArtifactPathGuard.php
+++ b/backend/app/Services/Career/CareerCliArtifactPathGuard.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class CareerCliArtifactPathGuard
+{
+    public static function outputPath(mixed $value, string $option = '--output'): ?string
+    {
+        $path = trim((string) ($value ?? ''));
+        if ($path === '') {
+            return null;
+        }
+
+        if (str_contains($path, "\0")) {
+            throw new RuntimeException($option.' contains a null byte.');
+        }
+
+        if (preg_match('/^[A-Za-z][A-Za-z0-9+.-]*:\/\//', $path) === 1 || str_starts_with($path, 'php://')) {
+            throw new RuntimeException($option.' must be a local filesystem path.');
+        }
+
+        $basename = basename($path);
+        if ($basename === '' || $basename === '.' || $basename === '..') {
+            throw new RuntimeException($option.' must include a file name.');
+        }
+
+        if (is_link($path)) {
+            throw new RuntimeException($option.' must not point to a symlink.');
+        }
+
+        $parent = dirname($path);
+        if ($parent === '' || $parent === '.') {
+            $parent = getcwd() ?: '.';
+        }
+
+        if (is_link($parent)) {
+            throw new RuntimeException($option.' parent directory must not be a symlink.');
+        }
+
+        $parentRealPath = realpath($parent);
+        if (! is_string($parentRealPath) || ! is_dir($parentRealPath)) {
+            throw new RuntimeException($option.' parent directory must exist.');
+        }
+
+        return $parentRealPath.DIRECTORY_SEPARATOR.$basename;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function writeJsonOutput(mixed $value, array $payload, string $option = '--output'): ?string
+    {
+        $path = self::outputPath($value, $option);
+        if ($path === null) {
+            return null;
+        }
+
+        $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($json)) {
+            throw new RuntimeException('Unable to encode JSON output.');
+        }
+
+        File::put($path, $json.PHP_EOL, true);
+
+        return $path;
+    }
+
+    public static function writeTextOutput(mixed $value, string $contents, string $option = '--output'): ?string
+    {
+        $path = self::outputPath($value, $option);
+        if ($path === null) {
+            return null;
+        }
+
+        File::put($path, $contents, true);
+
+        return $path;
+    }
+}

--- a/backend/tests/Feature/Console/CareerValidateAssetImportCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateAssetImportCommandTest.php
@@ -45,6 +45,33 @@ final class CareerValidateAssetImportCommandTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_symlinked_report_output_paths(): void
+    {
+        $dir = $this->tempDir();
+        $workbook = $dir.'/career_assets.xlsx';
+        $target = $dir.'/target-report.json';
+        $link = $dir.'/linked-report.json';
+        $this->writeWorkbook($workbook, CareerAssetImportValidator::expectedHeaders(), [
+            CareerAssetImportValidatorTest::actorsRow(),
+        ]);
+        file_put_contents($target, '{}');
+
+        if (! @symlink($target, $link)) {
+            $this->markTestSkipped('Symlink creation is not available in this environment.');
+        }
+
+        $exitCode = Artisan::call('career:validate-asset-import', [
+            '--file' => $workbook,
+            '--json' => true,
+            '--output' => $link,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--output must not point to a symlink.', Artisan::output());
+        $this->assertSame('{}', file_get_contents($target));
+    }
+
+    #[Test]
     public function it_exits_non_zero_for_header_mismatch(): void
     {
         $dir = $this->tempDir();

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -198,6 +198,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_cli_artifact_path_guard_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Career/CareerCliArtifactPathGuard.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_ci_scale_impact_command_changes(): void
     {
         $changed = [
@@ -1922,6 +1931,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerCliArtifactPathGuardFile($file)) {
+                continue;
+            }
+
             if ($this->isPublicContentReleaseGuardCommandFile($file)) {
                 continue;
             }
@@ -2434,6 +2447,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCareerConsoleCommandFile(string $file): bool
     {
         return preg_match('#^backend/app/Console/Commands/Career[A-Za-z0-9_]*\.php$#', $file) === 1;
+    }
+
+    private function isCareerCliArtifactPathGuardFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Career/CareerCliArtifactPathGuard.php';
     }
 
     private function isPublicContentReleaseGuardCommandFile(string $file): bool

--- a/backend/tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\CareerCliArtifactPathGuard;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Tests\TestCase;
+
+final class CareerCliArtifactPathGuardTest extends TestCase
+{
+    public function test_blank_output_path_is_ignored(): void
+    {
+        $this->assertNull(CareerCliArtifactPathGuard::outputPath(null));
+        $this->assertNull(CareerCliArtifactPathGuard::outputPath('  '));
+    }
+
+    public function test_safe_json_output_is_written_under_existing_parent(): void
+    {
+        $dir = $this->tempDir();
+        $path = $dir.'/report.json';
+
+        $safePath = CareerCliArtifactPathGuard::writeJsonOutput($path, ['status' => 'pass']);
+
+        $this->assertSame($path, $safePath);
+        $this->assertSame('pass', json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR)['status']);
+    }
+
+    public function test_output_path_rejects_null_bytes_and_stream_wrappers(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must be a local filesystem path');
+
+        CareerCliArtifactPathGuard::outputPath('php://filter/resource=/tmp/report.json');
+    }
+
+    public function test_output_path_rejects_missing_parent_directory(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('parent directory must exist');
+
+        CareerCliArtifactPathGuard::outputPath($this->tempDir().'/missing/report.json');
+    }
+
+    public function test_output_path_rejects_symlink_targets(): void
+    {
+        $dir = $this->tempDir();
+        $target = $dir.'/target.json';
+        $link = $dir.'/link.json';
+        File::put($target, '{}');
+
+        if (! @symlink($target, $link)) {
+            $this->markTestSkipped('Symlink creation is not available in this environment.');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must not point to a symlink');
+
+        CareerCliArtifactPathGuard::outputPath($link);
+    }
+
+    public function test_output_path_rejects_symlink_parent_directories(): void
+    {
+        $dir = $this->tempDir();
+        $realParent = $dir.'/real';
+        $linkParent = $dir.'/linked';
+        File::makeDirectory($realParent);
+
+        if (! @symlink($realParent, $linkParent)) {
+            $this->markTestSkipped('Symlink creation is not available in this environment.');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('parent directory must not be a symlink');
+
+        CareerCliArtifactPathGuard::outputPath($linkParent.'/report.json');
+    }
+
+    private function tempDir(): string
+    {
+        $dir = storage_path('framework/testing/career-cli-path-'.Str::random(12));
+        File::makeDirectory($dir, 0755, true);
+
+        return $dir;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16724,7 +16724,7 @@
         52,
         53
       ],
-      "commit_sha": "2627569807aedd0af7b8411400da335746729398",
+      "commit_sha": "d01c58ad97841b20511f90b1c248e4c0609481f6",
       "pr_url": null,
       "checks": {
         "dependency": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16725,7 +16725,7 @@
         53
       ],
       "commit_sha": "d01c58ad97841b20511f90b1c248e4c0609481f6",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1638",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -16776,6 +16776,11 @@
           "at": "2026-05-24T09:05:00+08:00",
           "status": "local_validated_with_external_sidecar",
           "summary": "Added shared Career CLI artifact path guard and routed scoped --output writes through it; targeted path guard and validate-asset-import tests passed, Pint and diff checks passed, Career baseline failures recorded as external sidecar."
+        },
+        {
+          "at": "2026-05-24T09:10:00+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1638 for CAREER-EXPORT-CLI-ROBUSTNESS-01."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16751,6 +16751,11 @@
           "command": "cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career tests",
           "evidence": "PASS, 1529 files."
         },
+        "mbti_freeze_targeted": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter 'runtime_paths_have_no_uncommitted_diff|career_cli_artifact_path_guard_changes' --no-ansi",
+          "evidence": "2 passed, 4 assertions after adding the scoped Career CLI artifact guard file to the existing Career allowlist."
+        },
         "diff_check": {
           "status": "pass",
           "command": "git diff --check && git diff --cached --check"
@@ -16781,6 +16786,11 @@
           "at": "2026-05-24T09:10:00+08:00",
           "status": "pr_opened",
           "summary": "Opened PR #1638 for CAREER-EXPORT-CLI-ROBUSTNESS-01."
+        },
+        {
+          "at": "2026-05-24T09:20:00+08:00",
+          "status": "github_checks_failed_scope_fix_applied",
+          "summary": "GitHub verify-mbti-legacy/v2 failed on the runtime-freeze classifier because the scoped Career CLI artifact path guard service was not allowlisted; added the allowlist predicate and verified the targeted classifier tests plus Pint."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T06:21:29+08:00",
+  "updated_at": "2026-05-24T09:05:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -15413,7 +15413,7 @@
     "SEARCH-CHANNEL-LIVE-MBTI-01": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-mbti-01-preflight",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-POST-ENQUEUE-REVIEW"
       ],
@@ -15475,8 +15475,8 @@
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-MBTI-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "98fbb92997bf72fc1c7983b275220c3bbcd8212b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1637",
       "checks": {
         "production_operation": {
           "approval_phrase": "passed: exact SEARCH-CHANNEL-LIVE-02 approval phrase present before any live gate change",
@@ -15502,8 +15502,8 @@
         "github": {}
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-24T00:09:01Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -16616,7 +16616,7 @@
     "CAREER-ROLLOUT-MATERIALIZATION-01": {
       "repo": "fap-api",
       "branch": "codex/career-rollout-materialization-01",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "CAREER-RELEASE-GATES-01"
       ],
@@ -16626,8 +16626,8 @@
         56,
         57
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "98fbb92997bf72fc1c7983b275220c3bbcd8212b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1637",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -16675,8 +16675,8 @@
         }
       ],
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-24T00:09:01Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "events": [
         {
@@ -16698,13 +16698,18 @@
           "at": "2026-05-24T08:59:00+08:00",
           "status": "github_checks_failed_scope_fix_applied",
           "summary": "GitHub verify-mbti-legacy/v2 failed on the existing runtime-freeze classifier because the scoped Career materialization service files were not allowlisted; added the files to the Career runtime publish projection allowlist and verified the targeted classifier tests plus Pint."
+        },
+        {
+          "at": "2026-05-24T09:05:00+08:00",
+          "status": "merged_reconciled",
+          "summary": "Reconciled GitHub merge for PR #1637; origin/main contains squash commit 98fbb92997bf72fc1c7983b275220c3bbcd8212b and the remote branch is deleted. Local cleanup script is not present in this clone."
         }
       ]
     },
     "CAREER-EXPORT-CLI-ROBUSTNESS-01": {
       "repo": "fap-api",
       "branch": "codex/career-export-cli-robustness-01",
-      "status": "pending",
+      "status": "local_validated_with_external_sidecar",
       "depends_on": [
         "CAREER-ROLLOUT-MATERIALIZATION-01"
       ],
@@ -16719,14 +16724,60 @@
         52,
         53
       ],
-      "commit_sha": null,
+      "commit_sha": "2627569807aedd0af7b8411400da335746729398",
       "pr_url": null,
-      "checks": {},
-      "sidecar_issues": [],
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "CAREER-ROLLOUT-MATERIALIZATION-01 is merged into main as 98fbb92997bf72fc1c7983b275220c3bbcd8212b."
+        },
+        "targeted_cli_output_path_tests": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php tests/Feature/Console/CareerValidateAssetImportCommandTest.php --no-ansi",
+          "evidence": "9 passed, 33 assertions."
+        },
+        "patched_command_regression_suite": {
+          "status": "external_baseline_failed",
+          "command": "cd backend && php artisan test tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php tests/Feature/Console/CareerAlignD8AuthorityCrosswalksCommandTest.php tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerPrepareCanonicalRuntimeCandidatesCommandTest.php tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/Console/CareerValidateAssetImportCommandTest.php tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php --no-ansi",
+          "evidence": "118 passed and 3 failed; the failures are existing Career display surface/public API baseline assertions outside output path handling."
+        },
+        "career_filter": {
+          "status": "external_baseline_failed",
+          "command": "cd backend && php artisan test --filter Career --no-ansi",
+          "evidence": "47 failed, 1313 passed, 52313 assertions. Failures remain concentrated in the pre-existing Career runtime projection/public surface baseline; the current PR's CLI output path tests passed."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career tests",
+          "evidence": "PASS, 1529 files."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are limited to allowed Career console commands, app/Services/Career, tests, and docs/codex state."
+        }
+      },
+      "sidecar_issues": [
+        {
+          "id": "CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01",
+          "status": "external_pre_existing",
+          "evidence": "Full Career filter and display-surface command regression tests still fail in existing runtime projection/public surface assertions; scoped CLI output path guard tests pass."
+        }
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-05-24T09:05:00+08:00",
+          "status": "local_validated_with_external_sidecar",
+          "summary": "Added shared Career CLI artifact path guard and routed scoped --output writes through it; targeted path guard and validate-asset-import tests passed, Pint and diff checks passed, Career baseline failures recorded as external sidecar."
+        }
+      ]
     },
     "CMS-ARTICLE-REPORT-CORRECTNESS-01": {
       "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Added a shared Career CLI artifact path guard for local output artifacts.
- Routed scoped Career --output report writers through the guard.
- Added path guard coverage and an end-to-end symlink rejection test for validate-asset-import.
- Reconciled prior PR-train state and recorded current validation results.

## Why
Codex security findings flagged untrusted Career CLI artifact paths. The new guard rejects null bytes, stream wrappers, missing parents, symlink parents, and symlink targets before writing reports.

## Validation
- cd backend && php artisan test tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php tests/Feature/Console/CareerValidateAssetImportCommandTest.php --no-ansi
- cd backend && php artisan test --filter Career --no-ansi (external baseline: 47 failed, 1313 passed, 52313 assertions)
- cd backend && vendor/bin/pint --test app/Console/Commands app/Services/Career tests
- git diff --check
- git diff --cached --check

## Deferred
- Existing Career runtime projection/public surface baseline failures are tracked as sidecar issue CAREER-RUNTIME-PROJECTION-TEST-SUITE-BASELINE-01 and are outside this PR scope.