### PR TITLE
fix(security): reject trailing-slash CLI symlink outputs

### DIFF
--- a/backend/app/Services/Career/CareerCliArtifactPathGuard.php
+++ b/backend/app/Services/Career/CareerCliArtifactPathGuard.php
@@ -24,6 +24,8 @@ final class CareerCliArtifactPathGuard
             throw new RuntimeException($option.' must be a local filesystem path.');
         }
 
+        $path = self::trimTrailingSeparators($path);
+
         $basename = basename($path);
         if ($basename === '' || $basename === '.' || $basename === '..') {
             throw new RuntimeException($option.' must include a file name.');
@@ -48,6 +50,11 @@ final class CareerCliArtifactPathGuard
         }
 
         return $parentRealPath.DIRECTORY_SEPARATOR.$basename;
+    }
+
+    private static function trimTrailingSeparators(string $path): string
+    {
+        return rtrim($path, '\\/');
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php
@@ -62,6 +62,23 @@ final class CareerCliArtifactPathGuardTest extends TestCase
         CareerCliArtifactPathGuard::outputPath($link);
     }
 
+    public function test_output_path_rejects_symlink_targets_with_trailing_separator(): void
+    {
+        $dir = $this->tempDir();
+        $target = $dir.'/target.json';
+        $link = $dir.'/link.json';
+        File::put($target, '{}');
+
+        if (! @symlink($target, $link)) {
+            $this->markTestSkipped('Symlink creation is not available in this environment.');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must not point to a symlink');
+
+        CareerCliArtifactPathGuard::outputPath($link.'/');
+    }
+
     public function test_output_path_rejects_symlink_parent_directories(): void
     {
         $dir = $this->tempDir();


### PR DESCRIPTION
## What changed
- Normalize trailing path separators before CLI artifact basename and symlink validation.
- Add regression coverage for symlink output paths supplied with a trailing slash.

## Why
Codex security finding: `CLI output symlink guard can be bypassed with trailing slash`. PHP can treat a symlink with a trailing slash as not-a-link before later basename normalization strips the slash.

## Validation
- `cd backend && php artisan test tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Career/CareerCliArtifactPathGuard.php tests/Unit/Services/Career/CareerCliArtifactPathGuardTest.php`
- `git diff --check`

## Deferred
- Other Codex findings are intentionally handled in separate scoped PRs.