### PR TITLE
fix(security): sanitize retryable submission errors

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -822,6 +822,10 @@ final class AttemptSubmissionService
         $resultPayload = $this->decodeJsonArray($row->response_payload_json ?? null);
         $errorCode = $this->nullableString($row->error_code ?? null);
         $errorMessage = $this->nullableString($row->error_message ?? null);
+        if ($errorMessage !== null && in_array($state, ['pending', 'running'], true)) {
+            $errorMessage = $this->publicRetryableSubmissionErrorMessage($errorCode);
+        }
+
         if ($state === 'failed') {
             $errorMessage = $this->publicSubmissionErrorMessage($errorCode, $errorMessage);
             $resultPayload = $this->sanitizeSubmissionResultPayload($resultPayload, $errorCode);
@@ -898,6 +902,16 @@ final class AttemptSubmissionService
             'SUBMISSION_JOB_RETRY_EXHAUSTED',
             'SUBMISSION_JOB_TERMINAL_FAILURE' => 'submission job terminal failure.',
             default => 'submission failed.',
+        };
+    }
+
+    private function publicRetryableSubmissionErrorMessage(?string $errorCode): string
+    {
+        $code = strtoupper(trim((string) $errorCode));
+
+        return match ($code) {
+            'SUBMISSION_QUEUE_DISPATCH_FAILED' => 'submission dispatch is being retried.',
+            default => 'submission processing is being retried.',
         };
     }
 

--- a/backend/tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php
@@ -409,6 +409,64 @@ class AttemptSubmissionAsyncFlowTest extends TestCase
         $this->assertNotNull($done->response_payload_json ?? null);
     }
 
+    public function test_submission_status_sanitizes_retryable_pending_error_message(): void
+    {
+        config()->set('fap.features.submit_async_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_async_retry_public_sanitized';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        Queue::fake();
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->demoAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $submit->assertStatus(202);
+        $submissionId = (string) $submit->json('submission_id');
+
+        DB::table('attempt_submissions')
+            ->where('id', $submissionId)
+            ->update([
+                'state' => 'pending',
+                'error_code' => 'SUBMISSION_JOB_FAILED',
+                'error_message' => 'PDOException: SQLSTATE[HY000] using /srv/app/.env secret=internal',
+                'updated_at' => now(),
+            ]);
+
+        $status = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/submission');
+
+        $status->assertStatus(202);
+        $status->assertJsonPath('generating', true);
+        $status->assertJsonPath('submission.id', $submissionId);
+        $status->assertJsonPath('submission.state', 'pending');
+        $status->assertJsonPath('submission.error_code', 'SUBMISSION_JOB_FAILED');
+        $status->assertJsonPath('submission.error_message', 'submission processing is being retried.');
+
+        $content = (string) $status->getContent();
+        $this->assertStringNotContainsString('PDOException', $content);
+        $this->assertStringNotContainsString('SQLSTATE', $content);
+        $this->assertStringNotContainsString('/srv/app/.env', $content);
+        $this->assertStringNotContainsString('secret=internal', $content);
+    }
+
     public function test_submit_async_replays_stored_result_when_submission_already_succeeded(): void
     {
         config()->set('fap.features.submit_async_v2', true);


### PR DESCRIPTION
## What changed
- Sanitize retryable pending/running submission error messages before they are returned by the public submission status formatter.
- Keep terminal failed submission sanitization unchanged.
- Add a regression test proving raw exception details are not returned from the pending submission status endpoint.

## Why
Retryable worker failures can store internal exception details while leaving the submission pending for queue retry. Public 202 status responses should not leak those raw details.

## Validation
- cd backend && php artisan test tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php --no-ansi
- cd backend && php artisan test --filter AttemptSubmission --no-ansi
- cd backend && vendor/bin/pint --test app/Services/Attempts/AttemptSubmissionService.php tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php
- git diff --check

## Deferred
- No operator/admin recovery UI changes.
- No changes to stored internal retry diagnostics.