### PR TITLE
PR-AUDIT-BE-02 payment webhook payload digest mismatch idempotency

### DIFF
--- a/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
@@ -154,6 +154,28 @@ class WebhookEntitlementService
                         return $this->core->serverError('EVENT_INIT_FAILED', 'payment event init failed.');
                     }
 
+                    $existingPayloadSha256 = trim((string) ($eventRow->payload_sha256 ?? ''));
+                    $incomingPayloadSha256 = trim((string) ($resolvedPayloadMeta['sha256'] ?? ''));
+                    if (
+                        $inserted === 0
+                        && $existingPayloadSha256 !== ''
+                        && $incomingPayloadSha256 !== ''
+                        && ! hash_equals($existingPayloadSha256, $incomingPayloadSha256)
+                    ) {
+                        Log::warning('PAYMENT_EVENT_PAYLOAD_DIGEST_MISMATCH', [
+                            'provider' => $provider,
+                            'provider_event_id' => $providerEventId,
+                            'order_id' => $eventRow->order_id ?? null,
+                            'order_no' => $eventRow->order_no ?? null,
+                            'incoming_order_no' => $orderNo,
+                            'old_digest' => $existingPayloadSha256,
+                            'new_digest' => $incomingPayloadSha256,
+                            'event_type' => $eventType,
+                        ]);
+
+                        return $this->core->badRequest('PAYLOAD_DIGEST_MISMATCH', 'payment event payload digest mismatch.');
+                    }
+
                     if ($inserted === 0 && $this->core->isEventProcessed($eventRow)) {
                         Log::info('PAYMENT_EVENT_ALREADY_PROCESSED', [
                             'provider' => $provider,

--- a/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
@@ -7,6 +7,7 @@ use App\Models\Result;
 use Database\Seeders\Pr19CommerceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Tests\Concerns\SignedBillingWebhook;
 use Tests\TestCase;
@@ -85,11 +86,8 @@ class PaymentWebhookIdempotencyTest extends TestCase
         return $attemptId;
     }
 
-    public function test_duplicate_event_idempotent(): void
+    private function insertCreditOrder(string $orderNo, int $amountCents = 4990, string $currency = 'USD'): void
     {
-        $this->seedCommerce();
-
-        $orderNo = 'ord_dup_1';
         DB::table('orders')->insert([
             'id' => (string) Str::uuid(),
             'order_no' => $orderNo,
@@ -99,15 +97,15 @@ class PaymentWebhookIdempotencyTest extends TestCase
             'sku' => 'MBTI_CREDIT',
             'quantity' => 1,
             'target_attempt_id' => null,
-            'amount_cents' => 4990,
-            'currency' => 'USD',
+            'amount_cents' => $amountCents,
+            'currency' => $currency,
             'status' => 'created',
             'provider' => 'billing',
             'external_trade_no' => null,
             'paid_at' => null,
             'created_at' => now(),
             'updated_at' => now(),
-            'amount_total' => 4990,
+            'amount_total' => $amountCents,
             'amount_refunded' => 0,
             'item_sku' => 'MBTI_CREDIT',
             'provider_order_id' => null,
@@ -117,6 +115,85 @@ class PaymentWebhookIdempotencyTest extends TestCase
             'fulfilled_at' => null,
             'refunded_at' => null,
         ]);
+    }
+
+    private function payloadDigest(array $payload): string
+    {
+        $raw = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        self::assertIsString($raw);
+
+        return hash('sha256', $raw);
+    }
+
+    private function assertDuplicateDigestMismatchIsRejected(array $mutatedFields): void
+    {
+        $this->seedCommerce();
+
+        $orderNo = 'ord_digest_mismatch_1';
+        $providerEventId = 'evt_digest_mismatch_1';
+        $this->insertCreditOrder($orderNo);
+
+        $payload = [
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_digest_mismatch_1',
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+        ];
+        $firstDigest = $this->payloadDigest($payload);
+
+        $first = $this->postSignedBillingWebhook($payload, [
+            'X-Org-Id' => '0',
+        ]);
+        $first->assertStatus(200);
+        $first->assertJson(['ok' => true]);
+
+        $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'topup')->count());
+        $this->assertSame($firstDigest, (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', $providerEventId)
+            ->value('payload_sha256'));
+
+        Log::spy();
+
+        $mutatedPayload = array_merge($payload, $mutatedFields);
+        $mutatedDigest = $this->payloadDigest($mutatedPayload);
+        $this->assertNotSame($firstDigest, $mutatedDigest);
+
+        $second = $this->postSignedBillingWebhook($mutatedPayload, [
+            'X-Org-Id' => '0',
+        ]);
+        $second->assertStatus(400);
+        $second->assertJsonPath('error_code', 'PAYLOAD_DIGEST_MISMATCH');
+
+        $this->assertSame(1, DB::table('payment_events')->where('provider_event_id', $providerEventId)->count());
+        $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'topup')->count());
+        $this->assertSame('fulfilled', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
+        $this->assertSame($firstDigest, (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', $providerEventId)
+            ->value('payload_sha256'));
+
+        Log::shouldHaveReceived('warning')->once()->withArgs(
+            static function (string $message, array $context) use ($providerEventId, $orderNo, $firstDigest, $mutatedDigest): bool {
+                return $message === 'PAYMENT_EVENT_PAYLOAD_DIGEST_MISMATCH'
+                    && (string) ($context['provider'] ?? '') === 'billing'
+                    && (string) ($context['provider_event_id'] ?? '') === $providerEventId
+                    && (string) ($context['order_no'] ?? '') === $orderNo
+                    && (string) ($context['old_digest'] ?? '') === $firstDigest
+                    && (string) ($context['new_digest'] ?? '') === $mutatedDigest
+                    && ! array_key_exists('payload', $context)
+                    && ! array_key_exists('payload_json', $context);
+            }
+        );
+    }
+
+    public function test_duplicate_event_idempotent(): void
+    {
+        $this->seedCommerce();
+
+        $orderNo = 'ord_dup_1';
+        $this->insertCreditOrder($orderNo);
 
         $payload = [
             'provider_event_id' => 'evt_dup_1',
@@ -143,6 +220,27 @@ class PaymentWebhookIdempotencyTest extends TestCase
 
         $this->assertSame(1, DB::table('payment_events')->count());
         $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'topup')->count());
+    }
+
+    public function test_duplicate_event_id_with_different_amount_is_rejected_without_regranting(): void
+    {
+        $this->assertDuplicateDigestMismatchIsRejected([
+            'amount_cents' => 5990,
+        ]);
+    }
+
+    public function test_duplicate_event_id_with_different_currency_is_rejected_without_regranting(): void
+    {
+        $this->assertDuplicateDigestMismatchIsRejected([
+            'currency' => 'CNY',
+        ]);
+    }
+
+    public function test_duplicate_event_id_with_different_order_no_is_rejected_without_regranting(): void
+    {
+        $this->assertDuplicateDigestMismatchIsRejected([
+            'order_no' => 'ord_digest_mismatch_other',
+        ]);
     }
 
     public function test_orphan_event_retries_after_order_created(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1031,6 +1031,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_payment_webhook_digest_idempotency_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_order_tenant_ownership_boundary_changes(): void
     {
         $changed = [
@@ -2565,6 +2574,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php',
             'backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php',
             'backend/app/Services/Commerce/OrderManager.php',
+            'backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T07:29:17.131Z",
+  "updated_at": "2026-05-24T07:55:33.131Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -16993,7 +16993,7 @@
     "PR-AUDIT-BE-01": {
       "repo": "fap-api",
       "branch": "codex/pr-audit-be-01-ci-supply-chain",
-      "status": "github_checks_passed",
+      "status": "merged",
       "depends_on": [],
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1644",
       "checks": {
@@ -17027,8 +17027,8 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-24T07:37:28Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "sidecar_issues": [],
       "events": [
@@ -17056,9 +17056,95 @@
           "at": "2026-05-24T07:29:17.131Z",
           "status": "github_checks_passed",
           "summary": "GitHub checks passed for PR #1644: hygiene, supply-chain, verify-mbti legacy/v2, blocking Semgrep secrets, SARIF upload, and Semgrep OSS."
+        },
+        {
+          "at": "2026-05-24T07:40:49.781Z",
+          "status": "merged_reconciled",
+          "summary": "Reconciled PR-AUDIT-BE-01 as merged via PR #1644 at c87d9bc11f4e1cf90e60c06660b472e8afeb10a0. Remote branch is deleted; scripts/post_merge_cleanup.sh is absent in this repo, so local cleanup script was not executed."
         }
       ],
-      "updated_at": "2026-05-24T07:29:17.131Z"
+      "updated_at": "2026-05-24T07:40:49.781Z",
+      "commit_sha": "c87d9bc11f4e1cf90e60c06660b472e8afeb10a0"
+    },
+    "PR-AUDIT-BE-02": {
+      "repo": "fap-api",
+      "branch": "codex/pr-audit-be-02-webhook-digest",
+      "status": "local_checks_passed_with_sidecar",
+      "depends_on": [
+        "PR-AUDIT-BE-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "status": "passed_with_sidecar",
+          "passed": [
+            "cd backend && php artisan test --filter=PaymentWebhookIdempotencyTest",
+            "cd backend && php artisan test --filter=CommerceWebhookIdempotencyTest",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "cd backend && bash scripts/ci_verify_mbti.sh",
+            "git diff --check"
+          ],
+          "failed": [
+            {
+              "command": "cd backend && php artisan test --filter=PaymentWebhook",
+              "summary": "Sidecar only: Tests\\Feature\\V0_3\\PaymentWebhookCnCallbackTest::test_wechatpay_valid_callback_calls_processor_and_returns_success_ack fails on clean origin/main c87d9bc11f4e1cf90e60c06660b472e8afeb10a0 with the same 400 / 签名异常: 微信签名为空 error."
+            }
+          ]
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "passed": [],
+          "failed": []
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "source_pr": "PR-AUDIT-BE-02",
+          "repo": "fap-api",
+          "branch": "codex/pr-audit-be-02-webhook-digest",
+          "command_or_check": "php artisan test --filter=PaymentWebhook",
+          "failing_test": "Tests\\Feature\\V0_3\\PaymentWebhookCnCallbackTest::test_wechatpay_valid_callback_calls_processor_and_returns_success_ack",
+          "evidence": "400 instead of 200; 签名异常: 微信签名为空",
+          "baseline_verification": "Exact test also fails on clean origin/main",
+          "baseline_commit": "c87d9bc11f4e1cf90e60c06660b472e8afeb10a0",
+          "why_external_to_current_pr": "BE-02 diff only touches payload digest idempotency service/test and ledger; failure is in WeChatPay CN callback signature chain.",
+          "impact_on_current_pr": "BE-02 targeted digest/idempotency tests pass; broad PaymentWebhook filter has unrelated legacy/provider signature failure.",
+          "owner": "backend/payment",
+          "follow_up_recommendation": "Create sidecar PR or issue to repair WeChatPay CN callback fixture/header/signature test harness.",
+          "required_checks_status": "pending until PR checks complete",
+          "scope_validation_status": "green for uncommitted working tree; final committed diff pending",
+          "continue_train_decision": "allowed only if GitHub required checks are green"
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-05-24T07:40:49.781Z",
+          "status": "in_progress",
+          "summary": "Initialized PR-AUDIT-BE-02 after PR-AUDIT-BE-01 merged. Scope is payment webhook payload digest mismatch idempotency."
+        },
+        {
+          "at": "2026-05-24T07:42:09.004Z",
+          "status": "local_check_failed",
+          "summary": "Local manifest check php artisan test --filter=PaymentWebhook failed in PaymentWebhookCnCallbackTest WeChatPay valid callback. Failure is outside current digest mismatch diff, but fap-api AGENTS blocks push/open PR after failed local checks."
+        },
+        {
+          "at": "2026-05-24T07:51:12.597Z",
+          "status": "sidecar_verified",
+          "summary": "Verified WeChatPay CN callback exact failing test also fails on clean origin/main c87d9bc11f4e1cf90e60c06660b472e8afeb10a0 with the same 400 / 签名异常: 微信签名为空 error. Treating broad PaymentWebhook filter failure as sidecar per user authorization."
+        },
+        {
+          "at": "2026-05-24T07:55:33.131Z",
+          "status": "local_checks_passed_with_sidecar",
+          "summary": "BE-02 blocking acceptance passed: targeted digest/idempotency tests, Composer validate/audit, ci_verify_mbti, and git diff --check. Broad PaymentWebhook filter failure is sidecar verified against clean origin/main."
+        }
+      ],
+      "updated_at": "2026-05-24T07:55:33.131Z"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T08:09:06.779Z",
+  "updated_at": "2026-05-24T08:17:08.119Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17069,7 +17069,7 @@
     "PR-AUDIT-BE-02": {
       "repo": "fap-api",
       "branch": "codex/pr-audit-be-02-webhook-digest",
-      "status": "ci_fix_local_checks_passed_pending_github_rerun",
+      "status": "github_checks_passed_pending_merge",
       "depends_on": [
         "PR-AUDIT-BE-01"
       ],
@@ -17096,31 +17096,28 @@
           ]
         },
         "github_required_checks": {
-          "status": "failed_ci_fix_applied_pending_rerun",
+          "status": "pass",
+          "head_sha": "ae06dddbe19f3d72d71ecc78ab3349062426c500",
           "passed": [
             "hygiene",
             "supply-chain",
             "Semgrep blocking secrets",
             "semgrep sarif non-blocking upload",
-            "Semgrep OSS"
+            "Semgrep OSS",
+            "verify-mbti-legacy",
+            "verify-mbti-v2"
           ],
-          "failed": [
-            {
-              "name": "verify-mbti-legacy",
-              "evidence": "Required GitHub check failed because BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff reported backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php as runtime path diff."
-            },
-            {
-              "name": "verify-mbti-v2",
-              "evidence": "Required GitHub check failed for the same runtime-freeze classifier reason as verify-mbti-legacy."
-            }
-          ],
-          "remediation": "Added a narrow runtime-freeze classifier evidence test for PR-AUDIT-BE-02 payment webhook digest idempotency and included WebhookEntitlementService.php in the commerce payment action classifier allowlist.",
-          "rerun_status": "pending push"
+          "failed": [],
+          "evidence": "GitHub required checks passed on PR #1645 after BE-02 runtime-freeze classifier evidence fix; verify-mbti-legacy and verify-mbti-v2 both passed on rerun."
         },
         "runtime_freeze_ci_fix": {
           "status": "pass",
           "command": "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|payment_webhook_digest_idempotency'",
           "evidence": "2 tests passed, 4 assertions; runtime paths gate accepts the BE-02 webhook digest idempotency service change."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to BE-02 webhook digest idempotency service/test, user-authorized runtime-freeze scope evidence, and PR train manifest/state."
         }
       },
       "failure_reason": null,
@@ -17181,9 +17178,15 @@
           "at": "2026-05-24T08:09:06.779Z",
           "status": "github_required_checks_failed_ci_fix_applied",
           "summary": "GitHub required checks verify-mbti-legacy and verify-mbti-v2 failed on runtime-freeze classification of WebhookEntitlementService.php. User authorized touching runtime-freeze scope helper; added narrow BE-02 classifier evidence and local ci_verify_mbti passed. Pending push and GitHub rerun."
+        },
+        {
+          "at": "2026-05-24T08:17:08.119Z",
+          "status": "github_checks_passed_pending_merge",
+          "summary": "GitHub required checks passed after runtime-freeze classifier evidence fix. PR #1645 is pending merge policy execution."
         }
       ],
-      "updated_at": "2026-05-24T08:09:06.779Z"
+      "updated_at": "2026-05-24T08:17:08.119Z",
+      "commit_sha": "ae06dddbe19f3d72d71ecc78ab3349062426c500"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T07:55:33.131Z",
+  "updated_at": "2026-05-24T07:55:47.051Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17069,11 +17069,10 @@
     "PR-AUDIT-BE-02": {
       "repo": "fap-api",
       "branch": "codex/pr-audit-be-02-webhook-digest",
-      "status": "local_checks_passed_with_sidecar",
+      "status": "committed",
       "depends_on": [
         "PR-AUDIT-BE-01"
       ],
-      "commit_sha": null,
       "pr_url": null,
       "checks": {
         "local": {
@@ -17142,9 +17141,14 @@
           "at": "2026-05-24T07:55:33.131Z",
           "status": "local_checks_passed_with_sidecar",
           "summary": "BE-02 blocking acceptance passed: targeted digest/idempotency tests, Composer validate/audit, ci_verify_mbti, and git diff --check. Broad PaymentWebhook filter failure is sidecar verified against clean origin/main."
+        },
+        {
+          "at": "2026-05-24T07:55:47.051Z",
+          "status": "committed",
+          "summary": "Committed scoped PR-AUDIT-BE-02 implementation as undefined."
         }
       ],
-      "updated_at": "2026-05-24T07:55:33.131Z"
+      "updated_at": "2026-05-24T07:55:47.051Z"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T07:56:22.289Z",
+  "updated_at": "2026-05-24T08:09:06.779Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17069,21 +17069,24 @@
     "PR-AUDIT-BE-02": {
       "repo": "fap-api",
       "branch": "codex/pr-audit-be-02-webhook-digest",
-      "status": "pr_open",
+      "status": "ci_fix_local_checks_passed_pending_github_rerun",
       "depends_on": [
         "PR-AUDIT-BE-01"
       ],
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1645",
       "checks": {
         "local": {
-          "status": "passed_with_sidecar",
+          "status": "passed_with_sidecar_and_runtime_freeze_fix",
           "passed": [
             "cd backend && php artisan test --filter=PaymentWebhookIdempotencyTest",
             "cd backend && php artisan test --filter=CommerceWebhookIdempotencyTest",
             "cd backend && composer validate --strict",
             "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
             "cd backend && bash scripts/ci_verify_mbti.sh",
-            "git diff --check"
+            "git diff --check",
+            "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|payment_webhook_digest_idempotency'",
+            "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\"); puts \"yaml ok\"'",
+            "ruby -e 'require \"json\"; JSON.parse(File.read(\"docs/codex/pr-train-state.json\")); puts \"json ok\"'"
           ],
           "failed": [
             {
@@ -17093,9 +17096,31 @@
           ]
         },
         "github_required_checks": {
-          "status": "pending",
-          "passed": [],
-          "failed": []
+          "status": "failed_ci_fix_applied_pending_rerun",
+          "passed": [
+            "hygiene",
+            "supply-chain",
+            "Semgrep blocking secrets",
+            "semgrep sarif non-blocking upload",
+            "Semgrep OSS"
+          ],
+          "failed": [
+            {
+              "name": "verify-mbti-legacy",
+              "evidence": "Required GitHub check failed because BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff reported backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php as runtime path diff."
+            },
+            {
+              "name": "verify-mbti-v2",
+              "evidence": "Required GitHub check failed for the same runtime-freeze classifier reason as verify-mbti-legacy."
+            }
+          ],
+          "remediation": "Added a narrow runtime-freeze classifier evidence test for PR-AUDIT-BE-02 payment webhook digest idempotency and included WebhookEntitlementService.php in the commerce payment action classifier allowlist.",
+          "rerun_status": "pending push"
+        },
+        "runtime_freeze_ci_fix": {
+          "status": "pass",
+          "command": "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|payment_webhook_digest_idempotency'",
+          "evidence": "2 tests passed, 4 assertions; runtime paths gate accepts the BE-02 webhook digest idempotency service change."
         }
       },
       "failure_reason": null,
@@ -17151,9 +17176,14 @@
           "at": "2026-05-24T07:56:22.289Z",
           "status": "pr_open",
           "summary": "Opened PR #1645 for PR-AUDIT-BE-02."
+        },
+        {
+          "at": "2026-05-24T08:09:06.779Z",
+          "status": "github_required_checks_failed_ci_fix_applied",
+          "summary": "GitHub required checks verify-mbti-legacy and verify-mbti-v2 failed on runtime-freeze classification of WebhookEntitlementService.php. User authorized touching runtime-freeze scope helper; added narrow BE-02 classifier evidence and local ci_verify_mbti passed. Pending push and GitHub rerun."
         }
       ],
-      "updated_at": "2026-05-24T07:56:22.289Z"
+      "updated_at": "2026-05-24T08:09:06.779Z"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T07:55:47.051Z",
+  "updated_at": "2026-05-24T07:56:22.289Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17069,11 +17069,11 @@
     "PR-AUDIT-BE-02": {
       "repo": "fap-api",
       "branch": "codex/pr-audit-be-02-webhook-digest",
-      "status": "committed",
+      "status": "pr_open",
       "depends_on": [
         "PR-AUDIT-BE-01"
       ],
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1645",
       "checks": {
         "local": {
           "status": "passed_with_sidecar",
@@ -17146,9 +17146,14 @@
           "at": "2026-05-24T07:55:47.051Z",
           "status": "committed",
           "summary": "Committed scoped PR-AUDIT-BE-02 implementation as undefined."
+        },
+        {
+          "at": "2026-05-24T07:56:22.289Z",
+          "status": "pr_open",
+          "summary": "Opened PR #1645 for PR-AUDIT-BE-02."
         }
       ],
-      "updated_at": "2026-05-24T07:55:47.051Z"
+      "updated_at": "2026-05-24T07:56:22.289Z"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6531,6 +6531,7 @@ prs:
     allowed_paths:
       - backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
       - backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     scope:
@@ -6542,6 +6543,7 @@ prs:
       - cd backend && php artisan test --filter=PaymentWebhook
       - cd backend && php artisan test --filter=CommerceWebhookIdempotencyTest
       - cd backend && php artisan test --filter=PaymentWebhookIdempotencyTest
+      - cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|payment_webhook_digest_idempotency'
       - cd backend && composer validate --strict
       - cd backend && composer audit --locked --no-interaction --ignore-unreachable
       - cd backend && bash scripts/ci_verify_mbti.sh

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6518,6 +6518,44 @@ prs:
     metabase_deployment: false
     human_review_required: false
     production_approval_required: false
+
+  - id: PR-AUDIT-BE-02
+    repo: fap-api
+    depends_on: [PR-AUDIT-BE-01]
+    branch: codex/pr-audit-be-02-webhook-digest
+    base: main
+    title: "PR-AUDIT-BE-02 payment webhook payload digest mismatch idempotency"
+    train_scope: prr_audit_remediation
+    risk_level: medium_payment_idempotency
+    findings: [M-BE-PAY-01]
+    allowed_paths:
+      - backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+      - backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Reject duplicate provider plus provider_event_id webhook deliveries when the incoming payload_sha256 differs from the stored payload_sha256.
+      - Keep matching duplicate payloads idempotent without regranting benefits or reprocessing orders.
+      - Log safe digest mismatch metadata without recording full webhook payloads.
+      - Do not change checkout, provider SDK, frontend payment flow, tenant, attempt, report, or unrelated order state-machine behavior.
+    validation:
+      - cd backend && php artisan test --filter=PaymentWebhook
+      - cd backend && php artisan test --filter=CommerceWebhookIdempotencyTest
+      - cd backend && php artisan test --filter=PaymentWebhookIdempotencyTest
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'
+      - ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: false
+    production_approval_required: false
     next_task: OPS-CI-CODESCAN-WEB-01
 
   - id: OPS-CI-CODESCAN-API-02


### PR DESCRIPTION
## PR id
PR-AUDIT-BE-02

## Audit risk
M-BE-PAY-01

## Changed files
- `backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php`
- `backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `docs/codex/pr-train.yaml`
- `docs/codex/pr-train-state.json`

## Behavior
- Same `provider + provider_event_id + payload_sha256` remains idempotent and returns duplicate success without regranting benefits or reprocessing the order.
- Same `provider + provider_event_id` with a different `payload_sha256` now fails closed with `PAYLOAD_DIGEST_MISMATCH`.
- Digest mismatch is checked after `lockForUpdate()` inside the transaction, before order state progression or entitlement writes.
- Digest mismatch logs only safe metadata: provider, provider event id, order references, old digest, new digest, and event type. It does not log the full webhook payload.
- Runtime-freeze evidence was added for the BE-02 payment webhook digest idempotency service path after required GitHub `verify-mbti-*` checks flagged the service file as an MBTI runtime diff.
- WeChatPay controller/provider/signature chain was not modified.

## Validation commands and results
- `cd backend && php artisan test --filter=PaymentWebhookIdempotencyTest` — PASS
- `cd backend && php artisan test --filter=CommerceWebhookIdempotencyTest` — PASS
- `cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|payment_webhook_digest_idempotency'` — PASS
- `cd backend && composer validate --strict` — PASS
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` — PASS
- `cd backend && bash scripts/ci_verify_mbti.sh` — PASS
- `git diff --check` — PASS
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'` — PASS
- `ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'` — PASS

## Scope validation result
Changed files are limited to BE-02 webhook digest idempotency logic, directly related payment webhook idempotency tests, the runtime-freeze scope evidence test explicitly authorized for BE-02, and current PR train manifest/state files.

## Sidecar issue
`cd backend && php artisan test --filter=PaymentWebhook` fails because of an existing WeChatPay CN callback signature fixture/harness issue:

- failing test: `Tests\Feature\V0_3\PaymentWebhookCnCallbackTest::test_wechatpay_valid_callback_calls_processor_and_returns_success_ack`
- evidence on current branch: expected HTTP 200, got HTTP 400; `签名异常: 微信签名为空`
- baseline verification: the exact same test also fails on clean `origin/main`
- baseline commit: `c87d9bc11f4e1cf90e60c06660b472e8afeb10a0`
- why external: BE-02 diff only touches payload digest idempotency service/test, runtime-freeze scope evidence, and ledger; failure is in the WeChatPay CN callback signature chain
- follow-up recommendation: create a sidecar PR or issue to repair the WeChatPay CN callback fixture/header/signature test harness

## Repository rule impact note
No content authority, publishing workflow, CMS ownership, or runtime content behavior changed.

## Rollback notes
Revert this PR to remove the digest mismatch guard, the idempotency regression tests, and the BE-02 runtime-freeze classifier evidence.