### PR TITLE
docs(seo-intel): add MBTI IndexNow 24h review

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-mbti-02-24h-review.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-mbti-02-24h-review.v1.json
@@ -1,0 +1,124 @@
+{
+  "schema_version": "v1",
+  "task": "SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW",
+  "final_decision": "search_channel_live_mbti_02_24h_review_completed_stable_ready_for_fix_02_prod_preflight",
+  "review_window_started_at": "2026-05-24T15:57:41+08:00",
+  "live_submission_time": "2026-05-23T13:18:45+08:00",
+  "elapsed_hours": 26.65,
+  "queue_item_id": 2,
+  "target_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "queue_item_state": {
+    "exists": true,
+    "id": 2,
+    "batch_id": 2,
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "locale": "en",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "source_authority": "scale_catalog",
+    "page_entity_type": "test_detail",
+    "entity_type": "test_detail",
+    "entity_id": "mbti-personality-test-16-personality-types",
+    "eligibility_state": "eligible",
+    "indexability_state": "indexable",
+    "claim_boundary_state": "claim_safe",
+    "private_flow": false,
+    "approved_by": "codex",
+    "approved_at": "2026-05-23T13:18:44+08:00",
+    "updated_at": "2026-05-23T13:18:45+08:00"
+  },
+  "event_state": {
+    "required_events_present": true,
+    "event_counts": {
+      "queue_item_planned": 1,
+      "live_submission_approved": 1,
+      "live_submission_response": 1
+    },
+    "live_submission_response": {
+      "endpoint_host": "api.indexnow.org",
+      "http_status": 200,
+      "submission_status": "accepted",
+      "exception_class": null
+    }
+  },
+  "duplicate_detected": false,
+  "retry_anomaly_detected": false,
+  "gate_state": {
+    "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED": false,
+    "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED": false,
+    "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED": false,
+    "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED": false
+  },
+  "public_url_status": {
+    "head_status": 200,
+    "get_status": 200,
+    "content_type": "text/html; charset=utf-8",
+    "target_url_returned_without_redirect": true,
+    "private_flow_leak_detected": false,
+    "target_slug_stale": false
+  },
+  "canonical_status": {
+    "canonical_href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "matches_target_url": true
+  },
+  "robots_status": {
+    "robots_content": "index, follow",
+    "index_follow_safe": true,
+    "noindex_detected": false
+  },
+  "issue_queue_summary": {
+    "table_available": true,
+    "high_or_critical_count_for_url_since_live": 0,
+    "specific_risk_count_for_url": 0,
+    "private_flow_leak_issue_detected": false,
+    "forbidden_authority_issue_detected": false,
+    "claim_unsafe_issue_detected": false,
+    "duplicate_search_channel_issue_detected": false
+  },
+  "ops_seo_visibility": {
+    "checked": false,
+    "status": "sidecar_not_blocking",
+    "reason": "Authenticated browser /ops/seo read-model inspection was not performed in this PR; production DB read-only queue evidence was available and sufficient for the technical review."
+  },
+  "crawler_aggregate_summary": {
+    "checked": true,
+    "aggregate_table_available": false,
+    "bot_family_signal_present": false,
+    "rows": [],
+    "indexing_inference_made": false
+  },
+  "external_search_visibility_observation": {
+    "checked": false,
+    "status": "not_checked_by_scope",
+    "observation_only": true
+  },
+  "indexing_claim_made": false,
+  "ranking_claim_made": false,
+  "live_submission_attempted": false,
+  "external_api_call_attempted": false,
+  "enqueue_attempted": false,
+  "cms_mutation_attempted": false,
+  "url_truth_write_attempted": false,
+  "sitemap_mutation_attempted": false,
+  "llms_mutation_attempted": false,
+  "sidecars": [
+    {
+      "id": "ops_seo_visibility_not_checked",
+      "severity": "info",
+      "summary": "Authenticated /ops/seo browser verification was not performed; do not block the 24h review because read-only DB evidence confirmed the queue state."
+    },
+    {
+      "id": "crawler_aggregate_table_unavailable",
+      "severity": "info",
+      "summary": "seo_crawler_log_daily_aggregates was not available in production at review time, so crawler observation remains unavailable and no indexing inference was made."
+    },
+    {
+      "id": "related_article_slug_observation",
+      "severity": "info",
+      "summary": "The public HTML contains a related article link with mbti-personality-test-science-vs-pseudoscience, but the target URL itself returned 200 with the exact expected canonical."
+    }
+  ],
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT"
+}

--- a/backend/docs/seo/search-channel-live-mbti-02-24h-review.md
+++ b/backend/docs/seo/search-channel-live-mbti-02-24h-review.md
@@ -1,0 +1,164 @@
+# SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW
+
+## 1. Executive Summary
+The 24h technical review window was met and the EN MBTI IndexNow canary remains stable.
+
+Final decision:
+
+`search_channel_live_mbti_02_24h_review_completed_stable_ready_for_fix_02_prod_preflight`
+
+No production writes, no live URL submission, no external search API calls, no enqueue, no CMS mutation, no URL Truth write, no sitemap mutation, and no llms mutation were attempted during this review.
+
+IndexNow `accepted` is recorded only as the provider accepting a URL update signal. It is not proof of indexing or ranking.
+
+## 2. Review Window Verification
+- Original live submission time: `2026-05-23T13:18:45+08:00`
+- Earliest allowed review time: `2026-05-24T13:20:00+08:00`
+- Review check time: `2026-05-24T15:57:41+08:00`
+- Elapsed time: `26.65` hours
+
+The review was started after the required 24h gate.
+
+## 3. Queue Item State
+Read-only production DB verification confirmed queue item `2` still exists and still matches the target canary:
+
+- URL: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- channel: `indexnow`
+- approval_state: `approved`
+- execution_state: `submitted`
+- source_authority: `scale_catalog`
+- page_entity_type: `test_detail`
+- private_flow: `false`
+- claim_boundary_state: `claim_safe`
+- indexability_state: `indexable`
+
+## 4. Event / Response State
+Read-only production DB verification confirmed the expected event trail for queue item `2`:
+
+- `queue_item_planned`: `1`
+- `live_submission_approved`: `1`
+- `live_submission_response`: `1`
+
+The recorded `live_submission_response` payload still contains:
+
+- endpoint_host: `api.indexnow.org`
+- http_status: `200`
+- submission_status: `accepted`
+- exception_class: `null`
+
+## 5. Gate State
+Read-only production config verification confirmed all relevant gates remain closed:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false`
+
+## 6. Duplicate / Retry Check
+No duplicate or retry anomaly was detected.
+
+- Duplicate queue rows for the same URL/channel: only queue item `2`
+- `live_submission_response` events for queue item `2`: `1`
+- bulk/retry event count since the live submission: `0`
+
+## 7. Public URL Runtime Check
+Public URL verification returned HTTP `200` for:
+
+`https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+
+HTML metadata check:
+
+- canonical: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- robots: `index, follow`
+- no `noindex` detected
+- no private-flow marker detected
+- target URL returned without redirect
+
+Sidecar: the HTML contains a related article link using `mbti-personality-test-science-vs-pseudoscience`, but the reviewed target URL itself is not stale and its canonical is exact.
+
+## 8. Issue Queue Check
+Read-only `seo_issue_queue` checks found:
+
+- high/critical issues for the target URL since live submission: `0`
+- private-flow leak issues for the target URL: `0`
+- forbidden-authority issues for the target URL: `0`
+- claim-unsafe issues for the target URL: `0`
+- duplicate search-channel issues for the target URL: `0`
+
+## 9. /ops/seo Visibility
+Authenticated browser `/ops/seo` verification was not performed in this PR.
+
+This is recorded as a non-blocking sidecar because the read-only production DB checks confirmed the queue item state and event trail directly.
+
+## 10. Crawler Aggregate Observation
+Crawler aggregate observation was not available.
+
+Production table availability check:
+
+- `seo_crawler_log_daily_aggregates`: unavailable
+
+No raw Nginx access logs were read, tailed, or parsed. No crawler observation was used as proof of indexing.
+
+## 11. External Search Visibility Observation
+External search visibility was not checked.
+
+No GSC, Baidu, Bing, 360, Sogou, Shenma, IndexNow live endpoint, or search-result proof path was called. No indexing or ranking claim is made.
+
+## 12. Ledger Reconciliation
+This PR registers `SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW` in the PR train manifest/state.
+
+Scoped ledger reconciliation was also needed for `SEARCH-CHANNEL-LIVE-MBTI-02`: the state ledger had drifted to PR `#1637`, which belongs to an unrelated career rollout PR. GitHub verification shows the correct `SEARCH-CHANNEL-LIVE-MBTI-02` PR is `#1606`, merged at `2026-05-23T05:28:44Z` with merge commit `2106b8146d3193c38c90bd68bb7dd67cd3e10147`.
+
+## 13. Validation
+Required local validation commands for this PR:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=SeoIntelSearchChannelLiveMbti02TwentyFourHourReview --no-ansi
+php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+
+cd /Users/rainie/Desktop/GitHub/fap-api
+python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-02-24h-review.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 - <<'PY'
+import yaml, pathlib
+yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+PY
+git diff --check
+git diff --cached --check
+```
+
+## 14. PR / Merge Result
+Pending for this PR.
+
+## 15. Sidecar Issues
+- `ops_seo_visibility_not_checked`: authenticated `/ops/seo` browser verification was not performed; DB evidence was used instead.
+- `crawler_aggregate_table_unavailable`: crawler aggregate table was unavailable in production.
+- `related_article_slug_observation`: target page HTML contains a related article link with a stale-looking slug, but the target canonical is exact.
+
+## 16. What Was Not Done
+- No deployment.
+- No production env edit.
+- No migration.
+- No collector write.
+- No scheduler activation.
+- No queue enqueue.
+- No URL submission.
+- No IndexNow live endpoint call.
+- No GSC, Baidu, Bing, 360, Sogou, or Shenma call.
+- No raw Nginx access log read.
+- No CMS mutation.
+- No article publication.
+- No internal link creation.
+- No URL Truth, `seo_urls`, or `seo_url_entities` write.
+- No Metabase exposure.
+- No email, DM, Digital PR outreach, or Outlook draft edit.
+- No indexing or ranking claim.
+
+## 17. Final Decision
+`search_channel_live_mbti_02_24h_review_completed_stable_ready_for_fix_02_prod_preflight`
+
+## 18. Next Task
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti02TwentyFourHourReviewTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti02TwentyFourHourReviewTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLiveMbti02TwentyFourHourReviewTest extends TestCase
+{
+    public function test_generated_artifact_exists_and_locks_twenty_four_hour_review_boundary(): void
+    {
+        $path = base_path('docs/seo/generated/search-channel-live-mbti-02-24h-review.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(2, $payload['queue_item_id']);
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $payload['target_url']
+        );
+        $this->assertSame('indexnow', $payload['channel']);
+        $this->assertFalse((bool) $payload['live_submission_attempted']);
+        $this->assertFalse((bool) $payload['external_api_call_attempted']);
+        $this->assertFalse((bool) $payload['enqueue_attempted']);
+        $this->assertFalse((bool) $payload['cms_mutation_attempted']);
+        $this->assertFalse((bool) $payload['url_truth_write_attempted']);
+        $this->assertFalse((bool) $payload['indexing_claim_made']);
+        $this->assertFalse((bool) $payload['ranking_claim_made']);
+
+        $this->assertSame([
+            'SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED' => false,
+            'SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED' => false,
+            'SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED' => false,
+            'SEO_INTEL_INDEXNOW_LIVE_API_ENABLED' => false,
+        ], $payload['gate_state']);
+
+        $this->assertNotEmpty($payload['final_decision'] ?? null);
+        $this->assertNotEmpty($payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15471,12 +15471,12 @@
     "SEARCH-CHANNEL-LIVE-MBTI-02": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-mbti-02",
-      "status": "local_validated",
+      "status": "merged",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-MBTI-01"
       ],
-      "commit_sha": "98fbb92997bf72fc1c7983b275220c3bbcd8212b",
-      "pr_url": "https://github.com/fermatmind/fap-api/pull/1637",
+      "commit_sha": "2106b8146d3193c38c90bd68bb7dd67cd3e10147",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1606",
       "checks": {
         "production_operation": {
           "approval_phrase": "passed: exact SEARCH-CHANNEL-LIVE-02 approval phrase present before any live gate change",
@@ -15502,7 +15502,7 @@
         "github": {}
       },
       "failure_reason": null,
-      "merged_at": "2026-05-24T00:09:01Z",
+      "merged_at": "2026-05-23T05:28:44Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
@@ -15530,6 +15530,73 @@
           "at": "2026-05-23T13:28:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1606 for SEARCH-CHANNEL-LIVE-MBTI-02 from codex/search-channel-live-mbti-02. The production operation stayed bounded to queue item 2 only; queue write remained disabled, and all three live gates were closed again immediately after submission."
+        },
+        {
+          "at": "2026-05-24T15:57:41+08:00",
+          "status": "ledger_reconciled",
+          "summary": "Reconciled light ledger pollution: SEARCH-CHANNEL-LIVE-MBTI-02 belongs to PR #1606 merged at 2026-05-23T05:28:44Z with merge commit 2106b8146d3193c38c90bd68bb7dd67cd3e10147, not unrelated PR #1637."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-mbti-02-24h-review",
+      "status": "local_validated",
+      "depends_on": [
+        "SEARCH-CHANNEL-LIVE-MBTI-02"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_read_only": {
+          "time_gate": "passed: review started at 2026-05-24T15:57:41+08:00 after required 2026-05-24T13:20:00+08:00 gate",
+          "queue_item_state": "passed: queue_item_id=2 exists with exact EN MBTI URL, channel=indexnow, approval_state=approved, execution_state=submitted, source_authority=scale_catalog, page_entity_type=test_detail, private_flow=false, claim_boundary_state=claim_safe",
+          "event_state": "passed: queue_item_planned=1, live_submission_approved=1, live_submission_response=1 with endpoint_host=api.indexnow.org http_status=200 submission_status=accepted",
+          "duplicate_retry_check": "passed: duplicate URL/channel rows only include queue_item_id=2; no bulk/retry events since live submission; no retry storm detected",
+          "gate_state": "passed: queue write, live submission, external API, and IndexNow live API gates are all false",
+          "public_url_runtime": "passed: public URL returned HTTP 200 with exact canonical and robots index, follow; no noindex or private-flow marker detected",
+          "issue_queue": "passed: no high/critical or private/forbidden/claim/duplicate issue rows tied to the target URL",
+          "ops_seo_visibility": "sidecar: authenticated /ops/seo browser verification was not performed; direct read-only DB queue evidence was available",
+          "crawler_aggregate": "sidecar: seo_crawler_log_daily_aggregates unavailable; no raw logs read and no indexing inference made",
+          "external_search_visibility": "not_checked_by_scope: no external search engines or IndexNow live endpoint called"
+        },
+        "local": {
+          "focused_twenty_four_hour_review_test": "passed_with_warnings: php artisan test --filter=SeoIntelSearchChannelLiveMbti02TwentyFourHourReview --no-ansi exited 0 with 1 warning and 14 assertions",
+          "search_channel_queue_suite": "passed_with_warnings: php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi exited 0 with 24 warnings and 214 assertions",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3518 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-02-24h-review.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT",
+      "history": [
+        {
+          "at": "2026-05-24T15:53:16+08:00",
+          "status": "time_gate_passed",
+          "summary": "Current time was after the required 2026-05-24T13:20:00+08:00 review window, so the 24h read-only review could start."
+        },
+        {
+          "at": "2026-05-24T15:57:41+08:00",
+          "status": "in_progress",
+          "summary": "Production read-only checks confirmed queue item 2 remains approved/submitted, expected events are present, gates are closed, the public URL is indexable with exact canonical, and no target URL issue queue regression was found."
+        },
+        {
+          "at": "2026-05-24T16:06:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused 24h review artifact test, Search Channel Queue suite, route list, Pint, JSON/YAML parsing, and diff checks exited 0. PHPUnit emitted warnings in the focused and queue suites, but assertions passed and no current-scope failure was observed."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15541,12 +15541,12 @@
     "SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-mbti-02-24h-review",
-      "status": "local_validated",
+      "status": "pr_open",
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-MBTI-02"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "e445c06d9d1479f63461f1c5a778a28eb82a7484",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1646",
       "checks": {
         "production_read_only": {
           "time_gate": "passed: review started at 2026-05-24T15:57:41+08:00 after required 2026-05-24T13:20:00+08:00 gate",
@@ -15597,6 +15597,11 @@
           "at": "2026-05-24T16:06:00+08:00",
           "status": "local_checks_passed",
           "summary": "Focused 24h review artifact test, Search Channel Queue suite, route list, Pint, JSON/YAML parsing, and diff checks exited 0. PHPUnit emitted warnings in the focused and queue suites, but assertions passed and no current-scope failure was observed."
+        },
+        {
+          "at": "2026-05-24T16:09:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1646 for SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW from codex/search-channel-live-mbti-02-24h-review."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10792,6 +10792,49 @@ prs:
     scheduler_activation: false
     next_task: SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW
 
+  - id: SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-LIVE-MBTI-02
+    branch: codex/search-channel-live-mbti-02-24h-review
+    base: main
+    title: "docs(seo-intel): add MBTI IndexNow 24h review"
+    name: "24h review for EN MBTI IndexNow live submission"
+    train_scope: search_channel_live_mbti
+    risk_level: read_only_production_verification
+    type: docs_generated_test
+    scope:
+      - Perform a read-only 24h technical review of queue item 2 after the EN MBTI IndexNow live canary.
+      - Verify queue item state, event state, duplicate/retry state, gates, public URL canonical/robots, and issue queue safety.
+      - Record crawler aggregate and /ops/seo visibility only when safely available; make no indexing or ranking claim.
+    allowed_paths:
+      - backend/docs/seo/search-channel-live-mbti-02-24h-review.md
+      - backend/docs/seo/generated/search-channel-live-mbti-02-24h-review.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveMbti02TwentyFourHourReviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, deploy files, production env, migrations, scheduler, collectors, CMS content, articles, internal links, URL Truth, seo_urls, seo_url_entities, sitemap, llms, Metabase, emails, DMs, Digital PR outreach, Outlook drafts, pSEO, business DB / Tencent RDS / Node2 DB, or frontend fallback authority.
+      - Enqueue Search Channel items, submit URLs, call IndexNow live endpoint, call GSC/Baidu/Bing/360/Sogou/Shenma, read raw Nginx access logs, mutate production data, or claim IndexNow acceptance as indexing/ranking proof.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLiveMbti02TwentyFourHourReview --no-ansi
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-02-24h-review.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT
+
   - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW docs report and generated JSON artifact.
- Added a focused feature test locking the generated review artifact boundary.
- Registered the scoped PR-train manifest/state entry and reconciled SEARCH-CHANNEL-LIVE-MBTI-02 ledger pollution to the correct merged PR #1606.

## Why
The EN MBTI IndexNow canary reached the 24h review window. This PR records read-only production verification without submitting URLs, calling external search APIs, enqueueing, or mutating production data.

## Validation
- cd backend && php artisan test --filter=SeoIntelSearchChannelLiveMbti02TwentyFourHourReview --no-ansi
- cd backend && php artisan test --filter=SeoIntelSearchChannelQueue --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/search-channel-live-mbti-02-24h-review.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

Note: the two PHPUnit commands exited 0 with warnings while all assertions passed. No current-scope failure was observed.

## Deferred
- No /ops/seo authenticated browser read-model verification.
- No crawler aggregate observation because the production aggregate table was unavailable.
- No external search visibility check; no indexing or ranking claim is made.

## What was not done
No deploy, no production env edit, no migration, no collector write, no scheduler activation, no enqueue, no live submission, no IndexNow live endpoint call, no GSC/Baidu/Bing/360/Sogou/Shenma call, no raw Nginx log read, no CMS mutation, no URL Truth write, no sitemap or llms mutation.