### PR TITLE
docs(seo-intel): add MBTI URL Truth production preflight

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-preflight.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-preflight.v1.json
@@ -1,0 +1,264 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-fix-02-prod-preflight.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT",
+  "executed_at": "2026-05-24T17:05:26+08:00",
+  "final_decision": "mbti_action_01b_fix_02_prod_preflight_blocked_www_conflict_requires_cleanup_plan",
+  "deployed_sha": "0338122739bbe4fd9645943d4f08372a3881f560",
+  "fix_02_merge_commit": "dcc557ce959a2d282d9199ee37da0e70f1102ef0",
+  "deployment_verification": {
+    "fix_02_merge_commit_is_ancestor_of_deployed_sha": true,
+    "verification_mode": "read_only_ssh",
+    "production_write_performed": false
+  },
+  "expected_candidate_urls": [
+    "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "test_detail_dry_run": {
+    "command": "php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=test_detail --limit=100",
+    "status": "success",
+    "dry_run": true,
+    "no_write": true,
+    "writes_attempted": false,
+    "writes_committed": false,
+    "external_calls_attempted": false,
+    "items_seen": 22,
+    "planned_url_count": 16,
+    "source_authority_breakdown": {
+      "scale_catalog": 16
+    },
+    "expected_candidate": {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "present": true,
+      "locale": "zh-CN",
+      "page_entity_type": "test_detail",
+      "source_authority": "scale_catalog",
+      "indexability_state": "indexable",
+      "is_private_flow": false,
+      "entity_id_or_slug": "mbti-personality-test-16-personality-types",
+      "canonical_url_hash": "2722a8bf117d0c118950152a512d58a1f2776d2e1370c11b42b538aed8ad2f89"
+    }
+  },
+  "research_report_dry_run": {
+    "command": "php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=research_report --limit=100",
+    "status": "success",
+    "dry_run": true,
+    "no_write": true,
+    "writes_attempted": false,
+    "writes_committed": false,
+    "external_calls_attempted": false,
+    "items_seen": 22,
+    "planned_url_count": 2,
+    "source_authority_breakdown": {
+      "backend_cms": 2
+    },
+    "expected_candidates": [
+      {
+        "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "present": true,
+        "locale": "en",
+        "page_entity_type": "research_report",
+        "source_authority": "backend_cms",
+        "indexability_state": "indexable",
+        "is_private_flow": false,
+        "entity_id_or_slug": "mbti-personality-types-salary-turnover-report",
+        "canonical_url_hash": "9061110e085cdf81786b4c0f20213f4d00f62e64ffdeb5dd4e4da4432b00e1cb"
+      },
+      {
+        "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "present": true,
+        "locale": "zh-CN",
+        "page_entity_type": "research_report",
+        "source_authority": "backend_cms",
+        "indexability_state": "indexable",
+        "is_private_flow": false,
+        "entity_id_or_slug": "mbti-personality-types-salary-turnover-report",
+        "canonical_url_hash": "e1fb2fc682ebc7bfc8369b20094edcf10bd6cb1109e2022741a906883a19d825"
+      }
+    ]
+  },
+  "expected_apex_candidates_present": {
+    "all_present": true,
+    "zh_mbti_test_apex": true,
+    "en_research_apex": true,
+    "zh_research_apex": true
+  },
+  "www_candidates_present": {
+    "backend_authority_dry_run_www_candidates_present": false,
+    "persisted_research_www_rows_present": true,
+    "persisted_research_www_rows": [
+      "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+    ]
+  },
+  "persisted_state": {
+    "tables": {
+      "seo_urls": true,
+      "seo_url_entities": true
+    },
+    "targets": {
+      "zh_mbti_apex": {
+        "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "seo_url_present": false,
+        "seo_url_entities_count": 0
+      },
+      "en_research_apex": {
+        "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "seo_url_present": false,
+        "seo_url_entities_count": 0
+      },
+      "zh_research_apex": {
+        "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "seo_url_present": false,
+        "seo_url_entities_count": 0
+      },
+      "en_research_www": {
+        "url": "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "seo_url_present": true,
+        "seo_url_entities_count": 1,
+        "page_entity_type": "research_report",
+        "locale": "en",
+        "source_authority": "backend_cms",
+        "indexability_state": "indexable",
+        "is_private_flow": false,
+        "last_seen_at": "2026-05-20 12:30:28"
+      },
+      "zh_research_www": {
+        "url": "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "seo_url_present": true,
+        "seo_url_entities_count": 1,
+        "page_entity_type": "research_report",
+        "locale": "zh-CN",
+        "source_authority": "backend_cms",
+        "indexability_state": "indexable",
+        "is_private_flow": false,
+        "last_seen_at": "2026-05-20 12:30:28"
+      }
+    }
+  },
+  "conflict_risk": {
+    "level": "blocking_for_full_three_url_bounded_write",
+    "would_writing_apex_research_rows_create_duplicate_canonical_clusters": true,
+    "old_www_research_rows_still_active": true,
+    "collector_upsert_by_canonical_url_hash_prevents_replacing_www_with_apex": true,
+    "cleanup_or_retire_step_needed": true,
+    "code_fix_needed_before_write": false,
+    "config_fix_needed_before_write": false,
+    "notes": [
+      "The backend-authoritative dry-run emits apex Research candidates.",
+      "Persisted production URL Truth still has active www Research rows and no apex Research rows.",
+      "Apex and www URLs have different canonical_url_hash values, so updateOrInsert will not replace the www rows."
+    ]
+  },
+  "search_channel_current_state": {
+    "overall_dry_run": {
+      "status": "success",
+      "dry_run": true,
+      "no_write": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "enqueue_attempted": false,
+      "enqueue_committed": false,
+      "external_calls_attempted": false,
+      "search_submission_attempted": false,
+      "candidate_count": 9,
+      "eligible_count": 9,
+      "planned_queue_count": 7,
+      "duplicate_detected": true,
+      "write_gate_enabled": false
+    },
+    "target_url_filters": {
+      "zh_mbti_apex": {
+        "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "status": "blocked",
+        "eligible": false,
+        "issues": [
+          "canonical_url_not_found"
+        ]
+      },
+      "en_research_apex": {
+        "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "status": "blocked",
+        "eligible": false,
+        "issues": [
+          "canonical_url_not_found"
+        ]
+      },
+      "zh_research_apex": {
+        "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "status": "blocked",
+        "eligible": false,
+        "issues": [
+          "canonical_url_not_found"
+        ]
+      },
+      "en_research_www": {
+        "url": "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "status": "success",
+        "eligible": true,
+        "issues": []
+      },
+      "zh_research_www": {
+        "url": "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "status": "success",
+        "eligible": true,
+        "issues": []
+      }
+    }
+  },
+  "public_runtime_state": {
+    "authority_boundary": "runtime_confirmation_only_not_url_truth",
+    "checks": [
+      {
+        "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "http_status": 200,
+        "canonical": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "robots_meta": "index, follow",
+        "noindex_present": false
+      },
+      {
+        "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "http_status": 200,
+        "canonical": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "robots_meta": "index, follow",
+        "noindex_present": false
+      },
+      {
+        "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "http_status": 200,
+        "canonical": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "robots_meta": "index, follow",
+        "noindex_present": false
+      },
+      {
+        "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-rate-report",
+        "http_status": 404,
+        "canonical": null,
+        "stale_indexable_page_present": false
+      },
+      {
+        "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-rate-report",
+        "http_status": 404,
+        "canonical": null,
+        "stale_indexable_page_present": false
+      }
+    ]
+  },
+  "bounded_write_recommendation": {
+    "safe_for_full_requested_three_url_write": false,
+    "safe_for_zh_mbti_apex_write_in_isolation": true,
+    "research_apex_write_requires_www_cleanup_plan_first": true,
+    "should_later_write_include_only_new_apex_rows": false,
+    "should_old_www_research_rows_be_retired_or_marked_superseded": true,
+    "sitemap_exposure_remains_separate_later_task": true,
+    "recommendation": "Create a scoped cleanup/retirement plan for old www Research URL Truth rows before the bounded apex Research write."
+  },
+  "no_write_performed": true,
+  "no_enqueue": true,
+  "no_submission": true,
+  "no_external_api_call": true,
+  "no_cms_mutation": true,
+  "sitemap_llms_authority_used": false,
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-preflight.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-preflight.md
@@ -1,0 +1,210 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT
+
+## Executive summary
+
+Production read-only verification confirms that the deployed backend release includes
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-02` and that the backend-authoritative URL Truth
+collector dry-run now emits the expected apex candidates for:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+No production URL Truth write was performed. No Search Channel enqueue or live
+submission was performed. No external search API was called.
+
+The preflight is blocked for the full three-URL bounded write because production
+`seo_urls` still contains active `www.fermatmind.com` Research rows while the new
+apex Research rows are absent. The current URL Truth writer upserts by
+`canonical_url_hash + locale`, so a later apex write would add new Research rows
+without replacing or retiring the old `www` rows. That creates duplicate canonical
+cluster risk unless a cleanup or retirement path is defined first.
+
+## Deployment verification
+
+- Deployed backend SHA observed by read-only SSH: `0338122739bbe4fd9645943d4f08372a3881f560`
+- FIX-02 merge commit: `dcc557ce959a2d282d9199ee37da0e70f1102ef0`
+- Verification result: the deployed SHA contains the FIX-02 merge commit.
+- Latest merged backend PRs observed locally included PR #1646 and PR #1645 after FIX-02.
+
+## URL Truth dry-run results
+
+### `test_detail`
+
+Command:
+
+```bash
+php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=test_detail --limit=100
+```
+
+Result:
+
+- status: `success`
+- dry_run: `true`
+- writes_attempted: `false`
+- writes_committed: `false`
+- external_calls_attempted: `false`
+- items_seen: `22`
+- planned_url_count: `16`
+- expected ZH MBTI candidate: present
+- `www.fermatmind.com` candidates: none observed in backend-authoritative source
+- stale `turnover-rate-report` candidates: none observed
+
+Expected ZH MBTI candidate:
+
+```text
+https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types
+```
+
+Observed properties:
+
+- locale: `zh-CN`
+- page_entity_type: `test_detail`
+- source_authority: `scale_catalog`
+- indexability_state: `indexable`
+- is_private_flow: `false`
+
+### `research_report`
+
+Command:
+
+```bash
+php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=research_report --limit=100
+```
+
+Result:
+
+- status: `success`
+- dry_run: `true`
+- writes_attempted: `false`
+- writes_committed: `false`
+- external_calls_attempted: `false`
+- items_seen: `22`
+- planned_url_count: `2`
+- expected EN Research apex candidate: present
+- expected ZH Research apex candidate: present
+- `www.fermatmind.com` candidates: none observed in backend-authoritative source
+- stale `turnover-rate-report` candidates: none observed
+
+Expected Research candidates:
+
+```text
+https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report
+https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report
+```
+
+Observed properties:
+
+- page_entity_type: `research_report`
+- source_authority: `backend_cms`
+- indexability_state: `indexable`
+- is_private_flow: `false`
+
+## Persisted URL Truth state
+
+Read-only production `seo_urls` / `seo_url_entities` checks showed:
+
+| Target | `seo_urls` | `seo_url_entities` | Notes |
+| --- | --- | --- | --- |
+| ZH MBTI apex | absent | 0 | Candidate exists in dry-run; persisted row not yet written. |
+| EN Research apex | absent | 0 | Candidate exists in dry-run; persisted row not yet written. |
+| ZH Research apex | absent | 0 | Candidate exists in dry-run; persisted row not yet written. |
+| EN Research www | present | 1 | Active `research_report`, `backend_cms`, `indexable`. |
+| ZH Research www | present | 1 | Active `research_report`, `backend_cms`, `indexable`. |
+
+The old `www` Research rows were last seen on `2026-05-20 12:30:28` and remain
+active indexable URL Truth rows.
+
+## Conflict risk
+
+Conflict risk is blocking for the full three-URL bounded write.
+
+- Writing the ZH MBTI apex row appears safe in isolation because no persisted ZH
+  MBTI apex row currently exists and no old `www` MBTI row was identified in this
+  target check.
+- Writing Research apex rows without a cleanup step would create parallel active
+  URL Truth rows for the same Research entity family.
+- The URL Truth writer uses `canonical_url_hash + locale` for `seo_urls` upsert.
+  Since apex and `www` URLs hash differently, apex writes do not replace the old
+  `www` rows.
+- A cleanup, retire, or superseded-canonical plan is needed before writing the
+  Research apex rows.
+
+## Search Channel current state
+
+Command:
+
+```bash
+php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=50
+```
+
+Result:
+
+- status: `success`
+- dry_run: `true`
+- no_write: `true`
+- writes_attempted: `false`
+- writes_committed: `false`
+- enqueue_attempted: `false`
+- enqueue_committed: `false`
+- external_calls_attempted: `false`
+- search_submission_attempted: `false`
+- candidate_count: `9`
+- eligible_count: `9`
+- planned_queue_count: `7`
+- duplicate_detected: `true`
+- write_gate_enabled: `false`
+
+Canonical URL filtered dry-runs showed:
+
+| URL | Current Search Channel state |
+| --- | --- |
+| ZH MBTI apex | `canonical_url_not_found`; not currently eligible until URL Truth row exists. |
+| EN Research apex | `canonical_url_not_found`; not currently eligible until URL Truth row exists. |
+| ZH Research apex | `canonical_url_not_found`; not currently eligible until URL Truth row exists. |
+| EN Research www | eligible as an old persisted URL Truth row. |
+| ZH Research www | eligible as an old persisted URL Truth row. |
+
+No enqueue was performed.
+
+## Public runtime checks
+
+Public runtime checks were used only as runtime confirmation, not as URL Truth.
+
+| URL | HTTP | Canonical | Robots | Notes |
+| --- | --- | --- | --- | --- |
+| `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types` | 200 | exact apex URL | `index, follow` | no `noindex` observed |
+| `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report` | 200 | exact apex URL | `index, follow` | no `noindex` observed |
+| `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report` | 200 | exact apex URL | `index, follow` | no `noindex` observed |
+| stale EN `turnover-rate-report` URL | 404 | none | not indexable response | no live indexable stale page observed |
+| stale ZH `turnover-rate-report` URL | 404 | none | not indexable response | no live indexable stale page observed |
+
+## Bounded write recommendation
+
+Do not run the requested full bounded production URL Truth write for all three
+targets yet.
+
+Recommended next step:
+
+1. Define a scoped Research `www` URL Truth cleanup or retirement plan.
+2. Keep Search Channel write gates closed.
+3. After the cleanup path is approved, perform a human-approved bounded write for
+   the ZH MBTI apex row and Research apex rows.
+4. Re-run Search Channel dry-run after URL Truth write evidence exists.
+
+## Safety boundary
+
+- no_write_performed: `true`
+- no_enqueue: `true`
+- no_submission: `true`
+- no_external_api_call: `true`
+- no_cms_mutation: `true`
+- sitemap_llms_authority_used: `false`
+
+## Final decision
+
+`mbti_action_01b_fix_02_prod_preflight_blocked_www_conflict_requires_cleanup_plan`
+
+## Next task
+
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdPreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdPreflightTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix02ProdPreflightTest extends TestCase
+{
+    #[Test]
+    public function generated_json_exists_and_parses(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'seo-growth-mbti-action-01b-fix-02-prod-preflight.v1',
+            $artifact['schema_version'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT',
+            $artifact['task'] ?? null
+        );
+    }
+
+    #[Test]
+    public function safety_flags_lock_no_write_no_enqueue_no_submission_no_external_api_and_no_cms_mutation(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['no_write_performed'] ?? false);
+        $this->assertTrue($artifact['no_enqueue'] ?? false);
+        $this->assertTrue($artifact['no_submission'] ?? false);
+        $this->assertTrue($artifact['no_external_api_call'] ?? false);
+        $this->assertTrue($artifact['no_cms_mutation'] ?? false);
+        $this->assertFalse($artifact['sitemap_llms_authority_used'] ?? true);
+    }
+
+    #[Test]
+    public function expected_candidate_urls_are_included(): void
+    {
+        $urls = $this->artifact()['expected_candidate_urls'] ?? [];
+
+        foreach ([
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $url) {
+            $this->assertContains($url, $urls);
+        }
+    }
+
+    #[Test]
+    public function final_decision_and_next_task_are_present(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertIsString($artifact['final_decision'] ?? null);
+        $this->assertNotSame('', $artifact['final_decision'] ?? '');
+        $this->assertIsString($artifact['next_task'] ?? null);
+        $this->assertNotSame('', $artifact['next_task'] ?? '');
+    }
+
+    #[Test]
+    public function report_records_expected_candidate_presence_and_persisted_www_conflict(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['expected_apex_candidates_present']['all_present'] ?? false);
+        $this->assertFalse($artifact['www_candidates_present']['backend_authority_dry_run_www_candidates_present'] ?? true);
+        $this->assertTrue($artifact['www_candidates_present']['persisted_research_www_rows_present'] ?? false);
+        $this->assertTrue($artifact['conflict_risk']['cleanup_or_retire_step_needed'] ?? false);
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-preflight.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15657,6 +15657,64 @@
         }
       ]
     },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-preflight",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-FIX-02"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_read_only": {
+          "deployment_verification": "passed: deployed backend SHA 0338122739bbe4fd9645943d4f08372a3881f560 contains FIX-02 merge commit dcc557ce959a2d282d9199ee37da0e70f1102ef0",
+          "test_detail_dry_run": "passed: production seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=test_detail returned status=success, writes_attempted=false, writes_committed=false, planned_url_count=16, and emitted the ZH MBTI apex candidate from scale_catalog",
+          "research_report_dry_run": "passed: production seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --page-type=research_report returned status=success, writes_attempted=false, writes_committed=false, planned_url_count=2, and emitted EN/ZH Research apex candidates from backend_cms",
+          "persisted_state": "blocking_conflict: ZH MBTI apex and EN/ZH Research apex rows are absent, while old EN/ZH Research www rows remain active indexable URL Truth rows with entity rows",
+          "search_channel_dry_run": "passed_no_write: production seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow returned no writes, no enqueue, no submission, and target apex URL filters are not currently eligible because canonical_url_not_found",
+          "public_runtime": "passed_runtime_only: target apex URLs returned HTTP 200 with exact apex canonical and index, follow; stale turnover-rate-report URLs returned 404; runtime was not used as URL Truth",
+          "final_decision": "mbti_action_01b_fix_02_prod_preflight_blocked_www_conflict_requires_cleanup_plan"
+        },
+        "local": {
+          "focused_prod_preflight_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdPreflight --no-ansi (5 tests, 29 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3519 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-preflight.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": "Production preflight report found active old www Research URL Truth rows. A full three-URL bounded apex write would create duplicate Research canonical clusters because URL Truth upsert keys use canonical_url_hash + locale.",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN",
+      "history": [
+        {
+          "at": "2026-05-24T17:05:26+08:00",
+          "status": "in_progress",
+          "summary": "Started production read-only preflight on codex/seo-growth-mbti-action-01b-fix-02-prod-preflight from latest main. Scope is limited to production no-write evidence, docs/generated report, focused test, and authorized PR-train metadata."
+        },
+        {
+          "at": "2026-05-24T17:05:26+08:00",
+          "status": "production_read_only_evidence_collected",
+          "summary": "Read-only SSH, collector dry-runs, persisted URL Truth SELECTs, Search Channel dry-run/no-write, and safe public runtime checks completed without production writes, enqueue, submission, CMS mutation, external search API call, or sitemap/llms authority use."
+        },
+        {
+          "at": "2026-05-24T17:12:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff checks exited 0 for the scoped production preflight report PR."
+        }
+      ]
+    },
     "OPS-SECURITY-STORAGE-PATH-SAFETY-01": {
       "repo": "fap-api",
       "branch": "codex/ops-security-storage-path-safety-01",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6574,7 +6574,7 @@
       "branch": "codex/repair-explicit-rollout-batch-ledger-authority-1",
       "title": "fix(api): honor explicit rollout batch ledger authority",
       "name": "Repair explicit rollout batch ledger authority after 800 apply verification",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "REPAIR-PROGRESSIVE-READINESS-SOFTWARE-MANUAL-HOLD-EXCLUSION-1"
       ],
@@ -15664,8 +15664,8 @@
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-FIX-02"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "20ce10e9459696c23770db0528f538e4793c7f9f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1647",
       "checks": {
         "production_read_only": {
           "deployment_verification": "passed: deployed backend SHA 0338122739bbe4fd9645943d4f08372a3881f560 contains FIX-02 merge commit dcc557ce959a2d282d9199ee37da0e70f1102ef0",
@@ -15712,6 +15712,11 @@
           "at": "2026-05-24T17:12:00+08:00",
           "status": "local_checks_passed",
           "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff checks exited 0 for the scoped production preflight report PR."
+        },
+        {
+          "at": "2026-05-24T17:16:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1647 for SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT from codex/seo-growth-mbti-action-01b-fix-02-prod-preflight."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10923,6 +10923,51 @@ prs:
     scheduler_activation: false
     next_task: BACKEND-DEPLOY-READINESS
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-FIX-02
+    branch: codex/seo-growth-mbti-action-01b-fix-02-prod-preflight
+    base: main
+    title: "docs(seo-intel): add MBTI URL Truth production preflight"
+    name: "Production URL Truth dry-run and bounded write preflight for ZH MBTI and Research apex alignment"
+    train_scope: seo_growth_mbti_action
+    risk_level: production_read_only_preflight
+    type: docs_generated_test
+    scope:
+      - Verify production deployment includes FIX-02 using read-only SSH evidence.
+      - Run production URL Truth collector dry-runs with --dry-run --no-write for test_detail and research_report.
+      - Verify persisted production URL Truth state for ZH MBTI apex, EN/ZH Research apex, and old EN/ZH Research www rows using read-only queries.
+      - Run Search Channel dry-run/no-write evidence and public runtime checks without treating runtime, sitemap, llms, crawler logs, or search responses as URL Truth.
+      - Record whether a later bounded production URL Truth write is safe.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-preflight.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-preflight.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdPreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, runtime services, migrations, production env/deploy files, CMS content, articles, internal links, sitemap, llms, crawler log readers, scheduler, collector write behavior, Search Channel write behavior, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform production URL Truth writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, or raw Nginx access log reads.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, or local copies as URL Truth.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdPreflight --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-preflight.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed

- Adds the production read-only/no-write preflight report for `SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT`.
- Adds generated JSON evidence for deployed FIX-02 SHA verification, URL Truth dry-runs, persisted URL Truth state, Search Channel dry-runs, public runtime checks, and bounded write recommendation.
- Adds a focused artifact contract test.
- Adds the authorized PR train manifest/state entry for this scoped task only.

## Why

The production collector dry-run now emits the expected ZH MBTI and EN/ZH Research apex candidates, but persisted production URL Truth still has active old Research `www` rows. Because URL Truth upsert keys use `canonical_url_hash + locale`, a direct apex Research write would create duplicate Research canonical clusters instead of replacing `www` rows. This PR records that preflight evidence without writing production data.

## Validation

- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdPreflight --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-preflight.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred

- No production URL Truth write.
- No Search Channel enqueue or live submission.
- No external search API calls.
- No CMS mutation, internal link mutation, deployment, scheduler activation, or migration.
- Research `www` URL Truth cleanup/retirement is deferred to the next scoped task.
