### PR TITLE
docs(seo-intel): add Research www canonical cleanup plan

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1.json
@@ -1,0 +1,155 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN",
+  "final_decision": "mbti_action_01b_fix_02_www_cleanup_plan_merged_ready_for_cleanup_runtime",
+  "stale_www_urls": [
+    "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "replacement_apex_urls": [
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "additional_safe_write_candidates": [
+    "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types"
+  ],
+  "already_submitted_urls_excluded": [
+    {
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "queue_item_id": 2,
+      "channel": "indexnow",
+      "state": "approved/submitted",
+      "must_not_modify": true
+    }
+  ],
+  "cleanup_strategy": {
+    "selected_option": "C",
+    "name": "future_scoped_cleanup_runtime_command",
+    "manual_db_update_rejected": true,
+    "manual_db_delete_rejected": true,
+    "blind_apex_insert_rejected": true,
+    "leave_www_active_while_adding_apex_rejected": true,
+    "search_channel_enqueue_rejected": true
+  },
+  "cleanup_strategy_reason": "Existing schema can express Search Channel exclusion and entity mapping demotion, but no existing official bounded runtime performs exact stale-row validation, apex candidate validation, old-row retirement, apex write, entity remap, and audit artifact emission atomically. A runtime command is required before production write execution.",
+  "entity_mapping_plan": {
+    "old_www_rows": {
+      "action": "mark seo_url_entities authority_status as superseded_canonical",
+      "preserve_old_canonical_url_hash": true,
+      "preserve_locale_page_type_entity_slug": true,
+      "metadata_json_not_retirement_truth": true
+    },
+    "replacement_research_apex_rows": {
+      "entity_source": "research_reports",
+      "authority_status": "published_approved",
+      "entity_id_or_slug": "mbti-personality-types-salary-turnover-report"
+    },
+    "zh_mbti_apex_row": {
+      "entity_source": "scales_registry",
+      "authority_status": "observed",
+      "entity_id_or_slug": "mbti-personality-test-16-personality-types"
+    }
+  },
+  "search_channel_exclusion_plan": {
+    "mechanism": "set old www seo_urls.indexability_state to a reserved non-indexable state such as superseded_canonical",
+    "current_eligibility_rule": "SearchChannelQueueEligibilityEvaluator blocks any row where indexability_state is not indexable",
+    "required_post_cleanup_dry_run_checks": [
+      "old EN Research www URL blocked",
+      "old ZH Research www URL blocked",
+      "EN Research apex URL present and eligible",
+      "ZH Research apex URL present and eligible",
+      "ZH MBTI apex URL present and eligible",
+      "no Research www URL planned for IndexNow",
+      "EN MBTI queue item 2 remains untouched"
+    ]
+  },
+  "duplicate_cluster_prevention": {
+    "canonical_url_hash_identity_preserved": true,
+    "apex_and_www_hashes_must_not_be_active_together": true,
+    "fail_if_old_www_active_and_apex_exists": true,
+    "fail_if_unexpected_research_row_exists_for_same_entity_family": true,
+    "write_order": [
+      "validate exact old rows",
+      "validate replacement apex candidates",
+      "retire old www rows",
+      "write apex rows",
+      "verify Search Channel exclusion and apex eligibility"
+    ]
+  },
+  "idempotency_plan": {
+    "exact_url_bounded": true,
+    "already_superseded_old_rows_are_verified_not_rewritten": true,
+    "already_present_matching_apex_rows_are_verified_not_duplicated": true,
+    "conflicting_apex_rows_fail_closed": true,
+    "en_mbti_already_submitted_url_excluded": true
+  },
+  "rollback_plan": {
+    "transaction_required": true,
+    "manual_db_rollback_rejected": true,
+    "partial_failure_rolls_back": true,
+    "post_commit_recovery_requires_separate_human_approved_forward_fix": true
+  },
+  "audit_trail_plan": {
+    "runtime_must_emit_audit_artifact": true,
+    "include_old_hashes": true,
+    "include_replacement_hashes": true,
+    "include_entity_mapping_before_after": true,
+    "include_no_enqueue_no_submission_flags": true,
+    "include_operator_approval_phrase": true
+  },
+  "existing_schema_support": {
+    "seo_urls_columns": [
+      "canonical_url_hash",
+      "canonical_url",
+      "locale",
+      "page_entity_type",
+      "entity_id_or_slug",
+      "cluster",
+      "source_authority",
+      "indexability_state",
+      "lastmod_at",
+      "lastmod_source",
+      "is_private_flow",
+      "first_seen_at",
+      "last_seen_at",
+      "metadata_json"
+    ],
+    "seo_url_entities_columns": [
+      "canonical_url_hash",
+      "locale",
+      "page_entity_type",
+      "entity_id_or_slug",
+      "entity_source",
+      "authority_status",
+      "source_updated_at",
+      "attributes_json"
+    ],
+    "supports_search_channel_exclusion_without_migration": true,
+    "supports_entity_mapping_demotion_without_migration": true,
+    "supports_atomic_cleanup_without_new_runtime": false,
+    "metadata_json_must_not_be_only_retirement_truth": true
+  },
+  "runtime_command_required": true,
+  "schema_change_required": false,
+  "production_write_performed": false,
+  "collector_write_performed": false,
+  "enqueue_performed": false,
+  "live_submission_performed": false,
+  "external_api_call_performed": false,
+  "cms_mutation_performed": false,
+  "sitemap_llms_authority_used": false,
+  "frontend_fallback_authority_used": false,
+  "future_human_approval_phrase": "I explicitly approve bounded URL Truth cleanup/write for MBTI FIX-02: retire old Research www rows, write Research apex rows, and write ZH MBTI apex row. Do not enqueue Search Channel items. Do not submit URLs.",
+  "no_go_conditions": [
+    "old Research www row is missing or does not match expected active state",
+    "replacement apex candidate is missing from backend-authoritative dry-run",
+    "apex row already exists but conflicts with expected authority fields",
+    "Search Channel has active old Research www queue items",
+    "EN MBTI already-submitted URL is included in the write set",
+    "write gate would enqueue Search Channel items",
+    "live submission gate is enabled",
+    "runtime command would use sitemap/llms/frontend/crawler/search response as URL Truth",
+    "production state cannot be read clearly"
+  ],
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-RUNTIME"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.md
@@ -1,0 +1,202 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN
+
+## Executive summary
+
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT` confirmed that production
+backend-authoritative dry-runs now emit apex Research URL Truth candidates, but
+persisted production URL Truth still contains active stale Research `www` rows.
+
+This plan selects Option C: add a future scoped runtime cleanup command before
+any bounded production URL Truth write. A manual DB update, manual delete, blind
+apex insert, or Search Channel enqueue is not acceptable.
+
+Existing schema can support the cleanup outcome without a migration:
+
+- `seo_urls.indexability_state` can make stale rows Search Channel-ineligible
+  because the planner only treats `indexability_state=indexable` as eligible.
+- `seo_url_entities.authority_status` can mark old entity mappings as
+  superseded while apex rows receive fresh authoritative mappings.
+- `metadata_json` may carry audit detail, but must not be the only source of
+  retirement truth.
+
+Existing runtime does not yet provide a safe official cleanup path that validates
+old rows, validates replacement apex candidates, retires old rows, writes apex
+rows, updates entity mappings, and emits an audit artifact in one bounded flow.
+That runtime command is required before production write execution.
+
+## Current conflict
+
+Stale Research `www` URL Truth rows:
+
+- `https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+Replacement Research apex URL Truth rows:
+
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+Additional safe write candidate from FIX-02:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+Already submitted and excluded from this cleanup/write:
+
+- `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- queue item: `2`
+- channel: `indexnow`
+- state: approved/submitted
+
+## Recommended cleanup strategy
+
+Selected strategy: Option C, future scoped runtime command.
+
+The command must:
+
+1. Validate exact stale `www` Research rows by canonical URL, locale, page type,
+   source authority, indexability state, private-flow flag, and entity slug.
+2. Validate exact replacement apex Research candidates from the backend
+   authority collector dry-run.
+3. Validate exact ZH MBTI apex candidate from the backend authority collector
+   dry-run.
+4. Refuse execution if the EN MBTI already-submitted URL is included.
+5. Refuse execution if Search Channel has active queue items for old Research
+   `www` URLs.
+6. In one transaction, mark old `www` `seo_urls` rows non-eligible with a
+   reserved non-indexable state such as `superseded_canonical`.
+7. In the same transaction, mark old `seo_url_entities.authority_status` as
+   `superseded_canonical`.
+8. Write or upsert the apex Research rows and ZH MBTI apex row from validated
+   backend-authoritative candidates only.
+9. Recreate or upsert apex `seo_url_entities` mappings for the replacement rows.
+10. Emit a local/report audit artifact summarizing old hashes, replacement
+    hashes, entity mappings, no-write dry-run evidence, and final write result.
+11. Never enqueue Search Channel items and never submit URLs.
+
+## Why this is safest
+
+Option A is incomplete because existing schema can exclude stale rows from Search
+Channel, but there is no existing official bounded runtime that performs the
+retire-and-replace flow safely.
+
+Option B is unsafe because updating `canonical_url` in place would fight the
+existing `canonical_url_hash + locale` identity model and risks corrupting
+idempotency/audit history.
+
+Option D is unnecessary for the immediate cleanup because the current string
+fields can express non-eligibility and entity demotion. A later schema enhancement
+for explicit lifecycle state may still be useful, but it is not required before
+the first safe cleanup runtime.
+
+## Entity mapping plan
+
+Old `www` `seo_url_entities` rows must not remain authoritative after cleanup.
+They should be updated to `authority_status=superseded_canonical`, preserving the
+old `canonical_url_hash`, locale, page type, entity slug, and source metadata for
+audit.
+
+Replacement apex rows must receive fresh `seo_url_entities` mappings with:
+
+- page_entity_type: `research_report`
+- entity_id_or_slug: `mbti-personality-types-salary-turnover-report`
+- entity_source: `research_reports`
+- authority_status: `published_approved`
+
+The ZH MBTI apex row must receive:
+
+- page_entity_type: `test_detail`
+- entity_id_or_slug: `mbti-personality-test-16-personality-types`
+- entity_source: `scales_registry`
+- authority_status: `observed`
+
+## Search Channel exclusion plan
+
+Search Channel eligibility currently rejects any `seo_urls` row where
+`indexability_state !== indexable`. Therefore stale `www` rows must be moved from
+`indexable` to a reserved non-indexable state before or atomically with apex row
+creation.
+
+After cleanup, dry-run checks must prove:
+
+- old EN Research `www` URL is blocked
+- old ZH Research `www` URL is blocked
+- EN Research apex URL is present and eligible
+- ZH Research apex URL is present and eligible
+- ZH MBTI apex URL is present and eligible
+- no Research `www` URL is planned for IndexNow
+- EN MBTI queue item `2` remains untouched
+
+## Idempotency and duplicate prevention
+
+The runtime command must be exact-URL bounded and idempotent:
+
+- If old `www` rows are already `superseded_canonical`, do not demote them again.
+- If replacement apex rows already exist with the expected authoritative state,
+  verify and report them instead of creating duplicates.
+- If both old active `www` rows and apex rows exist, fail closed until the old
+  rows are retired.
+- If any unexpected active Research row exists for the same entity family, fail
+  closed.
+- Never use sitemap, `llms.txt`, fap-web fallback, crawler logs, search engine
+  responses, Digital PR mentions, or local copies as URL Truth.
+
+## Rollback and recovery plan
+
+The future runtime command must support a dry-run preview and produce enough
+audit detail for recovery. If a write partially fails, transaction rollback must
+restore previous `seo_urls` and `seo_url_entities` state.
+
+If post-write verification fails after commit, recovery must be a separate
+human-approved forward fix that either:
+
+- restores old rows to `indexable` only if apex rows are removed or marked
+  non-authoritative, or
+- completes the apex write and keeps old rows superseded.
+
+Manual DB rollback is rejected.
+
+## Production preflight sequence
+
+Before the future write:
+
+1. Verify deployed SHA contains the cleanup runtime command.
+2. Run URL Truth collector dry-run/no-write for `test_detail`.
+3. Run URL Truth collector dry-run/no-write for `research_report`.
+4. Run cleanup command in dry-run/no-write mode for the exact old/replacement
+   URL set.
+5. Verify old Research `www` rows are currently active and not already queued.
+6. Verify replacement apex candidates exist and are claim-safe.
+7. Verify EN MBTI queue item `2` remains approved/submitted and excluded.
+8. Verify Search Channel dry-run still has no enqueue and no submission.
+9. Require exact human approval before write.
+
+## Future human approval phrase
+
+Future phrase only:
+
+```text
+I explicitly approve bounded URL Truth cleanup/write for MBTI FIX-02: retire old Research www rows, write Research apex rows, and write ZH MBTI apex row. Do not enqueue Search Channel items. Do not submit URLs.
+```
+
+## No-go conditions
+
+Stop if any of these are true:
+
+- old Research `www` row is missing or does not match expected active state
+- replacement apex candidate is missing from backend-authoritative dry-run
+- apex row already exists but conflicts with expected authority fields
+- Search Channel has active old Research `www` queue items
+- EN MBTI already-submitted URL is included in the write set
+- write gate would enqueue Search Channel items
+- live submission gate is enabled
+- runtime command would use sitemap/llms/frontend/crawler/search response as
+  URL Truth
+- production state cannot be read clearly
+
+## Final decision
+
+`mbti_action_01b_fix_02_www_cleanup_plan_merged_ready_for_cleanup_runtime`
+
+## Next task
+
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-RUNTIME`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlanTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlanTest extends TestCase
+{
+    #[Test]
+    public function generated_json_exists_and_parses(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1',
+            $artifact['schema_version'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN',
+            $artifact['task'] ?? null
+        );
+    }
+
+    #[Test]
+    public function expected_stale_replacement_and_excluded_urls_are_listed(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertContains(
+            'https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            $artifact['stale_www_urls'] ?? []
+        );
+        $this->assertContains(
+            'https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+            $artifact['stale_www_urls'] ?? []
+        );
+        $this->assertContains(
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            $artifact['replacement_apex_urls'] ?? []
+        );
+        $this->assertContains(
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+            $artifact['replacement_apex_urls'] ?? []
+        );
+        $this->assertContains(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $artifact['additional_safe_write_candidates'] ?? []
+        );
+
+        $excludedUrls = array_column($artifact['already_submitted_urls_excluded'] ?? [], 'url');
+        $this->assertContains(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $excludedUrls
+        );
+    }
+
+    #[Test]
+    public function safety_flags_lock_no_production_write_enqueue_submission_external_api_or_cms_mutation(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertFalse($artifact['production_write_performed'] ?? true);
+        $this->assertFalse($artifact['collector_write_performed'] ?? true);
+        $this->assertFalse($artifact['enqueue_performed'] ?? true);
+        $this->assertFalse($artifact['live_submission_performed'] ?? true);
+        $this->assertFalse($artifact['external_api_call_performed'] ?? true);
+        $this->assertFalse($artifact['cms_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['sitemap_llms_authority_used'] ?? true);
+        $this->assertFalse($artifact['frontend_fallback_authority_used'] ?? true);
+    }
+
+    #[Test]
+    public function cleanup_strategy_duplicate_prevention_approval_phrase_and_next_task_exist(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertNotEmpty($artifact['cleanup_strategy'] ?? []);
+        $this->assertNotEmpty($artifact['duplicate_cluster_prevention'] ?? []);
+        $this->assertIsString($artifact['future_human_approval_phrase'] ?? null);
+        $this->assertNotSame('', $artifact['future_human_approval_phrase'] ?? '');
+        $this->assertIsString($artifact['next_task'] ?? null);
+        $this->assertNotSame('', $artifact['next_task'] ?? '');
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -8606,7 +8606,7 @@
       "depends_on": [
         "REPAIR-DIRECTORY-DETAIL-PENDING-314-1"
       ],
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "train_scope": "career_directory_list_detail_api_authority",
       "risk_level": "medium",
       "title": "fix(api): align directory list with runtime detail authority",
@@ -15717,6 +15717,67 @@
           "at": "2026-05-24T17:16:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1647 for SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT from codex/seo-growth-mbti-action-01b-fix-02-prod-preflight."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-02-www-cleanup-plan",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT"
+      ],
+      "commit_sha": "14749d9e98a613425adcfed2f49c7e7cf86a9388",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1649",
+      "checks": {
+        "local_investigation": {
+          "seo_urls_schema": "seo_urls has canonical_url_hash, canonical_url, locale, page_entity_type, entity_id_or_slug, cluster, source_authority, indexability_state, is_private_flow, metadata_json, and timestamps; no explicit lifecycle/status column exists.",
+          "seo_url_entities_schema": "seo_url_entities has canonical_url_hash, locale, page_entity_type, entity_id_or_slug, entity_source, authority_status, source_updated_at, and attributes_json.",
+          "search_channel_exclusion": "SearchChannelQueueEligibilityEvaluator blocks any row whose indexability_state is not indexable, so stale www rows can be made Search Channel-ineligible without schema change.",
+          "runtime_gap": "Existing UrlTruthInventoryRecordWriter only upserts backend-authoritative records by canonical_url_hash + locale and does not retire stale www rows; a scoped cleanup runtime command is required.",
+          "selected_strategy": "Option C: future scoped cleanup runtime command; schema change not required for the immediate cleanup plan."
+        },
+        "local": {
+          "focused_www_cleanup_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlan --no-ansi (4 tests, 30 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3520 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        },
+        "github": {}
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-RUNTIME",
+      "history": [
+        {
+          "at": "2026-05-24T17:45:00+08:00",
+          "status": "in_progress",
+          "summary": "Started WWW canonical cleanup planning from latest origin/main in an isolated worktree because the primary worktree had unrelated dirty PR-AUDIT-BE-03 changes overlapping docs/codex files."
+        },
+        {
+          "at": "2026-05-24T17:45:00+08:00",
+          "status": "local_investigation_completed",
+          "summary": "Local schema and Search Channel inspection found existing fields can express non-eligibility and entity demotion, but current runtime lacks an official exact retire-and-replace cleanup command."
+        },
+        {
+          "at": "2026-05-24T17:55:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused cleanup plan artifact test, route list, Pint, JSON/YAML parsing, and diff checks exited 0 for the scoped docs/generated/tests PR."
+        },
+        {
+          "at": "2026-05-24T17:59:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1649 for SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN from codex/seo-growth-mbti-action-01b-fix-02-www-cleanup-plan."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10968,6 +10968,50 @@ prs:
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT
+    branch: codex/seo-growth-mbti-action-01b-fix-02-www-cleanup-plan
+    base: main
+    title: "docs(seo-intel): add Research www canonical cleanup plan"
+    name: "Plan safe retirement of stale Research www URL Truth rows"
+    train_scope: seo_growth_mbti_action
+    risk_level: docs_generated_test_only
+    type: docs_generated_test
+    scope:
+      - Define stale Research www URL Truth rows and replacement apex rows for the MBTI FIX-02 cleanup path.
+      - Decide whether existing schema can support safe retirement and whether a future runtime cleanup command or schema change is required.
+      - Define entity mapping handling, Search Channel exclusion, idempotency, rollback, audit, production preflight, no-go conditions, and future human approval phrase.
+      - Do not perform production cleanup, production URL Truth writes, Search Channel enqueue, live submission, runtime implementation, or schema changes.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlanTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, runtime services, migrations, production env/deploy files, CMS content, articles, internal links, sitemap, llms, crawler log readers, scheduler, Search Channel submitter code, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform production URL Truth writes, production collector writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, or raw Nginx access log reads.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, or local copies as URL Truth.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlan --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-RUNTIME
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed

- Adds the cleanup/retirement plan for stale Research `www.fermatmind.com` URL Truth rows before any MBTI FIX-02 bounded production write.
- Adds generated JSON locking the stale `www` URLs, replacement apex URLs, ZH MBTI apex candidate, EN MBTI exclusion, selected cleanup strategy, Search Channel safety, idempotency, rollback, audit requirements, future approval phrase, and next task.
- Adds a focused artifact test for the cleanup plan.
- Adds the authorized PR train manifest/state entry for this scoped PR ID only.

## Why

The prior production no-write preflight confirmed FIX-02 is active and emits the correct apex candidates, but old active Research `www` rows remain in persisted URL Truth. Since the writer upserts by `canonical_url_hash + locale`, directly writing apex Research rows would create duplicate active canonical clusters. This PR defines the safe next step: a future scoped cleanup runtime command, with no schema change required for the immediate cleanup plan.

## Validation

- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlan --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-www-canonical-cleanup-plan.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred

- No production URL Truth write.
- No runtime cleanup command in this PR.
- No migration or schema change.
- No Search Channel enqueue or live submission.
- No external search API calls.
- No CMS mutation, deployment, scheduler activation, internal link mutation, or fap-web changes.
