### PR TITLE
PR-AUDIT-BE-04 queue retry backoff jitter

### DIFF
--- a/backend/app/Jobs/ProcessAttemptSubmissionJob.php
+++ b/backend/app/Jobs/ProcessAttemptSubmissionJob.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Services\Attempts\AttemptSubmissionService;
+use Closure;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -16,14 +17,18 @@ class ProcessAttemptSubmissionJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** @var array<int, int> */
+    private const BASE_BACKOFF = [5, 15, 30];
+
+    private const MAX_BACKOFF_JITTER_SECONDS = 5;
+
+    private static ?Closure $backoffJitterResolver = null;
+
     public int $tries = 3;
 
     public int $timeout = 180;
 
     public bool $failOnTimeout = true;
-
-    /** @var array<int,int> */
-    public array $backoff = [5, 15, 30];
 
     public function __construct(
         public string $submissionId,
@@ -31,6 +36,37 @@ class ProcessAttemptSubmissionJob implements ShouldQueue
         $connection = config('fap.queue.attempt_connection');
         $this->onConnection((is_string($connection) && $connection !== '') ? $connection : (string) config('queue.default'));
         $this->onQueue(config('fap.queue.attempt_queue', 'attempts'));
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return array_values(array_map(
+            fn (int $seconds, int $attemptIndex): int => $seconds + $this->backoffJitterSeconds($seconds, $attemptIndex),
+            self::BASE_BACKOFF,
+            array_keys(self::BASE_BACKOFF),
+        ));
+    }
+
+    /**
+     * @template TReturn
+     *
+     * @param  Closure(int, int): int  $resolver
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public static function withBackoffJitterResolverForTest(Closure $resolver, Closure $callback): mixed
+    {
+        $previous = self::$backoffJitterResolver;
+        self::$backoffJitterResolver = $resolver;
+
+        try {
+            return $callback();
+        } finally {
+            self::$backoffJitterResolver = $previous;
+        }
     }
 
     public function handle(AttemptSubmissionService $service): void
@@ -48,5 +84,20 @@ class ProcessAttemptSubmissionJob implements ShouldQueue
             is_string($this->connection) ? $this->connection : null,
             is_string($this->queue) ? $this->queue : null,
         );
+    }
+
+    private function backoffJitterSeconds(int $baseSeconds, int $attemptIndex): int
+    {
+        $maxJitter = self::MAX_BACKOFF_JITTER_SECONDS;
+        if ($maxJitter <= 0) {
+            return 0;
+        }
+
+        $resolver = self::$backoffJitterResolver;
+        if ($resolver instanceof Closure) {
+            return max(0, min($maxJitter, (int) $resolver($baseSeconds, $attemptIndex)));
+        }
+
+        return random_int(0, $maxJitter);
     }
 }

--- a/backend/tests/Unit/Jobs/ProcessAttemptSubmissionJobTest.php
+++ b/backend/tests/Unit/Jobs/ProcessAttemptSubmissionJobTest.php
@@ -25,4 +25,51 @@ final class ProcessAttemptSubmissionJobTest extends TestCase
         $queueJob = new ProcessAttemptSubmissionJob('submission-queue');
         $this->assertSame('attempts', $queueJob->queue);
     }
+
+    public function test_process_attempt_submission_job_backoff_adds_bounded_jitter(): void
+    {
+        $job = new ProcessAttemptSubmissionJob('submission-jitter');
+
+        $backoff = ProcessAttemptSubmissionJob::withBackoffJitterResolverForTest(
+            static fn (int $baseSeconds, int $attemptIndex): int => [0, 2, 5][$attemptIndex] ?? 0,
+            static fn (): array => $job->backoff(),
+        );
+
+        $this->assertSame([5, 17, 35], $backoff);
+    }
+
+    public function test_process_attempt_submission_job_backoff_jitter_is_clamped_to_safe_bounds(): void
+    {
+        $job = new ProcessAttemptSubmissionJob('submission-clamped-jitter');
+
+        $backoff = ProcessAttemptSubmissionJob::withBackoffJitterResolverForTest(
+            static fn (int $baseSeconds, int $attemptIndex): int => [-10, 999, 1][$attemptIndex] ?? 0,
+            static fn (): array => $job->backoff(),
+        );
+
+        $this->assertSame([5, 20, 31], $backoff);
+        $this->assertSame([5, 15, 30], array_map(
+            static fn (int $seconds, int $index): int => $seconds - [0, 5, 1][$index],
+            $backoff,
+            array_keys($backoff),
+        ));
+    }
+
+    public function test_process_attempt_submission_job_backoff_can_vary_within_bounds(): void
+    {
+        $job = new ProcessAttemptSubmissionJob('submission-variable-jitter');
+
+        $minimumBackoff = ProcessAttemptSubmissionJob::withBackoffJitterResolverForTest(
+            static fn (): int => 0,
+            static fn (): array => $job->backoff(),
+        );
+        $maximumBackoff = ProcessAttemptSubmissionJob::withBackoffJitterResolverForTest(
+            static fn (): int => 5,
+            static fn (): array => $job->backoff(),
+        );
+
+        $this->assertSame([5, 15, 30], $minimumBackoff);
+        $this->assertSame([10, 20, 35], $maximumBackoff);
+        $this->assertNotSame($minimumBackoff, $maximumBackoff);
+    }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1428,6 +1428,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_attempt_submission_queue_jitter(): void
+    {
+        $changed = [
+            'backend/app/Jobs/ProcessAttemptSubmissionJob.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_riasec_measurement_contract_compare_policy_changes(): void
     {
         $changed = [
@@ -2369,6 +2378,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isAttemptSubmissionReliabilityHardeningFile($file)) {
+                continue;
+            }
+
+            if ($this->isAttemptSubmissionQueueJitterFile($file)) {
                 continue;
             }
 
@@ -3695,6 +3708,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isAttemptSubmissionReliabilityHardeningFile(string $file): bool
     {
         return $file === 'backend/app/Services/Attempts/AttemptSubmissionService.php';
+    }
+
+    private function isAttemptSubmissionQueueJitterFile(string $file): bool
+    {
+        return $file === 'backend/app/Jobs/ProcessAttemptSubmissionJob.php';
     }
 
     private function isCommerceTenantRepairCommandFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T10:53:12.300Z",
+  "updated_at": "2026-05-24T10:54:08.907Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17620,12 +17620,12 @@
     "PR-AUDIT-BE-04": {
       "repo": "fap-api",
       "branch": "codex/pr-audit-be-04-queue-jitter",
-      "status": "local_checks_passed_with_queue_sidecar",
+      "status": "pr_opened_github_checks_pending",
       "depends_on": [
         "PR-AUDIT-BE-03"
       ],
-      "pr_url": null,
-      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1651",
+      "commit_sha": "30d553f6adf3217c31355b62139992bab0ca440b",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -17655,6 +17655,10 @@
         "scope_validation": {
           "status": "pass",
           "evidence": "Changed files are confined to ProcessAttemptSubmissionJob jitter logic, deterministic job test, scoped Big Five runtime-freeze classifier evidence, and PR train manifest/state metadata."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR #1651 opened; GitHub checks pending."
         }
       },
       "failure_reason": null,
@@ -17699,9 +17703,14 @@
           "at": "2026-05-24T10:53:12.300Z",
           "status": "scope_validation_passed",
           "summary": "Final uncommitted diff is limited to BE-04 allowed files."
+        },
+        {
+          "at": "2026-05-24T10:54:08.907Z",
+          "status": "pr_opened_github_checks_pending",
+          "summary": "Opened PR #1651 for PR-AUDIT-BE-04. GitHub checks are pending."
         }
       ],
-      "updated_at": "2026-05-24T10:53:12.300Z"
+      "updated_at": "2026-05-24T10:54:08.907Z"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T18:32:00+08:00",
+  "updated_at": "2026-05-24T10:53:12.300Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17517,7 +17517,7 @@
     "PR-AUDIT-BE-03": {
       "repo": "fap-api",
       "branch": "codex/pr-audit-be-03-migration-evidence",
-      "status": "pr_opened_github_checks_pending",
+      "status": "merged",
       "depends_on": [
         "PR-AUDIT-BE-02"
       ],
@@ -17559,12 +17559,27 @@
           ],
           "failed": [],
           "evidence": "GitHub required checks passed on PR #1648 after adding the scoped runtime-freeze classifier evidence for the attempt_quality retirement migration."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "head_sha": "ac79f977b060252b0f4c0bde711643b2069c7380",
+          "passed": [
+            "hygiene",
+            "supply-chain",
+            "Semgrep blocking secrets",
+            "semgrep sarif non-blocking upload",
+            "Semgrep OSS",
+            "verify-mbti-legacy",
+            "verify-mbti-v2"
+          ],
+          "failed": [],
+          "evidence": "GitHub PR #1648 is MERGED and origin/main contains merge commit d18c0cc36a84ce50b823c995e4226b188551b0d0."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-24T09:57:44Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "events": [
         {
@@ -17591,10 +17606,102 @@
           "at": "2026-05-24T09:50:38Z",
           "status": "github_checks_passed_pending_merge",
           "summary": "GitHub required checks passed for PR #1648 on head 4aa43fd17a91dfca4f4b4035e3c77f9862f211dc. Merge state is CLEAN."
+        },
+        {
+          "at": "2026-05-24T10:46:53.618Z",
+          "status": "reconciled_merged",
+          "summary": "Reconciled ledger before PR-AUDIT-BE-04: GitHub PR #1648 is MERGED, origin/main contains merge commit d18c0cc36a84ce50b823c995e4226b188551b0d0, remote branch is deleted, and local cleanup was previously executed."
         }
       ],
-      "updated_at": "2026-05-24T09:50:38Z",
-      "commit_sha": "4aa43fd17a91dfca4f4b4035e3c77f9862f211dc"
+      "updated_at": "2026-05-24T10:46:53.618Z",
+      "commit_sha": "4aa43fd17a91dfca4f4b4035e3c77f9862f211dc",
+      "merge_commit": "d18c0cc36a84ce50b823c995e4226b188551b0d0"
+    },
+    "PR-AUDIT-BE-04": {
+      "repo": "fap-api",
+      "branch": "codex/pr-audit-be-04-queue-jitter",
+      "status": "local_checks_passed_with_queue_sidecar",
+      "depends_on": [
+        "PR-AUDIT-BE-03"
+      ],
+      "pr_url": null,
+      "commit_sha": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR-AUDIT-BE-03 merged as PR #1648 with merge commit d18c0cc36a84ce50b823c995e4226b188551b0d0 and origin/main contains it."
+        },
+        "local": {
+          "status": "passed_with_sidecar",
+          "passed": [
+            "cd backend && php artisan test --filter=ProcessAttemptSubmissionJob",
+            "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|attempt_submission_queue_jitter'",
+            "cd backend && php artisan test --filter=ReprocessPaymentEventJob (No tests found, exit 0)",
+            "cd backend && php artisan test --filter=GenerateReportPdfJob (No tests found, exit 0)",
+            "cd backend && vendor/bin/pint --test app/Jobs/ProcessAttemptSubmissionJob.php tests/Unit/Jobs/ProcessAttemptSubmissionJobTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && bash scripts/ci_verify_mbti.sh",
+            "ruby -e YAML parse docs/codex/pr-train.yaml",
+            "ruby -e JSON parse docs/codex/pr-train-state.json",
+            "git diff --check"
+          ],
+          "failed_sidecar": [
+            {
+              "command": "cd backend && php artisan test --filter=Queue",
+              "summary": "Sidecar only: CareerFirstWaveLaunchTierApiTest and SeoIntelOpsSeoNativeDashboardPanelsTest fail on clean origin/main ea12f9d0a5ff9927487eca9cb4abb0134f1f3b47 with the same unrelated Career/SeoIntel assertions."
+            }
+          ]
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to ProcessAttemptSubmissionJob jitter logic, deterministic job test, scoped Big Five runtime-freeze classifier evidence, and PR train manifest/state metadata."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "source_pr": "PR-AUDIT-BE-04",
+          "repo": "fap-api",
+          "branch": "codex/pr-audit-be-04-queue-jitter",
+          "command_or_check": "php artisan test --filter=Queue",
+          "failing_tests": [
+            "Tests\\Feature\\Career\\CareerFirstWaveLaunchTierApiTest::it exposes a machine readable first wave launch tier summary",
+            "Tests\\Feature\\Career\\CareerFirstWaveLaunchTierApiTest::it exposes candidate rows without turning them into rollout queue actions",
+            "Tests\\Feature\\SeoIntel\\SeoIntelOpsSeoNativeDashboardPanelsTest::blade renders issue and queue detail panels with safe columns only"
+          ],
+          "evidence": "Current branch broad Queue filter: 2 failed, 126 passed. Clean origin/main exact baseline: 3 failed, 1 passed with the same Career count assertions and missing issue queue detail panel string.",
+          "baseline_verification": "Exact failing test files also fail on clean origin/main",
+          "baseline_commit": "ea12f9d0a5ff9927487eca9cb4abb0134f1f3b47",
+          "why_external_to_current_pr": "BE-04 diff only touches ProcessAttemptSubmissionJob retry backoff jitter, deterministic unit tests, runtime-freeze classifier evidence, and train metadata; failures are in Career first-wave launch-tier API fixtures and SeoIntel Ops dashboard Blade panel text.",
+          "impact_on_current_pr": "Targeted ProcessAttemptSubmissionJob backoff tests, runtime-freeze evidence, route list, Pint, and ci_verify_mbti pass. Broad Queue filter has unrelated legacy Career/SeoIntel failures.",
+          "owner": "backend/career and backend/seo-intel",
+          "follow_up_recommendation": "Create sidecar PRs/issues to repair Career first-wave launch tier fixture/count expectations and SeoIntel native dashboard panel contract text.",
+          "required_checks_status": "pending until PR checks complete",
+          "scope_validation_status": "pending until final scope validation",
+          "continue_train_decision": "allowed only if GitHub required checks are green"
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-05-24T10:46:53.618Z",
+          "status": "in_progress",
+          "summary": "Initialized PR-AUDIT-BE-04 for bounded jitter on ProcessAttemptSubmissionJob retry backoff from latest main."
+        },
+        {
+          "at": "2026-05-24T10:52:55.533Z",
+          "status": "local_checks_passed_with_queue_sidecar",
+          "summary": "Targeted BE-04 checks, route list, Pint, ci_verify_mbti, YAML/JSON parse, and git diff check passed. Broad Queue filter has unrelated Career/SeoIntel failures reproduced on clean origin/main and recorded as sidecar."
+        },
+        {
+          "at": "2026-05-24T10:53:12.300Z",
+          "status": "scope_validation_passed",
+          "summary": "Final uncommitted diff is limited to BE-04 allowed files."
+        }
+      ],
+      "updated_at": "2026-05-24T10:53:12.300Z"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6602,6 +6602,45 @@ prs:
     human_review_required: false
     production_approval_required: false
 
+  - id: PR-AUDIT-BE-04
+    repo: fap-api
+    depends_on: [PR-AUDIT-BE-03]
+    branch: codex/pr-audit-be-04-queue-jitter
+    base: main
+    title: "PR-AUDIT-BE-04 queue retry backoff jitter"
+    train_scope: prr_audit_remediation
+    risk_level: medium_queue_resilience
+    findings: [M-BE-QUEUE-01]
+    allowed_paths:
+      - backend/app/Jobs/ProcessAttemptSubmissionJob.php
+      - backend/tests/Unit/Jobs/ProcessAttemptSubmissionJobTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add bounded jitter to ProcessAttemptSubmissionJob retry backoff.
+      - Keep tries, timeout, retry_after, queue names, and worker semantics unchanged.
+      - Add deterministic tests for jitter bounds and variability without relying on real randomness.
+      - Do not create new queue workers, change scheduler/supervisor, or alter payment/report state machines.
+    validation:
+      - cd backend && php artisan test --filter=Queue
+      - cd backend && php artisan test --filter=ProcessAttemptSubmissionJob
+      - cd backend && php artisan test --filter=ReprocessPaymentEventJob
+      - cd backend && php artisan test --filter=GenerateReportPdfJob
+      - cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|attempt_submission_queue_jitter'
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'
+      - ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: false
+    production_approval_required: false
+
   - id: OPS-CI-CODESCAN-API-02
     repo: fap-api
     depends_on: []


### PR DESCRIPTION
## PR id
PR-AUDIT-BE-04

## Repo / branch
- repo: fap-api
- branch: codex/pr-audit-be-04-queue-jitter

## Audit risk addressed
- M-BE-QUEUE-01

## What changed
- Replaced the fixed `ProcessAttemptSubmissionJob` `$backoff` property with a Laravel `backoff()` method that returns the existing base schedule plus bounded jitter.
- Kept `tries`, `timeout`, connection, queue name, worker, scheduler, and business processing behavior unchanged.
- Added deterministic unit coverage for jitter bounds, clamping, and variability without relying on real randomness.
- Added scoped Big Five runtime-freeze classifier evidence for this queue-only job change.
- Added PR-AUDIT-BE-04 manifest/state entries and reconciled PR-AUDIT-BE-03 merged state.

## Do not confirmation
- Did not create queue workers.
- Did not change supervisor, scheduler, production deploy, env, or secrets.
- Did not change payment/report/order state machines.
- Did not modify frontend or CMS authority.

## Changed files
- `backend/app/Jobs/ProcessAttemptSubmissionJob.php`
- `backend/tests/Unit/Jobs/ProcessAttemptSubmissionJobTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `docs/codex/pr-train.yaml`
- `docs/codex/pr-train-state.json`

## Validation
Passed:
- `cd backend && php artisan test --filter=ProcessAttemptSubmissionJob`
- `cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|attempt_submission_queue_jitter'`
- `cd backend && php artisan test --filter=ReprocessPaymentEventJob` (No tests found, exit 0)
- `cd backend && php artisan test --filter=GenerateReportPdfJob` (No tests found, exit 0)
- `cd backend && vendor/bin/pint --test app/Jobs/ProcessAttemptSubmissionJob.php tests/Unit/Jobs/ProcessAttemptSubmissionJobTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'`
- `ruby -e 'require "json"; JSON.parse(File.read("docs/codex/pr-train-state.json")); puts "json ok"'`
- `git diff --check`
- `git diff --cached --check`

## Sidecar blockers
`cd backend && php artisan test --filter=Queue` failed in unrelated Career/SeoIntel tests. Exact failing test files also fail on clean `origin/main` at `ea12f9d0a5ff9927487eca9cb4abb0134f1f3b47`, so this is not introduced by BE-04.

Failing baseline paths:
- `Tests\Feature\Career\CareerFirstWaveLaunchTierApiTest`
- `Tests\Feature\SeoIntel\SeoIntelOpsSeoNativeDashboardPanelsTest`

Follow-up recommendation: repair Career first-wave launch tier fixture/count expectations and SeoIntel native dashboard panel contract text in separate sidecar PRs/issues.

## Scope validation
Changed files are confined to BE-04 allowed files: queue backoff logic, deterministic job tests, runtime-freeze classifier evidence, and PR train metadata.

## Rollback notes
Reverting this PR restores the prior fixed `[5, 15, 30]` attempt submission retry backoff behavior.

## Post-merge revalidate plan
- `cd backend && php artisan test --filter=ProcessAttemptSubmissionJob`
- `cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|attempt_submission_queue_jitter'`
- `cd backend && bash scripts/ci_verify_mbti.sh`
