### PR TITLE
docs(seo-intel): add MBTI URL Truth cleanup production write preflight

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT",
+  "final_decision": "blocked_queue_item_2_risk",
+  "deployed_sha": "6bd384e7b1ff5e448db7d82419805e192620b566",
+  "command": "php artisan seo-intel:mbti-url-truth-cleanup --preset=mbti-fix-02-www-research-apex --dry-run --no-write --json",
+  "dry_run_result": {
+    "status": "dry_run_ready",
+    "dry_run": true,
+    "no_write": true,
+    "execute_attempted": false,
+    "writes_committed": false,
+    "old_www_rows_found": 2,
+    "old_www_rows_retired": 0,
+    "apex_research_candidates_found": true,
+    "apex_research_rows_written": 0,
+    "zh_mbti_candidate_found": true,
+    "zh_mbti_row_written": false,
+    "seo_url_entities_updated": 0,
+    "queue_item_2_untouched": false,
+    "search_channel_enqueue_attempted": false,
+    "live_submission_attempted": false,
+    "external_api_call_attempted": false,
+    "sitemap_llms_authority_used": false,
+    "frontend_fallback_authority_used": false,
+    "duplicate_cluster_prevented": true,
+    "issues": []
+  },
+  "planned_retire_www_rows": [
+    "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "planned_write_apex_rows": [
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "planned_write_zh_mbti_row": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+  "already_submitted_urls_excluded": [
+    {
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "queue_item_id": 2,
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    }
+  ],
+  "queue_item_2_untouched": false,
+  "queue_item_2_persisted_unchanged_after_dry_run": true,
+  "queue_item_2_persisted_state_after_dry_run": {
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "locale": "en",
+    "page_entity_type": "test_detail",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "indexability_state": "indexable",
+    "claim_boundary_state": "claim_safe"
+  },
+  "persisted_state_after_dry_run": {
+    "old_www_rows_still_present": true,
+    "old_www_rows_indexable": true,
+    "research_apex_rows_absent": true,
+    "zh_mbti_apex_row_absent": true,
+    "en_mbti_submitted_row_present": true,
+    "state_unchanged_by_dry_run": true
+  },
+  "no_write_performed": true,
+  "production_write_performed": false,
+  "collector_write_performed": false,
+  "enqueue_performed": false,
+  "live_submission_performed": false,
+  "external_api_call_performed": false,
+  "cms_mutation_performed": false,
+  "sitemap_mutation_performed": false,
+  "llms_mutation_performed": false,
+  "fap_web_mutation_performed": false,
+  "frontend_fallback_authority_used": false,
+  "sitemap_llms_authority_used": false,
+  "future_human_approval_phrase": "I explicitly approve bounded URL Truth cleanup/write for MBTI FIX-02: retire old Research www rows, write Research apex rows, and write ZH MBTI apex row. Do not enqueue Search Channel items. Do not submit URLs.",
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.md
@@ -1,0 +1,132 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT
+
+## Purpose
+
+This report records the production no-write preflight for the deployed MBTI URL
+Truth cleanup runtime:
+
+```bash
+php artisan seo-intel:mbti-url-truth-cleanup \
+  --preset=mbti-fix-02-www-research-apex \
+  --dry-run \
+  --no-write \
+  --json
+```
+
+No production URL Truth write, Search Channel enqueue, URL submission, external
+search API call, CMS mutation, sitemap mutation, `llms.txt` mutation, fap-web
+mutation, migration, scheduler activation, or Digital PR action was performed.
+
+## Deployment verification
+
+Production backend reported deployed SHA:
+
+```text
+6bd384e7b1ff5e448db7d82419805e192620b566
+```
+
+The deployed runtime exposes:
+
+```text
+seo-intel:mbti-url-truth-cleanup
+```
+
+This confirms the deployed backend contains the cleanup runtime introduced by
+PR #1650.
+
+## Dry-run result
+
+The production dry-run exited successfully with:
+
+- `dry_run=true`
+- `no_write=true`
+- `writes_committed=false`
+- `search_channel_enqueue_attempted=false`
+- `live_submission_attempted=false`
+- `external_api_call_attempted=false`
+- `old_www_rows_found=2`
+- `apex_research_candidates_found=true`
+- `zh_mbti_candidate_found=true`
+
+The dry-run identified the expected bounded target set, but it emitted:
+
+```text
+queue_item_2_untouched=false
+```
+
+That field does not satisfy the required safety proof for the later bounded
+write. The persisted queue item 2 row was checked read-only after the dry-run and
+remained the already-submitted EN MBTI IndexNow item, but the command output
+itself is the gate for this preflight. The preflight is therefore blocked until
+the dry-run report can prove queue item 2 is untouched.
+
+## Planned changes
+
+The bounded future write may only retire these stale Research `www` rows:
+
+- `https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+The bounded future write may only write these apex Research rows:
+
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+The bounded future write may only add this ZH MBTI row:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+The future write must not touch the already-submitted EN MBTI URL:
+
+- `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- queue item `2`
+- channel `indexnow`
+- execution state `submitted`
+
+## Persisted state after dry-run
+
+Read-only post-dry-run checks found:
+
+- old EN Research `www` row still present and `indexable`
+- old ZH Research `www` row still present and `indexable`
+- EN Research apex row absent
+- ZH Research apex row absent
+- ZH MBTI apex row absent
+- EN MBTI apex row still present
+- queue item 2 still points to EN MBTI, channel `indexnow`, approval state
+  `approved`, execution state `submitted`
+
+This confirms the dry-run did not perform the bounded URL Truth write.
+
+## Safety boundary
+
+The command did not plan or perform:
+
+- Search Channel enqueue
+- live URL submission
+- external search API call
+- CMS mutation
+- sitemap mutation
+- `llms.txt` mutation
+- fap-web mutation
+- frontend fallback authority
+- sitemap or `llms.txt` authority use
+
+Because `queue_item_2_untouched=false` appears in the dry-run output, the later
+bounded write must not proceed from this preflight.
+
+## Future approval phrase
+
+Future phrase only; not authorized by this report:
+
+```text
+I explicitly approve bounded URL Truth cleanup/write for MBTI FIX-02: retire old Research www rows, write Research apex rows, and write ZH MBTI apex row. Do not enqueue Search Channel items. Do not submit URLs.
+```
+
+## Final decision
+
+`blocked_queue_item_2_risk`
+
+## Next task
+
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightTest extends TestCase
+{
+    #[Test]
+    public function generated_json_exists_and_parses(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1',
+            $artifact['schema_version'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT',
+            $artifact['task'] ?? null
+        );
+    }
+
+    #[Test]
+    public function safety_flags_lock_no_write_no_production_write_no_enqueue_no_submission_and_no_external_api(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['no_write_performed'] ?? false);
+        $this->assertFalse($artifact['production_write_performed'] ?? true);
+        $this->assertFalse($artifact['enqueue_performed'] ?? true);
+        $this->assertFalse($artifact['live_submission_performed'] ?? true);
+        $this->assertFalse($artifact['external_api_call_performed'] ?? true);
+        $this->assertFalse($artifact['cms_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['sitemap_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['llms_mutation_performed'] ?? true);
+    }
+
+    #[Test]
+    public function planned_old_www_rows_and_research_apex_rows_are_listed(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            'https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $url) {
+            $this->assertContains($url, $artifact['planned_retire_www_rows'] ?? []);
+        }
+
+        foreach ([
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $url) {
+            $this->assertContains($url, $artifact['planned_write_apex_rows'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function planned_zh_mbti_row_and_queue_item_two_status_are_recorded(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $artifact['planned_write_zh_mbti_row'] ?? null
+        );
+        $this->assertFalse($artifact['queue_item_2_untouched'] ?? true);
+        $this->assertTrue($artifact['queue_item_2_persisted_unchanged_after_dry_run'] ?? false);
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $artifact['queue_item_2_persisted_state_after_dry_run']['canonical_url'] ?? null
+        );
+        $this->assertSame('submitted', $artifact['queue_item_2_persisted_state_after_dry_run']['execution_state'] ?? null);
+    }
+
+    #[Test]
+    public function future_approval_final_decision_and_next_task_are_present(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertIsString($artifact['future_human_approval_phrase'] ?? null);
+        $this->assertStringContainsString('Do not enqueue Search Channel items.', $artifact['future_human_approval_phrase']);
+        $this->assertSame('blocked_queue_item_2_risk', $artifact['final_decision'] ?? null);
+        $this->assertIsString($artifact['next_task'] ?? null);
+        $this->assertNotSame('', $artifact['next_task'] ?? '');
+    }
+
+    #[Test]
+    public function dry_run_result_records_fail_closed_no_write_behavior(): void
+    {
+        $dryRun = $this->artifact()['dry_run_result'] ?? [];
+
+        $this->assertTrue($dryRun['dry_run'] ?? false);
+        $this->assertTrue($dryRun['no_write'] ?? false);
+        $this->assertFalse($dryRun['writes_committed'] ?? true);
+        $this->assertFalse($dryRun['search_channel_enqueue_attempted'] ?? true);
+        $this->assertFalse($dryRun['live_submission_attempted'] ?? true);
+        $this->assertFalse($dryRun['external_api_call_attempted'] ?? true);
+        $this->assertTrue($dryRun['apex_research_candidates_found'] ?? false);
+        $this->assertTrue($dryRun['zh_mbti_candidate_found'] ?? false);
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T10:54:08.907Z",
+  "updated_at": "2026-05-24T12:12:00.000Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17711,6 +17711,61 @@
         }
       ],
       "updated_at": "2026-05-24T10:54:08.907Z"
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-write-preflight",
+      "status": "production_read_only_evidence_collected_blocked_queue_item_2_risk",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-RUNTIME"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "production_read_only": {
+          "deployment_verification": "passed: deployed backend SHA 6bd384e7b1ff5e448db7d82419805e192620b566 contains the MBTI URL Truth cleanup runtime from PR #1650.",
+          "command_exists": "passed: production artisan list exposes seo-intel:mbti-url-truth-cleanup.",
+          "dry_run_no_write": "blocked_queue_item_2_risk: command exited 0 with dry_run=true, no_write=true, writes_committed=false, no enqueue, no live submission, and no external API calls, but emitted queue_item_2_untouched=false.",
+          "planned_changes": "passed: dry-run target set contains both old Research www rows, both Research apex replacement rows, and the ZH MBTI apex row.",
+          "persisted_state_after_dry_run": "passed_no_write: old Research www rows remain indexable, Research apex rows are absent, ZH MBTI apex row is absent, and queue item 2 still points to the submitted EN MBTI IndexNow item.",
+          "final_decision": "blocked_queue_item_2_risk"
+        },
+        "local": {
+          "focused_prod_write_preflight_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWritePreflight --no-ansi (6 tests, 44 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3525 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check"
+        }
+      },
+      "failure_reason": "Production dry-run/no-write output did not prove queue item 2 untouched because queue_item_2_untouched=false, even though read-only persisted state after dry-run shows queue item 2 still submitted for EN MBTI. A runtime/reporting safety fix is required before bounded production write approval.",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX",
+      "history": [
+        {
+          "at": "2026-05-24T20:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started production write preflight report PR from latest clean main. Scope is limited to production dry-run/no-write evidence, docs/generated report, focused test, and authorized PR-train metadata."
+        },
+        {
+          "at": "2026-05-24T20:05:00+08:00",
+          "status": "production_read_only_evidence_collected_blocked_queue_item_2_risk",
+          "summary": "Production cleanup command dry-run/no-write emitted the expected bounded target set and no-write flags, but queue_item_2_untouched=false. Persisted queue item 2 remained submitted for EN MBTI after dry-run."
+        },
+        {
+          "at": "2026-05-24T20:12:00+08:00",
+          "status": "local_checks_passed_blocked_preflight_decision",
+          "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff check passed. The report remains blocked_queue_item_2_risk based on production dry-run output."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T12:12:00.000Z",
+  "updated_at": "2026-05-24T12:18:00.000Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17715,12 +17715,12 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-write-preflight",
-      "status": "production_read_only_evidence_collected_blocked_queue_item_2_risk",
+      "status": "pr_open_blocked_queue_item_2_risk",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-RUNTIME"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "b0e1bf8f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1652",
       "checks": {
         "production_read_only": {
           "deployment_verification": "passed: deployed backend SHA 6bd384e7b1ff5e448db7d82419805e192620b566 contains the MBTI URL Truth cleanup runtime from PR #1650.",
@@ -17764,6 +17764,11 @@
           "at": "2026-05-24T20:12:00+08:00",
           "status": "local_checks_passed_blocked_preflight_decision",
           "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff check passed. The report remains blocked_queue_item_2_risk based on production dry-run output."
+        },
+        {
+          "at": "2026-05-24T20:18:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1652 for the production write preflight report. The report documents blocked_queue_item_2_risk and does not authorize a production write."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11142,6 +11142,51 @@ prs:
     scheduler_activation: false
     next_task: BACKEND-DEPLOY-READINESS
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-RUNTIME
+    branch: codex/seo-growth-mbti-action-01b-fix-02-prod-write-preflight
+    base: main
+    title: "docs(seo-intel): add MBTI URL Truth cleanup production write preflight"
+    name: "Production dry-run preflight for MBTI URL Truth cleanup/write"
+    train_scope: seo_growth_mbti_action
+    risk_level: production_read_only_preflight
+    type: docs_generated_test
+    scope:
+      - Confirm production backend contains the deployed MBTI URL Truth cleanup runtime command.
+      - Run production `seo-intel:mbti-url-truth-cleanup` with `--dry-run --no-write --json` only.
+      - Verify the planned old Research www retire set, Research apex write set, and ZH MBTI apex write candidate.
+      - Verify safety boundaries for no production write, no Search Channel enqueue, no live submission, no external API call, no CMS mutation, no sitemap/llms mutation, and no fap-web mutation.
+      - Record whether a later human-approved bounded production write can proceed.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, runtime services, migrations, production env/deploy files, CMS content, articles, internal links, sitemap, llms, crawler log readers, scheduler, Search Channel submitter code, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform production URL Truth writes, production collector writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, or raw Nginx access log reads.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, or local copies as URL Truth.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWritePreflight --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed

- Added the production dry-run/no-write preflight report for `seo-intel:mbti-url-truth-cleanup`.
- Added generated JSON capturing the deployed SHA, dry-run result, planned bounded target set, persisted post-dry-run state, and safety flags.
- Added a focused artifact test for the report.
- Registered the scoped PR train item and ledger state.

## Why

The cleanup runtime is deployed, but the production dry-run output reported `queue_item_2_untouched=false`. The preflight therefore records `blocked_queue_item_2_risk` and does not authorize the bounded URL Truth write.

## Validation

- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWritePreflight --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'`
  `import yaml, pathlib`
  `yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())`
  `PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred

- No production URL Truth write.
- No Search Channel enqueue or live submission.
- No external search API call.
- No CMS, sitemap, llms, fap-web, migration, scheduler, or deploy mutation.
- Follow-up runtime/reporting fix is required before a bounded write can be approved.
