### PR TITLE
fix(seo-intel): verify MBTI cleanup leaves submitted queue item untouched

### DIFF
--- a/backend/app/Services/SeoIntel/MbtiUrlTruthCleanupService.php
+++ b/backend/app/Services/SeoIntel/MbtiUrlTruthCleanupService.php
@@ -28,6 +28,8 @@ final class MbtiUrlTruthCleanupService
 
     private const EN_MBTI_SUBMITTED = 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types';
 
+    private const EN_MBTI_SUBMITTED_QUEUE_ITEM_ID = 2;
+
     /**
      * @return array<string, mixed>
      */
@@ -39,6 +41,7 @@ final class MbtiUrlTruthCleanupService
         $connection = DB::connection($connectionName);
         $queueItem2Before = null;
         $queueItem2After = null;
+        $queueItem2SafetyIssues = [];
 
         $result = $this->baseResult($dryRun, $noWrite, $execute);
 
@@ -100,6 +103,10 @@ final class MbtiUrlTruthCleanupService
 
             if ($queueTableExists) {
                 $queueItem2Before = $this->queueItem2();
+                $queueItem2SafetyIssues = $this->queueItem2SafetyIssues($queueItem2Before);
+                $issues = array_merge($issues, $queueItem2SafetyIssues);
+            } else {
+                $issues[] = 'search_channel_queue_table_missing';
             }
         }
 
@@ -137,13 +144,20 @@ final class MbtiUrlTruthCleanupService
                 $writesCommitted = true;
             });
 
-            if ($queueTableExists) {
-                $queueItem2After = $this->queueItem2();
-            }
+        }
+
+        if ($queueTableExists) {
+            $queueItem2After = $this->queueItem2();
         }
 
         $result['writes_committed'] = $writesCommitted;
-        $result['queue_item_2_untouched'] = $this->queueItemUnchanged($queueItem2Before, $queueItem2After);
+        $result['queue_item_2_untouched'] = $queueItem2SafetyIssues === []
+            && $this->queueItemUnchanged($queueItem2Before, $queueItem2After);
+
+        if (! $result['queue_item_2_untouched']) {
+            $issues[] = 'queue_item_2_changed_or_unverified';
+        }
+
         $result['duplicate_cluster_prevented'] = $this->duplicateClusterPrevented($writeRequested);
 
         return $this->finish(
@@ -182,7 +196,7 @@ final class MbtiUrlTruthCleanupService
             'duplicate_cluster_prevented' => false,
             'idempotency_key' => hash('sha256', self::PRESET.'|'.implode('|', $this->expectedUrls())),
             'issues' => [],
-            'next_task' => 'BACKEND-DEPLOY-READINESS｜Deploy MBTI URL Truth cleanup runtime',
+            'next_task' => 'BACKEND-DEPLOY-READINESS｜Deploy MBTI cleanup queue-item safety fix',
             'targets' => [
                 'stale_www_urls' => [self::EN_RESEARCH_WWW, self::ZH_RESEARCH_WWW],
                 'replacement_apex_urls' => [self::EN_RESEARCH_APEX, self::ZH_RESEARCH_APEX],
@@ -355,10 +369,45 @@ final class MbtiUrlTruthCleanupService
     {
         $row = DB::connection((string) config('seo_intel.connection', 'seo_intel'))
             ->table('seo_search_channel_queue_items')
-            ->where('id', 2)
+            ->where('id', self::EN_MBTI_SUBMITTED_QUEUE_ITEM_ID)
             ->first();
 
         return $row === null ? null : (array) $row;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $queueItem
+     * @return list<string>
+     */
+    private function queueItem2SafetyIssues(?array $queueItem): array
+    {
+        if ($queueItem === null) {
+            return ['queue_item_2_missing'];
+        }
+
+        $issues = [];
+
+        if ((string) ($queueItem['canonical_url'] ?? '') !== self::EN_MBTI_SUBMITTED) {
+            $issues[] = 'queue_item_2_url_mismatch';
+        }
+
+        if ((string) ($queueItem['channel'] ?? '') !== 'indexnow') {
+            $issues[] = 'queue_item_2_channel_mismatch';
+        }
+
+        if ((string) ($queueItem['approval_state'] ?? '') !== 'approved') {
+            $issues[] = 'queue_item_2_approval_state_mismatch';
+        }
+
+        if ((string) ($queueItem['execution_state'] ?? '') !== 'submitted') {
+            $issues[] = 'queue_item_2_execution_state_mismatch';
+        }
+
+        if (in_array((string) ($queueItem['canonical_url'] ?? ''), $this->expectedUrls(), true)) {
+            $issues[] = 'queue_item_2_in_cleanup_target_set';
+        }
+
+        return $issues;
     }
 
     /**
@@ -367,8 +416,8 @@ final class MbtiUrlTruthCleanupService
      */
     private function queueItemUnchanged(?array $before, ?array $after): bool
     {
-        if ($before === null && $after === null) {
-            return true;
+        if ($before === null || $after === null) {
+            return false;
         }
 
         return $before === $after;

--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX",
+  "final_decision": "mbti_action_01b_fix_02_queue_item_2_safety_fix_ready_for_backend_deploy_readiness",
+  "blocked_reason_before_fix": "Production dry-run/no-write correctly planned the bounded MBTI URL Truth cleanup/write target set and performed no writes, but reported queue_item_2_untouched=false even though read-only persisted state showed queue item 2 remained submitted for the EN MBTI IndexNow item.",
+  "queue_item_2_safety_assertion_fixed": true,
+  "queue_item_2_untouched_expected": true,
+  "queue_item_2_expected_state": {
+    "id": 2,
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted"
+  },
+  "blocked_conditions": [
+    "queue_item_2_missing",
+    "queue_item_2_url_mismatch",
+    "queue_item_2_channel_mismatch",
+    "queue_item_2_approval_state_mismatch",
+    "queue_item_2_execution_state_mismatch",
+    "queue_item_2_in_cleanup_target_set",
+    "queue_item_2_changed_or_unverified"
+  ],
+  "production_write_performed": false,
+  "cleanup_execution_performed": false,
+  "enqueue_performed": false,
+  "live_submission_performed": false,
+  "external_api_call_performed": false,
+  "cms_mutation_performed": false,
+  "sitemap_llms_authority_used": false,
+  "frontend_fallback_authority_used": false,
+  "next_task": "BACKEND-DEPLOY-READINESS｜Deploy MBTI cleanup queue-item safety fix"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.md
@@ -1,0 +1,52 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX
+
+## Purpose
+
+This scoped runtime fix corrects the MBTI URL Truth cleanup command's dry-run safety assertion for the already submitted EN MBTI IndexNow queue item.
+
+The production write preflight was blocked because:
+
+- the cleanup dry-run found the correct bounded target set;
+- it reported no production write, no enqueue, no live submission, and no external API call;
+- read-only persisted state showed queue item 2 still unchanged;
+- but the command JSON emitted `queue_item_2_untouched=false`.
+
+## Root Cause
+
+The cleanup service captured the queue item 2 baseline snapshot before a potential write, but the after snapshot was only captured in the execute/write branch. In dry-run/no-write mode the after snapshot remained null, so the before/after comparison reported false even though no queue table mutation was attempted.
+
+The helper also treated a missing queue item as unchanged when both snapshots were null. That was not fail-closed enough for the bounded production write preflight.
+
+## Corrected Safety Assertion
+
+`queue_item_2_untouched=true` now requires all of the following:
+
+- queue item 2 exists;
+- `canonical_url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`;
+- `channel=indexnow`;
+- `approval_state=approved`;
+- `execution_state=submitted`;
+- queue item 2 is not part of the cleanup target set;
+- the before and after snapshots match.
+
+Dry-run/no-write and execute modes both capture an after snapshot. The assertion blocks or reports false when queue item 2 is missing, points to the wrong URL, uses the wrong channel, is not approved/submitted, is part of the cleanup target set, or cannot be verified unchanged.
+
+## Safety Boundary
+
+This PR does not run production cleanup and does not authorize a production write. It does not enqueue Search Channel items, submit URLs, call external APIs, mutate CMS content, edit sitemap or llms outputs, or use fap-web fallback as authority.
+
+The command continues to report:
+
+- `search_channel_enqueue_attempted=false`
+- `live_submission_attempted=false`
+- `external_api_call_attempted=false`
+- `sitemap_llms_authority_used=false`
+- `frontend_fallback_authority_used=false`
+
+## Next Task
+
+After this fix is merged and deployed, the next task is:
+
+`BACKEND-DEPLOY-READINESS｜Deploy MBTI cleanup queue-item safety fix`
+
+The production write preflight should then be rerun before any bounded production cleanup/write approval.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02QueueItem2DryRunSafetyFixTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02QueueItem2DryRunSafetyFixTest.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ResearchReport;
+use App\Services\Scale\ScaleRegistry;
+use App\Services\SeoIntel\MbtiUrlTruthCleanupService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix02QueueItem2DryRunSafetyFixTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const EN_MBTI_URL = 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'app.frontend_url' => 'https://www.fermatmind.com',
+            'seo_intel.public_canonical_host' => 'https://fermatmind.com',
+            'seo_intel.connection' => 'seo_intel',
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+        $this->mockScaleRegistry();
+        $this->seedResearchReports();
+        $this->seedOldWwwRows();
+    }
+
+    #[Test]
+    public function dry_run_reports_queue_item_2_untouched_for_submitted_en_mbti_item(): void
+    {
+        $this->seedSubmittedEnMbtiQueueItem();
+
+        $output = $this->runCleanupCommand();
+
+        $this->assertSame('dry_run_ready', $output['status'] ?? null);
+        $this->assertTrue((bool) ($output['queue_item_2_untouched'] ?? false));
+        $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($output['search_channel_enqueue_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['live_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['external_api_call_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['sitemap_llms_authority_used'] ?? true));
+        $this->assertFalse((bool) ($output['frontend_fallback_authority_used'] ?? true));
+    }
+
+    #[Test]
+    public function dry_run_blocks_when_queue_item_2_is_missing(): void
+    {
+        $output = $this->runCleanupCommand();
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertFalse((bool) ($output['queue_item_2_untouched'] ?? true));
+        $this->assertContains('queue_item_2_missing', $output['issues'] ?? []);
+        $this->assertContains('queue_item_2_changed_or_unverified', $output['issues'] ?? []);
+    }
+
+    #[Test]
+    public function dry_run_blocks_when_queue_item_2_url_mismatches(): void
+    {
+        $this->seedSubmittedEnMbtiQueueItem([
+            'canonical_url' => 'https://fermatmind.com/en/tests/not-mbti',
+        ]);
+
+        $output = $this->runCleanupCommand();
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertFalse((bool) ($output['queue_item_2_untouched'] ?? true));
+        $this->assertContains('queue_item_2_url_mismatch', $output['issues'] ?? []);
+    }
+
+    #[Test]
+    public function dry_run_blocks_when_queue_item_2_channel_mismatches(): void
+    {
+        $this->seedSubmittedEnMbtiQueueItem([
+            'channel' => 'bing',
+        ]);
+
+        $output = $this->runCleanupCommand();
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertFalse((bool) ($output['queue_item_2_untouched'] ?? true));
+        $this->assertContains('queue_item_2_channel_mismatch', $output['issues'] ?? []);
+    }
+
+    #[Test]
+    public function dry_run_blocks_when_queue_item_2_is_inside_cleanup_target_set(): void
+    {
+        $this->seedSubmittedEnMbtiQueueItem([
+            'canonical_url' => 'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            'locale' => 'zh-CN',
+            'url_hash' => hash('sha256', 'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types'),
+        ]);
+
+        $output = $this->runCleanupCommand();
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertFalse((bool) ($output['queue_item_2_untouched'] ?? true));
+        $this->assertContains('queue_item_2_url_mismatch', $output['issues'] ?? []);
+        $this->assertContains('queue_item_2_in_cleanup_target_set', $output['issues'] ?? []);
+    }
+
+    #[Test]
+    public function execute_mode_leaves_submitted_queue_item_2_unchanged(): void
+    {
+        $queueBefore = $this->seedSubmittedEnMbtiQueueItem();
+
+        $output = $this->runCleanupCommand([
+            '--preset' => MbtiUrlTruthCleanupService::PRESET,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame('success', $output['status'] ?? null);
+        $this->assertTrue((bool) ($output['queue_item_2_untouched'] ?? false));
+        $this->assertTrue((bool) ($output['writes_committed'] ?? false));
+        $this->assertFalse((bool) ($output['search_channel_enqueue_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['live_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['external_api_call_attempted'] ?? true));
+        $this->assertEquals($queueBefore, (array) DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', 2)->first());
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    private function runCleanupCommand(array $arguments = [
+        '--preset' => MbtiUrlTruthCleanupService::PRESET,
+        '--dry-run' => true,
+        '--no-write' => true,
+        '--json' => true,
+    ]): array
+    {
+        $exitCode = Artisan::call('seo-intel:mbti-url-truth-cleanup', $arguments);
+        $output = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($output);
+        $this->assertSame(0, $exitCode, (string) json_encode($output, JSON_UNESCAPED_SLASHES));
+
+        return $output;
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 64)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+            $table->unique(['canonical_url_hash', 'locale']);
+        });
+
+        Schema::connection('seo_intel')->create('seo_url_entities', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255);
+            $table->string('entity_source', 64);
+            $table->string('authority_status', 64);
+            $table->timestamp('source_updated_at')->nullable();
+            $table->json('attributes_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function mockScaleRegistry(): void
+    {
+        $registry = Mockery::mock(ScaleRegistry::class);
+        $registry->shouldReceive('listActivePublic')->zeroOrMoreTimes()->with(0)->andReturn([
+            [
+                'code' => 'MBTI',
+                'primary_slug' => 'mbti-personality-test-16-personality-types',
+                'updated_at' => now()->toISOString(),
+                'content_i18n_json' => [
+                    'en' => ['catalog' => ['questions_count' => 93, 'time_minutes' => 12]],
+                    'zh' => ['catalog' => ['questions_count' => 93, 'time_minutes' => 12]],
+                ],
+            ],
+        ]);
+
+        $this->app->instance(ScaleRegistry::class, $registry);
+    }
+
+    private function seedResearchReports(): void
+    {
+        foreach ([['en', '/en/research/mbti-personality-types-salary-turnover-report'], ['zh-CN', '/zh/research/mbti-personality-types-salary-turnover-report']] as [$locale, $path]) {
+            ResearchReport::query()->create([
+                'org_id' => 0,
+                'slug' => 'mbti-personality-types-salary-turnover-report',
+                'locale' => $locale,
+                'title' => 'MBTI salary turnover report',
+                'executive_summary' => 'Directional research summary.',
+                'body_md' => 'Research body.',
+                'research_type' => 'salary_turnover',
+                'methodology' => 'Modeled index methodology.',
+                'sample_disclaimer' => 'Exploratory, non-diagnostic, not hiring advice.',
+                'claim_boundary' => 'No salary guarantee or individual prediction.',
+                'author_name' => 'FermatMind Research',
+                'reviewer_name' => 'FermatMind Review',
+                'references' => [['title' => 'Reference', 'url' => 'https://example.com/reference']],
+                'downloadable_asset_placeholder' => 'Dataset schema blocked for first publish.',
+                'status' => ResearchReport::STATUS_PUBLISHED,
+                'review_state' => ResearchReport::REVIEW_APPROVED,
+                'is_public' => true,
+                'is_indexable' => true,
+                'last_reviewed_at' => now()->subDay(),
+                'published_at' => now()->subHour(),
+                'seo_title' => 'Safe Research Report',
+                'seo_description' => 'Safe Research Report description.',
+                'canonical_path' => $path,
+            ]);
+        }
+    }
+
+    private function seedOldWwwRows(): void
+    {
+        foreach ([
+            ['https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report', 'en'],
+            ['https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report', 'zh-CN'],
+        ] as [$url, $locale]) {
+            $hash = hash('sha256', $url);
+            DB::connection('seo_intel')->table('seo_urls')->insert([
+                'canonical_url_hash' => $hash,
+                'canonical_url' => $url,
+                'locale' => $locale,
+                'page_entity_type' => 'research_report',
+                'entity_id_or_slug' => 'mbti-personality-types-salary-turnover-report',
+                'cluster' => 'research',
+                'source_authority' => 'backend_cms',
+                'indexability_state' => 'indexable',
+                'lastmod_at' => now(),
+                'lastmod_source' => 'research_reports.updated_at',
+                'is_private_flow' => false,
+                'first_seen_at' => now(),
+                'last_seen_at' => now(),
+                'metadata_json' => json_encode(['claim_boundary_state' => 'claim_safe'], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            DB::connection('seo_intel')->table('seo_url_entities')->insert([
+                'canonical_url_hash' => $hash,
+                'locale' => $locale,
+                'page_entity_type' => 'research_report',
+                'entity_id_or_slug' => 'mbti-personality-types-salary-turnover-report',
+                'entity_source' => 'research_reports',
+                'authority_status' => 'published_approved',
+                'source_updated_at' => now(),
+                'attributes_json' => json_encode(['source_authority' => 'backend_cms'], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    /** @param array<string, mixed> $overrides */
+    private function seedSubmittedEnMbtiQueueItem(array $overrides = []): array
+    {
+        $url = (string) ($overrides['canonical_url'] ?? self::EN_MBTI_URL);
+        $row = array_merge([
+            'id' => 2,
+            'batch_id' => null,
+            'canonical_url' => $url,
+            'locale' => 'en',
+            'page_entity_type' => 'test_detail',
+            'entity_type' => 'test_detail',
+            'entity_id' => 'mbti-personality-test-16-personality-types',
+            'source_authority' => 'scale_catalog',
+            'source_table' => 'scales_registry',
+            'channel' => 'indexnow',
+            'eligibility_state' => 'eligible',
+            'approval_state' => 'approved',
+            'execution_state' => 'submitted',
+            'indexability_state' => 'indexable',
+            'claim_boundary_state' => 'claim_safe',
+            'private_flow' => false,
+            'reason_codes' => json_encode([], JSON_THROW_ON_ERROR),
+            'lastmod' => now(),
+            'content_hash' => null,
+            'url_hash' => hash('sha256', $url),
+            'idempotency_key' => hash('sha256', strtolower($url).'|en|indexnow'),
+            'approved_by' => 'human',
+            'approved_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], $overrides);
+
+        DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insert($row);
+
+        return (array) DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', 2)->first();
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -17771,6 +17771,56 @@
           "summary": "Opened PR #1652 for the production write preflight report. The report documents blocked_queue_item_2_risk and does not authorize a production write."
         }
       ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-02-queue-item-2-safety",
+      "status": "pr_open_github_checks_pending",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT"
+      ],
+      "commit_sha": "63b0a0b1",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1653",
+      "checks": {
+        "local": {
+          "focused_queue_item_2_safety_fix_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02QueueItem2DryRunSafetyFix --no-ansi (6 tests, 47 assertions)",
+          "focused_cleanup_runtime_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupRuntime --no-ansi (5 tests, 78 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi",
+          "pint": "passed: vendor/bin/pint --test (3526 files)",
+          "command_dry_run_no_write": "passed: php artisan seo-intel:mbti-url-truth-cleanup --preset=mbti-fix-02-www-research-apex --dry-run --no-write --json exited 0 locally with no writes; local environment lacks seo_intel tables and reports blocked as expected.",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "BACKEND-DEPLOY-READINESS",
+      "history": [
+        {
+          "at": "2026-05-24T20:36:00+08:00",
+          "status": "in_progress",
+          "summary": "Started scoped runtime safety fix from latest clean main. Scope is limited to queue item 2 dry-run safety assertion/reporting, docs/generated artifact, focused tests, and authorized PR-train metadata."
+        },
+        {
+          "at": "2026-05-24T20:48:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused queue item 2 safety test, existing cleanup runtime test, route list, Pint, local dry-run/no-write command, JSON/YAML parse, and diff checks passed."
+        },
+        {
+          "at": "2026-05-24T20:54:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1653 for the queue item 2 dry-run safety fix. GitHub checks are pending."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11187,6 +11187,55 @@ prs:
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT
+    branch: codex/seo-growth-mbti-action-01b-fix-02-queue-item-2-safety
+    base: main
+    title: "fix(seo-intel): verify MBTI cleanup leaves submitted queue item untouched"
+    name: "Fix MBTI URL Truth cleanup dry-run safety assertion for submitted queue item 2"
+    train_scope: seo_growth_mbti_action
+    risk_level: bounded_runtime_safety_fix
+    type: backend_runtime_test_docs
+    scope:
+      - Fix the MBTI URL Truth cleanup command/reporting so dry-run and execute-mode safety checks positively verify that submitted queue item 2 remains untouched.
+      - Block or report false when queue item 2 is missing, points to the wrong URL, uses the wrong channel, is not approved/submitted, is part of the cleanup target set, or cannot be verified unchanged.
+      - Preserve no production write, no Search Channel enqueue, no live submission, no external API calls, no sitemap/llms authority, and no frontend fallback authority.
+      - Add docs, generated JSON, focused tests, and authorized train metadata only.
+    allowed_paths:
+      - backend/app/Console/Commands/SeoIntelMbtiUrlTruthCleanupCommand.php
+      - backend/app/Services/SeoIntel/MbtiUrlTruthCleanupService.php
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02QueueItem2DryRunSafetyFixTest.php
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupRuntimeTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, migrations, production env/deploy files, CMS content, articles, internal links, sitemap/llms generators, Search Channel live submitter changes, crawler log readers, scheduler, Digital PR files, manual DB scripts, or business DB / Tencent RDS / Node2 DB.
+      - Perform production cleanup/write, production collector writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, or raw Nginx access log reads.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, or local copies as authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02QueueItem2DryRunSafetyFix --no-ansi
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupRuntime --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && php artisan seo-intel:mbti-url-truth-cleanup --preset=mbti-fix-02-www-research-apex --dry-run --no-write --json
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: BACKEND-DEPLOY-READINESS
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- Fixed the MBTI URL Truth cleanup service so dry-run/no-write captures queue item 2 before and after snapshots.
- Added fail-closed validation for submitted EN MBTI queue item 2: URL, channel, approval state, execution state, and cleanup target exclusion.
- Added focused coverage for safe dry-run, missing item, URL mismatch, channel mismatch, target-set risk, and execute-mode immutability.
- Added the scoped docs/generated report and authorized PR-train manifest/state entries.

## Why
The production write preflight was blocked because the cleanup command emitted `queue_item_2_untouched=false` during dry-run/no-write even though persisted read-only state showed queue item 2 was unchanged. The old code compared a before snapshot with a null after snapshot in dry-run and did not fail closed when the item was missing.

## Validation
- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02QueueItem2DryRunSafetyFix --no-ansi`
- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupRuntime --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && php artisan seo-intel:mbti-url-truth-cleanup --preset=mbti-fix-02-www-research-apex --dry-run --no-write --json`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-queue-item-2-dry-run-safety-fix.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production cleanup/write was run.
- No Search Channel enqueue or live submission was performed.
- No external search API was called.
- No deploy, migration, scheduler activation, CMS mutation, fap-web change, sitemap/llms mutation, or Digital PR action was performed.
