### PR TITLE
docs(seo-intel): rerun MBTI URL Truth cleanup production preflight

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2",
+  "final_decision": "mbti_action_01b_fix_02_prod_write_preflight_r2_ready_for_human_approved_write",
+  "deployed_sha": "2c1732a887cd32fc3773de73c150e097850cd592",
+  "command": "php artisan seo-intel:mbti-url-truth-cleanup --preset=mbti-fix-02-www-research-apex --dry-run --no-write --json",
+  "dry_run_result": {
+    "status": "dry_run_ready",
+    "dry_run": true,
+    "no_write": true,
+    "execute_attempted": false,
+    "writes_committed": false,
+    "old_www_rows_found": 2,
+    "old_www_rows_retired": 0,
+    "apex_research_candidates_found": true,
+    "apex_research_rows_written": 0,
+    "zh_mbti_candidate_found": true,
+    "zh_mbti_row_written": false,
+    "seo_url_entities_updated": 0,
+    "queue_item_2_untouched": true,
+    "search_channel_enqueue_attempted": false,
+    "live_submission_attempted": false,
+    "external_api_call_attempted": false,
+    "sitemap_llms_authority_used": false,
+    "frontend_fallback_authority_used": false,
+    "duplicate_cluster_prevented": true,
+    "issues": []
+  },
+  "queue_item_2_untouched": true,
+  "planned_retire_www_rows": [
+    "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "planned_write_apex_rows": [
+    "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+    "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+  ],
+  "planned_write_zh_mbti_row": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+  "queue_item_2_persisted_state_after_dry_run": {
+    "id": 2,
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "updated_at": "2026-05-23 05:18:45"
+  },
+  "persisted_state_after_dry_run": {
+    "old_research_www_rows_still_present": true,
+    "old_research_www_rows": [
+      {
+        "canonical_url": "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "locale": "en",
+        "page_entity_type": "research_report",
+        "indexability_state": "indexable",
+        "source_authority": "backend_cms"
+      },
+      {
+        "canonical_url": "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "locale": "zh-CN",
+        "page_entity_type": "research_report",
+        "indexability_state": "indexable",
+        "source_authority": "backend_cms"
+      }
+    ],
+    "research_apex_rows_absent": true,
+    "zh_mbti_apex_row_absent": true,
+    "queue_item_2_unchanged": true
+  },
+  "no_write_performed": true,
+  "production_write_performed": false,
+  "enqueue_performed": false,
+  "live_submission_performed": false,
+  "external_api_call_performed": false,
+  "cms_mutation_performed": false,
+  "sitemap_mutation_performed": false,
+  "llms_mutation_performed": false,
+  "fap_web_mutation_performed": false,
+  "future_human_approval_phrase": "I explicitly approve bounded URL Truth cleanup/write for MBTI FIX-02: retire old Research www rows, write Research apex rows, and write ZH MBTI apex row. Do not enqueue Search Channel items. Do not submit URLs.",
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE｜Human-approved bounded URL Truth cleanup/write"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.md
@@ -1,0 +1,89 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2
+
+## Executive Summary
+
+This production read-only/no-write preflight reran the MBTI URL Truth cleanup command after PR #1653 fixed the queue item 2 dry-run safety assertion.
+
+Production is deployed at:
+
+`2c1732a887cd32fc3773de73c150e097850cd592`
+
+That release contains PR #1653.
+
+The production dry-run/no-write command now reports `queue_item_2_untouched=true` and remains ready for a later human-approved bounded write.
+
+## Command
+
+```bash
+php artisan seo-intel:mbti-url-truth-cleanup \
+  --preset=mbti-fix-02-www-research-apex \
+  --dry-run \
+  --no-write \
+  --json
+```
+
+## Dry-run Result
+
+The dry-run reported:
+
+- `status=dry_run_ready`
+- `dry_run=true`
+- `no_write=true`
+- `writes_committed=false`
+- `queue_item_2_untouched=true`
+- `search_channel_enqueue_attempted=false`
+- `live_submission_attempted=false`
+- `external_api_call_attempted=false`
+- `issues=[]`
+
+## Planned Changes
+
+The later bounded write would retire these stale Research `www` rows:
+
+- `https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+It would write these apex Research rows:
+
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+It would also write this ZH MBTI test URL Truth row:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+## Queue Item 2 Safety
+
+Queue item 2 remains the already-submitted EN MBTI IndexNow item:
+
+- URL: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- channel: `indexnow`
+- approval_state: `approved`
+- execution_state: `submitted`
+
+The command did not plan or attempt any queue mutation, enqueue, live submission, or external API call.
+
+## Persisted State After Dry-run
+
+Read-only persisted state after dry-run confirmed:
+
+- old Research `www` rows are still present and indexable;
+- Research apex rows are still absent;
+- ZH MBTI apex row is still absent;
+- queue item 2 is unchanged.
+
+## Safety Boundary
+
+This preflight did not perform production URL Truth writes, collector writes, Search Channel enqueue, live URL submission, external API calls, CMS mutation, sitemap mutation, llms mutation, fap-web mutation, Digital PR action, migrations, scheduler activation, or deploy.
+
+Public runtime, sitemap, llms, fap-web fallback, crawler logs, search engine responses, Digital PR mentions, and local copies were not used as authority.
+
+## Future Human Approval Phrase
+
+```text
+I explicitly approve bounded URL Truth cleanup/write for MBTI FIX-02: retire old Research www rows, write Research apex rows, and write ZH MBTI apex row. Do not enqueue Search Channel items. Do not submit URLs.
+```
+
+## Next Task
+
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE｜Human-approved bounded URL Truth cleanup/write`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightR2Test.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightR2Test.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightR2Test extends TestCase
+{
+    #[Test]
+    public function generated_json_exists_and_parses(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1',
+            $artifact['schema_version'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2',
+            $artifact['task'] ?? null
+        );
+    }
+
+    #[Test]
+    public function safety_flags_lock_no_write_no_enqueue_no_submission_and_no_external_api(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['no_write_performed'] ?? false);
+        $this->assertFalse($artifact['production_write_performed'] ?? true);
+        $this->assertFalse($artifact['enqueue_performed'] ?? true);
+        $this->assertFalse($artifact['live_submission_performed'] ?? true);
+        $this->assertFalse($artifact['external_api_call_performed'] ?? true);
+        $this->assertFalse($artifact['cms_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['sitemap_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['llms_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['fap_web_mutation_performed'] ?? true);
+    }
+
+    #[Test]
+    public function queue_item_2_safety_fix_is_proven_in_production_dry_run(): void
+    {
+        $artifact = $this->artifact();
+        $dryRun = $artifact['dry_run_result'] ?? [];
+
+        $this->assertTrue($artifact['queue_item_2_untouched'] ?? false);
+        $this->assertTrue($dryRun['queue_item_2_untouched'] ?? false);
+        $this->assertSame('dry_run_ready', $dryRun['status'] ?? null);
+        $this->assertTrue($dryRun['dry_run'] ?? false);
+        $this->assertTrue($dryRun['no_write'] ?? false);
+        $this->assertFalse($dryRun['writes_committed'] ?? true);
+        $this->assertSame([], $dryRun['issues'] ?? null);
+    }
+
+    #[Test]
+    public function planned_rows_are_listed(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            'https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $url) {
+            $this->assertContains($url, $artifact['planned_retire_www_rows'] ?? []);
+        }
+
+        foreach ([
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $url) {
+            $this->assertContains($url, $artifact['planned_write_apex_rows'] ?? []);
+        }
+
+        $this->assertSame(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $artifact['planned_write_zh_mbti_row'] ?? null
+        );
+    }
+
+    #[Test]
+    public function persisted_state_after_dry_run_remains_unwritten(): void
+    {
+        $state = $this->artifact()['persisted_state_after_dry_run'] ?? [];
+
+        $this->assertTrue($state['old_research_www_rows_still_present'] ?? false);
+        $this->assertTrue($state['research_apex_rows_absent'] ?? false);
+        $this->assertTrue($state['zh_mbti_apex_row_absent'] ?? false);
+        $this->assertTrue($state['queue_item_2_unchanged'] ?? false);
+    }
+
+    #[Test]
+    public function future_approval_final_decision_and_next_task_are_present(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertIsString($artifact['future_human_approval_phrase'] ?? null);
+        $this->assertStringContainsString('Do not enqueue Search Channel items.', $artifact['future_human_approval_phrase']);
+        $this->assertIsString($artifact['final_decision'] ?? null);
+        $this->assertSame(
+            'mbti_action_01b_fix_02_prod_write_preflight_r2_ready_for_human_approved_write',
+            $artifact['final_decision'] ?? null
+        );
+        $this->assertIsString($artifact['next_task'] ?? null);
+        $this->assertNotSame('', $artifact['next_task'] ?? '');
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -17775,11 +17775,11 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-queue-item-2-safety",
-      "status": "pr_open_github_checks_pending",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT"
       ],
-      "commit_sha": "63b0a0b1",
+      "commit_sha": "2c1732a887cd32fc3773de73c150e097850cd592",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1653",
       "checks": {
         "local": {
@@ -17796,9 +17796,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-24T12:56:25Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -17819,6 +17819,72 @@
           "at": "2026-05-24T20:54:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1653 for the queue item 2 dry-run safety fix. GitHub checks are pending."
+        },
+        {
+          "at": "2026-05-24T21:56:25+08:00",
+          "status": "merged",
+          "summary": "Reconciled PR #1653 as merged with merge commit 2c1732a887cd32fc3773de73c150e097850cd592. Remote branch is deleted and local main contains the merge commit."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2",
+      "status": "in_progress",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX"
+      ],
+      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1654",
+      "checks": {
+        "production_read_only": {
+          "deployment_verification": "passed: deployed backend SHA 2c1732a887cd32fc3773de73c150e097850cd592 contains PR #1653.",
+          "command_exists": "passed: production artisan list exposes seo-intel:mbti-url-truth-cleanup.",
+          "dry_run_no_write": "passed: command exited 0 with dry_run=true, no_write=true, writes_committed=false, queue_item_2_untouched=true, no enqueue, no live submission, and no external API calls.",
+          "planned_changes": "passed: dry-run target set contains both old Research www rows, both Research apex replacement rows, and the ZH MBTI apex row.",
+          "persisted_state_after_dry_run": "passed_no_write: old Research www rows remain indexable, Research apex rows are absent, ZH MBTI apex row is absent, and queue item 2 remains submitted for EN MBTI.",
+          "final_decision": "mbti_action_01b_fix_02_prod_write_preflight_r2_ready_for_human_approved_write"
+        },
+        "local": {
+          "focused_prod_write_preflight_r2_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightR2 --no-ansi (6 tests, 45 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi",
+          "pint": "passed: vendor/bin/pint --test (3527 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE",
+      "history": [
+        {
+          "at": "2026-05-24T22:05:00+08:00",
+          "status": "in_progress",
+          "summary": "Started production write preflight R2 from latest clean main. Scope is limited to production dry-run/no-write evidence, docs/generated report, focused test, and authorized PR-train metadata."
+        },
+        {
+          "at": "2026-05-24T22:05:00+08:00",
+          "status": "production_read_only_evidence_collected_ready",
+          "summary": "Production cleanup command dry-run/no-write emitted queue_item_2_untouched=true with expected bounded target set and no-write flags. Persisted state remained unchanged after dry-run."
+        },
+        {
+          "at": "2026-05-24T22:12:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused R2 generated artifact test, route list, Pint, JSON/YAML parsing, and diff checks passed."
+        },
+        {
+          "at": "2026-05-24T22:14:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1654 for the production write preflight R2 report. GitHub checks are pending."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11236,6 +11236,51 @@ prs:
     scheduler_activation: false
     next_task: BACKEND-DEPLOY-READINESS
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX
+    branch: codex/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2
+    base: main
+    title: "docs(seo-intel): rerun MBTI URL Truth cleanup production preflight"
+    name: "Rerun production dry-run after queue item 2 safety fix"
+    train_scope: seo_growth_mbti_action
+    risk_level: production_read_only_preflight
+    type: docs_generated_test
+    scope:
+      - Confirm production backend contains PR #1653 and the deployed MBTI URL Truth cleanup safety fix.
+      - Run production `seo-intel:mbti-url-truth-cleanup` with `--dry-run --no-write --json` only.
+      - Verify the command reports `queue_item_2_untouched=true` while preserving no-write, no enqueue, no live submission, and no external API boundaries.
+      - Verify the planned old Research www retire set, Research apex write set, and ZH MBTI apex write candidate.
+      - Verify persisted state after dry-run remains unchanged and record whether a later human-approved bounded production write can proceed.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightR2Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, runtime services, migrations, production env/deploy files, CMS content, articles, internal links, sitemap, llms, crawler log readers, scheduler, Search Channel submitter code, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform production URL Truth writes, production collector writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, or raw Nginx access log reads.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, or local copies as URL Truth.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightR2 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- Added the R2 production dry-run/no-write preflight report for the MBTI URL Truth cleanup/write command after PR #1653 was deployed.
- Recorded that production dry-run now reports `queue_item_2_untouched=true` with the expected bounded cleanup/write target set.
- Added generated JSON and a focused test locking the no-write/no-enqueue/no-submit safety boundary.
- Updated authorized PR train manifest/state metadata, including reconciliation that PR #1653 is merged.

## Why
The previous production write preflight was blocked by `queue_item_2_untouched=false`. After the runtime safety fix was merged and deployed, this R2 preflight verifies the production command now proves queue item 2 remains untouched and the later bounded write can proceed only after human approval.

## Validation
- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWritePreflightR2 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production URL Truth write was performed.
- No collector write, Search Channel enqueue, live submission, external search API call, CMS mutation, sitemap/llms mutation, fap-web change, migration, scheduler activation, Digital PR action, or deploy was performed by this PR.
