### PR TITLE
docs(seo-intel): record MBTI URL Truth cleanup write

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write.v1.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-fix-02-prod-write.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE",
+  "final_decision": "mbti_action_01b_fix_02_prod_write_completed_ready_for_search_channel_rerun",
+  "approval_phrase_verified": true,
+  "deployed_sha": "2c1732a887cd32fc3773de73c150e097850cd592",
+  "command": "php artisan seo-intel:mbti-url-truth-cleanup --preset=mbti-fix-02-www-research-apex --execute --json",
+  "pre_write_dry_run": {
+    "status": "dry_run_ready",
+    "dry_run": true,
+    "no_write": true,
+    "writes_committed": false,
+    "queue_item_2_untouched": true,
+    "search_channel_enqueue_attempted": false,
+    "live_submission_attempted": false,
+    "external_api_call_attempted": false,
+    "issues": []
+  },
+  "execute_result": {
+    "status": "success",
+    "dry_run": false,
+    "no_write": false,
+    "execute_attempted": true,
+    "writes_committed": true,
+    "old_www_rows_found": 2,
+    "old_www_rows_retired": 2,
+    "apex_research_candidates_found": true,
+    "apex_research_rows_written": 2,
+    "zh_mbti_candidate_found": true,
+    "zh_mbti_row_written": true,
+    "seo_url_entities_updated": 5,
+    "queue_item_2_untouched": true,
+    "search_channel_enqueue_attempted": false,
+    "live_submission_attempted": false,
+    "external_api_call_attempted": false,
+    "sitemap_llms_authority_used": false,
+    "frontend_fallback_authority_used": false,
+    "duplicate_cluster_prevented": true,
+    "issues": []
+  },
+  "retired_www_rows": [
+    {
+      "canonical_url": "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "locale": "en",
+      "page_entity_type": "research_report",
+      "indexability_state": "superseded_canonical",
+      "entity_authority_status": "superseded_canonical"
+    },
+    {
+      "canonical_url": "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "locale": "zh-CN",
+      "page_entity_type": "research_report",
+      "indexability_state": "superseded_canonical",
+      "entity_authority_status": "superseded_canonical"
+    }
+  ],
+  "written_apex_research_rows": [
+    {
+      "canonical_url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "locale": "en",
+      "page_entity_type": "research_report",
+      "indexability_state": "indexable",
+      "source_authority": "backend_cms",
+      "entity_authority_status": "published_approved"
+    },
+    {
+      "canonical_url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "locale": "zh-CN",
+      "page_entity_type": "research_report",
+      "indexability_state": "indexable",
+      "source_authority": "backend_cms",
+      "entity_authority_status": "published_approved"
+    }
+  ],
+  "written_zh_mbti_row": {
+    "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "locale": "zh-CN",
+    "page_entity_type": "test_detail",
+    "indexability_state": "indexable",
+    "source_authority": "scale_catalog",
+    "entity_authority_status": "observed"
+  },
+  "seo_url_entities_updated": 5,
+  "queue_item_2_untouched": true,
+  "queue_item_2_state": {
+    "id": 2,
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "updated_at": "2026-05-23 05:18:45"
+  },
+  "enqueue_performed": false,
+  "live_submission_performed": false,
+  "external_api_call_performed": false,
+  "cms_mutation_performed": false,
+  "sitemap_mutation_performed": false,
+  "llms_mutation_performed": false,
+  "post_write_verification": {
+    "old_www_rows_retired": true,
+    "apex_research_rows_exist": true,
+    "zh_mbti_apex_row_exists": true,
+    "seo_url_entities_updated": true,
+    "queue_item_2_unchanged": true,
+    "duplicate_cluster_prevented": true,
+    "post_write_dry_run_status": "dry_run_ready",
+    "post_write_dry_run_issues": []
+  },
+  "search_channel_dry_run_after_write": {
+    "summary": {
+      "dry_run": true,
+      "no_write": true,
+      "enqueue_attempted": false,
+      "enqueue_committed": false,
+      "external_calls_attempted": false,
+      "live_submission_attempted": false,
+      "candidate_count": 12,
+      "eligible_count": 10,
+      "planned_queue_count": 8,
+      "written_items": 0,
+      "write_gate_enabled": false
+    },
+    "url_results": [
+      {
+        "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "status": "eligible",
+        "planned_queue_count": 1,
+        "reason_codes": []
+      },
+      {
+        "canonical_url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "status": "eligible",
+        "planned_queue_count": 1,
+        "reason_codes": []
+      },
+      {
+        "canonical_url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "status": "eligible",
+        "planned_queue_count": 1,
+        "reason_codes": []
+      },
+      {
+        "canonical_url": "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "status": "blocked",
+        "planned_queue_count": 0,
+        "reason_codes": [
+          "noindex"
+        ]
+      },
+      {
+        "canonical_url": "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "status": "blocked",
+        "planned_queue_count": 0,
+        "reason_codes": [
+          "noindex"
+        ]
+      }
+    ]
+  },
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write.md
@@ -1,0 +1,105 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE
+
+## Executive Summary
+
+The human-approved bounded production URL Truth cleanup/write completed successfully for MBTI FIX-02.
+
+The official runtime command retired the stale Research `www` URL Truth rows, wrote the Research apex rows, wrote the ZH MBTI apex row, updated corresponding `seo_url_entities`, and left the already-submitted EN MBTI Search Channel queue item untouched.
+
+No Search Channel enqueue, live submission, external API call, CMS mutation, sitemap mutation, llms mutation, fap-web mutation, manual SQL, broad collector write, migration, scheduler activation, crawler log read, Digital PR action, or deploy was performed.
+
+## Approval
+
+The required approval phrase was present:
+
+```text
+I explicitly approve bounded URL Truth cleanup/write for MBTI FIX-02: retire old Research www rows, write Research apex rows, and write ZH MBTI apex row. Do not enqueue Search Channel items. Do not submit URLs.
+```
+
+## Pre-write Dry-run
+
+The final production dry-run/no-write passed before execution:
+
+- `status=dry_run_ready`
+- `dry_run=true`
+- `no_write=true`
+- `writes_committed=false`
+- `queue_item_2_untouched=true`
+- `search_channel_enqueue_attempted=false`
+- `live_submission_attempted=false`
+- `external_api_call_attempted=false`
+- `issues=[]`
+
+## Bounded Write Result
+
+The approved command was:
+
+```bash
+php artisan seo-intel:mbti-url-truth-cleanup \
+  --preset=mbti-fix-02-www-research-apex \
+  --execute \
+  --json
+```
+
+Execution result:
+
+- `status=success`
+- `writes_committed=true`
+- `old_www_rows_retired=2`
+- `apex_research_rows_written=2`
+- `zh_mbti_row_written=true`
+- `seo_url_entities_updated=5`
+- `queue_item_2_untouched=true`
+- `search_channel_enqueue_attempted=false`
+- `live_submission_attempted=false`
+- `external_api_call_attempted=false`
+- `issues=[]`
+
+## Post-write Verification
+
+Retired stale rows:
+
+- `https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+Both are now `indexability_state=superseded_canonical`, and their entity mappings are `authority_status=superseded_canonical`.
+
+Written apex rows:
+
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+Both are `indexable`, `source_authority=backend_cms`, and mapped as `published_approved`.
+
+Written ZH MBTI row:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+It is `indexable`, `source_authority=scale_catalog`, and mapped to `scales_registry`.
+
+Queue item 2 remains unchanged:
+
+- URL: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- channel: `indexnow`
+- approval_state: `approved`
+- execution_state: `submitted`
+
+Post-write dry-run/no-write remained `dry_run_ready` with no issues, confirming idempotency and duplicate cluster prevention.
+
+## Search Channel Dry-run After Write
+
+Search Channel dry-run/no-write after the cleanup/write reported no enqueue, no writes, no external calls, and no live submission.
+
+Target URL results:
+
+- ZH MBTI apex: eligible
+- EN Research apex: eligible
+- ZH Research apex: eligible
+- old EN Research `www`: blocked as `noindex`
+- old ZH Research `www`: blocked as `noindex`
+
+The write gate remained closed and no queue rows were written.
+
+## Next Task
+
+`SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWriteTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWriteTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix02ProdWriteTest extends TestCase
+{
+    #[Test]
+    public function generated_json_exists_and_parses(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'seo-growth-mbti-action-01b-fix-02-prod-write.v1',
+            $artifact['schema_version'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE',
+            $artifact['task'] ?? null
+        );
+    }
+
+    #[Test]
+    public function approval_and_safety_flags_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['approval_phrase_verified'] ?? false);
+        $this->assertTrue($artifact['queue_item_2_untouched'] ?? false);
+        $this->assertFalse($artifact['enqueue_performed'] ?? true);
+        $this->assertFalse($artifact['live_submission_performed'] ?? true);
+        $this->assertFalse($artifact['external_api_call_performed'] ?? true);
+        $this->assertFalse($artifact['cms_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['sitemap_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['llms_mutation_performed'] ?? true);
+    }
+
+    #[Test]
+    public function execute_result_records_bounded_write_success(): void
+    {
+        $execute = $this->artifact()['execute_result'] ?? [];
+
+        $this->assertSame('success', $execute['status'] ?? null);
+        $this->assertTrue($execute['execute_attempted'] ?? false);
+        $this->assertTrue($execute['writes_committed'] ?? false);
+        $this->assertSame(2, $execute['old_www_rows_retired'] ?? null);
+        $this->assertSame(2, $execute['apex_research_rows_written'] ?? null);
+        $this->assertTrue($execute['zh_mbti_row_written'] ?? false);
+        $this->assertSame(5, $execute['seo_url_entities_updated'] ?? null);
+        $this->assertSame([], $execute['issues'] ?? null);
+    }
+
+    #[Test]
+    public function old_www_rows_are_listed_as_retired(): void
+    {
+        $urls = array_column($this->artifact()['retired_www_rows'] ?? [], 'canonical_url');
+
+        $this->assertContains(
+            'https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            $urls
+        );
+        $this->assertContains(
+            'https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+            $urls
+        );
+
+        foreach ($this->artifact()['retired_www_rows'] ?? [] as $row) {
+            $this->assertSame('superseded_canonical', $row['indexability_state'] ?? null);
+            $this->assertSame('superseded_canonical', $row['entity_authority_status'] ?? null);
+        }
+    }
+
+    #[Test]
+    public function research_apex_rows_and_zh_mbti_row_are_listed_as_written(): void
+    {
+        $researchUrls = array_column($this->artifact()['written_apex_research_rows'] ?? [], 'canonical_url');
+
+        $this->assertContains(
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            $researchUrls
+        );
+        $this->assertContains(
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+            $researchUrls
+        );
+        $this->assertSame(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $this->artifact()['written_zh_mbti_row']['canonical_url'] ?? null
+        );
+    }
+
+    #[Test]
+    public function search_channel_after_write_records_apex_eligible_and_old_www_blocked(): void
+    {
+        $results = collect($this->artifact()['search_channel_dry_run_after_write']['url_results'] ?? [])
+            ->keyBy('canonical_url');
+
+        $this->assertSame('eligible', $results['https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types']['status'] ?? null);
+        $this->assertSame('eligible', $results['https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report']['status'] ?? null);
+        $this->assertSame('eligible', $results['https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report']['status'] ?? null);
+        $this->assertSame('blocked', $results['https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report']['status'] ?? null);
+        $this->assertSame('blocked', $results['https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report']['status'] ?? null);
+    }
+
+    #[Test]
+    public function final_decision_and_next_task_are_present(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'mbti_action_01b_fix_02_prod_write_completed_ready_for_search_channel_rerun',
+            $artifact['final_decision'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW',
+            $artifact['next_task'] ?? null
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -17830,11 +17830,11 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-write-preflight-r2",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-QUEUE-ITEM-2-DRY-RUN-SAFETY-FIX"
       ],
-      "commit_sha": null,
+      "commit_sha": "f75cba2772c3c28b49bf94f3ee347f668121d364",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1654",
       "checks": {
         "production_read_only": {
@@ -17857,9 +17857,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-24T13:54:44Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -17885,6 +17885,72 @@
           "at": "2026-05-24T22:14:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1654 for the production write preflight R2 report. GitHub checks are pending."
+        },
+        {
+          "at": "2026-05-24T22:54:44+08:00",
+          "status": "merged",
+          "summary": "Reconciled PR #1654 as merged with merge commit f75cba2772c3c28b49bf94f3ee347f668121d364. Remote branch is deleted and local main contains the merge commit."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-write",
+      "status": "in_progress",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2"
+      ],
+      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1655",
+      "checks": {
+        "production_bounded_write": {
+          "approval_phrase_verified": "passed: exact bounded URL Truth cleanup/write approval phrase was present.",
+          "pre_write_dry_run": "passed: dry-run/no-write reported queue_item_2_untouched=true, expected target set, no enqueue, no live submission, no external API call, and issues=[].",
+          "execute": "passed: official command committed the bounded write with old_www_rows_retired=2, apex_research_rows_written=2, zh_mbti_row_written=true, seo_url_entities_updated=5, queue_item_2_untouched=true, and no enqueue/submission/API call.",
+          "post_write_verification": "passed: old Research www rows are superseded_canonical; Research apex rows and ZH MBTI apex row exist; entity mappings are updated; queue item 2 remains submitted.",
+          "post_write_dry_run": "passed: cleanup dry-run/no-write remains dry_run_ready with duplicate_cluster_prevented=true and issues=[].",
+          "search_channel_dry_run": "passed: ZH MBTI apex, EN Research apex, and ZH Research apex are eligible; old Research www rows are blocked as noindex; no queue rows were written."
+        },
+        "local": {
+          "focused_prod_write_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWrite --no-ansi (19 tests, 141 assertions; includes earlier ProdWrite preflight artifact tests matched by filter)",
+          "route_list": "passed: php artisan route:list --no-ansi",
+          "pint": "passed: vendor/bin/pint --test (3528 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW",
+      "history": [
+        {
+          "at": "2026-05-24T22:58:00+08:00",
+          "status": "in_progress",
+          "summary": "Started human-approved bounded production URL Truth cleanup/write from latest clean main. Scope is limited to the official MBTI cleanup command, verification dry-runs, docs/generated report, focused test, and authorized PR-train metadata."
+        },
+        {
+          "at": "2026-05-24T22:58:00+08:00",
+          "status": "production_bounded_write_completed",
+          "summary": "Executed the official cleanup command with preset mbti-fix-02-www-research-apex. It retired two old Research www rows, wrote two Research apex rows, wrote the ZH MBTI apex row, updated five entity mappings, preserved queue item 2, and performed no Search Channel enqueue or live submission."
+        },
+        {
+          "at": "2026-05-24T23:04:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff checks passed."
+        },
+        {
+          "at": "2026-05-24T23:06:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1655 for the bounded production URL Truth cleanup/write report. GitHub checks are pending."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11281,6 +11281,51 @@ prs:
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2
+    branch: codex/seo-growth-mbti-action-01b-fix-02-prod-write
+    base: main
+    title: "docs(seo-intel): record MBTI URL Truth cleanup write"
+    name: "Human-approved bounded URL Truth cleanup/write"
+    train_scope: seo_growth_mbti_action
+    risk_level: bounded_production_write_report
+    type: docs_generated_test
+    scope:
+      - Verify the exact human approval phrase for the bounded MBTI FIX-02 URL Truth cleanup/write.
+      - Run only the official `seo-intel:mbti-url-truth-cleanup` command with preset `mbti-fix-02-www-research-apex`.
+      - Retire old Research www URL Truth rows, write EN/ZH Research apex rows, write the ZH MBTI apex row, and update corresponding seo_url_entities.
+      - Verify queue item 2 remains untouched and no Search Channel enqueue, live submission, external API call, CMS mutation, sitemap/llms mutation, fap-web mutation, manual SQL, or broad collector write occurred.
+      - Run post-write cleanup dry-run/no-write and Search Channel dry-run/no-write, then record the report in docs/generated/test only.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-02-prod-write.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02ProdWriteTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, runtime services, migrations, production env/deploy files, CMS content, articles, internal links, sitemap, llms, crawler log readers, scheduler, Search Channel submitter code, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, raw Nginx access log reads, manual DB update/delete, broad collector writes, or unrelated URL Truth writes.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, or local copies as authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWrite --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- Recorded the human-approved bounded production URL Truth cleanup/write for MBTI FIX-02.
- Added generated JSON and a focused test covering the approved write, retired old Research www rows, written Research apex rows, written ZH MBTI row, queue item 2 protection, and no-enqueue/no-submit/no-external-API boundaries.
- Updated authorized PR train manifest/state metadata and reconciled the merged R2 preflight dependency.

## Why
The R2 preflight proved the production cleanup runtime was ready. This PR records the approved bounded write and post-write verification while keeping the repository changes to docs/generated/test/train metadata only.

## Validation
- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdWrite --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-prod-write.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No Search Channel enqueue was performed.
- No URL submission or external search API call was performed.
- No CMS mutation, sitemap/llms mutation, fap-web change, migration, scheduler activation, deployment, raw crawler log read, Digital PR action, manual SQL, broad collector write, or unrelated URL Truth write was performed.
