### PR TITLE
docs(seo-intel): add MBTI URL Truth post-write Search Channel review

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1.json
@@ -1,0 +1,253 @@
+{
+  "schema_version": "seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW",
+  "final_decision": "mbti_action_01b_fix_02_post_write_review_completed_ready_for_zh_mbti_queue_preflight",
+  "old_www_rows_state": [
+    {
+      "canonical_url": "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "locale": "en",
+      "page_entity_type": "research_report",
+      "source_authority": "backend_cms",
+      "indexability_state": "superseded_canonical",
+      "private_flow": false,
+      "entity_authority_status": "superseded_canonical",
+      "search_channel_eligibility": "blocked",
+      "reason_codes": [
+        "noindex"
+      ],
+      "non_eligible": true,
+      "superseded_by": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report"
+    },
+    {
+      "canonical_url": "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "locale": "zh-CN",
+      "page_entity_type": "research_report",
+      "source_authority": "backend_cms",
+      "indexability_state": "superseded_canonical",
+      "private_flow": false,
+      "entity_authority_status": "superseded_canonical",
+      "search_channel_eligibility": "blocked",
+      "reason_codes": [
+        "noindex"
+      ],
+      "non_eligible": true,
+      "superseded_by": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+    }
+  ],
+  "apex_research_rows_state": [
+    {
+      "canonical_url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "locale": "en",
+      "page_entity_type": "research_report",
+      "source_authority": "backend_cms",
+      "indexability_state": "indexable",
+      "private_flow": false,
+      "entity_source": "research_reports",
+      "entity_authority_status": "published_approved",
+      "search_channel_eligibility": "eligible",
+      "claim_boundary_state": "claim_safe"
+    },
+    {
+      "canonical_url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "locale": "zh-CN",
+      "page_entity_type": "research_report",
+      "source_authority": "backend_cms",
+      "indexability_state": "indexable",
+      "private_flow": false,
+      "entity_source": "research_reports",
+      "entity_authority_status": "published_approved",
+      "search_channel_eligibility": "eligible",
+      "claim_boundary_state": "claim_safe"
+    }
+  ],
+  "zh_mbti_row_state": {
+    "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "locale": "zh-CN",
+    "page_entity_type": "test_detail",
+    "source_authority": "scale_catalog",
+    "indexability_state": "indexable",
+    "private_flow": false,
+    "entity_source": "scales_registry",
+    "entity_authority_status": "observed",
+    "search_channel_eligibility": "eligible",
+    "claim_boundary_state": "claim_safe"
+  },
+  "seo_url_entities_state": {
+    "updated_mappings_observed": 5,
+    "old_www_research_authority_status": "superseded_canonical",
+    "apex_research_authority_status": "published_approved",
+    "zh_mbti_entity_source": "scales_registry",
+    "zh_mbti_authority_status": "observed"
+  },
+  "queue_item_2_state": {
+    "id": 2,
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "unchanged": true,
+    "duplicate_en_mbti_queue_item_detected": false,
+    "duplicate_live_event_detected": false,
+    "retry_storm_detected": false,
+    "queue_item_2_event_count": 3,
+    "queue_count_after_review": 2
+  },
+  "cleanup_command_idempotency_dry_run": {
+    "command": "php artisan seo-intel:mbti-url-truth-cleanup --preset=mbti-fix-02-www-research-apex --dry-run --no-write --json",
+    "status": "dry_run_ready",
+    "dry_run": true,
+    "no_write": true,
+    "execute_attempted": false,
+    "writes_committed": false,
+    "old_www_rows_found": 2,
+    "old_www_rows_retired": 0,
+    "apex_research_candidates_found": true,
+    "apex_research_rows_written": 0,
+    "zh_mbti_candidate_found": true,
+    "zh_mbti_row_written": false,
+    "seo_url_entities_updated": 0,
+    "queue_item_2_untouched": true,
+    "search_channel_enqueue_attempted": false,
+    "live_submission_attempted": false,
+    "external_api_call_attempted": false,
+    "sitemap_llms_authority_used": false,
+    "frontend_fallback_authority_used": false,
+    "duplicate_cluster_prevented": true,
+    "issues": []
+  },
+  "search_channel_dry_run": {
+    "broad": {
+      "command": "php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --limit=50",
+      "status": "success",
+      "dry_run": true,
+      "no_write": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "enqueue_attempted": false,
+      "enqueue_committed": false,
+      "external_calls_attempted": false,
+      "search_submission_attempted": false,
+      "live_submission_attempted": false,
+      "candidate_count": 12,
+      "eligible_count": 10,
+      "blocked_count": 4,
+      "planned_queue_count": 8,
+      "write_gate_enabled": false,
+      "issues": []
+    },
+    "url_results": [
+      {
+        "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "status": "eligible",
+        "source_authority": "scale_catalog",
+        "indexability_state": "indexable",
+        "claim_boundary_state": "claim_safe",
+        "reason_codes": [],
+        "planned_queue_count": 1
+      },
+      {
+        "canonical_url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "status": "eligible",
+        "source_authority": "backend_cms",
+        "indexability_state": "indexable",
+        "claim_boundary_state": "claim_safe",
+        "reason_codes": [],
+        "planned_queue_count": 1
+      },
+      {
+        "canonical_url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "status": "eligible",
+        "source_authority": "backend_cms",
+        "indexability_state": "indexable",
+        "claim_boundary_state": "claim_safe",
+        "reason_codes": [],
+        "planned_queue_count": 1
+      },
+      {
+        "canonical_url": "https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "status": "blocked",
+        "source_authority": "backend_cms",
+        "indexability_state": "superseded_canonical",
+        "claim_boundary_state": "claim_safe",
+        "reason_codes": [
+          "noindex"
+        ],
+        "planned_queue_count": 0
+      },
+      {
+        "canonical_url": "https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "status": "blocked",
+        "source_authority": "backend_cms",
+        "indexability_state": "superseded_canonical",
+        "claim_boundary_state": "claim_safe",
+        "reason_codes": [
+          "noindex"
+        ],
+        "planned_queue_count": 0
+      }
+    ],
+    "old_www_rows_not_eligible": true,
+    "apex_candidates_clean": true
+  },
+  "public_runtime_checks": [
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "http_status": 200,
+      "final_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "canonical": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "robots": [
+        "index, follow"
+      ],
+      "has_noindex": false,
+      "has_stale_turnover_rate_report": false,
+      "json_ld_count": 4,
+      "public_runtime_authority_used": false
+    },
+    {
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "http_status": 200,
+      "final_url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "canonical": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "robots": [
+        "index, follow"
+      ],
+      "has_noindex": false,
+      "has_stale_turnover_rate_report": false,
+      "json_ld_count": 0,
+      "public_runtime_authority_used": false
+    },
+    {
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "http_status": 200,
+      "final_url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "canonical": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "robots": [
+        "index, follow"
+      ],
+      "has_noindex": false,
+      "has_stale_turnover_rate_report": false,
+      "json_ld_count": 0,
+      "public_runtime_authority_used": false
+    }
+  ],
+  "accidental_enqueue_detected": false,
+  "accidental_submission_detected": false,
+  "external_api_call_detected": false,
+  "ops_seo_visibility": {
+    "checked": false,
+    "status": "not_checked_optional",
+    "sidecar": "Optional authenticated /ops/seo UI visibility was not checked; backend read-only URL Truth and Search Channel verification completed."
+  },
+  "recommended_next_task": "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT",
+  "research_queue_recommendation": "defer_to_SEO-GROWTH-MBTI-ACTION-RESEARCH-QUEUE-PREFLIGHT",
+  "research_deferred_reason": "Research pages are claim-sensitive and should use a separate stricter enqueue preflight even though their current URL Truth rows are dry-run eligible.",
+  "no_write_performed": true,
+  "no_enqueue": true,
+  "no_submission": true,
+  "no_external_api_call": true,
+  "no_cms_mutation": true,
+  "no_sitemap_mutation": true,
+  "no_llms_mutation": true,
+  "no_fap_web_mutation": true,
+  "next_task": "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.md
@@ -1,0 +1,146 @@
+# SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW
+
+## Executive Summary
+
+The post-write production review confirms that the MBTI FIX-02 bounded URL Truth cleanup/write left production in the expected state.
+
+The old Research `www` URL Truth rows are retained only as superseded canonicals and are not Search Channel eligible. The EN/ZH Research apex rows and ZH MBTI test apex row exist, are indexable, and are visible to the Search Channel dry-run as clean apex candidates.
+
+Queue item 2 remains unchanged for the already-submitted EN MBTI test URL. No Search Channel enqueue, live submission, external API call, CMS mutation, sitemap mutation, llms mutation, fap-web mutation, collector write, migration, scheduler activation, raw crawler log read, Digital PR action, or production deploy was performed during this review.
+
+## Persisted URL Truth State
+
+Old retired rows:
+
+- `https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+Both stale rows are present only as `indexability_state=superseded_canonical`. They are not Search Channel eligible and are blocked by the Search Channel dry-run with `reason_codes=["noindex"]`.
+
+New apex Research rows:
+
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+Both apex Research rows are present, `indexability_state=indexable`, `source_authority=backend_cms`, `private_flow=false`, and Search Channel dry-run eligible.
+
+ZH MBTI test row:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+The ZH MBTI test row is present, `indexability_state=indexable`, `source_authority=scale_catalog`, `private_flow=false`, and Search Channel dry-run eligible.
+
+## Entity Mapping State
+
+The old Research `www` rows have `seo_url_entities.authority_status=superseded_canonical`.
+
+The EN/ZH Research apex rows have `seo_url_entities.authority_status=published_approved` with `entity_source=research_reports`.
+
+The ZH MBTI test apex row has a `seo_url_entities` mapping from `entity_source=scales_registry` with the observed backend scale authority state recorded by the cleanup command.
+
+## Queue Item 2 Verification
+
+Queue item 2 remains unchanged:
+
+- `id=2`
+- `canonical_url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- `channel=indexnow`
+- `approval_state=approved`
+- `execution_state=submitted`
+
+No duplicate EN MBTI queue item was detected. The persisted Search Channel queue count remained stable during the read-only review, and no retry storm or duplicate live event was observed in the bounded queue state checked for this task.
+
+## Cleanup Command Idempotency Dry-run
+
+The production cleanup command was rerun in dry-run/no-write mode:
+
+```bash
+php artisan seo-intel:mbti-url-truth-cleanup \
+  --preset=mbti-fix-02-www-research-apex \
+  --dry-run \
+  --no-write \
+  --json
+```
+
+Result:
+
+- `status=dry_run_ready`
+- `dry_run=true`
+- `no_write=true`
+- `writes_committed=false`
+- `old_www_rows_found=2`
+- `apex_research_candidates_found=true`
+- `zh_mbti_candidate_found=true`
+- `queue_item_2_untouched=true`
+- `duplicate_cluster_prevented=true`
+- `search_channel_enqueue_attempted=false`
+- `live_submission_attempted=false`
+- `external_api_call_attempted=false`
+- `issues=[]`
+
+## Search Channel Dry-run
+
+The broad Search Channel dry-run/no-write completed without writes, enqueue, live submission, or external API calls.
+
+Bounded canonical URL dry-runs confirmed:
+
+- ZH MBTI apex: eligible
+- EN Research apex: eligible
+- ZH Research apex: eligible
+- old EN Research `www`: blocked / not eligible
+- old ZH Research `www`: blocked / not eligible
+
+The old `www` Research URLs are blocked by `indexability_state=superseded_canonical` and `reason_codes=["noindex"]`.
+
+## Public Runtime Checks
+
+Safe public runtime checks returned HTTP 200, exact apex canonical, `index, follow`, and no `noindex` for:
+
+- `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+
+No stale `turnover-rate-report` URL was observed. Dataset JSON-LD presence was recorded only as public runtime observation, not URL Truth.
+
+## /ops/seo Visibility
+
+Optional `/ops/seo` UI visibility was not checked. This does not block the review because production URL Truth, entity mappings, cleanup command idempotency, queue item 2 state, and Search Channel dry-run state were verified through read-only backend paths.
+
+## Recommendation / Next Task
+
+ZH MBTI can proceed to a human-approved Search Channel enqueue preflight.
+
+Research should remain deferred to a separate stricter claim-sensitive enqueue preflight because the Research pages are claim-sensitive even though the Search Channel dry-run currently marks their URL Truth rows as eligible.
+
+Recommended next task:
+
+`SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT`
+
+Deferred Research task:
+
+`SEO-GROWTH-MBTI-ACTION-RESEARCH-QUEUE-PREFLIGHT`
+
+## What Was Not Done
+
+- No Search Channel enqueue.
+- No live URL submission.
+- No external search API call.
+- No collector write.
+- No CMS mutation.
+- No article publish.
+- No internal link creation.
+- No sitemap or llms mutation.
+- No fap-web mutation.
+- No production deploy.
+- No migration.
+- No scheduler activation.
+- No raw Nginx access log read.
+- No Digital PR outreach.
+
+## Final Decision
+
+`mbti_action_01b_fix_02_post_write_review_completed_ready_for_zh_mbti_queue_preflight`
+
+## Next Task
+
+`SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02PostWriteSearchChannelReviewTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02PostWriteSearchChannelReviewTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01bFix02PostWriteSearchChannelReviewTest extends TestCase
+{
+    #[Test]
+    public function generated_json_exists_and_parses(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1',
+            $artifact['schema_version'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW',
+            $artifact['task'] ?? null
+        );
+    }
+
+    #[Test]
+    public function no_write_and_no_submission_boundaries_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['no_write_performed'] ?? false);
+        $this->assertTrue($artifact['no_enqueue'] ?? false);
+        $this->assertTrue($artifact['no_submission'] ?? false);
+        $this->assertTrue($artifact['no_external_api_call'] ?? false);
+        $this->assertTrue($artifact['no_cms_mutation'] ?? false);
+        $this->assertTrue($artifact['no_sitemap_mutation'] ?? false);
+        $this->assertTrue($artifact['no_llms_mutation'] ?? false);
+        $this->assertTrue($artifact['no_fap_web_mutation'] ?? false);
+        $this->assertFalse($artifact['accidental_enqueue_detected'] ?? true);
+        $this->assertFalse($artifact['accidental_submission_detected'] ?? true);
+        $this->assertFalse($artifact['external_api_call_detected'] ?? true);
+    }
+
+    #[Test]
+    public function old_www_research_rows_are_listed_as_non_eligible(): void
+    {
+        $rows = collect($this->artifact()['old_www_rows_state'] ?? [])->keyBy('canonical_url');
+
+        foreach ([
+            'https://www.fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            'https://www.fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+        ] as $url) {
+            $this->assertTrue($rows->has($url));
+            $this->assertSame('superseded_canonical', $rows[$url]['indexability_state'] ?? null);
+            $this->assertSame('superseded_canonical', $rows[$url]['entity_authority_status'] ?? null);
+            $this->assertSame('blocked', $rows[$url]['search_channel_eligibility'] ?? null);
+            $this->assertTrue($rows[$url]['non_eligible'] ?? false);
+        }
+    }
+
+    #[Test]
+    public function apex_research_and_zh_mbti_rows_are_listed(): void
+    {
+        $researchUrls = array_column($this->artifact()['apex_research_rows_state'] ?? [], 'canonical_url');
+
+        $this->assertContains(
+            'https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report',
+            $researchUrls
+        );
+        $this->assertContains(
+            'https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report',
+            $researchUrls
+        );
+
+        foreach ($this->artifact()['apex_research_rows_state'] ?? [] as $row) {
+            $this->assertSame('indexable', $row['indexability_state'] ?? null);
+            $this->assertSame('backend_cms', $row['source_authority'] ?? null);
+            $this->assertSame('eligible', $row['search_channel_eligibility'] ?? null);
+        }
+
+        $this->assertSame(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $this->artifact()['zh_mbti_row_state']['canonical_url'] ?? null
+        );
+        $this->assertSame('indexable', $this->artifact()['zh_mbti_row_state']['indexability_state'] ?? null);
+        $this->assertSame('eligible', $this->artifact()['zh_mbti_row_state']['search_channel_eligibility'] ?? null);
+    }
+
+    #[Test]
+    public function queue_item_2_state_is_recorded_as_unchanged(): void
+    {
+        $queue = $this->artifact()['queue_item_2_state'] ?? [];
+
+        $this->assertSame(2, $queue['id'] ?? null);
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $queue['canonical_url'] ?? null
+        );
+        $this->assertSame('indexnow', $queue['channel'] ?? null);
+        $this->assertSame('approved', $queue['approval_state'] ?? null);
+        $this->assertSame('submitted', $queue['execution_state'] ?? null);
+        $this->assertTrue($queue['unchanged'] ?? false);
+        $this->assertFalse($queue['duplicate_en_mbti_queue_item_detected'] ?? true);
+    }
+
+    #[Test]
+    public function cleanup_dry_run_and_search_channel_review_are_safe(): void
+    {
+        $artifact = $this->artifact();
+        $cleanup = $artifact['cleanup_command_idempotency_dry_run'] ?? [];
+        $search = $artifact['search_channel_dry_run'] ?? [];
+
+        $this->assertTrue($cleanup['dry_run'] ?? false);
+        $this->assertTrue($cleanup['no_write'] ?? false);
+        $this->assertFalse($cleanup['writes_committed'] ?? true);
+        $this->assertTrue($cleanup['queue_item_2_untouched'] ?? false);
+        $this->assertTrue($cleanup['duplicate_cluster_prevented'] ?? false);
+        $this->assertSame([], $cleanup['issues'] ?? null);
+
+        $this->assertTrue($search['old_www_rows_not_eligible'] ?? false);
+        $this->assertTrue($search['apex_candidates_clean'] ?? false);
+        $this->assertFalse($search['broad']['enqueue_attempted'] ?? true);
+        $this->assertFalse($search['broad']['live_submission_attempted'] ?? true);
+        $this->assertFalse($search['broad']['external_calls_attempted'] ?? true);
+    }
+
+    #[Test]
+    public function final_decision_and_recommended_next_task_are_present(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'mbti_action_01b_fix_02_post_write_review_completed_ready_for_zh_mbti_queue_preflight',
+            $artifact['final_decision'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT',
+            $artifact['recommended_next_task'] ?? null
+        );
+        $this->assertSame(
+            'SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT',
+            $artifact['next_task'] ?? null
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T15:42:00.000Z",
+  "updated_at": "2026-05-24T15:45:00.000Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17962,12 +17962,12 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-post-write-review",
-      "status": "local_checks_passed",
+      "status": "pr_open_github_checks_pending",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE"
       ],
-      "commit_sha": "b0b88701ea87f8f71a916c945d6bbec3e0339b19",
-      "pr_url": null,
+      "commit_sha": "ecf60562448aa8247163eb2342f5a37689078f62",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1656",
       "checks": {
         "production_read_only": {
           "persisted_url_truth_state": "passed: old Research www rows are superseded_canonical and not Search Channel eligible; EN/ZH Research apex rows and ZH MBTI apex row exist and are indexable.",
@@ -18018,6 +18018,11 @@
           "at": "2026-05-24T23:42:00+08:00",
           "status": "commit_created",
           "summary": "Created scoped commit b0b88701 for the post-write Search Channel review report."
+        },
+        {
+          "at": "2026-05-24T23:45:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1656 for the post-write URL Truth and Search Channel dry-run review report. GitHub checks are pending."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T12:18:00.000Z",
+  "updated_at": "2026-05-24T15:42:00.000Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -17896,11 +17896,11 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-write",
-      "status": "in_progress",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE-PREFLIGHT-R2"
       ],
-      "commit_sha": null,
+      "commit_sha": "954e275983d0a289007e5c69d51bdfe37152518d",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1655",
       "checks": {
         "production_bounded_write": {
@@ -17923,9 +17923,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-24T14:17:39Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": false,
@@ -17951,6 +17951,73 @@
           "at": "2026-05-24T23:06:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1655 for the bounded production URL Truth cleanup/write report. GitHub checks are pending."
+        },
+        {
+          "at": "2026-05-24T23:35:00+08:00",
+          "status": "merged",
+          "summary": "Reconciled PR #1655 as merged with merge commit 954e275983d0a289007e5c69d51bdfe37152518d. Remote branch is deleted and local main contains the merge commit."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01b-fix-02-post-write-review",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE"
+      ],
+      "commit_sha": "b0b88701ea87f8f71a916c945d6bbec3e0339b19",
+      "pr_url": null,
+      "checks": {
+        "production_read_only": {
+          "persisted_url_truth_state": "passed: old Research www rows are superseded_canonical and not Search Channel eligible; EN/ZH Research apex rows and ZH MBTI apex row exist and are indexable.",
+          "seo_url_entities_state": "passed: old Research www mappings are superseded_canonical; apex Research mappings are published_approved; ZH MBTI mapping exists from scales_registry.",
+          "queue_item_2": "passed: queue item 2 remains approved/submitted for EN MBTI IndexNow with no duplicate EN MBTI queue item detected.",
+          "cleanup_idempotency_dry_run": "passed: cleanup command dry-run/no-write reported queue_item_2_untouched=true, duplicate_cluster_prevented=true, writes_committed=false, and issues=[].",
+          "search_channel_dry_run": "passed: ZH MBTI apex, EN Research apex, and ZH Research apex are eligible in dry-run; old Research www rows are blocked as noindex; no enqueue/submission/API call occurred.",
+          "public_runtime": "passed: ZH MBTI apex and EN/ZH Research apex returned HTTP 200 with exact apex canonical, index/follow, and no noindex; public runtime was used only as observation.",
+          "ops_seo_visibility": "sidecar: optional authenticated /ops/seo UI visibility was not checked."
+        },
+        "local": {
+          "focused_post_write_review_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02PostWriteSearchChannelReview --no-ansi (7 tests, 77 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi",
+          "pint": "passed: vendor/bin/pint --test (3529 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT",
+      "history": [
+        {
+          "at": "2026-05-24T23:35:00+08:00",
+          "status": "in_progress",
+          "summary": "Started post-write production read-only review from latest clean main. Scope is limited to read-only URL Truth, Search Channel dry-run, public runtime observation, docs/generated report, focused test, and authorized PR-train metadata."
+        },
+        {
+          "at": "2026-05-24T23:35:00+08:00",
+          "status": "production_read_only_checks_passed",
+          "summary": "Verified old Research www rows are superseded/non-eligible, apex Research and ZH MBTI rows are indexable, queue item 2 remains unchanged, cleanup command dry-run is idempotent, Search Channel dry-run has clean apex candidates, and public runtime canonical remains apex."
+        },
+        {
+          "at": "2026-05-24T23:40:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff checks passed."
+        },
+        {
+          "at": "2026-05-24T23:42:00+08:00",
+          "status": "commit_created",
+          "summary": "Created scoped commit b0b88701 for the post-write Search Channel review report."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11326,6 +11326,51 @@ prs:
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW
 
+  - id: SEO-GROWTH-MBTI-ACTION-01B-FIX-02-POST-WRITE-SEARCH-CHANNEL-REVIEW
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-WRITE
+    branch: codex/seo-growth-mbti-action-01b-fix-02-post-write-review
+    base: main
+    title: "docs(seo-intel): add MBTI URL Truth post-write Search Channel review"
+    name: "Post-write URL Truth and Search Channel dry-run review"
+    train_scope: seo_growth_mbti_action
+    risk_level: production_read_only_report
+    type: docs_generated_test
+    scope:
+      - Verify old Research www URL Truth rows are superseded, non-indexable, and not Search Channel eligible after the bounded cleanup/write.
+      - Verify EN/ZH Research apex URL Truth rows and the ZH MBTI test apex URL Truth row exist, are indexable, and have entity mappings.
+      - Verify queue item 2 remains unchanged and no accidental Search Channel enqueue, live submission, external API call, CMS mutation, sitemap/llms mutation, or fap-web mutation occurred.
+      - Run cleanup command dry-run/no-write and Search Channel dry-run/no-write only, then record the report in docs/generated/test scope.
+      - Record that ZH MBTI can proceed to human-approved queue preflight while Research remains deferred to a separate claim-sensitive enqueue preflight.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02PostWriteSearchChannelReviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, runtime services, migrations, production env/deploy files, CMS content, articles, internal links, sitemap, llms, crawler log readers, scheduler, Search Channel submitter code, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform production writes, collector writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, raw Nginx access log reads, or manual DB update/delete.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, public runtime, or local copies as authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02PostWriteSearchChannelReview --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- Added the post-write MBTI FIX-02 URL Truth and Search Channel dry-run review report.
- Added generated JSON locking old Research www retirement, apex Research/ZH MBTI state, queue item 2 safety, Search Channel dry-run results, and public runtime observations.
- Added a focused artifact test and updated the PR-train manifest/state for this scoped task.

## Why
- Confirms the bounded production URL Truth cleanup/write left stale Research www rows non-eligible, apex rows clean, and queue item 2 unchanged before any human-approved ZH MBTI queue preflight.

## Validation
- cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02PostWriteSearchChannelReview --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01b-fix-02-post-write-search-channel-review.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No Search Channel enqueue or URL submission.
- No production write, collector write, CMS mutation, sitemap/llms mutation, fap-web mutation, deploy, or Digital PR action.
- Research enqueue remains deferred to a separate claim-sensitive preflight.