### PR TITLE
docs(seo-intel): add ZH MBTI post-enqueue review

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW",
+  "final_decision": "zh_mbti_post_enqueue_review_completed_ready_for_live_preflight",
+  "queue_item_id": 3,
+  "batch_id": 3,
+  "target_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "queue_item_state": {
+    "exists": true,
+    "id": 3,
+    "batch_id": 3,
+    "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "locale": "zh-CN",
+    "page_entity_type": "test_detail",
+    "entity_type": "test_detail",
+    "entity_id": "mbti-personality-test-16-personality-types",
+    "source_authority": "scale_catalog",
+    "source_table": "scales_registry",
+    "channel": "indexnow",
+    "eligibility_state": "eligible",
+    "approval_state": "pending",
+    "execution_state": "dry_run_ready",
+    "indexability_state": "indexable",
+    "claim_boundary_state": "claim_safe",
+    "private_flow": false,
+    "reason_codes": []
+  },
+  "batch_state": {
+    "exists": true,
+    "id": 3,
+    "channel": "indexnow",
+    "status": "dry_run",
+    "item_count": 1,
+    "created_by": "seo-intel:search-channel-queue",
+    "external_calls_attempted": false
+  },
+  "event_state": {
+    "queue_item_planned_event_exists": true,
+    "event_types": [
+      "queue_item_planned"
+    ],
+    "live_submission_approved_event_exists": false,
+    "live_submission_response_event_exists": false,
+    "submitted_event_exists": false,
+    "external_api_call_event_exists": false,
+    "submission_status_accepted_exists": false
+  },
+  "duplicate_check": {
+    "target_queue_count": 1,
+    "extra_active_queue_item_for_target": false,
+    "duplicate_dry_run_status": "blocked",
+    "duplicate_detected": true,
+    "blocked_reason": "existing_active_queue_item",
+    "planned_queue_count_after_enqueue": 0,
+    "no_extra_duplicate": true
+  },
+  "queue_item_2_state": {
+    "id": 2,
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "unchanged": true,
+    "duplicate_en_queue_item_detected": false
+  },
+  "gate_state": {
+    "queue_write_enabled": false,
+    "live_submission_enabled": false,
+    "external_api_calls_enabled": false,
+    "indexnow_live_api_enabled": false,
+    "gates_closed": true
+  },
+  "public_runtime_state": {
+    "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "http_status": 200,
+    "final_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "canonical": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "meta_robots": "index, follow",
+    "x_robots_tag": null,
+    "has_noindex": false,
+    "has_staging_canonical": false,
+    "public_runtime_authority_used": false
+  },
+  "ops_seo_visibility": {
+    "checked": false,
+    "sidecar": "Optional authenticated /ops/seo UI visibility was not checked; backend read-only queue, batch, event, duplicate, gate, and runtime checks are sufficient for this review."
+  },
+  "staging_sidecar_state": {
+    "checked": true,
+    "staging_noindex_active": true,
+    "staging_x_robots_tag": "noindex, nofollow, noarchive",
+    "staging_meta_robots": "noindex, nofollow, noarchive, nocache",
+    "staging_canonical_points_to_production_apex": true,
+    "baidu_stale_result_known_sidecar": true,
+    "baidu_removal_performed": false
+  },
+  "accidental_live_submission_detected": false,
+  "external_api_call_detected": false,
+  "enqueue_performed": false,
+  "live_submission_performed": false,
+  "cms_mutation_performed": false,
+  "fap_web_mutation_performed": false,
+  "research_deferred": true,
+  "next_task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-01"
+}

--- a/backend/docs/seo/seo-growth-mbti-action-zh-mbti-post-enqueue-review.md
+++ b/backend/docs/seo/seo-growth-mbti-action-zh-mbti-post-enqueue-review.md
@@ -1,0 +1,151 @@
+# SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW
+
+## Executive Summary
+
+The production read-only post-enqueue review confirms that ZH MBTI queue item 3 is stable and ready for a future live submission preflight.
+
+Queue item 3 exists for the exact ZH MBTI test URL, is still pending approval, remains in `dry_run_ready`, has only a planning event, and has no live submission approval or response event. Persistent Search Channel gates remain closed. Queue item 2 for EN MBTI remains unchanged.
+
+No Search Channel enqueue, live submission, external search API call, CMS mutation, sitemap/llms mutation, fap-web mutation, collector write, migration, scheduler activation, deploy, raw Nginx log read, Digital PR action, or production data write was performed during this review.
+
+## Queue Item 3 Verification
+
+Queue item 3 exists with the expected fields:
+
+- `id=3`
+- `batch_id=3`
+- `canonical_url=https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `locale=zh-CN`
+- `page_entity_type=test_detail`
+- `entity_type=test_detail`
+- `entity_id=mbti-personality-test-16-personality-types`
+- `source_authority=scale_catalog`
+- `source_table=scales_registry`
+- `channel=indexnow`
+- `eligibility_state=eligible`
+- `approval_state=pending`
+- `execution_state=dry_run_ready`
+- `indexability_state=indexable`
+- `claim_boundary_state=claim_safe`
+- `private_flow=false`
+
+## Batch / Event State
+
+Batch 3 exists:
+
+- `id=3`
+- `channel=indexnow`
+- `status=dry_run`
+- `item_count=1`
+- `created_by=seo-intel:search-channel-queue`
+
+Queue item 3 has one event:
+
+- `event_type=queue_item_planned`
+
+No queue item 3 event exists for:
+
+- `live_submission_approved`
+- `live_submission_response`
+- `submitted`
+- `external_api_call`
+
+## Duplicate Check
+
+Only one active queue item exists for:
+
+- `canonical_url=https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- `channel=indexnow`
+
+A post-enqueue dry-run/no-write for the same canonical URL now blocks with:
+
+- `duplicate_detected=true`
+- `reason_code=existing_active_queue_item`
+- `planned_queue_count=0`
+
+This confirms duplicate protection is active after the enqueue.
+
+## Queue Item 2 Verification
+
+The protected EN MBTI queue item 2 remains unchanged:
+
+- `id=2`
+- `canonical_url=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- `channel=indexnow`
+- `approval_state=approved`
+- `execution_state=submitted`
+
+No duplicate EN MBTI queue item was observed.
+
+## Gate State
+
+Persistent production gates remain closed:
+
+- queue write gate: `false`
+- live submission gate: `false`
+- external API call gate: `false`
+- IndexNow live API gate: not enabled
+
+No gate was opened during this read-only review.
+
+## Public Runtime Check
+
+Safe public runtime observation for the ZH MBTI URL returned:
+
+- HTTP status: `200`
+- final URL: `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- canonical: `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- HTML robots: `index, follow`
+- no `noindex`
+- no staging canonical
+
+Public runtime was used only as observation, not URL Truth.
+
+## /ops/seo Visibility
+
+Optional authenticated `/ops/seo` UI visibility was not checked. This does not block the review because production queue item, batch, event, duplicate protection, gate state, queue item 2, and public runtime state were verified through read-only backend and public runtime paths.
+
+## Staging / Baidu Sidecar
+
+Staging remains technically contained:
+
+- `https://staging.fermatmind.com/` returns HTTP 200
+- `X-Robots-Tag=noindex, nofollow, noarchive`
+- HTML meta robots: `noindex, nofollow, noarchive, nocache`
+- canonical points to production apex
+
+The known Baidu stale staging result remains a sidecar. No Baidu removal action was performed.
+
+## Recommendation / Next Task
+
+Queue item 3 is stable and ready for a future live submission preflight.
+
+Recommended next task:
+
+`SEARCH-CHANNEL-LIVE-ZH-MBTI-01｜Live submission preflight for queue item 3`
+
+## What Was Not Done
+
+- No Search Channel enqueue.
+- No live URL submission.
+- No external search API call.
+- No IndexNow/GSC/Baidu/Bing/360/Sogou/Shenma call.
+- No CMS mutation.
+- No article publish.
+- No internal link creation.
+- No sitemap or llms mutation.
+- No fap-web mutation.
+- No production deploy.
+- No migration.
+- No scheduler activation.
+- No raw Nginx access log read.
+- No Digital PR outreach.
+- No Baidu stale-result removal action.
+
+## Final Decision
+
+`zh_mbti_post_enqueue_review_completed_ready_for_live_preflight`
+
+## Next Task
+
+`SEARCH-CHANNEL-LIVE-ZH-MBTI-01`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiActionZhMbtiPostEnqueueReviewTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiActionZhMbtiPostEnqueueReviewTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiActionZhMbtiPostEnqueueReviewTest extends TestCase
+{
+    #[Test]
+    public function generated_json_exists_and_parses(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW', $artifact['task'] ?? null);
+    }
+
+    #[Test]
+    public function target_queue_item_and_channel_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(3, $artifact['queue_item_id'] ?? null);
+        $this->assertSame(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $artifact['target_url'] ?? null
+        );
+        $this->assertSame('indexnow', $artifact['channel'] ?? null);
+    }
+
+    #[Test]
+    public function queue_item_state_is_recorded(): void
+    {
+        $state = $this->artifact()['queue_item_state'] ?? [];
+
+        $this->assertTrue($state['exists'] ?? false);
+        $this->assertSame(3, $state['id'] ?? null);
+        $this->assertSame(3, $state['batch_id'] ?? null);
+        $this->assertSame('zh-CN', $state['locale'] ?? null);
+        $this->assertSame('test_detail', $state['page_entity_type'] ?? null);
+        $this->assertSame('scale_catalog', $state['source_authority'] ?? null);
+        $this->assertSame('indexnow', $state['channel'] ?? null);
+        $this->assertSame('pending', $state['approval_state'] ?? null);
+        $this->assertSame('dry_run_ready', $state['execution_state'] ?? null);
+        $this->assertSame('claim_safe', $state['claim_boundary_state'] ?? null);
+        $this->assertFalse($state['private_flow'] ?? true);
+    }
+
+    #[Test]
+    public function batch_and_event_state_are_safe(): void
+    {
+        $artifact = $this->artifact();
+        $batch = $artifact['batch_state'] ?? [];
+        $events = $artifact['event_state'] ?? [];
+
+        $this->assertTrue($batch['exists'] ?? false);
+        $this->assertSame(3, $batch['id'] ?? null);
+        $this->assertSame('indexnow', $batch['channel'] ?? null);
+        $this->assertSame('dry_run', $batch['status'] ?? null);
+        $this->assertSame(1, $batch['item_count'] ?? null);
+        $this->assertFalse($batch['external_calls_attempted'] ?? true);
+
+        $this->assertTrue($events['queue_item_planned_event_exists'] ?? false);
+        $this->assertSame(['queue_item_planned'], $events['event_types'] ?? null);
+        $this->assertFalse($events['live_submission_approved_event_exists'] ?? true);
+        $this->assertFalse($events['live_submission_response_event_exists'] ?? true);
+        $this->assertFalse($events['external_api_call_event_exists'] ?? true);
+        $this->assertFalse($events['submission_status_accepted_exists'] ?? true);
+    }
+
+    #[Test]
+    public function duplicate_check_blocks_second_queue_plan(): void
+    {
+        $duplicate = $this->artifact()['duplicate_check'] ?? [];
+
+        $this->assertSame(1, $duplicate['target_queue_count'] ?? null);
+        $this->assertFalse($duplicate['extra_active_queue_item_for_target'] ?? true);
+        $this->assertSame('blocked', $duplicate['duplicate_dry_run_status'] ?? null);
+        $this->assertTrue($duplicate['duplicate_detected'] ?? false);
+        $this->assertSame('existing_active_queue_item', $duplicate['blocked_reason'] ?? null);
+        $this->assertSame(0, $duplicate['planned_queue_count_after_enqueue'] ?? null);
+        $this->assertTrue($duplicate['no_extra_duplicate'] ?? false);
+    }
+
+    #[Test]
+    public function queue_item_2_state_is_recorded_as_unchanged(): void
+    {
+        $state = $this->artifact()['queue_item_2_state'] ?? [];
+
+        $this->assertSame(2, $state['id'] ?? null);
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $state['canonical_url'] ?? null
+        );
+        $this->assertSame('indexnow', $state['channel'] ?? null);
+        $this->assertSame('approved', $state['approval_state'] ?? null);
+        $this->assertSame('submitted', $state['execution_state'] ?? null);
+        $this->assertTrue($state['unchanged'] ?? false);
+        $this->assertFalse($state['duplicate_en_queue_item_detected'] ?? true);
+    }
+
+    #[Test]
+    public function gates_public_runtime_and_safety_boundaries_are_recorded(): void
+    {
+        $artifact = $this->artifact();
+        $gates = $artifact['gate_state'] ?? [];
+        $runtime = $artifact['public_runtime_state'] ?? [];
+
+        $this->assertFalse($gates['queue_write_enabled'] ?? true);
+        $this->assertFalse($gates['live_submission_enabled'] ?? true);
+        $this->assertFalse($gates['external_api_calls_enabled'] ?? true);
+        $this->assertFalse($gates['indexnow_live_api_enabled'] ?? true);
+        $this->assertTrue($gates['gates_closed'] ?? false);
+
+        $this->assertSame(200, $runtime['http_status'] ?? null);
+        $this->assertSame(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $runtime['canonical'] ?? null
+        );
+        $this->assertFalse($runtime['has_noindex'] ?? true);
+        $this->assertFalse($runtime['has_staging_canonical'] ?? true);
+
+        $this->assertFalse($artifact['accidental_live_submission_detected'] ?? true);
+        $this->assertFalse($artifact['external_api_call_detected'] ?? true);
+        $this->assertFalse($artifact['enqueue_performed'] ?? true);
+        $this->assertFalse($artifact['live_submission_performed'] ?? true);
+        $this->assertFalse($artifact['cms_mutation_performed'] ?? true);
+        $this->assertFalse($artifact['fap_web_mutation_performed'] ?? true);
+        $this->assertTrue($artifact['research_deferred'] ?? false);
+    }
+
+    #[Test]
+    public function final_decision_and_next_task_are_present(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'zh_mbti_post_enqueue_review_completed_ready_for_live_preflight',
+            $artifact['final_decision'] ?? null
+        );
+        $this->assertSame('SEARCH-CHANNEL-LIVE-ZH-MBTI-01', $artifact['next_task'] ?? null);
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T18:41:00.000Z",
+  "updated_at": "2026-05-24T18:44:00.000Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18208,12 +18208,12 @@
     "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-zh-mbti-post-enqueue-review",
-      "status": "commit_created",
+      "status": "pr_open_github_checks_pending",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE"
       ],
-      "commit_sha": "dfce93dd5276d26d223e1f0ae85de63aa5e04542",
-      "pr_url": null,
+      "commit_sha": "9d06a5c77a975e7b4f155b5229c8f57fb99e9ddc",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1659",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -18270,6 +18270,11 @@
           "at": "2026-05-25T02:41:00+08:00",
           "status": "commit_created",
           "summary": "Created scoped commit dfce93dd for the ZH MBTI post-enqueue review report."
+        },
+        {
+          "at": "2026-05-25T02:44:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1659 for the ZH MBTI post-enqueue review report. GitHub checks are pending."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T18:22:00.000Z",
+  "updated_at": "2026-05-24T18:40:00.000Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18116,11 +18116,11 @@
     "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-zh-mbti-queue",
-      "status": "pr_open_github_checks_pending",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE-PREFLIGHT"
       ],
-      "commit_sha": "b6b6995fa98e66c9409fb4ba126753b65c2ae174",
+      "commit_sha": "4225631bdb8abe426036cc4cfc899d95d720e688",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1658",
       "checks": {
         "dependency": {
@@ -18153,8 +18153,8 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-24T18:21:09Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -18196,6 +18196,75 @@
           "at": "2026-05-25T02:22:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1658 for the ZH MBTI Search Channel enqueue report. GitHub checks are pending."
+        },
+        {
+          "at": "2026-05-25T02:32:00+08:00",
+          "status": "merged_reconciled",
+          "summary": "Verified PR #1658 is merged, origin/main contains merge commit 4225631bdb8abe426036cc4cfc899d95d720e688, and the remote branch is deleted; reconciled state to unblock the post-enqueue review."
+        }
+      ],
+      "local_cleanup_note": "Reconciled while starting SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW; origin/main contains merge commit 4225631bdb8abe426036cc4cfc899d95d720e688. scripts/post_merge_cleanup.sh is absent in this clone."
+    },
+    "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-zh-mbti-post-enqueue-review",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "Dependency SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE is merged as 4225631bdb8abe426036cc4cfc899d95d720e688 on origin/main."
+        },
+        "production_read_only": {
+          "queue_item_3": "passed: queue item 3 exists for the exact ZH MBTI URL/channel with locale=zh-CN, page_entity_type=test_detail, source_authority=scale_catalog, approval_state=pending, execution_state=dry_run_ready, claim_boundary_state=claim_safe, private_flow=false.",
+          "batch_3": "passed: batch 3 exists with channel=indexnow, status=dry_run, item_count=1.",
+          "event_trail": "passed: queue item 3 has queue_item_planned event only; no live_submission_approved, live_submission_response, submitted, external_api_call, or accepted submission event exists.",
+          "duplicate_check": "passed: exactly one queue item exists for the ZH target URL/channel; post-enqueue dry-run/no-write blocks with existing_active_queue_item and planned_queue_count=0.",
+          "queue_item_2": "passed: EN MBTI queue item 2 remains approved/submitted and unchanged; no duplicate EN queue item detected.",
+          "gate_state": "passed: persistent queue write, live submission, external API call, and IndexNow live API gates remain closed.",
+          "public_runtime": "passed: ZH MBTI public URL returned HTTP 200, exact apex canonical, robots index/follow, no noindex, and no staging canonical.",
+          "staging_sidecar": "passed: staging noindex containment remains active; known Baidu stale result remains a sidecar.",
+          "ops_seo_visibility": "sidecar: optional authenticated /ops/seo UI visibility was not checked."
+        },
+        "local": {
+          "focused_post_enqueue_review_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiActionZhMbtiPostEnqueueReview --no-ansi (8 tests, 76 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi",
+          "pint": "passed: vendor/bin/pint --test (3532 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEARCH-CHANNEL-LIVE-ZH-MBTI-01",
+      "history": [
+        {
+          "at": "2026-05-25T02:32:00+08:00",
+          "status": "in_progress",
+          "summary": "Started post-enqueue review from latest clean main. Scope is limited to production read-only queue, batch, event, duplicate, gate, public runtime, staging sidecar checks, docs/generated report, focused test, and authorized PR-train metadata."
+        },
+        {
+          "at": "2026-05-25T02:34:00+08:00",
+          "status": "production_read_only_checks_passed",
+          "summary": "Verified queue item 3, batch 3, planned-only event trail, duplicate protection, queue item 2 preservation, closed gates, no accidental live submission or external API call, public runtime indexability, and staging sidecar containment."
+        },
+        {
+          "at": "2026-05-25T02:40:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff checks passed."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T18:40:00.000Z",
+  "updated_at": "2026-05-24T18:41:00.000Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18208,11 +18208,11 @@
     "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-zh-mbti-post-enqueue-review",
-      "status": "local_checks_passed",
+      "status": "commit_created",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE"
       ],
-      "commit_sha": null,
+      "commit_sha": "dfce93dd5276d26d223e1f0ae85de63aa5e04542",
       "pr_url": null,
       "checks": {
         "dependency": {
@@ -18265,6 +18265,11 @@
           "at": "2026-05-25T02:40:00+08:00",
           "status": "local_checks_passed",
           "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff checks passed."
+        },
+        {
+          "at": "2026-05-25T02:41:00+08:00",
+          "status": "commit_created",
+          "summary": "Created scoped commit dfce93dd for the ZH MBTI post-enqueue review report."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11460,6 +11460,50 @@ prs:
     scheduler_activation: false
     next_task: SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW
 
+  - id: SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE
+    branch: codex/seo-growth-mbti-action-zh-mbti-post-enqueue-review
+    base: main
+    title: "docs(seo-intel): add ZH MBTI post-enqueue review"
+    name: "Post-enqueue review for ZH MBTI queue item 3"
+    train_scope: seo_growth_mbti_action
+    risk_level: production_read_only_report
+    type: docs_generated_test
+    scope:
+      - Verify queue item 3 exists for the exact ZH MBTI URL with the expected pending/dry_run_ready IndexNow state.
+      - Verify batch 3, queue item 3 event trail, duplicate protection, queue item 2 preservation, closed gates, and no accidental live submission or external API call.
+      - Verify public runtime observation for the ZH MBTI URL and record staging/Baidu sidecars without performing Baidu removal.
+      - Record the production read-only post-enqueue review in docs/generated/test scope.
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-zh-mbti-post-enqueue-review.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiActionZhMbtiPostEnqueueReviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, runtime services, migrations, production env/deploy files, CMS content, articles, internal links, sitemap, llms, crawler log readers, scheduler, Search Channel enqueue/live submitter code, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform production writes, collector writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, raw Nginx access log reads, manual DB update/delete, or broad URL Truth writes.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, public runtime, or local copies as authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiActionZhMbtiPostEnqueueReview --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEARCH-CHANNEL-LIVE-ZH-MBTI-01
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- Added the production read-only post-enqueue review for ZH MBTI queue item 3.
- Added generated JSON and a focused test covering queue item, batch, events, duplicate protection, gates, queue item 2, runtime, and safety boundaries.
- Added the scoped PR-train manifest/state entry and reconciled the already-merged ZH MBTI queue dependency.

## Why
Queue item 3 was created for the ZH MBTI test URL and needs a read-only verification pass before any live submission preflight.

## Validation
- `cd backend && php artisan test --filter=SeoIntelGrowthMbtiActionZhMbtiPostEnqueueReview --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-zh-mbti-post-enqueue-review.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No Search Channel enqueue.
- No live URL submission.
- No external search API call.
- No CMS mutation, sitemap/llms mutation, fap-web change, deploy, migration, scheduler activation, or Digital PR action.
- /ops/seo UI visibility remains optional sidecar and was not checked.
