### PR TITLE
docs(seo-intel): add ZH MBTI IndexNow live preflight

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "search-channel-live-zh-mbti-01-preflight.v1",
+  "task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-01",
+  "final_decision": "blocked_indexnow_key_missing",
+  "queue_item_id": 3,
+  "target_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "queue_item_state": {
+    "exists": true,
+    "id": 3,
+    "batch_id": 3,
+    "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "locale": "zh-CN",
+    "page_entity_type": "test_detail",
+    "entity_type": "test_detail",
+    "entity_id": "mbti-personality-test-16-personality-types",
+    "source_authority": "scale_catalog",
+    "source_table": "scales_registry",
+    "channel": "indexnow",
+    "approval_state": "pending",
+    "execution_state": "dry_run_ready",
+    "eligibility_state": "eligible",
+    "indexability_state": "indexable",
+    "claim_boundary_state": "claim_safe",
+    "private_flow": false
+  },
+  "duplicate_check": {
+    "target_queue_count": 1,
+    "duplicate_dry_run_status": "blocked",
+    "duplicate_detected": true,
+    "blocked_reason": "existing_active_queue_item",
+    "planned_queue_count": 0,
+    "extra_active_queue_item_for_target": false,
+    "live_submission_approved_event_exists": false,
+    "live_submission_response_event_exists": false,
+    "submission_status_accepted_exists": false,
+    "retry_storm_detected": false,
+    "bulk_submit_event_detected": false
+  },
+  "queue_item_2_state": {
+    "exists": true,
+    "id": 2,
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "unchanged": true,
+    "duplicate_en_queue_item_detected": false
+  },
+  "gate_state": {
+    "queue_write_enabled": false,
+    "live_submission_enabled": false,
+    "external_api_calls_enabled": false,
+    "indexnow_live_api_enabled": false,
+    "gates_closed": true
+  },
+  "indexnow_key_readiness": {
+    "key_configured": true,
+    "raw_key_exposed": false,
+    "configured_key_sha256": "e9a3eca3e7c107d6e0ac63c1fdba24068d970aecb4bdf18ed69735e8b77cf143",
+    "configured_key_length": 32,
+    "key_location_configured": true,
+    "key_location": "https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt",
+    "public_key_location_status": 404,
+    "public_key_location_body_sha256": "e186ca91fd68bf566fce5b033aa5f404f5fcddf6f9fc09a5bd1ef6d6c53a00af",
+    "public_key_location_matches_configured_key": false,
+    "ready": false,
+    "blocker": "configured IndexNow keyLocation returned HTTP 404, so the public key file cannot be verified"
+  },
+  "submit_dry_run": {
+    "command": "php artisan seo-intel:search-channel-submit --queue-item-id=3 --dry-run --json",
+    "runtime": "search_channel_live_submission",
+    "status": "success",
+    "queue_item_id": 3,
+    "channel": "indexnow",
+    "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "dry_run": true,
+    "external_calls_attempted": false,
+    "search_submission_attempted": false,
+    "writes_attempted": false,
+    "writes_committed": false,
+    "submission_status": "not_attempted",
+    "execution_state": "dry_run_ready",
+    "bulk_submission": false,
+    "raw_secret_output": false,
+    "issues": []
+  },
+  "public_runtime_state": {
+    "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "http_status": 200,
+    "canonical": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "meta_robots": "index, follow",
+    "has_noindex": false,
+    "has_staging_canonical": false,
+    "private_flow_marker_detected": false,
+    "used_as_url_truth": false
+  },
+  "staging_sidecar_state": {
+    "checked": true,
+    "contained": true,
+    "http_status": 200,
+    "x_robots_tag": "noindex, nofollow, noarchive",
+    "meta_robots": "noindex, nofollow, noarchive, nocache",
+    "canonical": "https://fermatmind.com",
+    "baidu_stale_result_sidecar": true,
+    "baidu_mutation_performed": false
+  },
+  "future_approval_phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-ZH-MBTI-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.",
+  "future_gate_plan": {
+    "open_only": [
+      "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=true",
+      "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=true",
+      "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=true"
+    ],
+    "keep_closed": [
+      "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false"
+    ],
+    "after_live_submission": "close all live/external/indexnow gates again",
+    "not_actionable_until": "IndexNow keyLocation returns HTTP 200 and matches the configured key hash"
+  },
+  "live_submission_performed": false,
+  "external_api_call_performed": false,
+  "enqueue_performed": false,
+  "cms_mutation_performed": false,
+  "fap_web_mutation_performed": false,
+  "research_deferred": true,
+  "next_task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX"
+}

--- a/backend/docs/seo/search-channel-live-zh-mbti-01-preflight.md
+++ b/backend/docs/seo/search-channel-live-zh-mbti-01-preflight.md
@@ -1,0 +1,108 @@
+# SEARCH-CHANNEL-LIVE-ZH-MBTI-01 Preflight
+
+## Executive Summary
+
+This preflight reviewed production state for queue item 3 before any ZH MBTI IndexNow live submission.
+
+The queue item, duplicate protection, closed gate state, submit dry-run, public runtime, and protected EN queue item 2 are stable. The preflight is blocked because the configured IndexNow `keyLocation` currently returns HTTP 404 on the public apex host, so the key file cannot be verified without exposing the raw key.
+
+No live submission was performed. No external search API was called. No queue item was enqueued. No CMS, sitemap, llms, or fap-web mutation was performed.
+
+## Queue Item 3 Verification
+
+- Queue item id: `3`
+- URL: `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- Channel: `indexnow`
+- Locale: `zh-CN`
+- Page entity type: `test_detail`
+- Source authority: `scale_catalog`
+- Source table: `scales_registry`
+- Approval state: `pending`
+- Execution state: `dry_run_ready`
+- Eligibility state: `eligible`
+- Claim boundary state: `claim_safe`
+- Private flow: `false`
+
+## Duplicate / Event Check
+
+Exactly one active queue item exists for the ZH MBTI URL/channel. A no-write duplicate queue dry-run now blocks with `existing_active_queue_item`, `duplicate_detected=true`, and `planned_queue_count=0`.
+
+Queue item 3 has the planned queue event only. No `live_submission_approved`, `live_submission_response`, accepted submission, retry storm, or bulk submit event was observed.
+
+## Queue Item 2 Verification
+
+Protected EN MBTI queue item 2 remains unchanged:
+
+- URL: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- Channel: `indexnow`
+- Approval state: `approved`
+- Execution state: `submitted`
+
+No duplicate EN queue item was observed.
+
+## Gate State
+
+Production gates remain closed:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false` or not enabled
+
+## IndexNow Key Readiness
+
+The IndexNow key is configured, and the configured `keyLocation` is:
+
+`https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt`
+
+Public read-only verification returned HTTP 404. The raw key was not printed. Because the public key file cannot be verified at the configured location, live submission is blocked until the keyLocation returns HTTP 200 and the public body hash matches the configured key.
+
+## Submit Dry-run
+
+Command:
+
+```bash
+php artisan seo-intel:search-channel-submit --queue-item-id=3 --dry-run --json
+```
+
+Result:
+
+- Status: `success`
+- External calls attempted: `false`
+- Search submission attempted: `false`
+- Writes attempted: `false`
+- Writes committed: `false`
+- Submission status: `not_attempted`
+- Issues: `[]`
+
+## Public Runtime Check
+
+The public ZH MBTI URL returned HTTP 200 with exact apex canonical:
+
+`https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+The page emitted `robots=index, follow`, no `noindex`, and no staging canonical. Public runtime was used only as observation, not as URL Truth.
+
+## Staging / Baidu Sidecar
+
+Staging containment remains active:
+
+- `X-Robots-Tag: noindex, nofollow, noarchive`
+- HTML robots: `noindex, nofollow, noarchive, nocache`
+- Canonical points to production apex
+
+Known Baidu stale staging result remains a sidecar and was not mutated.
+
+## Future Approval Phrase
+
+Not actionable until IndexNow keyLocation readiness is fixed:
+
+`I explicitly approve SEARCH-CHANNEL-LIVE-ZH-MBTI-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.`
+
+## Final Decision
+
+`blocked_indexnow_key_missing`
+
+## Next Task
+
+`SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti01PreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti01PreflightTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLiveZhMbti01PreflightTest extends TestCase
+{
+    #[Test]
+    public function generated_json_exists_and_parses(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('search-channel-live-zh-mbti-01-preflight.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('SEARCH-CHANNEL-LIVE-ZH-MBTI-01', $artifact['task'] ?? null);
+    }
+
+    #[Test]
+    public function queue_item_target_and_channel_are_locked(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(3, $artifact['queue_item_id'] ?? null);
+        $this->assertSame(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $artifact['target_url'] ?? null
+        );
+        $this->assertSame('indexnow', $artifact['channel'] ?? null);
+    }
+
+    #[Test]
+    public function queue_item_state_is_recorded(): void
+    {
+        $state = $this->artifact()['queue_item_state'] ?? [];
+
+        $this->assertTrue($state['exists'] ?? false);
+        $this->assertSame(3, $state['id'] ?? null);
+        $this->assertSame('pending', $state['approval_state'] ?? null);
+        $this->assertSame('dry_run_ready', $state['execution_state'] ?? null);
+        $this->assertSame('eligible', $state['eligibility_state'] ?? null);
+        $this->assertSame('scale_catalog', $state['source_authority'] ?? null);
+        $this->assertSame('test_detail', $state['page_entity_type'] ?? null);
+        $this->assertSame('claim_safe', $state['claim_boundary_state'] ?? null);
+        $this->assertFalse($state['private_flow'] ?? true);
+    }
+
+    #[Test]
+    public function duplicate_check_and_queue_item_two_are_safe(): void
+    {
+        $artifact = $this->artifact();
+        $duplicate = $artifact['duplicate_check'] ?? [];
+        $item2 = $artifact['queue_item_2_state'] ?? [];
+
+        $this->assertSame(1, $duplicate['target_queue_count'] ?? null);
+        $this->assertTrue($duplicate['duplicate_detected'] ?? false);
+        $this->assertSame('existing_active_queue_item', $duplicate['blocked_reason'] ?? null);
+        $this->assertFalse($duplicate['live_submission_response_event_exists'] ?? true);
+
+        $this->assertSame(2, $item2['id'] ?? null);
+        $this->assertSame(
+            'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            $item2['canonical_url'] ?? null
+        );
+        $this->assertSame('approved', $item2['approval_state'] ?? null);
+        $this->assertSame('submitted', $item2['execution_state'] ?? null);
+        $this->assertTrue($item2['unchanged'] ?? false);
+    }
+
+    #[Test]
+    public function gate_and_submit_dry_run_state_are_safe(): void
+    {
+        $artifact = $this->artifact();
+        $gates = $artifact['gate_state'] ?? [];
+        $dryRun = $artifact['submit_dry_run'] ?? [];
+
+        $this->assertFalse($gates['queue_write_enabled'] ?? true);
+        $this->assertFalse($gates['live_submission_enabled'] ?? true);
+        $this->assertFalse($gates['external_api_calls_enabled'] ?? true);
+        $this->assertFalse($gates['indexnow_live_api_enabled'] ?? true);
+
+        $this->assertSame('success', $dryRun['status'] ?? null);
+        $this->assertTrue($dryRun['dry_run'] ?? false);
+        $this->assertFalse($dryRun['external_calls_attempted'] ?? true);
+        $this->assertFalse($dryRun['search_submission_attempted'] ?? true);
+        $this->assertFalse($dryRun['writes_attempted'] ?? true);
+        $this->assertFalse($dryRun['writes_committed'] ?? true);
+    }
+
+    #[Test]
+    public function indexnow_key_readiness_blocker_is_recorded_without_exposing_key(): void
+    {
+        $readiness = $this->artifact()['indexnow_key_readiness'] ?? [];
+
+        $this->assertTrue($readiness['key_configured'] ?? false);
+        $this->assertTrue($readiness['key_location_configured'] ?? false);
+        $this->assertSame(
+            'https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt',
+            $readiness['key_location'] ?? null
+        );
+        $this->assertSame(404, $readiness['public_key_location_status'] ?? null);
+        $this->assertFalse($readiness['public_key_location_matches_configured_key'] ?? true);
+        $this->assertFalse($readiness['ready'] ?? true);
+        $this->assertFalse($readiness['raw_key_exposed'] ?? true);
+    }
+
+    #[Test]
+    public function safety_boundaries_future_phrase_and_next_task_are_present(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(
+            'I explicitly approve SEARCH-CHANNEL-LIVE-ZH-MBTI-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.',
+            $artifact['future_approval_phrase'] ?? null
+        );
+        $this->assertFalse($artifact['live_submission_performed'] ?? true);
+        $this->assertFalse($artifact['external_api_call_performed'] ?? true);
+        $this->assertFalse($artifact['enqueue_performed'] ?? true);
+        $this->assertTrue($artifact['research_deferred'] ?? false);
+        $this->assertSame('blocked_indexnow_key_missing', $artifact['final_decision'] ?? null);
+        $this->assertSame('SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX', $artifact['next_task'] ?? null);
+    }
+
+    /** @return array<string, mixed> */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -18288,12 +18288,12 @@
     "SEARCH-CHANNEL-LIVE-ZH-MBTI-01": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-zh-mbti-01-preflight",
-      "status": "production_preflight_blocked_report_in_progress",
+      "status": "pr_open_github_checks_pending",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW"
       ],
-      "commit_sha": "ee2789474008b288be660ea360b35ca4c0635beb",
-      "pr_url": null,
+      "commit_sha": "ede7c8a4fe72a89926a08d3dc04f0163999db36a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1660",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -18350,6 +18350,11 @@
           "at": "2026-05-25T09:57:00+08:00",
           "status": "commit_created",
           "summary": "Created scoped commit ee278947 for the ZH MBTI live submission preflight report."
+        },
+        {
+          "at": "2026-05-25T10:00:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1660 for the ZH MBTI live submission preflight report. GitHub checks are pending."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -18208,11 +18208,12 @@
     "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-zh-mbti-post-enqueue-review",
-      "status": "pr_open_github_checks_pending",
+      "status": "merged",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-QUEUE"
       ],
       "commit_sha": "9d06a5c77a975e7b4f155b5229c8f57fb99e9ddc",
+      "merge_commit_sha": "35507328c25df3565679abdc8708fda96578c5d6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1659",
       "checks": {
         "dependency": {
@@ -18242,8 +18243,8 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-25T01:39:58Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_deploy_allowed": false,
       "production_migration_execution_allowed": false,
@@ -18275,6 +18276,80 @@
           "at": "2026-05-25T02:44:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1659 for the ZH MBTI post-enqueue review report. GitHub checks are pending."
+        },
+        {
+          "at": "2026-05-25T09:51:00+08:00",
+          "status": "merged_reconciled",
+          "summary": "Verified PR #1659 is merged, origin/main contains merge commit 35507328c25df3565679abdc8708fda96578c5d6, and the remote branch is deleted; reconciled state to unblock SEARCH-CHANNEL-LIVE-ZH-MBTI-01."
+        }
+      ],
+      "local_cleanup_note": "Reconciled while starting SEARCH-CHANNEL-LIVE-ZH-MBTI-01; origin/main contains merge commit 35507328c25df3565679abdc8708fda96578c5d6. scripts/post_merge_cleanup.sh is absent in this clone."
+    },
+    "SEARCH-CHANNEL-LIVE-ZH-MBTI-01": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-zh-mbti-01-preflight",
+      "status": "production_preflight_blocked_report_in_progress",
+      "depends_on": [
+        "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW"
+      ],
+      "commit_sha": "ee2789474008b288be660ea360b35ca4c0635beb",
+      "pr_url": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "Dependency SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW is merged as 35507328c25df3565679abdc8708fda96578c5d6 on origin/main."
+        },
+        "production_read_only": {
+          "queue_item_3": "passed: queue item 3 exists for the exact ZH MBTI URL/channel with locale=zh-CN, page_entity_type=test_detail, source_authority=scale_catalog, approval_state=pending, execution_state=dry_run_ready, eligibility_state=eligible, claim_boundary_state=claim_safe, private_flow=false.",
+          "duplicate_event_check": "passed: exactly one target queue item exists; no live_submission_approved, live_submission_response, accepted submission, retry storm, or bulk submit event exists. Duplicate dry-run blocks with existing_active_queue_item.",
+          "queue_item_2": "passed: EN MBTI queue item 2 remains approved/submitted and unchanged; no duplicate EN queue item detected.",
+          "gate_state": "passed: queue write, live submission, external API call, and IndexNow live API gates remain closed.",
+          "indexnow_key_readiness": "blocked: key is configured and raw key was not exposed, but configured keyLocation https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt returned HTTP 404 and could not be verified.",
+          "submit_dry_run": "passed: php artisan seo-intel:search-channel-submit --queue-item-id=3 --dry-run --json returned status=success, external_calls_attempted=false, search_submission_attempted=false, writes_attempted=false, writes_committed=false, submission_status=not_attempted, issues=[].",
+          "public_runtime": "passed: ZH MBTI public URL returned HTTP 200, exact apex canonical, robots index/follow, no noindex, and no staging canonical.",
+          "staging_sidecar": "passed: staging noindex containment remains active; known Baidu stale result remains a sidecar.",
+          "ops_seo_visibility": "sidecar: optional authenticated /ops/seo UI visibility was not checked."
+        },
+        "local": {
+          "focused_live_zh_mbti_preflight_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveZhMbti01Preflight --no-ansi (7 tests, 61 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi",
+          "pint": "passed: vendor/bin/pint --test (3533 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        }
+      },
+      "failure_reason": "blocked_indexnow_key_missing: configured IndexNow keyLocation returned HTTP 404, so live submission is not ready.",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": true,
+      "scheduler_activation": false,
+      "next_pr": "SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX",
+      "history": [
+        {
+          "at": "2026-05-25T09:51:00+08:00",
+          "status": "in_progress",
+          "summary": "Started live submission preflight from latest clean main. Scope is limited to production read-only queue, duplicate/event, gate, keyLocation, submit dry-run, public runtime, staging sidecar checks, docs/generated report, focused test, and authorized PR-train metadata."
+        },
+        {
+          "at": "2026-05-25T09:51:00+08:00",
+          "status": "production_read_only_preflight_blocked",
+          "summary": "Queue item 3, duplicate/event state, queue item 2, gates, submit dry-run, public runtime, and staging sidecar were stable, but configured IndexNow keyLocation returned HTTP 404; live submission remains blocked."
+        },
+        {
+          "at": "2026-05-25T09:56:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused generated artifact test, route list, Pint, JSON/YAML parsing, and diff checks passed for the blocked live preflight report."
+        },
+        {
+          "at": "2026-05-25T09:57:00+08:00",
+          "status": "commit_created",
+          "summary": "Created scoped commit ee278947 for the ZH MBTI live submission preflight report."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11504,6 +11504,49 @@ prs:
     scheduler_activation: false
     next_task: SEARCH-CHANNEL-LIVE-ZH-MBTI-01
 
+  - id: SEARCH-CHANNEL-LIVE-ZH-MBTI-01
+    repo: fap-api
+    depends_on:
+      - SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW
+    branch: codex/search-channel-live-zh-mbti-01-preflight
+    base: main
+    title: "docs(seo-intel): add ZH MBTI IndexNow live preflight"
+    name: "Live submission preflight for queue item 3"
+    train_scope: seo_growth_mbti_action
+    risk_level: production_read_only_report
+    type: docs_generated_test
+    scope:
+      - Verify queue item 3, duplicate/event state, protected queue item 2, closed gates, IndexNow key readiness, submit dry-run, public runtime, and staging/Baidu sidecar before any live submission.
+      - Record the exact future human approval phrase and gate plan only if safe, without opening gates or calling external search APIs.
+      - Record any blocker in docs/generated/test scope.
+    allowed_paths:
+      - backend/docs/seo/search-channel-live-zh-mbti-01-preflight.md
+      - backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti01PreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, runtime services, migrations, production env/deploy files, CMS content, articles, internal links, sitemap, llms, crawler log readers, scheduler, Search Channel enqueue/live submitter code, Digital PR files, or business DB / Tencent RDS / Node2 DB.
+      - Perform production writes, collector writes, Search Channel enqueue, live submission, external search API calls, scheduler activation, CMS mutation, Digital PR sends, pSEO generation, raw Nginx access log reads, manual DB update/delete, or broad URL Truth writes.
+      - Treat frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, public runtime, or local copies as authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLiveZhMbti01Preflight --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    next_task: SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- Added the ZH MBTI IndexNow live submission preflight report and generated JSON artifact.
- Added a focused test that locks queue item 3, no-live-submission boundaries, and the keyLocation blocker.
- Registered `SEARCH-CHANNEL-LIVE-ZH-MBTI-01` in the PR train manifest/state and reconciled the merged post-enqueue review dependency.

## Why
Queue item 3 is ready at the queue/dry-run level, but live submission must remain blocked until the configured IndexNow `keyLocation` is publicly verifiable. The public apex keyLocation currently returns HTTP 404.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelLiveZhMbti01Preflight --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Deferred intentionally
- No live IndexNow submission.
- No external search API calls.
- No gate changes.
- No queue enqueue.
- No fap-web, CMS, sitemap, llms, deploy, migration, or production env mutation.
