### PR TITLE
docs(seo-intel): add full-stack MBTI bilingual parity scan

### DIFF
--- a/backend/docs/seo/generated/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1.json
+++ b/backend/docs/seo/generated/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1.json
@@ -1,0 +1,11707 @@
+{
+  "schema_version": "seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1",
+  "task": "SEO-GROWTH-MBTI-ACTION-01D-SCAN-00",
+  "scanned_at": "2026-05-25T02:43:41.620Z",
+  "final_decision": "mbti_01d_scan_completed_ready_for_p0_visual_parity_fix",
+  "api_repo_sha": "084f5f369fc1ba8cde6d8dadbe574e12b3dee365",
+  "web_repo_sha": "aca20a5a548cf25110166d90e1f92b82db691703",
+  "live_target": "https://fermatmind.com",
+  "scanned_url_count": 35,
+  "public_indexable_url_count": 27,
+  "private_noindex_url_count": 0,
+  "page_family_counts": {
+    "home": 3,
+    "test_detail": 6,
+    "research_report": 2,
+    "topic": 4,
+    "help/content/policy": 8,
+    "career_guide": 2,
+    "unknown": 4,
+    "career_recommendation": 2,
+    "personality": 2,
+    "test_hub": 2
+  },
+  "inventory_sources": {
+    "sitemap": {
+      "status": 200,
+      "url_count": 114
+    },
+    "llms": {
+      "status": 0,
+      "url_count": 0,
+      "truncated_or_timeout": true
+    },
+    "llms_full": {
+      "status": 0,
+      "url_count": 0
+    },
+    "backend_url_truth_dry_run": {
+      "status": "success",
+      "items_seen": 7,
+      "metadata": {
+        "candidate_count": 7,
+        "planned_url_count": 7,
+        "planned_entity_count": 7,
+        "canary": false,
+        "limit": null,
+        "locale_filter": null,
+        "page_type_filter": null,
+        "source_authority_breakdown": {
+          "backend_public_surface": 4,
+          "scale_catalog": 3
+        },
+        "target_tables": [
+          "seo_urls",
+          "seo_url_entities"
+        ],
+        "write_requires_bound": true,
+        "skipped_private_flows": 0,
+        "skipped_forbidden_entity_types": 0,
+        "skipped_forbidden_source_authorities": 0,
+        "sample_hashes": [
+          "0fc45cd8de48e791c94f73f367dbf4520a802a91c1289f9e07e2d92222e6f3ed",
+          "1551c910fda424d219ab7f18d78d37e0919ac09441ec280afe83706d77ba5e45",
+          "1b04f5ef317bcd1dbed0254d65fa5836ed10b92fb5f0b514acd87c06d3f89626",
+          "4403609d40ab1dd5684e31ed159a60ca3652c3f6b84d33834e6093126412361a",
+          "6c9851d9ac655fcfa99275135cda32b4d0a992bd5af89ceb485d84e2d1faa56a"
+        ],
+        "writes_allowed": false,
+        "source": {
+          "source": "backend_authority_url_truth_candidate_source",
+          "source_authority": "backend_sitemap_source",
+          "backend_sitemap_source_available": true,
+          "scale_catalog_attempted": true,
+          "scale_catalog_available": false,
+          "scale_catalog_unavailable_reason": "scale_catalog_unavailable",
+          "research_reports_attempted": true,
+          "research_reports_available": false,
+          "research_reports_unavailable_reason": "research_reports_unavailable",
+          "configured_backend_authority_canary_available": true,
+          "fetches_public_html": false,
+          "external_api_calls": false,
+          "node2_local_laravel_data_source": false,
+          "node2_local_db_data_source": false,
+          "frontend_fallback_data_source": false,
+          "static_llms_fallback_graph_truth": false,
+          "synthetic_production_fixture": false
+        },
+        "fetches_public_html": false,
+        "performs_drift_detection": false,
+        "external_api_calls": false,
+        "node2_local_laravel_data_source": false,
+        "node2_local_db_data_source": false,
+        "frontend_fallback_data_source": false,
+        "static_llms_fallback_graph_truth": false,
+        "search_url_submission": false
+      }
+    },
+    "fap_web_route_family_count": 12
+  },
+  "mbti_core_pages": [
+    {
+      "url": "https://fermatmind.com/",
+      "locale": "zh-CN",
+      "page_family": "home",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "FermatMind / 费马测试",
+      "description": "费马测试提供清晰、可继续使用的测评结果，帮助你看清人格、能力与职业方向。",
+      "h1_text": "看清自己，走好每一步",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com",
+      "json_ld_types": [
+        "WebPage",
+        "ItemList",
+        "Organization"
+      ],
+      "sitemap_inclusion": false,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": false,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "text_sample": "FermatMind / 费马测试 看清自己，走好每一步 费马测试把自我认知、职业探索与能力成长，做成可测量、可训练、可复盘的成长系统。 免费测试、免费结果 核心测评围绕自我认知、职业判断与能力成长设计，并提供清晰结果。 我们高度重视您的隐私。 无需先注册账号，你可以先完成测试，再决定是否保存或继续深入。 百万用户进行了多次测试 从人格、能力到情绪状态，多个入口帮助你持续复盘自己的变化。 使用场景与引用 学习型群组 教练实践 组织与人效复盘 导师网络 内容与研究社群 “ 用于团队讨论中区分即时沟通顺畅感与长期岗位适",
+      "anchors": [
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/big-five-personality-test-ocean-model",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/iq-test-intelligence-quotient-assessment",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/holland-career-interest-test-riasec",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/enneagram-personality-test-nine-types",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/clinical-depression-anxiety-assessment-professional-edition",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "继续了解"
+        },
+        {
+          "href": "/zh/help",
+          "text": "继续了解"
+        },
+        {
+          "href": "/zh/career",
+          "text": "继续了解"
+        },
+        {
+          "href": "/zh/articles/big-five-personality-test-vs-mbti",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？"
+        },
+        {
+          "href": "/zh/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？"
+        },
+        {
+          "href": "/zh/articles/holland-career-interest-test-can-and-cannot-tell-you",
+          "text": "霍兰德职业兴趣测试能告诉你什么，不能告诉你什么？"
+        },
+        {
+          "href": "/zh/articles/which-love-script-fits-you-best",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配"
+        },
+        {
+          "href": "/zh/articles/how-personality-shapes-attitude-toward-ai",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任"
+        },
+        {
+          "href": "/zh/articles/how-16-personality-types-talk-to-an-ai-coach",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "查看全部文章"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "MBTI"
+        },
+        {
+          "href": "/zh/tests/big-five-personality-test-ocean-model",
+          "text": "Big Five"
+        },
+        {
+          "href": "/zh/tests/iq-test-intelligence-quotient-assessment",
+          "text": "IQ"
+        },
+        {
+          "href": "/zh/tests/eq-test-emotional-intelligence-assessment",
+          "text": "EQ"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "全部文章"
+        },
+        {
+          "href": "/zh/about",
+          "text": "关于我们"
+        },
+        {
+          "href": "/zh/charter",
+          "text": "我们的宪章"
+        },
+        {
+          "href": "/zh/foundation",
+          "text": "基金会"
+        },
+        {
+          "href": "/zh/careers",
+          "text": "工作机会"
+        },
+        {
+          "href": "/zh/brand",
+          "text": "品牌"
+        },
+        {
+          "href": "/zh/terms",
+          "text": "使用条款"
+        },
+        {
+          "href": "/zh/privacy",
+          "text": "隐私政策"
+        },
+        {
+          "href": "/zh/policies",
+          "text": "其他政策"
+        },
+        {
+          "href": "/",
+          "text": "费马测试"
+        },
+        {
+          "href": "/zh/tests",
+          "text": "测试"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "文章"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "人格"
+        },
+        {
+          "href": "/zh/career",
+          "text": "职业"
+        },
+        {
+          "href": "/zh/support",
+          "text": "帮助"
+        },
+        {
+          "href": "/zh/business",
+          "text": "企业版"
+        },
+        {
+          "href": "/zh/tests?q=",
+          "text": ""
+        },
+        {
+          "href": "/zh/results/lookup",
+          "text": "我的结果"
+        },
+        {
+          "href": "/en",
+          "text": "EN"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始"
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en",
+      "locale": "en",
+      "page_family": "home",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "FermatMind",
+      "description": "FermatMind provides clear, reusable assessment results for personality, ability, and career direction.",
+      "h1_text": "Understand yourself before the next step.",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en",
+      "json_ld_types": [
+        "WebPage",
+        "ItemList",
+        "Organization"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "text_sample": "FermatMind Understand yourself before the next step. Start with a clear, reusable assessment result for personality, ability, and career direction. Free and reliable Core assessments are built around self-knowledge, career judgment, and capability growth. We t",
+      "anchors": [
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Start test →"
+        },
+        {
+          "href": "/en/tests/big-five-personality-test-ocean-model",
+          "text": "Start test →"
+        },
+        {
+          "href": "/en/tests/iq-test-intelligence-quotient-assessment",
+          "text": "Start test →"
+        },
+        {
+          "href": "/en/tests/holland-career-interest-test-riasec",
+          "text": "Start test →"
+        },
+        {
+          "href": "/en/tests/enneagram-personality-test-nine-types",
+          "text": "Start test →"
+        },
+        {
+          "href": "/en/tests/clinical-depression-anxiety-assessment-professional-edition",
+          "text": "Start test →"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Read more"
+        },
+        {
+          "href": "/en/help",
+          "text": "Read more"
+        },
+        {
+          "href": "/en/career",
+          "text": "Read more"
+        },
+        {
+          "href": "/en/articles/big-five-personality-test-vs-mbti",
+          "text": "Big Five Personality Test: Is It More Scientific Than MBTI—and What Can It Really Tell You?"
+        },
+        {
+          "href": "/en/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?"
+        },
+        {
+          "href": "/en/articles/holland-career-interest-test-can-and-cannot-tell-you",
+          "text": "What Can a Holland Career Interest Test Tell You—and What It Cannot?"
+        },
+        {
+          "href": "/en/articles",
+          "text": "View all articles"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "MBTI"
+        },
+        {
+          "href": "/en/tests/big-five-personality-test-ocean-model",
+          "text": "Big Five"
+        },
+        {
+          "href": "/en/tests/iq-test-intelligence-quotient-assessment",
+          "text": "IQ"
+        },
+        {
+          "href": "/en/tests/eq-test-emotional-intelligence-assessment",
+          "text": "EQ"
+        },
+        {
+          "href": "/en/articles",
+          "text": "All articles"
+        },
+        {
+          "href": "/en",
+          "text": "FermatMind"
+        },
+        {
+          "href": "/en/tests",
+          "text": "Tests"
+        },
+        {
+          "href": "/en/articles",
+          "text": "Articles"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career",
+          "text": "Career"
+        },
+        {
+          "href": "/en/support",
+          "text": "Help"
+        },
+        {
+          "href": "/en/business",
+          "text": "Business"
+        },
+        {
+          "href": "/en/tests?q=",
+          "text": ""
+        },
+        {
+          "href": "/en/results/lookup",
+          "text": "My Results"
+        },
+        {
+          "href": "/",
+          "text": "中文"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Start"
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh",
+      "locale": "zh-CN",
+      "page_family": "home",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "FermatMind / 费马测试",
+      "description": "费马测试提供清晰、可继续使用的测评结果，帮助你看清人格、能力与职业方向。",
+      "h1_text": "看清自己，走好每一步",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com",
+      "json_ld_types": [
+        "WebPage",
+        "ItemList",
+        "Organization"
+      ],
+      "sitemap_inclusion": false,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": false,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "text_sample": "FermatMind / 费马测试 看清自己，走好每一步 费马测试把自我认知、职业探索与能力成长，做成可测量、可训练、可复盘的成长系统。 免费测试、免费结果 核心测评围绕自我认知、职业判断与能力成长设计，并提供清晰结果。 我们高度重视您的隐私。 无需先注册账号，你可以先完成测试，再决定是否保存或继续深入。 百万用户进行了多次测试 从人格、能力到情绪状态，多个入口帮助你持续复盘自己的变化。 使用场景与引用 学习型群组 教练实践 组织与人效复盘 导师网络 内容与研究社群 “ 用于团队讨论中区分即时沟通顺畅感与长期岗位适",
+      "anchors": [
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/big-five-personality-test-ocean-model",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/iq-test-intelligence-quotient-assessment",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/holland-career-interest-test-riasec",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/enneagram-personality-test-nine-types",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/tests/clinical-depression-anxiety-assessment-professional-edition",
+          "text": "开始测试 →"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "继续了解"
+        },
+        {
+          "href": "/zh/help",
+          "text": "继续了解"
+        },
+        {
+          "href": "/zh/career",
+          "text": "继续了解"
+        },
+        {
+          "href": "/zh/articles/big-five-personality-test-vs-mbti",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？"
+        },
+        {
+          "href": "/zh/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？"
+        },
+        {
+          "href": "/zh/articles/holland-career-interest-test-can-and-cannot-tell-you",
+          "text": "霍兰德职业兴趣测试能告诉你什么，不能告诉你什么？"
+        },
+        {
+          "href": "/zh/articles/which-love-script-fits-you-best",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配"
+        },
+        {
+          "href": "/zh/articles/how-personality-shapes-attitude-toward-ai",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任"
+        },
+        {
+          "href": "/zh/articles/how-16-personality-types-talk-to-an-ai-coach",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "查看全部文章"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "MBTI"
+        },
+        {
+          "href": "/zh/tests/big-five-personality-test-ocean-model",
+          "text": "Big Five"
+        },
+        {
+          "href": "/zh/tests/iq-test-intelligence-quotient-assessment",
+          "text": "IQ"
+        },
+        {
+          "href": "/zh/tests/eq-test-emotional-intelligence-assessment",
+          "text": "EQ"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "全部文章"
+        },
+        {
+          "href": "/zh/about",
+          "text": "关于我们"
+        },
+        {
+          "href": "/zh/charter",
+          "text": "我们的宪章"
+        },
+        {
+          "href": "/zh/foundation",
+          "text": "基金会"
+        },
+        {
+          "href": "/zh/careers",
+          "text": "工作机会"
+        },
+        {
+          "href": "/zh/brand",
+          "text": "品牌"
+        },
+        {
+          "href": "/zh/terms",
+          "text": "使用条款"
+        },
+        {
+          "href": "/zh/privacy",
+          "text": "隐私政策"
+        },
+        {
+          "href": "/zh/policies",
+          "text": "其他政策"
+        },
+        {
+          "href": "/",
+          "text": "费马测试"
+        },
+        {
+          "href": "/zh/tests",
+          "text": "测试"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "文章"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "人格"
+        },
+        {
+          "href": "/zh/career",
+          "text": "职业"
+        },
+        {
+          "href": "/zh/support",
+          "text": "帮助"
+        },
+        {
+          "href": "/zh/business",
+          "text": "企业版"
+        },
+        {
+          "href": "/zh/tests?q=",
+          "text": ""
+        },
+        {
+          "href": "/zh/results/lookup",
+          "text": "我的结果"
+        },
+        {
+          "href": "/en",
+          "text": "EN"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始"
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "locale": "en",
+      "page_family": "test_detail",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "MBTI Personality Test (16 Personality Types) | FermatMind",
+      "description": "Discover your MBTI profile across 16 personality types with a structured assessment.",
+      "h1_text": "MBTI Personality Test 【16 Personality Types】",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList",
+        "SoftwareApplication",
+        "FAQPage"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "text_sample": "MBTI Personality Test (16 Personality Types) | FermatMind MBTI Personality Test 【16 Personality Types】 ★ ★ ★ ★ ★ Discover your MBTI profile across 16 personality types with a structured assessment. 144 questions / 93 questions • 15 min / 10 min • MBTI Start De",
+      "anchors": [
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "Start Deep Profile"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_93&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_secondary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_93&landing_path=%2Fen%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "Start Quick Read"
+        },
+        {
+          "href": "/en/career/recommendations",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Continue"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Continue"
+        },
+        {
+          "href": "/en/career/recommendations",
+          "text": "Continue"
+        },
+        {
+          "href": "/en/personality/intp-a",
+          "text": "Continue"
+        },
+        {
+          "href": "/en/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?"
+        },
+        {
+          "href": "/en/articles/big-five-personality-test-vs-mbti",
+          "text": "Big Five Personality Test: Is It More Scientific Than MBTI—and What Can It Really Tell You?"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "Start Deep Profile"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_93&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_secondary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_93&landing_path=%2Fen%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "Start Quick Read"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "Start Deep Profile"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_93&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_secondary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_93&landing_path=%2Fen%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "Start Quick Read"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "MBTI"
+        },
+        {
+          "href": "/en/tests/big-five-personality-test-ocean-model",
+          "text": "Big Five"
+        },
+        {
+          "href": "/en/tests/iq-test-intelligence-quotient-assessment",
+          "text": "IQ"
+        },
+        {
+          "href": "/en/tests/eq-test-emotional-intelligence-assessment",
+          "text": "EQ"
+        },
+        {
+          "href": "/en/articles",
+          "text": "All articles"
+        },
+        {
+          "href": "/en",
+          "text": "FermatMind"
+        },
+        {
+          "href": "/en/tests",
+          "text": "Tests"
+        },
+        {
+          "href": "/en/articles",
+          "text": "Articles"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career",
+          "text": "Career"
+        },
+        {
+          "href": "/en/support",
+          "text": "Help"
+        },
+        {
+          "href": "/en/business",
+          "text": "Business"
+        },
+        {
+          "href": "/en/tests?q=",
+          "text": ""
+        },
+        {
+          "href": "/en/results/lookup",
+          "text": "My Results"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "中文"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Start"
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "locale": "zh-CN",
+      "page_family": "test_detail",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "MBTI 性格测试（16型人格测试） | FermatMind",
+      "description": "通过结构化测评了解你的 MBTI 类型、偏好强度与沟通协作方式。",
+      "h1_text": "MBTI 性格测试【16型人格】",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList",
+        "SoftwareApplication",
+        "FAQPage"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [
+        "诊断"
+      ],
+      "text_sample": "MBTI 性格测试（16型人格测试） | FermatMind MBTI 性格测试【16型人格】 ★ ★ ★ ★ ★ 通过结构化测评了解你的 MBTI 类型、偏好强度与沟通协作方式。 144题 / 93题 • 15分钟 / 10分钟 • MBTI 开始深度版 开始快速版 职业方向 先看适配岗位与职业路径，再决定下一步行动。 查看入口 专业选择 从 MBTI 主题页进入，快速建立专业与方向判断框架。 查看入口 团队协作 查看类型画像，理解协作偏好与沟通方式差异。 查看入口 关系相处 通过人格类型与主题内容，识别关系中",
+      "anchors": [
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fzh%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "开始深度版"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_93&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_secondary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_93&landing_path=%2Fzh%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "开始快速版"
+        },
+        {
+          "href": "/zh/career/recommendations",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "继续查看"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "继续查看"
+        },
+        {
+          "href": "/zh/career/recommendations",
+          "text": "继续查看"
+        },
+        {
+          "href": "/zh/personality/intp-a",
+          "text": "继续查看"
+        },
+        {
+          "href": "/zh/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？"
+        },
+        {
+          "href": "/zh/articles/big-five-personality-test-vs-mbti",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fzh%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "开始深度版"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_93&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_secondary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_93&landing_path=%2Fzh%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "开始快速版"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fzh%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "开始深度版"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_93&entrypoint=mbti_test_landing&entry_surface=mbti_test_landing&source_page_type=test_landing&target_action=start_mbti_test_secondary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_93&landing_path=%2Fzh%2Ftests%2Fmbti-personality-test-16-personality-types",
+          "text": "开始快速版"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "MBTI"
+        },
+        {
+          "href": "/zh/tests/big-five-personality-test-ocean-model",
+          "text": "Big Five"
+        },
+        {
+          "href": "/zh/tests/iq-test-intelligence-quotient-assessment",
+          "text": "IQ"
+        },
+        {
+          "href": "/zh/tests/eq-test-emotional-intelligence-assessment",
+          "text": "EQ"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "全部文章"
+        },
+        {
+          "href": "/zh/about",
+          "text": "关于我们"
+        },
+        {
+          "href": "/zh/charter",
+          "text": "我们的宪章"
+        },
+        {
+          "href": "/zh/foundation",
+          "text": "基金会"
+        },
+        {
+          "href": "/zh/careers",
+          "text": "工作机会"
+        },
+        {
+          "href": "/zh/brand",
+          "text": "品牌"
+        },
+        {
+          "href": "/zh/terms",
+          "text": "使用条款"
+        },
+        {
+          "href": "/zh/privacy",
+          "text": "隐私政策"
+        },
+        {
+          "href": "/zh/policies",
+          "text": "其他政策"
+        },
+        {
+          "href": "/",
+          "text": "费马测试"
+        },
+        {
+          "href": "/zh/tests",
+          "text": "测试"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "文章"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "人格"
+        },
+        {
+          "href": "/zh/career",
+          "text": "职业"
+        },
+        {
+          "href": "/zh/support",
+          "text": "帮助"
+        },
+        {
+          "href": "/zh/business",
+          "text": "企业版"
+        },
+        {
+          "href": "/zh/tests?q=",
+          "text": ""
+        },
+        {
+          "href": "/zh/results/lookup",
+          "text": "我的结果"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "EN"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始"
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "locale": "en",
+      "page_family": "research_report",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": null,
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": null,
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": false,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": false,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "text_sample": "",
+      "anchors": [],
+      "manual_runtime_check": true,
+      "curl_time_seconds": 15.21763
+    },
+    {
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "locale": "zh-CN",
+      "page_family": "research_report",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": null,
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": null,
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": false,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": false,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "text_sample": "",
+      "anchors": [],
+      "manual_runtime_check": true,
+      "curl_time_seconds": 15.396635
+    },
+    {
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "locale": "en",
+      "page_family": "topic",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/topics/mbti",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "MBTI topic hub | FermatMind",
+      "description": "Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub.",
+      "h1_text": "MBTI Topic Cluster",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/topics/mbti"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/topics/mbti"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/topics/mbti",
+      "json_ld_types": [
+        "CollectionPage",
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "text_sample": "MBTI topic hub | FermatMind Home / Topics / MBTI Topic Cluster mbti MBTI Topic Cluster Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub. Use this cluster when you want one page that connects MBTI interpretation, car",
+      "anchors": [
+        {
+          "href": "/en",
+          "text": "Home"
+        },
+        {
+          "href": "/en/topics",
+          "text": "Topics"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_topic_detail&entry_surface=mbti_topic_detail&source_page_type=topic_detail&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftopics%2Fmbti",
+          "text": "Start MBTI test"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Browse personality types"
+        },
+        {
+          "href": "/en/personality/intj-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/intj-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/entp-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/entp-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/entj-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/entj-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/intp-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/intp-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/infp-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/infp-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/infj-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/infj-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/enfj-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/enfj-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/enfp-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/enfp-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/istj-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/istj-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/isfj-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/isfj-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/estj-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/estj-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/esfj-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/esfj-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/istp-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/istp-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/isfp-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/isfp-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/estp-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/estp-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/personality/esfp-a",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/esfp-a",
+          "text": "Recommendation"
+        },
+        {
+          "href": "/en/career/recommendations",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Open entry"
+        },
+        {
+          "href": "/en/career/recommendations",
+          "text": "Open career recommendations"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/entp-a",
+          "text": "See ENTP recommendation sample"
+        },
+        {
+          "href": "/en/career/guides/from-mbti-to-job-fit",
+          "text": "Read MBTI job-fit guide"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_career_direction&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftopics%2Fmbti",
+          "text": "Start MBTI test"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Browse personality types"
+        },
+        {
+          "href": "/en/personality/infj-a",
+          "text": "Review INFJ collaboration profile"
+        },
+        {
+          "href": "/en/personality/estp-a",
+          "text": "Review ESTP collaboration profile"
+        },
+        {
+          "href": "/en/articles/mbti-growth-guide",
+          "text": "Read growth guide"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Return to MBTI topic hub"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Review MBTI topic framework"
+        },
+        {
+          "href": "/en/personality/istj-a",
+          "text": "Review ISTJ major-fit profile"
+        },
+        {
+          "href": "/en/personality/isfj-a",
+          "text": "Review ISFJ major-fit profile"
+        },
+        {
+          "href": "/en/articles/mbti-narrative-portrait",
+          "text": "Read narrative portrait"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_major_selection&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftopics%2Fmbti",
+          "text": "Take test before choosing path"
+        },
+        {
+          "href": "/en/articles/mbti-growth-guide",
+          "text": "Read MBTI growth guide"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/enfp-a",
+          "text": "Open ENFP growth-oriented recommendation"
+        },
+        {
+          "href": "/en/career/recommendations/mbti/infj-a",
+          "text": "Open INFJ growth-oriented recommendation"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_growth_planning&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftopics%2Fmbti",
+          "text": "Start test to unlock personalized growth path"
+        },
+        {
+          "href": "/en/career/recommendations",
+          "text": "Career direction"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Major selection"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Team collaboration"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "Relationship patterns"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Growth planning"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Take the MBTI test"
+        },
+        {
+          "href": "/en/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?"
+        },
+        {
+          "href": "/en/personality/intj",
+          "text": "INTJ - Architect"
+        },
+        {
+          "href": "/en/career/guides/from-mbti-to-job-fit",
+          "text": "From MBTI to Job Fit"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Take the MBTI test"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Take the test"
+        },
+        {
+          "href": "/en/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?"
+        },
+        {
+          "href": "/en/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "Read"
+        },
+        {
+          "href": "/en/personality/intj",
+          "text": "INTJ - Architect"
+        },
+        {
+          "href": "/en/personality/intj",
+          "text": "Explore"
+        },
+        {
+          "href": "/en/career/guides/from-mbti-to-job-fit",
+          "text": "From MBTI to Job Fit"
+        },
+        {
+          "href": "/en/career/guides/from-mbti-to-job-fit",
+          "text": "Read"
+        },
+        {
+          "href": "/en/career/guides/how-to-find-right-career-direction",
+          "text": "How to Find the Right Career Direction"
+        },
+        {
+          "href": "/en/career/guides/how-to-find-right-career-direction",
+          "text": "Read"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types?entry_surface=topic_detail_seo_cta&source_page_type=topic_detail&source_route_family=topic&source_slug=mbti&topic_id=3&target_action=seo_cta_start_test&test_slug=mbti-personality-test-16-personality-types&target_test_slug=mbti-personality-test-16-personality-types&cta_id=start_test&landing_path=%2Fen%2Ftopics%2Fmbti&entrypoint=seo_cta",
+          "text": "Take the test"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types?entry_surface=topic_detail_seo_cta&source_page_type=topic_detail&source_route_family=topic&source_slug=mbti&topic_id=3&target_action=seo_cta_continue_public_content&test_slug=mbti-personality-test-16-personality-types&target_test_slug=mbti-personality-test-16-personality-types&cta_id=continue_public_content&landing_path=%2Fen%2Ftopics%2Fmbti&entrypoint=seo_cta",
+          "text": "Take the test"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Personality hub"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "MBTI"
+        },
+        {
+          "href": "/en/tests/big-five-personality-test-ocean-model",
+          "text": "Big Five"
+        },
+        {
+          "href": "/en/tests/iq-test-intelligence-quotient-assessment",
+          "text": "IQ"
+        },
+        {
+          "href": "/en/tests/eq-test-emotional-intelligence-assessment",
+          "text": "EQ"
+        },
+        {
+          "href": "/en/articles",
+          "text": "All articles"
+        },
+        {
+          "href": "/en",
+          "text": "FermatMind"
+        },
+        {
+          "href": "/en/tests",
+          "text": "Tests"
+        },
+        {
+          "href": "/en/articles",
+          "text": "Articles"
+        },
+        {
+          "href": "/en/personality",
+          "text": "Personality"
+        },
+        {
+          "href": "/en/career",
+          "text": "Career"
+        },
+        {
+          "href": "/en/support",
+          "text": "Help"
+        },
+        {
+          "href": "/en/business",
+          "text": "Business"
+        },
+        {
+          "href": "/en/tests?q=",
+          "text": ""
+        },
+        {
+          "href": "/en/results/lookup",
+          "text": "My Results"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "中文"
+        },
+        {
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Start"
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "locale": "zh-CN",
+      "page_family": "topic",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/topics/mbti",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "MBTI 主题中心 | FermatMind",
+      "description": "把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。",
+      "h1_text": "MBTI 主题内容聚合",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/topics/mbti"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/topics/mbti"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/topics/mbti",
+      "json_ld_types": [
+        "CollectionPage",
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "text_sample": "MBTI 主题中心 | FermatMind 首页 / 主题 / MBTI 主题内容聚合 mbti MBTI 主题内容聚合 把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。 当你希望把 MBTI 解读、职业匹配和后续行动放到同一个内容路径里时，从这个主题页开始。 开始 MBTI 测试 查看人格类型 MBTI 主题内容聚合 当你希望把 MBTI 解读、职业匹配和后续行动放到同一个内容路径里时，从这个主题页开始。 MBTI 类型延伸入口 这里保持轻量，只提供类型入口与职业推荐入口，不把主题页变成长文页",
+      "anchors": [
+        {
+          "href": "/",
+          "text": "首页"
+        },
+        {
+          "href": "/zh/topics",
+          "text": "主题"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_topic_detail&entry_surface=mbti_topic_detail&source_page_type=topic_detail&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fzh%2Ftopics%2Fmbti",
+          "text": "开始 MBTI 测试"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "查看人格类型"
+        },
+        {
+          "href": "/zh/personality/intj-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/intj-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/entp-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/entp-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/entj-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/entj-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/intp-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/intp-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/infp-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/infp-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/infj-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/infj-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/enfj-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/enfj-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/enfp-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/enfp-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/istj-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/istj-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/isfj-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/isfj-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/estj-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/estj-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/esfj-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/esfj-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/istp-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/istp-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/isfp-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/isfp-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/estp-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/estp-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/personality/esfp-a",
+          "text": "类型页"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/esfp-a",
+          "text": "职业推荐"
+        },
+        {
+          "href": "/zh/career/recommendations",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "查看入口"
+        },
+        {
+          "href": "/zh/career/recommendations",
+          "text": "查看职业推荐入口"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/entp-a",
+          "text": "查看 ENTP 职业决策样例"
+        },
+        {
+          "href": "/zh/career/guides/from-mbti-to-job-fit",
+          "text": "阅读职业匹配指南"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_career_direction&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fzh%2Ftopics%2Fmbti",
+          "text": "开始 MBTI 测试"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "查看人格类型索引"
+        },
+        {
+          "href": "/zh/personality/infj-a",
+          "text": "查看 INFJ 协作画像"
+        },
+        {
+          "href": "/zh/personality/estp-a",
+          "text": "查看 ESTP 协作画像"
+        },
+        {
+          "href": "/zh/articles/mbti-growth-guide",
+          "text": "阅读成长实践指南"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "回到 MBTI 主题页"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "查看 MBTI 主题框架"
+        },
+        {
+          "href": "/zh/personality/istj-a",
+          "text": "查看 ISTJ 专业选择偏好"
+        },
+        {
+          "href": "/zh/personality/isfj-a",
+          "text": "查看 ISFJ 专业选择偏好"
+        },
+        {
+          "href": "/zh/articles/mbti-narrative-portrait",
+          "text": "阅读类型叙事画像"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_major_selection&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fzh%2Ftopics%2Fmbti",
+          "text": "先做测试再选方向"
+        },
+        {
+          "href": "/zh/articles/mbti-growth-guide",
+          "text": "阅读 MBTI 成长指南"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/enfp-a",
+          "text": "查看 ENFP 成长导向推荐"
+        },
+        {
+          "href": "/zh/career/recommendations/mbti/infj-a",
+          "text": "查看 INFJ 成长导向推荐"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_growth_planning&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fzh%2Ftopics%2Fmbti",
+          "text": "开始测试获取个性化成长路径"
+        },
+        {
+          "href": "/zh/career/recommendations",
+          "text": "职业方向"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "专业选择"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "团队协作"
+        },
+        {
+          "href": "/zh/topics/mbti",
+          "text": "关系相处"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "成长建议"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始 MBTI 性格测试"
+        },
+        {
+          "href": "/zh/articles/how-personality-shapes-attitude-toward-ai",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任"
+        },
+        {
+          "href": "/zh/personality/intj",
+          "text": "INTJ - 建筑师"
+        },
+        {
+          "href": "/zh/career/guides/from-mbti-to-job-fit",
+          "text": "如何将 MBTI 用于职业匹配"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始 MBTI 性格测试"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始测试"
+        },
+        {
+          "href": "/zh/articles/how-personality-shapes-attitude-toward-ai",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任"
+        },
+        {
+          "href": "/zh/articles/how-personality-shapes-attitude-toward-ai",
+          "text": "阅读"
+        },
+        {
+          "href": "/zh/articles/how-16-personality-types-talk-to-an-ai-coach",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说"
+        },
+        {
+          "href": "/zh/articles/how-16-personality-types-talk-to-an-ai-coach",
+          "text": "阅读"
+        },
+        {
+          "href": "/zh/articles/which-love-script-fits-you-best",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配"
+        },
+        {
+          "href": "/zh/articles/which-love-script-fits-you-best",
+          "text": "阅读"
+        },
+        {
+          "href": "/zh/articles/best-valentines-date-by-personality-and-relationship-science",
+          "text": "情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会"
+        },
+        {
+          "href": "/zh/articles/best-valentines-date-by-personality-and-relationship-science",
+          "text": "阅读"
+        },
+        {
+          "href": "/zh/articles/are-infj-men-rare-or-socially-silenced",
+          "text": "“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？"
+        },
+        {
+          "href": "/zh/articles/are-infj-men-rare-or-socially-silenced",
+          "text": "阅读"
+        },
+        {
+          "href": "/zh/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？"
+        },
+        {
+          "href": "/zh/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "阅读"
+        },
+        {
+          "href": "/zh/personality/intj",
+          "text": "INTJ - 建筑师"
+        },
+        {
+          "href": "/zh/personality/intj",
+          "text": "查看"
+        },
+        {
+          "href": "/zh/career/guides/from-mbti-to-job-fit",
+          "text": "如何将 MBTI 用于职业匹配"
+        },
+        {
+          "href": "/zh/career/guides/from-mbti-to-job-fit",
+          "text": "阅读"
+        },
+        {
+          "href": "/zh/career/guides/how-to-find-right-career-direction",
+          "text": "如何找到适合自己的职业方向"
+        },
+        {
+          "href": "/zh/career/guides/how-to-find-right-career-direction",
+          "text": "阅读"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types?entry_surface=topic_detail_seo_cta&source_page_type=topic_detail&source_route_family=topic&source_slug=mbti&topic_id=6&target_action=seo_cta_start_test&test_slug=mbti-personality-test-16-personality-types&target_test_slug=mbti-personality-test-16-personality-types&cta_id=start_test&landing_path=%2Fzh%2Ftopics%2Fmbti&entrypoint=seo_cta",
+          "text": "开始测试"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types?entry_surface=topic_detail_seo_cta&source_page_type=topic_detail&source_route_family=topic&source_slug=mbti&topic_id=6&target_action=seo_cta_continue_public_content&test_slug=mbti-personality-test-16-personality-types&target_test_slug=mbti-personality-test-16-personality-types&cta_id=continue_public_content&landing_path=%2Fzh%2Ftopics%2Fmbti&entrypoint=seo_cta",
+          "text": "开始测试"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "人格画像"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "MBTI"
+        },
+        {
+          "href": "/zh/tests/big-five-personality-test-ocean-model",
+          "text": "Big Five"
+        },
+        {
+          "href": "/zh/tests/iq-test-intelligence-quotient-assessment",
+          "text": "IQ"
+        },
+        {
+          "href": "/zh/tests/eq-test-emotional-intelligence-assessment",
+          "text": "EQ"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "全部文章"
+        },
+        {
+          "href": "/zh/about",
+          "text": "关于我们"
+        },
+        {
+          "href": "/zh/charter",
+          "text": "我们的宪章"
+        },
+        {
+          "href": "/zh/foundation",
+          "text": "基金会"
+        },
+        {
+          "href": "/zh/careers",
+          "text": "工作机会"
+        },
+        {
+          "href": "/zh/brand",
+          "text": "品牌"
+        },
+        {
+          "href": "/zh/terms",
+          "text": "使用条款"
+        },
+        {
+          "href": "/zh/privacy",
+          "text": "隐私政策"
+        },
+        {
+          "href": "/zh/policies",
+          "text": "其他政策"
+        },
+        {
+          "href": "/",
+          "text": "费马测试"
+        },
+        {
+          "href": "/zh/tests",
+          "text": "测试"
+        },
+        {
+          "href": "/zh/articles",
+          "text": "文章"
+        },
+        {
+          "href": "/zh/personality",
+          "text": "人格"
+        },
+        {
+          "href": "/zh/career",
+          "text": "职业"
+        },
+        {
+          "href": "/zh/support",
+          "text": "帮助"
+        },
+        {
+          "href": "/zh/business",
+          "text": "企业版"
+        },
+        {
+          "href": "/zh/tests?q=",
+          "text": ""
+        },
+        {
+          "href": "/zh/results/lookup",
+          "text": "我的结果"
+        },
+        {
+          "href": "/en/topics/mbti",
+          "text": "EN"
+        },
+        {
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "text": "开始"
+        }
+      ]
+    }
+  ],
+  "bilingual_pair_summary": {
+    "checked_pair_count": 33,
+    "gaps": [
+      {
+        "url": "https://fermatmind.com/en",
+        "expected_pair": "https://fermatmind.com/",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Understand yourself before the next step.",
+        "pair_h1": "看清自己，走好每一步"
+      },
+      {
+        "url": "https://fermatmind.com/zh",
+        "expected_pair": "https://fermatmind.com/en",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "看清自己，走好每一步",
+        "pair_h1": "Understand yourself before the next step."
+      },
+      {
+        "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "expected_pair": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": false,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "expected_pair": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": false,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/en/about",
+        "expected_pair": "https://fermatmind.com/zh/about",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/zh/about",
+        "expected_pair": "https://fermatmind.com/en/about",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/en/help/for-business-and-research",
+        "expected_pair": "https://fermatmind.com/zh/help/for-business-and-research",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/zh/help/for-business-and-research",
+        "expected_pair": "https://fermatmind.com/en/help/for-business-and-research",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/en/method-boundaries",
+        "expected_pair": "https://fermatmind.com/zh/method-boundaries",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": "测评方法与使用边界"
+      },
+      {
+        "url": "https://fermatmind.com/zh/method-boundaries",
+        "expected_pair": "https://fermatmind.com/en/method-boundaries",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": "测评方法与使用边界",
+        "pair_h1": null
+      }
+    ],
+    "pairs": [
+      {
+        "url": "https://fermatmind.com/",
+        "expected_pair": "https://fermatmind.com/en",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "看清自己，走好每一步",
+        "pair_h1": "Understand yourself before the next step."
+      },
+      {
+        "url": "https://fermatmind.com/en",
+        "expected_pair": "https://fermatmind.com/",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Understand yourself before the next step.",
+        "pair_h1": "看清自己，走好每一步"
+      },
+      {
+        "url": "https://fermatmind.com/zh",
+        "expected_pair": "https://fermatmind.com/en",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "看清自己，走好每一步",
+        "pair_h1": "Understand yourself before the next step."
+      },
+      {
+        "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+        "expected_pair": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "MBTI Personality Test 【16 Personality Types】",
+        "pair_h1": "MBTI 性格测试【16型人格】"
+      },
+      {
+        "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "expected_pair": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "MBTI 性格测试【16型人格】",
+        "pair_h1": "MBTI Personality Test 【16 Personality Types】"
+      },
+      {
+        "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "expected_pair": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": false,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+        "expected_pair": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": false,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/en/topics/mbti",
+        "expected_pair": "https://fermatmind.com/zh/topics/mbti",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "MBTI Topic Cluster",
+        "pair_h1": "MBTI 主题内容聚合"
+      },
+      {
+        "url": "https://fermatmind.com/zh/topics/mbti",
+        "expected_pair": "https://fermatmind.com/en/topics/mbti",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "MBTI 主题内容聚合",
+        "pair_h1": "MBTI Topic Cluster"
+      },
+      {
+        "url": "https://fermatmind.com/en/about",
+        "expected_pair": "https://fermatmind.com/zh/about",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/zh/about",
+        "expected_pair": "https://fermatmind.com/en/about",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/en/career/guides",
+        "expected_pair": "https://fermatmind.com/zh/career/guides",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Turn career choice into a testable decision",
+        "pair_h1": "把职业选择变成可验证的判断"
+      },
+      {
+        "url": "https://fermatmind.com/zh/career/guides",
+        "expected_pair": "https://fermatmind.com/en/career/guides",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "把职业选择变成可验证的判断",
+        "pair_h1": "Turn career choice into a testable decision"
+      },
+      {
+        "url": "https://fermatmind.com/en/career",
+        "expected_pair": "https://fermatmind.com/zh/career",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Start with the library, then narrow the path",
+        "pair_h1": "从职业库开始，逐层缩小选择"
+      },
+      {
+        "url": "https://fermatmind.com/zh/career",
+        "expected_pair": "https://fermatmind.com/en/career",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "从职业库开始，逐层缩小选择",
+        "pair_h1": "Start with the library, then narrow the path"
+      },
+      {
+        "url": "https://fermatmind.com/en/career/recommendations",
+        "expected_pair": "https://fermatmind.com/zh/career/recommendations",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "A decision platform for young adults",
+        "pair_h1": "青年人的认知成长与决策平台"
+      },
+      {
+        "url": "https://fermatmind.com/zh/career/recommendations",
+        "expected_pair": "https://fermatmind.com/en/career/recommendations",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "青年人的认知成长与决策平台",
+        "pair_h1": "A decision platform for young adults"
+      },
+      {
+        "url": "https://fermatmind.com/en/career/tests",
+        "expected_pair": "https://fermatmind.com/zh/career/tests",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Start with a career interest test",
+        "pair_h1": "先做职业兴趣测试"
+      },
+      {
+        "url": "https://fermatmind.com/zh/career/tests",
+        "expected_pair": "https://fermatmind.com/en/career/tests",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "先做职业兴趣测试",
+        "pair_h1": "Start with a career interest test"
+      },
+      {
+        "url": "https://fermatmind.com/en/help/for-business-and-research",
+        "expected_pair": "https://fermatmind.com/zh/help/for-business-and-research",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/zh/help/for-business-and-research",
+        "expected_pair": "https://fermatmind.com/en/help/for-business-and-research",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/en/method-boundaries",
+        "expected_pair": "https://fermatmind.com/zh/method-boundaries",
+        "pair_exists": true,
+        "hreflang_points_to_pair": false,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": null,
+        "pair_h1": "测评方法与使用边界"
+      },
+      {
+        "url": "https://fermatmind.com/zh/method-boundaries",
+        "expected_pair": "https://fermatmind.com/en/method-boundaries",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": false,
+        "title_pair_present": true,
+        "h1_pair_present": false,
+        "h1": "测评方法与使用边界",
+        "pair_h1": null
+      },
+      {
+        "url": "https://fermatmind.com/en/personality",
+        "expected_pair": "https://fermatmind.com/zh/personality",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "16 Personality Types",
+        "pair_h1": "16 型人格画像"
+      },
+      {
+        "url": "https://fermatmind.com/zh/personality",
+        "expected_pair": "https://fermatmind.com/en/personality",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "16 型人格画像",
+        "pair_h1": "16 Personality Types"
+      },
+      {
+        "url": "https://fermatmind.com/en/tests/category/career",
+        "expected_pair": "https://fermatmind.com/zh/tests/category/career",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Career & Direction Tests",
+        "pair_h1": "职业与方向测评"
+      },
+      {
+        "url": "https://fermatmind.com/en/tests/category/personality",
+        "expected_pair": "https://fermatmind.com/zh/tests/category/personality",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Personality & Style Tests",
+        "pair_h1": "人格与风格测评"
+      },
+      {
+        "url": "https://fermatmind.com/zh/tests/category/career",
+        "expected_pair": "https://fermatmind.com/en/tests/category/career",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "职业与方向测评",
+        "pair_h1": "Career & Direction Tests"
+      },
+      {
+        "url": "https://fermatmind.com/zh/tests/category/personality",
+        "expected_pair": "https://fermatmind.com/en/tests/category/personality",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "人格与风格测评",
+        "pair_h1": "Personality & Style Tests"
+      },
+      {
+        "url": "https://fermatmind.com/en/tests",
+        "expected_pair": "https://fermatmind.com/zh/tests",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Start from a clearer question and find the assessment that fits.",
+        "pair_h1": "帮助青年人看清自己、理解真实世界"
+      },
+      {
+        "url": "https://fermatmind.com/zh/tests",
+        "expected_pair": "https://fermatmind.com/en/tests",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "帮助青年人看清自己、理解真实世界",
+        "pair_h1": "Start from a clearer question and find the assessment that fits."
+      },
+      {
+        "url": "https://fermatmind.com/en/topics",
+        "expected_pair": "https://fermatmind.com/zh/topics",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "Topic clusters",
+        "pair_h1": "主题内容聚合"
+      },
+      {
+        "url": "https://fermatmind.com/zh/topics",
+        "expected_pair": "https://fermatmind.com/en/topics",
+        "pair_exists": true,
+        "hreflang_points_to_pair": true,
+        "reciprocal_hreflang": true,
+        "title_pair_present": true,
+        "h1_pair_present": true,
+        "h1": "主题内容聚合",
+        "pair_h1": "Topic clusters"
+      }
+    ]
+  },
+  "canonical_hreflang_findings": [
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "broken core public URL",
+      "status": 404,
+      "evidence": "manual curl -L public runtime check"
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "broken core public URL",
+      "status": 404,
+      "evidence": "manual curl -L public runtime check"
+    }
+  ],
+  "visual_scan_mode": "playwright_headless_chromium",
+  "visual_overflow_findings": [
+    {
+      "url": "https://fermatmind.com/",
+      "viewport": "desktop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1440,
+      "viewport_width": 1440,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "从一个清楚的问题开始。",
+          "scrollWidth": 672,
+          "clientWidth": 672,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 384,
+            "right": 1056,
+            "top": 1841.765625,
+            "bottom": 1881.765625,
+            "width": 672,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 性格测试",
+          "scrollWidth": 124,
+          "clientWidth": 124,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 208,
+            "right": 332.171875,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 124.171875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five 大五人格测试",
+          "scrollWidth": 185,
+          "clientWidth": 185,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 573.328125,
+            "right": 758.703125,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 185.375,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ 智商测试",
+          "scrollWidth": 99,
+          "clientWidth": 99,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 938.65625,
+            "right": 1037.875,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 99.21875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 208,
+            "right": 381.703125,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "九型人格测试",
+          "scrollWidth": 116,
+          "clientWidth": 116,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 573.328125,
+            "right": 689.140625,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 115.8125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "抑郁焦虑综合症测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 938.65625,
+            "right": 1112.359375,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "关于 费马测试",
+          "scrollWidth": 768,
+          "clientWidth": 768,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 336,
+            "right": 1104,
+            "top": 2613.765625,
+            "bottom": 2653.765625,
+            "width": 768,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "结果可复用",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 272,
+            "right": 512,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "方法边界透明",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 600,
+            "right": 840,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "连接职业方向",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 928,
+            "right": 1168,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "推荐阅读",
+          "scrollWidth": 1072,
+          "clientWidth": 1072,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 184,
+            "right": 1256,
+            "top": 3281.765625,
+            "bottom": 3329.765625,
+            "width": 1072,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 184,
+            "right": 520,
+            "top": 3557.765625,
+            "bottom": 3707.765625,
+            "width": 336,
+            "height": 150
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 552,
+            "right": 888,
+            "top": 3557.765625,
+            "bottom": 3632.765625,
+            "width": 336,
+            "height": 75
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 920,
+            "right": 1256,
+            "top": 3557.765625,
+            "bottom": 3670.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 184,
+            "right": 520,
+            "top": 4003.765625,
+            "bottom": 4116.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 552,
+            "right": 888,
+            "top": 4003.765625,
+            "bottom": 4116.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 920,
+            "right": 1256,
+            "top": 4003.765625,
+            "bottom": 4153.765625,
+            "width": 336,
+            "height": 150
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/",
+      "viewport": "laptop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1280,
+      "viewport_width": 1280,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "从一个清楚的问题开始。",
+          "scrollWidth": 672,
+          "clientWidth": 672,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 304,
+            "right": 976,
+            "top": 1841.765625,
+            "bottom": 1881.765625,
+            "width": 672,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 性格测试",
+          "scrollWidth": 124,
+          "clientWidth": 124,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 128,
+            "right": 252.171875,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 124.171875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five 大五人格测试",
+          "scrollWidth": 185,
+          "clientWidth": 185,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 493.328125,
+            "right": 678.703125,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 185.375,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ 智商测试",
+          "scrollWidth": 99,
+          "clientWidth": 99,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 858.65625,
+            "right": 957.875,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 99.21875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 128,
+            "right": 301.703125,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "九型人格测试",
+          "scrollWidth": 116,
+          "clientWidth": 116,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 493.328125,
+            "right": 609.140625,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 115.8125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "抑郁焦虑综合症测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 858.65625,
+            "right": 1032.359375,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "关于 费马测试",
+          "scrollWidth": 768,
+          "clientWidth": 768,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 256,
+            "right": 1024,
+            "top": 2613.765625,
+            "bottom": 2653.765625,
+            "width": 768,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "结果可复用",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 192,
+            "right": 432,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "方法边界透明",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 520,
+            "right": 760,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "连接职业方向",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 848,
+            "right": 1088,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "推荐阅读",
+          "scrollWidth": 1072,
+          "clientWidth": 1072,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 104,
+            "right": 1176,
+            "top": 3281.765625,
+            "bottom": 3329.765625,
+            "width": 1072,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 104,
+            "right": 440,
+            "top": 3557.765625,
+            "bottom": 3707.765625,
+            "width": 336,
+            "height": 150
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 472,
+            "right": 808,
+            "top": 3557.765625,
+            "bottom": 3632.765625,
+            "width": 336,
+            "height": 75
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 840,
+            "right": 1176,
+            "top": 3557.765625,
+            "bottom": 3670.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 104,
+            "right": 440,
+            "top": 4003.765625,
+            "bottom": 4116.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 472,
+            "right": 808,
+            "top": 4003.765625,
+            "bottom": 4116.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 840,
+            "right": 1176,
+            "top": 4003.765625,
+            "bottom": 4153.765625,
+            "width": 336,
+            "height": 150
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/",
+      "viewport": "mobile",
+      "horizontal_scroll": false,
+      "document_scroll_width": 390,
+      "viewport_width": 390,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "使用场景与引用",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 1591.296875,
+            "bottom": 1627.296875,
+            "width": 342,
+            "height": 36
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "从一个清楚的问题开始。",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 3083.296875,
+            "bottom": 3119.296875,
+            "width": 342,
+            "height": 36
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 性格测试",
+          "scrollWidth": 124,
+          "clientWidth": 124,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 172.171875,
+            "top": 3183.296875,
+            "bottom": 3211.296875,
+            "width": 124.171875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five 大五人格测试",
+          "scrollWidth": 185,
+          "clientWidth": 185,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 233.375,
+            "top": 3411.296875,
+            "bottom": 3439.296875,
+            "width": 185.375,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ 智商测试",
+          "scrollWidth": 99,
+          "clientWidth": 99,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 147.21875,
+            "top": 3639.296875,
+            "bottom": 3667.296875,
+            "width": 99.21875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 221.703125,
+            "top": 3867.296875,
+            "bottom": 3895.296875,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "九型人格测试",
+          "scrollWidth": 116,
+          "clientWidth": 116,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 163.8125,
+            "top": 4095.296875,
+            "bottom": 4123.296875,
+            "width": 115.8125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "抑郁焦虑综合症测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 221.703125,
+            "top": 4323.296875,
+            "bottom": 4351.296875,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "关于 费马测试",
+          "scrollWidth": 294,
+          "clientWidth": 294,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 342,
+            "top": 4715.296875,
+            "bottom": 4751.296875,
+            "width": 294,
+            "height": 36
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "结果可复用",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5035.296875,
+            "bottom": 5063.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "方法边界透明",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5351.296875,
+            "bottom": 5379.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "连接职业方向",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5667.296875,
+            "bottom": 5695.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "推荐阅读",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 6027.296875,
+            "bottom": 6067.296875,
+            "width": 342,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 6295.296875,
+            "bottom": 6407.796875,
+            "width": 342,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 6703.796875,
+            "bottom": 6778.796875,
+            "width": 342,
+            "height": 75
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 7074.796875,
+            "bottom": 7149.796875,
+            "width": 342,
+            "height": 75
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 7445.796875,
+            "bottom": 7558.296875,
+            "width": 342,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 7854.296875,
+            "bottom": 7966.796875,
+            "width": 342,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 8262.796875,
+            "bottom": 8412.796875,
+            "width": 342,
+            "height": 150
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en",
+      "viewport": "desktop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1440,
+      "viewport_width": 1440,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h1",
+          "text": "Understand yourself before the next step.",
+          "scrollWidth": 1719,
+          "clientWidth": 960,
+          "overflowX": true,
+          "outsideViewport": false,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "nowrap",
+          "lineClamp": "none",
+          "rect": {
+            "left": 240,
+            "right": 1200,
+            "top": 359.5,
+            "bottom": 443.5,
+            "width": 960,
+            "height": 84
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Start from one clear question.",
+          "scrollWidth": 672,
+          "clientWidth": 672,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 384,
+            "right": 1056,
+            "top": 1983.765625,
+            "bottom": 2023.765625,
+            "width": 672,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test",
+          "scrollWidth": 162,
+          "clientWidth": 162,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 208,
+            "right": 370.4375,
+            "top": 2087.765625,
+            "bottom": 2143.765625,
+            "width": 162.4375,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five Personality Test",
+          "scrollWidth": 162,
+          "clientWidth": 162,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 573.328125,
+            "right": 735.765625,
+            "top": 2087.765625,
+            "bottom": 2143.765625,
+            "width": 162.4375,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ Test",
+          "scrollWidth": 61,
+          "clientWidth": 61,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 938.65625,
+            "right": 999.4375,
+            "top": 2087.765625,
+            "bottom": 2115.765625,
+            "width": 60.78125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Holland Career Interest Test",
+          "scrollWidth": 166,
+          "clientWidth": 166,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 208,
+            "right": 373.734375,
+            "top": 2343.765625,
+            "bottom": 2399.765625,
+            "width": 165.734375,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Enneagram Test",
+          "scrollWidth": 144,
+          "clientWidth": 144,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 573.328125,
+            "right": 716.890625,
+            "top": 2343.765625,
+            "bottom": 2371.765625,
+            "width": 143.5625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Depression and Anxiety Assessment",
+          "scrollWidth": 138,
+          "clientWidth": 138,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 938.65625,
+            "right": 1076.34375,
+            "top": 2343.765625,
+            "bottom": 2427.765625,
+            "width": 137.6875,
+            "height": 84
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "About FermatMind",
+          "scrollWidth": 768,
+          "clientWidth": 768,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 336,
+            "right": 1104,
+            "top": 2867.765625,
+            "bottom": 2907.765625,
+            "width": 768,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Reusable result",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 272,
+            "right": 512,
+            "top": 3111.765625,
+            "bottom": 3139.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Transparent boundaries",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 600,
+            "right": 840,
+            "top": 3111.765625,
+            "bottom": 3139.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Career direction",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 928,
+            "right": 1168,
+            "top": 3111.765625,
+            "bottom": 3139.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Recommended reading",
+          "scrollWidth": 1072,
+          "clientWidth": 1072,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 184,
+            "right": 1256,
+            "top": 3531.765625,
+            "bottom": 3579.765625,
+            "width": 1072,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five Personality Test: Is It More Scientific Than MBTI—and What Can It Really Tell You?",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 184,
+            "right": 520,
+            "top": 3807.765625,
+            "bottom": 3957.765625,
+            "width": 336,
+            "height": 150
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 552,
+            "right": 888,
+            "top": 3807.765625,
+            "bottom": 3920.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "What Can a Holland Career Interest Test Tell You—and What It Cannot?",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 920,
+            "right": 1256,
+            "top": 3807.765625,
+            "bottom": 3920.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en",
+      "viewport": "laptop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1280,
+      "viewport_width": 1280,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h1",
+          "text": "Understand yourself before the next step.",
+          "scrollWidth": 1719,
+          "clientWidth": 960,
+          "overflowX": true,
+          "outsideViewport": false,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "nowrap",
+          "lineClamp": "none",
+          "rect": {
+            "left": 160,
+            "right": 1120,
+            "top": 359.5,
+            "bottom": 443.5,
+            "width": 960,
+            "height": 84
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Start from one clear question.",
+          "scrollWidth": 672,
+          "clientWidth": 672,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 304,
+            "right": 976,
+            "top": 1983.765625,
+            "bottom": 2023.765625,
+            "width": 672,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test",
+          "scrollWidth": 162,
+          "clientWidth": 162,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 128,
+            "right": 290.4375,
+            "top": 2087.765625,
+            "bottom": 2143.765625,
+            "width": 162.4375,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five Personality Test",
+          "scrollWidth": 162,
+          "clientWidth": 162,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 493.328125,
+            "right": 655.765625,
+            "top": 2087.765625,
+            "bottom": 2143.765625,
+            "width": 162.4375,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ Test",
+          "scrollWidth": 61,
+          "clientWidth": 61,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 858.65625,
+            "right": 919.4375,
+            "top": 2087.765625,
+            "bottom": 2115.765625,
+            "width": 60.78125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Holland Career Interest Test",
+          "scrollWidth": 166,
+          "clientWidth": 166,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 128,
+            "right": 293.734375,
+            "top": 2343.765625,
+            "bottom": 2399.765625,
+            "width": 165.734375,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Enneagram Test",
+          "scrollWidth": 144,
+          "clientWidth": 144,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 493.328125,
+            "right": 636.890625,
+            "top": 2343.765625,
+            "bottom": 2371.765625,
+            "width": 143.5625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Depression and Anxiety Assessment",
+          "scrollWidth": 138,
+          "clientWidth": 138,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 858.65625,
+            "right": 996.34375,
+            "top": 2343.765625,
+            "bottom": 2427.765625,
+            "width": 137.6875,
+            "height": 84
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "About FermatMind",
+          "scrollWidth": 768,
+          "clientWidth": 768,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 256,
+            "right": 1024,
+            "top": 2867.765625,
+            "bottom": 2907.765625,
+            "width": 768,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Reusable result",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 192,
+            "right": 432,
+            "top": 3111.765625,
+            "bottom": 3139.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Transparent boundaries",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 520,
+            "right": 760,
+            "top": 3111.765625,
+            "bottom": 3139.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Career direction",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 848,
+            "right": 1088,
+            "top": 3111.765625,
+            "bottom": 3139.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Recommended reading",
+          "scrollWidth": 1072,
+          "clientWidth": 1072,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 104,
+            "right": 1176,
+            "top": 3531.765625,
+            "bottom": 3579.765625,
+            "width": 1072,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five Personality Test: Is It More Scientific Than MBTI—and What Can It Really Tell You?",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 104,
+            "right": 440,
+            "top": 3807.765625,
+            "bottom": 3957.765625,
+            "width": 336,
+            "height": 150
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 472,
+            "right": 808,
+            "top": 3807.765625,
+            "bottom": 3920.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "What Can a Holland Career Interest Test Tell You—and What It Cannot?",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 840,
+            "right": 1176,
+            "top": 3807.765625,
+            "bottom": 3920.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en",
+      "viewport": "mobile",
+      "horizontal_scroll": false,
+      "document_scroll_width": 390,
+      "viewport_width": 390,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "Users and use cases",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 1591.296875,
+            "bottom": 1627.296875,
+            "width": 342,
+            "height": 36
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Start from one clear question.",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 3155.296875,
+            "bottom": 3227.296875,
+            "width": 342,
+            "height": 72
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test",
+          "scrollWidth": 163,
+          "clientWidth": 163,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 211.109375,
+            "top": 3291.296875,
+            "bottom": 3347.296875,
+            "width": 163.109375,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five Personality Test",
+          "scrollWidth": 163,
+          "clientWidth": 163,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 211.109375,
+            "top": 3547.296875,
+            "bottom": 3603.296875,
+            "width": 163.109375,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ Test",
+          "scrollWidth": 61,
+          "clientWidth": 61,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 108.78125,
+            "top": 3803.296875,
+            "bottom": 3831.296875,
+            "width": 60.78125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Holland Career Interest Test",
+          "scrollWidth": 166,
+          "clientWidth": 166,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 214.40625,
+            "top": 4031.296875,
+            "bottom": 4087.296875,
+            "width": 166.40625,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Enneagram Test",
+          "scrollWidth": 144,
+          "clientWidth": 144,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 191.5625,
+            "top": 4287.296875,
+            "bottom": 4315.296875,
+            "width": 143.5625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Depression and Anxiety Assessment",
+          "scrollWidth": 138,
+          "clientWidth": 138,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 186.34375,
+            "top": 4515.296875,
+            "bottom": 4599.296875,
+            "width": 138.34375,
+            "height": 84
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "About FermatMind",
+          "scrollWidth": 294,
+          "clientWidth": 294,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 342,
+            "top": 4991.296875,
+            "bottom": 5027.296875,
+            "width": 294,
+            "height": 36
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Reusable result",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5279.296875,
+            "bottom": 5307.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Transparent boundaries",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5651.296875,
+            "bottom": 5679.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Career direction",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5995.296875,
+            "bottom": 6023.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Recommended reading",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 6383.296875,
+            "bottom": 6463.296875,
+            "width": 342,
+            "height": 80
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five Personality Test: Is It More Scientific Than MBTI—and What Can It Really Tell You?",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 6691.296875,
+            "bottom": 6841.296875,
+            "width": 342,
+            "height": 150
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 7137.296875,
+            "bottom": 7249.796875,
+            "width": 342,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "What Can a Holland Career Interest Test Tell You—and What It Cannot?",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 7545.796875,
+            "bottom": 7658.296875,
+            "width": 342,
+            "height": 112.5
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh",
+      "viewport": "desktop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1440,
+      "viewport_width": 1440,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "从一个清楚的问题开始。",
+          "scrollWidth": 672,
+          "clientWidth": 672,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 384,
+            "right": 1056,
+            "top": 1841.765625,
+            "bottom": 1881.765625,
+            "width": 672,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 性格测试",
+          "scrollWidth": 124,
+          "clientWidth": 124,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 208,
+            "right": 332.171875,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 124.171875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five 大五人格测试",
+          "scrollWidth": 185,
+          "clientWidth": 185,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 573.328125,
+            "right": 758.703125,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 185.375,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ 智商测试",
+          "scrollWidth": 99,
+          "clientWidth": 99,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 938.65625,
+            "right": 1037.875,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 99.21875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 208,
+            "right": 381.703125,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "九型人格测试",
+          "scrollWidth": 116,
+          "clientWidth": 116,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 573.328125,
+            "right": 689.140625,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 115.8125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "抑郁焦虑综合症测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 938.65625,
+            "right": 1112.359375,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "关于 费马测试",
+          "scrollWidth": 768,
+          "clientWidth": 768,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 336,
+            "right": 1104,
+            "top": 2613.765625,
+            "bottom": 2653.765625,
+            "width": 768,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "结果可复用",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 272,
+            "right": 512,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "方法边界透明",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 600,
+            "right": 840,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "连接职业方向",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 928,
+            "right": 1168,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "推荐阅读",
+          "scrollWidth": 1072,
+          "clientWidth": 1072,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 184,
+            "right": 1256,
+            "top": 3281.765625,
+            "bottom": 3329.765625,
+            "width": 1072,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 184,
+            "right": 520,
+            "top": 3557.765625,
+            "bottom": 3707.765625,
+            "width": 336,
+            "height": 150
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 552,
+            "right": 888,
+            "top": 3557.765625,
+            "bottom": 3632.765625,
+            "width": 336,
+            "height": 75
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 920,
+            "right": 1256,
+            "top": 3557.765625,
+            "bottom": 3670.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 184,
+            "right": 520,
+            "top": 4003.765625,
+            "bottom": 4116.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 552,
+            "right": 888,
+            "top": 4003.765625,
+            "bottom": 4116.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 920,
+            "right": 1256,
+            "top": 4003.765625,
+            "bottom": 4153.765625,
+            "width": 336,
+            "height": 150
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh",
+      "viewport": "laptop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1280,
+      "viewport_width": 1280,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "从一个清楚的问题开始。",
+          "scrollWidth": 672,
+          "clientWidth": 672,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 304,
+            "right": 976,
+            "top": 1841.765625,
+            "bottom": 1881.765625,
+            "width": 672,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 性格测试",
+          "scrollWidth": 124,
+          "clientWidth": 124,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 128,
+            "right": 252.171875,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 124.171875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five 大五人格测试",
+          "scrollWidth": 185,
+          "clientWidth": 185,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 493.328125,
+            "right": 678.703125,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 185.375,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ 智商测试",
+          "scrollWidth": 99,
+          "clientWidth": 99,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 858.65625,
+            "right": 957.875,
+            "top": 1945.765625,
+            "bottom": 1973.765625,
+            "width": 99.21875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 128,
+            "right": 301.703125,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "九型人格测试",
+          "scrollWidth": 116,
+          "clientWidth": 116,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 493.328125,
+            "right": 609.140625,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 115.8125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "抑郁焦虑综合症测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 858.65625,
+            "right": 1032.359375,
+            "top": 2173.765625,
+            "bottom": 2201.765625,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "关于 费马测试",
+          "scrollWidth": 768,
+          "clientWidth": 768,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 256,
+            "right": 1024,
+            "top": 2613.765625,
+            "bottom": 2653.765625,
+            "width": 768,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "结果可复用",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 192,
+            "right": 432,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "方法边界透明",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 520,
+            "right": 760,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "连接职业方向",
+          "scrollWidth": 240,
+          "clientWidth": 240,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 848,
+            "right": 1088,
+            "top": 2889.765625,
+            "bottom": 2917.765625,
+            "width": 240,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "推荐阅读",
+          "scrollWidth": 1072,
+          "clientWidth": 1072,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 104,
+            "right": 1176,
+            "top": 3281.765625,
+            "bottom": 3329.765625,
+            "width": 1072,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 104,
+            "right": 440,
+            "top": 3557.765625,
+            "bottom": 3707.765625,
+            "width": 336,
+            "height": 150
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 472,
+            "right": 808,
+            "top": 3557.765625,
+            "bottom": 3632.765625,
+            "width": 336,
+            "height": 75
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 840,
+            "right": 1176,
+            "top": 3557.765625,
+            "bottom": 3670.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 104,
+            "right": 440,
+            "top": 4003.765625,
+            "bottom": 4116.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 472,
+            "right": 808,
+            "top": 4003.765625,
+            "bottom": 4116.265625,
+            "width": 336,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 336,
+          "clientWidth": 336,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 840,
+            "right": 1176,
+            "top": 4003.765625,
+            "bottom": 4153.765625,
+            "width": 336,
+            "height": 150
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh",
+      "viewport": "mobile",
+      "horizontal_scroll": false,
+      "document_scroll_width": 390,
+      "viewport_width": 390,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "使用场景与引用",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 1591.296875,
+            "bottom": 1627.296875,
+            "width": 342,
+            "height": 36
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "从一个清楚的问题开始。",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 3083.296875,
+            "bottom": 3119.296875,
+            "width": 342,
+            "height": 36
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 性格测试",
+          "scrollWidth": 124,
+          "clientWidth": 124,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 172.171875,
+            "top": 3183.296875,
+            "bottom": 3211.296875,
+            "width": 124.171875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Big Five 大五人格测试",
+          "scrollWidth": 185,
+          "clientWidth": 185,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 233.375,
+            "top": 3411.296875,
+            "bottom": 3439.296875,
+            "width": 185.375,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "IQ 智商测试",
+          "scrollWidth": 99,
+          "clientWidth": 99,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 147.21875,
+            "top": 3639.296875,
+            "bottom": 3667.296875,
+            "width": 99.21875,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 221.703125,
+            "top": 3867.296875,
+            "bottom": 3895.296875,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "九型人格测试",
+          "scrollWidth": 116,
+          "clientWidth": 116,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 163.8125,
+            "top": 4095.296875,
+            "bottom": 4123.296875,
+            "width": 115.8125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "抑郁焦虑综合症测试",
+          "scrollWidth": 174,
+          "clientWidth": 174,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 221.703125,
+            "top": 4323.296875,
+            "bottom": 4351.296875,
+            "width": 173.703125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "关于 费马测试",
+          "scrollWidth": 294,
+          "clientWidth": 294,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 48,
+            "right": 342,
+            "top": 4715.296875,
+            "bottom": 4751.296875,
+            "width": 294,
+            "height": 36
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "结果可复用",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5035.296875,
+            "bottom": 5063.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "方法边界透明",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5351.296875,
+            "bottom": 5379.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "连接职业方向",
+          "scrollWidth": 246,
+          "clientWidth": 246,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 72,
+            "right": 318,
+            "top": 5667.296875,
+            "bottom": 5695.296875,
+            "width": 246,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "推荐阅读",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 6027.296875,
+            "bottom": 6067.296875,
+            "width": 342,
+            "height": 40
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "大五人格测试：比 MBTI 更科学吗？五大特质能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 6295.296875,
+            "bottom": 6407.796875,
+            "width": 342,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 6703.796875,
+            "bottom": 6778.796875,
+            "width": 342,
+            "height": 75
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "霍兰德职业兴趣测试能告诉你什么，不能告诉你什么？",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 7074.796875,
+            "bottom": 7149.796875,
+            "width": 342,
+            "height": 75
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 7445.796875,
+            "bottom": 7558.296875,
+            "width": 342,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 7854.296875,
+            "bottom": 7966.796875,
+            "width": 342,
+            "height": 112.5
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 342,
+          "clientWidth": 342,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 24,
+            "right": 366,
+            "top": 8262.796875,
+            "bottom": 8412.796875,
+            "width": 342,
+            "height": 150
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "viewport": "desktop",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "viewport": "laptop",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "viewport": "mobile",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "viewport": "desktop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1440,
+      "viewport_width": 1440,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h1",
+          "text": "MBTI 性格测试【16型人格】",
+          "scrollWidth": 475,
+          "clientWidth": 450,
+          "overflowX": true,
+          "outsideViewport": false,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "nowrap",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 651,
+            "top": 138,
+            "bottom": 183.109375,
+            "width": 450,
+            "height": 45.109375
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你将获得什么",
+          "scrollWidth": 686,
+          "clientWidth": 686,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 887,
+            "top": 1491.109375,
+            "bottom": 1516.109375,
+            "width": 686,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "相关文章",
+          "scrollWidth": 686,
+          "clientWidth": 686,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 887,
+            "top": 1730.109375,
+            "bottom": 1755.109375,
+            "width": 686,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "FAQ",
+          "scrollWidth": 736,
+          "clientWidth": 736,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 912,
+            "top": 1848.109375,
+            "bottom": 1880.109375,
+            "width": 736,
+            "height": 32
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "viewport": "laptop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1280,
+      "viewport_width": 1280,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h1",
+          "text": "MBTI 性格测试【16型人格】",
+          "scrollWidth": 475,
+          "clientWidth": 450,
+          "overflowX": true,
+          "outsideViewport": false,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "nowrap",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 571,
+            "top": 138,
+            "bottom": 183.109375,
+            "width": 450,
+            "height": 45.109375
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你将获得什么",
+          "scrollWidth": 686,
+          "clientWidth": 686,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 807,
+            "top": 1491.109375,
+            "bottom": 1516.109375,
+            "width": 686,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "相关文章",
+          "scrollWidth": 686,
+          "clientWidth": 686,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 807,
+            "top": 1730.109375,
+            "bottom": 1755.109375,
+            "width": 686,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "FAQ",
+          "scrollWidth": 736,
+          "clientWidth": 736,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 832,
+            "top": 1848.109375,
+            "bottom": 1880.109375,
+            "width": 736,
+            "height": 32
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "viewport": "mobile",
+      "horizontal_scroll": false,
+      "document_scroll_width": 390,
+      "viewport_width": 390,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "何时使用这份测评",
+          "scrollWidth": 316,
+          "clientWidth": 316,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 37,
+            "right": 353,
+            "top": 2098,
+            "bottom": 2126,
+            "width": 316,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你将获得什么",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 2368,
+            "bottom": 2393,
+            "width": 324,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "相关文章",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 2623,
+            "bottom": 2648,
+            "width": 324,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "FAQ",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 2725,
+            "bottom": 2757,
+            "width": 358,
+            "height": 32
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "viewport": "desktop",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "viewport": "laptop",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "viewport": "mobile",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "viewport": "desktop",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "viewport": "laptop",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "viewport": "mobile",
+      "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+    },
+    {
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "viewport": "desktop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1440,
+      "viewport_width": 1440,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "MBTI scene depth on the topic hub",
+          "scrollWidth": 1046,
+          "clientWidth": 1046,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 197,
+            "right": 1243,
+            "top": 1686,
+            "bottom": 1714,
+            "width": 1046,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Career direction: frame fit first, then evaluate roles",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 214,
+            "right": 1226,
+            "top": 1775,
+            "bottom": 1799,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Team collaboration: convert style differences into operating rules",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 214,
+            "right": 1226,
+            "top": 1965,
+            "bottom": 1989,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Major selection: use type signals, not trend-only choices",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 214,
+            "right": 1226,
+            "top": 2155,
+            "bottom": 2179,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Growth planning: convert type strengths into quarter-level actions",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 214,
+            "right": 1226,
+            "top": 2389,
+            "bottom": 2413,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "overview",
+          "scrollWidth": 665,
+          "clientWidth": 665,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 865.65625,
+            "top": 2664,
+            "bottom": 2689,
+            "width": 664.65625,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "why_it_matters",
+          "scrollWidth": 665,
+          "clientWidth": 665,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 865.65625,
+            "top": 2835,
+            "bottom": 2860,
+            "width": 664.65625,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Quick answers",
+          "scrollWidth": 673,
+          "clientWidth": 673,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 197,
+            "right": 869.65625,
+            "top": 2974,
+            "bottom": 3002,
+            "width": 672.65625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Featured",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 890.65625,
+            "top": 4187,
+            "bottom": 4219,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Take the MBTI test",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 4278,
+            "bottom": 4306,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related articles",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 890.65625,
+            "top": 4451,
+            "bottom": 4483,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 4542,
+            "bottom": 4598,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related personality profiles",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 890.65625,
+            "top": 4723,
+            "bottom": 4755,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "INTJ - Architect",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 4814,
+            "bottom": 4842,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related links",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 890.65625,
+            "top": 4967,
+            "bottom": 4999,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "From MBTI to Job Fit",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 5058,
+            "bottom": 5086,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "How to Find the Right Career Direction",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 564.328125,
+            "right": 865.65625,
+            "top": 5058,
+            "bottom": 5114,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Continue with related public guides",
+          "scrollWidth": 673,
+          "clientWidth": 673,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 197,
+            "right": 869.65625,
+            "top": 5260,
+            "bottom": 5288,
+            "width": 672.65625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Topic summary",
+          "scrollWidth": 307,
+          "clientWidth": 307,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 931.65625,
+            "right": 1239,
+            "top": 2664,
+            "bottom": 2689,
+            "width": 307.34375,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "SEO snapshot",
+          "scrollWidth": 307,
+          "clientWidth": 307,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 931.65625,
+            "right": 1239,
+            "top": 2879,
+            "bottom": 2904,
+            "width": 307.34375,
+            "height": 25
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "viewport": "laptop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1280,
+      "viewport_width": 1280,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "MBTI scene depth on the topic hub",
+          "scrollWidth": 1046,
+          "clientWidth": 1046,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 117,
+            "right": 1163,
+            "top": 1686,
+            "bottom": 1714,
+            "width": 1046,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Career direction: frame fit first, then evaluate roles",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 134,
+            "right": 1146,
+            "top": 1775,
+            "bottom": 1799,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Team collaboration: convert style differences into operating rules",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 134,
+            "right": 1146,
+            "top": 1965,
+            "bottom": 1989,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Major selection: use type signals, not trend-only choices",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 134,
+            "right": 1146,
+            "top": 2155,
+            "bottom": 2179,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Growth planning: convert type strengths into quarter-level actions",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 134,
+            "right": 1146,
+            "top": 2389,
+            "bottom": 2413,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "overview",
+          "scrollWidth": 665,
+          "clientWidth": 665,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 785.65625,
+            "top": 2664,
+            "bottom": 2689,
+            "width": 664.65625,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "why_it_matters",
+          "scrollWidth": 665,
+          "clientWidth": 665,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 785.65625,
+            "top": 2835,
+            "bottom": 2860,
+            "width": 664.65625,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Quick answers",
+          "scrollWidth": 673,
+          "clientWidth": 673,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 117,
+            "right": 789.65625,
+            "top": 2974,
+            "bottom": 3002,
+            "width": 672.65625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Featured",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 810.65625,
+            "top": 4187,
+            "bottom": 4219,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Take the MBTI test",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 4278,
+            "bottom": 4306,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related articles",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 810.65625,
+            "top": 4451,
+            "bottom": 4483,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 4542,
+            "bottom": 4598,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related personality profiles",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 810.65625,
+            "top": 4723,
+            "bottom": 4755,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "INTJ - Architect",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 4814,
+            "bottom": 4842,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related links",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 810.65625,
+            "top": 4967,
+            "bottom": 4999,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "From MBTI to Job Fit",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 5058,
+            "bottom": 5086,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "How to Find the Right Career Direction",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 484.328125,
+            "right": 785.65625,
+            "top": 5058,
+            "bottom": 5114,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Continue with related public guides",
+          "scrollWidth": 673,
+          "clientWidth": 673,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 117,
+            "right": 789.65625,
+            "top": 5260,
+            "bottom": 5288,
+            "width": 672.65625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Topic summary",
+          "scrollWidth": 307,
+          "clientWidth": 307,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 851.65625,
+            "right": 1159,
+            "top": 2664,
+            "bottom": 2689,
+            "width": 307.34375,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "SEO snapshot",
+          "scrollWidth": 307,
+          "clientWidth": 307,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 851.65625,
+            "right": 1159,
+            "top": 2879,
+            "bottom": 2904,
+            "width": 307.34375,
+            "height": 25
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "viewport": "mobile",
+      "horizontal_scroll": false,
+      "document_scroll_width": 390,
+      "viewport_width": 390,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h3",
+          "text": "SJ",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 1827,
+            "bottom": 1855,
+            "width": 282,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "SP",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 2281,
+            "bottom": 2309,
+            "width": 282,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "MBTI scene depth on the topic hub",
+          "scrollWidth": 316,
+          "clientWidth": 316,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 37,
+            "right": 353,
+            "top": 3556,
+            "bottom": 3612,
+            "width": 316,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Career direction: frame fit first, then evaluate roles",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 3729,
+            "bottom": 3777,
+            "width": 282,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Team collaboration: convert style differences into operating rules",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 4215,
+            "bottom": 4263,
+            "width": 282,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Major selection: use type signals, not trend-only choices",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 4773,
+            "bottom": 4821,
+            "width": 282,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Growth planning: convert type strengths into quarter-level actions",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 5331,
+            "bottom": 5379,
+            "width": 282,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "overview",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 5865,
+            "bottom": 5890,
+            "width": 324,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "why_it_matters",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 6040,
+            "bottom": 6065,
+            "width": 324,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Quick answers",
+          "scrollWidth": 316,
+          "clientWidth": 316,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 37,
+            "right": 353,
+            "top": 6219,
+            "bottom": 6247,
+            "width": 316,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Featured",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 8154,
+            "bottom": 8186,
+            "width": 358,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Take the MBTI test",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 8237,
+            "bottom": 8265,
+            "width": 324,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related articles",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 8374,
+            "bottom": 8406,
+            "width": 358,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 8457,
+            "bottom": 8513,
+            "width": 324,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related personality profiles",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 8622,
+            "bottom": 8654,
+            "width": 358,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "INTJ - Architect",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 8705,
+            "bottom": 8733,
+            "width": 324,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Related links",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 8842,
+            "bottom": 8874,
+            "width": 358,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "From MBTI to Job Fit",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 8925,
+            "bottom": 8953,
+            "width": 324,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "How to Find the Right Career Direction",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 9109,
+            "bottom": 9137,
+            "width": 324,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "Continue with related public guides",
+          "scrollWidth": 316,
+          "clientWidth": 316,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 37,
+            "right": 353,
+            "top": 9267,
+            "bottom": 9323,
+            "width": 316,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "Topic summary",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 9457,
+            "bottom": 9482,
+            "width": 324,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "SEO snapshot",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 9648,
+            "bottom": 9673,
+            "width": 324,
+            "height": 25
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "viewport": "desktop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1440,
+      "viewport_width": 1440,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "MBTI 场景深化（主题页）",
+          "scrollWidth": 1046,
+          "clientWidth": 1046,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 197,
+            "right": 1243,
+            "top": 1510,
+            "bottom": 1538,
+            "width": 1046,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "职业方向：先建立匹配框架，再看岗位细节",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 214,
+            "right": 1226,
+            "top": 1599,
+            "bottom": 1623,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "团队协作：把风格差异转成可执行协作规则",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 214,
+            "right": 1226,
+            "top": 1761,
+            "bottom": 1785,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "专业选择：用类型偏好校准方向，不只看热门专业",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 214,
+            "right": 1226,
+            "top": 1923,
+            "bottom": 1947,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "成长建议：把类型优势转成季度可执行行动",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 214,
+            "right": 1226,
+            "top": 2085,
+            "bottom": 2109,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "overview",
+          "scrollWidth": 665,
+          "clientWidth": 665,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 865.65625,
+            "top": 2288,
+            "bottom": 2313,
+            "width": 664.65625,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "why_it_matters",
+          "scrollWidth": 665,
+          "clientWidth": 665,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 865.65625,
+            "top": 2431,
+            "bottom": 2456,
+            "width": 664.65625,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "快速答案",
+          "scrollWidth": 673,
+          "clientWidth": 673,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 197,
+            "right": 869.65625,
+            "top": 2570,
+            "bottom": 2598,
+            "width": 672.65625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "精选内容",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 890.65625,
+            "top": 3671,
+            "bottom": 3703,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "开始 MBTI 性格测试",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 3762,
+            "bottom": 3790,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "相关文章",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 890.65625,
+            "top": 3915,
+            "bottom": 3947,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 4006,
+            "bottom": 4062,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 564.328125,
+            "right": 865.65625,
+            "top": 4006,
+            "bottom": 4090,
+            "width": 301.328125,
+            "height": 84
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 4270,
+            "bottom": 4326,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 564.328125,
+            "right": 865.65625,
+            "top": 4270,
+            "bottom": 4326,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 4506,
+            "bottom": 4562,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 564.328125,
+            "right": 865.65625,
+            "top": 4506,
+            "bottom": 4562,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "相关人格画像",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 890.65625,
+            "top": 4687,
+            "bottom": 4719,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "INTJ - 建筑师",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 4778,
+            "bottom": 4806,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "延伸阅读",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 176,
+            "right": 890.65625,
+            "top": 4931,
+            "bottom": 4963,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "如何将 MBTI 用于职业匹配",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 201,
+            "right": 502.328125,
+            "top": 5022,
+            "bottom": 5050,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "如何找到适合自己的职业方向",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 564.328125,
+            "right": 865.65625,
+            "top": 5022,
+            "bottom": 5050,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "继续延伸阅读",
+          "scrollWidth": 673,
+          "clientWidth": 673,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 197,
+            "right": 869.65625,
+            "top": 5176,
+            "bottom": 5204,
+            "width": 672.65625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "主题摘要",
+          "scrollWidth": 307,
+          "clientWidth": 307,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 931.65625,
+            "right": 1239,
+            "top": 2288,
+            "bottom": 2313,
+            "width": 307.34375,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "SEO 快照",
+          "scrollWidth": 307,
+          "clientWidth": 307,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 931.65625,
+            "right": 1239,
+            "top": 2503,
+            "bottom": 2528,
+            "width": 307.34375,
+            "height": 25
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "viewport": "laptop",
+      "horizontal_scroll": false,
+      "document_scroll_width": 1280,
+      "viewport_width": 1280,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h2",
+          "text": "MBTI 场景深化（主题页）",
+          "scrollWidth": 1046,
+          "clientWidth": 1046,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 117,
+            "right": 1163,
+            "top": 1510,
+            "bottom": 1538,
+            "width": 1046,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "职业方向：先建立匹配框架，再看岗位细节",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 134,
+            "right": 1146,
+            "top": 1599,
+            "bottom": 1623,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "团队协作：把风格差异转成可执行协作规则",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 134,
+            "right": 1146,
+            "top": 1761,
+            "bottom": 1785,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "专业选择：用类型偏好校准方向，不只看热门专业",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 134,
+            "right": 1146,
+            "top": 1923,
+            "bottom": 1947,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "成长建议：把类型优势转成季度可执行行动",
+          "scrollWidth": 1012,
+          "clientWidth": 1012,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 134,
+            "right": 1146,
+            "top": 2085,
+            "bottom": 2109,
+            "width": 1012,
+            "height": 24
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "overview",
+          "scrollWidth": 665,
+          "clientWidth": 665,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 785.65625,
+            "top": 2288,
+            "bottom": 2313,
+            "width": 664.65625,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "why_it_matters",
+          "scrollWidth": 665,
+          "clientWidth": 665,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 785.65625,
+            "top": 2431,
+            "bottom": 2456,
+            "width": 664.65625,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "快速答案",
+          "scrollWidth": 673,
+          "clientWidth": 673,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 117,
+            "right": 789.65625,
+            "top": 2570,
+            "bottom": 2598,
+            "width": 672.65625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "精选内容",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 810.65625,
+            "top": 3671,
+            "bottom": 3703,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "开始 MBTI 性格测试",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 3762,
+            "bottom": 3790,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "相关文章",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 810.65625,
+            "top": 3915,
+            "bottom": 3947,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 4006,
+            "bottom": 4062,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 484.328125,
+            "right": 785.65625,
+            "top": 4006,
+            "bottom": 4090,
+            "width": 301.328125,
+            "height": 84
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 4270,
+            "bottom": 4326,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 484.328125,
+            "right": 785.65625,
+            "top": 4270,
+            "bottom": 4326,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 4506,
+            "bottom": 4562,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 484.328125,
+            "right": 785.65625,
+            "top": 4506,
+            "bottom": 4562,
+            "width": 301.328125,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "相关人格画像",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 810.65625,
+            "top": 4687,
+            "bottom": 4719,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "INTJ - 建筑师",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 4778,
+            "bottom": 4806,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "延伸阅读",
+          "scrollWidth": 715,
+          "clientWidth": 715,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 96,
+            "right": 810.65625,
+            "top": 4931,
+            "bottom": 4963,
+            "width": 714.65625,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "如何将 MBTI 用于职业匹配",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 121,
+            "right": 422.328125,
+            "top": 5022,
+            "bottom": 5050,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "如何找到适合自己的职业方向",
+          "scrollWidth": 301,
+          "clientWidth": 301,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 484.328125,
+            "right": 785.65625,
+            "top": 5022,
+            "bottom": 5050,
+            "width": 301.328125,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "继续延伸阅读",
+          "scrollWidth": 673,
+          "clientWidth": 673,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 117,
+            "right": 789.65625,
+            "top": 5176,
+            "bottom": 5204,
+            "width": 672.65625,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "主题摘要",
+          "scrollWidth": 307,
+          "clientWidth": 307,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 851.65625,
+            "right": 1159,
+            "top": 2288,
+            "bottom": 2313,
+            "width": 307.34375,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "SEO 快照",
+          "scrollWidth": 307,
+          "clientWidth": 307,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 851.65625,
+            "right": 1159,
+            "top": 2503,
+            "bottom": 2528,
+            "width": 307.34375,
+            "height": 25
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "viewport": "mobile",
+      "horizontal_scroll": false,
+      "document_scroll_width": 390,
+      "viewport_width": 390,
+      "nav_overflow": false,
+      "footer_overflow": false,
+      "cta_overflow": [],
+      "heading_issues": [
+        {
+          "tag": "h3",
+          "text": "SJ",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 1719,
+            "bottom": 1747,
+            "width": 282,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "SP",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 2173,
+            "bottom": 2201,
+            "width": 282,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "MBTI 场景深化（主题页）",
+          "scrollWidth": 316,
+          "clientWidth": 316,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 37,
+            "right": 353,
+            "top": 3336,
+            "bottom": 3364,
+            "width": 316,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "职业方向：先建立匹配框架，再看岗位细节",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 3453,
+            "bottom": 3501,
+            "width": 282,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "团队协作：把风格差异转成可执行协作规则",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 3867,
+            "bottom": 3915,
+            "width": 282,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "专业选择：用类型偏好校准方向，不只看热门专业",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 4253,
+            "bottom": 4301,
+            "width": 282,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "成长建议：把类型优势转成季度可执行行动",
+          "scrollWidth": 282,
+          "clientWidth": 282,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 54,
+            "right": 336,
+            "top": 4683,
+            "bottom": 4731,
+            "width": 282,
+            "height": 48
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "overview",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 5174,
+            "bottom": 5199,
+            "width": 324,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "why_it_matters",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 5321,
+            "bottom": 5346,
+            "width": 324,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "快速答案",
+          "scrollWidth": 316,
+          "clientWidth": 316,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 37,
+            "right": 353,
+            "top": 5472,
+            "bottom": 5500,
+            "width": 316,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "精选内容",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 7183,
+            "bottom": 7215,
+            "width": 358,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "开始 MBTI 性格测试",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 7266,
+            "bottom": 7294,
+            "width": 324,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "相关文章",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 7383,
+            "bottom": 7415,
+            "width": 358,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 7466,
+            "bottom": 7522,
+            "width": 324,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 7678,
+            "bottom": 7762,
+            "width": 324,
+            "height": 84
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 7918,
+            "bottom": 7974,
+            "width": 324,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 8130,
+            "bottom": 8186,
+            "width": 324,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 8342,
+            "bottom": 8398,
+            "width": 324,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 8554,
+            "bottom": 8610,
+            "width": 324,
+            "height": 56
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "相关人格画像",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 8719,
+            "bottom": 8751,
+            "width": 358,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "INTJ - 建筑师",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 8802,
+            "bottom": 8830,
+            "width": 324,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "延伸阅读",
+          "scrollWidth": 358,
+          "clientWidth": 358,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 16,
+            "right": 374,
+            "top": 8939,
+            "bottom": 8971,
+            "width": 358,
+            "height": 32
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "如何将 MBTI 用于职业匹配",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 9022,
+            "bottom": 9050,
+            "width": 324,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "如何找到适合自己的职业方向",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 9186,
+            "bottom": 9214,
+            "width": 324,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h2",
+          "text": "继续延伸阅读",
+          "scrollWidth": 316,
+          "clientWidth": 316,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 37,
+            "right": 353,
+            "top": 9324,
+            "bottom": 9352,
+            "width": 316,
+            "height": 28
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "主题摘要",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 9442,
+            "bottom": 9467,
+            "width": 324,
+            "height": 25
+          }
+        },
+        {
+          "tag": "h3",
+          "text": "SEO 快照",
+          "scrollWidth": 324,
+          "clientWidth": 324,
+          "overflowX": false,
+          "outsideViewport": true,
+          "textOverflow": "clip",
+          "overflow": "visible",
+          "whiteSpace": "normal",
+          "lineClamp": "none",
+          "rect": {
+            "left": 33,
+            "right": 357,
+            "top": 9613,
+            "bottom": 9638,
+            "width": 324,
+            "height": 25
+          }
+        }
+      ]
+    }
+  ],
+  "h1_visual_risk_findings": [
+    {
+      "url": "https://fermatmind.com/en",
+      "viewport": "desktop",
+      "h1": {
+        "tag": "h1",
+        "text": "Understand yourself before the next step.",
+        "scrollWidth": 1719,
+        "clientWidth": 960,
+        "overflowX": true,
+        "outsideViewport": false,
+        "textOverflow": "clip",
+        "overflow": "visible",
+        "whiteSpace": "nowrap",
+        "lineClamp": "none",
+        "rect": {
+          "left": 240,
+          "right": 1200,
+          "top": 359.5,
+          "bottom": 443.5,
+          "width": 960,
+          "height": 84
+        }
+      }
+    },
+    {
+      "url": "https://fermatmind.com/en",
+      "viewport": "laptop",
+      "h1": {
+        "tag": "h1",
+        "text": "Understand yourself before the next step.",
+        "scrollWidth": 1719,
+        "clientWidth": 960,
+        "overflowX": true,
+        "outsideViewport": false,
+        "textOverflow": "clip",
+        "overflow": "visible",
+        "whiteSpace": "nowrap",
+        "lineClamp": "none",
+        "rect": {
+          "left": 160,
+          "right": 1120,
+          "top": 359.5,
+          "bottom": 443.5,
+          "width": 960,
+          "height": 84
+        }
+      }
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "viewport": "desktop",
+      "h1": {
+        "tag": "h1",
+        "text": "MBTI 性格测试【16型人格】",
+        "scrollWidth": 475,
+        "clientWidth": 450,
+        "overflowX": true,
+        "outsideViewport": false,
+        "textOverflow": "clip",
+        "overflow": "visible",
+        "whiteSpace": "nowrap",
+        "lineClamp": "none",
+        "rect": {
+          "left": 201,
+          "right": 651,
+          "top": 138,
+          "bottom": 183.109375,
+          "width": 450,
+          "height": 45.109375
+        }
+      }
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "viewport": "laptop",
+      "h1": {
+        "tag": "h1",
+        "text": "MBTI 性格测试【16型人格】",
+        "scrollWidth": 475,
+        "clientWidth": 450,
+        "overflowX": true,
+        "outsideViewport": false,
+        "textOverflow": "clip",
+        "overflow": "visible",
+        "whiteSpace": "nowrap",
+        "lineClamp": "none",
+        "rect": {
+          "left": 121,
+          "right": 571,
+          "top": 138,
+          "bottom": 183.109375,
+          "width": 450,
+          "height": 45.109375
+        }
+      }
+    }
+  ],
+  "internal_link_readiness": [
+    {
+      "edge": "test -> topic",
+      "status": "runtime_observed_only",
+      "examples": [
+        {
+          "from": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/en/topics/mbti",
+          "text": "Open entry"
+        },
+        {
+          "from": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/en/topics/mbti",
+          "text": "Open entry"
+        },
+        {
+          "from": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/en/topics/mbti",
+          "text": "Continue"
+        },
+        {
+          "from": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/zh/topics/mbti",
+          "text": "查看入口"
+        },
+        {
+          "from": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/zh/topics/mbti",
+          "text": "查看入口"
+        }
+      ]
+    },
+    {
+      "edge": "test -> research",
+      "status": "missing",
+      "examples": []
+    },
+    {
+      "edge": "test -> article",
+      "status": "runtime_observed_only",
+      "examples": [
+        {
+          "from": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/en/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?"
+        },
+        {
+          "from": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/en/articles/big-five-personality-test-vs-mbti",
+          "text": "Big Five Personality Test: Is It More Scientific Than MBTI—and What Can It Really Tell You?"
+        },
+        {
+          "from": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/en/articles",
+          "text": "All articles"
+        },
+        {
+          "from": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/en/articles",
+          "text": "Articles"
+        },
+        {
+          "from": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+          "to": "https://fermatmind.com/zh/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI 16 型人格测试：是科学工具，还是赛博算命？"
+        }
+      ]
+    },
+    {
+      "edge": "topic -> test",
+      "status": "runtime_observed_only",
+      "examples": [
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_topic_detail&entry_surface=mbti_topic_detail&source_page_type=topic_detail&target_action=start_mbti_test_primary&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftopics%2Fmbti",
+          "text": "Start MBTI test"
+        },
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Open entry"
+        },
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_career_direction&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftopics%2Fmbti",
+          "text": "Start MBTI test"
+        },
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_major_selection&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftopics%2Fmbti",
+          "text": "Take test before choosing path"
+        },
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types/take?form=mbti_144&entrypoint=mbti_scene_block&entry_surface=mbti_scene_block&source_page_type=topic_detail&target_action=start_mbti_test_scene_growth_planning&test_slug=mbti-personality-test-16-personality-types&form_code=mbti_144&landing_path=%2Fen%2Ftopics%2Fmbti",
+          "text": "Start test to unlock personalized growth path"
+        }
+      ]
+    },
+    {
+      "edge": "topic -> research",
+      "status": "missing",
+      "examples": []
+    },
+    {
+      "edge": "topic -> article",
+      "status": "runtime_observed_only",
+      "examples": [
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/articles/mbti-growth-guide",
+          "text": "Read growth guide"
+        },
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/articles/mbti-narrative-portrait",
+          "text": "Read narrative portrait"
+        },
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/articles/mbti-growth-guide",
+          "text": "Read MBTI growth guide"
+        },
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?"
+        },
+        {
+          "from": "https://fermatmind.com/en/topics/mbti",
+          "to": "https://fermatmind.com/en/articles/mbti-personality-test-science-vs-pseudoscience",
+          "text": "MBTI Personality Test: Scientific Tool or Cyber Fortune-Telling?"
+        }
+      ]
+    },
+    {
+      "edge": "research -> test",
+      "status": "missing",
+      "examples": []
+    },
+    {
+      "edge": "research -> topic",
+      "status": "missing",
+      "examples": []
+    },
+    {
+      "edge": "article -> test",
+      "status": "missing",
+      "examples": []
+    },
+    {
+      "edge": "article -> topic",
+      "status": "missing",
+      "examples": []
+    },
+    {
+      "edge": "article -> research",
+      "status": "missing",
+      "examples": []
+    },
+    {
+      "edge": "personality -> test",
+      "status": "runtime_observed_only",
+      "examples": [
+        {
+          "from": "https://fermatmind.com/en/personality",
+          "to": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "text": "Start MBTI test"
+        },
+        {
+          "from": "https://fermatmind.com/en/personality",
+          "to": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+          "text": "MBTI"
+        },
+        {
+          "from": "https://fermatmind.com/en/personality",
+          "to": "https://fermatmind.com/en/tests/big-five-personality-test-ocean-model",
+          "text": "Big Five"
+        },
+        {
+          "from": "https://fermatmind.com/en/personality",
+          "to": "https://fermatmind.com/en/tests/iq-test-intelligence-quotient-assessment",
+          "text": "IQ"
+        },
+        {
+          "from": "https://fermatmind.com/en/personality",
+          "to": "https://fermatmind.com/en/tests/eq-test-emotional-intelligence-assessment",
+          "text": "EQ"
+        }
+      ]
+    },
+    {
+      "edge": "personality -> topic",
+      "status": "missing",
+      "examples": []
+    },
+    {
+      "edge": "personality -> article",
+      "status": "runtime_observed_only",
+      "examples": [
+        {
+          "from": "https://fermatmind.com/en/personality",
+          "to": "https://fermatmind.com/en/articles",
+          "text": "All articles"
+        },
+        {
+          "from": "https://fermatmind.com/en/personality",
+          "to": "https://fermatmind.com/en/articles",
+          "text": "Articles"
+        },
+        {
+          "from": "https://fermatmind.com/zh/personality",
+          "to": "https://fermatmind.com/zh/articles",
+          "text": "全部文章"
+        },
+        {
+          "from": "https://fermatmind.com/zh/personality",
+          "to": "https://fermatmind.com/zh/articles",
+          "text": "文章"
+        }
+      ]
+    }
+  ],
+  "claim_boundary_findings": [
+    {
+      "priority": "Observation",
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "markers": [
+        "诊断"
+      ],
+      "page_family": "test_detail",
+      "claim_context": "allowed_non_diagnostic_disclaimer",
+      "snippet": "这是诊断吗？不是。本测评用于教育性自我理解，不替代专业建议。"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/method-boundaries",
+      "markers": [
+        "诊断",
+        "治疗"
+      ],
+      "page_family": "help/content/policy",
+      "claim_context": "page_404_observation_not_indexable_copy",
+      "snippet": "runtime returned 404 during manual verification"
+    },
+    {
+      "priority": "Observation",
+      "url": "https://fermatmind.com/en/tests/category/career",
+      "markers": [
+        "treatment"
+      ],
+      "page_family": "test_detail",
+      "claim_context": "allowed_non_diagnostic_disclaimer",
+      "snippet": "not formal diagnosis, treatment, or legal guidance"
+    },
+    {
+      "priority": "Observation",
+      "url": "https://fermatmind.com/en/tests/category/personality",
+      "markers": [
+        "treatment"
+      ],
+      "page_family": "test_detail",
+      "claim_context": "allowed_non_diagnostic_disclaimer",
+      "snippet": "not formal diagnosis, treatment, or legal guidance"
+    },
+    {
+      "priority": "Observation",
+      "url": "https://fermatmind.com/zh/tests/category/career",
+      "markers": [
+        "诊断"
+      ],
+      "page_family": "test_detail",
+      "claim_context": "allowed_non_diagnostic_disclaimer",
+      "snippet": "不替代医疗、法律或诊断意见；不能替代专业诊疗、法律意见或高风险决策中的正式评估。"
+    },
+    {
+      "priority": "Observation",
+      "url": "https://fermatmind.com/zh/tests/category/personality",
+      "markers": [
+        "诊断"
+      ],
+      "page_family": "test_detail",
+      "claim_context": "allowed_non_diagnostic_disclaimer",
+      "snippet": "不替代医疗、法律或诊断意见；不能替代专业诊疗、法律意见或高风险决策中的正式评估。"
+    }
+  ],
+  "geo_answer_surface_findings": [
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "issue": "FAQPage JSON-LD not clearly backed by visible FAQ sample"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "research page lacks Article/Dataset/WebPage JSON-LD type in parsed scripts"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "research page lacks Article/Dataset/WebPage JSON-LD type in parsed scripts"
+    }
+  ],
+  "sitemap_llms_observation": {
+    "sitemap_sample": [
+      "https://fermatmind.com/en/about",
+      "https://fermatmind.com/zh/about",
+      "https://fermatmind.com/zh/brand",
+      "https://fermatmind.com/en/business",
+      "https://fermatmind.com/zh/business",
+      "https://fermatmind.com/en/career/guides",
+      "https://fermatmind.com/zh/career/guides",
+      "https://fermatmind.com/en/career",
+      "https://fermatmind.com/zh/career",
+      "https://fermatmind.com/en/career/recommendations",
+      "https://fermatmind.com/zh/career/recommendations",
+      "https://fermatmind.com/en/career/tests",
+      "https://fermatmind.com/zh/career/tests",
+      "https://fermatmind.com/zh/careers",
+      "https://fermatmind.com/zh/charter",
+      "https://fermatmind.com/zh/foundation",
+      "https://fermatmind.com/en/help/about",
+      "https://fermatmind.com/en/help/contact",
+      "https://fermatmind.com/en/help/faq",
+      "https://fermatmind.com/en/help/for-business-and-research",
+      "https://fermatmind.com/en/help/team",
+      "https://fermatmind.com/en/help/used-and-mentioned",
+      "https://fermatmind.com/zh/help/contact",
+      "https://fermatmind.com/zh/help/faq",
+      "https://fermatmind.com/zh/help/for-business-and-research",
+      "https://fermatmind.com/en/method-boundaries",
+      "https://fermatmind.com/zh/method-boundaries",
+      "https://fermatmind.com/en/personality",
+      "https://fermatmind.com/zh/personality",
+      "https://fermatmind.com/zh/policies"
+    ],
+    "llms_sample": [],
+    "llms_full_sample": [],
+    "sitemap_only_count": 114,
+    "llms_not_sitemap_count": 0
+  },
+  "frontend_fallback_risks": [
+    {
+      "url": "https://fermatmind.com/en",
+      "page_family": "home",
+      "title": "FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "page_family": "test_detail",
+      "title": "MBTI Personality Test (16 Personality Types) | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "page_family": "test_detail",
+      "title": "MBTI 性格测试（16型人格测试） | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "page_family": "topic",
+      "title": "MBTI topic hub | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "page_family": "topic",
+      "title": "MBTI 主题中心 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/about",
+      "page_family": "help/content/policy",
+      "title": "Page Not Found | FermatMind",
+      "robots": "noindex"
+    },
+    {
+      "url": "https://fermatmind.com/zh/about",
+      "page_family": "help/content/policy",
+      "title": "Page Not Found | FermatMind",
+      "robots": "noindex"
+    },
+    {
+      "url": "https://fermatmind.com/en/career/guides",
+      "page_family": "career_guide",
+      "title": "Career Guides | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/career/guides",
+      "page_family": "career_guide",
+      "title": "职业发展 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/career",
+      "page_family": "unknown",
+      "title": "Career Library and Explorer | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/career",
+      "page_family": "unknown",
+      "title": "职业库与职业探索 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/career/recommendations",
+      "page_family": "career_recommendation",
+      "title": "Career Recommendations | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/career/recommendations",
+      "page_family": "career_recommendation",
+      "title": "职业推荐 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/career/tests",
+      "page_family": "unknown",
+      "title": "Career Tests | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/career/tests",
+      "page_family": "unknown",
+      "title": "职业测试 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/careers",
+      "page_family": "help/content/policy",
+      "title": "加入费马测试 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/help/about",
+      "page_family": "help/content/policy",
+      "title": "Page Not Found | FermatMind",
+      "robots": "noindex"
+    },
+    {
+      "url": "https://fermatmind.com/en/help/for-business-and-research",
+      "page_family": "help/content/policy",
+      "title": "Page Not Found | FermatMind",
+      "robots": "noindex"
+    },
+    {
+      "url": "https://fermatmind.com/zh/help/for-business-and-research",
+      "page_family": "help/content/policy",
+      "title": "Page Not Found | FermatMind",
+      "robots": "noindex"
+    },
+    {
+      "url": "https://fermatmind.com/en/method-boundaries",
+      "page_family": "help/content/policy",
+      "title": "Page Not Found | FermatMind",
+      "robots": "noindex"
+    },
+    {
+      "url": "https://fermatmind.com/zh/method-boundaries",
+      "page_family": "help/content/policy",
+      "title": "测评方法与使用边界 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/personality",
+      "page_family": "personality",
+      "title": "Personality Types | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/personality",
+      "page_family": "personality",
+      "title": "人格类型 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/category/career",
+      "page_family": "test_detail",
+      "title": "Career & Direction Tests | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/category/personality",
+      "page_family": "test_detail",
+      "title": "Personality & Style Tests | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/category/career",
+      "page_family": "test_detail",
+      "title": "职业与方向测评 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/category/personality",
+      "page_family": "test_detail",
+      "title": "人格与风格测评 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/tests",
+      "page_family": "test_hub",
+      "title": "Tests Hub | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests",
+      "page_family": "test_hub",
+      "title": "测评入口中心 | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/en/topics",
+      "page_family": "topic",
+      "title": "Topic Clusters | FermatMind",
+      "robots": "index, follow"
+    },
+    {
+      "url": "https://fermatmind.com/zh/topics",
+      "page_family": "topic",
+      "title": "主题内容聚合 | FermatMind",
+      "robots": "index, follow"
+    }
+  ],
+  "url_truth_alignment_summary": {
+    "local_dry_run_available": true,
+    "production_api_sitemap_source_available": false,
+    "note": "Public api.fermatmind.com sitemap-source fetch failed from local curl with SSL_ERROR_SYSCALL; scan uses local dry-run metadata and production public runtime observations."
+  },
+  "p0_findings": [
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "broken public core URL returns 404",
+      "status": 404,
+      "evidence": "manual curl -L public runtime check",
+      "curl_time_seconds": 15.396635
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "broken public core URL returns 404",
+      "status": 404,
+      "evidence": "manual curl -L public runtime check",
+      "curl_time_seconds": 15.21763
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/en",
+      "issue": "severe H1 visual truncation/overflow risk",
+      "viewport": "desktop",
+      "detail": {
+        "tag": "h1",
+        "text": "Understand yourself before the next step.",
+        "scrollWidth": 1719,
+        "clientWidth": 960,
+        "overflowX": true,
+        "outsideViewport": false,
+        "textOverflow": "clip",
+        "overflow": "visible",
+        "whiteSpace": "nowrap",
+        "lineClamp": "none",
+        "rect": {
+          "left": 240,
+          "right": 1200,
+          "top": 359.5,
+          "bottom": 443.5,
+          "width": 960,
+          "height": 84
+        }
+      }
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/en",
+      "issue": "severe H1 visual truncation/overflow risk",
+      "viewport": "laptop",
+      "detail": {
+        "tag": "h1",
+        "text": "Understand yourself before the next step.",
+        "scrollWidth": 1719,
+        "clientWidth": 960,
+        "overflowX": true,
+        "outsideViewport": false,
+        "textOverflow": "clip",
+        "overflow": "visible",
+        "whiteSpace": "nowrap",
+        "lineClamp": "none",
+        "rect": {
+          "left": 160,
+          "right": 1120,
+          "top": 359.5,
+          "bottom": 443.5,
+          "width": 960,
+          "height": 84
+        }
+      }
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "issue": "severe H1 visual truncation/overflow risk",
+      "viewport": "desktop",
+      "detail": {
+        "tag": "h1",
+        "text": "MBTI 性格测试【16型人格】",
+        "scrollWidth": 475,
+        "clientWidth": 450,
+        "overflowX": true,
+        "outsideViewport": false,
+        "textOverflow": "clip",
+        "overflow": "visible",
+        "whiteSpace": "nowrap",
+        "lineClamp": "none",
+        "rect": {
+          "left": 201,
+          "right": 651,
+          "top": 138,
+          "bottom": 183.109375,
+          "width": 450,
+          "height": 45.109375
+        }
+      }
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "issue": "severe H1 visual truncation/overflow risk",
+      "viewport": "laptop",
+      "detail": {
+        "tag": "h1",
+        "text": "MBTI 性格测试【16型人格】",
+        "scrollWidth": 475,
+        "clientWidth": 450,
+        "overflowX": true,
+        "outsideViewport": false,
+        "textOverflow": "clip",
+        "overflow": "visible",
+        "whiteSpace": "nowrap",
+        "lineClamp": "none",
+        "rect": {
+          "left": 121,
+          "right": 571,
+          "top": 138,
+          "bottom": 183.109375,
+          "width": 450,
+          "height": 45.109375
+        }
+      }
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/en",
+      "issue": "core bilingual pair or reciprocal hreflang gap",
+      "pair": "https://fermatmind.com/",
+      "pair_exists": true,
+      "hreflang_points_to_pair": false,
+      "reciprocal_hreflang": true
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/zh",
+      "issue": "core bilingual pair or reciprocal hreflang gap",
+      "pair": "https://fermatmind.com/en",
+      "pair_exists": true,
+      "hreflang_points_to_pair": true,
+      "reciprocal_hreflang": false
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "core bilingual pair or reciprocal hreflang gap",
+      "pair": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "pair_exists": true,
+      "hreflang_points_to_pair": false,
+      "reciprocal_hreflang": false
+    },
+    {
+      "priority": "P0",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "core bilingual pair or reciprocal hreflang gap",
+      "pair": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "pair_exists": true,
+      "hreflang_points_to_pair": false,
+      "reciprocal_hreflang": false
+    }
+  ],
+  "p1_findings": [
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "desktop",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 18,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "laptop",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 18,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 19,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 16,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "desktop",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 18,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "laptop",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 18,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 19,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "desktop",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "laptop",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 4,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "desktop",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "laptop",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "desktop",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "laptop",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "cta_overflow_count": 0,
+        "heading_issue_count": 0,
+        "error": "page.goto: Timeout 15000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "desktop",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 20,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "laptop",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 20,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 22,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "desktop",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 25,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "laptop",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 25,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "issue": "visual/responsive overflow risk",
+      "viewport": "mobile",
+      "summary": {
+        "horizontal_scroll": false,
+        "nav_overflow": false,
+        "footer_overflow": false,
+        "cta_overflow_count": 0,
+        "heading_issue_count": 27,
+        "error": null
+      }
+    },
+    {
+      "priority": "P1",
+      "issue": "MBTI internal link readiness edge missing",
+      "edge": "test -> research"
+    },
+    {
+      "priority": "P1",
+      "issue": "MBTI internal link readiness edge missing",
+      "edge": "topic -> research"
+    },
+    {
+      "priority": "P1",
+      "issue": "MBTI internal link readiness edge missing",
+      "edge": "research -> test"
+    },
+    {
+      "priority": "P1",
+      "issue": "MBTI internal link readiness edge missing",
+      "edge": "research -> topic"
+    },
+    {
+      "priority": "P1",
+      "issue": "MBTI internal link readiness edge missing",
+      "edge": "article -> test"
+    },
+    {
+      "priority": "P1",
+      "issue": "MBTI internal link readiness edge missing",
+      "edge": "article -> topic"
+    },
+    {
+      "priority": "P1",
+      "issue": "MBTI internal link readiness edge missing",
+      "edge": "article -> research"
+    },
+    {
+      "priority": "P1",
+      "issue": "MBTI internal link readiness edge missing",
+      "edge": "personality -> topic"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "issue": "FAQPage JSON-LD not clearly backed by visible FAQ sample"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "research page lacks Article/Dataset/WebPage JSON-LD type in parsed scripts"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "research page lacks Article/Dataset/WebPage JSON-LD type in parsed scripts"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "issue": "bilingual title/H1 pair incomplete",
+      "pair": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "issue": "bilingual title/H1 pair incomplete",
+      "pair": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/about",
+      "issue": "bilingual title/H1 pair incomplete",
+      "pair": "https://fermatmind.com/zh/about"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/about",
+      "issue": "bilingual title/H1 pair incomplete",
+      "pair": "https://fermatmind.com/en/about"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/help/for-business-and-research",
+      "issue": "bilingual title/H1 pair incomplete",
+      "pair": "https://fermatmind.com/zh/help/for-business-and-research"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/help/for-business-and-research",
+      "issue": "bilingual title/H1 pair incomplete",
+      "pair": "https://fermatmind.com/en/help/for-business-and-research"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/en/method-boundaries",
+      "issue": "bilingual title/H1 pair incomplete",
+      "pair": "https://fermatmind.com/zh/method-boundaries"
+    },
+    {
+      "priority": "P1",
+      "url": "https://fermatmind.com/zh/method-boundaries",
+      "issue": "bilingual title/H1 pair incomplete",
+      "pair": "https://fermatmind.com/en/method-boundaries"
+    }
+  ],
+  "p2_findings": [
+    {
+      "priority": "P2",
+      "url": "https://fermatmind.com/en/about",
+      "issue": "non-core help/content/policy parity observed only; detailed copy parity deferred"
+    },
+    {
+      "priority": "P2",
+      "url": "https://fermatmind.com/zh/about",
+      "issue": "non-core help/content/policy parity observed only; detailed copy parity deferred"
+    },
+    {
+      "priority": "P2",
+      "url": "https://fermatmind.com/zh/careers",
+      "issue": "non-core help/content/policy parity observed only; detailed copy parity deferred"
+    },
+    {
+      "priority": "P2",
+      "url": "https://fermatmind.com/en/help/about",
+      "issue": "non-core help/content/policy parity observed only; detailed copy parity deferred"
+    },
+    {
+      "priority": "P2",
+      "url": "https://fermatmind.com/en/help/for-business-and-research",
+      "issue": "non-core help/content/policy parity observed only; detailed copy parity deferred"
+    },
+    {
+      "priority": "P2",
+      "url": "https://fermatmind.com/zh/help/for-business-and-research",
+      "issue": "non-core help/content/policy parity observed only; detailed copy parity deferred"
+    },
+    {
+      "priority": "P2",
+      "url": "https://fermatmind.com/en/method-boundaries",
+      "issue": "non-core help/content/policy parity observed only; detailed copy parity deferred"
+    },
+    {
+      "priority": "P2",
+      "url": "https://fermatmind.com/zh/method-boundaries",
+      "issue": "non-core help/content/policy parity observed only; detailed copy parity deferred"
+    }
+  ],
+  "recommended_next_tasks": [
+    {
+      "id": "SEO-GROWTH-MBTI-ACTION-01D-P0-VISUAL-PARITY-FIX-01",
+      "when": "if homepage/test H1 or CTA overflow is confirmed",
+      "scope": "fap-web visual parity fix only"
+    },
+    {
+      "id": "SEO-GROWTH-MBTI-ACTION-01D-P0-HREFLANG-CANONICAL-FIX-01",
+      "when": "if core reciprocal hreflang/canonical gaps are accepted as P0",
+      "scope": "fap-web metadata/hreflang only"
+    },
+    {
+      "id": "SEO-GROWTH-MBTI-ACTION-01D-P1-INTERNAL-LINK-WAVE-01",
+      "when": "after P0 visual/canonical issues are closed",
+      "scope": "backend/CMS-authoritative internal link wave; no frontend fallback authority"
+    }
+  ],
+  "no_mutation_performed": true,
+  "search_channel_action_performed": false,
+  "cms_mutation_performed": false,
+  "deploy_performed": false,
+  "next_task": "SEO-GROWTH-MBTI-ACTION-01D-P0-VISUAL-PARITY-FIX-01",
+  "runtime_observations": [
+    {
+      "url": "https://fermatmind.com/",
+      "locale": "zh-CN",
+      "page_family": "home",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "FermatMind / 费马测试",
+      "description": "费马测试提供清晰、可继续使用的测评结果，帮助你看清人格、能力与职业方向。",
+      "h1_text": "看清自己，走好每一步",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com",
+      "json_ld_types": [
+        "WebPage",
+        "ItemList",
+        "Organization"
+      ],
+      "sitemap_inclusion": false,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": false,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 40
+    },
+    {
+      "url": "https://fermatmind.com/en",
+      "locale": "en",
+      "page_family": "home",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "FermatMind",
+      "description": "FermatMind provides clear, reusable assessment results for personality, ability, and career direction.",
+      "h1_text": "Understand yourself before the next step.",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en",
+      "json_ld_types": [
+        "WebPage",
+        "ItemList",
+        "Organization"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 29
+    },
+    {
+      "url": "https://fermatmind.com/zh",
+      "locale": "zh-CN",
+      "page_family": "home",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "FermatMind / 费马测试",
+      "description": "费马测试提供清晰、可继续使用的测评结果，帮助你看清人格、能力与职业方向。",
+      "h1_text": "看清自己，走好每一步",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com",
+      "json_ld_types": [
+        "WebPage",
+        "ItemList",
+        "Organization"
+      ],
+      "sitemap_inclusion": false,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": false,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 40
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "locale": "en",
+      "page_family": "test_detail",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "MBTI Personality Test (16 Personality Types) | FermatMind",
+      "description": "Discover your MBTI profile across 16 personality types with a structured assessment.",
+      "h1_text": "MBTI Personality Test 【16 Personality Types】",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList",
+        "SoftwareApplication",
+        "FAQPage"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 33
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "locale": "zh-CN",
+      "page_family": "test_detail",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "MBTI 性格测试（16型人格测试） | FermatMind",
+      "description": "通过结构化测评了解你的 MBTI 类型、偏好强度与沟通协作方式。",
+      "h1_text": "MBTI 性格测试【16型人格】",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList",
+        "SoftwareApplication",
+        "FAQPage"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [
+        "诊断"
+      ],
+      "anchor_count": 41
+    },
+    {
+      "url": "https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report",
+      "locale": "en",
+      "page_family": "research_report",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": null,
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": null,
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": false,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": false,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 0,
+      "manual_runtime_check": true,
+      "curl_time_seconds": 15.21763
+    },
+    {
+      "url": "https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report",
+      "locale": "zh-CN",
+      "page_family": "research_report",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": null,
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": null,
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": false,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": false,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 0,
+      "manual_runtime_check": true,
+      "curl_time_seconds": 15.396635
+    },
+    {
+      "url": "https://fermatmind.com/en/topics/mbti",
+      "locale": "en",
+      "page_family": "topic",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/topics/mbti",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "MBTI topic hub | FermatMind",
+      "description": "Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub.",
+      "h1_text": "MBTI Topic Cluster",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/topics/mbti"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/topics/mbti"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/topics/mbti",
+      "json_ld_types": [
+        "CollectionPage",
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 97
+    },
+    {
+      "url": "https://fermatmind.com/zh/topics/mbti",
+      "locale": "zh-CN",
+      "page_family": "topic",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/topics/mbti",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "MBTI 主题中心 | FermatMind",
+      "description": "把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。",
+      "h1_text": "MBTI 主题内容聚合",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/topics/mbti"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/topics/mbti"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/topics/mbti",
+      "json_ld_types": [
+        "CollectionPage",
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 115
+    },
+    {
+      "url": "https://fermatmind.com/en/about",
+      "locale": "en",
+      "page_family": "help/content/policy",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": "noindex",
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": "FermatMind assessments and personality tests.",
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 0
+    },
+    {
+      "url": "https://fermatmind.com/zh/about",
+      "locale": "zh-CN",
+      "page_family": "help/content/policy",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": "noindex",
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": "FermatMind assessments and personality tests.",
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 0
+    },
+    {
+      "url": "https://fermatmind.com/en/career/guides",
+      "locale": "en",
+      "page_family": "career_guide",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/career/guides",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Career Guides | FermatMind",
+      "description": "20 structured guides for career planning, transition, and professional growth.",
+      "h1_text": "Turn career choice into a testable decision",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/career/guides"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/career/guides"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/career/guides",
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 21
+    },
+    {
+      "url": "https://fermatmind.com/zh/career/guides",
+      "locale": "zh-CN",
+      "page_family": "career_guide",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/career/guides",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "职业发展 | FermatMind",
+      "description": "围绕职业规划、转型与成长的 20 篇结构化实战指南。",
+      "h1_text": "把职业选择变成可验证的判断",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/career/guides"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/career/guides"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/career/guides",
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 54
+    },
+    {
+      "url": "https://fermatmind.com/en/career",
+      "locale": "en",
+      "page_family": "unknown",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/career",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Career Library and Explorer | FermatMind",
+      "description": "Enter career profiles through the full occupation library, industry directories, and personality-based recommendations.",
+      "h1_text": "Start with the library, then narrow the path",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/career"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/career"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/career",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 23
+    },
+    {
+      "url": "https://fermatmind.com/zh/career",
+      "locale": "zh-CN",
+      "page_family": "unknown",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/career",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "职业库与职业探索 | FermatMind",
+      "description": "从全部职业库、行业目录和测评结果进入职业详情与职业推荐。",
+      "h1_text": "从职业库开始，逐层缩小选择",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/career"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/career"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/career",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 31
+    },
+    {
+      "url": "https://fermatmind.com/en/career/recommendations",
+      "locale": "en",
+      "page_family": "career_recommendation",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/career/recommendations",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Career Recommendations | FermatMind",
+      "description": "Start from an assessment result, choose a direction, then drill into candidate roles.",
+      "h1_text": "A decision platform for young adults",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/career/recommendations"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/career/recommendations"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/career/recommendations",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 40
+    },
+    {
+      "url": "https://fermatmind.com/zh/career/recommendations",
+      "locale": "zh-CN",
+      "page_family": "career_recommendation",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/career/recommendations",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "职业推荐 | FermatMind",
+      "description": "从测评结果进入职业方向建议，再下钻到候选职业。",
+      "h1_text": "青年人的认知成长与决策平台",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/career/recommendations"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/career/recommendations"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/career/recommendations",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 48
+    },
+    {
+      "url": "https://fermatmind.com/en/career/tests",
+      "locale": "en",
+      "page_family": "unknown",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/career/tests",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Career Tests | FermatMind",
+      "description": "Start with a career interest test and get a direction to explore.",
+      "h1_text": "Start with a career interest test",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/career/tests"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/career/tests"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/career/tests",
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 19
+    },
+    {
+      "url": "https://fermatmind.com/zh/career/tests",
+      "locale": "zh-CN",
+      "page_family": "unknown",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/career/tests",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "职业测试 | FermatMind",
+      "description": "先做职业兴趣测试，得到一个职业方向起点。",
+      "h1_text": "先做职业兴趣测试",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/career/tests"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/career/tests"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/career/tests",
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 27
+    },
+    {
+      "url": "https://fermatmind.com/zh/careers",
+      "locale": "zh-CN",
+      "page_family": "help/content/policy",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/careers",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "加入费马测试 | FermatMind",
+      "description": "我们寻找愿意把心理测量、产品设计、内容质量和工程系统结合起来的人，一起构建下一代个人成长工具。",
+      "h1_text": "加入费马测试",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/careers"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/careers"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com/zh/careers"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/careers",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 29
+    },
+    {
+      "url": "https://fermatmind.com/en/help/about",
+      "locale": "en",
+      "page_family": "help/content/policy",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": "noindex",
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": "FermatMind assessments and personality tests.",
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 0
+    },
+    {
+      "url": "https://fermatmind.com/en/help/for-business-and-research",
+      "locale": "en",
+      "page_family": "help/content/policy",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": "noindex",
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": "FermatMind assessments and personality tests.",
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 0
+    },
+    {
+      "url": "https://fermatmind.com/zh/help/for-business-and-research",
+      "locale": "zh-CN",
+      "page_family": "help/content/policy",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": "noindex",
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": "FermatMind assessments and personality tests.",
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 0
+    },
+    {
+      "url": "https://fermatmind.com/en/method-boundaries",
+      "locale": "en",
+      "page_family": "help/content/policy",
+      "http_status": 404,
+      "canonical": null,
+      "canonical_host": null,
+      "robots_meta": "noindex",
+      "x_robots_tag": null,
+      "title": "Page Not Found | FermatMind",
+      "description": "FermatMind assessments and personality tests.",
+      "h1_text": null,
+      "html_lang": null,
+      "hreflang_alternates": [],
+      "og_url": null,
+      "json_ld_types": [],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 0
+    },
+    {
+      "url": "https://fermatmind.com/zh/method-boundaries",
+      "locale": "zh-CN",
+      "page_family": "help/content/policy",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/method-boundaries",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "测评方法与使用边界 | FermatMind",
+      "description": "说明费马测试的测评结果可以如何使用、不能替代什么，以及数据、隐私和解释上的边界。",
+      "h1_text": "测评方法与使用边界",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/method-boundaries"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/method-boundaries"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com/zh/method-boundaries"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/method-boundaries",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [
+        "诊断",
+        "治疗"
+      ],
+      "anchor_count": 28
+    },
+    {
+      "url": "https://fermatmind.com/en/personality",
+      "locale": "en",
+      "page_family": "personality",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/personality",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Personality Types | FermatMind",
+      "description": "Start the MBTI test or browse the 16 personality type profiles directly.",
+      "h1_text": "16 Personality Types",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/personality"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/personality"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/personality",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList",
+        "ItemList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 35
+    },
+    {
+      "url": "https://fermatmind.com/zh/personality",
+      "locale": "zh-CN",
+      "page_family": "personality",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/personality",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "人格类型 | FermatMind",
+      "description": "先做 MBTI 测试，或直接浏览 16 型人格内容。",
+      "h1_text": "16 型人格画像",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/personality"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/personality"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/personality",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList",
+        "ItemList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 43
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/category/career",
+      "locale": "en",
+      "page_family": "test_detail",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/tests/category/career",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Career & Direction Tests | FermatMind",
+      "description": "A category hub for career interest, work style, and decision-relevant signals with a clearer way to choose where to start.",
+      "h1_text": "Career & Direction Tests",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests/category/career"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests/category/career"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/tests/category/career",
+      "json_ld_types": [
+        "BreadcrumbList",
+        "CollectionPage",
+        "ItemList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [
+        "treatment"
+      ],
+      "anchor_count": 42
+    },
+    {
+      "url": "https://fermatmind.com/en/tests/category/personality",
+      "locale": "en",
+      "page_family": "test_detail",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/tests/category/personality",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Personality & Style Tests | FermatMind",
+      "description": "A category hub for personality style, stable traits, and collaboration preferences with a clearer path into the right test.",
+      "h1_text": "Personality & Style Tests",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests/category/personality"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests/category/personality"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/tests/category/personality",
+      "json_ld_types": [
+        "BreadcrumbList",
+        "CollectionPage",
+        "ItemList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [
+        "treatment"
+      ],
+      "anchor_count": 40
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/category/career",
+      "locale": "zh-CN",
+      "page_family": "test_detail",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/tests/category/career",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "职业与方向测评 | FermatMind",
+      "description": "围绕职业兴趣、工作风格与职业决策线索的测评聚合页，帮助你更快判断从哪一个入口开始。",
+      "h1_text": "职业与方向测评",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests/category/career"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests/category/career"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/tests/category/career",
+      "json_ld_types": [
+        "BreadcrumbList",
+        "CollectionPage",
+        "ItemList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [
+        "诊断"
+      ],
+      "anchor_count": 50
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests/category/personality",
+      "locale": "zh-CN",
+      "page_family": "test_detail",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/tests/category/personality",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "人格与风格测评 | FermatMind",
+      "description": "围绕人格风格、稳定特质与协作偏好的测评聚合页，帮助你更快判断先做哪一个。",
+      "h1_text": "人格与风格测评",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests/category/personality"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests/category/personality"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/tests/category/personality",
+      "json_ld_types": [
+        "BreadcrumbList",
+        "CollectionPage",
+        "ItemList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [
+        "诊断"
+      ],
+      "anchor_count": 48
+    },
+    {
+      "url": "https://fermatmind.com/en/tests",
+      "locale": "en",
+      "page_family": "test_hub",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/tests",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Tests Hub | FermatMind",
+      "description": "Start from a clearer question or category and choose the right FermatMind assessment more quickly.",
+      "h1_text": "Start from a clearer question and find the assessment that fits.",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/tests",
+      "json_ld_types": [
+        "BreadcrumbList",
+        "CollectionPage",
+        "ItemList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 24
+    },
+    {
+      "url": "https://fermatmind.com/zh/tests",
+      "locale": "zh-CN",
+      "page_family": "test_hub",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/tests",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "测评入口中心 | FermatMind",
+      "description": "按问题或分类进入 FermatMind 测评入口，更快判断从哪一个测试开始。",
+      "h1_text": "帮助青年人看清自己、理解真实世界",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/tests"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/tests"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/tests",
+      "json_ld_types": [
+        "BreadcrumbList",
+        "CollectionPage",
+        "ItemList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 32
+    },
+    {
+      "url": "https://fermatmind.com/en/topics",
+      "locale": "en",
+      "page_family": "topic",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/en/topics",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "Topic Clusters | FermatMind",
+      "description": "Structured topic hubs that connect articles, tests, and personality-led guidance.",
+      "h1_text": "Topic clusters",
+      "html_lang": "en",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/topics"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/topics"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/en/topics",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 29
+    },
+    {
+      "url": "https://fermatmind.com/zh/topics",
+      "locale": "zh-CN",
+      "page_family": "topic",
+      "http_status": 200,
+      "canonical": "https://fermatmind.com/zh/topics",
+      "canonical_host": "fermatmind.com",
+      "robots_meta": "index, follow",
+      "x_robots_tag": null,
+      "title": "主题内容聚合 | FermatMind",
+      "description": "把文章、职业发展和人格相关内容串成结构化主题簇。",
+      "h1_text": "主题内容聚合",
+      "html_lang": "zh",
+      "hreflang_alternates": [
+        {
+          "hreflang": "en",
+          "href": "https://fermatmind.com/en/topics"
+        },
+        {
+          "hreflang": "zh-CN",
+          "href": "https://fermatmind.com/zh/topics"
+        },
+        {
+          "hreflang": "x-default",
+          "href": "https://fermatmind.com"
+        }
+      ],
+      "og_url": "https://fermatmind.com/zh/topics",
+      "json_ld_types": [
+        "WebPage",
+        "BreadcrumbList"
+      ],
+      "sitemap_inclusion": true,
+      "llms_inclusion": false,
+      "url_truth_presence": null,
+      "source_authority": null,
+      "frontend_fallback_risk": true,
+      "staging_host_contamination": false,
+      "www_host_contamination": false,
+      "stale_slug_contamination": false,
+      "noindex_private_leakage": false,
+      "claim_markers": [],
+      "anchor_count": 37
+    }
+  ]
+}

--- a/backend/docs/seo/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.md
+++ b/backend/docs/seo/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.md
@@ -1,0 +1,266 @@
+# SEO-GROWTH-MBTI-ACTION-01D-SCAN-00 Report
+
+## 1. Executive Summary
+
+Final decision: `mbti_01d_scan_completed_ready_for_p0_visual_parity_fix`.
+
+This read-only scan found P0 issues on production public MBTI surfaces: the EN homepage H1 has confirmed desktop/laptop overflow, the ZH MBTI test H1 has confirmed desktop/laptop overflow, both EN/ZH Research core URLs return 404 in manual public curl checks, and core homepage/research hreflang reciprocity is incomplete. The scan did not mutate CMS, Search Channel, URL Truth, fap-web, production env, DNS, deploy state, or runtime code.
+
+Counts: scanned URLs `35`, public indexable observations `27`, private/noindex observations `0`, P0 `10`, P1 `42`, P2 `8`.
+
+## 2. Scan Method
+
+- fap-api was the report/aggregator repository.
+- fap-web was inspected reference-only; no fap-web files were modified or staged.
+- Production runtime was observed with bounded public HTTP fetches and Playwright headless Chromium DOM checks.
+- Backend URL Truth was observed through the safe local dry-run collector metadata: `php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --json`.
+- Sitemap, `llms.txt`, and `llms-full.txt` were used as observation surfaces only, not authority.
+- Claim markers were classified with context; explicit non-diagnostic disclaimers were not treated as unsafe claims.
+
+## 3. URL Inventory Scope
+
+Inventory sources:
+
+- Production sitemap: status `200`, URL count `114`.
+- Production llms.txt: status `0`, URL count `0`.
+- Production llms-full.txt: status `0`, URL count `0`.
+- Backend URL Truth dry-run: status `success`, items seen `7`.
+- fap-web route family references: `12`.
+
+Runtime URL cap used in the successful scan: 35 URLs. This is below the allowed maximum and still includes all requested MBTI core URLs.
+
+## 4. Page Family Coverage
+
+```json
+{
+  "home": 3,
+  "test_detail": 6,
+  "research_report": 2,
+  "topic": 4,
+  "help/content/policy": 8,
+  "career_guide": 2,
+  "unknown": 4,
+  "career_recommendation": 2,
+  "personality": 2,
+  "test_hub": 2
+}
+```
+
+## 5. MBTI Core Page Findings
+
+- https://fermatmind.com/: status=200, canonical=https://fermatmind.com, h1=看清自己，走好每一步, hreflang=3, json_ld=WebPage,ItemList,Organization.
+- https://fermatmind.com/en: status=200, canonical=https://fermatmind.com/en, h1=Understand yourself before the next step., hreflang=3, json_ld=WebPage,ItemList,Organization.
+- https://fermatmind.com/zh: status=200, canonical=https://fermatmind.com, h1=看清自己，走好每一步, hreflang=3, json_ld=WebPage,ItemList,Organization.
+- https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types: status=200, canonical=https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types, h1=MBTI Personality Test 【16 Personality Types】, hreflang=3, json_ld=WebPage,BreadcrumbList,SoftwareApplication,FAQPage.
+- https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types: status=200, canonical=https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types, h1=MBTI 性格测试【16型人格】, hreflang=3, json_ld=WebPage,BreadcrumbList,SoftwareApplication,FAQPage.
+- https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report: status=404, canonical=None, h1=None, hreflang=0, json_ld=.
+- https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report: status=404, canonical=None, h1=None, hreflang=0, json_ld=.
+- https://fermatmind.com/en/topics/mbti: status=200, canonical=https://fermatmind.com/en/topics/mbti, h1=MBTI Topic Cluster, hreflang=3, json_ld=CollectionPage,WebPage,BreadcrumbList.
+- https://fermatmind.com/zh/topics/mbti: status=200, canonical=https://fermatmind.com/zh/topics/mbti, h1=MBTI 主题内容聚合, hreflang=3, json_ld=CollectionPage,WebPage,BreadcrumbList.
+
+Manual public curl checks confirmed both Research apex URLs return 404:
+
+- `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report` -> 404, title `Page Not Found | FermatMind`.
+- `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report` -> 404, title `Page Not Found | FermatMind`.
+
+## 6. Bilingual Pair Findings
+
+Core pair gaps:
+
+- core bilingual pair or reciprocal hreflang gap — https://fermatmind.com/en -> https://fermatmind.com/; pair_exists=True, points_to_pair=False, reciprocal=True.
+- core bilingual pair or reciprocal hreflang gap — https://fermatmind.com/zh -> https://fermatmind.com/en; pair_exists=True, points_to_pair=True, reciprocal=False.
+- core bilingual pair or reciprocal hreflang gap — https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report -> https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report; pair_exists=True, points_to_pair=False, reciprocal=False.
+- core bilingual pair or reciprocal hreflang gap — https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report -> https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report; pair_exists=True, points_to_pair=False, reciprocal=False.
+
+Homepage note: `/zh` renders the ZH homepage but canonicalizes to `/`; EN `/en` did not point to the canonical root ZH pair in the captured hreflang set, while `/zh` did point to `/en`. This creates a reciprocal/canonical ambiguity for the root ZH homepage cluster.
+
+## 7. Canonical / Hreflang / Robots Findings
+
+- P0: broken core public URL — https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report status=404 canonical=
+- P0: broken core public URL — https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report status=404 canonical=
+
+No staging or `www` canonical contamination was found in the successful public runtime sample. Private/noindex flows were excluded from the public inventory and no private indexable leak was observed in the bounded sample.
+
+## 8. Visual / Responsive Findings
+
+Visual scan mode: `playwright_headless_chromium`.
+
+P0 visual findings:
+
+- severe H1 visual truncation/overflow risk — https://fermatmind.com/en (desktop); H1 `Understand yourself before the next step.`, scrollWidth=1719, clientWidth=960, whiteSpace=nowrap.
+- severe H1 visual truncation/overflow risk — https://fermatmind.com/en (laptop); H1 `Understand yourself before the next step.`, scrollWidth=1719, clientWidth=960, whiteSpace=nowrap.
+- severe H1 visual truncation/overflow risk — https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types (desktop); H1 `MBTI 性格测试【16型人格】`, scrollWidth=475, clientWidth=450, whiteSpace=nowrap.
+- severe H1 visual truncation/overflow risk — https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types (laptop); H1 `MBTI 性格测试【16型人格】`, scrollWidth=475, clientWidth=450, whiteSpace=nowrap.
+
+Representative P1 visual findings:
+
+- https://fermatmind.com/ (desktop): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=18.
+- https://fermatmind.com/ (laptop): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=18.
+- https://fermatmind.com/ (mobile): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=19.
+- https://fermatmind.com/en (desktop): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=16.
+- https://fermatmind.com/en (laptop): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=16.
+- https://fermatmind.com/en (mobile): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=16.
+- https://fermatmind.com/zh (desktop): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=18.
+- https://fermatmind.com/zh (laptop): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=18.
+- https://fermatmind.com/zh (mobile): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=19.
+- https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types (desktop): horizontal=None, nav=None, footer=None, cta_count=0, heading_count=0.
+- https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types (laptop): horizontal=None, nav=None, footer=None, cta_count=0, heading_count=0.
+- https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types (mobile): horizontal=None, nav=None, footer=None, cta_count=0, heading_count=0.
+- https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types (desktop): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=4.
+- https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types (laptop): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=4.
+- https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types (mobile): horizontal=False, nav=False, footer=False, cta_count=0, heading_count=4.
+- https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report (desktop): horizontal=None, nav=None, footer=None, cta_count=0, heading_count=0.
+- https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report (laptop): horizontal=None, nav=None, footer=None, cta_count=0, heading_count=0.
+- https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report (mobile): horizontal=None, nav=None, footer=None, cta_count=0, heading_count=0.
+- https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report (desktop): horizontal=None, nav=None, footer=None, cta_count=0, heading_count=0.
+- https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report (laptop): horizontal=None, nav=None, footer=None, cta_count=0, heading_count=0.
+
+The user-observed EN homepage truncation is confirmed by DOM metrics: H1 text `Understand yourself before the next step.` has `scrollWidth=1719` and `clientWidth=960` with `whiteSpace=nowrap` on desktop and laptop.
+
+## 9. Internal Link Readiness
+
+- test -> topic: runtime_observed_only (5 examples captured).
+- test -> research: missing (0 examples captured).
+- test -> article: runtime_observed_only (5 examples captured).
+- topic -> test: runtime_observed_only (5 examples captured).
+- topic -> research: missing (0 examples captured).
+- topic -> article: runtime_observed_only (5 examples captured).
+- research -> test: missing (0 examples captured).
+- research -> topic: missing (0 examples captured).
+- article -> test: missing (0 examples captured).
+- article -> topic: missing (0 examples captured).
+- article -> research: missing (0 examples captured).
+- personality -> test: runtime_observed_only (5 examples captured).
+- personality -> topic: missing (0 examples captured).
+- personality -> article: runtime_observed_only (4 examples captured).
+
+The captured runtime links show test/topic/article and personality/test/article edges, but research edges are missing because the Research core pages return 404 and no valid research runtime link targets were observed in the bounded sample.
+
+## 10. Claim Boundary Findings
+
+- Observation: https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types markers=诊断; context=allowed_non_diagnostic_disclaimer; snippet=这是诊断吗？不是。本测评用于教育性自我理解，不替代专业建议。
+- P1: https://fermatmind.com/zh/method-boundaries markers=诊断,治疗; context=page_404_observation_not_indexable_copy; snippet=runtime returned 404 during manual verification
+- Observation: https://fermatmind.com/en/tests/category/career markers=treatment; context=allowed_non_diagnostic_disclaimer; snippet=not formal diagnosis, treatment, or legal guidance
+- Observation: https://fermatmind.com/en/tests/category/personality markers=treatment; context=allowed_non_diagnostic_disclaimer; snippet=not formal diagnosis, treatment, or legal guidance
+- Observation: https://fermatmind.com/zh/tests/category/career markers=诊断; context=allowed_non_diagnostic_disclaimer; snippet=不替代医疗、法律或诊断意见；不能替代专业诊疗、法律意见或高风险决策中的正式评估。
+- Observation: https://fermatmind.com/zh/tests/category/personality markers=诊断; context=allowed_non_diagnostic_disclaimer; snippet=不替代医疗、法律或诊断意见；不能替代专业诊疗、法律意见或高风险决策中的正式评估。
+
+No unsafe overclaim was confirmed. The raw markers found in the sample were in explicit non-diagnostic disclaimer contexts such as `不是。本测评用于教育性自我理解，不替代专业建议` and `not formal diagnosis, treatment, or legal guidance`.
+
+## 11. GEO / FAQ / JSON-LD Findings
+
+- P1: FAQPage JSON-LD not clearly backed by visible FAQ sample — https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types
+- P1: research page lacks Article/Dataset/WebPage JSON-LD type in parsed scripts — https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report
+- P1: research page lacks Article/Dataset/WebPage JSON-LD type in parsed scripts — https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report
+
+Core MBTI test pages expose `WebPage`, `BreadcrumbList`, `SoftwareApplication`, and `FAQPage`. Topic pages expose `CollectionPage`, `WebPage`, and `BreadcrumbList`. Research pages could not be validated for schema because both requested Research URLs return 404.
+
+## 12. Priority Backlog
+
+P0 backlog:
+
+- broken public core URL returns 404 — https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report; status=404; evidence=manual curl -L public runtime check.
+- broken public core URL returns 404 — https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report; status=404; evidence=manual curl -L public runtime check.
+- severe H1 visual truncation/overflow risk — https://fermatmind.com/en (desktop); H1 `Understand yourself before the next step.`, scrollWidth=1719, clientWidth=960, whiteSpace=nowrap.
+- severe H1 visual truncation/overflow risk — https://fermatmind.com/en (laptop); H1 `Understand yourself before the next step.`, scrollWidth=1719, clientWidth=960, whiteSpace=nowrap.
+- severe H1 visual truncation/overflow risk — https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types (desktop); H1 `MBTI 性格测试【16型人格】`, scrollWidth=475, clientWidth=450, whiteSpace=nowrap.
+- severe H1 visual truncation/overflow risk — https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types (laptop); H1 `MBTI 性格测试【16型人格】`, scrollWidth=475, clientWidth=450, whiteSpace=nowrap.
+- core bilingual pair or reciprocal hreflang gap — https://fermatmind.com/en -> https://fermatmind.com/; pair_exists=True, points_to_pair=False, reciprocal=True.
+- core bilingual pair or reciprocal hreflang gap — https://fermatmind.com/zh -> https://fermatmind.com/en; pair_exists=True, points_to_pair=True, reciprocal=False.
+- core bilingual pair or reciprocal hreflang gap — https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report -> https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report; pair_exists=True, points_to_pair=False, reciprocal=False.
+- core bilingual pair or reciprocal hreflang gap — https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report -> https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report; pair_exists=True, points_to_pair=False, reciprocal=False.
+
+P1 backlog, first 20:
+
+- visual/responsive overflow risk — https://fermatmind.com/ (desktop).
+- visual/responsive overflow risk — https://fermatmind.com/ (laptop).
+- visual/responsive overflow risk — https://fermatmind.com/ (mobile).
+- visual/responsive overflow risk — https://fermatmind.com/en (mobile).
+- visual/responsive overflow risk — https://fermatmind.com/zh (desktop).
+- visual/responsive overflow risk — https://fermatmind.com/zh (laptop).
+- visual/responsive overflow risk — https://fermatmind.com/zh (mobile).
+- visual/responsive overflow risk — https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types (desktop).
+- visual/responsive overflow risk — https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types (laptop).
+- visual/responsive overflow risk — https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types (mobile).
+- visual/responsive overflow risk — https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types (mobile).
+- visual/responsive overflow risk — https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report (desktop).
+- visual/responsive overflow risk — https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report (laptop).
+- visual/responsive overflow risk — https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report (mobile).
+- visual/responsive overflow risk — https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report (desktop).
+- visual/responsive overflow risk — https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report (laptop).
+- visual/responsive overflow risk — https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report (mobile).
+- visual/responsive overflow risk — https://fermatmind.com/en/topics/mbti (desktop).
+- visual/responsive overflow risk — https://fermatmind.com/en/topics/mbti (laptop).
+- visual/responsive overflow risk — https://fermatmind.com/en/topics/mbti (mobile).
+
+P2 backlog:
+
+- non-core help/content/policy parity observed only; detailed copy parity deferred — https://fermatmind.com/en/about
+- non-core help/content/policy parity observed only; detailed copy parity deferred — https://fermatmind.com/zh/about
+- non-core help/content/policy parity observed only; detailed copy parity deferred — https://fermatmind.com/zh/careers
+- non-core help/content/policy parity observed only; detailed copy parity deferred — https://fermatmind.com/en/help/about
+- non-core help/content/policy parity observed only; detailed copy parity deferred — https://fermatmind.com/en/help/for-business-and-research
+- non-core help/content/policy parity observed only; detailed copy parity deferred — https://fermatmind.com/zh/help/for-business-and-research
+- non-core help/content/policy parity observed only; detailed copy parity deferred — https://fermatmind.com/en/method-boundaries
+- non-core help/content/policy parity observed only; detailed copy parity deferred — https://fermatmind.com/zh/method-boundaries
+
+## 13. Recommended Next Tasks
+
+- SEO-GROWTH-MBTI-ACTION-01D-P0-VISUAL-PARITY-FIX-01: fap-web visual parity fix only (if homepage/test H1 or CTA overflow is confirmed)
+- SEO-GROWTH-MBTI-ACTION-01D-P0-HREFLANG-CANONICAL-FIX-01: fap-web metadata/hreflang only (if core reciprocal hreflang/canonical gaps are accepted as P0)
+- SEO-GROWTH-MBTI-ACTION-01D-P1-INTERNAL-LINK-WAVE-01: backend/CMS-authoritative internal link wave; no frontend fallback authority (after P0 visual/canonical issues are closed)
+
+Expected next task: `SEO-GROWTH-MBTI-ACTION-01D-P0-VISUAL-PARITY-FIX-01`.
+
+## 14. Validation
+
+Required validation commands for this PR:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParity --no-ansi
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+
+cd /Users/rainie/Desktop/GitHub/fap-api
+python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 - <<'PY'
+import yaml, pathlib
+yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+PY
+git diff --check
+git diff --cached --check
+```
+
+Reference validation requested for fap-web is listed as a PR validation target. At scan time, fap-web was on `codex/search-channel-live-zh-mbti-01a-indexnow-keylocation-fix` with untracked `.playwright-mcp/`; this repo is reference-only and was not modified.
+
+## 15. PR / Merge Result
+
+Pending. This file is the report artifact for branch `codex/seo-growth-mbti-action-01d-scan-00`.
+
+## 16. Sidecar Issues
+
+- `api.fermatmind.com/api/v0.5/seo/sitemap-source` public curl from this local environment failed with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`; backend URL Truth was therefore represented by local safe dry-run metadata plus production public runtime observations.
+- fap-web reference worktree was not on main and had untracked `.playwright-mcp/`; no fap-web changes were staged or committed.
+- Production DB, production env/secrets, Redis, S3, CDN, Search Console, Baidu, IndexNow, Bing, 360, Sogou, Shenma, and raw Nginx logs were not inspected by design.
+
+## 17. What Was Not Done
+
+- No implementation.
+- No CMS mutation.
+- No Search Channel enqueue or live submission.
+- No URL Truth mutation.
+- No internal link creation.
+- No article publish or content rewrite.
+- No deploy, SSH, DNS/nginx/env edits, production migration, or production secret reads.
+- No fap-web code changes.
+- No committed screenshots.
+
+## 18. Final Decision
+
+`mbti_01d_scan_completed_ready_for_p0_visual_parity_fix`
+
+## 19. Next Task
+
+`SEO-GROWTH-MBTI-ACTION-01D-P0-VISUAL-PARITY-FIX-01`

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParityTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParityTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParityTest extends TestCase
+{
+    #[Test]
+    public function generated_scan_artifact_exists_and_parses(): void
+    {
+        $path = base_path('docs/seo/generated/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('SEO-GROWTH-MBTI-ACTION-01D-SCAN-00', $payload['task'] ?? null);
+        $this->assertTrue((bool) ($payload['no_mutation_performed'] ?? false));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertArrayHasKey('scanned_url_count', $payload);
+        $this->assertArrayHasKey('page_family_counts', $payload);
+        $this->assertArrayHasKey('mbti_core_pages', $payload);
+        $this->assertIsArray($payload['p0_findings'] ?? null);
+        $this->assertIsArray($payload['p1_findings'] ?? null);
+        $this->assertIsArray($payload['p2_findings'] ?? null);
+        $this->assertArrayHasKey('recommended_next_tasks', $payload);
+        $this->assertArrayHasKey('final_decision', $payload);
+        $this->assertArrayHasKey('next_task', $payload);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -18361,10 +18361,10 @@
     "SEO-GROWTH-MBTI-ACTION-01D-SCAN-00": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01d-scan-00",
-      "status": "local_validation_passed",
+      "status": "pr_open_github_checks_pending",
       "depends_on": [],
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1661",
       "checks": {
         "scope_boundary": {
           "status": "pass",
@@ -18388,7 +18388,8 @@
           "evidence": "Passed: php artisan test --filter=SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParity --no-ansi; php artisan route:list --no-ansi; vendor/bin/pint --test; generated JSON parse; PR-train JSON/YAML parse; git diff --check. fap-web reference-only validation passed: pnpm lint, pnpm test:contract, NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build."
         },
         "github_required_checks": {
-          "status": "pending"
+          "status": "pending",
+          "evidence": "PR #1661 is open; required GitHub checks are pending."
         }
       },
       "failure_reason": null,
@@ -18423,6 +18424,11 @@
           "at": "2026-05-25T10:59:53+08:00",
           "status": "local_validation_passed",
           "summary": "Backend focused report test, route list, Pint, generated JSON, train metadata parsing, diff check, and fap-web reference lint/contract/build validation passed. Scope remains docs/generated/test/state only in fap-api."
+        },
+        {
+          "at": "2026-05-25T11:03:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1661 for the read-only MBTI bilingual parity scan; waiting for GitHub required checks."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-24T18:44:00.000Z",
+  "updated_at": "2026-05-25T02:53:27.628310Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18355,6 +18355,74 @@
           "at": "2026-05-25T10:00:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1660 for the ZH MBTI live submission preflight report. GitHub checks are pending."
+        }
+      ]
+    },
+    "SEO-GROWTH-MBTI-ACTION-01D-SCAN-00": {
+      "repo": "fap-api",
+      "branch": "codex/seo-growth-mbti-action-01d-scan-00",
+      "status": "local_validation_passed",
+      "depends_on": [],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Changed files are limited to the generated SEO scan report/artifact/test plus docs/codex PR-train metadata."
+        },
+        "public_runtime_scan": {
+          "status": "pass",
+          "evidence": "Bounded public runtime scan completed for 35 URLs with Playwright headless Chromium visual checks; no CMS/Search Channel/deploy mutations performed."
+        },
+        "backend_url_truth_dry_run": {
+          "status": "pass",
+          "command": "cd backend && php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --json",
+          "evidence": "Dry-run returned success with writes_attempted=false and external_calls_attempted=false."
+        },
+        "fap_web_reference_state": {
+          "status": "sidecar_observed",
+          "evidence": "fap-web was reference-only on codex/search-channel-live-zh-mbti-01a-indexnow-keylocation-fix with untracked .playwright-mcp/; no fap-web changes were staged or committed. Build-generated public/sitemap.xml was restored after reference validation."
+        },
+        "validation": {
+          "status": "pass",
+          "evidence": "Passed: php artisan test --filter=SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParity --no-ansi; php artisan route:list --no-ansi; vendor/bin/pint --test; generated JSON parse; PR-train JSON/YAML parse; git diff --check. fap-web reference-only validation passed: pnpm lint, pnpm test:contract, NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build."
+        },
+        "github_required_checks": {
+          "status": "pending"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "Public api.fermatmind.com sitemap-source check failed from local curl",
+          "repo": "fap-api",
+          "affected_command_or_check": "curl https://api.fermatmind.com/api/v0.5/seo/sitemap-source",
+          "evidence": "LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to api.fermatmind.com:443",
+          "why_external_to_current_pr": "This scan does not modify API TLS, gateway, DNS, or backend runtime; production public page checks still completed through fermatmind.com.",
+          "follow_up_recommendation": "Verify API gateway TLS reachability separately if backend sitemap-source must be included in future live scans."
+        },
+        {
+          "title": "fap-web reference worktree is not clean main",
+          "repo": "fap-web",
+          "affected_command_or_check": "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short",
+          "evidence": "branch codex/search-channel-live-zh-mbti-01a-indexnow-keylocation-fix with untracked .playwright-mcp/",
+          "why_external_to_current_pr": "fap-web is reference-only for this fap-api report PR and no files are staged or committed there.",
+          "follow_up_recommendation": "Run fap-web reference validation from clean main before implementation PRs that touch frontend runtime."
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-05-25T02:53:27.627612+00:00",
+          "status": "scan_report_generated",
+          "summary": "Generated read-only MBTI bilingual parity scan artifact and report from bounded public runtime checks, local URL Truth dry-run metadata, and fap-web source inspection."
+        },
+        {
+          "at": "2026-05-25T10:59:53+08:00",
+          "status": "local_validation_passed",
+          "summary": "Backend focused report test, route list, Pint, generated JSON, train metadata parsing, diff check, and fap-web reference lint/contract/build validation passed. Scope remains docs/generated/test/state only in fap-api."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -6519,6 +6519,53 @@ prs:
     human_review_required: false
     production_approval_required: false
 
+  - id: SEO-GROWTH-MBTI-ACTION-01D-SCAN-00
+    repo: fap-api
+    depends_on: []
+    branch: codex/seo-growth-mbti-action-01d-scan-00
+    base: main
+    title: "docs(seo-intel): add full-stack MBTI bilingual parity scan"
+    train_scope: seo_growth_mbti_action_01d_scan
+    risk_level: scan_only_public_runtime_observation
+    allowed_paths:
+      - backend/docs/seo/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.md
+      - backend/docs/seo/generated/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParityTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add a read-only full-stack MBTI bilingual parity, SEO authority, visual overflow, and internal-link readiness scan report.
+      - Use fap-api as the report and test owner while treating fap-web as reference-only.
+      - Record bounded public runtime observations, backend URL Truth dry-run metadata, and Playwright visual scan results.
+      - Do not mutate CMS, Search Channel, URL Truth, fap-web runtime code, production env, DNS/nginx, or deploy state.
+    do_not:
+      - Implement fixes or change runtime behavior.
+      - Modify fap-web.
+      - Mutate CMS, Search Channel, seo_urls, seo_url_entities, sitemap, llms, or internal links.
+      - Submit URLs or call IndexNow, GSC, Baidu, Bing, 360, Sogou, or Shenma.
+      - Read raw Nginx access logs, production secrets, or production env.
+      - Deploy, SSH, edit DNS/nginx/env, or run production migrations.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParity --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("docs/codex/pr-train.yaml").read_text())'
+      - git diff --check
+      - git diff --cached --check
+    reference_validation:
+      - cd /Users/rainie/Desktop/GitHub/fap-web && git status --short
+      - cd /Users/rainie/Desktop/GitHub/fap-web && pnpm lint
+      - cd /Users/rainie/Desktop/GitHub/fap-web && pnpm test:contract
+      - cd /Users/rainie/Desktop/GitHub/fap-web && NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    next_task: SEO-GROWTH-MBTI-ACTION-01D-P0-VISUAL-PARITY-FIX-01
+
   - id: PR-AUDIT-BE-02
     repo: fap-api
     depends_on: [PR-AUDIT-BE-01]


### PR DESCRIPTION
## PR id
SEO-GROWTH-MBTI-ACTION-01D-SCAN-00

## What changed
- Added a read-only MBTI bilingual parity, SEO authority, visual overflow, and internal-link readiness scan report.
- Added the generated JSON artifact for the scan.
- Added a focused SeoIntel test that asserts the generated artifact exists, parses, and records no mutation/Search Channel/CMS/deploy actions.
- Added the scoped PR-train manifest/state entry for this scan task.

## Why
The MBTI growth loop needs a production-observation report before any visual, hreflang/canonical, or internal-link implementation PR. fap-api owns the report artifact; fap-web was used only as reference/runtime observation.

## Scope confirmation
- No fap-web runtime code changed or committed.
- No CMS mutation, Search Channel action, URL submission, deploy, SSH, DNS/nginx/env edit, production migration, or production secret access.
- Sitemap/llms/frontend fallback were treated as observation surfaces only, not authority.

## Validation
Passed:
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=SeoIntelGrowthMbtiAction01dScan00PublicPageBilingualParity --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list --no-ansi
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && vendor/bin/pint --test
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool backend/docs/seo/generated/seo-growth-mbti-action-01d-scan-00-public-page-bilingual-parity.v1.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- cd /Users/rainie/Desktop/GitHub/fap-api && python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("docs/codex/pr-train.yaml").read_text())'
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --check
- cd /Users/rainie/Desktop/GitHub/fap-api && git diff --cached --check

Reference-only fap-web validation passed:
- cd /Users/rainie/Desktop/GitHub/fap-web && pnpm lint
- cd /Users/rainie/Desktop/GitHub/fap-web && pnpm test:contract
- cd /Users/rainie/Desktop/GitHub/fap-web && NEXT_PUBLIC_API_URL=https://api.fermatmind.com pnpm build

## Sidecar issues
- Public api.fermatmind.com sitemap-source curl failed locally with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`; this scan did not modify API TLS/gateway/DNS/runtime.
- fap-web reference worktree was not clean main (`?? .playwright-mcp/`) and was on `codex/search-channel-live-zh-mbti-01a-indexnow-keylocation-fix`; no fap-web file was staged or committed. Build-generated `public/sitemap.xml` was restored after validation.

## Intentionally deferred
- No visual fix, canonical/hreflang fix, internal-link creation, CMS mutation, content rewrite, or Search Channel action in this scan PR.
- Next recommended task: SEO-GROWTH-MBTI-ACTION-01D-P0-VISUAL-PARITY-FIX-01.