### PR TITLE
docs(seo-intel): add ZH MBTI IndexNow live preflight

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "search-channel-live-zh-mbti-01-preflight.v1",
   "task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-01",
-  "final_decision": "blocked_indexnow_key_missing",
+  "final_decision": "ready_for_human_approved_zh_mbti_live_submission",
   "queue_item_id": 3,
   "target_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
   "channel": "indexnow",
@@ -61,11 +61,13 @@
     "configured_key_length": 32,
     "key_location_configured": true,
     "key_location": "https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt",
-    "public_key_location_status": 404,
-    "public_key_location_body_sha256": "e186ca91fd68bf566fce5b033aa5f404f5fcddf6f9fc09a5bd1ef6d6c53a00af",
-    "public_key_location_matches_configured_key": false,
-    "ready": false,
-    "blocker": "configured IndexNow keyLocation returned HTTP 404, so the public key file cannot be verified"
+    "public_key_location_status": 200,
+    "public_key_location_body_sha256": "e9a3eca3e7c107d6e0ac63c1fdba24068d970aecb4bdf18ed69735e8b77cf143",
+    "public_key_location_matches_configured_key": true,
+    "ready": true,
+    "blocker": null,
+    "content_type": "text/plain; charset=UTF-8",
+    "body_length": 32
   },
   "submit_dry_run": {
     "command": "php artisan seo-intel:search-channel-submit --queue-item-id=3 --dry-run --json",
@@ -83,7 +85,9 @@
     "execution_state": "dry_run_ready",
     "bulk_submission": false,
     "raw_secret_output": false,
-    "issues": []
+    "issues": [],
+    "approval_phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.",
+    "runtime_approval_phrase_matches_future_task_label": false
   },
   "public_runtime_state": {
     "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
@@ -105,7 +109,7 @@
     "baidu_stale_result_sidecar": true,
     "baidu_mutation_performed": false
   },
-  "future_approval_phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-ZH-MBTI-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.",
+  "future_approval_phrase": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.",
   "future_gate_plan": {
     "open_only": [
       "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=true",
@@ -116,7 +120,7 @@
       "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false"
     ],
     "after_live_submission": "close all live/external/indexnow gates again",
-    "not_actionable_until": "IndexNow keyLocation returns HTTP 200 and matches the configured key hash"
+    "not_actionable_until": "Human-approved SEARCH-CHANNEL-LIVE-ZH-MBTI-02 task with runtime approval phrase and live/external/IndexNow gates opened only for the bounded queue item 3 submission."
   },
   "live_submission_performed": false,
   "external_api_call_performed": false,
@@ -124,5 +128,6 @@
   "cms_mutation_performed": false,
   "fap_web_mutation_performed": false,
   "research_deferred": true,
-  "next_task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX"
+  "next_task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-02｜Human-approved live submission for queue item 3",
+  "future_task_label": "SEARCH-CHANNEL-LIVE-ZH-MBTI-02｜Human-approved live submission for queue item 3"
 }

--- a/backend/docs/seo/search-channel-live-zh-mbti-01-preflight.md
+++ b/backend/docs/seo/search-channel-live-zh-mbti-01-preflight.md
@@ -2,9 +2,9 @@
 
 ## Executive Summary
 
-This preflight reviewed production state for queue item 3 before any ZH MBTI IndexNow live submission.
+This rerun preflight reviewed production state for queue item 3 before any ZH MBTI IndexNow live submission, after the frontend IndexNow keyLocation fix was deployed.
 
-The queue item, duplicate protection, closed gate state, submit dry-run, public runtime, and protected EN queue item 2 are stable. The preflight is blocked because the configured IndexNow `keyLocation` currently returns HTTP 404 on the public apex host, so the key file cannot be verified without exposing the raw key.
+The queue item, duplicate protection, closed gate state, submit dry-run, IndexNow keyLocation readiness, public runtime, and protected EN queue item 2 are stable. The configured IndexNow `keyLocation` now returns HTTP 200 on the public apex host, with a 32-byte text body whose SHA-256 hash matches the configured key hash. The raw key was not printed.
 
 No live submission was performed. No external search API was called. No queue item was enqueued. No CMS, sitemap, llms, or fap-web mutation was performed.
 
@@ -55,7 +55,7 @@ The IndexNow key is configured, and the configured `keyLocation` is:
 
 `https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt`
 
-Public read-only verification returned HTTP 404. The raw key was not printed. Because the public key file cannot be verified at the configured location, live submission is blocked until the keyLocation returns HTTP 200 and the public body hash matches the configured key.
+Public read-only verification returned HTTP 200. The response is `text/plain`, 32 bytes, and its SHA-256 hash matches the configured key hash. The raw key was not printed. IndexNow keyLocation readiness is now satisfied.
 
 ## Submit Dry-run
 
@@ -95,14 +95,16 @@ Known Baidu stale staging result remains a sidecar and was not mutated.
 
 ## Future Approval Phrase
 
-Not actionable until IndexNow keyLocation readiness is fixed:
+Runtime dry-run returned the exact approval phrase required by the current live submission command:
 
-`I explicitly approve SEARCH-CHANNEL-LIVE-ZH-MBTI-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.`
+`I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.`
+
+The next task remains the scoped ZH MBTI live submission task. The runtime approval phrase uses the generic `SEARCH-CHANNEL-LIVE-02` label from the deployed command and must be used exactly unless the command is changed before execution.
 
 ## Final Decision
 
-`blocked_indexnow_key_missing`
+`ready_for_human_approved_zh_mbti_live_submission`
 
 ## Next Task
 
-`SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX`
+`SEARCH-CHANNEL-LIVE-ZH-MBTI-02｜Human-approved live submission for queue item 3`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti01PreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti01PreflightTest.php
@@ -90,7 +90,7 @@ final class SeoIntelSearchChannelLiveZhMbti01PreflightTest extends TestCase
     }
 
     #[Test]
-    public function indexnow_key_readiness_blocker_is_recorded_without_exposing_key(): void
+    public function indexnow_key_readiness_is_verified_without_exposing_key(): void
     {
         $readiness = $this->artifact()['indexnow_key_readiness'] ?? [];
 
@@ -100,9 +100,10 @@ final class SeoIntelSearchChannelLiveZhMbti01PreflightTest extends TestCase
             'https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt',
             $readiness['key_location'] ?? null
         );
-        $this->assertSame(404, $readiness['public_key_location_status'] ?? null);
-        $this->assertFalse($readiness['public_key_location_matches_configured_key'] ?? true);
-        $this->assertFalse($readiness['ready'] ?? true);
+        $this->assertSame(200, $readiness['public_key_location_status'] ?? null);
+        $this->assertSame(32, $readiness['body_length'] ?? null);
+        $this->assertTrue($readiness['public_key_location_matches_configured_key'] ?? false);
+        $this->assertTrue($readiness['ready'] ?? false);
         $this->assertFalse($readiness['raw_key_exposed'] ?? true);
     }
 
@@ -112,15 +113,18 @@ final class SeoIntelSearchChannelLiveZhMbti01PreflightTest extends TestCase
         $artifact = $this->artifact();
 
         $this->assertSame(
-            'I explicitly approve SEARCH-CHANNEL-LIVE-ZH-MBTI-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.',
+            'I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.',
             $artifact['future_approval_phrase'] ?? null
         );
         $this->assertFalse($artifact['live_submission_performed'] ?? true);
         $this->assertFalse($artifact['external_api_call_performed'] ?? true);
         $this->assertFalse($artifact['enqueue_performed'] ?? true);
         $this->assertTrue($artifact['research_deferred'] ?? false);
-        $this->assertSame('blocked_indexnow_key_missing', $artifact['final_decision'] ?? null);
-        $this->assertSame('SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX', $artifact['next_task'] ?? null);
+        $this->assertSame('ready_for_human_approved_zh_mbti_live_submission', $artifact['final_decision'] ?? null);
+        $this->assertSame(
+            'SEARCH-CHANNEL-LIVE-ZH-MBTI-02｜Human-approved live submission for queue item 3',
+            $artifact['next_task'] ?? null
+        );
     }
 
     /** @return array<string, mixed> */

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T02:53:27.628310Z",
+  "updated_at": "2026-05-25T11:54:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18288,7 +18288,7 @@
     "SEARCH-CHANNEL-LIVE-ZH-MBTI-01": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-zh-mbti-01-preflight",
-      "status": "pr_open_github_checks_pending",
+      "status": "in_progress_rerun_after_keylocation_fix",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW"
       ],
@@ -18304,16 +18304,16 @@
           "duplicate_event_check": "passed: exactly one target queue item exists; no live_submission_approved, live_submission_response, accepted submission, retry storm, or bulk submit event exists. Duplicate dry-run blocks with existing_active_queue_item.",
           "queue_item_2": "passed: EN MBTI queue item 2 remains approved/submitted and unchanged; no duplicate EN queue item detected.",
           "gate_state": "passed: queue write, live submission, external API call, and IndexNow live API gates remain closed.",
-          "indexnow_key_readiness": "blocked: key is configured and raw key was not exposed, but configured keyLocation https://fermatmind.com/8d59565935303aad72c5eb0ec5bfa42e.txt returned HTTP 404 and could not be verified.",
-          "submit_dry_run": "passed: php artisan seo-intel:search-channel-submit --queue-item-id=3 --dry-run --json returned status=success, external_calls_attempted=false, search_submission_attempted=false, writes_attempted=false, writes_committed=false, submission_status=not_attempted, issues=[].",
+          "indexnow_key_readiness": "passed: key is configured, raw key was not exposed, and configured keyLocation returned HTTP 200 with a 32-byte text/plain body whose SHA-256 hash matches the configured key hash.",
+          "submit_dry_run": "passed: php artisan seo-intel:search-channel-submit --queue-item-id=3 --dry-run --json returned status=success, external_calls_attempted=false, search_submission_attempted=false, writes_attempted=false, writes_committed=false, submission_status=not_attempted, issues=[]. Runtime approval phrase uses SEARCH-CHANNEL-LIVE-02 label.",
           "public_runtime": "passed: ZH MBTI public URL returned HTTP 200, exact apex canonical, robots index/follow, no noindex, and no staging canonical.",
           "staging_sidecar": "passed: staging noindex containment remains active; known Baidu stale result remains a sidecar.",
           "ops_seo_visibility": "sidecar: optional authenticated /ops/seo UI visibility was not checked."
         },
         "local": {
-          "focused_live_zh_mbti_preflight_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveZhMbti01Preflight --no-ansi (7 tests, 61 assertions)",
+          "focused_live_zh_mbti_preflight_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveZhMbti01Preflight --no-ansi (7 tests, 62 assertions)",
           "route_list": "passed: php artisan route:list --no-ansi",
-          "pint": "passed: vendor/bin/pint --test (3533 files)",
+          "pint": "passed: vendor/bin/pint --test (3534 files)",
           "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json",
           "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
@@ -18321,7 +18321,7 @@
           "git_diff_cached_check": "passed: git diff --cached --check"
         }
       },
-      "failure_reason": "blocked_indexnow_key_missing: configured IndexNow keyLocation returned HTTP 404, so live submission is not ready.",
+      "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -18329,7 +18329,7 @@
       "production_migration_execution_allowed": false,
       "external_api_credentials_required": true,
       "scheduler_activation": false,
-      "next_pr": "SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX",
+      "next_pr": "SEARCH-CHANNEL-LIVE-ZH-MBTI-02",
       "history": [
         {
           "at": "2026-05-25T09:51:00+08:00",
@@ -18355,6 +18355,16 @@
           "at": "2026-05-25T10:00:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1660 for the ZH MBTI live submission preflight report. GitHub checks are pending."
+        },
+        {
+          "at": "2026-05-25T11:50:00+08:00",
+          "status": "rerun_in_progress_after_keylocation_fix",
+          "summary": "After fap-web keyLocation fix deployment, reran production read-only live preflight evidence for queue item 3. KeyLocation now returns HTTP 200 and matches the configured key hash; submit dry-run remains safe with no writes or external calls."
+        },
+        {
+          "at": "2026-05-25T11:54:00+08:00",
+          "status": "local_checks_passed_rerun",
+          "summary": "Focused preflight test, route list, Pint, generated JSON/state parse, manifest parse, and diff checks passed for the rerun-ready report."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T11:54:00+08:00",
+  "updated_at": "2026-05-25T11:55:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18288,11 +18288,11 @@
     "SEARCH-CHANNEL-LIVE-ZH-MBTI-01": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-zh-mbti-01-preflight",
-      "status": "in_progress_rerun_after_keylocation_fix",
+      "status": "local_checks_passed_rerun_ready_for_pr",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW"
       ],
-      "commit_sha": "ede7c8a4fe72a89926a08d3dc04f0163999db36a",
+      "commit_sha": "467b4caf1e7e4885b95c1215bc3c38292c628c6a",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1660",
       "checks": {
         "dependency": {
@@ -18365,6 +18365,11 @@
           "at": "2026-05-25T11:54:00+08:00",
           "status": "local_checks_passed_rerun",
           "summary": "Focused preflight test, route list, Pint, generated JSON/state parse, manifest parse, and diff checks passed for the rerun-ready report."
+        },
+        {
+          "at": "2026-05-25T11:55:00+08:00",
+          "status": "commit_created_rerun",
+          "summary": "Created scoped rerun commit 467b4caf1e7e4885b95c1215bc3c38292c628c6a with keyLocation-ready live preflight report updates."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T11:55:00+08:00",
+  "updated_at": "2026-05-25T11:56:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18288,12 +18288,12 @@
     "SEARCH-CHANNEL-LIVE-ZH-MBTI-01": {
       "repo": "fap-api",
       "branch": "codex/search-channel-live-zh-mbti-01-preflight",
-      "status": "local_checks_passed_rerun_ready_for_pr",
+      "status": "pr_open_github_checks_pending_rerun",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-ZH-MBTI-POST-ENQUEUE-REVIEW"
       ],
       "commit_sha": "467b4caf1e7e4885b95c1215bc3c38292c628c6a",
-      "pr_url": "https://github.com/fermatmind/fap-api/pull/1660",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1662",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -18370,6 +18370,11 @@
           "at": "2026-05-25T11:55:00+08:00",
           "status": "commit_created_rerun",
           "summary": "Created scoped rerun commit 467b4caf1e7e4885b95c1215bc3c38292c628c6a with keyLocation-ready live preflight report updates."
+        },
+        {
+          "at": "2026-05-25T11:56:00+08:00",
+          "status": "pr_open_github_checks_pending_rerun",
+          "summary": "Opened rerun PR #1662 for the ZH MBTI live preflight report after keyLocation readiness passed."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11592,7 +11592,7 @@ prs:
     production_deploy_allowed: false
     production_migration_execution_allowed: false
     scheduler_activation: false
-    next_task: SEARCH-CHANNEL-LIVE-ZH-MBTI-01A-INDEXNOW-KEYLOCATION-FIX
+    next_task: SEARCH-CHANNEL-LIVE-ZH-MBTI-02
 
   - id: OPS-ADMIN-UI-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Reran `SEARCH-CHANNEL-LIVE-ZH-MBTI-01` after the fap-web IndexNow keyLocation fix was deployed.
- Updated the generated preflight report from `blocked_indexnow_key_missing` to `ready_for_human_approved_zh_mbti_live_submission`.
- Recorded that keyLocation now returns HTTP 200 with a 32-byte text response whose SHA-256 hash matches the configured IndexNow key hash, without printing the raw key.
- Updated the focused contract test and PR train state/manifest next task.

## Why
The prior preflight was blocked because the configured IndexNow keyLocation returned 404. The deployed frontend fix restored the public verification file, so the live submission preflight needed to be rerun before any human-approved live submission.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelLiveZhMbti01Preflight --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-01-preflight.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No live IndexNow submission.
- No Search Channel enqueue.
- No live/external/search gates opened.
- No CMS, sitemap, llms, fap-web, production env, migration, scheduler, or deployment changes.
