### PR TITLE
docs(seo-intel): record ZH MBTI IndexNow live submission

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-zh-mbti-02.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-zh-mbti-02.v1.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "v1",
+  "task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-02",
+  "final_decision": "search_channel_live_zh_mbti_02_completed_ready_for_24h_review",
+  "approval_phrase_verified": true,
+  "queue_item_id": 3,
+  "target_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "pre_submit_state": {
+    "approval_state": "pending",
+    "execution_state": "dry_run_ready",
+    "eligibility_state": "eligible",
+    "claim_boundary_state": "claim_safe",
+    "private_flow": false,
+    "duplicate_target_queue_count": 1
+  },
+  "keylocation_verified": {
+    "http_status": 200,
+    "body_length": 32,
+    "body_hash_matches_config_expected": true,
+    "raw_key_printed": false
+  },
+  "final_dry_run": {
+    "status": "success",
+    "external_calls_attempted": false,
+    "search_submission_attempted": false,
+    "writes_attempted": false,
+    "writes_committed": false,
+    "submission_status": "not_attempted",
+    "issues": []
+  },
+  "live_submission_result": {
+    "status": "success",
+    "external_calls_attempted": true,
+    "search_submission_attempted": true,
+    "writes_attempted": true,
+    "writes_committed": true,
+    "execution_state": "submitted"
+  },
+  "http_status": 200,
+  "submission_status": "accepted",
+  "queue_item_3_post_state": {
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "approved_by": "codex",
+    "events": [
+      "queue_item_planned",
+      "live_submission_approved",
+      "live_submission_response"
+    ],
+    "endpoint_host": "api.indexnow.org"
+  },
+  "queue_item_2_state": {
+    "queue_item_id": 2,
+    "target_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "unchanged": true
+  },
+  "gates_closed_after_submission": true,
+  "gate_state_after_submission": {
+    "queue_write": false,
+    "live_submission": false,
+    "external_api": false,
+    "indexnow_live_api": false
+  },
+  "duplicate_check": {
+    "zh_mbti_queue_count": 1,
+    "research_queue_count": 0,
+    "no_retry_storm_detected": true
+  },
+  "research_deferred": true,
+  "enqueue_performed": false,
+  "live_submission_performed": true,
+  "external_api_call_performed": true,
+  "cms_mutation_performed": false,
+  "fap_web_mutation_performed": false,
+  "url_truth_write_performed": false,
+  "collector_write_performed": false,
+  "scheduler_enabled": false,
+  "bulk_submission_performed": false,
+  "next_task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW"
+}

--- a/backend/docs/seo/search-channel-live-zh-mbti-02.md
+++ b/backend/docs/seo/search-channel-live-zh-mbti-02.md
@@ -1,0 +1,88 @@
+# SEARCH-CHANNEL-LIVE-ZH-MBTI-02
+
+## Scope
+- Human-approved one-shot IndexNow live submission for existing Search Channel queue item `3`.
+- Production action was limited to `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types` on channel `indexnow`.
+- No enqueue, no collector write, no CMS mutation, no URL Truth write, no bulk submission, and no non-IndexNow search API calls occurred.
+
+## Approval Verification
+- Exact approval phrase verified before any live submission:
+  - `I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item 3 channel indexnow URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types.`
+
+## Pre-submit Verification
+- Queue item `3` existed and matched:
+  - `channel=indexnow`
+  - `approval_state=pending`
+  - `execution_state=dry_run_ready`
+  - `eligibility_state=eligible`
+  - `claim_boundary_state=claim_safe`
+  - `private_flow=false`
+- Duplicate check found exactly one ZH MBTI queue row for the target URL/channel.
+- Protected queue item `2` remained the EN MBTI item with `approval_state=approved` and `execution_state=submitted`.
+- Official dry-run submit command passed with no external call and no write:
+  - `php artisan seo-intel:search-channel-submit --queue-item-id=3 --dry-run --json`
+
+## KeyLocation Verification
+- The configured apex IndexNow keyLocation returned HTTP `200`.
+- The response body length was `32` bytes.
+- The response body hash matched the configured key hash.
+- The raw IndexNow key was not printed in logs, docs, JSON, or the final report.
+
+## Gate Open / Close Result
+- Opened only process-scoped gates for the single command:
+  - `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=true`
+  - `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=true`
+  - `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=true`
+- Kept closed:
+  - `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- No production env file was edited.
+- Verified after submission:
+  - `queue_write_gate=false`
+  - `live_submission_gate=false`
+  - `external_api_gate=false`
+  - `indexnow_live_api_gate=false`
+
+## Live Submission Result
+- Official command used:
+  - `php artisan seo-intel:search-channel-submit --queue-item-id=3 --approval-phrase="<exact phrase>" --actor=codex --json`
+- Result:
+  - `status=success`
+  - `submission_status=accepted`
+  - `http_status=200`
+  - `external_calls_attempted=true`
+  - `search_submission_attempted=true`
+  - `writes_committed=true`
+  - `execution_state=submitted`
+
+## Post-submit Queue Verification
+- Queue item `3` after submission:
+  - `approval_state=approved`
+  - `execution_state=submitted`
+  - `approved_by=codex`
+- Queue item `3` event trail:
+  - `queue_item_planned`
+  - `live_submission_approved`
+  - `live_submission_response`
+- `live_submission_response` payload recorded:
+  - `endpoint_host=api.indexnow.org`
+  - `http_status=200`
+  - `submission_status=accepted`
+  - `exception_class=null`
+- Duplicate check remained bounded:
+  - ZH MBTI queue row count: `1`
+  - Research queue row count: `0`
+- Queue item `2` remained unchanged as the EN MBTI approved/submitted item.
+
+## Deferred / Forbidden URLs
+- Research URLs remained deferred:
+  - `https://fermatmind.com/en/research/mbti-personality-types-salary-turnover-report`
+  - `https://fermatmind.com/zh/research/mbti-personality-types-salary-turnover-report`
+- No Search Channel enqueue occurred.
+- No Baidu, GSC, Bing, 360, Sogou, or Shenma submission occurred.
+- No CMS, sitemap, llms, fap-web, URL Truth, or internal link mutation occurred.
+
+## Final Decision
+- `search_channel_live_zh_mbti_02_completed_ready_for_24h_review`
+
+## Next Task
+- `SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti02Test.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti02Test.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLiveZhMbti02Test extends TestCase
+{
+    public function test_generated_artifact_exists_and_locks_live_submission_result(): void
+    {
+        $path = base_path('docs/seo/generated/search-channel-live-zh-mbti-02.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertTrue($payload['approval_phrase_verified']);
+        $this->assertSame(3, $payload['queue_item_id']);
+        $this->assertSame('https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types', $payload['target_url']);
+        $this->assertSame('indexnow', $payload['channel']);
+        $this->assertTrue($payload['live_submission_performed']);
+        $this->assertTrue($payload['external_api_call_performed']);
+        $this->assertFalse($payload['enqueue_performed']);
+        $this->assertTrue($payload['research_deferred']);
+        $this->assertTrue($payload['gates_closed_after_submission']);
+        $this->assertSame('accepted', $payload['submission_status']);
+        $this->assertSame(200, $payload['http_status']);
+        $this->assertSame('submitted', $payload['queue_item_3_post_state']['execution_state'] ?? null);
+        $this->assertSame('submitted', $payload['queue_item_2_state']['execution_state'] ?? null);
+        $this->assertSame(1, $payload['duplicate_check']['zh_mbti_queue_count'] ?? null);
+        $this->assertSame(0, $payload['duplicate_check']['research_queue_count'] ?? null);
+        $this->assertFalse($payload['cms_mutation_performed']);
+        $this->assertFalse($payload['fap_web_mutation_performed']);
+        $this->assertNotEmpty($payload['final_decision'] ?? null);
+        $this->assertNotEmpty($payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -9992,7 +9992,7 @@
       "depends_on": [
         "SEO-DASH-PROD-00"
       ],
-      "status": "local_checks_passed",
+      "status": "commit_created",
       "train_scope": "production_seo_intel_db_user_migration_runbook",
       "risk_level": "low_docs_contract_no_execution",
       "title": "docs(seo-intel): add production DB migration runbook",
@@ -18375,6 +18375,76 @@
           "at": "2026-05-25T11:56:00+08:00",
           "status": "pr_open_github_checks_pending_rerun",
           "summary": "Opened rerun PR #1662 for the ZH MBTI live preflight report after keyLocation readiness passed."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-LIVE-ZH-MBTI-02": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-zh-mbti-02",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "SEARCH-CHANNEL-LIVE-ZH-MBTI-01"
+      ],
+      "commit_sha": "f40071d7",
+      "pr_url": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "Dependency SEARCH-CHANNEL-LIVE-ZH-MBTI-01 is merged via PR #1662 and produced the exact runtime approval phrase after keyLocation readiness passed."
+        },
+        "human_approval": {
+          "status": "pass",
+          "evidence": "Exact approval phrase was provided for queue item 3, channel indexnow, URL https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types."
+        },
+        "production_operation": {
+          "status": "pass",
+          "command": "cd /var/www/fap-api/current/backend && php artisan seo-intel:search-channel-submit --queue-item-id=3 --approval-phrase=<exact approved phrase> --actor=codex --json",
+          "evidence": "Official one-shot live submit returned status=success, http_status=200, submission_status=accepted, external_calls_attempted=true, search_submission_attempted=true, writes_committed=true, and execution_state=submitted."
+        },
+        "post_submit_verification": {
+          "status": "pass",
+          "evidence": "Queue item 3 is approved/submitted with live_submission_approved and live_submission_response events; endpoint_host=api.indexnow.org; queue item 2 remains approved/submitted; ZH target queue count is 1; Research queue count is 0; queue write, live submission, external API, and IndexNow live API gates are false after submission."
+        },
+        "local": {
+          "focused_live_zh_mbti_02_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveZhMbti02 --no-ansi (1 test, 20 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi",
+          "pint": "passed: vendor/bin/pint --test (3535 files)",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-02.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": true,
+      "scheduler_activation": false,
+      "next_pr": "SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW",
+      "history": [
+        {
+          "at": "2026-05-25T12:09:00+08:00",
+          "status": "production_live_submission_completed",
+          "summary": "Executed the exact human-approved one-shot IndexNow live submission for queue item 3 only. The executor returned status=success, HTTP 200, submission_status=accepted, and execution_state=submitted."
+        },
+        {
+          "at": "2026-05-25T12:12:00+08:00",
+          "status": "post_submit_verification_passed",
+          "summary": "Verified queue item 3 is approved/submitted with live submission audit events, queue item 2 remains unchanged, all live/external gates are closed, there is no duplicate ZH queue item, and no Research queue item was submitted."
+        },
+        {
+          "at": "2026-05-25T12:23:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused generated artifact test, route list, Pint, generated JSON/state parse, manifest parse, and diff checks passed for the ZH MBTI live submission report."
+        },
+        {
+          "at": "2026-05-25T12:24:00+08:00",
+          "status": "commit_created",
+          "summary": "Created scoped commit f40071d7 for the ZH MBTI live submission report."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -9992,7 +9992,7 @@
       "depends_on": [
         "SEO-DASH-PROD-00"
       ],
-      "status": "commit_created",
+      "status": "pr_open_github_checks_pending",
       "train_scope": "production_seo_intel_db_user_migration_runbook",
       "risk_level": "low_docs_contract_no_execution",
       "title": "docs(seo-intel): add production DB migration runbook",
@@ -18385,8 +18385,8 @@
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-ZH-MBTI-01"
       ],
-      "commit_sha": "f40071d7",
-      "pr_url": null,
+      "commit_sha": "c663feca",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1664",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -18444,7 +18444,12 @@
         {
           "at": "2026-05-25T12:24:00+08:00",
           "status": "commit_created",
-          "summary": "Created scoped commit f40071d7 for the ZH MBTI live submission report."
+          "summary": "Created scoped commit c663feca for the ZH MBTI live submission report."
+        },
+        {
+          "at": "2026-05-25T12:31:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1664 for the ZH MBTI live submission report. GitHub checks are pending."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11635,6 +11635,53 @@ prs:
     scheduler_activation: false
     next_task: SEARCH-CHANNEL-LIVE-ZH-MBTI-02
 
+  - id: SEARCH-CHANNEL-LIVE-ZH-MBTI-02
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-LIVE-ZH-MBTI-01
+    branch: codex/search-channel-live-zh-mbti-02
+    base: main
+    title: "docs(seo-intel): record ZH MBTI IndexNow live submission"
+    name: "Human-approved ZH MBTI IndexNow live submission"
+    train_scope: seo_intel_search_channel_live_submission
+    risk_level: L1
+    type: human-approved production operation ledger
+    scope:
+      - Perform exactly one human-approved IndexNow live submission for queue item 3.
+      - Record the bounded live submission result, post-submit queue state, gate closure, and deferred URL boundary.
+      - Keep queue write gate closed and avoid any enqueue, bulk submission, scheduler, CMS, URL Truth, fap-web, sitemap, or llms mutation.
+    allowed_paths:
+      - backend/docs/seo/search-channel-live-zh-mbti-02.md
+      - backend/docs/seo/generated/search-channel-live-zh-mbti-02.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti02Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Submit any URL except queue item 3.
+      - Enqueue Search Channel items.
+      - Call GSC, Baidu, Bing, 360, Sogou, or Shenma.
+      - Persistently edit production env, deploy, run migrations, mutate CMS, create internal links, create pSEO, or modify fap-web.
+      - Use frontend fallback, static sitemap, static llms, crawler logs, search engine responses, Digital PR mentions, or local copies as authority.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLiveZhMbti02 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-02.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    external_api_credentials_required: true
+    scheduler_activation: false
+    live_external_submission_allowed: true
+    next_task: SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- Recorded the human-approved one-shot IndexNow live submission for ZH MBTI queue item 3.
- Added generated JSON and a focused artifact test locking the post-submit state.
- Registered SEARCH-CHANNEL-LIVE-ZH-MBTI-02 in the PR train manifest/state.

## Why
- Queue item 3 was approved by the exact runtime approval phrase and submitted through the guarded Search Channel live executor only.
- The report preserves the gate closure, queue item 2 protection, no-enqueue boundary, and Research deferral evidence.

## Validation
- cd backend && php artisan test --filter=SeoIntelSearchChannelLiveZhMbti02 --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-02.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
PY
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No additional URL submission.
- No Search Channel enqueue.
- No Research URL submission.
- No deploy, migration, CMS mutation, fap-web change, sitemap/llms change, or persistent production env edit.