### PR TITLE
docs(seo-intel): add RESULT-EN-PARITY-00 assessment result inventory

### DIFF
--- a/backend/docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json
+++ b/backend/docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json
@@ -1,0 +1,681 @@
+{
+  "schema_version": "result-en-parity-00-assessment-result-content-inventory.v1",
+  "task": "RESULT-EN-PARITY-00",
+  "scanned_at": "2026-05-25T15:20:00+08:00",
+  "live_target": "https://fermatmind.com",
+  "final_decision": "result_en_parity_inventory_completed_ready_for_asset_catalog_fix",
+  "no_mutation_performed": true,
+  "cms_mutation_performed": false,
+  "search_channel_action_performed": false,
+  "deploy_performed": false,
+  "production_migration_performed": false,
+  "url_submission_performed": false,
+  "fap_web_commit_performed": false,
+  "production_user_data_accessed": false,
+  "production_runtime_observation": {
+    "status": "homepage_only_read_only",
+    "tooling": "Chrome via Computer Use / Chrome plugin",
+    "observed_url": "https://fermatmind.com",
+    "observed_title": "FermatMind / fee-ma ce-shi",
+    "observed_surfaces": [
+      "home page",
+      "public zh test links",
+      "public en locale link",
+      "results lookup link"
+    ],
+    "private_result_pages_observed": false,
+    "reason_private_result_pages_not_observed": "Result/report/My Results pages are dynamic private or noindex surfaces and were not accessed without credentials or attempt identifiers."
+  },
+  "authority_rule": {
+    "result_asset_authority": "backend scoring, CMS, and result/report asset catalogs",
+    "frontend_fallback_authority": false,
+    "frontend_presentation_labels": "record_only",
+    "frontend_interpretation_copy": "flag_authority_violation_risk_unless_backend_catalog_owned"
+  },
+  "scan_scope": {
+    "fap_api_paths": [
+      "backend/app/Services/Assessment",
+      "backend/app/Services/Report",
+      "backend/app/Services/Results",
+      "backend/app/Services/Email",
+      "backend/app/Http/Controllers/Api/V03",
+      "backend/content_packs",
+      "backend/content_assets",
+      "backend/resources/views/emails",
+      "backend/tests"
+    ],
+    "fap_web_paths_reference_only": [
+      "app",
+      "components",
+      "lib",
+      "messages",
+      "tests",
+      "public"
+    ],
+    "test_families_covered": [
+      "MBTI",
+      "BIG5_OCEAN",
+      "ENNEAGRAM",
+      "EQ_60",
+      "RIASEC",
+      "SDS_20",
+      "CLINICAL_COMBO_68",
+      "IQ_INTELLIGENCE_QUOTIENT"
+    ]
+  },
+  "api_inventory": {
+    "attempt_start": "POST /api/v0.3/attempts/start",
+    "attempt_submit": "POST /api/v0.3/attempts/submit",
+    "attempt_email_bind": "POST /api/v0.3/attempts/{id}/email-bind",
+    "attempt_show": "GET /api/v0.3/attempts/{id}",
+    "attempt_result": "GET /api/v0.3/attempts/{id}/result",
+    "attempt_report": "GET /api/v0.3/attempts/{id}/report",
+    "attempt_report_access": "GET /api/v0.3/attempts/{id}/report-access",
+    "attempt_report_pdf": "GET /api/v0.3/attempts/{id}/report.pdf",
+    "attempt_share_create": "POST /api/v0.3/attempts/{id}/share",
+    "attempt_share_show": "GET /api/v0.3/attempts/{id}/share",
+    "public_share_show": "GET /api/v0.3/shares/{id}",
+    "result_lookup": "POST /api/v0.3/results/lookup-by-email"
+  },
+  "route_inventory": {
+    "fap_web_result": "app/(localized)/[locale]/(app)/result/[id]/page.tsx",
+    "fap_web_attempt_report": "app/(localized)/[locale]/attempts/[attemptId]/report/page.tsx",
+    "fap_web_results_lookup": "app/(localized)/[locale]/results/lookup/page.tsx",
+    "fap_web_share": "app/(localized)/[locale]/share/[id]/page.tsx",
+    "fap_web_og_share": "app/og/share/[id]/route.tsx",
+    "fap_web_history_mbti": "app/(localized)/[locale]/(app)/history/mbti/page.tsx",
+    "fap_web_history_big5": "app/(localized)/[locale]/(app)/history/big5/page.tsx",
+    "fap_web_history_big5_compare": "app/(localized)/[locale]/(app)/history/big5/compare/page.tsx",
+    "fap_web_history_enneagram": "app/(localized)/[locale]/(app)/history/enneagram/page.tsx",
+    "fap_web_history_riasec": "app/(localized)/[locale]/(app)/history/riasec/page.tsx"
+  },
+  "frontend_renderer_inventory": [
+    "components/result/RichResultReport.tsx",
+    "components/result/ResultClient.tsx",
+    "components/result/mbti/MbtiResultShell.tsx",
+    "components/result/big5/Big5ResultShell.tsx",
+    "components/result/big5/Big5ResultPageV2Shell.tsx",
+    "components/result/enneagram/EnneagramResultShell.tsx",
+    "components/result/eq/EQResultV5.tsx",
+    "components/result/riasec/RiasecResultShell.tsx",
+    "components/result/iq/IqResultShell.tsx",
+    "components/result/iq/IqReportModule.tsx",
+    "components/clinical/report/ClinicalReportClient.tsx",
+    "components/clinical/report/ReportSectionRenderer.tsx",
+    "components/share/MbtiShareSummaryCard.tsx",
+    "components/share/EnneagramShareSummaryCard.tsx",
+    "components/big5/pdf/PdfDownloadButton.tsx",
+    "components/commerce/AttemptPdfDownloadButton.tsx",
+    "components/support/ResultEmailLookupForm.tsx"
+  ],
+  "backend_common_sources": {
+    "report_composer_registry": "backend/app/Services/Report/ReportComposerRegistry.php",
+    "attempt_read_controller": "backend/app/Http/Controllers/Api/V03/AttemptReadController.php",
+    "result_lookup_service": "backend/app/Services/Results/ResultEmailLookupService.php",
+    "share_service": "backend/app/Services/Share/ShareService.php",
+    "generic_pdf_service": "backend/app/Services/Report/Pdf/ReportPdfDocumentService.php",
+    "big_five_pdf_service": "backend/app/Services/Report/Pdf/BigFivePdfDocumentService.php",
+    "email_templates_en": "backend/resources/views/emails/en",
+    "email_templates_zh": "backend/resources/views/emails/zh"
+  },
+  "test_families": [
+    {
+      "test_code": "MBTI",
+      "result_routes": [
+        "GET /api/v0.3/attempts/{id}/result",
+        "/[locale]/result/[id]",
+        "/[locale]/history/mbti"
+      ],
+      "report_routes": [
+        "GET /api/v0.3/attempts/{id}/report",
+        "GET /api/v0.3/attempts/{id}/report.pdf"
+      ],
+      "backend_scoring_source": [
+        "backend/app/Services/Assessment/Drivers/MbtiDriver.php",
+        "backend/app/Services/Score/MbtiAttemptScorer.php"
+      ],
+      "backend_result_serializer": [
+        "backend/app/Services/Report/ReportComposer.php",
+        "backend/app/Services/Report/ReportPayloadAssembler.php",
+        "backend/app/Services/Mbti/MbtiPublicProjectionService.php",
+        "backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php",
+        "backend/app/Services/Mbti/MbtiPublicSummaryV1Builder.php",
+        "backend/app/Internal/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilderV2Core.php"
+      ],
+      "frontend_renderer": [
+        "components/result/mbti/MbtiResultShell.tsx",
+        "components/result/RichResultReport.tsx",
+        "components/share/MbtiShareSummaryCard.tsx"
+      ],
+      "report_section_keys": [
+        "profile",
+        "summary",
+        "strengths",
+        "risks",
+        "career",
+        "relationships",
+        "growth",
+        "locked_report_sections"
+      ],
+      "zh_asset_count": 0,
+      "en_asset_count": 0,
+      "repo_visible_frontend_zh_clone_asset_count": 48,
+      "missing_en_asset_keys": [
+        "backend_external_content_package_export_required",
+        "legacy_mbti_generated_fallback_copy.en",
+        "frontend_mbti_clone_content_base.en",
+        "frontend_mbti_clone_content_variants.en"
+      ],
+      "chinese_leakage_risk": "high",
+      "pdf_email_share_coverage": {
+        "pdf": "generic metadata PDF only; full localized prose export not verified",
+        "email": "shared bilingual email templates exist, but MBTI-specific result prose email asset catalog not repo-visible",
+        "share": "MBTI share summary renderer exists in fap-web; backend ShareService public projection is authority"
+      },
+      "my_results_card_coverage": "history route exists; backend email lookup private helper supports MBTI but public lookup currently requires verification",
+      "claim_boundary_coverage": "partial; paid report and career copy must remain evidence-backed and not career-success prediction",
+      "locale_behavior_tests": [
+        "backend tests cover MBTI scoring/report compatibility, but repo-visible exported MBTI content package parity test was not found in this scan"
+      ],
+      "result_content_architecture": "mixed: structured result codes plus external content packages, legacy backend fallbacks, and frontend clone content. Backend export is required before English parity can be certified.",
+      "notes": "The repo does not materialize the authoritative MBTI content package catalog scanned by ReportPayloadAssembler roots. Frontend clone content contains large Chinese interpretation copy and must not be treated as authority."
+    },
+    {
+      "test_code": "BIG5_OCEAN",
+      "result_routes": [
+        "GET /api/v0.3/attempts/{id}/result",
+        "/[locale]/result/[id]",
+        "/[locale]/history/big5",
+        "/[locale]/history/big5/compare"
+      ],
+      "report_routes": [
+        "GET /api/v0.3/attempts/{id}/report",
+        "GET /api/v0.3/attempts/{id}/report.pdf"
+      ],
+      "backend_scoring_source": [
+        "backend/app/Services/Assessment/Drivers/BigFiveOceanDriver.php",
+        "backend/app/Services/Assessment/Scoring/BigFiveScorerV3.php"
+      ],
+      "backend_result_serializer": [
+        "backend/app/Services/Report/BigFiveReportComposer.php",
+        "backend/app/Services/BigFive/BigFivePublicProjectionService.php",
+        "backend/app/Services/BigFive/BigFivePackLoader.php",
+        "backend/app/Services/BigFive/ResultPageV2/*"
+      ],
+      "frontend_renderer": [
+        "components/result/big5/Big5ResultShell.tsx",
+        "components/result/big5/Big5ResultPageV2Shell.tsx",
+        "components/big5/pdf/PdfDownloadButton.tsx"
+      ],
+      "report_section_keys": [
+        "copy.compiled",
+        "blocks.compiled",
+        "landing.compiled",
+        "result_page_v2.route_matrix",
+        "result_page_v2.coupling_assets",
+        "result_page_v2.scenario_action_assets",
+        "result_page_v2.facet_assets",
+        "result_page_v2.canonical_profiles"
+      ],
+      "zh_asset_count": 436,
+      "en_asset_count": 436,
+      "repo_visible_result_page_v2_asset_file_count": 419,
+      "repo_visible_result_page_v2_en_counterpart_count": 0,
+      "missing_en_asset_keys": [
+        "result_page_v2.route_matrix.en",
+        "result_page_v2.coupling_assets.en",
+        "result_page_v2.scenario_action_assets.en",
+        "result_page_v2.facet_assets.en",
+        "result_page_v2.canonical_profiles.en",
+        "result_page_v2.core_body.en",
+        "result_page_v2.selector_ready_assets.en"
+      ],
+      "chinese_leakage_risk": "high_for_result_page_v2_medium_for_v1",
+      "pdf_email_share_coverage": {
+        "pdf": "BigFivePdfDocumentService exists, but full EN v2 prose parity depends on backend content assets",
+        "email": "shared bilingual email templates exist; Big Five result-specific email prose asset not separately verified",
+        "share": "backend projection exists; frontend share-specific Big Five route not found"
+      },
+      "my_results_card_coverage": "history and compare routes exist; backend email lookup helper supports BIG5_OCEAN but public lookup currently requires verification",
+      "claim_boundary_coverage": "partial; Big Five must stay trait/workstyle explanation, not career recommender",
+      "locale_behavior_tests": [
+        "Big Five fixture and renderer tests exist for result payloads",
+        "No focused no-zh-fallback parity gate found for ResultPageV2 assets"
+      ],
+      "result_content_architecture": "mixed: v1 compiled localized rows have parity, but v2 content assets are Chinese-heavy repo-visible catalogs. BigFiveReportComposer fallback order can fall through to zh-CN for missing English rows.",
+      "notes": "The v1 compiled copy/block counts are balanced, but the newer result-page-v2 asset system needs explicit EN catalog counterparts before EN reports can be certified."
+    },
+    {
+      "test_code": "ENNEAGRAM",
+      "result_routes": [
+        "GET /api/v0.3/attempts/{id}/result",
+        "/[locale]/result/[id]",
+        "/[locale]/history/enneagram"
+      ],
+      "report_routes": [
+        "GET /api/v0.3/attempts/{id}/report",
+        "GET /api/v0.3/attempts/{id}/report.pdf"
+      ],
+      "backend_scoring_source": [
+        "backend/app/Services/Assessment/Drivers/EnneagramDriver.php",
+        "backend/app/Services/Assessment/Scoring/EnneagramForcedChoice144Scorer.php",
+        "backend/app/Services/Assessment/Scoring/EnneagramLikert105Scorer.php"
+      ],
+      "backend_result_serializer": [
+        "backend/app/Services/Report/EnneagramReportComposer.php",
+        "backend/app/Services/Enneagram/EnneagramPublicProjectionService.php",
+        "backend/content_packs/ENNEAGRAM/v2/registry/*"
+      ],
+      "frontend_renderer": [
+        "components/result/enneagram/EnneagramResultShell.tsx",
+        "components/result/enneagram/EnneagramTechnicalNotePage.tsx",
+        "components/share/EnneagramShareSummaryCard.tsx"
+      ],
+      "report_section_keys": [
+        "type_registry",
+        "pair_registry",
+        "group_registry",
+        "observation_registry",
+        "technical_note_registry",
+        "method_registry",
+        "sample_report_registry",
+        "state_registry",
+        "scenario_registry",
+        "theory_hint_registry",
+        "ui_copy_registry"
+      ],
+      "zh_asset_count": 9,
+      "en_asset_count": 0,
+      "missing_en_asset_keys": [
+        "type_registry.en",
+        "pair_registry.en",
+        "group_registry.en",
+        "observation_registry.en",
+        "technical_note_registry.en",
+        "method_registry.en",
+        "sample_report_registry.en",
+        "state_registry.en",
+        "scenario_registry.en",
+        "ui_copy_registry.en"
+      ],
+      "chinese_leakage_risk": "high",
+      "pdf_email_share_coverage": {
+        "pdf": "generic metadata PDF only",
+        "email": "shared bilingual email templates exist; Enneagram-specific result prose email asset not separately verified",
+        "share": "backend ShareService and EnneagramShareSummaryCard exist"
+      },
+      "my_results_card_coverage": "history route exists; backend email lookup helper supports ENNEAGRAM but public lookup currently requires verification",
+      "claim_boundary_coverage": "partial; self-knowledge language is safer than clinical or hiring claims",
+      "locale_behavior_tests": [
+        "Enneagram scoring and report tests exist, but no generated registry EN counterpart gate was found"
+      ],
+      "result_content_architecture": "mixed: composer has bilingual structural labels, while registry catalogs are repo-visible zh-CN only.",
+      "notes": "English result rendering can only be certified after registry-level EN assets are added or exported."
+    },
+    {
+      "test_code": "EQ_60",
+      "result_routes": [
+        "GET /api/v0.3/attempts/{id}/result",
+        "/[locale]/result/[id]"
+      ],
+      "report_routes": [
+        "GET /api/v0.3/attempts/{id}/report",
+        "GET /api/v0.3/attempts/{id}/report.pdf"
+      ],
+      "backend_scoring_source": [
+        "backend/app/Services/Assessment/Drivers/Eq60Driver.php",
+        "backend/app/Services/Assessment/Scoring/Eq60ScorerV1NormedValidity.php"
+      ],
+      "backend_result_serializer": [
+        "backend/app/Services/Report/Eq60ReportComposer.php",
+        "backend/app/Services/Eq60/Eq60PackLoader.php",
+        "backend/content_packs/EQ_60/v1/compiled/*"
+      ],
+      "frontend_renderer": [
+        "components/result/eq/EQResultV5.tsx",
+        "components/result/RichResultReport.tsx"
+      ],
+      "report_section_keys": [
+        "report.compiled.blocks_by_locale",
+        "report_assets.compiled.localized_maps"
+      ],
+      "zh_asset_count": 130,
+      "en_asset_count": 130,
+      "missing_en_asset_keys": [],
+      "chinese_leakage_risk": "low_current_assets_medium_future_fallback",
+      "pdf_email_share_coverage": {
+        "pdf": "generic metadata PDF only",
+        "email": "shared bilingual email templates exist",
+        "share": "generic backend ShareService path exists; EQ-specific share UI not found"
+      },
+      "my_results_card_coverage": "backend email lookup helper supports EQ_60 but public lookup currently requires verification",
+      "claim_boundary_coverage": "partial; avoid clinical or employment suitability claims",
+      "locale_behavior_tests": [
+        "backend/tests/Fixtures/eq/v5 include _en and _zh fixtures"
+      ],
+      "result_content_architecture": "localized compiled report packs with balanced zh-CN and en rows. Composer fallback can still fall through to zh-CN if future EN rows are missing.",
+      "notes": "EQ is the closest repo-visible result/report asset parity baseline among the scanned non-MBTI tests."
+    },
+    {
+      "test_code": "RIASEC",
+      "result_routes": [
+        "GET /api/v0.3/attempts/{id}/result",
+        "/[locale]/result/[id]",
+        "/[locale]/history/riasec"
+      ],
+      "report_routes": [
+        "GET /api/v0.3/attempts/{id}/report",
+        "GET /api/v0.3/attempts/{id}/report.pdf"
+      ],
+      "backend_scoring_source": [
+        "backend/app/Services/Assessment/Drivers/RiasecDriver.php",
+        "backend/app/Services/Assessment/Scoring/RiasecScorer.php"
+      ],
+      "backend_result_serializer": [
+        "backend/app/Services/Report/RiasecReportComposer.php",
+        "backend/app/Services/Riasec/RiasecPublicProjectionService.php",
+        "backend/app/Services/Riasec/RiasecLifecycleCopyService.php",
+        "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
+        "backend/content_assets/riasec/*"
+      ],
+      "frontend_renderer": [
+        "components/result/riasec/RiasecResultShell.tsx",
+        "components/result/RichResultReport.tsx"
+      ],
+      "report_section_keys": [
+        "activity_task_examples",
+        "occupation_examples_boundary",
+        "next_exploration_nodes",
+        "feedback_action_lab",
+        "top3_code_chain_strategy",
+        "professional_method_boundary",
+        "share_pdf_history",
+        "faq",
+        "technical_note_user_summary"
+      ],
+      "zh_asset_count": 19,
+      "en_asset_count": 0,
+      "missing_en_asset_keys": [
+        "content_assets/riasec/*.en.json",
+        "riasec.lifecycle_copy.share_pdf_history_v1.en",
+        "riasec.lifecycle_copy.faq_v1.en",
+        "riasec.lifecycle_copy.technical_note_user_summary_v1.en",
+        "riasec.lifecycle_copy.professional_method_boundary_v1.en"
+      ],
+      "chinese_leakage_risk": "high",
+      "pdf_email_share_coverage": {
+        "pdf": "generic metadata PDF only; lifecycle PDF/share/history copy points to zh-CN assets",
+        "email": "shared bilingual email templates exist; RIASEC result-specific email copy not verified",
+        "share": "lifecycle share/pdf/history assets are zh-CN only in repo-visible catalog"
+      },
+      "my_results_card_coverage": "history route exists; backend email lookup helper supports RIASEC but public lookup currently requires verification",
+      "claim_boundary_coverage": "strong_rule_needed; RIASEC is interest signal and exploration support, not active career recommendation",
+      "locale_behavior_tests": [
+        "RiasecContentRegistrySlotContract forbids frontend fallback",
+        "No EN lifecycle copy counterpart gate found"
+      ],
+      "result_content_architecture": "mixed: report composer has English hardcoded summary scaffolding, but lifecycle/content asset catalogs are zh-CN only and authority-owned by backend.",
+      "notes": "RIASEC is the highest-priority asset-catalog fix because it is commercially important and claim-sensitive."
+    },
+    {
+      "test_code": "SDS_20",
+      "result_routes": [
+        "GET /api/v0.3/attempts/{id}/result",
+        "/[locale]/result/[id]",
+        "/[locale]/attempts/[attemptId]/report"
+      ],
+      "report_routes": [
+        "GET /api/v0.3/attempts/{id}/report",
+        "GET /api/v0.3/attempts/{id}/report.pdf"
+      ],
+      "backend_scoring_source": [
+        "backend/app/Services/Assessment/Drivers/Sds20Driver.php",
+        "backend/app/Services/Assessment/Scoring/Sds20ScorerV2FactorLogic.php"
+      ],
+      "backend_result_serializer": [
+        "backend/app/Services/Report/Sds20ReportComposer.php",
+        "backend/app/Services/Sds20/Sds20PackLoader.php",
+        "backend/content_packs/SDS_20/v1/compiled/report.compiled.json",
+        "backend/content_packs/DEPRESSION_SCREENING_STANDARD/v1/compiled/report.compiled.json"
+      ],
+      "frontend_renderer": [
+        "components/clinical/report/ClinicalReportClient.tsx",
+        "components/clinical/report/ReportSectionRenderer.tsx",
+        "components/clinical/report/CrisisOverlay.tsx",
+        "components/clinical/report/SdsFactorPanel.tsx"
+      ],
+      "report_section_keys": [
+        "sds_20.report.blocks_by_locale",
+        "depression_screening_standard.report.blocks_by_locale",
+        "landing.localized_map"
+      ],
+      "zh_asset_count": 5,
+      "en_asset_count": 5,
+      "missing_en_asset_keys": [],
+      "chinese_leakage_risk": "medium_due_sensitive_fallback",
+      "pdf_email_share_coverage": {
+        "pdf": "generic metadata PDF only",
+        "email": "shared bilingual email templates exist; sensitive-result email copy not verified",
+        "share": "generic ShareService path exists; sensitive sharing should remain constrained"
+      },
+      "my_results_card_coverage": "backend result lookup excludes SDS_20 in current private helper; public lookup requires verification",
+      "claim_boundary_coverage": "required; non-diagnosis and professional-help boundaries are critical",
+      "locale_behavior_tests": [
+        "SDS pack tests exist, but no explicit fail-closed missing-EN gate found"
+      ],
+      "result_content_architecture": "localized compiled report packs with current zh-CN/en parity. Loader can fall back to zh-CN when requested locale rows are missing.",
+      "notes": "Current repo-visible assets are balanced, but any fallback to Chinese on EN sensitive pages should fail closed instead of silently passing."
+    },
+    {
+      "test_code": "CLINICAL_COMBO_68",
+      "result_routes": [
+        "GET /api/v0.3/attempts/{id}/result",
+        "/[locale]/result/[id]",
+        "/[locale]/attempts/[attemptId]/report"
+      ],
+      "report_routes": [
+        "GET /api/v0.3/attempts/{id}/report",
+        "GET /api/v0.3/attempts/{id}/report.pdf"
+      ],
+      "backend_scoring_source": [
+        "backend/app/Services/Assessment/Drivers/ClinicalCombo68Driver.php",
+        "backend/app/Services/Assessment/Scoring/ClinicalCombo68ScorerV1.php"
+      ],
+      "backend_result_serializer": [
+        "backend/app/Services/Report/ClinicalCombo68ReportComposer.php",
+        "backend/app/Services/ClinicalCombo/ClinicalComboPackLoader.php",
+        "backend/app/Services/ClinicalCombo/ClinicalComboBlockSelector.php",
+        "backend/content_packs/CLINICAL_COMBO_68/v1/compiled/report.compiled.json",
+        "backend/content_packs/CLINICAL_DEPRESSION_ANXIETY_PRO/v1/compiled/report.compiled.json"
+      ],
+      "frontend_renderer": [
+        "components/clinical/report/ClinicalReportClient.tsx",
+        "components/clinical/report/ReportSectionRenderer.tsx",
+        "components/clinical/report/CrisisOverlay.tsx"
+      ],
+      "report_section_keys": [
+        "clinical_combo_68.report.blocks_by_locale",
+        "clinical_depression_anxiety_pro.report.blocks_by_locale",
+        "paid_action_*",
+        "paid_perf_*",
+        "landing.localized_map"
+      ],
+      "zh_asset_count": 46,
+      "en_asset_count": 38,
+      "missing_en_asset_keys": [
+        "clinical_combo_68.paid_action_anxiety_14d.en",
+        "clinical_combo_68.paid_action_burnout.en",
+        "clinical_combo_68.paid_action_depression_14d.en",
+        "clinical_combo_68.paid_action_ocd_erp_start.en",
+        "clinical_combo_68.paid_action_perfectionism_14d.en",
+        "clinical_combo_68.paid_perf_cm_mistakes.en",
+        "clinical_combo_68.paid_perf_da_doubts.en",
+        "clinical_combo_68.paid_perf_org_order.en",
+        "clinical_combo_68.paid_perf_pe_parental.en",
+        "clinical_combo_68.paid_perf_ps_standards.en"
+      ],
+      "chinese_leakage_risk": "high_for_paid_sections_medium_for_free_sections",
+      "pdf_email_share_coverage": {
+        "pdf": "generic metadata PDF only",
+        "email": "shared bilingual email templates exist; sensitive paid-section email copy not verified",
+        "share": "generic ShareService path exists; sensitive sharing should remain constrained"
+      },
+      "my_results_card_coverage": "backend result lookup excludes CLINICAL_COMBO_68 in current private helper; public lookup requires verification",
+      "claim_boundary_coverage": "required; self-assessment, non-diagnosis, crisis and professional-help boundaries must be visible",
+      "locale_behavior_tests": [
+        "Clinical combo pack tests exist",
+        "No explicit missing paid EN block fail-closed gate found"
+      ],
+      "result_content_architecture": "localized compiled report packs with incomplete paid-section EN rows. Loader can fall back to zh-CN when localized rows are missing.",
+      "notes": "Clinical paid action/performance blocks are the clearest concrete missing-EN backend assets in this scan."
+    },
+    {
+      "test_code": "IQ_INTELLIGENCE_QUOTIENT",
+      "result_routes": [
+        "GET /api/v0.3/attempts/{id}/result",
+        "/[locale]/result/[id]"
+      ],
+      "report_routes": [
+        "GET /api/v0.3/attempts/{id}/report",
+        "GET /api/v0.3/attempts/{id}/report.pdf"
+      ],
+      "backend_scoring_source": [
+        "backend/app/Services/Assessment/Drivers/IqTestDriver.php"
+      ],
+      "backend_result_serializer": [
+        "backend/app/Services/Report/IqReportBuilder.php",
+        "backend/app/Services/Iq/IqResultPayloadRedactor.php"
+      ],
+      "frontend_renderer": [
+        "components/result/iq/IqResultShell.tsx",
+        "components/result/iq/IqReportModule.tsx",
+        "lib/iq/result.ts"
+      ],
+      "report_section_keys": [
+        "iq.dimensions.visual_spatial_insight",
+        "iq.dimensions.visual_spatial_pattern_reasoning",
+        "iq.dimensions.numeric_pattern_reasoning",
+        "iq_pro.pdf_payload",
+        "iq_pro.certificate_payload"
+      ],
+      "zh_asset_count": 3,
+      "en_asset_count": 0,
+      "missing_en_asset_keys": [
+        "iq.dimensions.visual_spatial_insight.en",
+        "iq.dimensions.visual_spatial_pattern_reasoning.en",
+        "iq.dimensions.numeric_pattern_reasoning.en",
+        "iq_pro.pdf_payload.en",
+        "iq_pro.certificate_payload.en"
+      ],
+      "chinese_leakage_risk": "high",
+      "pdf_email_share_coverage": {
+        "pdf": "contract-defined IQ pro PDF/certificate payload not implemented; generic metadata PDF only",
+        "email": "shared bilingual email templates exist; IQ result-specific email copy not verified",
+        "share": "generic ShareService path exists; IQ-specific share copy not verified"
+      },
+      "my_results_card_coverage": "backend email lookup helper supports IQ_RAVEN but public lookup currently requires verification",
+      "claim_boundary_coverage": "required; online estimate and confidence interval language must avoid real IQ or clinical authority claims",
+      "locale_behavior_tests": [
+        "IQ report contract tests exist, but no localized dimension-label parity gate found"
+      ],
+      "result_content_architecture": "backend-generated report sections include Chinese dimension labels without an obvious locale parameter. English rendering is at high leakage risk.",
+      "notes": "IQ should be a small but urgent locale-safe backend builder fix before English paid/report surfaces are expanded."
+    }
+  ],
+  "architecture_findings": [
+    {
+      "id": "backend_authority_mixed_by_family",
+      "severity": "high",
+      "summary": "Result/report content architecture is not uniform across scales. Some families use compiled localized packs, some use backend hardcoded scaffolds, some use repo-visible zh-only content_assets, and MBTI relies on external packages plus legacy fallbacks."
+    },
+    {
+      "id": "zh_fallback_can_silently_pass",
+      "severity": "high",
+      "summary": "Several loaders/composers allow fallback to zh-CN when requested English content is missing. That is acceptable for controlled internal preview only, but unsafe for public EN result/report parity."
+    },
+    {
+      "id": "frontend_interpretation_copy_authority_risk",
+      "severity": "high",
+      "summary": "fap-web contains large Chinese interpretation-copy islands, especially MBTI clone content and Big Five fixtures/assets. Presentation labels can remain frontend, but report interpretation copy should be backend/CMS asset authority."
+    },
+    {
+      "id": "my_results_public_lookup_not_live_inventory",
+      "severity": "medium",
+      "summary": "ResultEmailLookupService public lookup currently returns email_verification_required with an empty list. Private lookup helpers support only non-sensitive scales and exclude SDS/clinical combo."
+    },
+    {
+      "id": "pdf_export_is_metadata_not_report_parity",
+      "severity": "medium",
+      "summary": "Generic and Big Five PDF services exist, but the scan found metadata-style PDF output rather than full bilingual report prose export parity across all families."
+    }
+  ],
+  "frontend_authority_risks": [
+    {
+      "id": "mbti_frontend_clone_content",
+      "severity": "high",
+      "paths": [
+        "lib/mbti/mbtiTypeContentPacks.generated.ts",
+        "components/result/mbti/clone/content/*.zh.ts",
+        "components/result/mbti/clone/variants/*.zh.ts"
+      ],
+      "finding": "Large Chinese interpretation copy exists in fap-web with no matching .en.ts clone content counterpart in the scan."
+    },
+    {
+      "id": "big5_result_page_v2_frontend_payload_dependence",
+      "severity": "high",
+      "paths": [
+        "components/result/big5/Big5ResultPageV2Shell.tsx",
+        "lib/big5/microcopy.ts"
+      ],
+      "finding": "Renderer can display localized key variants but depends on backend payload parity. Unsuffixed or zh-only payload bodies can leak Chinese into EN."
+    },
+    {
+      "id": "iq_frontend_labels",
+      "severity": "medium",
+      "paths": [
+        "lib/iq/result.ts",
+        "components/result/iq/IqResultShell.tsx",
+        "components/result/iq/IqReportModule.tsx"
+      ],
+      "finding": "Frontend contains IQ labels and modules that must remain presentation-only; backend IqReportBuilder still needs locale-safe section labels."
+    }
+  ],
+  "recommended_next_prs": [
+    {
+      "id": "RESULT-EN-PARITY-01",
+      "title": "Result/report asset catalog export and fail-closed locale parity gate",
+      "scope": "Add backend-generated inventory command/test that exports authoritative result/report asset keys by family and fails when public EN depends on zh-CN fallback.",
+      "dependency_assumption": "RESULT-EN-PARITY-00 merged"
+    },
+    {
+      "id": "RESULT-EN-PARITY-02",
+      "title": "RIASEC result/report English asset catalog",
+      "scope": "Add English backend content_assets counterparts for RIASEC lifecycle/share/pdf/history/FAQ/method-boundary assets without changing scoring.",
+      "dependency_assumption": "RESULT-EN-PARITY-01 catalog gate available"
+    },
+    {
+      "id": "RESULT-EN-PARITY-03",
+      "title": "IQ locale-safe report builder labels",
+      "scope": "Move IQ dimension labels into locale-aware backend catalog and add EN/ZH tests for result/report payloads.",
+      "dependency_assumption": "RESULT-EN-PARITY-01 catalog gate available"
+    },
+    {
+      "id": "RESULT-EN-PARITY-04",
+      "title": "Clinical combo paid section EN parity",
+      "scope": "Add missing English paid_action and paid_perf blocks and fail if sensitive EN reports fall back to zh-CN.",
+      "dependency_assumption": "RESULT-EN-PARITY-01 catalog gate available"
+    },
+    {
+      "id": "RESULT-EN-PARITY-05",
+      "title": "MBTI backend content package export and frontend interpretation de-authoring",
+      "scope": "Materialize or export authoritative MBTI result/report content packages and mark frontend clone content as non-authoritative or migration-only.",
+      "dependency_assumption": "RESULT-EN-PARITY-01 catalog gate available"
+    },
+    {
+      "id": "RESULT-EN-PARITY-06",
+      "title": "Big Five ResultPageV2 EN asset catalog parity",
+      "scope": "Add English counterparts for Big Five v2 route matrix, coupling, scenario action, facets, and canonical profiles.",
+      "dependency_assumption": "RESULT-EN-PARITY-01 catalog gate available"
+    }
+  ]
+}

--- a/backend/docs/seo/result-en-parity-00-assessment-result-content-inventory.md
+++ b/backend/docs/seo/result-en-parity-00-assessment-result-content-inventory.md
@@ -1,0 +1,159 @@
+# RESULT-EN-PARITY-00 Assessment Result/Report Content Inventory
+
+Decision output: `result_en_parity_inventory_completed_ready_for_asset_catalog_fix`
+
+This is a read-only inventory for assessment result, report, My Results, PDF, email, and share content assets. It does not translate content, modify scoring, mutate CMS, deploy, submit URLs, run production migrations, access production user data, or commit fap-web changes.
+
+## Scope
+
+Covered test families:
+
+- MBTI
+- Big Five / `BIG5_OCEAN`
+- Enneagram
+- EQ / `EQ_60`
+- RIASEC / Holland Career Interest
+- Depression Screening / `SDS_20`
+- Depression + Anxiety Assessment / `CLINICAL_COMBO_68`
+- IQ / `IQ_INTELLIGENCE_QUOTIENT`
+
+Authority boundary:
+
+- Backend scoring, CMS, and result/report asset catalogs are authority.
+- fap-web fallback content is not authority.
+- fap-web Chinese labels used only for presentation are recorded.
+- fap-web report interpretation copy is flagged as an authority risk unless it is explicitly migration-only or backend-owned by repo convention.
+
+Production observation was limited to a read-only Chrome visit to `https://fermatmind.com`. The public homepage loaded and exposed public test links plus `/zh/results/lookup` and `/en` navigation. Private result/report/My Results pages were not accessed without credentials, attempt IDs, or secrets.
+
+## Routes And APIs
+
+Backend result/report API inventory:
+
+- `POST /api/v0.3/attempts/start`
+- `POST /api/v0.3/attempts/submit`
+- `POST /api/v0.3/attempts/{id}/email-bind`
+- `GET /api/v0.3/attempts/{id}`
+- `GET /api/v0.3/attempts/{id}/result`
+- `GET /api/v0.3/attempts/{id}/report`
+- `GET /api/v0.3/attempts/{id}/report-access`
+- `GET /api/v0.3/attempts/{id}/report.pdf`
+- `POST /api/v0.3/attempts/{id}/share`
+- `GET /api/v0.3/attempts/{id}/share`
+- `GET /api/v0.3/shares/{id}`
+- `POST /api/v0.3/results/lookup-by-email`
+
+fap-web route inventory, reference-only:
+
+- `app/(localized)/[locale]/(app)/result/[id]/page.tsx`
+- `app/(localized)/[locale]/attempts/[attemptId]/report/page.tsx`
+- `app/(localized)/[locale]/results/lookup/page.tsx`
+- `app/(localized)/[locale]/share/[id]/page.tsx`
+- `app/og/share/[id]/route.tsx`
+- `app/(localized)/[locale]/(app)/history/mbti/page.tsx`
+- `app/(localized)/[locale]/(app)/history/big5/page.tsx`
+- `app/(localized)/[locale]/(app)/history/big5/compare/page.tsx`
+- `app/(localized)/[locale]/(app)/history/enneagram/page.tsx`
+- `app/(localized)/[locale]/(app)/history/riasec/page.tsx`
+
+## Backend Source Inventory
+
+Common backend sources:
+
+- `backend/app/Services/Report/ReportComposerRegistry.php`
+- `backend/app/Http/Controllers/Api/V03/AttemptReadController.php`
+- `backend/app/Services/Results/ResultEmailLookupService.php`
+- `backend/app/Services/Share/ShareService.php`
+- `backend/app/Services/Report/Pdf/ReportPdfDocumentService.php`
+- `backend/app/Services/Report/Pdf/BigFivePdfDocumentService.php`
+- `backend/resources/views/emails/en`
+- `backend/resources/views/emails/zh`
+
+Composer mapping:
+
+- MBTI: `ReportComposer`, `ReportPayloadAssembler`, MBTI public projection builders, legacy compatibility builders.
+- Big Five: `BigFiveReportComposer`, `BigFivePublicProjectionService`, `BigFivePackLoader`, ResultPageV2 assets.
+- Enneagram: `EnneagramReportComposer`, `EnneagramPublicProjectionService`, `backend/content_packs/ENNEAGRAM/v2/registry/*`.
+- EQ: `Eq60ReportComposer`, `Eq60PackLoader`, `backend/content_packs/EQ_60/v1/compiled/*`.
+- RIASEC: `RiasecReportComposer`, `RiasecPublicProjectionService`, `RiasecLifecycleCopyService`, `backend/content_assets/riasec/*`.
+- Depression screening: `Sds20ReportComposer`, `Sds20PackLoader`, `SDS_20` and `DEPRESSION_SCREENING_STANDARD` packs.
+- Depression + Anxiety: `ClinicalCombo68ReportComposer`, `ClinicalComboPackLoader`, `ClinicalComboBlockSelector`.
+- IQ: `IqReportBuilder`, `IqResultPayloadRedactor`.
+
+## Frontend Renderer Inventory
+
+Reference-only fap-web renderers:
+
+- `components/result/ResultClient.tsx`
+- `components/result/RichResultReport.tsx`
+- `components/result/mbti/MbtiResultShell.tsx`
+- `components/result/big5/Big5ResultShell.tsx`
+- `components/result/big5/Big5ResultPageV2Shell.tsx`
+- `components/result/enneagram/EnneagramResultShell.tsx`
+- `components/result/eq/EQResultV5.tsx`
+- `components/result/riasec/RiasecResultShell.tsx`
+- `components/result/iq/IqResultShell.tsx`
+- `components/result/iq/IqReportModule.tsx`
+- `components/clinical/report/ClinicalReportClient.tsx`
+- `components/clinical/report/ReportSectionRenderer.tsx`
+- `components/share/MbtiShareSummaryCard.tsx`
+- `components/share/EnneagramShareSummaryCard.tsx`
+- `components/support/ResultEmailLookupForm.tsx`
+
+Important frontend risk: MBTI clone content and Big Five result page fixtures/assets include large Chinese interpretation-copy islands. They must not become result/report authority. Presentation labels can remain frontend product code, but result interpretation prose belongs in backend/CMS asset catalogs.
+
+## Asset Matrix
+
+Counts below are repo-visible backend result/report asset counts, not production CMS data and not private user data.
+
+| Test family | Backend content architecture | zh assets | en assets | Missing English asset keys | Chinese leakage risk | PDF/email/share/My Results coverage |
+|---|---:|---:|---:|---|---|---|
+| MBTI | Structured result codes plus external content packages, legacy backend fallbacks, and frontend clone content | 0 repo-visible backend package exports | 0 repo-visible backend package exports | `backend_external_content_package_export_required`, `legacy_mbti_generated_fallback_copy.en`, `frontend_mbti_clone_content_base.en`, `frontend_mbti_clone_content_variants.en` | High | Generic metadata PDF only; shared email templates exist; MBTI share renderer exists; history route exists; lookup helper supports MBTI but public lookup requires verification |
+| Big Five | v1 localized compiled rows plus v2 Chinese-heavy backend content assets | 436 v1 rows; 419 v2 repo-visible asset files | 436 v1 rows; 0 v2 counterparts | `result_page_v2.route_matrix.en`, `coupling_assets.en`, `scenario_action_assets.en`, `facet_assets.en`, `canonical_profiles.en`, `core_body.en`, `selector_ready_assets.en` | High for v2, medium for v1 | BigFive PDF service exists; shared email templates exist; history/compare routes exist; lookup helper supports BIG5 |
+| Enneagram | Composer labels plus zh-CN registry catalogs | 9 registry groups | 0 registry groups | `type_registry.en`, `pair_registry.en`, `group_registry.en`, `observation_registry.en`, `technical_note_registry.en`, `method_registry.en`, `sample_report_registry.en`, `state_registry.en`, `scenario_registry.en`, `ui_copy_registry.en` | High | Generic metadata PDF only; shared email templates exist; share renderer exists; history route exists; lookup helper supports ENNEAGRAM |
+| EQ | Localized compiled report packs | 130 | 130 | None found in current repo-visible packs | Low current assets, medium future fallback | Generic metadata PDF only; shared email templates exist; generic share path exists; lookup helper supports EQ_60 |
+| RIASEC | Backend composer plus zh-CN-only lifecycle/content assets | 19 | 0 | `content_assets/riasec/*.en.json`, lifecycle `share_pdf_history`, `faq`, `technical_note_user_summary`, `professional_method_boundary` | High | Generic metadata PDF only; lifecycle share/pdf/history assets point to zh-CN; history route exists; lookup helper supports RIASEC |
+| Depression Screening | Localized compiled report packs | 5 | 5 | None found in current repo-visible packs | Medium due sensitive fallback | Generic metadata PDF only; shared email templates exist; sensitive sharing should remain constrained; lookup helper excludes SDS_20 |
+| Depression + Anxiety | Localized compiled packs with incomplete EN paid rows | 46 | 38 | `paid_action_anxiety_14d.en`, `paid_action_burnout.en`, `paid_action_depression_14d.en`, `paid_action_ocd_erp_start.en`, `paid_action_perfectionism_14d.en`, `paid_perf_cm_mistakes.en`, `paid_perf_da_doubts.en`, `paid_perf_org_order.en`, `paid_perf_pe_parental.en`, `paid_perf_ps_standards.en` | High for paid sections | Generic metadata PDF only; shared email templates exist; sensitive sharing should remain constrained; lookup helper excludes CLINICAL_COMBO_68 |
+| IQ | Backend-generated report sections with Chinese dimension labels | 3 | 0 | `iq.dimensions.visual_spatial_insight.en`, `iq.dimensions.visual_spatial_pattern_reasoning.en`, `iq.dimensions.numeric_pattern_reasoning.en`, `iq_pro.pdf_payload.en`, `iq_pro.certificate_payload.en` | High | IQ pro PDF/certificate payload is contract-defined not implemented; shared email templates exist; generic share path exists; lookup helper supports IQ_RAVEN |
+
+## Architecture Findings
+
+1. Result/report content is not one architecture. Some tests use compiled localized packs, some use backend hardcoded scaffolds, some use zh-only content asset catalogs, and MBTI relies on external packages plus legacy fallbacks.
+2. Several loaders/composers can fall back to `zh-CN` when requested English content is missing. That makes missing English assets hard to detect and risks Chinese leakage on EN result/report pages.
+3. Big Five v1 has balanced compiled localized rows, but Big Five ResultPageV2 assets do not have repo-visible English counterparts.
+4. EQ and SDS currently have balanced repo-visible compiled packs, but sensitive or paid result surfaces still need fail-closed no-zh-fallback gates.
+5. PDF services exist, but current scanned PDF coverage is metadata-style, not full report-prose bilingual parity.
+6. Result email lookup public behavior currently requires verification and returns an empty list. Private helper coverage excludes sensitive SDS/clinical combo scales.
+
+## Claim Boundary Coverage
+
+Sensitive tests require stricter result/report wording gates:
+
+- Depression and anxiety pages must remain self-assessment, non-diagnostic, and professional-help bounded.
+- IQ must remain online estimate / confidence-interval language, not real IQ or clinical authority.
+- RIASEC and Big Five must remain interest signal / workstyle explanation, not precise career recommendation or hiring suitability.
+- MBTI career language must avoid career success prediction.
+
+## Recommended Next PRs
+
+Proposed follow-up PRs need explicit manifest/state authorization before implementation:
+
+1. `RESULT-EN-PARITY-01` - Result/report asset catalog export and fail-closed locale parity gate. Scope: export authoritative backend result/report asset keys by family and fail when public EN depends on zh-CN fallback.
+2. `RESULT-EN-PARITY-02` - RIASEC result/report English asset catalog. Scope: add English backend content asset counterparts for lifecycle/share/pdf/history/FAQ/method-boundary copy.
+3. `RESULT-EN-PARITY-03` - IQ locale-safe report builder labels. Scope: move IQ dimensions into locale-aware backend catalog and add EN/ZH tests.
+4. `RESULT-EN-PARITY-04` - Clinical combo paid section EN parity. Scope: add missing paid action/performance EN blocks and fail sensitive EN reports that fall back to zh-CN.
+5. `RESULT-EN-PARITY-05` - MBTI backend content package export and frontend interpretation de-authoring. Scope: materialize/export authoritative MBTI content package keys and mark frontend clone content non-authoritative or migration-only.
+6. `RESULT-EN-PARITY-06` - Big Five ResultPageV2 EN asset catalog parity. Scope: add English counterparts for route matrix, coupling, scenario action, facets, and canonical profiles.
+
+## Validation Target
+
+Generated JSON artifact:
+
+- `backend/docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json`
+
+Focused test:
+
+- `backend/tests/Feature/SeoIntel/ResultEnParity00AssessmentResultContentInventoryTest.php`
+
+Repository rule impact: this PR changes no runtime ownership. It records that result/report interpretation content must remain backend/CMS authoritative and that fap-web fallback content is not authority.

--- a/backend/tests/Feature/SeoIntel/ResultEnParity00AssessmentResultContentInventoryTest.php
+++ b/backend/tests/Feature/SeoIntel/ResultEnParity00AssessmentResultContentInventoryTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ResultEnParity00AssessmentResultContentInventoryTest extends TestCase
+{
+    #[Test]
+    public function generated_inventory_artifact_lands_expected_read_only_baseline(): void
+    {
+        $jsonPath = base_path('docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json');
+        $markdownPath = base_path('docs/seo/result-en-parity-00-assessment-result-content-inventory.md');
+
+        $this->assertFileExists($jsonPath);
+        $this->assertFileExists($markdownPath);
+
+        $payload = json_decode((string) file_get_contents($jsonPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('result-en-parity-00-assessment-result-content-inventory.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('RESULT-EN-PARITY-00', $payload['task'] ?? null);
+        $this->assertSame(
+            'result_en_parity_inventory_completed_ready_for_asset_catalog_fix',
+            $payload['final_decision'] ?? null
+        );
+
+        $this->assertTrue((bool) ($payload['no_mutation_performed'] ?? false));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['fap_web_commit_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_user_data_accessed'] ?? true));
+
+        $this->assertFalse((bool) ($payload['authority_rule']['frontend_fallback_authority'] ?? true));
+        $this->assertSame(
+            'backend scoring, CMS, and result/report asset catalogs',
+            $payload['authority_rule']['result_asset_authority'] ?? null
+        );
+
+        $families = $payload['test_families'] ?? [];
+        $this->assertCount(8, $families);
+
+        $byCode = [];
+        foreach ($families as $family) {
+            $this->assertIsArray($family['result_routes'] ?? null);
+            $this->assertIsArray($family['backend_scoring_source'] ?? null);
+            $this->assertIsArray($family['backend_result_serializer'] ?? null);
+            $this->assertIsArray($family['frontend_renderer'] ?? null);
+            $this->assertIsArray($family['report_section_keys'] ?? null);
+            $this->assertIsInt($family['zh_asset_count'] ?? null);
+            $this->assertIsInt($family['en_asset_count'] ?? null);
+            $this->assertIsArray($family['missing_en_asset_keys'] ?? null);
+            $this->assertIsArray($family['pdf_email_share_coverage'] ?? null);
+            $this->assertArrayHasKey('my_results_card_coverage', $family);
+            $this->assertArrayHasKey('claim_boundary_coverage', $family);
+            $this->assertIsArray($family['locale_behavior_tests'] ?? null);
+            $this->assertArrayHasKey('result_content_architecture', $family);
+
+            $byCode[$family['test_code']] = $family;
+        }
+
+        foreach ([
+            'MBTI',
+            'BIG5_OCEAN',
+            'ENNEAGRAM',
+            'EQ_60',
+            'RIASEC',
+            'SDS_20',
+            'CLINICAL_COMBO_68',
+            'IQ_INTELLIGENCE_QUOTIENT',
+        ] as $requiredCode) {
+            $this->assertArrayHasKey($requiredCode, $byCode);
+        }
+
+        $this->assertSame('high', $byCode['MBTI']['chinese_leakage_risk'] ?? null);
+        $this->assertContains(
+            'backend_external_content_package_export_required',
+            $byCode['MBTI']['missing_en_asset_keys'] ?? []
+        );
+
+        $this->assertSame(436, $byCode['BIG5_OCEAN']['zh_asset_count'] ?? null);
+        $this->assertSame(436, $byCode['BIG5_OCEAN']['en_asset_count'] ?? null);
+        $this->assertContains(
+            'result_page_v2.route_matrix.en',
+            $byCode['BIG5_OCEAN']['missing_en_asset_keys'] ?? []
+        );
+
+        $this->assertSame(19, $byCode['RIASEC']['zh_asset_count'] ?? null);
+        $this->assertSame(0, $byCode['RIASEC']['en_asset_count'] ?? null);
+        $this->assertContains(
+            'content_assets/riasec/*.en.json',
+            $byCode['RIASEC']['missing_en_asset_keys'] ?? []
+        );
+
+        $this->assertSame(46, $byCode['CLINICAL_COMBO_68']['zh_asset_count'] ?? null);
+        $this->assertSame(38, $byCode['CLINICAL_COMBO_68']['en_asset_count'] ?? null);
+        $this->assertContains(
+            'clinical_combo_68.paid_action_anxiety_14d.en',
+            $byCode['CLINICAL_COMBO_68']['missing_en_asset_keys'] ?? []
+        );
+
+        $this->assertSame(3, $byCode['IQ_INTELLIGENCE_QUOTIENT']['zh_asset_count'] ?? null);
+        $this->assertSame(0, $byCode['IQ_INTELLIGENCE_QUOTIENT']['en_asset_count'] ?? null);
+        $this->assertContains(
+            'iq.dimensions.visual_spatial_insight.en',
+            $byCode['IQ_INTELLIGENCE_QUOTIENT']['missing_en_asset_keys'] ?? []
+        );
+
+        $findingIds = array_column($payload['architecture_findings'] ?? [], 'id');
+        $this->assertContains('backend_authority_mixed_by_family', $findingIds);
+        $this->assertContains('zh_fallback_can_silently_pass', $findingIds);
+        $this->assertContains('frontend_interpretation_copy_authority_risk', $findingIds);
+
+        $nextPrIds = array_column($payload['recommended_next_prs'] ?? [], 'id');
+        $this->assertContains('RESULT-EN-PARITY-01', $nextPrIds);
+        $this->assertContains('RESULT-EN-PARITY-02', $nextPrIds);
+        $this->assertContains('RESULT-EN-PARITY-03', $nextPrIds);
+
+        $markdown = (string) file_get_contents($markdownPath);
+        $this->assertStringContainsString(
+            'Decision output: `result_en_parity_inventory_completed_ready_for_asset_catalog_fix`',
+            $markdown
+        );
+        $this->assertStringContainsString('does not translate content, modify scoring, mutate CMS, deploy', $markdown);
+        $this->assertStringContainsString('no runtime ownership', $markdown);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T04:09:12.192416+00:00",
+  "updated_at": "2026-05-25T07:35:00+00:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -9992,7 +9992,7 @@
       "depends_on": [
         "SEO-DASH-PROD-00"
       ],
-      "status": "pr_open_github_checks_pending",
+      "status": "merged",
       "train_scope": "production_seo_intel_db_user_migration_runbook",
       "risk_level": "low_docs_contract_no_execution",
       "title": "docs(seo-intel): add production DB migration runbook",
@@ -18687,6 +18687,73 @@
           "at": "2026-05-25T12:51:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1665 for EN-PARITY-01 and pushed branch codex/en-parity-01-url-truth-canonical."
+        }
+      ]
+    },
+    "RESULT-EN-PARITY-00": {
+      "repo": "fap-api",
+      "branch": "codex/result-en-parity-00-assessment-result-content-inventory",
+      "status": "local_validation_passed",
+      "depends_on": [
+        "EN-PARITY-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency_en_parity_00": {
+          "status": "pass",
+          "evidence": "PR #1663 is MERGED and origin/main contains merge commit a95de5c9ff047851336ee1f7c35b2255ac8ba683."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Planned files are limited to RESULT-EN-PARITY-00 report, generated JSON, focused test, and PR-train manifest/state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "Inventory is read-only. No production mutation, CMS mutation, deploy, production migration, URL submission, production user data access, or fap-web commit."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=ResultEnParity00AssessmentResultContentInventoryTest --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json >/dev/null",
+            "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+            "git diff --check",
+            "git diff --name-only origin/main...HEAD"
+          ],
+          "evidence": "Focused test passed with 1 test and 151 assertions. route:list exited 0 with 203 routes. Pint passed 3537 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON, manifest/state parsing, and git diff --check passed."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "title": "Private result runtime pages not accessed",
+          "evidence": "Chrome read-only observation was limited to the public homepage and navigation because result/report/My Results pages require private attempt or account state.",
+          "impact_on_current_pr": "No impact on repo-visible inventory; protected runtime observation remains out of scope without explicit test data."
+        },
+        {
+          "title": "MBTI authoritative content package not repo-visible",
+          "evidence": "MBTI composer roots include external content package locations that are not materialized in this repository snapshot.",
+          "impact_on_current_pr": "Inventory records MBTI backend export as a required follow-up before English parity can be certified."
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-05-25T07:35:00+00:00",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Generated RESULT-EN-PARITY-00 read-only result/report content inventory report, generated JSON, focused test, and authorized manifest/state entry. No translation, runtime logic change, CMS mutation, production mutation, deploy, URL submission, or fap-web commit performed."
+        },
+        {
+          "at": "2026-05-25T07:45:00+00:00",
+          "status": "local_validation_passed",
+          "summary": "RESULT-EN-PARITY-00 focused test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, and diff check passed locally."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -18697,7 +18697,7 @@
       "depends_on": [
         "EN-PARITY-00"
       ],
-      "commit_sha": null,
+      "commit_sha": "bca04819ad8e42c65217cb8f5c51598a47baae18",
       "pr_url": null,
       "checks": {
         "dependency_en_parity_00": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T07:35:00+00:00",
+  "updated_at": "2026-05-25T07:58:00+00:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18693,12 +18693,12 @@
     "RESULT-EN-PARITY-00": {
       "repo": "fap-api",
       "branch": "codex/result-en-parity-00-assessment-result-content-inventory",
-      "status": "local_validation_passed",
+      "status": "pr_open_github_checks_pending",
       "depends_on": [
         "EN-PARITY-00"
       ],
-      "commit_sha": "bca04819ad8e42c65217cb8f5c51598a47baae18",
-      "pr_url": null,
+      "commit_sha": "4a7c701dd232a6778801a2f386222fe7a564bb01",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1666",
       "checks": {
         "dependency_en_parity_00": {
           "status": "pass",
@@ -18726,6 +18726,10 @@
             "git diff --name-only origin/main...HEAD"
           ],
           "evidence": "Focused test passed with 1 test and 151 assertions. route:list exited 0 with 203 routes. Pint passed 3537 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON, manifest/state parsing, and git diff --check passed."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR #1666 is open; GitHub checks are pending."
         }
       },
       "failure_reason": null,
@@ -18754,6 +18758,11 @@
           "at": "2026-05-25T07:45:00+00:00",
           "status": "local_validation_passed",
           "summary": "RESULT-EN-PARITY-00 focused test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, and diff check passed locally."
+        },
+        {
+          "at": "2026-05-25T07:58:00+00:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1666 for RESULT-EN-PARITY-00 result/report content inventory; waiting for GitHub checks. No production mutation, CMS mutation, deploy, URL submission, or fap-web commit performed."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5685,6 +5685,48 @@ prs:
     deploy_allowed: false
     next_task: EN-PARITY-02
 
+  - id: RESULT-EN-PARITY-00
+    repo: fap-api
+    depends_on: [EN-PARITY-00]
+    branch: codex/result-en-parity-00-assessment-result-content-inventory
+    base: main
+    title: "docs(seo-intel): add RESULT-EN-PARITY-00 assessment result inventory"
+    train_scope: assessment_result_report_content_asset_bilingual_inventory
+    risk_level: scan_only_private_result_asset_inventory
+    allowed_paths:
+      - backend/docs/seo/result-en-parity-00-assessment-result-content-inventory.md
+      - backend/docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json
+      - backend/tests/Feature/SeoIntel/ResultEnParity00AssessmentResultContentInventoryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Scan assessment result, report, My Results, PDF, email, and share content asset parity for MBTI, Big Five, Enneagram, EQ, RIASEC, depression screening, depression plus anxiety, and IQ.
+      - Classify backend scoring/result/report catalog authority separately from fap-web presentation labels and fallback content.
+      - Land a generated inventory report, generated JSON artifact, and focused validation test only.
+      - Record missing English asset keys, Chinese leakage risks, PDF/email/share/My Results coverage, claim-boundary coverage, and recommended follow-up PRs.
+    do_not:
+      - Translate result/report content.
+      - Modify result logic, scoring, serializers, renderers, fap-web runtime, CMS content, production data, production secrets, sitemap, llms, Search Channel, or URL submission state.
+      - Mutate production CMS, access protected user data, run production migrations, deploy, or submit URLs.
+      - Commit fap-web changes or treat frontend fallback content as authority.
+    validation:
+      - cd backend && php artisan test --filter=ResultEnParity00AssessmentResultContentInventoryTest --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --name-only origin/main...HEAD
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: false }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    next_task: RESULT-EN-PARITY-01
+
   - id: SEO-DASH-PROD-04B
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed

- Added `RESULT-EN-PARITY-00` read-only assessment result/report bilingual inventory.
- Added generated JSON artifact for backend-authoritative result/report content assets across 8 test families.
- Added a focused Feature test that validates schema, no-mutation flags, covered families, key missing EN asset findings, and recommended next PRs.
- Added authorized PR-train manifest/state entries and reconciled stale `EN-PARITY-00` ledger status after confirming PR #1663 is merged into `origin/main`.

## Why

Public EN/ZH test landing routes do not prove post-submit result/report content has English asset parity. This inventory scans result/report/My Results/PDF/email/share related backend and frontend-reference paths, while preserving the hard authority rule: backend/scoring/CMS/result asset catalog is authority and fap-web fallback is not authority.

## Test families covered

- MBTI
- Big Five / `BIG5_OCEAN`
- Enneagram
- EQ / `EQ_60`
- RIASEC / Holland Career Interest
- Depression Screening / `SDS_20`
- Depression + Anxiety Assessment / `CLINICAL_COMBO_68`
- IQ / `IQ_INTELLIGENCE_QUOTIENT`

## Result/report route inventory

Backend APIs inventoried:

- `POST /api/v0.3/attempts/start`
- `POST /api/v0.3/attempts/submit`
- `POST /api/v0.3/attempts/{id}/email-bind`
- `GET /api/v0.3/attempts/{id}`
- `GET /api/v0.3/attempts/{id}/result`
- `GET /api/v0.3/attempts/{id}/report`
- `GET /api/v0.3/attempts/{id}/report-access`
- `GET /api/v0.3/attempts/{id}/report.pdf`
- `POST|GET /api/v0.3/attempts/{id}/share`
- `GET /api/v0.3/shares/{id}`
- `POST /api/v0.3/results/lookup-by-email`

fap-web reference routes inventoried:

- `/[locale]/result/[id]`
- `/[locale]/attempts/[attemptId]/report`
- `/[locale]/results/lookup`
- `/[locale]/share/[id]`
- `/og/share/[id]`
- `/[locale]/history/mbti`
- `/[locale]/history/big5`
- `/[locale]/history/big5/compare`
- `/[locale]/history/enneagram`
- `/[locale]/history/riasec`

## Backend source inventory

Key backend sources inventoried:

- `ReportComposerRegistry`
- `AttemptReadController`
- `ResultEmailLookupService`
- `ShareService`
- `ReportPdfDocumentService`
- `BigFivePdfDocumentService`
- per-family assessment drivers/scorers
- per-family report composers/public projections/content packs/content assets
- `resources/views/emails/en` and `resources/views/emails/zh`

## Frontend renderer inventory

Reference-only fap-web renderers inventoried:

- `ResultClient`
- `RichResultReport`
- MBTI/Big Five/Enneagram/EQ/RIASEC/IQ result shells
- clinical report client/renderers
- MBTI and Enneagram share summary cards
- PDF download buttons
- result email lookup form

## zh/en asset matrix

- MBTI: backend authoritative content package is not repo-visible; large Chinese frontend clone content exists and is flagged as non-authoritative risk.
- Big Five: v1 compiled rows have zh/en balance, but ResultPageV2 repo-visible backend assets lack EN counterparts.
- Enneagram: registry catalogs are zh-CN only in the repo-visible scan.
- EQ: current repo-visible compiled packs have zh/en parity.
- RIASEC: repo-visible lifecycle/content assets are zh-CN only.
- SDS/depression screening: current repo-visible compiled packs have zh/en parity, but sensitive fallback should fail closed.
- Clinical combo: paid action/performance blocks are missing multiple EN rows.
- IQ: backend report builder uses Chinese dimension labels and lacks locale-safe EN labels.

## Missing English asset keys

Representative missing keys recorded in the JSON/report include:

- `backend_external_content_package_export_required`
- `result_page_v2.route_matrix.en`
- `type_registry.en`
- `content_assets/riasec/*.en.json`
- `clinical_combo_68.paid_action_anxiety_14d.en`
- `clinical_combo_68.paid_perf_cm_mistakes.en`
- `iq.dimensions.visual_spatial_insight.en`
- `iq_pro.pdf_payload.en`

## Chinese leakage risks

- High: MBTI, Big Five ResultPageV2, Enneagram, RIASEC, clinical combo paid sections, IQ.
- Medium: SDS/depression screening due sensitive fallback risk.
- Low current assets but medium future fallback: EQ.

## PDF/email/share/My Results coverage

- PDF services exist, but scanned coverage is largely metadata-style rather than full bilingual report-prose export parity.
- Shared EN/ZH email templates exist; per-family result prose email parity still needs catalog gating.
- ShareService and selected fap-web share renderers exist; sensitive share behavior should remain constrained.
- Public result email lookup currently requires verification and returns an empty list; private helper support excludes SDS/clinical combo.

## Architecture finding

Result/report content is mixed: structured result codes, localized compiled packs, backend content catalogs, backend hardcoded scaffolds, legacy generated fallback copy, and frontend renderer/fallback copy. Several loaders can silently fall through to `zh-CN`; future asset fixes should add fail-closed EN parity gates instead of translating stored Chinese prose at render time.

## Recommended next PRs

- `RESULT-EN-PARITY-01`: backend result/report asset catalog export and fail-closed locale parity gate.
- `RESULT-EN-PARITY-02`: RIASEC English result/report asset catalog.
- `RESULT-EN-PARITY-03`: IQ locale-safe report builder labels.
- `RESULT-EN-PARITY-04`: clinical combo paid section EN parity.
- `RESULT-EN-PARITY-05`: MBTI backend content package export and frontend interpretation de-authoring.
- `RESULT-EN-PARITY-06`: Big Five ResultPageV2 EN asset catalog parity.

## Validation commands

- `cd backend && php artisan test --filter=ResultEnParity00AssessmentResultContentInventoryTest --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load/json.load ... PY`
- `git diff --check`
- `git diff --name-only origin/main...HEAD`

## Intentionally deferred

- No translation implementation.
- No result logic, scoring, serializer, renderer, CMS, production data, production secret, sitemap, llms, or Search Channel change.
- No production mutation, CMS mutation, production migration, deploy, URL submission, protected user-data access, or fap-web commit.

Decision output: `result_en_parity_inventory_completed_ready_for_asset_catalog_fix`
