### PR TITLE
EN-PARITY-02 translation group schema and read model

### DIFF
--- a/backend/app/Services/SeoIntel/TranslationParity/TranslationParityMatrixReadModel.php
+++ b/backend/app/Services/SeoIntel/TranslationParity/TranslationParityMatrixReadModel.php
@@ -1,0 +1,653 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\TranslationParity;
+
+use App\Models\Article;
+use App\Models\CareerGuide;
+use App\Models\ContentPage;
+use App\Models\LandingSurface;
+use App\Models\MediaAsset;
+use App\Models\PersonalityProfile;
+use App\Models\ResearchReport;
+use App\Models\TopicProfile;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+
+final class TranslationParityMatrixReadModel
+{
+    private const TARGET_LOCALES = ['en', 'zh-CN'];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(): array
+    {
+        $rows = [
+            ...$this->contentPageRows(),
+            ...$this->articleRows(),
+            ...$this->careerGuideRows(),
+            ...$this->researchReportRows(),
+            ...$this->topicRows(),
+            ...$this->personalityRows(),
+            ...$this->landingSurfaceRows(),
+            ...$this->mediaAssetRows(),
+            ...$this->configuredPublicSurfaceRows(),
+        ];
+
+        usort($rows, static fn (array $left, array $right): int => [
+            $left['entity_type'],
+            $left['translation_group_id'],
+            $left['locale'],
+            $left['slug'],
+        ] <=> [
+            $right['entity_type'],
+            $right['translation_group_id'],
+            $right['locale'],
+            $right['slug'],
+        ]);
+
+        $groups = $this->groups($rows);
+        $rows = $this->attachCounterparts($rows, $groups);
+        $missing = $this->missingCounterparts($groups);
+
+        return [
+            'schema_version' => 'en-parity-02-translation-group-read-model.v1',
+            'task' => 'EN-PARITY-02',
+            'generated_at' => now()->toIso8601String(),
+            'source_authority' => 'backend_cms_url_truth',
+            'frontend_fallback_authority_used' => false,
+            'cms_mutation_performed' => false,
+            'production_migration_performed' => false,
+            'deploy_performed' => false,
+            'search_channel_action_performed' => false,
+            'target_locales' => self::TARGET_LOCALES,
+            'covered_entity_families' => $this->coveredEntityFamilies(),
+            'summary' => [
+                'row_count' => count($rows),
+                'group_count' => count($groups),
+                'missing_counterpart_count' => count($missing),
+                'counterpart_lookup_uses_slug_guessing_only' => false,
+            ],
+            'rows' => $rows,
+            'missing_counterparts' => $missing,
+            'read_model_contract' => [
+                'required_fields' => [
+                    'entity_type',
+                    'entity_key',
+                    'translation_group_id',
+                    'locale',
+                    'slug',
+                    'canonical_url',
+                    'publication_state',
+                    'source_of_truth',
+                    'counterpart_locale',
+                    'counterpart_canonical_url',
+                    'counterpart_status',
+                ],
+                'pairing_preference_order' => [
+                    'translation_group_id',
+                    'entity_key',
+                    'stable business key such as guide_code/topic_code/surface_key/type_code',
+                    'slug only as a last-resort transitional signal',
+                ],
+            ],
+            'next_task' => 'EN-PARITY-03 content pages EN/ZH parity',
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function contentPageRows(): array
+    {
+        if (! Schema::hasTable('content_pages')) {
+            return [];
+        }
+
+        return ContentPage::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('locale', self::TARGET_LOCALES)
+            ->orderBy('translation_group_id')
+            ->orderBy('locale')
+            ->get()
+            ->map(fn (ContentPage $page): array => $this->row(
+                entityType: 'content_page',
+                entityKey: 'content_page:'.$this->stableString($page->translation_group_id, (string) $page->slug),
+                translationGroupId: $this->stableString($page->translation_group_id, 'content_page:'.$page->id),
+                locale: (string) $page->locale,
+                slug: (string) $page->slug,
+                canonicalUrl: $this->localizedUrl($page->locale, (string) ($page->canonical_path ?: $page->path ?: $page->slug)),
+                publicationState: $this->publicationState($page, ContentPage::STATUS_PUBLISHED),
+                sourceOfTruth: 'content_pages',
+                sourceId: (int) $page->id,
+                sourceUpdatedAt: $page->updated_at,
+            ))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function articleRows(): array
+    {
+        if (! Schema::hasTable('articles')) {
+            return [];
+        }
+
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('locale', self::TARGET_LOCALES)
+            ->whereNull('deleted_at')
+            ->orderBy('translation_group_id')
+            ->orderBy('locale')
+            ->get()
+            ->map(fn (Article $article): array => $this->row(
+                entityType: 'article',
+                entityKey: 'article:'.$this->stableString($article->translation_group_id, (string) $article->slug),
+                translationGroupId: $this->stableString($article->translation_group_id, 'article:'.$article->id),
+                locale: (string) $article->locale,
+                slug: (string) $article->slug,
+                canonicalUrl: $this->localizedUrl($article->locale, '/articles/'.$article->slug),
+                publicationState: $this->publicationState($article, 'published'),
+                sourceOfTruth: 'articles',
+                sourceId: (int) $article->id,
+                sourceUpdatedAt: $article->updated_at,
+            ))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function careerGuideRows(): array
+    {
+        if (! Schema::hasTable('career_guides')) {
+            return [];
+        }
+
+        return CareerGuide::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('locale', self::TARGET_LOCALES)
+            ->orderBy('guide_code')
+            ->orderBy('locale')
+            ->get()
+            ->map(fn (CareerGuide $guide): array => $this->row(
+                entityType: 'career_guide',
+                entityKey: 'career_guide:'.$this->stableString($guide->guide_code, (string) $guide->slug),
+                translationGroupId: 'career_guide:'.$this->stableString($guide->guide_code, (string) $guide->slug),
+                locale: (string) $guide->locale,
+                slug: (string) $guide->slug,
+                canonicalUrl: $this->localizedUrl($guide->locale, '/career/guides/'.$guide->slug),
+                publicationState: $this->publicationState($guide, CareerGuide::STATUS_PUBLISHED),
+                sourceOfTruth: 'career_guides.guide_code',
+                sourceId: (int) $guide->id,
+                sourceUpdatedAt: $guide->updated_at,
+            ))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function researchReportRows(): array
+    {
+        if (! Schema::hasTable('research_reports')) {
+            return [];
+        }
+
+        return ResearchReport::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('locale', self::TARGET_LOCALES)
+            ->orderBy('research_type')
+            ->orderBy('slug')
+            ->orderBy('locale')
+            ->get()
+            ->map(fn (ResearchReport $report): array => $this->row(
+                entityType: 'research_report',
+                entityKey: 'research_report:'.$this->stableString($report->research_type, 'report').':'.$report->slug,
+                translationGroupId: 'research_report:'.$this->stableString($report->research_type, 'report').':'.$report->slug,
+                locale: (string) $report->locale,
+                slug: (string) $report->slug,
+                canonicalUrl: $this->localizedUrl($report->locale, (string) ($report->canonical_path ?: '/research/'.$report->slug)),
+                publicationState: $this->publicationState($report, ResearchReport::STATUS_PUBLISHED),
+                sourceOfTruth: 'research_reports.research_type_slug',
+                sourceId: (int) $report->id,
+                sourceUpdatedAt: $report->updated_at,
+            ))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function topicRows(): array
+    {
+        if (! Schema::hasTable('topic_profiles')) {
+            return [];
+        }
+
+        return TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('locale', self::TARGET_LOCALES)
+            ->orderBy('topic_code')
+            ->orderBy('locale')
+            ->get()
+            ->map(fn (TopicProfile $topic): array => $this->row(
+                entityType: 'topic',
+                entityKey: 'topic:'.$this->stableString($topic->topic_code, (string) $topic->slug),
+                translationGroupId: 'topic:'.$this->stableString($topic->topic_code, (string) $topic->slug),
+                locale: (string) $topic->locale,
+                slug: (string) $topic->slug,
+                canonicalUrl: $this->localizedUrl($topic->locale, '/topics/'.$topic->slug),
+                publicationState: $this->publicationState($topic, TopicProfile::STATUS_PUBLISHED),
+                sourceOfTruth: 'topic_profiles.topic_code',
+                sourceId: (int) $topic->id,
+                sourceUpdatedAt: $topic->updated_at,
+            ))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function personalityRows(): array
+    {
+        if (! Schema::hasTable('personality_profiles')) {
+            return [];
+        }
+
+        return PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('locale', self::TARGET_LOCALES)
+            ->orderBy('scale_code')
+            ->orderBy('canonical_type_code')
+            ->orderBy('locale')
+            ->get()
+            ->map(fn (PersonalityProfile $profile): array => $this->row(
+                entityType: 'personality',
+                entityKey: 'personality:'.strtolower((string) $profile->scale_code).':'.strtolower((string) $profile->canonical_type_code),
+                translationGroupId: 'personality:'.strtolower((string) $profile->scale_code).':'.strtolower((string) $profile->canonical_type_code),
+                locale: (string) $profile->locale,
+                slug: (string) $profile->slug,
+                canonicalUrl: $this->localizedUrl($profile->locale, '/personality/'.$profile->slug),
+                publicationState: $this->publicationState($profile, 'published'),
+                sourceOfTruth: 'personality_profiles.scale_code_canonical_type_code',
+                sourceId: (int) $profile->id,
+                sourceUpdatedAt: $profile->updated_at,
+            ))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function landingSurfaceRows(): array
+    {
+        if (! Schema::hasTable('landing_surfaces')) {
+            return [];
+        }
+
+        return LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('locale', self::TARGET_LOCALES)
+            ->orderBy('surface_key')
+            ->orderBy('locale')
+            ->get()
+            ->map(fn (LandingSurface $surface): array => $this->row(
+                entityType: 'landing_surface',
+                entityKey: 'landing_surface:'.$this->stableString($surface->surface_key, (string) $surface->id),
+                translationGroupId: 'landing_surface:'.$this->stableString($surface->surface_key, (string) $surface->id),
+                locale: (string) $surface->locale,
+                slug: (string) $surface->surface_key,
+                canonicalUrl: $this->surfaceUrl((string) $surface->locale, (string) $surface->surface_key),
+                publicationState: $this->publicationState($surface, LandingSurface::STATUS_PUBLISHED),
+                sourceOfTruth: 'landing_surfaces.surface_key',
+                sourceId: (int) $surface->id,
+                sourceUpdatedAt: $surface->updated_at,
+            ))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function mediaAssetRows(): array
+    {
+        if (! Schema::hasTable('media_assets')) {
+            return [];
+        }
+
+        return MediaAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->orderBy('asset_key')
+            ->get()
+            ->map(function (MediaAsset $asset): array {
+                $payload = is_array($asset->payload_json) ? $asset->payload_json : [];
+                $locale = $this->normalizeLocale((string) ($payload['locale'] ?? 'und'));
+                $variantGroup = $this->stableString(
+                    $payload['locale_variant_group_id'] ?? null,
+                    (string) $asset->asset_key
+                );
+
+                return $this->row(
+                    entityType: 'media_asset',
+                    entityKey: 'media_asset:'.$variantGroup,
+                    translationGroupId: 'media_asset:'.$variantGroup,
+                    locale: $locale,
+                    slug: (string) $asset->asset_key,
+                    canonicalUrl: (string) ($asset->url ?? ''),
+                    publicationState: $this->publicationState($asset, MediaAsset::STATUS_PUBLISHED),
+                    sourceOfTruth: 'media_assets.asset_key_payload_locale_variant_group_id',
+                    sourceId: (int) $asset->id,
+                    sourceUpdatedAt: $asset->updated_at,
+                );
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function configuredPublicSurfaceRows(): array
+    {
+        $rows = [];
+        $candidates = config('seo_intel.url_truth_inventory.backend_authority_canary_candidates', []);
+        if (! is_array($candidates)) {
+            return [];
+        }
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $entityType = (string) ($candidate['page_entity_type'] ?? '');
+            $entityId = (string) ($candidate['entity_id_or_slug'] ?? '');
+            $locale = (string) ($candidate['locale'] ?? '');
+            $path = (string) ($candidate['path'] ?? '');
+            if ($entityType === '' || $entityId === '' || $locale === '' || $path === '') {
+                continue;
+            }
+
+            $rows[] = $this->row(
+                entityType: $entityType,
+                entityKey: $entityType.':'.$entityId,
+                translationGroupId: $this->configuredTranslationGroupId($entityType, $entityId),
+                locale: $locale,
+                slug: $entityId,
+                canonicalUrl: $this->absoluteUrl($path),
+                publicationState: 'published_contract',
+                sourceOfTruth: 'seo_intel.backend_authority_canary_candidates',
+                sourceId: null,
+                sourceUpdatedAt: null,
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string, mixed>  $groups
+     * @return list<array<string, mixed>>
+     */
+    private function attachCounterparts(array $rows, array $groups): array
+    {
+        return array_map(function (array $row) use ($groups): array {
+            $counterpartLocale = $row['locale'] === 'en' ? 'zh-CN' : 'en';
+            $group = $groups[$row['entity_type'].'|'.$row['translation_group_id']] ?? [];
+            $counterpart = $group[$counterpartLocale] ?? null;
+
+            $row['counterpart_locale'] = $counterpartLocale;
+            $row['counterpart_canonical_url'] = is_array($counterpart) ? ($counterpart['canonical_url'] ?? null) : null;
+            $row['counterpart_status'] = is_array($counterpart)
+                ? (string) ($counterpart['publication_state'] ?? 'present')
+                : 'missing';
+
+            return $row;
+        }, $rows);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private function groups(array $rows): array
+    {
+        $groups = [];
+        foreach ($rows as $row) {
+            $key = $row['entity_type'].'|'.$row['translation_group_id'];
+            $groups[$key][$row['locale']] = $row;
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @param  array<string, array<string, array<string, mixed>>>  $groups
+     * @return list<array<string, mixed>>
+     */
+    private function missingCounterparts(array $groups): array
+    {
+        $missing = [];
+        foreach ($groups as $key => $localizedRows) {
+            [$entityType, $translationGroupId] = explode('|', $key, 2);
+            foreach (self::TARGET_LOCALES as $locale) {
+                if (isset($localizedRows[$locale])) {
+                    continue;
+                }
+
+                $source = $localizedRows[$locale === 'en' ? 'zh-CN' : 'en'] ?? reset($localizedRows);
+                if (! is_array($source)) {
+                    continue;
+                }
+
+                $missing[] = [
+                    'entity_type' => $entityType,
+                    'translation_group_id' => $translationGroupId,
+                    'missing_locale' => $locale,
+                    'source_locale' => $source['locale'] ?? null,
+                    'source_slug' => $source['slug'] ?? null,
+                    'source_of_truth' => $source['source_of_truth'] ?? null,
+                    'classification' => 'missing_counterpart_explicit',
+                ];
+            }
+        }
+
+        usort($missing, static fn (array $left, array $right): int => [
+            $left['entity_type'],
+            $left['translation_group_id'],
+            $left['missing_locale'],
+        ] <=> [
+            $right['entity_type'],
+            $right['translation_group_id'],
+            $right['missing_locale'],
+        ]);
+
+        return $missing;
+    }
+
+    private function row(
+        string $entityType,
+        string $entityKey,
+        string $translationGroupId,
+        string $locale,
+        string $slug,
+        ?string $canonicalUrl,
+        string $publicationState,
+        string $sourceOfTruth,
+        ?int $sourceId,
+        mixed $sourceUpdatedAt,
+    ): array {
+        return [
+            'entity_type' => $entityType,
+            'entity_key' => $entityKey,
+            'translation_group_id' => $translationGroupId,
+            'locale' => $this->normalizeLocale($locale),
+            'slug' => $slug,
+            'canonical_url' => $canonicalUrl,
+            'publication_state' => $publicationState,
+            'source_of_truth' => $sourceOfTruth,
+            'source_id' => $sourceId,
+            'source_updated_at' => $sourceUpdatedAt instanceof Carbon ? $sourceUpdatedAt->toIso8601String() : null,
+        ];
+    }
+
+    private function publicationState(Model $model, string $publishedStatus): string
+    {
+        $status = trim((string) ($model->getAttribute('status') ?? ''));
+        $isPublic = (bool) ($model->getAttribute('is_public') ?? false);
+        $isIndexable = (bool) ($model->getAttribute('is_indexable') ?? true);
+        $publishedAt = $model->getAttribute('published_at');
+        $isPublishedAtReady = ! $publishedAt instanceof Carbon || $publishedAt->lessThanOrEqualTo(now());
+
+        if ($status === $publishedStatus && $isPublic && $isIndexable && $isPublishedAtReady) {
+            return 'published_indexable';
+        }
+
+        return $status !== '' ? $status : 'unknown';
+    }
+
+    private function configuredTranslationGroupId(string $entityType, string $entityId): string
+    {
+        if (str_starts_with($entityId, $entityType.':')) {
+            return $entityId;
+        }
+
+        if ($entityType === 'home' && str_starts_with($entityId, 'home:')) {
+            return 'home';
+        }
+
+        if ($entityType === 'test_hub' && str_starts_with($entityId, 'test_hub:')) {
+            return 'test_hub';
+        }
+
+        return $entityType.':'.$entityId;
+    }
+
+    private function surfaceUrl(string $locale, string $surfaceKey): string
+    {
+        return match ($surfaceKey) {
+            'home' => $this->localizedUrl($locale, '/'),
+            'tests' => $this->localizedUrl($locale, '/tests'),
+            default => $this->localizedUrl($locale, '/'.$surfaceKey),
+        };
+    }
+
+    private function localizedUrl(string $locale, string $path): string
+    {
+        $path = '/'.ltrim($path, '/');
+        $locale = $this->normalizeLocale($locale);
+
+        if (preg_match('#^/(en|zh)(?:/|$)#', $path) === 1) {
+            return $this->absoluteUrl($path);
+        }
+
+        if ($path === '/') {
+            return $locale === 'zh-CN'
+                ? $this->absoluteUrl('/')
+                : $this->absoluteUrl('/en');
+        }
+
+        return $this->absoluteUrl('/'.$this->localeSegment($locale).$path);
+    }
+
+    private function absoluteUrl(string $path): string
+    {
+        $baseUrl = rtrim((string) config('seo_intel.public_canonical_host', 'https://fermatmind.com'), '/');
+        if ($baseUrl === '') {
+            $baseUrl = 'https://fermatmind.com';
+        }
+
+        return $baseUrl.'/'.ltrim($path, '/');
+    }
+
+    private function localeSegment(string $locale): string
+    {
+        return $this->normalizeLocale($locale) === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $locale = trim($locale);
+        if (in_array($locale, ['zh', 'zh-CN', 'zh-Hans'], true)) {
+            return 'zh-CN';
+        }
+
+        if ($locale === 'en') {
+            return 'en';
+        }
+
+        return $locale !== '' ? $locale : 'und';
+    }
+
+    private function stableString(mixed $preferred, string $fallback): string
+    {
+        $value = trim((string) $preferred);
+
+        return $value !== '' ? $value : $fallback;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function coveredEntityFamilies(): array
+    {
+        return [
+            'content_pages' => [
+                'entity_type' => 'content_page',
+                'authority_key' => 'translation_group_id',
+            ],
+            'articles' => [
+                'entity_type' => 'article',
+                'authority_key' => 'translation_group_id',
+            ],
+            'career_guides' => [
+                'entity_type' => 'career_guide',
+                'authority_key' => 'guide_code',
+            ],
+            'research_reports' => [
+                'entity_type' => 'research_report',
+                'authority_key' => 'research_type + slug',
+            ],
+            'topics' => [
+                'entity_type' => 'topic',
+                'authority_key' => 'topic_code',
+            ],
+            'personality' => [
+                'entity_type' => 'personality',
+                'authority_key' => 'scale_code + canonical_type_code',
+            ],
+            'tests' => [
+                'entity_type' => 'test_detail',
+                'authority_key' => 'scale_catalog primary slug',
+            ],
+            'landing_surfaces_page_blocks' => [
+                'entity_type' => 'landing_surface',
+                'authority_key' => 'surface_key',
+            ],
+            'media_assets' => [
+                'entity_type' => 'media_asset',
+                'authority_key' => 'asset_key + payload.locale_variant_group_id',
+            ],
+        ];
+    }
+}

--- a/backend/docs/seo/en-parity-02-translation-group-read-model.md
+++ b/backend/docs/seo/en-parity-02-translation-group-read-model.md
@@ -1,0 +1,78 @@
+# EN-PARITY-02 Translation Group Schema And Read Model
+
+## Decision
+
+EN-PARITY-02 adds a backend-owned bilingual parity read model for EN/ZH counterpart discovery. It does not generate English prose, publish content, mutate production CMS, run production migrations, deploy, or submit URLs.
+
+The read model lives at `App\Services\SeoIntel\TranslationParity\TranslationParityMatrixReadModel` and emits a matrix with:
+
+- `entity_type`
+- `entity_key`
+- `translation_group_id` or stable equivalent
+- `locale`
+- `slug`
+- `canonical_url`
+- `publication_state`
+- `source_of_truth`
+- `counterpart_locale`
+- `counterpart_canonical_url`
+- `counterpart_status`
+
+## Authority Rules
+
+Backend/CMS/URL Truth remains the authority. fap-web fallback, sitemap, llms, and runtime observation are not accepted as content or counterpart authority.
+
+Counterpart lookup preference:
+
+1. `translation_group_id`
+2. `entity_key`
+3. Stable backend business keys such as `guide_code`, `topic_code`, `surface_key`, or `scale_code + canonical_type_code`
+4. Slug only as a transitional last-resort signal
+
+## Entity Coverage
+
+The read model covers:
+
+- `content_pages`
+- `articles`
+- `career_guides`
+- `research_reports`
+- `topics`
+- `personality`
+- `tests`
+- `landing_surfaces / page_blocks`
+- `media_assets`
+
+Missing counterparts are explicit matrix findings. They are not hidden behind frontend fallback and are not forced to `200`.
+
+## Content Generation Boundary
+
+The remaining EN-PARITY content tasks must respect the additional control rule:
+
+- EN-PARITY-03 content pages: contract/import package first unless page authority already exists.
+- EN-PARITY-04 articles: no mass generation of all missing English articles in one PR.
+- EN-PARITY-05 career guides: no mass generation of all English career guide details in one PR.
+- Drafts, placeholders, fallback-only pages, noindex/private pages, 404s, soft 404s, and missing-authority pages must not enter sitemap or llms.
+
+## Validation
+
+Focused validation:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=EnParity02 --no-ansi
+APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd /Users/rainie/Desktop/GitHub/fap-api
+python3 -m json.tool backend/docs/seo/generated/en-parity-02-translation-group-read-model.v1.json >/dev/null
+python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+git diff --check
+```
+
+## Next Task
+
+EN-PARITY-03 content pages EN/ZH parity.

--- a/backend/docs/seo/generated/en-parity-02-translation-group-read-model.v1.json
+++ b/backend/docs/seo/generated/en-parity-02-translation-group-read-model.v1.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": "en-parity-02-translation-group-read-model.v1",
+  "task": "EN-PARITY-02",
+  "source_authority": "backend_cms_url_truth",
+  "frontend_fallback_authority_used": false,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "content_generation_performed": false,
+  "target_locales": [
+    "en",
+    "zh-CN"
+  ],
+  "read_model": {
+    "service": "App\\Services\\SeoIntel\\TranslationParity\\TranslationParityMatrixReadModel",
+    "output_schema": {
+      "entity_type": "string",
+      "entity_key": "stable backend authority key, not frontend fallback",
+      "translation_group_id": "translation group id or stable equivalent",
+      "locale": "en | zh-CN",
+      "slug": "backend/CMS slug or stable public key",
+      "canonical_url": "public canonical URL when available",
+      "publication_state": "published_indexable | draft | archived | unknown | explicit state",
+      "source_of_truth": "backend table/config field that owns the row",
+      "counterpart_locale": "opposite target locale",
+      "counterpart_canonical_url": "counterpart canonical URL or null",
+      "counterpart_status": "counterpart publication state or missing"
+    },
+    "counterpart_lookup_uses_slug_guessing_only": false,
+    "pairing_preference_order": [
+      "translation_group_id",
+      "entity_key",
+      "stable business key such as guide_code/topic_code/surface_key/type_code",
+      "slug only as a last-resort transitional signal"
+    ]
+  },
+  "covered_entity_families": {
+    "content_pages": {
+      "entity_type": "content_page",
+      "authority_key": "translation_group_id",
+      "next_content_task": "EN-PARITY-03"
+    },
+    "articles": {
+      "entity_type": "article",
+      "authority_key": "translation_group_id",
+      "next_content_task": "EN-PARITY-04"
+    },
+    "career_guides": {
+      "entity_type": "career_guide",
+      "authority_key": "guide_code",
+      "next_content_task": "EN-PARITY-05"
+    },
+    "research_reports": {
+      "entity_type": "research_report",
+      "authority_key": "research_type + slug"
+    },
+    "topics": {
+      "entity_type": "topic",
+      "authority_key": "topic_code"
+    },
+    "personality": {
+      "entity_type": "personality",
+      "authority_key": "scale_code + canonical_type_code"
+    },
+    "tests": {
+      "entity_type": "test_detail",
+      "authority_key": "scale_catalog primary slug"
+    },
+    "landing_surfaces_page_blocks": {
+      "entity_type": "landing_surface",
+      "authority_key": "surface_key"
+    },
+    "media_assets": {
+      "entity_type": "media_asset",
+      "authority_key": "asset_key + payload.locale_variant_group_id",
+      "next_content_task": "EN-PARITY-06"
+    }
+  },
+  "content_generation_policy": {
+    "auto_publish_allowed": false,
+    "mass_english_generation_allowed": false,
+    "content_pages": "contract/import package first unless page authority already exists",
+    "articles": "inventory/draft package or first small batch only",
+    "career_guides": "inventory/template/import package or first small batch only",
+    "draft_exposure_allowed_in_sitemap_llms": false
+  },
+  "acceptance_contract": {
+    "missing_counterparts_are_explicit": true,
+    "slug_mismatch_can_pair_when_translation_group_exists": true,
+    "frontend_fallback_can_never_satisfy_counterpart": true,
+    "production_migration_required": false,
+    "production_cms_mutation_required": false
+  },
+  "sample_matrix_expectations": [
+    {
+      "entity_type": "content_page",
+      "source_of_truth": "content_pages",
+      "pairing_key": "translation_group_id",
+      "slug_mismatch_expected_to_pair": true
+    },
+    {
+      "entity_type": "article",
+      "source_of_truth": "articles",
+      "pairing_key": "translation_group_id",
+      "slug_mismatch_expected_to_pair": true
+    },
+    {
+      "entity_type": "career_guide",
+      "source_of_truth": "career_guides.guide_code",
+      "pairing_key": "guide_code",
+      "slug_mismatch_expected_to_pair": true
+    }
+  ],
+  "deferred_items": [
+    {
+      "id": "en_parity_03_content_import_package",
+      "reason": "Substantial English prose must be handled as authority-backed import package, small reviewed batch, or explicit deferral."
+    },
+    {
+      "id": "en_parity_04_article_draft_batch_control",
+      "reason": "Missing English article counterparts must not be mass-generated or auto-published in one PR."
+    },
+    {
+      "id": "en_parity_05_career_guide_draft_batch_control",
+      "reason": "Missing English career guide details must not be mass-generated or auto-published in one PR."
+    }
+  ],
+  "next_task": "EN-PARITY-03 content pages EN/ZH parity"
+}

--- a/backend/tests/Feature/SeoIntel/EnParity02TranslationGroupReadModelTest.php
+++ b/backend/tests/Feature/SeoIntel/EnParity02TranslationGroupReadModelTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\CareerGuide;
+use App\Models\ContentPage;
+use App\Services\SeoIntel\TranslationParity\TranslationParityMatrixReadModel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class EnParity02TranslationGroupReadModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function generated_artifact_records_read_model_contract_and_content_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/en-parity-02-translation-group-read-model.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('en-parity-02-translation-group-read-model.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('EN-PARITY-02', $payload['task'] ?? null);
+        $this->assertSame('backend_cms_url_truth', $payload['source_authority'] ?? null);
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['content_generation_performed'] ?? true));
+        $this->assertFalse((bool) data_get($payload, 'content_generation_policy.auto_publish_allowed'));
+        $this->assertFalse((bool) data_get($payload, 'content_generation_policy.mass_english_generation_allowed'));
+        $this->assertTrue((bool) data_get($payload, 'acceptance_contract.slug_mismatch_can_pair_when_translation_group_exists'));
+        $this->assertContains('translation_group_id', data_get($payload, 'read_model.pairing_preference_order', []));
+
+        foreach ([
+            'content_pages',
+            'articles',
+            'career_guides',
+            'research_reports',
+            'topics',
+            'personality',
+            'tests',
+            'landing_surfaces_page_blocks',
+            'media_assets',
+        ] as $family) {
+            $this->assertArrayHasKey($family, $payload['covered_entity_families'] ?? []);
+        }
+
+        $this->assertSame('EN-PARITY-03 content pages EN/ZH parity', $payload['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function read_model_pairs_content_pages_by_translation_group_not_slug_guessing(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+
+        $this->createContentPage([
+            'slug' => 'about',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'content-page-about-group',
+            'translation_status' => ContentPage::TRANSLATION_STATUS_SOURCE,
+            'source_locale' => 'zh-CN',
+            'canonical_path' => '/about',
+            'title' => '关于费马测试',
+        ]);
+        $this->createContentPage([
+            'slug' => 'about-fermatmind',
+            'locale' => 'en',
+            'translation_group_id' => 'content-page-about-group',
+            'translation_status' => ContentPage::TRANSLATION_STATUS_PUBLISHED,
+            'source_locale' => 'zh-CN',
+            'canonical_path' => '/en/about',
+            'title' => 'About FermatMind',
+        ]);
+
+        $rows = app(TranslationParityMatrixReadModel::class)->build()['rows'];
+        $aboutRows = collect($rows)
+            ->where('entity_type', 'content_page')
+            ->where('translation_group_id', 'content-page-about-group')
+            ->values();
+
+        $this->assertCount(2, $aboutRows);
+
+        $zh = $aboutRows->firstWhere('locale', 'zh-CN');
+        $en = $aboutRows->firstWhere('locale', 'en');
+
+        $this->assertSame('about', $zh['slug'] ?? null);
+        $this->assertSame('about-fermatmind', $en['slug'] ?? null);
+        $this->assertSame('https://fermatmind.com/en/about', $zh['counterpart_canonical_url'] ?? null);
+        $this->assertSame('https://fermatmind.com/zh/about', $en['counterpart_canonical_url'] ?? null);
+        $this->assertSame('published_indexable', $zh['counterpart_status'] ?? null);
+        $this->assertSame('published_indexable', $en['counterpart_status'] ?? null);
+    }
+
+    #[Test]
+    public function read_model_pairs_articles_by_translation_group_when_slugs_differ(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+
+        $this->createArticle([
+            'slug' => 'mbti-basics',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'article-mbti-basics-group',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'source_locale' => 'zh-CN',
+            'title' => 'MBTI 基础',
+        ]);
+        $this->createArticle([
+            'slug' => 'mbti-basics-guide',
+            'locale' => 'en',
+            'translation_group_id' => 'article-mbti-basics-group',
+            'translation_status' => Article::TRANSLATION_STATUS_PUBLISHED,
+            'source_locale' => 'zh-CN',
+            'title' => 'MBTI Basics Guide',
+        ]);
+
+        $rows = app(TranslationParityMatrixReadModel::class)->build()['rows'];
+        $articleRows = collect($rows)
+            ->where('entity_type', 'article')
+            ->where('translation_group_id', 'article-mbti-basics-group')
+            ->values();
+
+        $this->assertCount(2, $articleRows);
+        $this->assertSame(
+            'https://fermatmind.com/en/articles/mbti-basics-guide',
+            $articleRows->firstWhere('locale', 'zh-CN')['counterpart_canonical_url'] ?? null
+        );
+        $this->assertSame(
+            'https://fermatmind.com/zh/articles/mbti-basics',
+            $articleRows->firstWhere('locale', 'en')['counterpart_canonical_url'] ?? null
+        );
+    }
+
+    #[Test]
+    public function missing_counterparts_are_explicit_and_backend_authority_backed(): void
+    {
+        $this->createCareerGuide([
+            'guide_code' => 'salary-negotiation-framework',
+            'slug' => 'salary-negotiation-framework',
+            'locale' => 'zh-CN',
+            'title' => '薪资沟通框架',
+        ]);
+
+        $matrix = app(TranslationParityMatrixReadModel::class)->build();
+        $missing = collect($matrix['missing_counterparts'])
+            ->firstWhere('translation_group_id', 'career_guide:salary-negotiation-framework');
+
+        $this->assertIsArray($missing);
+        $this->assertSame('career_guide', $missing['entity_type'] ?? null);
+        $this->assertSame('en', $missing['missing_locale'] ?? null);
+        $this->assertSame('zh-CN', $missing['source_locale'] ?? null);
+        $this->assertSame('career_guides.guide_code', $missing['source_of_truth'] ?? null);
+        $this->assertSame('missing_counterpart_explicit', $missing['classification'] ?? null);
+        $this->assertFalse((bool) ($matrix['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($matrix['summary']['counterpart_lookup_uses_slug_guessing_only'] ?? true));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createContentPage(array $overrides = []): ContentPage
+    {
+        return ContentPage::query()->create($overrides + [
+            'org_id' => 0,
+            'slug' => 'about',
+            'path' => '/about',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'about',
+            'title' => 'About FermatMind',
+            'summary' => 'Authority-backed content page.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'en',
+            'translation_group_id' => 'content-page-about',
+            'source_locale' => 'zh-CN',
+            'translation_status' => ContentPage::TRANSLATION_STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'review_state' => 'approved',
+            'content_md' => '## Overview'.PHP_EOL.'Authority-backed body.',
+            'content_html' => '',
+            'seo_title' => 'About FermatMind',
+            'seo_description' => 'Authority-backed content page.',
+            'meta_description' => 'Authority-backed content page.',
+            'canonical_path' => '/en/about',
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createArticle(array $overrides = []): Article
+    {
+        return Article::query()->create($overrides + [
+            'org_id' => 0,
+            'slug' => 'mbti-basics',
+            'locale' => 'en',
+            'translation_group_id' => 'article-mbti-basics',
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_PUBLISHED,
+            'title' => 'MBTI Basics',
+            'excerpt' => 'A bounded guide.',
+            'content_md' => '## Overview'.PHP_EOL.'Non-diagnostic educational content.',
+            'content_html' => '',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createCareerGuide(array $overrides = []): CareerGuide
+    {
+        return CareerGuide::query()->create($overrides + [
+            'org_id' => 0,
+            'guide_code' => 'salary-negotiation-framework',
+            'slug' => 'salary-negotiation-framework',
+            'locale' => 'zh-CN',
+            'title' => '薪资沟通框架',
+            'excerpt' => '职业方向参考。',
+            'category_slug' => 'career-growth',
+            'body_md' => '## Overview'.PHP_EOL.'方向性建议。',
+            'body_html' => '',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 10,
+            'published_at' => now()->subDay(),
+            'schema_version' => 'v1',
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -712,6 +712,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_translation_parity_read_model_files(): void
+    {
+        $changed = [
+            'backend/app/Services/SeoIntel/TranslationParity/TranslationParityMatrixReadModel.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_chinese_claim_linter_runtime_files(): void
     {
         $changed = [
@@ -2161,6 +2170,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isTranslationParityReadModelFile($file)) {
+                continue;
+            }
+
             if ($this->isChineseClaimLinterRuntimeFile($file)) {
                 continue;
             }
@@ -2914,6 +2927,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/SeoIntelInternalLinkGraphCommand.php',
             'backend/app/Services/SeoIntel/InternalLink/InternalLinkGraphDryRun.php',
         ], true);
+    }
+
+    private function isTranslationParityReadModelFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/SeoIntel/TranslationParity/TranslationParityMatrixReadModel.php';
     }
 
     private function isChineseClaimLinterRuntimeFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T13:34:00+08:00",
+  "updated_at": "2026-05-25T13:53:01+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18924,7 +18924,7 @@
       "depends_on": [
         "EN-PARITY-01"
       ],
-      "commit_sha": "5a37feb01672bdb2bc2e4b8c8f9e525817d4cc22",
+      "commit_sha": "00ea3405",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1667",
       "checks": {
         "dependency_en_parity_01": {
@@ -18962,7 +18962,7 @@
         },
         "github_required_checks": {
           "status": "pending_after_rebase",
-          "evidence": "PR #1667 was rebased onto origin/main after resolving docs/codex/pr-train-state.json conflict; GitHub checks must rerun on the rebased head."
+          "evidence": "PR #1667 was rebased onto origin/main after PR #1669 merged; GitHub checks must rerun on the rebased head."
         }
       },
       "failure_reason": null,
@@ -18995,6 +18995,11 @@
           "at": "2026-05-25T13:34:00+08:00",
           "status": "rebased_conflict_resolved_pending_push",
           "summary": "Rebased EN-PARITY-02 onto origin/main after PR #1668 merged. Resolved pr-train-state ledger by preserving EN-PARITY-01, RESULT-EN-PARITY-00, RESULT-EN-PARITY-01 merged states and EN-PARITY-02 current PR state."
+        },
+        {
+          "at": "2026-05-25T13:53:01+08:00",
+          "status": "rebased_conflict_resolved_pending_push",
+          "summary": "Rebased EN-PARITY-02 onto origin/main after PR #1669 merged. Resolved pr-train-state ledger by preserving current main entries, including RESULT-EN-PARITY-02, and keeping EN-PARITY-02 current PR state."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T13:32:00+08:00",
+  "updated_at": "2026-05-25T13:34:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18920,11 +18920,11 @@
     "EN-PARITY-02": {
       "repo": "fap-api",
       "branch": "codex/en-parity-02-translation-groups",
-      "status": "pr_open_github_checks_pending",
+      "status": "pr_open_rebased_github_checks_pending",
       "depends_on": [
         "EN-PARITY-01"
       ],
-      "commit_sha": "e9690fa4bd54ebc6f3f6519547671cef55a43127",
+      "commit_sha": "5a37feb01672bdb2bc2e4b8c8f9e525817d4cc22",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1667",
       "checks": {
         "dependency_en_parity_01": {
@@ -18932,8 +18932,8 @@
           "evidence": "PR #1665 is MERGED and origin/main contains merge commit d938a2a27cb0184222b87a21035daf274e3ce107."
         },
         "scope_boundary": {
-          "status": "pass_pending_commit",
-          "evidence": "Changed files are limited to translation parity read model, EN-PARITY-02 docs/generated/test, and PR-train manifest/state."
+          "status": "pass",
+          "evidence": "Changed files are limited to translation parity read model, EN-PARITY-02 docs/generated/test, runtime-freeze allowlist evidence, and PR-train manifest/state."
         },
         "production_safety": {
           "status": "pass",
@@ -18961,8 +18961,8 @@
           "evidence": "Focused EN-PARITY-02 test passed with 4 tests and 42 assertions. SQLite pretend migration, route:list, Pint, composer validate, composer audit, ci_verify_mbti, generated JSON parse, manifest/state parse, and diff checks passed."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR #1667 is open; GitHub checks pending."
+          "status": "pending_after_rebase",
+          "evidence": "PR #1667 was rebased onto origin/main after resolving docs/codex/pr-train-state.json conflict; GitHub checks must rerun on the rebased head."
         }
       },
       "failure_reason": null,
@@ -18990,6 +18990,11 @@
           "at": "2026-05-25T13:32:00+08:00",
           "status": "ledger_rebase_conflict_resolved",
           "summary": "Resolved docs/codex/pr-train-state.json against origin/main by preserving RESULT-EN-PARITY-01 merged state and adding EN-PARITY-02 state without overwriting unrelated train entries."
+        },
+        {
+          "at": "2026-05-25T13:34:00+08:00",
+          "status": "rebased_conflict_resolved_pending_push",
+          "summary": "Rebased EN-PARITY-02 onto origin/main after PR #1668 merged. Resolved pr-train-state ledger by preserving EN-PARITY-01, RESULT-EN-PARITY-00, RESULT-EN-PARITY-01 merged states and EN-PARITY-02 current PR state."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T08:55:00+00:00",
+  "updated_at": "2026-05-25T13:32:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18914,6 +18914,82 @@
           "at": "2026-05-25T06:30:00Z",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1669 for RESULT-EN-PARITY-02 RIASEC English asset catalog; waiting for GitHub checks."
+        }
+      ]
+    },
+    "EN-PARITY-02": {
+      "repo": "fap-api",
+      "branch": "codex/en-parity-02-translation-groups",
+      "status": "pr_open_github_checks_pending",
+      "depends_on": [
+        "EN-PARITY-01"
+      ],
+      "commit_sha": "e9690fa4bd54ebc6f3f6519547671cef55a43127",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1667",
+      "checks": {
+        "dependency_en_parity_01": {
+          "status": "pass",
+          "evidence": "PR #1665 is MERGED and origin/main contains merge commit d938a2a27cb0184222b87a21035daf274e3ce107."
+        },
+        "scope_boundary": {
+          "status": "pass_pending_commit",
+          "evidence": "Changed files are limited to translation parity read model, EN-PARITY-02 docs/generated/test, and PR-train manifest/state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "Read model and tests only. No production mutation, CMS mutation, deploy, production migration, URL submission, or fap-web commit."
+        },
+        "content_generation_boundary": {
+          "status": "pass",
+          "evidence": "EN-PARITY-02 does not create English prose and records controls for EN-PARITY-03/04/05."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=EnParity02 --no-ansi",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "cd backend && bash scripts/ci_verify_mbti.sh",
+            "python3 -m json.tool backend/docs/seo/generated/en-parity-02-translation-group-read-model.v1.json >/dev/null",
+            "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "Focused EN-PARITY-02 test passed with 4 tests and 42 assertions. SQLite pretend migration, route:list, Pint, composer validate, composer audit, ci_verify_mbti, generated JSON parse, manifest/state parse, and diff checks passed."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR #1667 is open; GitHub checks pending."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "events": [
+        {
+          "at": "2026-05-25T05:01:32Z",
+          "status": "started",
+          "summary": "Started EN-PARITY-02 from latest fap-api main after verifying EN-PARITY-01 landed and reconciling merged ledger state."
+        },
+        {
+          "at": "2026-05-25T05:06:11Z",
+          "status": "local_validation_passed",
+          "summary": "Focused EN-PARITY-02 validation and backend common checks passed. No content generation, CMS mutation, production migration, deploy, URL submission, or fap-web commit performed."
+        },
+        {
+          "at": "2026-05-25T05:07:44Z",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1667 for EN-PARITY-02 translation group read model; waiting for GitHub checks."
+        },
+        {
+          "at": "2026-05-25T13:32:00+08:00",
+          "status": "ledger_rebase_conflict_resolved",
+          "summary": "Resolved docs/codex/pr-train-state.json against origin/main by preserving RESULT-EN-PARITY-01 merged state and adding EN-PARITY-02 state without overwriting unrelated train entries."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5685,6 +5685,54 @@ prs:
     deploy_allowed: false
     next_task: EN-PARITY-02
 
+  - id: EN-PARITY-02
+    repo: fap-api
+    depends_on: [EN-PARITY-01]
+    branch: codex/en-parity-02-translation-groups
+    base: main
+    title: "EN-PARITY-02 translation group schema and read model"
+    train_scope: en_parity_translation_group_read_model
+    risk_level: p0_seo_authority_read_model
+    allowed_paths:
+      - backend/app/Services/SeoIntel/TranslationParity/TranslationParityMatrixReadModel.php
+      - backend/docs/seo/en-parity-02-translation-group-read-model.md
+      - backend/docs/seo/generated/en-parity-02-translation-group-read-model.v1.json
+      - backend/tests/Feature/SeoIntel/EnParity02TranslationGroupReadModelTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add a backend-owned EN/ZH translation parity read model that emits entity_type, entity_key, translation_group_id or stable equivalent, locale, slug, canonical_url, publication_state, source_of_truth, and counterpart fields.
+      - Cover content_pages, articles, career_guides, research_reports, topics, personality, tests, landing_surfaces/page_blocks, and media_assets.
+      - Prove counterpart lookup can pair slug-mismatched rows through translation_group_id or stable backend business keys instead of frontend fallback or slug-only guessing.
+      - Keep missing counterparts explicit and do not force missing EN/ZH counterparts to public 200 pages.
+      - Record the content-generation control boundary for EN-PARITY-03/04/05.
+    do_not:
+      - Create full English article, content page, or career guide body content.
+      - Mass-generate or auto-publish English counterparts.
+      - Mutate production CMS, production URL Truth, sitemap, llms, Search Channel, production env, or production migrations.
+      - Modify fap-web or treat frontend fallback as content/counterpart authority.
+      - Expose drafts, placeholders, fallback-only pages, noindex/private pages, 404s, soft 404s, or missing-authority pages in sitemap/llms.
+    validation:
+      - cd backend && php artisan test --filter=EnParity02 --no-ansi
+      - cd backend && php artisan test --filter=SeoIntel --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/en-parity-02-translation-group-read-model.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: EN-PARITY-03
+
   - id: RESULT-EN-PARITY-00
     repo: fap-api
     depends_on: [EN-PARITY-00]


### PR DESCRIPTION
## PR id
EN-PARITY-02

## What changed
- Added backend-owned `TranslationParityMatrixReadModel` for EN/ZH counterpart discovery.
- Added EN-PARITY-02 generated JSON and Markdown report documenting the read model contract and content-generation boundaries.
- Added focused tests proving:
  - content pages can pair by `translation_group_id` even when slugs differ;
  - articles can pair by `translation_group_id` even when slugs differ;
  - missing counterparts are explicit;
  - frontend fallback is not accepted as authority.
- Added EN-PARITY-02 manifest/state entry and reconciled already-merged EN-PARITY-01 / RESULT-EN-PARITY-00 ledger state.

## Why
EN-PARITY-03/04/05 need a backend/CMS authority read model before content/page/article/career-guide parity work can proceed. This PR establishes that missing counterparts are observable as explicit backend findings instead of being hidden by frontend fallback or slug guessing.

## Changed files
- `backend/app/Services/SeoIntel/TranslationParity/TranslationParityMatrixReadModel.php`
- `backend/docs/seo/en-parity-02-translation-group-read-model.md`
- `backend/docs/seo/generated/en-parity-02-translation-group-read-model.v1.json`
- `backend/tests/Feature/SeoIntel/EnParity02TranslationGroupReadModelTest.php`
- `docs/codex/pr-train.yaml`
- `docs/codex/pr-train-state.json`

## Validation
- `cd backend && php artisan test --filter=EnParity02 --no-ansi` — PASS, 4 tests / 42 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force` — PASS
- `cd backend && php artisan route:list --no-ansi` — PASS
- `cd backend && vendor/bin/pint --test` — PASS, 3540 files
- `cd backend && composer validate --strict` — PASS
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` — PASS, no advisories
- `cd backend && bash scripts/ci_verify_mbti.sh` — PASS
- `python3 -m json.tool backend/docs/seo/generated/en-parity-02-translation-group-read-model.v1.json >/dev/null` — PASS
- `python3` YAML/JSON parse for train manifest/state — PASS
- `git diff --check` / `git diff --cached --check` — PASS

## Scope validation
Changed files are limited to EN-PARITY-02 read model, docs/generated artifact, focused test, and train manifest/state.

## Intentionally deferred
- EN-PARITY-03 content pages: contract/import package first unless page authority already exists.
- EN-PARITY-04 articles: no mass generation of all missing English articles in one PR.
- EN-PARITY-05 career guides: no mass generation of all English career guide detail pages in one PR.
- No draft, placeholder, fallback-only, 404, soft-404, private, noindex, or missing-authority pages may enter sitemap/llms.

## Do-not confirmation
No fap-web changes. No production deploy. No production migration. No production CMS mutation. No URL submission. No Search Channel enqueue. No English prose generation or auto-publish. Frontend fallback is not treated as authority.

## Repository rule impact
This PR reinforces existing backend/CMS authority rules by adding a read model for translation/counterpart visibility. It does not introduce a new runtime content authority or public content surface.
