### PR TITLE
RESULT-EN-PARITY-02 RIASEC result/report English asset catalog

### DIFF
--- a/backend/app/Services/Riasec/RiasecLifecycleCopyService.php
+++ b/backend/app/Services/Riasec/RiasecLifecycleCopyService.php
@@ -6,34 +6,41 @@ namespace App\Services\Riasec;
 
 final class RiasecLifecycleCopyService
 {
-    private const SHARE_PDF_HISTORY_ASSET_PATH = 'content_assets/riasec/share_pdf_history_v1.zh-CN.json';
+    private const DEFAULT_LOCALE = 'zh-CN';
 
-    private const FAQ_JSON_ASSET_PATH = 'content_assets/riasec/faq_v1.zh-CN.json';
+    private const SUPPORTED_LOCALES = [
+        'en',
+        'zh-CN',
+    ];
 
-    private const FAQ_MARKDOWN_ASSET_PATH = 'content_assets/riasec/faq_v1.zh-CN.md';
+    private const SHARE_PDF_HISTORY_ASSET_PATH_TEMPLATE = 'content_assets/riasec/share_pdf_history_v1.%s.json';
 
-    private const TECHNICAL_NOTE_SUMMARY_ASSET_PATH = 'content_assets/riasec/technical_note_user_summary_v1.zh-CN.json';
+    private const FAQ_JSON_ASSET_PATH_TEMPLATE = 'content_assets/riasec/faq_v1.%s.json';
 
-    private const PROFESSIONAL_METHOD_BOUNDARY_ASSET_PATH = 'content_assets/riasec/professional_method_boundary_v1.zh-CN.json';
+    private const FAQ_MARKDOWN_ASSET_PATH_TEMPLATE = 'content_assets/riasec/faq_v1.%s.md';
 
-    /** @var array<string,mixed>|null */
-    private ?array $sharePdfHistoryCache = null;
+    private const TECHNICAL_NOTE_SUMMARY_ASSET_PATH_TEMPLATE = 'content_assets/riasec/technical_note_user_summary_v1.%s.json';
 
-    /** @var array<string,mixed>|null */
-    private ?array $faqJsonCache = null;
+    private const PROFESSIONAL_METHOD_BOUNDARY_ASSET_PATH_TEMPLATE = 'content_assets/riasec/professional_method_boundary_v1.%s.json';
 
-    /** @var array<string,mixed>|null */
-    private ?array $technicalNoteSummaryCache = null;
+    /** @var array<string,array<string,mixed>> */
+    private array $sharePdfHistoryCache = [];
 
-    /** @var array<string,mixed>|null */
-    private ?array $professionalMethodBoundaryCache = null;
+    /** @var array<string,array<string,mixed>> */
+    private array $faqJsonCache = [];
+
+    /** @var array<string,array<string,mixed>> */
+    private array $technicalNoteSummaryCache = [];
+
+    /** @var array<string,array<string,mixed>> */
+    private array $professionalMethodBoundaryCache = [];
 
     /**
      * @return list<array{title:string,copy:string}>
      */
-    public function technicalNoteSummarySections(): array
+    public function technicalNoteSummarySections(string $locale = self::DEFAULT_LOCALE): array
     {
-        $asset = $this->technicalNoteSummaryAsset();
+        $asset = $this->technicalNoteSummaryAsset($this->normalizeLocale($locale));
         $rows = is_array($asset['summary_sections'] ?? null) ? $asset['summary_sections'] : [];
         $sections = [];
 
@@ -60,9 +67,9 @@ final class RiasecLifecycleCopyService
     /**
      * @return list<array{key:string,title:string,body:string}>
      */
-    public function professionalMethodBoundarySections(): array
+    public function professionalMethodBoundarySections(string $locale = self::DEFAULT_LOCALE): array
     {
-        $asset = $this->professionalMethodBoundaryAsset();
+        $asset = $this->professionalMethodBoundaryAsset($this->normalizeLocale($locale));
         $rows = is_array($asset['sections'] ?? null) ? $asset['sections'] : [];
         $sections = [];
 
@@ -91,23 +98,27 @@ final class RiasecLifecycleCopyService
     /**
      * @return array<string,mixed>
      */
-    public function lifecycleCopyContract(bool $snapshotBound = false): array
+    public function lifecycleCopyContract(bool $snapshotBound = false, string $locale = self::DEFAULT_LOCALE): array
     {
-        $shareAsset = $this->sharePdfHistoryAsset();
-        $faqAsset = $this->faqAsset();
+        $normalizedLocale = $this->normalizeLocale($locale);
+        $shareAsset = $this->sharePdfHistoryAsset($normalizedLocale);
+        $faqAsset = $this->faqAsset($normalizedLocale);
+        $technicalNoteSummaryAsset = $this->technicalNoteSummaryAsset($normalizedLocale);
+        $professionalMethodBoundaryAsset = $this->professionalMethodBoundaryAsset($normalizedLocale);
 
         return [
             'schema_version' => 'riasec.lifecycle_copy.v1',
             'content_authority' => 'backend_riasec_lifecycle_assets',
-            'status' => $shareAsset !== [] && $faqAsset !== [] ? 'available' : 'unavailable',
+            'locale' => $normalizedLocale,
+            'status' => $shareAsset !== [] && $faqAsset !== [] && $technicalNoteSummaryAsset !== [] && $professionalMethodBoundaryAsset !== [] ? 'available' : 'unavailable',
             'snapshot_bound' => $snapshotBound,
             'share_pdf_history_asset_id' => (string) ($shareAsset['asset_id'] ?? ''),
             'faq_asset_id' => (string) ($faqAsset['asset_id'] ?? ''),
-            'technical_note_summary_asset_id' => (string) ($this->technicalNoteSummaryAsset()['asset_id'] ?? ''),
-            'professional_method_boundary_asset_id' => (string) ($this->professionalMethodBoundaryAsset()['asset_id'] ?? ''),
+            'technical_note_summary_asset_id' => (string) ($technicalNoteSummaryAsset['asset_id'] ?? ''),
+            'professional_method_boundary_asset_id' => (string) ($professionalMethodBoundaryAsset['asset_id'] ?? ''),
             'surfaces' => $this->normalizedShareSurfaces($shareAsset),
             'faq_items' => $this->normalizedFaqItems($faqAsset),
-            'faq_markdown_reference_available' => $this->faqMarkdownAvailable(),
+            'faq_markdown_reference_available' => $this->faqMarkdownAvailable($normalizedLocale),
             'public_safe_default_surface_keys' => [
                 'share_safe_card',
                 'share_detail_boundary',
@@ -127,49 +138,49 @@ final class RiasecLifecycleCopyService
     /**
      * @return array<string,mixed>
      */
-    private function sharePdfHistoryAsset(): array
+    private function sharePdfHistoryAsset(string $locale): array
     {
-        if ($this->sharePdfHistoryCache !== null) {
-            return $this->sharePdfHistoryCache;
+        if (array_key_exists($locale, $this->sharePdfHistoryCache)) {
+            return $this->sharePdfHistoryCache[$locale];
         }
 
-        return $this->sharePdfHistoryCache = $this->loadJsonAsset(self::SHARE_PDF_HISTORY_ASSET_PATH);
+        return $this->sharePdfHistoryCache[$locale] = $this->loadJsonAsset($this->assetPath(self::SHARE_PDF_HISTORY_ASSET_PATH_TEMPLATE, $locale));
     }
 
     /**
      * @return array<string,mixed>
      */
-    private function faqAsset(): array
+    private function faqAsset(string $locale): array
     {
-        if ($this->faqJsonCache !== null) {
-            return $this->faqJsonCache;
+        if (array_key_exists($locale, $this->faqJsonCache)) {
+            return $this->faqJsonCache[$locale];
         }
 
-        return $this->faqJsonCache = $this->loadJsonAsset(self::FAQ_JSON_ASSET_PATH);
+        return $this->faqJsonCache[$locale] = $this->loadJsonAsset($this->assetPath(self::FAQ_JSON_ASSET_PATH_TEMPLATE, $locale));
     }
 
     /**
      * @return array<string,mixed>
      */
-    private function technicalNoteSummaryAsset(): array
+    private function technicalNoteSummaryAsset(string $locale): array
     {
-        if ($this->technicalNoteSummaryCache !== null) {
-            return $this->technicalNoteSummaryCache;
+        if (array_key_exists($locale, $this->technicalNoteSummaryCache)) {
+            return $this->technicalNoteSummaryCache[$locale];
         }
 
-        return $this->technicalNoteSummaryCache = $this->loadJsonAsset(self::TECHNICAL_NOTE_SUMMARY_ASSET_PATH);
+        return $this->technicalNoteSummaryCache[$locale] = $this->loadJsonAsset($this->assetPath(self::TECHNICAL_NOTE_SUMMARY_ASSET_PATH_TEMPLATE, $locale));
     }
 
     /**
      * @return array<string,mixed>
      */
-    private function professionalMethodBoundaryAsset(): array
+    private function professionalMethodBoundaryAsset(string $locale): array
     {
-        if ($this->professionalMethodBoundaryCache !== null) {
-            return $this->professionalMethodBoundaryCache;
+        if (array_key_exists($locale, $this->professionalMethodBoundaryCache)) {
+            return $this->professionalMethodBoundaryCache[$locale];
         }
 
-        return $this->professionalMethodBoundaryCache = $this->loadJsonAsset(self::PROFESSIONAL_METHOD_BOUNDARY_ASSET_PATH);
+        return $this->professionalMethodBoundaryCache[$locale] = $this->loadJsonAsset($this->assetPath(self::PROFESSIONAL_METHOD_BOUNDARY_ASSET_PATH_TEMPLATE, $locale));
     }
 
     /**
@@ -233,11 +244,31 @@ final class RiasecLifecycleCopyService
         return $items;
     }
 
-    private function faqMarkdownAvailable(): bool
+    private function faqMarkdownAvailable(string $locale): bool
     {
-        $path = base_path(self::FAQ_MARKDOWN_ASSET_PATH);
+        $path = base_path($this->assetPath(self::FAQ_MARKDOWN_ASSET_PATH_TEMPLATE, $locale));
 
         return is_file($path) && trim((string) file_get_contents($path)) !== '';
+    }
+
+    private function assetPath(string $template, string $locale): string
+    {
+        return sprintf($template, $locale);
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $normalized = trim($locale);
+
+        if (str_starts_with(strtolower($normalized), 'en')) {
+            return 'en';
+        }
+
+        if ($normalized === 'zh' || $normalized === 'zh_CN' || $normalized === 'zh-CN') {
+            return 'zh-CN';
+        }
+
+        return in_array($normalized, self::SUPPORTED_LOCALES, true) ? $normalized : self::DEFAULT_LOCALE;
     }
 
     /**

--- a/backend/content_assets/riasec/faq_v1.en.json
+++ b/backend/content_assets/riasec/faq_v1.en.json
@@ -1,0 +1,122 @@
+{
+  "asset_id": "faq_v1.en",
+  "asset_status": "draft_authority_candidate_human_review_required",
+  "locale": "en",
+  "scale_code": "RIASEC",
+  "review_status": "draft_human_review_required",
+  "questions": [
+    {
+      "q": "What does IAS mean?",
+      "a": "I, A, and S are the three interest dimensions that stand out in this result. Their order describes this result ranking; it is not a fixed identity."
+    },
+    {
+      "q": "Does this tell me which career I should choose?",
+      "a": "No. It points to work activities that may be worth exploring or validating first. Real choices also depend on ability, experience, opportunity, values, entry barriers, and market conditions."
+    },
+    {
+      "q": "Does a score of 80 mean I scored higher than 80% of people?",
+      "a": "No. The current 0-100 score is a within-form interest-strength conversion. It is not a population percentile and it is not an ability score."
+    },
+    {
+      "q": "Does low E mean I cannot start a business, sell, or manage?",
+      "a": "No. Low E only means high-persuasion, high-exposure, and high-competition activities may not be the most natural interest entry point. Capability still depends on skills, experience, and real opportunities."
+    },
+    {
+      "q": "Does low R mean I cannot do technical or hands-on work?",
+      "a": "No. Low R does not mean clumsy or unable to learn technical work. It means tools, field work, and physical operation may not be the most natural interest entry point right now."
+    },
+    {
+      "q": "Is 140Q more accurate?",
+      "a": "Do not read it that way. 140Q observes tasks, environments, and role responsibilities in more context. It does not overturn 60Q and it does not compare raw scores across forms."
+    },
+    {
+      "q": "What if I disagree with the result?",
+      "a": "Record the disagreement, check answer quality, near ties, and activity imagination, then use low-risk experiments or a same-form retest to validate. Feedback does not change scores."
+    },
+    {
+      "q": "Why are occupation examples not expanded into a direct list?",
+      "a": "Occupation names are easy to misread as conclusions. FermatMind shows activities and tasks first. Occupation names are only context examples and must keep source status visible."
+    },
+    {
+      "q": "Can I share the report with a teacher, counselor, or friend?",
+      "a": "Start with the safe share version. When a full report includes personal interest structure or feedback history, you should decide whether to show it."
+    },
+    {
+      "q": "Can an employer use this for screening?",
+      "a": "No. This report must not be used for recruiting, admission, promotion, elimination, or qualification decisions."
+    },
+    {
+      "q": "Why does the result page include Action Lab?",
+      "a": "Career interests need real-world validation. Action Lab supports low-risk experiments and does not generate career conclusions."
+    },
+    {
+      "q": "What if a retest looks different?",
+      "a": "First check whether it used the same form, answer quality, near ties, and your state at the time. Do not chart raw score gains or drops across different forms."
+    },
+    {
+      "q": "Can a Holland Code change over time?",
+      "a": "Interest structure often has some stability, but experience, opportunity, and environment can affect expression. Treat retesting as a clue about change, not a win-or-lose result."
+    },
+    {
+      "q": "How is this different from an ability test?",
+      "a": "RIASEC looks at interest in activities. It does not decide whether you are already good at them. Ability needs other evidence."
+    },
+    {
+      "q": "Why not just tell me the single path I should take?",
+      "a": "A direct conclusion can hide real-world constraints. A steadier approach is to read activities, tasks, environments, and roles first, then test small next steps."
+    },
+    {
+      "q": "If I already have a target occupation, should I still read RIASEC?",
+      "a": "Yes. Put the target into aspiration calibration and read which activities overlap with current interest clues, and which real-world parts still need validation."
+    },
+    {
+      "q": "Can I show the PDF to a counselor?",
+      "a": "Yes, but once a PDF is forwarded the platform cannot remotely recall it. A counselor discussion version should be used only with your permission."
+    },
+    {
+      "q": "Why does the result page not show every score detail by default?",
+      "a": "The default view shows levels and explanations to reduce false precision. Expanded views can show more evidence when appropriate."
+    },
+    {
+      "q": "Is a higher score always better?",
+      "a": "No. High interest can be a more natural energy entry point, but it can also carry practical costs. Low interest is not a defect."
+    },
+    {
+      "q": "Can I use this report to choose a college major?",
+      "a": "It can be an exploration input, but not the only basis. Major decisions also depend on course content, ability foundation, portfolio, resources, location, and long-term commitment."
+    }
+  ],
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "examples_not_matches",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "forbidden_claims": [
+    "personality_identity",
+    "ability_or_skill_inference",
+    "career_match",
+    "career_recommendation",
+    "job_fit",
+    "fit_score",
+    "occupation_ranking",
+    "success_prediction",
+    "hiring_suitability",
+    "screening_use",
+    "140q_more_accurate",
+    "raw_score_delta",
+    "onet_soc_source_invention"
+  ],
+  "frontend_fallback_allowed": false,
+  "fallback_behavior": "omit_module",
+  "v5_editorial_note": "English FAQ lifecycle draft covers user misunderstanding paths, share/PDF/history, and non-recommendation boundaries."
+}

--- a/backend/content_assets/riasec/faq_v1.en.md
+++ b/backend/content_assets/riasec/faq_v1.en.md
@@ -1,0 +1,27 @@
+# RIASEC result FAQ
+
+This English FAQ is a backend-owned draft counterpart for the RIASEC result, report, share, PDF, and history lifecycle copy. It treats RIASEC as an interest-signal assessment and not as a career recommendation engine.
+
+## What does IAS mean?
+
+I, A, and S are the three interest dimensions that stand out in this result. Their order describes this result ranking; it is not a fixed identity.
+
+## Does this tell me which career I should choose?
+
+No. It points to work activities that may be worth exploring or validating first. Real choices also depend on ability, experience, opportunity, values, entry barriers, and market conditions.
+
+## Does a score of 80 mean I scored higher than 80% of people?
+
+No. The current 0-100 score is a within-form interest-strength conversion. It is not a population percentile and it is not an ability score.
+
+## Is 140Q more accurate?
+
+Do not read it that way. 140Q observes tasks, environments, and role responsibilities in more context. It does not overturn 60Q and it does not compare raw scores across forms.
+
+## Can an employer use this for screening?
+
+No. This report must not be used for recruiting, admission, promotion, elimination, or qualification decisions.
+
+## Can I use this report to choose a college major?
+
+It can be an exploration input, but not the only basis. Major decisions also depend on course content, ability foundation, portfolio, resources, location, and long-term commitment.

--- a/backend/content_assets/riasec/professional_method_boundary_v1.en.json
+++ b/backend/content_assets/riasec/professional_method_boundary_v1.en.json
@@ -1,0 +1,82 @@
+{
+  "asset_id": "professional_method_boundary_v1.en",
+  "asset_status": "draft_authority_candidate_human_review_required",
+  "locale": "en",
+  "content_version": "riasec_professional_method_boundary_v1.en",
+  "review_status": "draft_human_review_required",
+  "sections": [
+    {
+      "key": "measurement_object",
+      "title": "Measurement object",
+      "body": "RIASEC explains tendencies in work-activity interests. It does not measure ability, personality identity, career values, mental state, income potential, or probability of career success."
+    },
+    {
+      "key": "score_space",
+      "title": "Score space",
+      "body": "0-100 is a within-form interest-strength conversion. It is not a population percentile and should not be used to compare raw score movement across 60Q and 140Q."
+    },
+    {
+      "key": "forms",
+      "title": "60Q and 140Q",
+      "body": "60Q describes the basic interest structure. 140Q describes more contextual clues from tasks, environments, and role responsibilities. 140Q is more specific, not more accurate."
+    },
+    {
+      "key": "examples",
+      "title": "Occupation example boundary",
+      "body": "Occupation examples must be mediated by activity and task explanations. They are content examples, not matches, recommendations, rankings, or job-fit decisions."
+    },
+    {
+      "key": "validation_status",
+      "title": "Validation status",
+      "body": "When external validity evidence is not attached, use theory_based, under_validation, or internally_pilot_required. Do not claim externally_validated status."
+    },
+    {
+      "key": "feedback",
+      "title": "Feedback boundary",
+      "body": "Saved, excluded, aspiration, and disagreement feedback only affects exploration paths. It does not change the measured Holland Code, scores, or report snapshot."
+    },
+    {
+      "key": "privacy",
+      "title": "Privacy and use",
+      "body": "Share and PDF surfaces do not expose raw feedback, life stage, organization context, or internal snapshot_id by default."
+    },
+    {
+      "key": "restricted_use",
+      "title": "Restricted use",
+      "body": "This report must not be used for recruiting screening, admission, promotion, elimination, qualification decisions, medical diagnosis, or psychological diagnosis."
+    }
+  ],
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "examples_not_matches",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "forbidden_claims": [
+    "personality_identity",
+    "ability_or_skill_inference",
+    "career_match",
+    "career_recommendation",
+    "job_fit",
+    "fit_score",
+    "occupation_ranking",
+    "success_prediction",
+    "hiring_suitability",
+    "screening_use",
+    "140q_more_accurate",
+    "raw_score_delta",
+    "onet_soc_source_invention"
+  ],
+  "frontend_fallback_allowed": false,
+  "fallback_behavior": "omit_module",
+  "v5_editorial_note": "English professional boundary draft keeps prohibited terms only in negative constraint contexts."
+}

--- a/backend/content_assets/riasec/share_pdf_history_v1.en.json
+++ b/backend/content_assets/riasec/share_pdf_history_v1.en.json
@@ -1,0 +1,91 @@
+{
+  "asset_id": "share_pdf_history_v1.en",
+  "asset_status": "draft_authority_candidate_human_review_required",
+  "locale": "en",
+  "scale_code": "RIASEC",
+  "review_status": "draft_human_review_required",
+  "surfaces": [
+    {
+      "surface": "share_safe_card",
+      "copy": "My RIASEC result points to work activities that may be worth exploring first. The share version shows only a safe summary and does not expose raw feedback or private context.",
+      "public_safe": true,
+      "raw_scores_allowed": false,
+      "raw_feedback_allowed": false
+    },
+    {
+      "surface": "share_detail_boundary",
+      "copy": "The share page is not a full report and does not state a career conclusion. It summarizes the interest pattern and the method boundaries for this result.",
+      "public_safe": true,
+      "raw_scores_allowed": false,
+      "raw_feedback_allowed": false
+    },
+    {
+      "surface": "pdf_personal",
+      "copy": "A personal PDF can preserve the full result, generation time, and method boundaries. Once a PDF is forwarded, the platform cannot remotely recall it.",
+      "public_safe": false,
+      "raw_scores_allowed": false,
+      "raw_feedback_allowed": false
+    },
+    {
+      "surface": "pdf_counselor_discussion",
+      "copy": "A counselor discussion version may show more exploration summary with user permission. It must not be used for screening, admission, promotion, elimination, or qualification decisions.",
+      "public_safe": false,
+      "raw_scores_allowed": false,
+      "raw_feedback_allowed": false
+    },
+    {
+      "surface": "history_same_form",
+      "copy": "History for the same form should emphasize Top 3 overlap, near ties, and reading strength. It should not draw cross-form raw score movement.",
+      "public_safe": false,
+      "raw_scores_allowed": false,
+      "raw_feedback_allowed": false
+    },
+    {
+      "surface": "history_cross_form",
+      "copy": "60Q and 140Q use different score spaces. History can explain which interest clues were emphasized in each result, but it must not chart raw score gains or drops across forms.",
+      "public_safe": false,
+      "raw_scores_allowed": false,
+      "raw_feedback_allowed": false
+    },
+    {
+      "surface": "low_quality_share",
+      "copy": "A cautious-reading result allows only a safe share summary by default and does not show a strong activity chain or occupation-context examples.",
+      "public_safe": true,
+      "raw_scores_allowed": false,
+      "raw_feedback_allowed": false
+    }
+  ],
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "examples_not_matches",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "forbidden_claims": [
+    "personality_identity",
+    "ability_or_skill_inference",
+    "career_match",
+    "career_recommendation",
+    "job_fit",
+    "fit_score",
+    "occupation_ranking",
+    "success_prediction",
+    "hiring_suitability",
+    "screening_use",
+    "140q_more_accurate",
+    "raw_score_delta",
+    "onet_soc_source_invention"
+  ],
+  "frontend_fallback_allowed": false,
+  "fallback_behavior": "omit_module",
+  "v5_editorial_note": "English share/PDF/history lifecycle draft keeps RIASEC as an interest-signal assessment and requires human review before broad content expansion."
+}

--- a/backend/content_assets/riasec/technical_note_user_summary_v1.en.json
+++ b/backend/content_assets/riasec/technical_note_user_summary_v1.en.json
@@ -1,0 +1,66 @@
+{
+  "asset_id": "technical_note_user_summary_v1.en",
+  "asset_status": "draft_authority_candidate_human_review_required",
+  "locale": "en",
+  "scale_code": "RIASEC",
+  "review_status": "draft_human_review_required",
+  "summary_sections": [
+    {
+      "title": "What this assessment measures",
+      "copy": "RIASEC measures your interest strength across different work activities, such as hands-on work, analysis, expression, support, persuasion, and organization."
+    },
+    {
+      "title": "What this assessment does not measure",
+      "copy": "It does not measure ability, personality identity, career success, income, job performance, or hiring risk."
+    },
+    {
+      "title": "How 60Q and 140Q relate",
+      "copy": "60Q describes the basic interest structure. 140Q separates task, environment, and role-responsibility clues. 140Q is more contextual, not more accurate, and it does not overturn 60Q."
+    },
+    {
+      "title": "How to read scores",
+      "copy": "0-100 is a within-form interest-strength conversion. It is not a population percentile and it is not an ability score."
+    },
+    {
+      "title": "How to read occupation examples",
+      "copy": "Occupation examples only show where some activities may appear. When source rows are not attached, they must be labeled as content examples."
+    },
+    {
+      "title": "How feedback is used",
+      "copy": "Saved, excluded, aspiration, disagreement, and experiment feedback can shape exploration paths, but they do not change assessment scores, report snapshots, or share content."
+    }
+  ],
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "examples_not_matches",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "forbidden_claims": [
+    "personality_identity",
+    "ability_or_skill_inference",
+    "career_match",
+    "career_recommendation",
+    "job_fit",
+    "fit_score",
+    "occupation_ranking",
+    "success_prediction",
+    "hiring_suitability",
+    "screening_use",
+    "140q_more_accurate",
+    "raw_score_delta",
+    "onet_soc_source_invention"
+  ],
+  "frontend_fallback_allowed": false,
+  "fallback_behavior": "omit_module",
+  "v5_editorial_note": "English technical summary draft separates measurement, form specificity, and feedback scope."
+}

--- a/backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json
+++ b/backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json
@@ -1,0 +1,178 @@
+{
+  "pr_id": "RESULT-EN-PARITY-02",
+  "title": "RIASEC result/report English asset catalog",
+  "family": "riasec",
+  "generated_at": "2026-05-25T00:00:00Z",
+  "authority": {
+    "backend_result_asset_catalog_is_authority": true,
+    "frontend_fallback_is_authority": false,
+    "production_cms_mutation": false,
+    "production_user_data_access": false,
+    "deployment": false,
+    "search_submission": false
+  },
+  "english_runtime_policy": "fail_closed_no_zh_fallback",
+  "implemented_runtime_surface": {
+    "service": "App\\Services\\Riasec\\RiasecLifecycleCopyService",
+    "default_locale_preserved": "zh-CN",
+    "explicit_english_locale": "en",
+    "missing_english_behavior": "unavailable_empty_assets_no_zh_fallback",
+    "frontend_fallback_allowed": false,
+    "fallback_behavior": "omit_module_fail_closed"
+  },
+  "prepared_english_assets": [
+    "share_pdf_history_v1.en",
+    "faq_v1.en",
+    "faq_v1.en.md",
+    "technical_note_user_summary_v1.en",
+    "professional_method_boundary_v1.en"
+  ],
+  "prepared_asset_files": [
+    "backend/content_assets/riasec/share_pdf_history_v1.en.json",
+    "backend/content_assets/riasec/faq_v1.en.json",
+    "backend/content_assets/riasec/faq_v1.en.md",
+    "backend/content_assets/riasec/technical_note_user_summary_v1.en.json",
+    "backend/content_assets/riasec/professional_method_boundary_v1.en.json"
+  ],
+  "prepared_asset_status": "draft_authority_candidate_human_review_required",
+  "asset_matrix": [
+    {
+      "asset_key": "share_pdf_history_v1",
+      "surfaces": ["share", "pdf", "history"],
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "claim_boundary": "interest-signal, not career recommendation"
+    },
+    {
+      "asset_key": "faq_v1",
+      "surfaces": ["faq", "result", "report"],
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "claim_boundary": "interest-signal, not career recommendation"
+    },
+    {
+      "asset_key": "technical_note_user_summary_v1",
+      "surfaces": ["result", "report", "method_boundary"],
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "claim_boundary": "measurement boundary, not ability or success prediction"
+    },
+    {
+      "asset_key": "professional_method_boundary_v1",
+      "surfaces": ["report", "professional_boundary"],
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "claim_boundary": "restricted use, not screening, diagnosis, or career-success prediction"
+    }
+  ],
+  "deferred_assets": [
+    {
+      "asset_key": "140q_task_environment_role_v1",
+      "zh_file": "backend/content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl",
+      "reason": "large 140Q task/environment/role prose requires batch translation and human review"
+    },
+    {
+      "asset_key": "activity_task_examples_v1",
+      "zh_file": "backend/content_assets/riasec/activity_task_examples_v1.zh-CN.jsonl",
+      "reason": "occupation/activity examples require source and claim-boundary review"
+    },
+    {
+      "asset_key": "aspirations_calibration_v1",
+      "zh_file": "backend/content_assets/riasec/aspirations_calibration_v1.zh-CN.jsonl",
+      "reason": "aspiration guidance is substantial user-facing prose"
+    },
+    {
+      "asset_key": "dimension_deep_copy_v1",
+      "zh_file": "backend/content_assets/riasec/dimension_deep_copy_v1.zh-CN.r3.json",
+      "reason": "deep dimension interpretation requires reviewed English content batch"
+    },
+    {
+      "asset_key": "disagree_path_v1",
+      "zh_file": "backend/content_assets/riasec/disagree_path_v1.zh-CN.jsonl",
+      "reason": "disagreement-path guidance requires reviewed English content batch"
+    },
+    {
+      "asset_key": "feedback_action_lab_v1",
+      "zh_file": "backend/content_assets/riasec/feedback_action_lab_v1.zh-CN.jsonl",
+      "reason": "Action Lab copy must remain exploratory and needs human review"
+    },
+    {
+      "asset_key": "low_quality_cautious_reading_v1",
+      "zh_file": "backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json",
+      "reason": "low-quality result guidance affects interpretation and should be reviewed"
+    },
+    {
+      "asset_key": "near_tie_alternate_code_copy_v1",
+      "zh_file": "backend/content_assets/riasec/near_tie_alternate_code_copy_v1.zh-CN.json",
+      "reason": "near-tie interpretation requires reviewed English content batch"
+    },
+    {
+      "asset_key": "next_exploration_nodes_v1",
+      "zh_file": "backend/content_assets/riasec/next_exploration_nodes_v1.zh-CN.jsonl",
+      "reason": "next-step exploration copy should be reviewed before activation"
+    },
+    {
+      "asset_key": "occupation_examples_boundary_v1",
+      "zh_file": "backend/content_assets/riasec/occupation_examples_boundary_v1.zh-CN.jsonl",
+      "reason": "occupation examples need source and no-match language review"
+    },
+    {
+      "asset_key": "pair_blend_15_pairs_v1",
+      "zh_file": "backend/content_assets/riasec/pair_blend_15_pairs_v1.zh-CN.jsonl",
+      "reason": "pair-blend interpretation is substantial prose"
+    },
+    {
+      "asset_key": "profile_shape_copy_v1",
+      "zh_file": "backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json",
+      "reason": "profile-shape interpretation requires reviewed English counterpart"
+    },
+    {
+      "asset_key": "top3_code_chain_strategy_v1",
+      "zh_file": "backend/content_assets/riasec/top3_code_chain_strategy_v1.zh-CN.jsonl",
+      "reason": "Top 3 code-chain interpretation is large report prose"
+    },
+    {
+      "asset_key": "top_code_confidence_copy_v1",
+      "zh_file": "backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json",
+      "reason": "confidence copy affects result interpretation and should be reviewed"
+    }
+  ],
+  "claim_boundary": {
+    "allowed": [
+      "interest signal",
+      "work-activity tendency",
+      "exploratory guidance",
+      "low-risk validation step",
+      "not an ability score",
+      "not a career recommendation"
+    ],
+    "forbidden": [
+      "precise career recommendation",
+      "best career for you",
+      "hiring suitability",
+      "job fit guarantee",
+      "career success prediction",
+      "salary prediction",
+      "diagnosis",
+      "treatment",
+      "cure"
+    ]
+  },
+  "validation_targets": [
+    "php artisan test --filter=ResultEnParity02RiasecEnAssets --no-ansi",
+    "php artisan route:list --no-ansi",
+    "vendor/bin/pint --test",
+    "composer validate --strict",
+    "composer audit --locked --no-interaction --ignore-unreachable",
+    "python3 -m json.tool backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json"
+  ],
+  "decision": "riasec_lifecycle_en_assets_prepared_fail_closed_with_deferred_deep_assets"
+}

--- a/backend/docs/seo/result-en-parity-02-riasec-en-assets.md
+++ b/backend/docs/seo/result-en-parity-02-riasec-en-assets.md
@@ -1,0 +1,127 @@
+# RESULT-EN-PARITY-02 RIASEC Result/Report English Asset Catalog
+
+## Decision
+
+`riasec_lifecycle_en_assets_prepared_fail_closed_with_deferred_deep_assets`
+
+This PR prepares backend-owned English counterparts for the RIASEC lifecycle assets used by result/report share, PDF, history, FAQ, and method-boundary surfaces. Existing default Chinese runtime behavior remains unchanged. English runtime access is explicit and fail-closed: an English request reads `.en` assets and does not silently fall back to `zh-CN`.
+
+## Scope
+
+Covered:
+
+- `share_pdf_history_v1.en`
+- `faq_v1.en`
+- `faq_v1.en.md`
+- `technical_note_user_summary_v1.en`
+- `professional_method_boundary_v1.en`
+- `RiasecLifecycleCopyService` locale-aware lookup
+- generated inventory artifact
+- focused parity tests
+
+Not covered:
+
+- full RIASEC deep-copy English report prose
+- pair-blend, Top 3 chain, activity examples, aspirations, disagreement, Action Lab, occupation examples, near-tie, low-quality, profile-shape, or confidence-copy translation
+- CMS mutation
+- production user result access
+- fap-web changes
+- deployment or search submission
+
+## Architecture Finding
+
+RIASEC lifecycle copy is backend-owned and file-backed under `backend/content_assets/riasec`. Before this PR, the lifecycle service loaded only `zh-CN` files. This PR keeps `zh-CN` as the default locale but adds explicit `en` lookup paths.
+
+For English:
+
+- `en-US` and other `en*` inputs normalize to `en`.
+- English assets are read from `.en` files.
+- Missing English assets return unavailable/empty payloads rather than using `zh-CN`.
+- `frontend_fallback_allowed` remains `false`.
+- `missing_content_behavior` remains `omit_module_fail_closed`.
+
+## Prepared English Asset Matrix
+
+| Asset | Surface | Status | EN fallback policy |
+|---|---|---|---|
+| `share_pdf_history_v1.en` | share / PDF / history | draft authority candidate, human review required | no zh fallback |
+| `faq_v1.en` | result / report FAQ | draft authority candidate, human review required | no zh fallback |
+| `faq_v1.en.md` | FAQ markdown reference | draft authority candidate, human review required | no zh fallback |
+| `technical_note_user_summary_v1.en` | result/report method summary | draft authority candidate, human review required | no zh fallback |
+| `professional_method_boundary_v1.en` | professional method boundary | draft authority candidate, human review required | no zh fallback |
+
+## Deferred RIASEC Assets
+
+The following remain intentionally deferred because they are substantial interpretation prose and require reviewed content batches:
+
+- `140q_task_environment_role_v1`
+- `activity_task_examples_v1`
+- `aspirations_calibration_v1`
+- `dimension_deep_copy_v1`
+- `disagree_path_v1`
+- `feedback_action_lab_v1`
+- `low_quality_cautious_reading_v1`
+- `near_tie_alternate_code_copy_v1`
+- `next_exploration_nodes_v1`
+- `occupation_examples_boundary_v1`
+- `pair_blend_15_pairs_v1`
+- `profile_shape_copy_v1`
+- `top3_code_chain_strategy_v1`
+- `top_code_confidence_copy_v1`
+
+## Claim Boundary
+
+RIASEC remains a Holland interest assessment and six-dimensional result vector. This PR does not turn RIASEC into an active career recommendation engine.
+
+Allowed wording:
+
+- interest signal
+- work-activity tendency
+- exploratory guidance
+- low-risk validation step
+- not an ability score
+- not a career recommendation
+
+Forbidden wording:
+
+- precise career recommendation
+- best career for you
+- hiring suitability
+- job fit guarantee
+- career success prediction
+- salary prediction
+- diagnosis / treatment / cure
+
+## Validation
+
+Required focused test:
+
+```bash
+cd backend
+php artisan test --filter=ResultEnParity02RiasecEnAssets --no-ansi
+```
+
+Common validation:
+
+```bash
+cd backend
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd ..
+python3 -m json.tool backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json >/dev/null
+python3 - <<'PY'
+import yaml, json
+yaml.safe_load(open('docs/codex/pr-train.yaml'))
+json.load(open('docs/codex/pr-train-state.json'))
+print('manifest/state parse ok')
+PY
+git diff --check
+git diff --cached --check
+```
+
+## Next PR
+
+`RESULT-EN-PARITY-03` should handle IQ locale-safe report builder labels and keep IQ wording bounded as online estimate / confidence-bound, not clinical IQ authority.

--- a/backend/tests/Feature/SeoIntel/ResultEnParity02RiasecEnAssetsTest.php
+++ b/backend/tests/Feature/SeoIntel/ResultEnParity02RiasecEnAssetsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\Riasec\RiasecLifecycleCopyService;
+use Tests\TestCase;
+
+final class ResultEnParity02RiasecEnAssetsTest extends TestCase
+{
+    public function test_riasec_lifecycle_contract_has_explicit_english_assets(): void
+    {
+        $service = new RiasecLifecycleCopyService;
+
+        $contract = $service->lifecycleCopyContract(snapshotBound: true, locale: 'en-US');
+
+        $this->assertSame('available', $contract['status']);
+        $this->assertSame('en', $contract['locale']);
+        $this->assertSame('share_pdf_history_v1.en', $contract['share_pdf_history_asset_id']);
+        $this->assertSame('faq_v1.en', $contract['faq_asset_id']);
+        $this->assertSame('technical_note_user_summary_v1.en', $contract['technical_note_summary_asset_id']);
+        $this->assertSame('professional_method_boundary_v1.en', $contract['professional_method_boundary_asset_id']);
+        $this->assertCount(7, $contract['surfaces']);
+        $this->assertCount(20, $contract['faq_items']);
+        $this->assertTrue($contract['faq_markdown_reference_available']);
+        $this->assertFalse($contract['frontend_fallback_allowed']);
+        $this->assertSame('omit_module_fail_closed', $contract['missing_content_behavior']);
+    }
+
+    public function test_english_lifecycle_copy_does_not_fall_back_to_chinese(): void
+    {
+        $service = new RiasecLifecycleCopyService;
+
+        $payload = [
+            'contract' => $service->lifecycleCopyContract(snapshotBound: true, locale: 'en'),
+            'technical_note_summary' => $service->technicalNoteSummarySections('en'),
+            'professional_method_boundary' => $service->professionalMethodBoundarySections('en'),
+        ];
+
+        $serialized = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        $this->assertDoesNotMatchRegularExpression('/[\x{4e00}-\x{9fff}]/u', $serialized);
+        $this->assertStringNotContainsString('.zh-CN', $serialized);
+        $this->assertStringContainsString('share_pdf_history_v1.en', $serialized);
+        $this->assertStringContainsString('faq_v1.en', $serialized);
+    }
+
+    public function test_english_lifecycle_copy_keeps_riasec_claim_boundaries(): void
+    {
+        $service = new RiasecLifecycleCopyService;
+        $payload = [
+            'contract' => $service->lifecycleCopyContract(snapshotBound: true, locale: 'en'),
+            'technical_note_summary' => $service->technicalNoteSummarySections('en'),
+            'professional_method_boundary' => $service->professionalMethodBoundarySections('en'),
+        ];
+
+        $visibleText = $this->visibleText($payload);
+
+        foreach ([
+            'best career for you',
+            'precise career',
+            'job fit guarantee',
+            'career success prediction',
+            'salary prediction',
+            'hiring suitability',
+            'treatment plan',
+            'cure',
+        ] as $claim) {
+            $this->assertStringNotContainsString($claim, strtolower($visibleText), $claim);
+        }
+
+        $this->assertStringContainsString('not a population percentile', $visibleText);
+        $this->assertStringContainsString('not an ability score', $visibleText);
+        $this->assertStringContainsString('not be used for recruiting', $visibleText);
+        $this->assertStringContainsString('not a full report', $visibleText);
+    }
+
+    public function test_default_chinese_lifecycle_behavior_remains_unchanged(): void
+    {
+        $service = new RiasecLifecycleCopyService;
+
+        $contract = $service->lifecycleCopyContract(snapshotBound: true);
+
+        $this->assertSame('zh-CN', $contract['locale']);
+        $this->assertSame('share_pdf_history_v1.zh-CN', $contract['share_pdf_history_asset_id']);
+        $this->assertSame('faq_v1.zh-CN', $contract['faq_asset_id']);
+        $this->assertCount(7, $contract['surfaces']);
+        $this->assertCount(20, $contract['faq_items']);
+        $this->assertCount(6, $service->technicalNoteSummarySections());
+        $this->assertCount(8, $service->professionalMethodBoundarySections());
+    }
+
+    public function test_generated_riasec_inventory_json_parses_and_records_deferred_assets(): void
+    {
+        $path = base_path('docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('RESULT-EN-PARITY-02', $decoded['pr_id'] ?? null);
+        $this->assertSame('riasec', $decoded['family'] ?? null);
+        $this->assertSame('fail_closed_no_zh_fallback', $decoded['english_runtime_policy'] ?? null);
+        $this->assertContains('share_pdf_history_v1.en', $decoded['prepared_english_assets'] ?? []);
+        $this->assertContains('faq_v1.en', $decoded['prepared_english_assets'] ?? []);
+        $this->assertNotEmpty($decoded['deferred_assets'] ?? []);
+    }
+
+    /**
+     * @param  mixed  $payload
+     */
+    private function visibleText($payload): string
+    {
+        if (is_string($payload)) {
+            return $payload;
+        }
+
+        if (! is_array($payload)) {
+            return '';
+        }
+
+        $parts = [];
+        foreach ($payload as $key => $value) {
+            if (in_array($key, ['asset_id', 'faq_asset_id', 'share_pdf_history_asset_id', 'technical_note_summary_asset_id', 'professional_method_boundary_asset_id'], true)) {
+                continue;
+            }
+
+            $parts[] = $this->visibleText($value);
+        }
+
+        return trim(implode(' ', array_filter($parts)));
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -18530,7 +18530,7 @@
     "EN-PARITY-00": {
       "repo": "fap-api",
       "branch": "codex/en-parity-00-full-site-inventory",
-      "status": "pr_open_github_checks_pending",
+      "status": "merged",
       "depends_on": [],
       "commit_sha": "a95de5c9ff047851336ee1f7c35b2255ac8ba683",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1663",
@@ -18778,7 +18778,7 @@
       "depends_on": [
         "RESULT-EN-PARITY-00"
       ],
-      "commit_sha": null,
+      "commit_sha": "3fb430f1b1592127cb8c42857e15fd42b0a11feb",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1668",
       "checks": {
         "dependency_result_en_parity_00": {
@@ -18810,14 +18810,14 @@
           "evidence": "Focused test passed with 3 tests and 601 assertions. route:list exited 0 with 203 routes. Pint passed 3540 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON parse, manifest/state parse, and git diff --check passed. fap-web reference status was inspected and only unrelated .playwright-mcp/ was untracked."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR #1668 is open; GitHub checks are pending."
+          "status": "pass",
+          "evidence": "PR #1668 passed hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep, and supply-chain checks; mergeStateStatus was CLEAN before squash merge."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T05:24:17Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "events": [
         {
@@ -18839,6 +18839,81 @@
           "at": "2026-05-25T09:15:00+00:00",
           "status": "ci_fix_pushed",
           "summary": "Removed runtime app service draft after Big Five runtime freeze flagged backend/app path drift; kept non-runtime generated artifact plus focused test and updated PR body."
+        },
+        {
+          "at": "2026-05-25T05:24:17Z",
+          "status": "merged",
+          "summary": "PR #1668 was squash merged as 3fb430f1b1592127cb8c42857e15fd42b0a11feb; remote branch deleted; isolated worktree main synchronized and focused post-merge test passed."
+        }
+      ]
+    },
+    "RESULT-EN-PARITY-02": {
+      "repo": "fap-api",
+      "branch": "codex/result-en-parity-02-riasec-en-assets",
+      "status": "local_files_generated_pending_validation",
+      "depends_on": [
+        "RESULT-EN-PARITY-01"
+      ],
+      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1669",
+      "checks": {
+        "dependency_result_en_parity_00": {
+          "status": "pass",
+          "evidence": "PR #1666 is MERGED and origin/main contains merge commit a93345e5a24f1f579495bcfd78f30b4c5984bd1a."
+        },
+        "dependency_result_en_parity_01": {
+          "status": "pass",
+          "evidence": "PR #1668 is MERGED and origin/main contains merge commit 3fb430f1b1592127cb8c42857e15fd42b0a11feb."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Planned files are limited to RIASEC lifecycle content assets, RiasecLifecycleCopyService locale-safe lookup, generated report/artifact, focused SeoIntel test, and PR-train metadata."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No production mutation, CMS mutation, deploy, production migration, URL submission, production user data access, or fap-web commit."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=ResultEnParity02RiasecEnAssets --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json >/dev/null",
+            "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+            "git diff --check",
+            "git diff --cached --check",
+            "git diff --name-only origin/main...HEAD"
+          ],
+          "evidence": "Focused ResultEnParity02RiasecEnAssets test passed with 5 tests and 41 assertions. Existing RiasecFullContentFixtureMatrixTest passed with 3 tests and 354 assertions. route:list exited 0 with 203 routes. Pint passed 3540 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON parse, manifest/state parse, git diff --check, git diff --cached --check, and Big Five runtime freeze focused check passed. fap-web reference status was inspected and only unrelated .playwright-mcp/ was untracked."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR #1669 is open; GitHub checks are pending."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "events": [
+        {
+          "at": "2026-05-25T06:10:00Z",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Prepared RIASEC English lifecycle assets for share/PDF/history/FAQ/method-boundary, added locale-aware fail-closed service lookup, generated inventory artifact/report, focused test, and manifest/state entry. Deep RIASEC interpretation assets remain deferred for human-reviewed batches."
+        },
+        {
+          "at": "2026-05-25T06:25:00Z",
+          "status": "local_validation_passed",
+          "summary": "RESULT-EN-PARITY-02 focused test, existing RIASEC fixture test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, diff checks, fap-web reference status, and focused Big Five runtime freeze check passed locally."
+        },
+        {
+          "at": "2026-05-25T06:30:00Z",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1669 for RESULT-EN-PARITY-02 RIASEC English asset catalog; waiting for GitHub checks."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5772,6 +5772,54 @@ prs:
     fap_web_commit_allowed: false
     next_task: RESULT-EN-PARITY-02
 
+  - id: RESULT-EN-PARITY-02
+    repo: fap-api
+    depends_on: [RESULT-EN-PARITY-01]
+    branch: codex/result-en-parity-02-riasec-en-assets
+    base: main
+    title: "RESULT-EN-PARITY-02 RIASEC result/report English asset catalog"
+    train_scope: riasec_result_report_english_asset_catalog
+    risk_level: backend_riasec_lifecycle_assets_locale_safe_fail_closed
+    allowed_paths:
+      - backend/content_assets/riasec/**
+      - backend/content_packs/RIASEC/**
+      - backend/app/Services/Riasec/**
+      - backend/docs/seo/result-en-parity-02-riasec-en-assets.md
+      - backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json
+      - backend/tests/Feature/SeoIntel/ResultEnParity02RiasecEnAssetsTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Prepare backend-owned English counterparts for RIASEC lifecycle, share, PDF, history, FAQ, and method-boundary assets.
+      - Make RIASEC lifecycle copy locale-aware while preserving zh-CN default behavior.
+      - Ensure explicit English RIASEC lifecycle output does not silently fall back to zh-CN.
+      - Mark deeper RIASEC interpretation assets as deferred instead of mass-generating unsupported English report prose.
+      - Keep RIASEC language bounded as interest signal and exploratory guidance, not active career recommendation authority.
+    do_not:
+      - Claim active RIASEC-to-career recommendation, precise career matching, hiring fit, success prediction, salary prediction, diagnosis, treatment, or cure.
+      - Mutate CMS, production user data, production secrets, sitemap, llms, Search Channel, or URL submission state.
+      - Run production migrations, deploy, submit URLs, or access protected result data.
+      - Modify fap-web or treat frontend fallback content as authority.
+      - Change scoring algorithms.
+    validation:
+      - cd backend && php artisan test --filter=ResultEnParity02RiasecEnAssets --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+      - git diff --name-only origin/main...HEAD
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: false }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    next_task: RESULT-EN-PARITY-03
+
   - id: SEO-DASH-PROD-04B
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added backend-owned English RIASEC lifecycle assets for share/PDF/history, FAQ, FAQ markdown, technical-note summary, and professional method-boundary copy.
- Made `RiasecLifecycleCopyService` locale-aware while preserving default `zh-CN` behavior.
- Added fail-closed English lookup behavior: explicit English requests read `.en` assets and do not silently fall back to `zh-CN` interpretation copy.
- Added generated inventory/report artifacts and a focused SeoIntel parity test.
- Reconciled RESULT-EN-PARITY-01 train state after PR #1668 merged.

## Why
`RESULT-EN-PARITY-00/01` identified RIASEC as high risk for English result/report fallback because lifecycle/share/PDF/history/FAQ/method-boundary assets were zh-only. This PR prepares the first backend-authoritative English lifecycle batch and records deeper RIASEC interpretation assets as deferred for reviewed batches instead of mass-generating report prose.

## Validation
- `cd backend && php artisan test --filter=ResultEnParity02RiasecEnAssets --no-ansi`
- `cd backend && php artisan test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php --no-ansi`
- `cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json >/dev/null`
- `python3 - <<'PY' ... yaml/json manifest-state parse ... PY`
- `git diff --check`
- `git diff --cached --check`
- `cd /Users/rainie/Desktop/GitHub/fap-web && git status --short`

## Intentionally deferred
- Full English RIASEC deep-copy report prose: pair blends, Top 3 chains, activity examples, aspirations, disagreement paths, Action Lab, low-quality guidance, near-tie copy, occupation examples, profile-shape copy, and confidence copy.
- No fap-web de-authoring changes in this PR.
- No production CMS mutation, no production user data access, no deploy, no URL/search submission.

## Claim boundary
- RIASEC remains an interest-signal assessment and six-dimensional result vector.
- This PR does not claim active RIASEC-to-career recommendation, precise career matching, hiring fit, success prediction, salary prediction, diagnosis, treatment, or cure.
