### PR TITLE
RESULT-EN-PARITY-04 clinical combo paid section EN parity

### DIFF
--- a/backend/app/Services/Report/ClinicalCombo/ClinicalComboBlockSelector.php
+++ b/backend/app/Services/Report/ClinicalCombo/ClinicalComboBlockSelector.php
@@ -353,7 +353,7 @@ final class ClinicalComboBlockSelector
             return ['zh-CN'];
         }
 
-        return [$resolved, 'zh-CN'];
+        return [$resolved];
     }
 
     private function normalizeLocale(string $locale): string

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/blocks.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/blocks.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.blocks.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196851Z",
+    "generated_at": "2026-05-25T06:12:00.145432Z",
     "blocks_by_locale": {
         "zh-CN": [
             {
@@ -1340,6 +1340,101 @@
                 "conditions": []
             },
             {
+                "block_id": "paid_perf_pe_parental_en",
+                "section": "paid_deep_dive",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 220,
+                "exclusive_group": "perf_dominant",
+                "conditions": [
+                    {
+                        "path": "report_tags",
+                        "op": "contains",
+                        "value": "trait:parental_expectation_dominant"
+                    }
+                ],
+                "title": "Your perfectionism pattern is more externally driven",
+                "body_md": "This self-report pattern suggests your self-evaluation may be more sensitive to external approval or expectations. A safer next step is to track controllable process indicators before judging outcomes, while seeking professional support if distress or impairment feels significant.",
+                "id": "paid_perf_pe_parental_en",
+                "body": "This self-report pattern suggests your self-evaluation may be more sensitive to external approval or expectations. A safer next step is to track controllable process indicators before judging outcomes, while seeking professional support if distress or impairment feels significant."
+            },
+            {
+                "block_id": "paid_perf_org_order_en",
+                "section": "paid_deep_dive",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 220,
+                "exclusive_group": "perf_dominant",
+                "conditions": [
+                    {
+                        "path": "report_tags",
+                        "op": "contains",
+                        "value": "trait:orderliness_dominant"
+                    }
+                ],
+                "title": "Your perfectionism pattern is more order-driven",
+                "body_md": "This pattern suggests you may feel steadier when tasks have clear structure and order. Consider separating high-standard work from lower-risk tasks where an 80% delivery standard is acceptable.",
+                "id": "paid_perf_org_order_en",
+                "body": "This pattern suggests you may feel steadier when tasks have clear structure and order. Consider separating high-standard work from lower-risk tasks where an 80% delivery standard is acceptable."
+            },
+            {
+                "block_id": "paid_perf_ps_standards_en",
+                "section": "paid_deep_dive",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 220,
+                "exclusive_group": "perf_dominant",
+                "conditions": [
+                    {
+                        "path": "report_tags",
+                        "op": "contains",
+                        "value": "trait:high_standards_dominant"
+                    }
+                ],
+                "title": "Your perfectionism pattern is more self-standard driven",
+                "body_md": "High standards can be useful, but they become harder to carry when performance is tied to personal worth. Try reviewing whether the strategy worked instead of judging what the outcome says about you as a person.",
+                "id": "paid_perf_ps_standards_en",
+                "body": "High standards can be useful, but they become harder to carry when performance is tied to personal worth. Try reviewing whether the strategy worked instead of judging what the outcome says about you as a person."
+            },
+            {
+                "block_id": "paid_perf_cm_mistakes_en",
+                "section": "paid_deep_dive",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 220,
+                "exclusive_group": "perf_dominant",
+                "conditions": [
+                    {
+                        "path": "report_tags",
+                        "op": "contains",
+                        "value": "trait:mistake_concern_dominant"
+                    }
+                ],
+                "title": "Your perfectionism pattern is more mistake-sensitive",
+                "body_md": "This pattern suggests mistakes may feel unusually costly, which can lead to over-preparation or delay. A bounded next step is to practice low-risk experiments where small errors are expected and reviewed without self-judgment.",
+                "id": "paid_perf_cm_mistakes_en",
+                "body": "This pattern suggests mistakes may feel unusually costly, which can lead to over-preparation or delay. A bounded next step is to practice low-risk experiments where small errors are expected and reviewed without self-judgment."
+            },
+            {
+                "block_id": "paid_perf_da_doubts_en",
+                "section": "paid_deep_dive",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 220,
+                "exclusive_group": "perf_dominant",
+                "conditions": [
+                    {
+                        "path": "report_tags",
+                        "op": "contains",
+                        "value": "trait:doubt_checking_dominant"
+                    }
+                ],
+                "title": "Your perfectionism pattern is more doubt-checking driven",
+                "body_md": "This pattern suggests uncertainty may trigger repeated checking or reassurance seeking. Try setting a clear checking rule in advance, then delaying extra checks long enough to observe whether the urge changes.",
+                "id": "paid_perf_da_doubts_en",
+                "body": "This pattern suggests uncertainty may trigger repeated checking or reassurance seeking. Try setting a clear checking rule in advance, then delaying extra checks long enough to observe whether the urge changes."
+            },
+            {
                 "block_id": "paid_perf_generic_en",
                 "section": "paid_deep_dive",
                 "locale": "en",
@@ -1373,6 +1468,124 @@
                 "body_md": "You retain stronger recovery under pressure. Preserve this advantage with explicit recovery routines and boundaries.",
                 "id": "paid_resilience_praise_en",
                 "body": "You retain stronger recovery under pressure. Preserve this advantage with explicit recovery routines and boundaries."
+            },
+            {
+                "block_id": "paid_action_depression_14d_en",
+                "section": "action_plan",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 200,
+                "exclusive_group": "action_depression",
+                "conditions": [
+                    {
+                        "path": "scores.depression.level",
+                        "op": "in",
+                        "value": [
+                            "moderate",
+                            "severe"
+                        ]
+                    }
+                ],
+                "title": "14-day activation self-observation plan",
+                "body_md": "Use very small, observable actions and record completion without judging yourself. This is not a diagnosis or clinical care guidance; if symptoms are persistent, intense, or impair daily life, consider contacting a qualified professional.",
+                "id": "paid_action_depression_14d_en",
+                "body": "Use very small, observable actions and record completion without judging yourself. This is not a diagnosis or clinical care guidance; if symptoms are persistent, intense, or impair daily life, consider contacting a qualified professional."
+            },
+            {
+                "block_id": "paid_action_anxiety_14d_en",
+                "section": "action_plan",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 190,
+                "exclusive_group": "action_anxiety",
+                "conditions": [
+                    {
+                        "path": "scores.anxiety.level",
+                        "op": "in",
+                        "value": [
+                            "moderate",
+                            "severe"
+                        ]
+                    }
+                ],
+                "title": "14-day anxiety self-observation plan",
+                "body_md": "Schedule a short worry window, separate controllable from uncontrollable concerns, and add one low-intensity body-based reset each day. This is self-assessment guidance, not medical advice.",
+                "id": "paid_action_anxiety_14d_en",
+                "body": "Schedule a short worry window, separate controllable from uncontrollable concerns, and add one low-intensity body-based reset each day. This is self-assessment guidance, not medical advice."
+            },
+            {
+                "block_id": "paid_action_ocd_erp_start_en",
+                "section": "action_plan",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 180,
+                "exclusive_group": "action_ocd",
+                "conditions": [
+                    {
+                        "path": "scores.ocd.level",
+                        "op": "in",
+                        "value": [
+                            "moderate",
+                            "severe"
+                        ]
+                    }
+                ],
+                "title": "ERP-informed discussion note",
+                "body_md": "If intrusive thoughts or compulsive checking feel relevant, consider asking a qualified clinician about evidence-informed options such as ERP. Do not treat this self-assessment as instructions to start clinical exposure work on your own.",
+                "id": "paid_action_ocd_erp_start_en",
+                "body": "If intrusive thoughts or compulsive checking feel relevant, consider asking a qualified clinician about evidence-informed options such as ERP. Do not treat this self-assessment as instructions to start clinical exposure work on your own."
+            },
+            {
+                "block_id": "paid_action_perfectionism_14d_en",
+                "section": "action_plan",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 170,
+                "exclusive_group": "action_perfectionism",
+                "conditions": [
+                    {
+                        "path": "scores.perfectionism.level",
+                        "op": "in",
+                        "value": [
+                            "perfectionist",
+                            "rigid"
+                        ]
+                    }
+                ],
+                "title": "14-day perfectionism flexibility plan",
+                "body_md": "Choose one low-risk task each day where an 80% delivery standard is enough. Separate minimum acceptable criteria from optional improvement criteria, then review facts instead of making global self-judgments.",
+                "id": "paid_action_perfectionism_14d_en",
+                "body": "Choose one low-risk task each day where an 80% delivery standard is enough. Separate minimum acceptable criteria from optional improvement criteria, then review facts instead of making global self-judgments."
+            },
+            {
+                "block_id": "paid_action_burnout_en",
+                "section": "action_plan",
+                "locale": "en",
+                "access_level": "paid",
+                "priority": 160,
+                "exclusive_group": "action_burnout",
+                "conditions": [
+                    {
+                        "path": "scores.stress.level",
+                        "op": "in",
+                        "value": [
+                            "high",
+                            "extreme"
+                        ]
+                    },
+                    {
+                        "path": "scores.resilience.level",
+                        "op": "in",
+                        "value": [
+                            "fragile",
+                            "low"
+                        ]
+                    }
+                ],
+                "title": "Burnout risk self-observation plan",
+                "body_md": "Sort tasks into must-do, can-delay, and can-drop groups. Protect sleep and recovery first, then rebuild workload gradually; seek professional support if functioning continues to decline.",
+                "id": "paid_action_burnout_en",
+                "body": "Sort tasks into must-do, can-delay, and can-drop groups. Protect sleep and recovery first, then rebuild workload gradually; seek professional support if functioning continues to decline."
             },
             {
                 "block_id": "paid_action_safety_core_en",

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/consent.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/consent.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.consent.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196881Z",
+    "generated_at": "2026-05-25T06:12:00.145461Z",
     "consent_by_locale": {
         "zh-CN": {
             "version": "CLINICAL_COMBO_68_CONSENT_2026_02",

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/crisis_resources.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/crisis_resources.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.crisis_resources.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196910Z",
+    "generated_at": "2026-05-25T06:12:00.145489Z",
     "crisis_resources": {
         "version": "CLINICAL_COMBO_68_CRISIS_2026_02",
         "default_region": "CN_MAINLAND",

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/golden_cases.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/golden_cases.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.golden_cases.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196924Z",
+    "generated_at": "2026-05-25T06:12:00.145506Z",
     "cases": [
         {
             "case_id": "ALL_A",

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/landing.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/landing.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.landing.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196866Z",
+    "generated_at": "2026-05-25T06:12:00.145447Z",
     "landing": {
         "pack_id": "CLINICAL_COMBO_68",
         "pack_version": "v1",

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/layout.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/layout.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.layout.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196832Z",
+    "generated_at": "2026-05-25T06:12:00.145410Z",
     "layout": {
         "schema": "clinical_combo_68.report.layout.v2",
         "conflict_rules": {

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/manifest.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/manifest.json
@@ -3,40 +3,40 @@
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
     "policy_version": "2026.02.v1",
-    "compiled_at": "2026-03-22T16:33:55.201572Z",
-    "generated_at": "2026-03-22T16:33:55.201604Z",
-    "content_hash": "0a26da278d9a39d22866c16aa72a981829feb53c76c9b4f2be57dea7ed127e9f",
-    "compiled_hash": "a42444d804303b611c18b8a31c4f0581057a9a4a7c4c82f9637b372b4e7ab152",
+    "compiled_at": "2026-05-25T06:12:00.149739Z",
+    "generated_at": "2026-05-25T06:12:00.149777Z",
+    "content_hash": "2c4112c6c1c76dceda4d6796fe1a4379b6293e4bc657cba2b9abea559f50b17e",
+    "compiled_hash": "9ef273dd9a693e3f905b306fbb2125bcaf994adc7e6ed228443db08910b26bce",
     "files": {
         "blocks.compiled.json": {
-            "sha256": "4414ee41445ddece105e69bfd5c155f40117677073e551974fef02dd91d4060c"
+            "sha256": "36d219f839b0e863a0a1ee43574f01074e3e1b62b71a37e7e44d84c0ff29ae45"
         },
         "consent.compiled.json": {
-            "sha256": "b0dd9d9e469af1b9b4469adde057674ebe6c024959f7ec6578179cfc1d7e3c42"
+            "sha256": "3357d184ec963e2300316bc0b5d9367d67e0855b9e0a8941c0566a9d04cbe5d9"
         },
         "crisis_resources.compiled.json": {
-            "sha256": "9958f6b7d90b1341d7390e8aee58eca0e3fe56be804aa2388ae9a9a61eb63eb3"
+            "sha256": "55c03d164683d6c4b0110eea2643e420020a6146816b6d848d8cda782c957680"
         },
         "golden_cases.compiled.json": {
-            "sha256": "6c341a9a3981d890be46d6c123b7db5475b1426add697ea9818624d21b50eeb3"
+            "sha256": "1fbe0323d02fe63984e9eb4835578402b7d88bf8a43c9612b6375d34b763bf39"
         },
         "landing.compiled.json": {
-            "sha256": "a435b5e024722f91a5728e849891595c40f153bc5c2b4089bcb29e8d3c974e2b"
+            "sha256": "000dde7a6587d7798fa4ef4473ec52dadca1a79eb2015aa158e051e6041b3daa"
         },
         "layout.compiled.json": {
-            "sha256": "1b40c0c6c6dd977e1f8b60ec75f571439606ae92421b86a0806d61cfbbbaebd1"
+            "sha256": "6336b8a70d180daf26da907169fb7ea02743106a50907e52c47e25a67e1f9ce6"
         },
         "options_sets.compiled.json": {
-            "sha256": "ee28cb68abe48320dec81dfee8e8f4d08a82bb6f0b356cfa47cecd0a2cd22da1"
+            "sha256": "37a7576a868c3d44d247c1f10947ca70a6f585c591fb72b18227c77b70df8fa0"
         },
         "policy.compiled.json": {
-            "sha256": "50aa3317caad99e03988df4b0f215f4a91c0f033be893c8b8157ea5a3050f8e4"
+            "sha256": "09c8702cdfd2f0519b519745aaafdefa6b0588d79cf429db5ece4ebbf3c254f7"
         },
         "privacy_addendum.compiled.json": {
-            "sha256": "47b567f24fea51737b364c335e345253e5a69feb3362aa48a115f68a7cf5f3ea"
+            "sha256": "cb6d8eda4619b05a0206a0bbda5796472b706a560ae37481ec8d81073111062c"
         },
         "questions.compiled.json": {
-            "sha256": "6451c264aa5ed492e53d1fe1ea1f8f13538b7329b2ac14bf2677cca35890cf35"
+            "sha256": "e49ad98a531cb4fb913b057fe404a669b2510381218869c9b34f070c241f459a"
         }
     }
 }

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/options_sets.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/options_sets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.options.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196691Z",
+    "generated_at": "2026-05-25T06:12:00.145247Z",
     "sets": {
         "M1_FREQ_2W": {
             "scoring": {

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/policy.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/policy.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.policy.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196709Z",
+    "generated_at": "2026-05-25T06:12:00.145265Z",
     "policy": {
         "pack_id": "CLINICAL_COMBO_68",
         "pack_version": "v1",

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/privacy_addendum.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/privacy_addendum.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.privacy.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196896Z",
+    "generated_at": "2026-05-25T06:12:00.145475Z",
     "privacy_addendum_by_locale": {
         "zh-CN": {
             "version": "CLINICAL_COMBO_68_PRIVACY_2026_02",

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/questions.compiled.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/compiled/questions.compiled.json
@@ -2,7 +2,7 @@
     "schema": "clinical_combo_68.questions.compiled.v1",
     "pack_id": "CLINICAL_COMBO_68",
     "pack_version": "v1",
-    "generated_at": "2026-03-22T16:33:55.196644Z",
+    "generated_at": "2026-05-25T06:12:00.145111Z",
     "question_index": {
         "1": {
             "module_code": "M1",

--- a/backend/content_packs/CLINICAL_COMBO_68/v1/raw/blocks/paid_blocks.json
+++ b/backend/content_packs/CLINICAL_COMBO_68/v1/raw/blocks/paid_blocks.json
@@ -66,23 +66,108 @@
       "title": "你的完美主义更像“反复确认驱动”",
       "body_md": "你对不确定性的耐受阈值偏低，容易反复确认。建议设置明确确认规则，并用延迟技术削弱“必须马上确认”的冲动。"
     },
-    {
-      "block_id": "paid_resilience_praise_zh",
-      "section": "paid_deep_dive",
-      "locale": "zh-CN",
+        {
+            "block_id": "paid_resilience_praise_zh",
+            "section": "paid_deep_dive",
+            "locale": "zh-CN",
       "access_level": "paid",
       "priority": 180,
       "exclusive_group": "resilience_bonus",
       "conditions": [
         { "path": "scores.resilience.level", "op": "in", "value": ["strong_band"] }
       ],
-      "title": "你的韧性是稀缺优势资产",
-      "body_md": "你在压力下仍能保持恢复与推进能力。建议把恢复仪式、支持网络与节律管理固定化，防止高韧性人群的隐性透支。"
-    },
-    {
-      "block_id": "paid_perf_generic_en",
-      "section": "paid_deep_dive",
-      "locale": "en",
+            "title": "你的韧性是稀缺优势资产",
+            "body_md": "你在压力下仍能保持恢复与推进能力。建议把恢复仪式、支持网络与节律管理固定化，防止高韧性人群的隐性透支。"
+        },
+        {
+            "block_id": "paid_perf_pe_parental_en",
+            "section": "paid_deep_dive",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 220,
+            "exclusive_group": "perf_dominant",
+            "conditions": [
+                {
+                    "path": "report_tags",
+                    "op": "contains",
+                    "value": "trait:parental_expectation_dominant"
+                }
+            ],
+            "title": "Your perfectionism pattern is more externally driven",
+            "body_md": "This self-report pattern suggests your self-evaluation may be more sensitive to external approval or expectations. A safer next step is to track controllable process indicators before judging outcomes, while seeking professional support if distress or impairment feels significant."
+        },
+        {
+            "block_id": "paid_perf_org_order_en",
+            "section": "paid_deep_dive",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 220,
+            "exclusive_group": "perf_dominant",
+            "conditions": [
+                {
+                    "path": "report_tags",
+                    "op": "contains",
+                    "value": "trait:orderliness_dominant"
+                }
+            ],
+            "title": "Your perfectionism pattern is more order-driven",
+            "body_md": "This pattern suggests you may feel steadier when tasks have clear structure and order. Consider separating high-standard work from lower-risk tasks where an 80% delivery standard is acceptable."
+        },
+        {
+            "block_id": "paid_perf_ps_standards_en",
+            "section": "paid_deep_dive",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 220,
+            "exclusive_group": "perf_dominant",
+            "conditions": [
+                {
+                    "path": "report_tags",
+                    "op": "contains",
+                    "value": "trait:high_standards_dominant"
+                }
+            ],
+            "title": "Your perfectionism pattern is more self-standard driven",
+            "body_md": "High standards can be useful, but they become harder to carry when performance is tied to personal worth. Try reviewing whether the strategy worked instead of judging what the outcome says about you as a person."
+        },
+        {
+            "block_id": "paid_perf_cm_mistakes_en",
+            "section": "paid_deep_dive",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 220,
+            "exclusive_group": "perf_dominant",
+            "conditions": [
+                {
+                    "path": "report_tags",
+                    "op": "contains",
+                    "value": "trait:mistake_concern_dominant"
+                }
+            ],
+            "title": "Your perfectionism pattern is more mistake-sensitive",
+            "body_md": "This pattern suggests mistakes may feel unusually costly, which can lead to over-preparation or delay. A bounded next step is to practice low-risk experiments where small errors are expected and reviewed without self-judgment."
+        },
+        {
+            "block_id": "paid_perf_da_doubts_en",
+            "section": "paid_deep_dive",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 220,
+            "exclusive_group": "perf_dominant",
+            "conditions": [
+                {
+                    "path": "report_tags",
+                    "op": "contains",
+                    "value": "trait:doubt_checking_dominant"
+                }
+            ],
+            "title": "Your perfectionism pattern is more doubt-checking driven",
+            "body_md": "This pattern suggests uncertainty may trigger repeated checking or reassurance seeking. Try setting a clear checking rule in advance, then delaying extra checks long enough to observe whether the urge changes."
+        },
+        {
+            "block_id": "paid_perf_generic_en",
+            "section": "paid_deep_dive",
+            "locale": "en",
       "access_level": "paid",
       "priority": 120,
       "exclusive_group": "perf_dominant",
@@ -155,10 +240,10 @@
       "title": "把完美主义从折磨变成能力",
       "body_md": "每天选择 1 件任务做 80 分交付；区分最低可交付标准与优化标准；使用事实陈述替代人格审判。"
     },
-    {
-      "block_id": "paid_action_burnout_zh",
-      "section": "action_plan",
-      "locale": "zh-CN",
+        {
+            "block_id": "paid_action_burnout_zh",
+            "section": "action_plan",
+            "locale": "zh-CN",
       "access_level": "paid",
       "priority": 160,
       "exclusive_group": "action_burnout",
@@ -166,12 +251,120 @@
         { "path": "scores.stress.level", "op": "in", "value": ["high", "extreme"] },
         { "path": "scores.resilience.level", "op": "in", "value": ["fragile", "low"] }
       ],
-      "title": "倦怠风险：先止损再重建",
-      "body_md": "对任务做必须/可延后/可放弃分层，建立硬边界，优先恢复睡眠与身体，再逐步重建执行能力。"
-    },
-    {
-      "block_id": "paid_action_safety_core_en",
-      "section": "action_plan",
+            "title": "倦怠风险：先止损再重建",
+            "body_md": "对任务做必须/可延后/可放弃分层，建立硬边界，优先恢复睡眠与身体，再逐步重建执行能力。"
+        },
+        {
+            "block_id": "paid_action_depression_14d_en",
+            "section": "action_plan",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 200,
+            "exclusive_group": "action_depression",
+            "conditions": [
+                {
+                    "path": "scores.depression.level",
+                    "op": "in",
+                    "value": [
+                        "moderate",
+                        "severe"
+                    ]
+                }
+            ],
+            "title": "14-day activation self-observation plan",
+            "body_md": "Use very small, observable actions and record completion without judging yourself. This is not a diagnosis or clinical care guidance; if symptoms are persistent, intense, or impair daily life, consider contacting a qualified professional."
+        },
+        {
+            "block_id": "paid_action_anxiety_14d_en",
+            "section": "action_plan",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 190,
+            "exclusive_group": "action_anxiety",
+            "conditions": [
+                {
+                    "path": "scores.anxiety.level",
+                    "op": "in",
+                    "value": [
+                        "moderate",
+                        "severe"
+                    ]
+                }
+            ],
+            "title": "14-day anxiety self-observation plan",
+            "body_md": "Schedule a short worry window, separate controllable from uncontrollable concerns, and add one low-intensity body-based reset each day. This is self-assessment guidance, not medical advice."
+        },
+        {
+            "block_id": "paid_action_ocd_erp_start_en",
+            "section": "action_plan",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 180,
+            "exclusive_group": "action_ocd",
+            "conditions": [
+                {
+                    "path": "scores.ocd.level",
+                    "op": "in",
+                    "value": [
+                        "moderate",
+                        "severe"
+                    ]
+                }
+            ],
+            "title": "ERP-informed discussion note",
+            "body_md": "If intrusive thoughts or compulsive checking feel relevant, consider asking a qualified clinician about evidence-informed options such as ERP. Do not treat this self-assessment as instructions to start clinical exposure work on your own."
+        },
+        {
+            "block_id": "paid_action_perfectionism_14d_en",
+            "section": "action_plan",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 170,
+            "exclusive_group": "action_perfectionism",
+            "conditions": [
+                {
+                    "path": "scores.perfectionism.level",
+                    "op": "in",
+                    "value": [
+                        "perfectionist",
+                        "rigid"
+                    ]
+                }
+            ],
+            "title": "14-day perfectionism flexibility plan",
+            "body_md": "Choose one low-risk task each day where an 80% delivery standard is enough. Separate minimum acceptable criteria from optional improvement criteria, then review facts instead of making global self-judgments."
+        },
+        {
+            "block_id": "paid_action_burnout_en",
+            "section": "action_plan",
+            "locale": "en",
+            "access_level": "paid",
+            "priority": 160,
+            "exclusive_group": "action_burnout",
+            "conditions": [
+                {
+                    "path": "scores.stress.level",
+                    "op": "in",
+                    "value": [
+                        "high",
+                        "extreme"
+                    ]
+                },
+                {
+                    "path": "scores.resilience.level",
+                    "op": "in",
+                    "value": [
+                        "fragile",
+                        "low"
+                    ]
+                }
+            ],
+            "title": "Burnout risk self-observation plan",
+            "body_md": "Sort tasks into must-do, can-delay, and can-drop groups. Protect sleep and recovery first, then rebuild workload gradually; seek professional support if functioning continues to decline."
+        },
+        {
+            "block_id": "paid_action_safety_core_en",
+            "section": "action_plan",
       "locale": "en",
       "access_level": "paid",
       "priority": 100,

--- a/backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json
+++ b/backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json
@@ -1,0 +1,177 @@
+{
+  "pr_id": "RESULT-EN-PARITY-04",
+  "title": "clinical combo paid section EN parity",
+  "family": "clinical_combo_68",
+  "generated_at": "2026-05-25T00:00:00Z",
+  "authority": {
+    "backend_content_pack_is_authority": true,
+    "frontend_fallback_is_authority": false,
+    "scoring_change": false,
+    "production_cms_mutation": false,
+    "production_user_data_access": false,
+    "deployment": false,
+    "search_submission": false
+  },
+  "content_pack": {
+    "raw_path": "backend/content_packs/CLINICAL_COMBO_68/v1/raw/blocks/paid_blocks.json",
+    "compiled_path": "backend/content_packs/CLINICAL_COMBO_68/v1/compiled/blocks.compiled.json",
+    "pack_id": "CLINICAL_COMBO_68",
+    "pack_version": "v1"
+  },
+  "english_runtime_policy": "fail_closed_no_zh_paid_block_fallback",
+  "fixed_keys": [
+    "paid_action_anxiety_14d.en",
+    "paid_action_burnout.en",
+    "paid_action_depression_14d.en",
+    "paid_action_ocd_erp_start.en",
+    "paid_action_perfectionism_14d.en",
+    "paid_perf_cm_mistakes.en",
+    "paid_perf_da_doubts.en",
+    "paid_perf_org_order.en",
+    "paid_perf_pe_parental.en",
+    "paid_perf_ps_standards.en"
+  ],
+  "asset_matrix": [
+    {
+      "asset_key": "paid_action_anxiety_14d",
+      "zh_block_id": "paid_action_anxiety_14d_zh",
+      "en_block_id": "paid_action_anxiety_14d_en",
+      "section": "action_plan",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_action_burnout",
+      "zh_block_id": "paid_action_burnout_zh",
+      "en_block_id": "paid_action_burnout_en",
+      "section": "action_plan",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_action_depression_14d",
+      "zh_block_id": "paid_action_depression_14d_zh",
+      "en_block_id": "paid_action_depression_14d_en",
+      "section": "action_plan",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_action_ocd_erp_start",
+      "zh_block_id": "paid_action_ocd_erp_start_zh",
+      "en_block_id": "paid_action_ocd_erp_start_en",
+      "section": "action_plan",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_action_perfectionism_14d",
+      "zh_block_id": "paid_action_perfectionism_14d_zh",
+      "en_block_id": "paid_action_perfectionism_14d_en",
+      "section": "action_plan",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_perf_cm_mistakes",
+      "zh_block_id": "paid_perf_cm_mistakes_zh",
+      "en_block_id": "paid_perf_cm_mistakes_en",
+      "section": "paid_deep_dive",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_perf_da_doubts",
+      "zh_block_id": "paid_perf_da_doubts_zh",
+      "en_block_id": "paid_perf_da_doubts_en",
+      "section": "paid_deep_dive",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_perf_org_order",
+      "zh_block_id": "paid_perf_org_order_zh",
+      "en_block_id": "paid_perf_org_order_en",
+      "section": "paid_deep_dive",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_perf_pe_parental",
+      "zh_block_id": "paid_perf_pe_parental_zh",
+      "en_block_id": "paid_perf_pe_parental_en",
+      "section": "paid_deep_dive",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    },
+    {
+      "asset_key": "paid_perf_ps_standards",
+      "zh_block_id": "paid_perf_ps_standards_zh",
+      "en_block_id": "paid_perf_ps_standards_en",
+      "section": "paid_deep_dive",
+      "has_zh": true,
+      "has_en": true,
+      "missing_en": false,
+      "fallback_to_zh_allowed": false,
+      "sensitive_claim_boundary": true
+    }
+  ],
+  "claim_boundary": {
+    "allowed": [
+      "self-assessment guidance",
+      "self-observation",
+      "not a diagnosis",
+      "not medical advice",
+      "qualified professional support when distress or impairment is significant"
+    ],
+    "forbidden": [
+      "diagnosis",
+      "treatment plan",
+      "cure",
+      "guarantee",
+      "clinical diagnosis authority",
+      "emergency protocol beyond approved crisis resources"
+    ]
+  },
+  "review_control": {
+    "content_generation_mode": "small_first_batch",
+    "mass_translation": false,
+    "human_review_recommended_before_broad_promotion": true
+  },
+  "validation_targets": [
+    "php artisan test --filter=ResultEnParity04ClinicalComboEnPaid --no-ansi",
+    "php artisan route:list --no-ansi",
+    "vendor/bin/pint --test",
+    "composer validate --strict",
+    "composer audit --locked --no-interaction --ignore-unreachable",
+    "python3 -m json.tool backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json"
+  ],
+  "decision": "clinical_combo_en_paid_first_batch_locale_safe"
+}

--- a/backend/docs/seo/result-en-parity-04-clinical-combo-en-paid.md
+++ b/backend/docs/seo/result-en-parity-04-clinical-combo-en-paid.md
@@ -1,0 +1,101 @@
+# RESULT-EN-PARITY-04 Clinical Combo Paid Section EN Parity
+
+## Decision
+
+`clinical_combo_en_paid_first_batch_locale_safe`
+
+This PR adds a small backend-owned English first batch for the clinical combo paid action/performance blocks and changes the clinical block selector so English report sections do not silently select `zh-CN` blocks.
+
+## Scope
+
+Covered:
+
+- `paid_action_anxiety_14d.en`
+- `paid_action_burnout.en`
+- `paid_action_depression_14d.en`
+- `paid_action_ocd_erp_start.en`
+- `paid_action_perfectionism_14d.en`
+- `paid_perf_cm_mistakes.en`
+- `paid_perf_da_doubts.en`
+- `paid_perf_org_order.en`
+- `paid_perf_pe_parental.en`
+- `paid_perf_ps_standards.en`
+- generated inventory artifact
+- focused fail-closed EN paid-block tests
+
+Not covered:
+
+- clinical scoring changes
+- diagnosis, treatment, cure, or emergency protocol expansion
+- production CMS mutation
+- production user result access
+- deploy or URL submission
+- fap-web changes
+
+## Architecture Finding
+
+Clinical combo paid content is backend content-pack authority:
+
+`backend/content_packs/CLINICAL_COMBO_68/v1/raw/blocks/paid_blocks.json`
+
+Compiled runtime artifact:
+
+`backend/content_packs/CLINICAL_COMBO_68/v1/compiled/blocks.compiled.json`
+
+Before this PR, explicit English paid output had generic EN safety blocks, but the named paid action/performance counterparts identified in RESULT-EN-PARITY-00/01 were missing. The selector also listed `zh-CN` as a secondary candidate for English selection. This PR removes that selector-level Chinese fallback and adds English counterparts for the named paid block keys.
+
+## Claim Boundary
+
+Clinical combo wording remains:
+
+- self-assessment
+- self-observation
+- non-diagnostic
+- not medical advice
+- bounded to qualified professional support when distress or impairment is significant
+
+This PR does not add:
+
+- diagnosis
+- treatment plan
+- cure claims
+- medical authority claims
+- emergency protocol changes
+
+## Review Control
+
+This is a small first batch, not mass-generated clinical prose. Human clinical/editorial review is still recommended before broad promotion or paid-report marketing expansion.
+
+## Validation
+
+Focused validation:
+
+```bash
+cd backend
+php artisan test --filter=ResultEnParity04ClinicalComboEnPaid --no-ansi
+```
+
+Common validation:
+
+```bash
+cd backend
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd ..
+python3 -m json.tool backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json >/dev/null
+python3 - <<'PY'
+import yaml, json
+yaml.safe_load(open('docs/codex/pr-train.yaml'))
+json.load(open('docs/codex/pr-train-state.json'))
+print('manifest/state parse ok')
+PY
+git diff --check
+git diff --cached --check
+```
+
+## Next PR
+
+`RESULT-EN-PARITY-05` should materialize MBTI backend content package export and classify frontend MBTI clone interpretation copy as non-authoritative / migration-only.

--- a/backend/tests/Feature/SeoIntel/ResultEnParity04ClinicalComboEnPaidTest.php
+++ b/backend/tests/Feature/SeoIntel/ResultEnParity04ClinicalComboEnPaidTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Content\ClinicalComboPackLoader;
+use App\Services\Report\ClinicalCombo\ClinicalComboBlockSelector;
+use App\Services\Report\ClinicalCombo68ReportComposer;
+use App\Services\Report\ReportAccess;
+use Tests\TestCase;
+
+final class ResultEnParity04ClinicalComboEnPaidTest extends TestCase
+{
+    public function test_clinical_combo_paid_blocks_have_english_counterparts_for_known_missing_keys(): void
+    {
+        /** @var ClinicalComboPackLoader $loader */
+        $loader = app(ClinicalComboPackLoader::class);
+        $blocks = $loader->loadBlocks('en', 'v1');
+        $ids = array_values(array_filter(array_map(
+            static fn (array $row): string => (string) ($row['block_id'] ?? ''),
+            $blocks
+        )));
+
+        foreach ($this->requiredEnglishPaidBlockIds() as $requiredId) {
+            $this->assertContains($requiredId, $ids, $requiredId);
+        }
+
+        $englishPaidText = json_encode(
+            array_values(array_filter(
+                $blocks,
+                static fn (array $row): bool => ($row['access_level'] ?? null) === 'paid'
+            )),
+            JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+        );
+
+        $this->assertDoesNotMatchRegularExpression('/[\x{4e00}-\x{9fff}]/u', $englishPaidText);
+    }
+
+    public function test_clinical_combo_selector_fails_closed_instead_of_using_zh_for_english(): void
+    {
+        /** @var ClinicalComboBlockSelector $selector */
+        $selector = app(ClinicalComboBlockSelector::class);
+
+        $selected = $selector->select(
+            allBlocks: [[
+                'block_id' => 'paid_action_depression_14d_zh',
+                'section' => 'action_plan',
+                'locale' => 'zh-CN',
+                'access_level' => 'paid',
+                'priority' => 200,
+            ]],
+            sectionKey: 'action_plan',
+            locale: 'en',
+            allowedAccessLevels: ['paid'],
+            minBlocks: 0,
+            maxBlocks: 3,
+            context: [],
+            policy: []
+        );
+
+        $this->assertSame([], $selected);
+    }
+
+    public function test_english_full_report_selects_specific_paid_blocks_without_chinese_fallback(): void
+    {
+        $payload = app(ClinicalCombo68ReportComposer::class)->composeVariant(
+            $this->attempt('en-US'),
+            $this->scoredResult(),
+            ReportAccess::VARIANT_FULL,
+            [
+                'report_access_level' => ReportAccess::REPORT_ACCESS_FULL,
+            ]
+        );
+
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $report = (array) ($payload['report'] ?? []);
+        $this->assertSame('en', $report['locale'] ?? null);
+
+        $ids = $this->reportBlockIds($report);
+        foreach ([
+            'paid_perf_cm_mistakes_en',
+            'paid_action_depression_14d_en',
+            'paid_action_anxiety_14d_en',
+            'paid_action_ocd_erp_start_en',
+            'paid_action_perfectionism_14d_en',
+            'paid_action_burnout_en',
+        ] as $expectedId) {
+            $this->assertContains($expectedId, $ids, $expectedId);
+        }
+
+        $serialized = json_encode($report, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $this->assertDoesNotMatchRegularExpression('/[\x{4e00}-\x{9fff}]/u', $serialized);
+        $this->assertStringContainsString('not a diagnosis', strtolower($serialized));
+        $this->assertStringContainsString('not medical advice', strtolower($serialized));
+
+        foreach (['cure', 'guarantee', 'clinical diagnosis', 'treatment plan'] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, strtolower($serialized), $forbidden);
+        }
+    }
+
+    public function test_generated_clinical_combo_inventory_json_parses(): void
+    {
+        $path = base_path('docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('RESULT-EN-PARITY-04', $decoded['pr_id'] ?? null);
+        $this->assertSame('clinical_combo_68', $decoded['family'] ?? null);
+        $this->assertSame('fail_closed_no_zh_paid_block_fallback', $decoded['english_runtime_policy'] ?? null);
+        $this->assertContains('paid_action_anxiety_14d.en', $decoded['fixed_keys'] ?? []);
+        $this->assertContains('paid_perf_cm_mistakes.en', $decoded['fixed_keys'] ?? []);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredEnglishPaidBlockIds(): array
+    {
+        return [
+            'paid_action_anxiety_14d_en',
+            'paid_action_burnout_en',
+            'paid_action_depression_14d_en',
+            'paid_action_ocd_erp_start_en',
+            'paid_action_perfectionism_14d_en',
+            'paid_perf_cm_mistakes_en',
+            'paid_perf_da_doubts_en',
+            'paid_perf_org_order_en',
+            'paid_perf_pe_parental_en',
+            'paid_perf_ps_standards_en',
+        ];
+    }
+
+    private function attempt(string $locale): Attempt
+    {
+        return new Attempt([
+            'id' => 'attempt-clinical-combo-en-paid',
+            'scale_code' => 'CLINICAL_COMBO_68',
+            'locale' => $locale,
+            'region' => 'US',
+            'dir_version' => 'v1',
+        ]);
+    }
+
+    private function scoredResult(): Result
+    {
+        return new Result([
+            'scale_code' => 'CLINICAL_COMBO_68',
+            'result_json' => [
+                'normed_json' => [
+                    'scale_code' => 'CLINICAL_COMBO_68',
+                    'quality' => [
+                        'crisis_alert' => false,
+                        'crisis_reasons' => [],
+                    ],
+                    'scores' => [
+                        'depression' => ['level' => 'severe'],
+                        'anxiety' => ['level' => 'severe'],
+                        'ocd' => ['level' => 'severe'],
+                        'stress' => ['level' => 'high'],
+                        'resilience' => ['level' => 'low'],
+                        'perfectionism' => ['level' => 'extreme'],
+                    ],
+                    'facts' => [
+                        'function_impairment_level' => 'moderate',
+                    ],
+                    'report_tags' => [
+                        'trait:mistake_concern_dominant',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return list<string>
+     */
+    private function reportBlockIds(array $report): array
+    {
+        $ids = [];
+        foreach ((array) ($report['sections'] ?? []) as $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+            foreach ((array) ($section['blocks'] ?? []) as $block) {
+                if (! is_array($block)) {
+                    continue;
+                }
+                $id = trim((string) ($block['id'] ?? ''));
+                if ($id !== '') {
+                    $ids[] = $id;
+                }
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -328,6 +328,27 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_clinical_combo_en_paid_parity_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Report/ClinicalCombo/ClinicalComboBlockSelector.php',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/blocks.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/consent.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/crisis_resources.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/golden_cases.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/landing.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/layout.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/manifest.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/options_sets.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/policy.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/privacy_addendum.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/compiled/questions.compiled.json',
+            'backend/content_packs/CLINICAL_COMBO_68/v1/raw/blocks/paid_blocks.json',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_eq_v5_report_asset_layer_changes(): void
     {
         $changed = [
@@ -2483,6 +2504,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isClinicalComboEnPaidParityFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCiAuthBypassHardeningOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
@@ -3191,6 +3216,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Report/ReportSnapshotStore.php',
             'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
         ], true);
+    }
+
+    private function isClinicalComboEnPaidParityFile(string $file): bool
+    {
+        if ($file === 'backend/app/Services/Report/ClinicalCombo/ClinicalComboBlockSelector.php') {
+            return true;
+        }
+
+        if ($file === 'backend/content_packs/CLINICAL_COMBO_68/v1/raw/blocks/paid_blocks.json') {
+            return true;
+        }
+
+        return preg_match('#^backend/content_packs/CLINICAL_COMBO_68/v1/compiled/[a-z_]+(?:\\.compiled)?\\.json$#', $file) === 1;
     }
 
     private function isEq60FreeReportContractChange(string $file, string $repoRoot, string $baseRef): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T13:53:01+08:00",
+  "updated_at": "2026-05-25T06:52:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -18925,12 +18925,12 @@
     "RESULT-EN-PARITY-03": {
       "repo": "fap-api",
       "branch": "codex/result-en-parity-03-iq-locale-safe-labels",
-      "status": "local_files_generated_pending_validation",
+      "status": "merged",
       "depends_on": [
         "RESULT-EN-PARITY-02"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "e3469213abfe02b38a57b959f9394dfe4fcd53f4",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1670",
       "checks": {
         "dependency_result_en_parity_00": {
           "status": "pass",
@@ -18970,14 +18970,14 @@
           "evidence": "Focused ResultEnParity03IqLocaleSafeLabels test passed with 4 tests and 29 assertions. Existing IqReportBuilder test passed with 2 tests and 23 assertions. route:list exited 0 with 203 routes. Pint passed 3541 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON parse, manifest/state parse, git diff --check, git diff --cached --check, and Big Five runtime freeze focused check passed. fap-web reference status was inspected and only unrelated .playwright-mcp/ was untracked."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR #1670 is open; GitHub checks are pending."
+          "status": "pass",
+          "evidence": "PR #1670 passed hygiene, verify-mbti-legacy, verify-mbti-v2, semgrep, and supply-chain checks; mergeStateStatus was CLEAN before squash merge."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T06:02:20Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "events": [
         {
@@ -18994,6 +18994,11 @@
           "at": "2026-05-25T07:10:00Z",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1670 for RESULT-EN-PARITY-03 IQ locale-safe report builder labels; waiting for GitHub checks."
+        },
+        {
+          "at": "2026-05-25T06:02:20Z",
+          "status": "merged",
+          "summary": "PR #1670 was squash merged as e3469213abfe02b38a57b959f9394dfe4fcd53f4; remote branch deleted; isolated worktree main synchronized and focused post-merge test passed."
         }
       ]
     },
@@ -19080,6 +19085,101 @@
           "at": "2026-05-25T13:53:01+08:00",
           "status": "rebased_conflict_resolved_pending_push",
           "summary": "Rebased EN-PARITY-02 onto origin/main after PR #1669 merged. Resolved pr-train-state ledger by preserving current main entries, including RESULT-EN-PARITY-02, and keeping EN-PARITY-02 current PR state."
+        }
+      ]
+    },
+    "RESULT-EN-PARITY-04": {
+      "repo": "fap-api",
+      "branch": "codex/result-en-parity-04-clinical-combo-en-paid",
+      "status": "pr_open_rebased_github_checks_pending",
+      "depends_on": [
+        "RESULT-EN-PARITY-03"
+      ],
+      "commit_sha": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1671",
+      "checks": {
+        "dependency_result_en_parity_00": {
+          "status": "pass",
+          "evidence": "PR #1666 is MERGED and origin/main contains merge commit a93345e5a24f1f579495bcfd78f30b4c5984bd1a."
+        },
+        "dependency_result_en_parity_01": {
+          "status": "pass",
+          "evidence": "PR #1668 is MERGED and origin/main contains merge commit 3fb430f1b1592127cb8c42857e15fd42b0a11feb."
+        },
+        "dependency_result_en_parity_02": {
+          "status": "pass",
+          "evidence": "PR #1669 is MERGED and origin/main contains merge commit a803ccbb5ebf405d0e7f2de332e7bfd2a92d1085."
+        },
+        "dependency_result_en_parity_03": {
+          "status": "pass",
+          "evidence": "PR #1670 is MERGED and origin/main contains merge commit e3469213abfe02b38a57b959f9394dfe4fcd53f4."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Changed files are limited to clinical combo content pack paid blocks, ClinicalCombo report selector fail-closed behavior, generated report/artifact, focused SeoIntel test, minimum Big Five runtime-freeze classifier update for this clinical-combo-only scope, and PR-train metadata."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No production mutation, CMS mutation, deploy, production migration, URL submission, production user data access, scoring change, or fap-web commit."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=ResultEnParity04ClinicalComboEnPaid --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json >/dev/null",
+            "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+            "git diff --check",
+            "git diff --cached --check",
+            "git diff --name-only origin/main...HEAD",
+            "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_freeze_classifier_ignores_clinical_combo_en_paid_parity_changes --no-ansi",
+            "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_paths_have_no_uncommitted_diff --no-ansi"
+          ],
+          "evidence": "Focused ResultEnParity04ClinicalComboEnPaid test passed with 4 tests and 33 assertions. route:list exited 0 with 203 routes. Pint passed 3542 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON parse, manifest/state parse, git diff checks, fap-web reference status, focused Big Five runtime freeze classifier test, and runtime_paths_have_no_uncommitted_diff passed locally."
+        },
+        "github_required_checks": {
+          "status": "pending_after_rebase",
+          "evidence": "PR #1671 required checks passed before rebase, but branch was DIRTY after origin/main advanced. Rebase is in progress; GitHub checks must rerun on the rebased head."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "events": [
+        {
+          "at": "2026-05-25T06:15:00Z",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Added clinical combo English paid block first batch, removed selector-level EN-to-zh paid block fallback, regenerated clinical combo compiled content pack artifacts, added generated artifact/report, focused test, and manifest/state entries for remaining RESULT-EN-PARITY train items."
+        },
+        {
+          "at": "2026-05-25T06:25:00Z",
+          "status": "local_validation_passed",
+          "summary": "RESULT-EN-PARITY-04 focused test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, diff checks, fap-web reference status, and focused Big Five runtime freeze check passed locally."
+        },
+        {
+          "at": "2026-05-25T06:32:00Z",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1671 for RESULT-EN-PARITY-04 clinical combo paid section EN parity; waiting for GitHub checks."
+        },
+        {
+          "at": "2026-05-25T06:45:00Z",
+          "status": "github_checks_failed_current_pr_fix_in_progress",
+          "summary": "GitHub verify-mbti-legacy and verify-mbti-v2 failed on the Big Five runtime freeze diff classifier for current PR clinical combo files; added minimum classifier coverage within PR4."
+        },
+        {
+          "at": "2026-05-25T06:52:00Z",
+          "status": "ci_fix_pushed_pending_checks",
+          "summary": "Added minimum Big Five runtime freeze classifier for RESULT-EN-PARITY-04 clinical combo EN paid parity files; focused PR4 test, classifier test, runtime_paths_have_no_uncommitted_diff, Pint, manifest/state parse, and diff checks passed locally."
+        },
+        {
+          "at": "2026-05-25T06:58:00Z",
+          "status": "rebased_conflict_resolved_pending_push",
+          "summary": "Rebased RESULT-EN-PARITY-04 onto origin/main after EN-PARITY-02 merged. Resolved pr-train-state ledger by preserving current main entries, including EN-PARITY-02, and keeping RESULT-EN-PARITY-03/04 current states."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5915,6 +5915,145 @@ prs:
     fap_web_commit_allowed: false
     next_task: RESULT-EN-PARITY-04
 
+  - id: RESULT-EN-PARITY-04
+    repo: fap-api
+    depends_on: [RESULT-EN-PARITY-03]
+    branch: codex/result-en-parity-04-clinical-combo-en-paid
+    base: main
+    title: "RESULT-EN-PARITY-04 clinical combo paid section EN parity"
+    train_scope: clinical_combo_paid_section_en_parity
+    risk_level: backend_clinical_content_pack_small_first_batch_fail_closed
+    allowed_paths:
+      - backend/content_packs/CLINICAL*/**
+      - backend/app/Services/Clinical/**
+      - backend/app/Services/Report/**
+      - backend/docs/seo/result-en-parity-04-clinical-combo-en-paid.md
+      - backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json
+      - backend/tests/Feature/SeoIntel/ResultEnParity04ClinicalComboEnPaidTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add a small backend-owned English first batch for missing clinical combo paid action and performance blocks.
+      - Ensure explicit EN clinical paid reports do not silently select zh-CN paid interpretation blocks.
+      - Keep all clinical wording self-assessment, non-diagnostic, non-treatment, and professional-help bounded.
+      - Produce generated artifact/report and focused tests.
+    do_not:
+      - Diagnose, recommend treatment as medical advice, claim cure, or add emergency protocol claims beyond approved crisis resources.
+      - Change scoring, payment, unlock, CMS, production data, production secrets, sitemap, llms, Search Channel, or URL submission state.
+      - Run production migrations, deploy, submit URLs, or access protected result data.
+      - Modify fap-web.
+    validation:
+      - cd backend && php artisan test --filter=ResultEnParity04ClinicalComboEnPaid --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+      - git diff --name-only origin/main...HEAD
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: false }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    next_task: RESULT-EN-PARITY-05
+
+  - id: RESULT-EN-PARITY-05
+    repo: fap-api
+    depends_on: [RESULT-EN-PARITY-04]
+    branch: codex/result-en-parity-05-mbti-content-export
+    base: main
+    title: "RESULT-EN-PARITY-05 MBTI backend content package export and frontend interpretation de-authoring"
+    train_scope: mbti_backend_content_package_export_frontend_interpretation_de_authoring
+    risk_level: backend_mbti_authority_inventory_no_frontend_commit
+    allowed_paths:
+      - backend/app/Services/Mbti/**
+      - backend/app/Services/Report/**
+      - backend/docs/seo/result-en-parity-05-mbti-content-export.md
+      - backend/docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json
+      - backend/tests/Feature/SeoIntel/ResultEnParity05MbtiContentExportTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Materialize or export authoritative MBTI result/report content package keys.
+      - Classify fap-web MBTI clone interpretation content as non-authoritative or migration-only.
+      - Add backend-owned MBTI asset key inventory and tests preventing frontend clone interpretation copy from becoming authority.
+      - Keep missing English keys explicit without mass-generating MBTI interpretation prose.
+    do_not:
+      - Mass-generate all MBTI English interpretation prose.
+      - Use frontend clone copy as source of truth.
+      - Mutate CMS, production user data, production secrets, sitemap, llms, Search Channel, or URL submission state.
+      - Run production migrations, deploy, submit URLs, or access protected result data.
+      - Modify fap-web without an explicitly authorized linked PR.
+      - Change MBTI scoring.
+    validation:
+      - cd backend && php artisan test --filter=ResultEnParity05MbtiContentExport --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+      - git diff --name-only origin/main...HEAD
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: false }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    next_task: RESULT-EN-PARITY-06
+
+  - id: RESULT-EN-PARITY-06
+    repo: fap-api
+    depends_on: [RESULT-EN-PARITY-05]
+    branch: codex/result-en-parity-06-bigfive-v2-en-assets
+    base: main
+    title: "RESULT-EN-PARITY-06 Big Five ResultPageV2 EN asset catalog parity"
+    train_scope: bigfive_result_page_v2_en_asset_catalog_parity
+    risk_level: backend_bigfive_v2_asset_catalog_parity_no_scoring_change
+    allowed_paths:
+      - backend/app/Services/BigFive/**
+      - backend/content_packs/BIG5_OCEAN/**
+      - backend/docs/seo/result-en-parity-06-bigfive-v2-en-assets.md
+      - backend/docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json
+      - backend/tests/Feature/SeoIntel/ResultEnParity06BigFiveV2EnAssetsTest.php
+      - backend/tests/Unit/Services/BigFive/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add or draft English counterparts for Big Five ResultPageV2 route matrix, coupling, scenario action, facet, canonical profile, core body, and selector-ready assets.
+      - Ensure explicit EN Big Five V2 output cannot silently fall back to zh-CN interpretation copy.
+      - Preserve Big Five as trait-vector, workstyle, and behavioral explanation, not career recommendation authority.
+      - Produce generated artifact/report and focused tests.
+    do_not:
+      - Claim Big Five precise career matching, hiring fit, career success prediction, diagnosis, treatment, or cure.
+      - Change scoring, V2 import/selector gates, payment, unlock, CMS, production data, production secrets, sitemap, llms, Search Channel, or URL submission state.
+      - Run production migrations, deploy, submit URLs, or access protected result data.
+      - Modify fap-web.
+    validation:
+      - cd backend && php artisan test --filter=ResultEnParity06BigFiveV2EnAssets --no-ansi
+      - cd backend && php artisan test --filter=BigFive --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+      - git diff --name-only origin/main...HEAD
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: false }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+
   - id: SEO-DASH-PROD-04B
     repo: fap-api
     depends_on:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5930,12 +5930,14 @@ prs:
       - backend/docs/seo/result-en-parity-04-clinical-combo-en-paid.md
       - backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json
       - backend/tests/Feature/SeoIntel/ResultEnParity04ClinicalComboEnPaidTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     scope:
       - Add a small backend-owned English first batch for missing clinical combo paid action and performance blocks.
       - Ensure explicit EN clinical paid reports do not silently select zh-CN paid interpretation blocks.
       - Keep all clinical wording self-assessment, non-diagnostic, non-treatment, and professional-help bounded.
+      - Add the minimum Big Five runtime-freeze classifier case for this clinical-combo-only parity scope.
       - Produce generated artifact/report and focused tests.
     do_not:
       - Diagnose, recommend treatment as medical advice, claim cure, or add emergency protocol claims beyond approved crisis resources.


### PR DESCRIPTION
## What changed

- Added a small backend-owned English first batch for clinical combo paid action/performance blocks:
  - `paid_action_anxiety_14d.en`
  - `paid_action_burnout.en`
  - `paid_action_depression_14d.en`
  - `paid_action_ocd_erp_start.en`
  - `paid_action_perfectionism_14d.en`
  - `paid_perf_cm_mistakes.en`
  - `paid_perf_da_doubts.en`
  - `paid_perf_org_order.en`
  - `paid_perf_pe_parental.en`
  - `paid_perf_ps_standards.en`
- Recompiled the CLINICAL_COMBO_68 v1 content-pack artifacts.
- Made `ClinicalComboBlockSelector` fail closed for English locale selection instead of trying `zh-CN` as a secondary candidate.
- Added generated inventory/report artifacts and focused SeoIntel coverage.
- Added the minimum Big Five runtime-freeze classifier case for this clinical-combo-only scope after CI classified the clinical content-pack files as runtime drift.
- Added RESULT-EN-PARITY-04/05/06 manifest entries and reconciled RESULT-EN-PARITY-03 as merged in the train ledger.

## Why

RESULT-EN-PARITY-00/01 identified clinical combo paid-section English gaps. The prior runtime had generic English paid blocks, but the named paid action/performance counterparts were missing and selector-level locale candidates still allowed an English request to consider `zh-CN` rows. Sensitive clinical report content must be explicit and fail closed instead of silently leaking Chinese interpretation copy.

## Validation

```bash
cd backend && php artisan test --filter=ResultEnParity04ClinicalComboEnPaid --no-ansi
cd backend && php artisan route:list --no-ansi
cd backend && vendor/bin/pint --test
cd backend && composer validate --strict
cd backend && composer audit --locked --no-interaction --ignore-unreachable
python3 -m json.tool backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json >/dev/null
python3 - <<'PY'
import yaml, json
yaml.safe_load(open('docs/codex/pr-train.yaml'))
json.load(open('docs/codex/pr-train-state.json'))
print('manifest/state parse ok')
PY
git diff --check
git diff --cached --check
cd /Users/rainie/Desktop/GitHub/fap-web && git status --short
cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_freeze_classifier_ignores_clinical_combo_en_paid_parity_changes --no-ansi
cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_paths_have_no_uncommitted_diff --no-ansi
```

Result: all passed locally. fap-web was reference-only; it has only unrelated untracked `.playwright-mcp/` and was not modified.

## Intentionally deferred

- No clinical scoring changes.
- No mass clinical prose generation.
- Human clinical/editorial review is still recommended before broad paid-report promotion.
- No fap-web de-authoring work in this PR; that remains for RESULT-EN-PARITY-05 if needed as a linked PR.

## Safety / authority statement

- No production mutation.
- No CMS mutation.
- No deploy.
- No production migration.
- No protected user result data access.
- No URL/search submission.
- No fap-web commit.
- Backend clinical combo content pack remains authority; frontend fallback is not authority.
