### PR TITLE
EN-PARITY-03 content pages EN/ZH parity

### DIFF
--- a/backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
@@ -156,18 +156,29 @@ final class ContentPagesImportLocalBaseline extends Command
             'slug' => $slug,
             'path' => trim((string) ($row['path'] ?? '')) ?: '/'.$slug,
             'kind' => $this->normalizeKind($row['kind'] ?? null),
+            'page_type' => $this->normalizePageType($row['pageType'] ?? $row['page_type'] ?? $slug),
             'title' => trim((string) $row['title']),
             'kicker' => $this->nullableString($row['kicker'] ?? null),
             'summary' => $this->nullableString($row['summary'] ?? null),
             'template' => $this->normalizeTemplate($row['template'] ?? null),
             'animation_profile' => $this->normalizeAnimationProfile($row['animationProfile'] ?? $row['animation_profile'] ?? null),
             'locale' => $locale,
+            'translation_group_id' => $this->nullableString($row['translationGroupId'] ?? $row['translation_group_id'] ?? null)
+                ?? $this->defaultTranslationGroupId($slug),
+            'source_locale' => $this->nullableString($row['sourceLocale'] ?? $row['source_locale'] ?? null)
+                ?? 'zh-CN',
+            'translation_status' => $this->normalizeTranslationStatus(
+                $row['translationStatus'] ?? $row['translation_status'] ?? null,
+                $locale,
+                $status,
+            ),
             'published_at' => $this->nullableString($row['publishedAt'] ?? $row['published_at'] ?? null),
             'source_updated_at' => $this->nullableString($row['updatedAt'] ?? $row['updated_at'] ?? null),
             'effective_at' => $this->nullableString($row['effectiveAt'] ?? $row['effective_at'] ?? null),
             'source_doc' => $this->nullableString($row['sourceDoc'] ?? $row['source_doc'] ?? null),
             'is_public' => (bool) ($row['isPublic'] ?? $row['is_public'] ?? true),
             'is_indexable' => (bool) ($row['isIndexable'] ?? $row['is_indexable'] ?? true),
+            'review_state' => $this->normalizeReviewState($row['reviewState'] ?? $row['review_state'] ?? null, $status),
             'headings_json' => array_values(array_filter(array_map(
                 static fn (mixed $heading): string => trim((string) $heading),
                 is_array($row['headings'] ?? null) ? $row['headings'] : $this->extractHeadings($contentMd),
@@ -176,6 +187,8 @@ final class ContentPagesImportLocalBaseline extends Command
             'content_html' => $contentHtml,
             'seo_title' => $this->nullableString($row['seoTitle'] ?? $row['seo_title'] ?? $row['title'] ?? null),
             'meta_description' => $this->nullableString($row['metaDescription'] ?? $row['meta_description'] ?? $row['summary'] ?? null),
+            'seo_description' => $this->nullableString($row['seoDescription'] ?? $row['seo_description'] ?? $row['metaDescription'] ?? $row['meta_description'] ?? $row['summary'] ?? null),
+            'canonical_path' => $this->nullableString($row['canonicalPath'] ?? $row['canonical_path'] ?? null),
             'status' => $status,
         ];
     }
@@ -203,6 +216,73 @@ final class ContentPagesImportLocalBaseline extends Command
         return in_array($normalized, ['company', 'charter', 'foundation', 'careers', 'brand', 'policy', 'help'], true)
             ? $normalized
             : 'company';
+    }
+
+    private function normalizePageType(mixed $value): string
+    {
+        $normalized = strtolower(str_replace(['_', ' '], '-', trim((string) $value)));
+        $aliases = [
+            'method-boundaries' => 'boundary',
+            'methodology-boundaries' => 'boundary',
+            'careers' => 'company',
+            'brand' => 'company',
+            'charter' => 'company',
+            'foundation' => 'company',
+            'policies' => 'policy',
+            'faq' => 'support_static',
+            'help-faq' => 'support_static',
+            'help-about' => 'about',
+            'help-contact' => 'support_static',
+            'help-team' => 'company',
+            'help-used-and-mentioned' => 'company',
+            'help-for-business-and-research' => 'company',
+        ];
+
+        $normalized = $aliases[$normalized] ?? $normalized;
+
+        return in_array($normalized, ContentPage::PAGE_TYPES, true)
+            ? $normalized
+            : ContentPage::PAGE_TYPES[7];
+    }
+
+    private function normalizeTranslationStatus(mixed $value, string $locale, string $status): string
+    {
+        $normalized = strtolower(trim((string) $value));
+        if (in_array($normalized, [
+            ContentPage::TRANSLATION_STATUS_SOURCE,
+            ContentPage::TRANSLATION_STATUS_DRAFT,
+            ContentPage::TRANSLATION_STATUS_MACHINE_DRAFT,
+            ContentPage::TRANSLATION_STATUS_HUMAN_REVIEW,
+            ContentPage::TRANSLATION_STATUS_APPROVED,
+            ContentPage::TRANSLATION_STATUS_PUBLISHED,
+            ContentPage::TRANSLATION_STATUS_STALE,
+            ContentPage::TRANSLATION_STATUS_ARCHIVED,
+        ], true)) {
+            return $normalized;
+        }
+
+        if ($locale === 'zh-CN') {
+            return ContentPage::TRANSLATION_STATUS_SOURCE;
+        }
+
+        return $status === ContentPage::STATUS_PUBLISHED
+            ? ContentPage::TRANSLATION_STATUS_PUBLISHED
+            : ContentPage::TRANSLATION_STATUS_DRAFT;
+    }
+
+    private function normalizeReviewState(mixed $value, string $status): string
+    {
+        $normalized = strtolower(trim((string) $value));
+        if (in_array($normalized, ContentPage::REVIEW_STATES, true)) {
+            return $normalized;
+        }
+
+        return $status === ContentPage::STATUS_PUBLISHED ? 'approved' : 'draft';
+    }
+
+    private function defaultTranslationGroupId(string $slug): string
+    {
+        return 'content-page-'.preg_replace('/[^a-z0-9]+/', '-', $slug);
     }
 
     private function normalizeAnimationProfile(mixed $value): string

--- a/backend/docs/seo/en-parity-03-content-pages-parity-import-package.md
+++ b/backend/docs/seo/en-parity-03-content-pages-parity-import-package.md
@@ -1,0 +1,76 @@
+# EN-PARITY-03 Content Pages EN/ZH Parity Import Package
+
+## Decision
+
+EN-PARITY-03 lands a repository-backed content page parity package for foundational company, help, and policy pages. It does not create substantial new English prose, publish content, mutate production CMS, deploy, run production migrations, submit URLs, or modify fap-web.
+
+The existing `content_baselines/content_pages` authority source already contains bilingual help pages and a smaller set of English company/policy pages. This PR strengthens the local baseline importer so those rows carry content-page translation group metadata when imported into a local or operator-controlled environment.
+
+## Authority Boundary
+
+- Backend `content_pages` remains the content authority.
+- `content_baselines/content_pages` is an import/recovery package, not frontend runtime authority.
+- fap-web fallback, sitemap, `llms.txt`, and production runtime observation are not accepted as content authority.
+- Missing English counterparts stay explicit and must not be exposed in sitemap, llms, hreflang, or public URL Truth.
+
+## Current Import Package
+
+The generated JSON artifact records:
+
+- existing EN/ZH authority-backed pairs that can be imported from current baselines;
+- missing English counterpart candidates that require human-reviewed copy before import;
+- support/root-route decisions that remain outside content authority until a real `content_pages` row exists;
+- claim-boundary controls for about/support/help/company/policy pages.
+
+This PR updates `content-pages:import-local-baseline` to preserve or derive:
+
+- `translation_group_id`
+- `source_locale`
+- `translation_status`
+- `page_type`
+- `review_state`
+- `seo_description`
+- `canonical_path`
+
+The importer remains operator-run. No production import is executed.
+
+## Missing English Counterparts
+
+The following Chinese baseline pages have no English content page counterpart in the current repository baseline and are deferred to human-reviewed draft/import work:
+
+- `brand`
+- `careers`
+- `charter`
+- `foundation`
+- `policies`
+
+The package intentionally does not invent body copy for these pages.
+
+## Validation
+
+Focused validation:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=EnParity03 --no-ansi
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd /Users/rainie/Desktop/GitHub/fap-api
+python3 -m json.tool backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json >/dev/null
+python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+git diff --check
+```
+
+## Deferred Items
+
+- Human-reviewed English copy for `brand`, `careers`, `charter`, `foundation`, and `policies`.
+- Production CMS import or publish approval.
+- fap-web runtime restoration for hard/soft 404 pages.
+- Sitemap, llms, JSON-LD, and FAQ parity gates remain EN-PARITY-07.
+
+## Next Task
+
+EN-PARITY-04 article English counterpart completion, under the no-mass-generation control rule.

--- a/backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json
+++ b/backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json
@@ -1,0 +1,171 @@
+{
+  "schema_version": "en-parity-03-content-pages-parity-import-package.v1",
+  "task": "EN-PARITY-03",
+  "source_authority": "backend_content_pages_import_package",
+  "frontend_fallback_authority_used": false,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "auto_publish_performed": false,
+  "substantial_english_prose_generated": false,
+  "fap_web_modified": false,
+  "target_locales": [
+    "en",
+    "zh-CN"
+  ],
+  "baseline_sources": [
+    "content_baselines/content_pages/content_pages.en.json",
+    "content_baselines/content_pages/content_pages.zh-CN.json",
+    "content_baselines/content_pages/help_pages.en.json",
+    "content_baselines/content_pages/help_pages.zh-CN.json"
+  ],
+  "importer_contract": {
+    "command": "content-pages:import-local-baseline",
+    "dry_run_supported": true,
+    "upsert_supported": true,
+    "preserved_or_derived_fields": [
+      "translation_group_id",
+      "source_locale",
+      "translation_status",
+      "page_type",
+      "review_state",
+      "seo_description",
+      "canonical_path"
+    ],
+    "runtime_authority": "content_pages",
+    "baseline_runtime_authority": false
+  },
+  "content_generation_policy": {
+    "auto_publish_allowed": false,
+    "mass_english_generation_allowed": false,
+    "draft_exposure_allowed_in_sitemap_llms": false,
+    "missing_counterpart_handling": "explicit_deferred_until_human_reviewed_authority_exists",
+    "english_copy_creation_mode": "import_package_metadata_only"
+  },
+  "current_baseline_summary": {
+    "content_pages_en_count": 4,
+    "content_pages_zh_count": 9,
+    "help_pages_en_count": 6,
+    "help_pages_zh_count": 6,
+    "total_rows": 25,
+    "existing_authority_pairs": [
+      "about",
+      "help-about",
+      "help-contact",
+      "help-faq",
+      "help-for-business-and-research",
+      "help-team",
+      "help-used-and-mentioned",
+      "method-boundaries",
+      "privacy",
+      "terms"
+    ],
+    "missing_english_counterparts": [
+      "brand",
+      "careers",
+      "charter",
+      "foundation",
+      "policies"
+    ],
+    "missing_chinese_counterparts": []
+  },
+  "deferred_import_candidates": [
+    {
+      "entity_type": "content_page",
+      "source_locale": "zh-CN",
+      "target_locale": "en",
+      "source_slug": "brand",
+      "translation_group_id": "content-page-brand",
+      "target_publication_state": "draft_import_candidate",
+      "body_status": "requires_human_translation",
+      "sitemap_llms_exposure_allowed": false,
+      "claim_boundary_required": true
+    },
+    {
+      "entity_type": "content_page",
+      "source_locale": "zh-CN",
+      "target_locale": "en",
+      "source_slug": "careers",
+      "translation_group_id": "content-page-careers",
+      "target_publication_state": "draft_import_candidate",
+      "body_status": "requires_human_translation",
+      "sitemap_llms_exposure_allowed": false,
+      "claim_boundary_required": true
+    },
+    {
+      "entity_type": "content_page",
+      "source_locale": "zh-CN",
+      "target_locale": "en",
+      "source_slug": "charter",
+      "translation_group_id": "content-page-charter",
+      "target_publication_state": "draft_import_candidate",
+      "body_status": "requires_human_translation",
+      "sitemap_llms_exposure_allowed": false,
+      "claim_boundary_required": true
+    },
+    {
+      "entity_type": "content_page",
+      "source_locale": "zh-CN",
+      "target_locale": "en",
+      "source_slug": "foundation",
+      "translation_group_id": "content-page-foundation",
+      "target_publication_state": "draft_import_candidate",
+      "body_status": "requires_human_translation",
+      "sitemap_llms_exposure_allowed": false,
+      "claim_boundary_required": true
+    },
+    {
+      "entity_type": "content_page",
+      "source_locale": "zh-CN",
+      "target_locale": "en",
+      "source_slug": "policies",
+      "translation_group_id": "content-page-policies",
+      "target_publication_state": "draft_import_candidate",
+      "body_status": "requires_human_translation",
+      "sitemap_llms_exposure_allowed": false,
+      "claim_boundary_required": true
+    }
+  ],
+  "route_decisions": [
+    {
+      "url": "https://fermatmind.com/en/about",
+      "classification": "authority_exists_in_import_package",
+      "source": "content_baselines/content_pages/content_pages.en.json",
+      "follow_up": "frontend/runtime route restoration remains outside backend import package"
+    },
+    {
+      "url": "https://fermatmind.com/zh/about",
+      "classification": "authority_exists_in_import_package",
+      "source": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "follow_up": "frontend/runtime route restoration remains outside backend import package"
+    },
+    {
+      "url": "https://fermatmind.com/en/support",
+      "classification": "missing_content_page_authority",
+      "source": null,
+      "follow_up": "create human-reviewed support content_page authority or keep route retired"
+    },
+    {
+      "url": "https://fermatmind.com/zh/support",
+      "classification": "missing_content_page_authority",
+      "source": null,
+      "follow_up": "create human-reviewed support content_page authority or keep route retired"
+    }
+  ],
+  "exposure_guards": {
+    "draft_candidates_must_not_enter_sitemap": true,
+    "draft_candidates_must_not_enter_llms": true,
+    "frontend_fallback_must_not_be_counterpart": true,
+    "missing_authority_must_remain_explicit": true,
+    "claim_unsafe_copy_must_not_be_created": true
+  },
+  "recommended_next_tasks": [
+    "Human-reviewed EN content_page draft package for brand/careers/charter/foundation/policies",
+    "Route/runtime restoration for content pages whose backend authority exists",
+    "EN-PARITY-07 sitemap/llms/schema parity gate"
+  ],
+  "final_decision": "en_parity_03_import_package_landed_missing_copy_deferred",
+  "next_task": "EN-PARITY-04 articles English counterpart completion"
+}

--- a/backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php
+++ b/backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ContentPage;
+use App\Services\Scale\ScaleRegistry;
+use App\Services\SEO\SitemapGenerator;
+use App\Services\SeoIntel\TranslationParity\TranslationParityMatrixReadModel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class EnParity03ContentPagesParityImportPackageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function generated_import_package_records_draft_only_content_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('en-parity-03-content-pages-parity-import-package.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('EN-PARITY-03', $payload['task'] ?? null);
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['auto_publish_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['substantial_english_prose_generated'] ?? true));
+        $this->assertFalse((bool) data_get($payload, 'content_generation_policy.auto_publish_allowed'));
+        $this->assertFalse((bool) data_get($payload, 'content_generation_policy.mass_english_generation_allowed'));
+        $this->assertFalse((bool) data_get($payload, 'content_generation_policy.draft_exposure_allowed_in_sitemap_llms'));
+
+        $this->assertSame(25, data_get($payload, 'current_baseline_summary.total_rows'));
+        $this->assertSame([
+            'brand',
+            'careers',
+            'charter',
+            'foundation',
+            'policies',
+        ], data_get($payload, 'current_baseline_summary.missing_english_counterparts'));
+
+        foreach ($payload['deferred_import_candidates'] ?? [] as $candidate) {
+            $this->assertSame('draft_import_candidate', $candidate['target_publication_state'] ?? null);
+            $this->assertSame('requires_human_translation', $candidate['body_status'] ?? null);
+            $this->assertFalse((bool) ($candidate['sitemap_llms_exposure_allowed'] ?? true));
+        }
+    }
+
+    #[Test]
+    public function local_baseline_import_preserves_content_page_translation_metadata(): void
+    {
+        $this->artisan('content-pages:import-local-baseline', [
+            '--source-dir' => '../content_baselines/content_pages',
+            '--status' => ContentPage::STATUS_PUBLISHED,
+            '--upsert' => true,
+        ])->assertExitCode(0);
+
+        $aboutZh = ContentPage::query()
+            ->withoutGlobalScopes()
+            ->where('locale', 'zh-CN')
+            ->where('slug', 'about')
+            ->firstOrFail();
+        $aboutEn = ContentPage::query()
+            ->withoutGlobalScopes()
+            ->where('locale', 'en')
+            ->where('slug', 'about')
+            ->firstOrFail();
+        $helpContactEn = ContentPage::query()
+            ->withoutGlobalScopes()
+            ->where('locale', 'en')
+            ->where('slug', 'help-contact')
+            ->firstOrFail();
+
+        $this->assertSame('content-page-about', $aboutZh->translation_group_id);
+        $this->assertSame('content-page-about', $aboutEn->translation_group_id);
+        $this->assertSame(ContentPage::TRANSLATION_STATUS_SOURCE, $aboutZh->translation_status);
+        $this->assertSame(ContentPage::TRANSLATION_STATUS_PUBLISHED, $aboutEn->translation_status);
+        $this->assertSame('zh-CN', $aboutEn->source_locale);
+        $this->assertSame('approved', $aboutEn->review_state);
+        $this->assertSame('support_static', $helpContactEn->page_type);
+        $this->assertNotEmpty($aboutEn->seo_description);
+    }
+
+    #[Test]
+    public function missing_content_page_counterparts_are_explicit_and_not_frontend_fallback(): void
+    {
+        $this->artisan('content-pages:import-local-baseline', [
+            '--source-dir' => '../content_baselines/content_pages',
+            '--status' => ContentPage::STATUS_PUBLISHED,
+            '--upsert' => true,
+        ])->assertExitCode(0);
+
+        $matrix = app(TranslationParityMatrixReadModel::class)->build();
+        $missing = collect($matrix['missing_counterparts'] ?? [])
+            ->where('entity_type', 'content_page')
+            ->where('missing_locale', 'en')
+            ->pluck('translation_group_id')
+            ->sort()
+            ->values()
+            ->all();
+
+        $this->assertSame([
+            'content-page-brand',
+            'content-page-careers',
+            'content-page-charter',
+            'content-page-foundation',
+            'content-page-policies',
+        ], $missing);
+        $this->assertFalse((bool) ($matrix['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($matrix['summary']['counterpart_lookup_uses_slug_guessing_only'] ?? true));
+    }
+
+    #[Test]
+    public function deferred_missing_english_pages_do_not_enter_sitemap(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $this->app->instance(ScaleRegistry::class, $this->mockScaleRegistry());
+
+        $this->artisan('content-pages:import-local-baseline', [
+            '--source-dir' => '../content_baselines/content_pages',
+            '--status' => ContentPage::STATUS_PUBLISHED,
+            '--upsert' => true,
+        ])->assertExitCode(0);
+
+        $locs = array_map(
+            static fn (array $row): string => (string) ($row['loc'] ?? ''),
+            app(SitemapGenerator::class)->generateUrls()
+        );
+
+        $this->assertContains('https://fermatmind.com/zh/brand', $locs);
+        $this->assertContains('https://fermatmind.com/en/about', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/brand', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/careers', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/charter', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/foundation', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/policies', $locs);
+    }
+
+    private function mockScaleRegistry(): ScaleRegistry
+    {
+        $registry = \Mockery::mock(ScaleRegistry::class);
+        $registry->shouldReceive('listActivePublic')->andReturn([]);
+
+        return $registry;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -742,6 +742,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ContentPagesImportLocalBaseline.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_chinese_claim_linter_runtime_files(): void
     {
         $changed = [
@@ -2195,6 +2204,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isContentPagesLocalBaselineImportPackageFile($file)) {
+                continue;
+            }
+
             if ($this->isChineseClaimLinterRuntimeFile($file)) {
                 continue;
             }
@@ -2957,6 +2970,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isTranslationParityReadModelFile(string $file): bool
     {
         return $file === 'backend/app/Services/SeoIntel/TranslationParity/TranslationParityMatrixReadModel.php';
+    }
+
+    private function isContentPagesLocalBaselineImportPackageFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/ContentPagesImportLocalBaseline.php';
     }
 
     private function isChineseClaimLinterRuntimeFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -18618,11 +18618,11 @@
     "EN-PARITY-01": {
       "repo": "fap-api",
       "branch": "codex/en-parity-01-url-truth-canonical",
-      "status": "local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "EN-PARITY-00"
       ],
-      "commit_sha": "956d6646f0b539d0bfb7e471d3908f35bb17023a",
+      "commit_sha": "d938a2a27cb0184222b87a21035daf274e3ce107",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1665",
       "checks": {
         "dependency_en_parity_00": {
@@ -18634,7 +18634,8 @@
           "evidence": "EN-PARITY-01 focused test, route list, Pint, composer validate, composer audit, JSON/YAML parse, and diff checks passed. Broad php artisan test --filter=SeoIntel has six unrelated failures that reproduce on clean origin/main."
         },
         "github_required_checks": {
-          "status": "pending"
+          "status": "pass",
+          "evidence": "PR 1665 is MERGED and origin/main contains merge commit d938a2a27cb0184222b87a21035daf274e3ce107."
         },
         "scope_boundary": {
           "status": "pass",
@@ -18642,9 +18643,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T04:40:38Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "title": "fap-web runtime rendering may still need linked frontend cleanup",
@@ -18687,6 +18688,11 @@
           "at": "2026-05-25T12:51:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1665 for EN-PARITY-01 and pushed branch codex/en-parity-01-url-truth-canonical."
+        },
+        {
+          "at": "2026-05-25T06:15:55Z",
+          "status": "ledger_reconciled_merged",
+          "summary": "Reconciled ledger before EN-PARITY-03: GitHub reports https://github.com/fermatmind/fap-api/pull/1665 merged and origin/main contains merge commit d938a2a27cb0184222b87a21035daf274e3ce107."
         }
       ]
     },
@@ -19005,11 +19011,11 @@
     "EN-PARITY-02": {
       "repo": "fap-api",
       "branch": "codex/en-parity-02-translation-groups",
-      "status": "pr_open_rebased_github_checks_pending",
+      "status": "merged",
       "depends_on": [
         "EN-PARITY-01"
       ],
-      "commit_sha": "00ea3405",
+      "commit_sha": "45cb2da4ce62bea6528049eb3860053d2a55fce9",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1667",
       "checks": {
         "dependency_en_parity_01": {
@@ -19046,14 +19052,14 @@
           "evidence": "Focused EN-PARITY-02 test passed with 4 tests and 42 assertions. SQLite pretend migration, route:list, Pint, composer validate, composer audit, ci_verify_mbti, generated JSON parse, manifest/state parse, and diff checks passed."
         },
         "github_required_checks": {
-          "status": "pending_after_rebase",
-          "evidence": "PR #1667 was rebased onto origin/main after PR #1669 merged; GitHub checks must rerun on the rebased head."
+          "status": "pass",
+          "evidence": "PR 1667 is MERGED and origin/main contains merge commit 45cb2da4ce62bea6528049eb3860053d2a55fce9."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T06:05:12Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "events": [
         {
@@ -19085,6 +19091,95 @@
           "at": "2026-05-25T13:53:01+08:00",
           "status": "rebased_conflict_resolved_pending_push",
           "summary": "Rebased EN-PARITY-02 onto origin/main after PR #1669 merged. Resolved pr-train-state ledger by preserving current main entries, including RESULT-EN-PARITY-02, and keeping EN-PARITY-02 current PR state."
+        },
+        {
+          "at": "2026-05-25T06:15:55Z",
+          "status": "ledger_reconciled_merged",
+          "summary": "Reconciled ledger before EN-PARITY-03: GitHub reports https://github.com/fermatmind/fap-api/pull/1667 merged and origin/main contains merge commit 45cb2da4ce62bea6528049eb3860053d2a55fce9."
+        }
+      ]
+    },
+    "EN-PARITY-03": {
+      "repo": "fap-api",
+      "branch": "codex/en-parity-03-content-pages",
+      "status": "github_checks_passed_ready_to_merge",
+      "depends_on": [
+        "EN-PARITY-02"
+      ],
+      "commit_sha": "8b0e5b4cf7a6f80429c6f70284369a39cae6a4fc",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1672",
+      "checks": {
+        "dependency_en_parity_02": {
+          "status": "pass",
+          "evidence": "PR #1667 is MERGED and origin/main contains merge commit 45cb2da4ce62bea6528049eb3860053d2a55fce9."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Changed files are limited to content_pages local baseline importer metadata support, EN-PARITY-03 report/generated JSON/focused test, Big Five runtime-freeze allowlist evidence for the importer command, and PR-train manifest/state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No production CMS mutation, production migration, deploy, URL submission, Search Channel action, secrets access, or fap-web commit."
+        },
+        "content_generation_boundary": {
+          "status": "pass",
+          "evidence": "EN-PARITY-03 lands an import package and metadata gate only. Missing English company/policy content is explicit deferred human-review work; no substantial English prose is generated and nothing is auto-published."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=EnParity03 --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json >/dev/null",
+            "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "Focused php artisan test --filter=EnParity03 --no-ansi passed; BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff passed; BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes passed; php artisan route:list --no-ansi passed; vendor/bin/pint --test passed; composer validate --strict passed; composer audit --locked --no-interaction --ignore-unreachable passed; APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force passed; bash scripts/ci_verify_mbti.sh passed before the runtime-freeze allowlist evidence fix; the exact failing runtime-freeze branch-diff PHPUnit gates passed after the fix; generated JSON parsed; PR-train YAML/state JSON parsed; git diff --check and git diff --cached --check passed."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1672 second run passed hygiene, supply-chain, Semgrep blocking secrets, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2. GitHub mergeStateStatus is CLEAN at head 8b0e5b4cf7a6f80429c6f70284369a39cae6a4fc."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "events": [
+        {
+          "at": "2026-05-25T06:15:55Z",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Started EN-PARITY-03 from latest fap-api main after verifying EN-PARITY-02 landed. Added content_pages import package, metadata-preserving importer support, focused test, and current manifest/state entry. No production or fap-web mutation performed."
+        },
+        {
+          "at": "2026-05-25T06:29:40Z",
+          "status": "local_validation_passed",
+          "summary": "EN-PARITY-03 focused validation, backend common checks, SQLite pretend migration, ci_verify_mbti, generated JSON parse, manifest/state parse, and diff checks passed locally."
+        },
+        {
+          "at": "2026-05-25T06:31:18Z",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1672 for EN-PARITY-03 and pushed branch codex/en-parity-03-content-pages; waiting for GitHub checks."
+        },
+        {
+          "at": "2026-05-25T06:37:38Z",
+          "status": "github_checks_failed_current_scope_fixing",
+          "summary": "GitHub verify-mbti-legacy/v2 failed on runtime-freeze branch-diff gate for ContentPagesImportLocalBaseline.php; adding scoped allowlist evidence test without modifying runtime behavior."
+        },
+        {
+          "at": "2026-05-25T06:38:44Z",
+          "status": "local_validation_passed_after_ci_fix",
+          "summary": "Added scoped Big Five runtime-freeze allowlist evidence for ContentPagesImportLocalBaseline.php. Exact failing runtime-freeze tests, EN-PARITY-03 focused test, Pint, parse checks, and diff checks passed locally."
+        },
+        {
+          "at": "2026-05-25T06:45:46Z",
+          "status": "github_checks_passed_ready_to_merge",
+          "summary": "GitHub checks passed on PR #1672 after adding scoped runtime-freeze allowlist evidence; mergeStateStatus CLEAN."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5733,6 +5733,55 @@ prs:
     content_generation_allowed: false
     next_task: EN-PARITY-03
 
+  - id: EN-PARITY-03
+    repo: fap-api
+    depends_on: [EN-PARITY-02]
+    branch: codex/en-parity-03-content-pages
+    base: main
+    title: "EN-PARITY-03 content pages EN/ZH parity"
+    train_scope: en_parity_content_pages_import_package
+    risk_level: p0_content_authority_parity
+    allowed_paths:
+      - backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
+      - backend/docs/seo/en-parity-03-content-pages-parity-import-package.md
+      - backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json
+      - backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Land a repository-backed content_pages EN/ZH parity import package and generated parity artifact.
+      - Strengthen content-pages:import-local-baseline so local/operator imports preserve translation_group_id, source_locale, translation_status, page_type, review_state, seo_description, and canonical_path metadata.
+      - Prove existing EN/ZH content page baseline pairs are authority-backed and missing English counterparts remain explicit.
+      - Keep missing English company/policy pages deferred until human-reviewed content authority exists.
+      - Prevent draft, placeholder, fallback-only, 404, soft-404, noindex/private, or missing-authority pages from entering sitemap/llms.
+    do_not:
+      - Generate substantial English prose for missing content pages.
+      - Auto-publish, mutate production CMS, run production migration, deploy, or submit URLs.
+      - Modify fap-web or treat frontend fallback as content authority.
+      - Modify articles, career guides, media assets, sitemap generator, llms generator, JSON-LD, FAQ, or Search Channel.
+      - Expose draft/import candidates in sitemap, llms, hreflang, URL Truth, or public runtime.
+    validation:
+      - cd backend && php artisan test --filter=EnParity03 --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: EN-PARITY-04
+
   - id: RESULT-EN-PARITY-00
     repo: fap-api
     depends_on: [EN-PARITY-00]


### PR DESCRIPTION
## PR id
EN-PARITY-03

## What changed
- Added a repo-backed content_pages EN/ZH parity import package and generated JSON baseline.
- Strengthened `content-pages:import-local-baseline` so local/operator imports preserve translation metadata: translation_group_id, source_locale, translation_status, page_type, review_state, seo_description, and canonical_path.
- Added focused SeoIntel tests proving existing content page pairs are authority-backed, missing English counterparts remain explicit, and deferred/draft candidates do not enter sitemap exposure.
- Added scoped Big Five runtime-freeze allowlist evidence for `ContentPagesImportLocalBaseline.php`; this is importer/tooling scope only and does not modify Big Five runtime behavior.
- Added the current PR-train manifest/state entry and reconciled EN-PARITY-01 / EN-PARITY-02 merged ledger state.

## Why
EN-PARITY-03 must not mass-generate or auto-publish substantial English content. This PR lands the import package and metadata gate first, so missing English company/policy/support pages stay explicit until human-reviewed content authority exists.

## Validation
- `cd backend && php artisan test --filter=EnParity03 --no-ansi` PASS
- `cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi` PASS
- `cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes --no-ansi` PASS
- `cd backend && php artisan route:list --no-ansi` PASS
- `cd backend && vendor/bin/pint --test` PASS
- `cd backend && composer validate --strict` PASS
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` PASS
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE='':memory:'' php artisan migrate --pretend --no-ansi --force` PASS
- `cd backend && bash scripts/ci_verify_mbti.sh` PASS before allowlist evidence fix; exact failing runtime-freeze gates pass after fix
- `python3 -m json.tool backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json >/dev/null` PASS
- manifest/state YAML/JSON parse PASS
- `git diff --check` PASS
- `git diff --cached --check` PASS

## Intentionally deferred
- Human-reviewed English copy for `brand`, `careers`, `charter`, `foundation`, and `policies`.
- Production CMS import/publish.
- fap-web runtime rendering or routing changes.
- Sitemap/llms/JSON-LD/FAQ parity gates remain for EN-PARITY-07.

## Do-not confirmation
- No production CMS mutation.
- No production migration.
- No deploy.
- No Search Channel or URL submission.
- No fap-web commit.
- No substantial English prose generation or auto-publish.
- No frontend fallback treated as authority.

## Repository rule impact
Backend `content_pages` remains the authority for help, policy, company, brand, careers, about, charter, foundation, privacy, terms, refund, support, and similar static-content pages. `content_baselines` remain import/recovery/dry-run inputs only and are not runtime page-rendering authority.

## Scope validation
Changed files are limited to the content page local baseline importer, EN-PARITY-03 report/generated JSON/focused test, Big Five runtime-freeze allowlist evidence for that importer command, and PR-train manifest/state.