### PR TITLE
RESULT-EN-PARITY-05 MBTI backend content package export and frontend interpretation de-authoring

### DIFF
--- a/backend/docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json
+++ b/backend/docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json
@@ -1,0 +1,377 @@
+{
+    "schema_version": "result-en-parity-05-mbti-content-export.v1",
+    "pr_id": "RESULT-EN-PARITY-05",
+    "family": "MBTI",
+    "decision": "mbti_backend_content_package_export_manifest_ready_frontend_clone_deauthorized",
+    "generated_from": [
+        "RESULT-EN-PARITY-00 inventory",
+        "RESULT-EN-PARITY-01 asset catalog gate",
+        "backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php",
+        "backend/app/Services/Legacy/Mbti/Content/LegacyMbtiPackRepository.php",
+        "backend/app/Services/Legacy/Mbti/Report/LegacyMbtiReportAssetRepository.php",
+        "backend/app/Services/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilder.php",
+        "backend/app/Services/Mbti/Adapters/MbtiReportAuthoritySourceAdapter.php",
+        "backend/app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php",
+        "reference-only:/Users/rainie/Desktop/GitHub/fap-web/components/result/mbti/clone/content/index.ts"
+    ],
+    "authority": {
+        "backend_scoring_cms_result_asset_catalog_is_authority": true,
+        "frontend_fallback_is_authority": false,
+        "frontend_interpretation_copy_authority_allowed": false,
+        "fap_web_modified": false,
+        "scoring_change": false,
+        "production_mutation": false,
+        "cms_mutation": false,
+        "deploy": false,
+        "search_channel_action": false,
+        "production_user_data_access": false
+    },
+    "architecture_finding": {
+        "result_content_architecture": "mixed_structured_codes_plus_backend_external_content_package_plus_legacy_generated_fallback_plus_frontend_clone_seed",
+        "backend_export_status": "repo_visible_manifest_export_only",
+        "full_authoritative_content_package_status": "not_materialized_in_repo",
+        "english_runtime_policy": "fail_closed_missing_authoritative_en_no_frontend_clone_fallback",
+        "frontend_clone_policy": "non_authoritative_migration_only_historical_seed_source",
+        "mass_content_generation": false
+    },
+    "backend_authority_sources": [
+        {
+            "path": "backend/app/Services/Assessment/Drivers/MbtiDriver.php",
+            "role": "assessment_driver_and_scoring_entry",
+            "authority_status": "backend_scoring_authority"
+        },
+        {
+            "path": "backend/app/Services/Legacy/Mbti/Content/LegacyMbtiPackRepository.php",
+            "role": "external_content_package_loader",
+            "authority_status": "backend_content_package_read_path"
+        },
+        {
+            "path": "backend/app/Services/Legacy/Mbti/Report/LegacyMbtiReportAssetRepository.php",
+            "role": "legacy_report_asset_loader_and_schema_finalizer",
+            "authority_status": "backend_report_asset_read_path"
+        },
+        {
+            "path": "backend/app/Services/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilder.php",
+            "role": "legacy_report_payload_compatibility_builder",
+            "authority_status": "backend_compatibility_path_not_current_v0_3_runtime_chain"
+        },
+        {
+            "path": "backend/app/Services/Mbti/Adapters/MbtiReportAuthoritySourceAdapter.php",
+            "role": "report_payload_to_public_result_authority_adapter",
+            "authority_status": "backend_public_result_authority_adapter"
+        },
+        {
+            "path": "backend/app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php",
+            "role": "cms_personality_profile_and_variant_authority_adapter",
+            "authority_status": "backend_cms_authority_adapter"
+        },
+        {
+            "path": "backend/app/Services/Mbti/MbtiPublicProjectionService.php",
+            "role": "public_projection_builder",
+            "authority_status": "backend_public_projection_authority"
+        }
+    ],
+    "canonical_section_export": {
+        "registry_path": "backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php",
+        "section_key_count": 33,
+        "section_keys": [
+            "letters_intro",
+            "overview",
+            "trait_overview",
+            "traits.why_this_type",
+            "traits.close_call_axes",
+            "traits.adjacent_type_contrast",
+            "traits.decision_style",
+            "career.summary",
+            "career.collaboration_fit",
+            "career.work_environment",
+            "career.work_experiments",
+            "career.advantages",
+            "career.weaknesses",
+            "career.preferred_roles",
+            "career.next_step",
+            "career.upgrade_suggestions",
+            "growth.summary",
+            "growth.stability_confidence",
+            "growth.next_actions",
+            "growth.weekly_experiments",
+            "growth.strengths",
+            "growth.weaknesses",
+            "growth.stress_recovery",
+            "growth.watchouts",
+            "growth.motivators",
+            "growth.drainers",
+            "relationships.summary",
+            "relationships.strengths",
+            "relationships.weaknesses",
+            "relationships.communication_style",
+            "relationships.try_this_week",
+            "relationships.rel_advantages",
+            "relationships.rel_risks"
+        ],
+        "render_variants": [
+            "letters_intro",
+            "rich_text",
+            "trait_dimension_grid",
+            "bullets",
+            "preferred_role_list",
+            "premium_teaser"
+        ],
+        "premium_teaser_keys": [
+            "growth.motivators",
+            "growth.drainers",
+            "relationships.rel_advantages",
+            "relationships.rel_risks"
+        ]
+    },
+    "asset_key_inventory": [
+        {
+            "key": "mbti.result.structured_type_code",
+            "surface": "result",
+            "asset_kind": "structured_result_code",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "presentation_label_only": false,
+            "interpretation_copy": false,
+            "authority_status": "backend_scoring_authority",
+            "fallback_to_zh_detected": false,
+            "fail_closed_for_en": false
+        },
+        {
+            "key": "mbti.result.trait_axis_scores",
+            "surface": "result",
+            "asset_kind": "structured_score_signal",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "presentation_label_only": false,
+            "interpretation_copy": false,
+            "authority_status": "backend_scoring_authority",
+            "fallback_to_zh_detected": false,
+            "fail_closed_for_en": false
+        },
+        {
+            "key": "mbti.report.canonical_section_registry",
+            "surface": "report",
+            "asset_kind": "backend_section_key_export",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "presentation_label_only": true,
+            "interpretation_copy": false,
+            "authority_status": "backend_registry_authority",
+            "fallback_to_zh_detected": false,
+            "fail_closed_for_en": false
+        },
+        {
+            "key": "mbti.report.external_content_package",
+            "surface": "report",
+            "asset_kind": "interpretation_copy_catalog",
+            "has_zh": "not_repo_visible",
+            "has_en": "not_repo_visible",
+            "missing_en": true,
+            "presentation_label_only": false,
+            "interpretation_copy": true,
+            "authority_status": "backend_export_required",
+            "fallback_to_zh_detected": false,
+            "fail_closed_for_en": true,
+            "deferred_reason": "authoritative_backend_content_package_not_materialized_in_repo"
+        },
+        {
+            "key": "mbti.report.legacy_generated_fallback_copy",
+            "surface": "report",
+            "asset_kind": "legacy_interpretation_copy",
+            "has_zh": true,
+            "has_en": false,
+            "missing_en": true,
+            "presentation_label_only": false,
+            "interpretation_copy": true,
+            "authority_status": "legacy_backend_fallback_must_not_be_en_authority",
+            "fallback_to_zh_detected": true,
+            "fail_closed_for_en": true,
+            "deferred_reason": "legacy_zh_fallback_risk"
+        },
+        {
+            "key": "mbti.frontend_clone_content_base",
+            "surface": "result_desktop_clone",
+            "asset_kind": "frontend_clone_interpretation_copy",
+            "has_zh": true,
+            "has_en": false,
+            "missing_en": true,
+            "presentation_label_only": false,
+            "interpretation_copy": true,
+            "authority_status": "non_authoritative_migration_only",
+            "fallback_to_zh_detected": true,
+            "fail_closed_for_en": true,
+            "deferred_reason": "fap_web_clone_content_is_historical_seed_not_report_authority"
+        },
+        {
+            "key": "mbti.frontend_clone_content_variants",
+            "surface": "result_desktop_clone",
+            "asset_kind": "frontend_clone_variant_patch_copy",
+            "has_zh": true,
+            "has_en": false,
+            "missing_en": true,
+            "presentation_label_only": false,
+            "interpretation_copy": true,
+            "authority_status": "non_authoritative_migration_only",
+            "fallback_to_zh_detected": true,
+            "fail_closed_for_en": true,
+            "deferred_reason": "fap_web_clone_variant_patches_are_historical_seed_not_report_authority"
+        },
+        {
+            "key": "mbti.share.public_projection_summary",
+            "surface": "share",
+            "asset_kind": "backend_public_projection_summary",
+            "has_zh": true,
+            "has_en": "requires_backend_payload",
+            "missing_en": true,
+            "presentation_label_only": false,
+            "interpretation_copy": true,
+            "authority_status": "backend_public_projection_authority",
+            "fallback_to_zh_detected": "not_certified",
+            "fail_closed_for_en": true,
+            "deferred_reason": "share_summary_english_prose_requires_authoritative_backend_payload_export"
+        },
+        {
+            "key": "mbti.pdf.report_payload",
+            "surface": "pdf",
+            "asset_kind": "report_export_payload",
+            "has_zh": "not_repo_visible",
+            "has_en": "not_repo_visible",
+            "missing_en": true,
+            "presentation_label_only": false,
+            "interpretation_copy": true,
+            "authority_status": "backend_report_export_required",
+            "fallback_to_zh_detected": "not_certified",
+            "fail_closed_for_en": true,
+            "deferred_reason": "localized_pdf_report_prose_export_not_materialized"
+        },
+        {
+            "key": "mbti.email.result_report_summary",
+            "surface": "email",
+            "asset_kind": "email_result_report_copy",
+            "has_zh": "shared_template_only",
+            "has_en": "shared_template_only",
+            "missing_en": true,
+            "presentation_label_only": false,
+            "interpretation_copy": true,
+            "authority_status": "backend_email_asset_export_required",
+            "fallback_to_zh_detected": "not_certified",
+            "fail_closed_for_en": true,
+            "deferred_reason": "mbti_specific_email_result_prose_catalog_not_repo_visible"
+        },
+        {
+            "key": "mbti.my_results.card_summary",
+            "surface": "my_results",
+            "asset_kind": "history_card_summary",
+            "has_zh": true,
+            "has_en": "requires_backend_payload",
+            "missing_en": true,
+            "presentation_label_only": false,
+            "interpretation_copy": true,
+            "authority_status": "backend_saved_result_authority",
+            "fallback_to_zh_detected": "not_certified",
+            "fail_closed_for_en": true,
+            "deferred_reason": "my_results_summary_english_prose_requires_authoritative_backend_payload_export"
+        }
+    ],
+    "missing_en_asset_keys": [
+        "backend_external_content_package_export_required",
+        "legacy_mbti_generated_fallback_copy.en",
+        "frontend_mbti_clone_content_base.en",
+        "frontend_mbti_clone_content_variants.en",
+        "mbti.share.public_projection_summary.en",
+        "mbti.pdf.report_payload.en",
+        "mbti.email.result_report_summary.en",
+        "mbti.my_results.card_summary.en"
+    ],
+    "frontend_clone_classification": {
+        "repo": "fap-web",
+        "modified_in_this_pr": false,
+        "authority_status": "non_authoritative_migration_only",
+        "base_content_file_count": 16,
+        "variant_patch_file_count": 32,
+        "total_clone_content_file_count": 48,
+        "reference_paths": [
+            "components/result/mbti/clone/content/index.ts",
+            "components/result/mbti/clone/content/*.zh.ts",
+            "components/result/mbti/clone/content/variants/*.zh.ts",
+            "components/result/mbti/clone/mbtiDesktopClone.resolve.ts",
+            "lib/cms/personality-desktop-clone.ts"
+        ],
+        "evidence": [
+            "components/result/mbti/clone/content/index.ts imports 16 base zh files and 32 variant zh patches.",
+            "components/result/mbti/clone/content/index.ts declares the registry as a migration artifact only.",
+            "frontend clone interpretation copy must not be used as backend authority or English fallback."
+        ]
+    },
+    "claim_boundary": {
+        "career_language": "exploratory_workstyle_signal_only",
+        "forbidden_claims": [
+            "precise career recommendation",
+            "best career for you",
+            "hiring suitability",
+            "job fit guarantee",
+            "career success prediction",
+            "salary prediction",
+            "turnover prediction"
+        ],
+        "allowed_language": [
+            "workstyle tendency",
+            "career direction reference",
+            "exploratory guidance",
+            "snapshot-based support",
+            "evidence-backed explanation"
+        ]
+    },
+    "deferred_assets": [
+        {
+            "key": "mbti.report.external_content_package.en",
+            "reason": "requires reviewed authoritative MBTI English interpretation package; not generated in this PR"
+        },
+        {
+            "key": "mbti.report.legacy_generated_fallback_copy.en",
+            "reason": "legacy zh fallback must be replaced or gated, not translated ad hoc in this PR"
+        },
+        {
+            "key": "mbti.share.public_projection_summary.en",
+            "reason": "requires backend payload export and share-safe summary review"
+        },
+        {
+            "key": "mbti.pdf.report_payload.en",
+            "reason": "requires reviewed report export copy package"
+        },
+        {
+            "key": "mbti.email.result_report_summary.en",
+            "reason": "requires reviewed lifecycle/email copy package"
+        },
+        {
+            "key": "mbti.my_results.card_summary.en",
+            "reason": "requires backend saved-result summary catalog"
+        }
+    ],
+    "next_pr_recommendations": [
+        {
+            "id": "RESULT-EN-PARITY-MBTI-ASSET-BATCH-01",
+            "title": "MBTI reviewed English report content package first batch",
+            "scope": "Create backend-owned reviewed EN import package for a small MBTI type subset, with fail-closed missing-key behavior.",
+            "requires_human_review": true
+        },
+        {
+            "id": "RESULT-EN-PARITY-MBTI-FE-DEAUTH-01",
+            "title": "fap-web MBTI clone runtime de-authoring follow-up",
+            "scope": "If runtime still consumes clone interpretation content, replace it with backend authority reads or explicit migration-only empty states.",
+            "requires_linked_fap_web_pr": true
+        }
+    ],
+    "validation_contract": {
+        "generated_json_parses": true,
+        "backend_asset_key_export_exists": true,
+        "frontend_clone_content_classified_non_authoritative": true,
+        "missing_english_keys_explicit": true,
+        "english_must_not_fallback_to_zh_interpretation_copy": true,
+        "no_scoring_change": true
+    }
+}

--- a/backend/docs/seo/result-en-parity-05-mbti-content-export.md
+++ b/backend/docs/seo/result-en-parity-05-mbti-content-export.md
@@ -1,0 +1,77 @@
+# RESULT-EN-PARITY-05 MBTI Content Export and Frontend De-Authoring
+
+Decision output for this PR: `result_en_parity_05_mbti_content_export_ready_for_reviewed_asset_batch`
+
+This PR materializes a backend-owned MBTI result/report asset inventory and explicitly classifies fap-web MBTI clone interpretation content as non-authoritative migration-only content. It does not translate MBTI report prose, change MBTI scoring, mutate CMS, deploy, submit URLs, access production user result data, or modify fap-web.
+
+## Scope
+
+Covered MBTI surfaces:
+
+- Result structured type code and axis scores.
+- Report canonical section registry.
+- External backend content package read path.
+- Legacy generated fallback copy.
+- Share public projection summary.
+- PDF report payload.
+- Email result/report summary.
+- My Results card summary.
+- fap-web desktop clone base and variant content as reference-only migration artifacts.
+
+Generated artifact:
+
+- `backend/docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json`
+
+## Authority Finding
+
+Backend scoring, CMS/personality profile authority adapters, result/report payload builders, and backend content package read paths remain authority.
+
+fap-web clone content is not authority. The reference-only scan found:
+
+- 16 base zh clone content files under `components/result/mbti/clone/content/*.zh.ts`.
+- 32 variant zh patch files under `components/result/mbti/clone/content/variants/*.zh.ts`.
+- `components/result/mbti/clone/content/index.ts` already labels the registry as a migration artifact and historical seed source.
+
+This PR records that classification in fap-api so downstream result/report parity work cannot treat those frontend clone files as authoritative English source material or a fallback source.
+
+## Backend Export
+
+The generated artifact exports:
+
+- 32 canonical MBTI report section keys from `MbtiCanonicalSectionRegistry`.
+- Backend source files that own scoring, external content-package loading, legacy report assets, CMS personality profile authority, and public projections.
+- Missing English keys that must fail closed rather than render zh-CN prose.
+
+The export is intentionally a manifest/inventory, not a runtime report rewrite.
+
+## Missing English Keys
+
+Explicitly deferred English assets:
+
+- `backend_external_content_package_export_required`
+- `legacy_mbti_generated_fallback_copy.en`
+- `frontend_mbti_clone_content_base.en`
+- `frontend_mbti_clone_content_variants.en`
+- `mbti.share.public_projection_summary.en`
+- `mbti.pdf.report_payload.en`
+- `mbti.email.result_report_summary.en`
+- `mbti.my_results.card_summary.en`
+
+## Fail-Closed Rule
+
+English MBTI result/report interpretation copy must not silently fall back to zh-CN. If a backend-owned English interpretation asset is missing, the module must fail closed, omit the unavailable copy, or show an explicitly unavailable state. Presentation labels are separate and do not make frontend interpretation prose authoritative.
+
+## Claim Boundary
+
+MBTI career wording must stay non-deterministic:
+
+- allowed: workstyle tendency, career direction reference, exploratory guidance, snapshot-based support, evidence-backed explanation;
+- forbidden: precise career recommendation, best career for you, hiring suitability, job fit guarantee, career success prediction, salary prediction, turnover prediction.
+
+## Deferred Items
+
+This PR does not generate the full MBTI English report content package. The next backend content work should create a reviewed small-batch English import package or draft package before expanding coverage.
+
+If fap-web runtime still consumes clone interpretation copy as public result/report content, that should be handled in a linked fap-web PR after this backend authority export. This fap-api PR does not modify fap-web.
+
+Repository rule impact: MBTI result/report interpretation copy is reaffirmed as backend/CMS authoritative. fap-web clone content is recorded as non-authoritative migration-only material. No runtime ownership is transferred to frontend code.

--- a/backend/tests/Feature/SeoIntel/ResultEnParity05MbtiContentExportTest.php
+++ b/backend/tests/Feature/SeoIntel/ResultEnParity05MbtiContentExportTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class ResultEnParity05MbtiContentExportTest extends TestCase
+{
+    public function test_mbti_backend_asset_key_export_exists(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('result-en-parity-05-mbti-content-export.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('RESULT-EN-PARITY-05', $artifact['pr_id'] ?? null);
+        $this->assertSame('MBTI', $artifact['family'] ?? null);
+        $this->assertSame(
+            'mbti_backend_content_package_export_manifest_ready_frontend_clone_deauthorized',
+            $artifact['decision'] ?? null
+        );
+
+        $this->assertTrue((bool) ($artifact['authority']['backend_scoring_cms_result_asset_catalog_is_authority'] ?? false));
+        $this->assertFalse((bool) ($artifact['authority']['frontend_fallback_is_authority'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['frontend_interpretation_copy_authority_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['fap_web_modified'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['scoring_change'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['production_mutation'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['cms_mutation'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['deploy'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['search_channel_action'] ?? true));
+
+        $sources = array_column($artifact['backend_authority_sources'] ?? [], 'path');
+
+        $this->assertContains('backend/app/Services/Assessment/Drivers/MbtiDriver.php', $sources);
+        $this->assertContains('backend/app/Services/Legacy/Mbti/Content/LegacyMbtiPackRepository.php', $sources);
+        $this->assertContains('backend/app/Services/Legacy/Mbti/Report/LegacyMbtiReportAssetRepository.php', $sources);
+        $this->assertContains('backend/app/Services/Mbti/Adapters/MbtiReportAuthoritySourceAdapter.php', $sources);
+        $this->assertContains('backend/app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php', $sources);
+    }
+
+    public function test_canonical_report_section_keys_are_exported_without_using_frontend_authority(): void
+    {
+        $artifact = $this->artifact();
+        $sectionExport = $artifact['canonical_section_export'] ?? [];
+
+        $this->assertSame('backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php', $sectionExport['registry_path'] ?? null);
+        $this->assertSame(33, $sectionExport['section_key_count'] ?? null);
+
+        foreach ([
+            'letters_intro',
+            'overview',
+            'trait_overview',
+            'career.summary',
+            'growth.summary',
+            'relationships.summary',
+            'growth.motivators',
+            'relationships.rel_risks',
+        ] as $sectionKey) {
+            $this->assertContains($sectionKey, $sectionExport['section_keys'] ?? []);
+        }
+
+        $assetKeys = array_column($artifact['asset_key_inventory'] ?? [], 'key');
+
+        $this->assertContains('mbti.report.canonical_section_registry', $assetKeys);
+        $this->assertContains('mbti.report.external_content_package', $assetKeys);
+        $this->assertContains('mbti.report.legacy_generated_fallback_copy', $assetKeys);
+    }
+
+    public function test_frontend_clone_content_is_classified_non_authoritative_migration_only(): void
+    {
+        $artifact = $this->artifact();
+        $classification = $artifact['frontend_clone_classification'] ?? [];
+
+        $this->assertSame('fap-web', $classification['repo'] ?? null);
+        $this->assertFalse((bool) ($classification['modified_in_this_pr'] ?? true));
+        $this->assertSame('non_authoritative_migration_only', $classification['authority_status'] ?? null);
+        $this->assertSame(16, $classification['base_content_file_count'] ?? null);
+        $this->assertSame(32, $classification['variant_patch_file_count'] ?? null);
+        $this->assertSame(48, $classification['total_clone_content_file_count'] ?? null);
+        $this->assertContains(
+            'components/result/mbti/clone/content/index.ts',
+            $classification['reference_paths'] ?? []
+        );
+
+        $assetByKey = $this->assetByKey($artifact);
+
+        foreach ([
+            'mbti.frontend_clone_content_base',
+            'mbti.frontend_clone_content_variants',
+        ] as $key) {
+            $this->assertSame('non_authoritative_migration_only', $assetByKey[$key]['authority_status'] ?? null);
+            $this->assertTrue((bool) ($assetByKey[$key]['missing_en'] ?? false));
+            $this->assertTrue((bool) ($assetByKey[$key]['interpretation_copy'] ?? false));
+            $this->assertTrue((bool) ($assetByKey[$key]['fail_closed_for_en'] ?? false));
+        }
+    }
+
+    public function test_missing_english_interpretation_keys_are_explicit_and_fail_closed(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'backend_external_content_package_export_required',
+            'legacy_mbti_generated_fallback_copy.en',
+            'frontend_mbti_clone_content_base.en',
+            'frontend_mbti_clone_content_variants.en',
+            'mbti.share.public_projection_summary.en',
+            'mbti.pdf.report_payload.en',
+            'mbti.email.result_report_summary.en',
+            'mbti.my_results.card_summary.en',
+        ] as $key) {
+            $this->assertContains($key, $artifact['missing_en_asset_keys'] ?? []);
+        }
+
+        foreach ($artifact['asset_key_inventory'] ?? [] as $asset) {
+            if (! (bool) ($asset['interpretation_copy'] ?? false)) {
+                continue;
+            }
+
+            if (! (bool) ($asset['missing_en'] ?? false)) {
+                continue;
+            }
+
+            $this->assertTrue(
+                (bool) ($asset['fail_closed_for_en'] ?? false),
+                sprintf('%s must fail closed when English interpretation copy is missing.', $asset['key'] ?? 'unknown')
+            );
+        }
+
+        $this->assertSame(
+            'fail_closed_missing_authoritative_en_no_frontend_clone_fallback',
+            $artifact['architecture_finding']['english_runtime_policy'] ?? null
+        );
+    }
+
+    public function test_claim_boundary_and_deferred_assets_remain_review_gated(): void
+    {
+        $artifact = $this->artifact();
+        $boundary = $artifact['claim_boundary'] ?? [];
+
+        $this->assertSame('exploratory_workstyle_signal_only', $boundary['career_language'] ?? null);
+
+        foreach ([
+            'precise career recommendation',
+            'best career for you',
+            'hiring suitability',
+            'job fit guarantee',
+            'career success prediction',
+            'salary prediction',
+            'turnover prediction',
+        ] as $claim) {
+            $this->assertContains($claim, $boundary['forbidden_claims'] ?? []);
+        }
+
+        $this->assertNotEmpty($artifact['deferred_assets'] ?? []);
+        $this->assertNotEmpty($artifact['next_pr_recommendations'] ?? []);
+        $this->assertFalse((bool) ($artifact['architecture_finding']['mass_content_generation'] ?? true));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, array<string, mixed>>
+     */
+    private function assetByKey(array $artifact): array
+    {
+        $assets = [];
+        foreach ($artifact['asset_key_inventory'] ?? [] as $asset) {
+            if (! is_array($asset) || ! is_string($asset['key'] ?? null)) {
+                continue;
+            }
+
+            $assets[$asset['key']] = $asset;
+        }
+
+        return $assets;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T06:52:00Z",
+  "updated_at": "2026-05-25T07:05:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -24192,5 +24192,106 @@
         }
       ]
     }
+  },
+  "RESULT-EN-PARITY-04": {
+    "repo": "fap-api",
+    "branch": "codex/result-en-parity-04-clinical-combo-en-paid",
+    "status": "merged",
+    "depends_on": [
+      "RESULT-EN-PARITY-03"
+    ],
+    "commit_sha": "e63038c74c3e65812ea05ce16209f539794724fe",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1671",
+    "failure_reason": null,
+    "merged_at": "2026-05-25T06:47:24Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
+    "checks": {
+      "github_required_checks": {
+        "status": "pass",
+        "evidence": "PR #1671 is MERGED and origin/main contains squash merge e63038c74c3e65812ea05ce16209f539794724fe."
+      },
+      "post_merge_cleanup": {
+        "status": "pass",
+        "evidence": "origin/main synced to e63038c74c3e65812ea05ce16209f539794724fe, local main matched origin/main, task branch cleanup completed, and focused post-merge ResultEnParity04ClinicalComboEnPaid test passed."
+      }
+    },
+    "events": [
+      {
+        "at": "2026-05-25T06:55:00Z",
+        "status": "merged_reconciled_before_result_en_parity_05",
+        "summary": "Reconciled PR #1671 as merged with origin/main containing e63038c74c3e65812ea05ce16209f539794724fe; remote branch deleted and local cleanup executed before RESULT-EN-PARITY-05."
+      }
+    ]
+  },
+  "RESULT-EN-PARITY-05": {
+    "repo": "fap-api",
+    "branch": "codex/result-en-parity-05-mbti-content-export",
+    "status": "pr_open_github_checks_pending",
+    "depends_on": [
+      "RESULT-EN-PARITY-04"
+    ],
+    "commit_sha": "27a1fb50302d2eb9e517a8739628a365861c030d",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1673",
+    "checks": {
+      "dependency_result_en_parity_00": {
+        "status": "pass",
+        "evidence": "PR #1666 is MERGED and origin/main contains merge commit a93345e5a24f1f579495bcfd78f30b4c5984bd1a."
+      },
+      "dependency_result_en_parity_04": {
+        "status": "pass",
+        "evidence": "PR #1671 is MERGED and origin/main contains merge commit e63038c74c3e65812ea05ce16209f539794724fe."
+      },
+      "scope_boundary": {
+        "status": "pass",
+        "evidence": "Changed files are limited to MBTI generated inventory/report, focused SeoIntel test, and PR-train state reconciliation. fap-web was inspected reference-only and not modified."
+      },
+      "production_safety": {
+        "status": "pass",
+        "evidence": "No production mutation, CMS mutation, deploy, production migration, URL submission, production user data access, scoring change, or fap-web commit."
+      },
+      "local_validation": {
+        "status": "pass",
+        "commands": [
+          "cd backend && php artisan test --filter=ResultEnParity05MbtiContentExport --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json >/dev/null",
+          "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+          "git diff --check",
+          "git diff --cached --check",
+          "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short"
+        ],
+        "evidence": "Focused ResultEnParity05MbtiContentExport test passed with 5 tests and 79 assertions. route:list exited 0 with 203 routes. Pint passed 3545 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON parse, manifest/state parse, git diff checks, and fap-web reference status passed; fap-web only has pre-existing untracked .playwright-mcp/."
+      },
+      "github_required_checks": {
+        "status": "pending",
+        "evidence": "PR #1673 opened for RESULT-EN-PARITY-05; waiting for required GitHub checks."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "events": [
+      {
+        "at": "2026-05-25T06:55:00Z",
+        "status": "local_files_generated_pending_validation",
+        "summary": "Added MBTI backend-owned generated inventory/report classifying fap-web clone interpretation content as non-authoritative migration-only, listing backend authority sources, canonical section keys, missing English keys, fail-closed policy, and deferred reviewed asset batch work."
+      },
+      {
+        "at": "2026-05-25T07:00:00Z",
+        "status": "local_validation_passed",
+        "summary": "RESULT-EN-PARITY-05 focused test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, diff checks, and fap-web reference status passed locally."
+      },
+      {
+        "at": "2026-05-25T07:05:00Z",
+        "status": "pr_open_github_checks_pending",
+        "summary": "Opened PR #1673 for RESULT-EN-PARITY-05 MBTI backend content package export and frontend interpretation de-authoring; waiting for GitHub checks."
+      }
+    ]
   }
 }


### PR DESCRIPTION
## What changed
- Added a backend-owned generated MBTI result/report asset inventory for RESULT-EN-PARITY-05.
- Exported MBTI backend authority sources, canonical report section keys, missing English asset keys, and fail-closed EN policy.
- Classified fap-web MBTI clone content as non-authoritative / migration-only / historical seed material, without modifying fap-web.
- Reconciled RESULT-EN-PARITY-04 ledger state as merged to unblock this PR-train item.

## Why
RESULT-EN-PARITY-00/01 found that MBTI result/report interpretation assets are mixed across structured backend result codes, external backend content packages, legacy fallback copy, and large fap-web zh clone content islands. This PR records the backend authority boundary and prevents frontend clone prose from being treated as English report authority.

## Validation
- `cd backend && php artisan test --filter=ResultEnParity05MbtiContentExport --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json >/dev/null`
- `python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'`
- `git diff --check`
- `git diff --cached --check`
- `cd /Users/rainie/Desktop/GitHub/fap-web && git status --short`

## Intentionally deferred
- No full MBTI English report prose generation in this PR.
- No fap-web runtime changes in this PR.
- MBTI English report, share, PDF, email, and My Results prose remain deferred for a reviewed backend asset batch.
- If fap-web runtime still consumes clone interpretation copy as public result/report content, handle it in a linked fap-web PR.

## Repository rule impact
MBTI result/report interpretation copy is reaffirmed as backend/CMS authoritative. fap-web clone interpretation content is explicitly non-authoritative migration-only material. No scoring, CMS, production data, deploy, sitemap, llms, or Search Channel behavior changed.
