### PR TITLE
EN-PARITY-04 article English counterpart completion

### DIFF
--- a/backend/app/Console/Commands/ArticleImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ArticleImportLocalBaseline.php
@@ -15,6 +15,7 @@ use App\Services\Cms\ArticleService;
 use App\Services\Cms\ArticleTranslationRevisionWorkspace;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use RuntimeException;
 
@@ -241,13 +242,7 @@ final class ArticleImportLocalBaseline extends Command
             }
         }
 
-        usort(
-            $rows,
-            static fn (array $left, array $right): int => [$left['locale'], $left['slug']]
-                <=> [$right['locale'], $right['slug']],
-        );
-
-        return $rows;
+        return $this->withTranslationMetadata($rows);
     }
 
     /**
@@ -336,6 +331,9 @@ final class ArticleImportLocalBaseline extends Command
             'related_test_slug' => $this->normalizeNullableSlug($row['related_test_slug'] ?? null),
             'voice' => $this->normalizeNullableString($row['voice'] ?? null),
             'voice_order' => $this->normalizeNullablePositiveInteger($row['voice_order'] ?? null, $file, $slug, 'voice_order'),
+            'translation_group_id' => $this->normalizeNullableString($row['translation_group_id'] ?? null),
+            'source_locale' => $this->normalizeNullableString($row['source_locale'] ?? null),
+            'translation_status' => $this->normalizeNullableString($row['translation_status'] ?? null),
             'category' => $this->normalizeNullableString($row['category'] ?? null),
             'tags' => $this->normalizeStringList($row['tags'] ?? []),
             'status' => $this->normalizeStatus($row['status'] ?? 'published', $file, $slug),
@@ -343,6 +341,65 @@ final class ArticleImportLocalBaseline extends Command
             'is_indexable' => (bool) ($row['is_indexable'] ?? true),
             'published_at' => $publishedAt,
         ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return list<array<string, mixed>>
+     */
+    private function withTranslationMetadata(array $rows): array
+    {
+        /** @var Collection<string, Collection<int, array<string, mixed>>> $groups */
+        $groups = collect($rows)->groupBy(
+            static fn (array $row): string => (string) ($row['translation_group_id'] ?: 'article:'.$row['slug'])
+        );
+
+        $normalized = [];
+        foreach ($groups as $translationGroupId => $groupRows) {
+            $locales = $groupRows
+                ->pluck('locale')
+                ->map(static fn (mixed $locale): string => (string) $locale)
+                ->unique()
+                ->values()
+                ->all();
+            $sourceLocale = in_array('zh-CN', $locales, true) ? 'zh-CN' : (string) ($locales[0] ?? 'en');
+
+            foreach ($groupRows as $row) {
+                $locale = (string) $row['locale'];
+                $row['translation_group_id'] = (string) ($row['translation_group_id'] ?: $translationGroupId);
+                $row['source_locale'] = (string) ($row['source_locale'] ?: $sourceLocale);
+                $row['translation_status'] = (string) ($row['translation_status'] ?: $this->defaultTranslationStatus($locale, $sourceLocale, (string) $row['status']));
+                $normalized[] = $row;
+            }
+        }
+
+        usort(
+            $normalized,
+            static fn (array $left, array $right): int => [
+                $left['translation_group_id'],
+                (string) $left['locale'] === (string) $left['source_locale'] ? 0 : 1,
+                $left['locale'],
+                $left['slug'],
+            ] <=> [
+                $right['translation_group_id'],
+                (string) $right['locale'] === (string) $right['source_locale'] ? 0 : 1,
+                $right['locale'],
+                $right['slug'],
+            ],
+        );
+
+        return array_values($normalized);
+    }
+
+    private function defaultTranslationStatus(string $locale, string $sourceLocale, string $status): string
+    {
+        if ($locale === $sourceLocale) {
+            return Article::TRANSLATION_STATUS_SOURCE;
+        }
+
+        return $status === 'published'
+            ? Article::TRANSLATION_STATUS_PUBLISHED
+            : Article::TRANSLATION_STATUS_HUMAN_REVIEW;
     }
 
     /**
@@ -460,6 +517,7 @@ final class ArticleImportLocalBaseline extends Command
                 'voice_order' => $desired['voice_order'],
                 'is_indexable' => (bool) $desired['is_indexable'],
             ], $tagIds);
+            $article = $this->syncTranslationAuthority($article, $desired);
 
             $article = $this->syncSeoAuthority(
                 $article,
@@ -518,6 +576,9 @@ final class ArticleImportLocalBaseline extends Command
             'related_test_slug' => $row['related_test_slug'],
             'voice' => $row['voice'],
             'voice_order' => $row['voice_order'],
+            'translation_group_id' => $row['translation_group_id'],
+            'source_locale' => $row['source_locale'],
+            'translation_status' => $row['translation_status'],
             'category' => $row['category'],
             'tags' => $row['tags'],
             'status' => $status,
@@ -580,6 +641,15 @@ final class ArticleImportLocalBaseline extends Command
             return false;
         }
         if (($article->voice_order !== null ? (int) $article->voice_order : null) !== ($desired['voice_order'] ?? null)) {
+            return false;
+        }
+        if ((string) ($article->translation_group_id ?? '') !== (string) ($desired['translation_group_id'] ?? '')) {
+            return false;
+        }
+        if ((string) ($article->source_locale ?? '') !== (string) ($desired['source_locale'] ?? '')) {
+            return false;
+        }
+        if ((string) ($article->translation_status ?? '') !== (string) ($desired['translation_status'] ?? '')) {
             return false;
         }
         if ($this->currentCategoryName($article) !== ($desired['category'] ?? null)) {
@@ -661,6 +731,38 @@ final class ArticleImportLocalBaseline extends Command
     /**
      * @param  array<string, mixed>  $desired
      */
+    private function syncTranslationAuthority(Article $article, array $desired): Article
+    {
+        $translationGroupId = (string) $desired['translation_group_id'];
+        $sourceLocale = (string) $desired['source_locale'];
+        $locale = (string) $desired['locale'];
+        $sourceArticle = $locale === $sourceLocale
+            ? null
+            : Article::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', (int) $article->org_id)
+                ->where('translation_group_id', $translationGroupId)
+                ->where('locale', $sourceLocale)
+                ->first();
+        $sourceVersionHash = $sourceArticle instanceof Article
+            ? (string) $sourceArticle->source_version_hash
+            : null;
+
+        $article->forceFill([
+            'translation_group_id' => $translationGroupId,
+            'source_locale' => $sourceLocale,
+            'translation_status' => (string) $desired['translation_status'],
+            'translated_from_article_id' => $sourceArticle instanceof Article ? (int) $sourceArticle->id : null,
+            'source_article_id' => $sourceArticle instanceof Article ? (int) $sourceArticle->id : null,
+            'translated_from_version_hash' => $sourceVersionHash,
+        ])->save();
+
+        return $article->fresh(['seoMeta', 'publishedRevision', 'workingRevision']) ?? $article;
+    }
+
+    /**
+     * @param  array<string, mixed>  $desired
+     */
     private function syncSeoAuthority(
         Article $article,
         array $desired,
@@ -671,6 +773,10 @@ final class ArticleImportLocalBaseline extends Command
         $seoDescription = $this->normalizeNullableString($desired['seo_description'] ?? null);
         $canonicalUrl = $articleSeoService->buildCanonicalUrl((string) $desired['slug'], (string) $desired['locale']);
         $robots = (bool) ($desired['is_indexable'] ?? true) ? 'index,follow' : 'noindex,nofollow';
+        $sourceArticleId = $article->source_article_id !== null ? (int) $article->source_article_id : (int) $article->id;
+        $sourceVersionHash = $article->source_article_id !== null
+            ? (string) (Article::query()->withoutGlobalScopes()->whereKey((int) $article->source_article_id)->value('source_version_hash') ?? '')
+            : null;
 
         ArticleSeoMeta::query()
             ->withoutGlobalScopes()
@@ -712,13 +818,13 @@ final class ArticleImportLocalBaseline extends Command
         $revision->forceFill([
             'org_id' => (int) $article->org_id,
             'article_id' => (int) $article->id,
-            'source_article_id' => (int) $article->id,
+            'source_article_id' => $sourceArticleId,
             'translation_group_id' => (string) $article->translation_group_id,
             'locale' => (string) $desired['locale'],
-            'source_locale' => (string) $desired['locale'],
-            'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+            'source_locale' => (string) $desired['source_locale'],
+            'revision_status' => (string) $desired['translation_status'],
             'source_version_hash' => $revisionHash,
-            'translated_from_version_hash' => $revisionHash,
+            'translated_from_version_hash' => $sourceVersionHash ?: $revisionHash,
             'title' => (string) $desired['title'],
             'excerpt' => (string) $desired['excerpt'],
             'content_md' => (string) $desired['content_md'],

--- a/backend/docs/seo/en-parity-04-article-counterpart-import-package.md
+++ b/backend/docs/seo/en-parity-04-article-counterpart-import-package.md
@@ -1,0 +1,75 @@
+# EN-PARITY-04 Article English Counterpart Import Package
+
+## Executive Summary
+
+EN-PARITY-04 lands a repository-backed article counterpart inventory and import-readiness gate. It does not publish articles, mutate production CMS, submit URLs, deploy, or use fap-web fallback content as authority.
+
+The current article baseline contains 25 zh-CN rows and 20 en rows. The 10 EN-PARITY-00 target article counterparts are already present in the repository baseline as English Article authority rows and can be imported through the controlled backend Article baseline importer after operator review. No new long-form English prose was generated in this PR.
+
+## Scope
+
+- Strengthen `articles:import-local-baseline` so imported Article rows receive stable translation metadata:
+  - `translation_group_id`
+  - `source_locale`
+  - `translation_status`
+  - `source_article_id`
+- Add a generated import-readiness JSON artifact for article parity.
+- Add a focused test proving the target 10 article counterparts are repo-backed, paired by backend translation authority, and not satisfied by frontend fallback.
+
+## Current Baseline
+
+- English article baseline rows: 20
+- Chinese article baseline rows: 25
+- EN-PARITY-00 target English counterparts present in repo baseline: 10
+- zh-CN article rows still missing English counterpart in repo baseline: 6
+
+## Target Counterparts Ready For Review
+
+- `big-five-growth-guide`
+- `big-five-narrative-portrait`
+- `big-five-tool-guide`
+- `eq-test-tool-guide`
+- `iq-test-growth-guide`
+- `iq-test-narrative-portrait`
+- `iq-test-tool-guide`
+- `mbti-basics`
+- `mbti-growth-guide`
+- `mbti-narrative-portrait`
+
+These rows are not auto-published by this PR. They remain repo-backed baseline content requiring the existing controlled import/publish workflow.
+
+## Deferred Article Counterparts
+
+The following zh-CN long-form/editorial articles do not have English repo-backed counterparts in the baseline and are deferred for human translation or a separately reviewed draft package:
+
+- `are-infj-men-rare-or-socially-silenced`
+- `best-valentines-date-by-personality-and-relationship-science`
+- `childhood-dream-job-still-shapes-career-choice`
+- `how-16-personality-types-talk-to-an-ai-coach`
+- `how-personality-shapes-attitude-toward-ai`
+- `which-love-script-fits-you-best`
+
+## Controls
+
+- No fap-web files changed.
+- No frontend fallback used as Article authority.
+- No production CMS mutation performed.
+- No production migration performed.
+- No deploy performed.
+- No Search Channel action or URL submission performed.
+- No mass English article generation performed.
+- No auto-publish performed.
+
+## Validation
+
+- `php artisan test --filter=EnParity04 --no-ansi`
+- `php artisan test --filter=ArticleBaselineImportTest --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- `python3 -m json.tool backend/docs/seo/generated/en-parity-04-article-counterpart-import-package.v1.json >/dev/null`
+
+## Next Task
+
+EN-PARITY-05 should prepare a career-guide detail inventory/template/import package or a small reviewed batch only. It must not mass-generate or auto-publish English career guide prose.

--- a/backend/docs/seo/generated/en-parity-04-article-counterpart-import-package.v1.json
+++ b/backend/docs/seo/generated/en-parity-04-article-counterpart-import-package.v1.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "en-parity-04-article-counterpart-import-package.v1",
+  "task": "EN-PARITY-04",
+  "source_authority": "backend_cms_article_baseline",
+  "frontend_fallback_authority_used": false,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "auto_publish_performed": false,
+  "mass_english_generation_performed": false,
+  "substantial_english_prose_generated": false,
+  "fap_web_modified": false,
+  "baseline_sources": [
+    "content_baselines/articles/articles.en.json",
+    "content_baselines/articles/articles.zh-CN.json"
+  ],
+  "current_baseline_summary": {
+    "articles_en_count": 20,
+    "articles_zh_count": 25,
+    "target_counterpart_count": 10,
+    "target_counterparts_present_in_repo_baseline": 10,
+    "missing_english_counterparts_count": 6,
+    "counterpart_lookup_uses_slug_guessing_only": false
+  },
+  "target_counterparts_ready_for_review": [
+    "big-five-growth-guide",
+    "big-five-narrative-portrait",
+    "big-five-tool-guide",
+    "eq-test-tool-guide",
+    "iq-test-growth-guide",
+    "iq-test-narrative-portrait",
+    "iq-test-tool-guide",
+    "mbti-basics",
+    "mbti-growth-guide",
+    "mbti-narrative-portrait"
+  ],
+  "deferred_missing_english_counterparts": [
+    {
+      "slug": "are-infj-men-rare-or-socially-silenced",
+      "reason": "Requires separately reviewed English draft; no mass generation or auto-publish in EN-PARITY-04.",
+      "target_publication_state": "deferred_draft_required",
+      "sitemap_llms_exposure_allowed": false
+    },
+    {
+      "slug": "best-valentines-date-by-personality-and-relationship-science",
+      "reason": "Requires separately reviewed English draft; no mass generation or auto-publish in EN-PARITY-04.",
+      "target_publication_state": "deferred_draft_required",
+      "sitemap_llms_exposure_allowed": false
+    },
+    {
+      "slug": "childhood-dream-job-still-shapes-career-choice",
+      "reason": "Requires separately reviewed English draft; no mass generation or auto-publish in EN-PARITY-04.",
+      "target_publication_state": "deferred_draft_required",
+      "sitemap_llms_exposure_allowed": false
+    },
+    {
+      "slug": "how-16-personality-types-talk-to-an-ai-coach",
+      "reason": "Requires separately reviewed English draft; no mass generation or auto-publish in EN-PARITY-04.",
+      "target_publication_state": "deferred_draft_required",
+      "sitemap_llms_exposure_allowed": false
+    },
+    {
+      "slug": "how-personality-shapes-attitude-toward-ai",
+      "reason": "Requires separately reviewed English draft; no mass generation or auto-publish in EN-PARITY-04.",
+      "target_publication_state": "deferred_draft_required",
+      "sitemap_llms_exposure_allowed": false
+    },
+    {
+      "slug": "which-love-script-fits-you-best",
+      "reason": "Requires separately reviewed English draft; no mass generation or auto-publish in EN-PARITY-04.",
+      "target_publication_state": "deferred_draft_required",
+      "sitemap_llms_exposure_allowed": false
+    }
+  ],
+  "import_controls": {
+    "controlled_import_command": "articles:import-local-baseline",
+    "production_import_executed": false,
+    "production_publish_executed": false,
+    "requires_operator_review": true,
+    "requires_controlled_publish_workflow": true,
+    "draft_exposure_allowed_in_sitemap_llms": false
+  },
+  "translation_authority_contract": {
+    "entity_type": "article",
+    "source_of_truth": "articles",
+    "translation_group_id_pattern": "article:<stable-slug> unless explicitly provided",
+    "source_locale_preference": "zh-CN when a zh-CN source row exists in the same group",
+    "frontend_fallback_can_satisfy_counterpart": false
+  },
+  "recommended_next_tasks": [
+    {
+      "id": "EN-PARITY-04A",
+      "title": "Article English draft package for six deferred editorial counterparts",
+      "scope": "Create human-reviewed draft package only; do not auto-publish or expose in sitemap/llms."
+    },
+    {
+      "id": "EN-PARITY-07",
+      "title": "Sitemap llms JSON-LD FAQ grounding parity gate",
+      "scope": "Verify Article URLs only enter public SEO surfaces when backend Article authority is published and indexable."
+    }
+  ],
+  "final_decision": "en_parity_04_import_package_landed_target_articles_ready_deferred_longform_copy",
+  "next_task": "EN-PARITY-05 career guides English detail completion"
+}

--- a/backend/tests/Feature/SeoIntel/EnParity04ArticleCounterpartImportPackageTest.php
+++ b/backend/tests/Feature/SeoIntel/EnParity04ArticleCounterpartImportPackageTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Services\SeoIntel\TranslationParity\TranslationParityMatrixReadModel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class EnParity04ArticleCounterpartImportPackageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TARGET_COUNTERPART_SLUGS = [
+        'big-five-growth-guide',
+        'big-five-narrative-portrait',
+        'big-five-tool-guide',
+        'eq-test-tool-guide',
+        'iq-test-growth-guide',
+        'iq-test-narrative-portrait',
+        'iq-test-tool-guide',
+        'mbti-basics',
+        'mbti-growth-guide',
+        'mbti-narrative-portrait',
+    ];
+
+    private const DEFERRED_COUNTERPART_SLUGS = [
+        'are-infj-men-rare-or-socially-silenced',
+        'best-valentines-date-by-personality-and-relationship-science',
+        'childhood-dream-job-still-shapes-career-choice',
+        'how-16-personality-types-talk-to-an-ai-coach',
+        'how-personality-shapes-attitude-toward-ai',
+        'which-love-script-fits-you-best',
+    ];
+
+    #[Test]
+    public function generated_import_package_records_article_content_controls(): void
+    {
+        $path = base_path('docs/seo/generated/en-parity-04-article-counterpart-import-package.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('en-parity-04-article-counterpart-import-package.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('EN-PARITY-04', $payload['task'] ?? null);
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['auto_publish_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['mass_english_generation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['substantial_english_prose_generated'] ?? true));
+        $this->assertFalse((bool) ($payload['fap_web_modified'] ?? true));
+
+        $this->assertSame(20, data_get($payload, 'current_baseline_summary.articles_en_count'));
+        $this->assertSame(25, data_get($payload, 'current_baseline_summary.articles_zh_count'));
+        $this->assertSame(10, data_get($payload, 'current_baseline_summary.target_counterparts_present_in_repo_baseline'));
+        $this->assertSame(self::TARGET_COUNTERPART_SLUGS, $payload['target_counterparts_ready_for_review'] ?? []);
+
+        $deferred = collect($payload['deferred_missing_english_counterparts'] ?? [])
+            ->pluck('slug')
+            ->values()
+            ->all();
+        $this->assertSame(self::DEFERRED_COUNTERPART_SLUGS, $deferred);
+
+        foreach ($payload['deferred_missing_english_counterparts'] ?? [] as $candidate) {
+            $this->assertSame('deferred_draft_required', $candidate['target_publication_state'] ?? null);
+            $this->assertFalse((bool) ($candidate['sitemap_llms_exposure_allowed'] ?? true));
+        }
+    }
+
+    #[Test]
+    public function article_baseline_import_pairs_target_counterparts_with_backend_translation_authority(): void
+    {
+        $this->artisan('articles:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+        ])
+            ->expectsOutputToContain('files_found=2')
+            ->expectsOutputToContain('articles_found=45')
+            ->assertExitCode(0);
+
+        foreach (self::TARGET_COUNTERPART_SLUGS as $slug) {
+            $zh = Article::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->where('locale', 'zh-CN')
+                ->where('slug', $slug)
+                ->firstOrFail();
+            $en = Article::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->where('locale', 'en')
+                ->where('slug', $slug)
+                ->firstOrFail();
+
+            $this->assertSame('article:'.$slug, (string) $zh->translation_group_id);
+            $this->assertSame((string) $zh->translation_group_id, (string) $en->translation_group_id);
+            $this->assertSame(Article::TRANSLATION_STATUS_SOURCE, (string) $zh->translation_status);
+            $this->assertSame(Article::TRANSLATION_STATUS_PUBLISHED, (string) $en->translation_status);
+            $this->assertSame('zh-CN', (string) $en->source_locale);
+            $this->assertSame((int) $zh->id, (int) $en->source_article_id);
+            $this->assertSame((int) $zh->id, (int) ($en->publishedRevision?->source_article_id ?? 0));
+            $this->assertSame('zh-CN', (string) ($en->publishedRevision?->source_locale ?? ''));
+        }
+    }
+
+    #[Test]
+    public function missing_article_counterparts_are_explicit_and_not_frontend_fallback(): void
+    {
+        $this->artisan('articles:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+        ])->assertExitCode(0);
+
+        $matrix = app(TranslationParityMatrixReadModel::class)->build();
+        $missing = collect($matrix['missing_counterparts'] ?? [])
+            ->where('entity_type', 'article')
+            ->where('missing_locale', 'en')
+            ->pluck('source_slug')
+            ->sort()
+            ->values()
+            ->all();
+
+        $expected = self::DEFERRED_COUNTERPART_SLUGS;
+        sort($expected);
+
+        $this->assertSame($expected, $missing);
+        $this->assertFalse((bool) ($matrix['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($matrix['summary']['counterpart_lookup_uses_slug_guessing_only'] ?? true));
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -7922,7 +7922,7 @@
       "depends_on": [
         "AUDIT-API-CAREER-ARTIFACT-READINESS"
       ],
-      "status": "local_validation_passed",
+      "status": "pr_open_github_checks_pending",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): require editorial approval for controlled article publish",
@@ -19195,8 +19195,8 @@
       "depends_on": [
         "EN-PARITY-03"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "042f5f45",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1674",
       "checks": {
         "dependency_en_parity_03": {
           "status": "pass",
@@ -19250,6 +19250,11 @@
           "at": "2026-05-25T07:20:00Z",
           "status": "local_validation_passed",
           "summary": "EN-PARITY-04 focused test, ArticleBaselineImportTest, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, and diff checks passed locally."
+        },
+        {
+          "at": "2026-05-25T07:24:00Z",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1674 for EN-PARITY-04 and pushed branch codex/en-parity-04-articles; waiting for GitHub checks."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -19102,11 +19102,11 @@
     "EN-PARITY-03": {
       "repo": "fap-api",
       "branch": "codex/en-parity-03-content-pages",
-      "status": "github_checks_passed_ready_to_merge",
+      "status": "merged",
       "depends_on": [
         "EN-PARITY-02"
       ],
-      "commit_sha": "8b0e5b4cf7a6f80429c6f70284369a39cae6a4fc",
+      "commit_sha": "f1a8a1c7afb4ac0468176cb9ddcb60bcc10bdb9f",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1672",
       "checks": {
         "dependency_en_parity_02": {
@@ -19142,12 +19142,12 @@
         },
         "github_required_checks": {
           "status": "pass",
-          "evidence": "PR #1672 second run passed hygiene, supply-chain, Semgrep blocking secrets, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2. GitHub mergeStateStatus is CLEAN at head 8b0e5b4cf7a6f80429c6f70284369a39cae6a4fc."
+          "evidence": "PR #1672 passed hygiene, supply-chain, Semgrep blocking secrets, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2 after rebase; GitHub mergeStateStatus was CLEAN and PR #1672 was squash-merged as f1a8a1c7afb4ac0468176cb9ddcb60bcc10bdb9f."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-25T07:00:22Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "sidecar_issues": [],
       "events": [
@@ -19180,6 +19180,76 @@
           "at": "2026-05-25T06:45:46Z",
           "status": "github_checks_passed_ready_to_merge",
           "summary": "GitHub checks passed on PR #1672 after adding scoped runtime-freeze allowlist evidence; mergeStateStatus CLEAN."
+        },
+        {
+          "at": "2026-05-25T07:00:22Z",
+          "status": "merged",
+          "summary": "PR #1672 was squash-merged into main as f1a8a1c7afb4ac0468176cb9ddcb60bcc10bdb9f and the remote branch was deleted. No post-merge cleanup script exists in this repository."
+        }
+      ]
+    },
+    "EN-PARITY-04": {
+      "repo": "fap-api",
+      "branch": "codex/en-parity-04-articles",
+      "status": "local_validation_passed",
+      "depends_on": [
+        "EN-PARITY-03"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency_en_parity_03": {
+          "status": "pass",
+          "evidence": "PR #1672 is MERGED and origin/main contains merge commit f1a8a1c7afb4ac0468176cb9ddcb60bcc10bdb9f."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Changed files are limited to Article local baseline importer translation metadata support, EN-PARITY-04 report/generated JSON/focused test, and current PR-train manifest/state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No production CMS mutation, production migration, deploy, URL submission, Search Channel action, secrets access, or fap-web commit."
+        },
+        "content_generation_boundary": {
+          "status": "pass",
+          "evidence": "EN-PARITY-04 lands an import-readiness package and metadata gate only. The target 10 English counterparts already exist in repo baseline authority; remaining long-form English counterparts are explicit deferred human-review work."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=EnParity04 --no-ansi",
+            "cd backend && php artisan test --filter=ArticleBaselineImportTest --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/en-parity-04-article-counterpart-import-package.v1.json >/dev/null",
+            "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "Focused php artisan test --filter=EnParity04 --no-ansi passed; php artisan test --filter=ArticleBaselineImportTest --no-ansi passed; php artisan route:list --no-ansi passed; vendor/bin/pint --test passed; composer validate --strict passed; composer audit --locked --no-interaction --ignore-unreachable passed; generated JSON parsed; PR-train YAML/state JSON parsed; git diff --check and git diff --cached --check passed."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "events": [
+        {
+          "at": "2026-05-25T07:10:00Z",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Started EN-PARITY-04 after EN-PARITY-03 merged. Added Article counterpart import-readiness package, stable Article translation metadata import support, focused test, and current manifest/state entry. No production or fap-web mutation performed."
+        },
+        {
+          "at": "2026-05-25T07:20:00Z",
+          "status": "local_validation_passed",
+          "summary": "EN-PARITY-04 focused test, ArticleBaselineImportTest, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, and diff checks passed locally."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5782,6 +5782,53 @@ prs:
     content_generation_allowed: false
     next_task: EN-PARITY-04
 
+  - id: EN-PARITY-04
+    repo: fap-api
+    depends_on: [EN-PARITY-03]
+    branch: codex/en-parity-04-articles
+    base: main
+    title: "EN-PARITY-04 article English counterpart completion"
+    train_scope: en_parity_article_counterpart_import_package
+    risk_level: p0_article_authority_parity
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleImportLocalBaseline.php
+      - backend/docs/seo/en-parity-04-article-counterpart-import-package.md
+      - backend/docs/seo/generated/en-parity-04-article-counterpart-import-package.v1.json
+      - backend/tests/Feature/SeoIntel/EnParity04ArticleCounterpartImportPackageTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Land a repository-backed Article EN/ZH counterpart import-readiness package and generated artifact.
+      - Strengthen articles:import-local-baseline so local/operator imports preserve stable translation_group_id, source_locale, translation_status, and source_article_id metadata.
+      - Prove the EN-PARITY-00 target 10 English article counterparts are already present in repo-backed Article baseline authority.
+      - Keep remaining long-form/editorial missing English counterparts explicit and deferred for separately reviewed draft/import packages.
+      - Prevent frontend fallback from satisfying Article counterpart authority.
+    do_not:
+      - Generate all missing English articles or substantial English prose.
+      - Auto-publish, mutate production CMS, run production migration, deploy, or submit URLs.
+      - Modify fap-web or treat frontend fallback as Article authority.
+      - Modify career guides, content pages, media assets, sitemap generator, llms generator, JSON-LD, FAQ, or Search Channel.
+      - Expose draft/import candidates in sitemap, llms, hreflang, URL Truth, or public runtime.
+    validation:
+      - cd backend && php artisan test --filter=EnParity04 --no-ansi
+      - cd backend && php artisan test --filter=ArticleBaselineImportTest --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/en-parity-04-article-counterpart-import-package.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: EN-PARITY-05
+
   - id: RESULT-EN-PARITY-00
     repo: fap-api
     depends_on: [EN-PARITY-00]


### PR DESCRIPTION
## PR id
EN-PARITY-04

## What changed
- Added an Article EN/ZH counterpart import-readiness report and generated JSON artifact.
- Strengthened `articles:import-local-baseline` so local/operator Article baseline imports preserve stable translation metadata:
  - `translation_group_id`
  - `source_locale`
  - `translation_status`
  - `source_article_id`
- Added focused SeoIntel coverage proving the EN-PARITY-00 target 10 English article counterparts are repo-backed and paired by backend Article authority.
- Reconciled EN-PARITY-03 as merged in the train state and added the current EN-PARITY-04 manifest/state entry.

## Why
EN-PARITY-00 reported missing English Article counterparts in production observation. Repository baseline inspection shows the 10 target counterpart rows already exist in backend Article baseline authority; the gap is import/exposure/read-model readiness, not permission to mass-generate prose in fap-web.

## Target articles ready for controlled review/import
- `big-five-growth-guide`
- `big-five-narrative-portrait`
- `big-five-tool-guide`
- `eq-test-tool-guide`
- `iq-test-growth-guide`
- `iq-test-narrative-portrait`
- `iq-test-tool-guide`
- `mbti-basics`
- `mbti-growth-guide`
- `mbti-narrative-portrait`

## Intentionally deferred
The following zh-CN long-form/editorial articles still need separately reviewed English draft/import packages and are not published or exposed by this PR:
- `are-infj-men-rare-or-socially-silenced`
- `best-valentines-date-by-personality-and-relationship-science`
- `childhood-dream-job-still-shapes-career-choice`
- `how-16-personality-types-talk-to-an-ai-coach`
- `how-personality-shapes-attitude-toward-ai`
- `which-love-script-fits-you-best`

## Validation
- PASS `cd backend && php artisan test --filter=EnParity04 --no-ansi`
- PASS `cd backend && php artisan test --filter=ArticleBaselineImportTest --no-ansi`
- PASS `cd backend && php artisan route:list --no-ansi`
- PASS `cd backend && vendor/bin/pint --test`
- PASS `cd backend && composer validate --strict`
- PASS `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- PASS `python3 -m json.tool backend/docs/seo/generated/en-parity-04-article-counterpart-import-package.v1.json >/dev/null`
- PASS manifest/state YAML/JSON parse
- PASS `git diff --check`
- PASS `git diff --cached --check`

## Safety / do-not confirmation
- No production CMS mutation.
- No production migration.
- No deploy.
- No URL submission or Search Channel action.
- No fap-web commit.
- No frontend fallback treated as Article authority.
- No mass English article generation.
- No auto-publish.

## Repository rule impact
This PR reinforces existing backend Article authority rules. Article counterpart parity remains owned by backend Article baseline/CMS authority and controlled import/publish workflow; fap-web fallback is not an authority source.

## Post-merge revalidate plan
- `cd backend && php artisan test --filter=EnParity04 --no-ansi`
- `cd backend && php artisan test --filter=ArticleBaselineImportTest --no-ansi`
- parse generated JSON and PR-train manifest/state

## Next task
EN-PARITY-05 career guide detail inventory/template/import package or small reviewed batch only.
