### PR TITLE
RESULT-EN-PARITY-06 Big Five ResultPageV2 EN asset catalog parity

### DIFF
--- a/backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json
@@ -1,0 +1,173 @@
+{
+    "schema": "fap.big5.result_page_v2.en_parity_draft.v1",
+    "draft_id": "big5_result_page_v2_en_parity_draft_2026_05_25",
+    "scale_code": "BIG5_OCEAN",
+    "locale": "en",
+    "source_registry": "backend/content_packs/BIG5_OCEAN/v2/registry",
+    "runtime_use": "draft_review_only",
+    "ready_for_runtime": false,
+    "ready_for_production": false,
+    "production_use_allowed": false,
+    "mass_content_generation": false,
+    "claim_boundary": {
+        "allowed": [
+            "trait tendency",
+            "workstyle pattern",
+            "behavioral explanation",
+            "contextual self-reflection",
+            "snapshot-based support"
+        ],
+        "forbidden": [
+            "precise career matching",
+            "hiring fit",
+            "career success prediction",
+            "salary prediction",
+            "turnover prediction",
+            "clinical diagnosis",
+            "treatment advice"
+        ],
+        "boundary_note_en": "Big Five results describe trait tendencies and workstyle patterns. They are not a hiring decision, clinical diagnosis, treatment plan, or career-success prediction."
+    },
+    "draft_asset_groups": {
+        "route_matrix": {
+            "status": "draft_skeleton",
+            "ready_for_runtime": false,
+            "keys": [
+                "big5.result_page_v2.route_matrix.en"
+            ],
+            "labels": {
+                "low": "Lower range",
+                "mid": "Middle range",
+                "high": "Higher range"
+            },
+            "deferred": [
+                "full route-row copy for every selected OCEAN band combination"
+            ]
+        },
+        "coupling_assets": {
+            "status": "draft_skeleton",
+            "ready_for_runtime": false,
+            "keys": [
+                "big5.result_page_v2.coupling_assets.en"
+            ],
+            "labels": {
+                "synergy": "Combined trait pattern",
+                "tension": "Trait tension",
+                "modifier": "Context modifier"
+            },
+            "deferred": [
+                "reviewed English synergy and modifier prose for all selector outputs"
+            ]
+        },
+        "scenario_action_assets": {
+            "status": "draft_skeleton",
+            "ready_for_runtime": false,
+            "keys": [
+                "big5.result_page_v2.scenario_action_assets.en"
+            ],
+            "scenario_labels": {
+                "workplace": "Workplace",
+                "relationships": "Relationships",
+                "stress_recovery": "Stress and recovery",
+                "personal_growth": "Personal growth"
+            },
+            "deferred": [
+                "reviewed scenario actions for all rule buckets"
+            ]
+        },
+        "facet_assets": {
+            "status": "draft_skeleton",
+            "ready_for_runtime": false,
+            "keys": [
+                "big5.result_page_v2.facet_assets.en"
+            ],
+            "facet_label_seed": {
+                "O1": "Imagination",
+                "O2": "Aesthetic sensitivity",
+                "O3": "Emotional awareness",
+                "O4": "Openness to action",
+                "O5": "Intellectual exploration",
+                "O6": "Value flexibility",
+                "C1": "Competence",
+                "C2": "Order",
+                "C3": "Dutifulness",
+                "C4": "Achievement striving",
+                "C5": "Self-discipline",
+                "C6": "Deliberation",
+                "E1": "Warmth",
+                "E2": "Sociability",
+                "E3": "Assertiveness",
+                "E4": "Activity level",
+                "E5": "Excitement seeking",
+                "E6": "Positive emotion",
+                "A1": "Trust",
+                "A2": "Straightforwardness",
+                "A3": "Altruism",
+                "A4": "Compliance",
+                "A5": "Modesty",
+                "A6": "Tender-mindedness",
+                "N1": "Anxiety sensitivity",
+                "N2": "Irritability",
+                "N3": "Emotional volatility",
+                "N4": "Self-consciousness",
+                "N5": "Impulse pressure",
+                "N6": "Stress vulnerability"
+            },
+            "deferred": [
+                "reviewed glossary, daily meaning, and why-it-matters prose for all 30 facets"
+            ]
+        },
+        "canonical_profiles": {
+            "status": "draft_skeleton",
+            "ready_for_runtime": false,
+            "keys": [
+                "big5.result_page_v2.canonical_profiles.en"
+            ],
+            "trait_label_seed": {
+                "O": "Openness to Experience",
+                "C": "Conscientiousness",
+                "E": "Extraversion",
+                "A": "Agreeableness",
+                "N": "Neuroticism"
+            },
+            "deferred": [
+                "reviewed profile signatures and full portrait copy for canonical profile combinations"
+            ]
+        },
+        "core_body": {
+            "status": "draft_skeleton",
+            "ready_for_runtime": false,
+            "keys": [
+                "big5.result_page_v2.core_body.en"
+            ],
+            "section_headlines": {
+                "hero_summary": "Big Five report summary",
+                "domains_overview": "Five-domain overview",
+                "domain_deep_dive": "Domain deep dive",
+                "facet_details": "Facet-level signals",
+                "core_portrait": "Core portrait",
+                "norms_comparison": "Norm comparison",
+                "action_plan": "Action plan",
+                "methodology_and_access": "Method and access"
+            },
+            "deferred": [
+                "reviewed English body, bullets, tables, actions, and CTA copy for each module"
+            ]
+        },
+        "selector_ready_assets": {
+            "status": "draft_skeleton",
+            "ready_for_runtime": false,
+            "keys": [
+                "big5.result_page_v2.selector_ready_assets.en"
+            ],
+            "selector_policy": "English selector output must not select zh-CN interpretation copy. Missing reviewed English content must fail closed or omit the unavailable module.",
+            "deferred": [
+                "asset checksums",
+                "selector fixture coverage",
+                "human-reviewed production release manifest"
+            ]
+        }
+    },
+    "human_review_required": true,
+    "next_batch_policy": "Convert one asset group at a time from draft_skeleton to reviewed_import_package after editorial review; do not flip ready_for_runtime in this draft file."
+}

--- a/backend/docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json
+++ b/backend/docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json
@@ -1,0 +1,183 @@
+{
+    "schema_version": "result-en-parity-06-bigfive-v2-en-assets.v1",
+    "pr_id": "RESULT-EN-PARITY-06",
+    "family": "BIG5_OCEAN",
+    "decision": "bigfive_result_page_v2_en_parity_draft_ready_for_human_review",
+    "source": {
+        "zh_runtime_registry": "backend/content_packs/BIG5_OCEAN/v2/registry",
+        "en_draft_catalog": "backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json",
+        "result_page_v2_services": "backend/app/Services/BigFive/ResultPageV2",
+        "previous_gate": "backend/docs/seo/generated/result-en-parity-01-asset-catalog-gate.v1.json"
+    },
+    "authority": {
+        "backend_content_pack_is_authority": true,
+        "frontend_fallback_is_authority": false,
+        "scoring_change": false,
+        "selector_change": false,
+        "production_mutation": false,
+        "cms_mutation": false,
+        "deploy": false,
+        "search_channel_action": false,
+        "production_user_data_access": false
+    },
+    "runtime_policy": {
+        "english_runtime_behavior": "fail_closed_no_zh_interpretation_fallback",
+        "draft_runtime_use": "draft_review_only",
+        "draft_ready_for_runtime": false,
+        "draft_ready_for_production": false,
+        "production_use_allowed": false,
+        "missing_reviewed_en_behavior": "omit_or_unavailable_state_not_zh_fallback"
+    },
+    "asset_groups": [
+        {
+            "key": "big5.result_page_v2.route_matrix.en",
+            "surface": "route_matrix",
+            "status": "draft_skeleton",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "interpretation_copy": true,
+            "fail_closed_for_unreviewed_en": true,
+            "ready_for_runtime": false
+        },
+        {
+            "key": "big5.result_page_v2.coupling_assets.en",
+            "surface": "coupling_assets",
+            "status": "draft_skeleton",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "interpretation_copy": true,
+            "fail_closed_for_unreviewed_en": true,
+            "ready_for_runtime": false
+        },
+        {
+            "key": "big5.result_page_v2.scenario_action_assets.en",
+            "surface": "scenario_action_assets",
+            "status": "draft_skeleton",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "interpretation_copy": true,
+            "fail_closed_for_unreviewed_en": true,
+            "ready_for_runtime": false
+        },
+        {
+            "key": "big5.result_page_v2.facet_assets.en",
+            "surface": "facet_assets",
+            "status": "draft_skeleton",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "interpretation_copy": true,
+            "fail_closed_for_unreviewed_en": true,
+            "ready_for_runtime": false
+        },
+        {
+            "key": "big5.result_page_v2.canonical_profiles.en",
+            "surface": "canonical_profiles",
+            "status": "draft_skeleton",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "interpretation_copy": true,
+            "fail_closed_for_unreviewed_en": true,
+            "ready_for_runtime": false
+        },
+        {
+            "key": "big5.result_page_v2.core_body.en",
+            "surface": "core_body",
+            "status": "draft_skeleton",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "interpretation_copy": true,
+            "fail_closed_for_unreviewed_en": true,
+            "ready_for_runtime": false
+        },
+        {
+            "key": "big5.result_page_v2.selector_ready_assets.en",
+            "surface": "selector_ready_assets",
+            "status": "draft_skeleton",
+            "has_zh": true,
+            "has_en": true,
+            "missing_en": false,
+            "interpretation_copy": true,
+            "fail_closed_for_unreviewed_en": true,
+            "ready_for_runtime": false
+        }
+    ],
+    "draft_seed_coverage": {
+        "trait_labels": [
+            "O",
+            "C",
+            "E",
+            "A",
+            "N"
+        ],
+        "facet_labels": 30,
+        "section_headlines": [
+            "hero_summary",
+            "domains_overview",
+            "domain_deep_dive",
+            "facet_details",
+            "core_portrait",
+            "norms_comparison",
+            "action_plan",
+            "methodology_and_access"
+        ],
+        "scenario_labels": [
+            "workplace",
+            "relationships",
+            "stress_recovery",
+            "personal_growth"
+        ]
+    },
+    "claim_boundary": {
+        "semantics": "trait_vector_workstyle_behavioral_explanation_only",
+        "allowed": [
+            "trait tendency",
+            "workstyle pattern",
+            "behavioral explanation",
+            "contextual self-reflection",
+            "snapshot-based support"
+        ],
+        "forbidden": [
+            "precise career matching",
+            "hiring fit",
+            "career success prediction",
+            "salary prediction",
+            "turnover prediction",
+            "clinical diagnosis",
+            "treatment advice"
+        ]
+    },
+    "deferred_assets": [
+        "reviewed full English route-row copy for selected OCEAN band combinations",
+        "reviewed English synergy and modifier prose for all selector outputs",
+        "reviewed English scenario actions for all rule buckets",
+        "reviewed English facet glossary, daily meaning, and why-it-matters prose for all 30 facets",
+        "reviewed English profile signatures and core portrait copy for canonical profile combinations",
+        "reviewed English body, bullets, tables, actions, and CTA copy for each ResultPageV2 module",
+        "selector fixture coverage and checksums before any runtime release"
+    ],
+    "remaining_missing_en_asset_keys": [],
+    "remaining_unreviewed_en_asset_keys": [
+        "big5.result_page_v2.route_matrix.en",
+        "big5.result_page_v2.coupling_assets.en",
+        "big5.result_page_v2.scenario_action_assets.en",
+        "big5.result_page_v2.facet_assets.en",
+        "big5.result_page_v2.canonical_profiles.en",
+        "big5.result_page_v2.core_body.en",
+        "big5.result_page_v2.selector_ready_assets.en"
+    ],
+    "validation_contract": {
+        "generated_json_parses": true,
+        "draft_catalog_parses": true,
+        "all_required_v2_groups_accounted_for": true,
+        "no_zh_fallback_policy_recorded": true,
+        "selector_source_authority_unchanged": true,
+        "trait_vector_semantics_preserved": true,
+        "no_scoring_change": true
+    }
+}

--- a/backend/docs/seo/result-en-parity-06-bigfive-v2-en-assets.md
+++ b/backend/docs/seo/result-en-parity-06-bigfive-v2-en-assets.md
@@ -1,0 +1,84 @@
+# RESULT-EN-PARITY-06 Big Five ResultPageV2 EN Asset Catalog Parity
+
+Decision output for this PR: `result_en_parity_06_bigfive_v2_en_assets_ready_for_human_review_batch`
+
+This PR adds a non-runtime English draft catalog for Big Five ResultPageV2 assets and records the generated parity inventory. It does not change scoring, selector logic, runtime release gates, CMS, production data, deployment, Search Channel submission, or fap-web.
+
+## Scope
+
+Covered ResultPageV2 asset groups:
+
+- route matrix
+- coupling assets
+- scenario action assets
+- facet assets
+- canonical profiles
+- core body
+- selector-ready assets
+
+Generated artifact:
+
+- `backend/docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json`
+
+Draft package:
+
+- `backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json`
+
+## Runtime Boundary
+
+The English draft package is explicitly:
+
+- `runtime_use = draft_review_only`
+- `ready_for_runtime = false`
+- `ready_for_production = false`
+- `production_use_allowed = false`
+
+The current zh-CN runtime registry remains under:
+
+- `backend/content_packs/BIG5_OCEAN/v2/registry`
+
+This PR does not wire the draft package into runtime selection.
+
+## Fail-Closed Rule
+
+English Big Five V2 output must not silently fall back to zh-CN interpretation copy. Until reviewed English assets are promoted through a future release package, missing or unreviewed English modules must omit the unavailable module or render an explicit unavailable state.
+
+## Draft Coverage
+
+The draft catalog accounts for:
+
+- 5 OCEAN trait labels.
+- 30 facet label seeds.
+- 8 ResultPageV2 section headlines.
+- 4 scenario labels.
+- no-zh-fallback selector policy.
+
+It intentionally defers full English prose for route rows, synergies, modifiers, scenario actions, facet explanations, profile signatures, core body modules, and selector fixtures.
+
+## Claim Boundary
+
+Big Five remains a trait-vector, workstyle, and behavioral explanation system.
+
+Allowed language:
+
+- trait tendency
+- workstyle pattern
+- behavioral explanation
+- contextual self-reflection
+- snapshot-based support
+
+Forbidden language:
+
+- precise career matching
+- hiring fit
+- career success prediction
+- salary prediction
+- turnover prediction
+- clinical diagnosis
+- treatment advice
+
+## Deferred Items
+
+The next Big Five content batch should convert one draft group at a time into a reviewed English import package with checksums, selector fixtures, and release review. Do not flip this draft package to runtime use.
+
+Repository rule impact: Big Five ResultPageV2 interpretation assets remain backend content-pack authoritative. This PR adds a draft asset catalog only and does not transfer authority to frontend code or runtime fallback.

--- a/backend/tests/Feature/SeoIntel/ResultEnParity06BigFiveV2EnAssetsTest.php
+++ b/backend/tests/Feature/SeoIntel/ResultEnParity06BigFiveV2EnAssetsTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class ResultEnParity06BigFiveV2EnAssetsTest extends TestCase
+{
+    public function test_bigfive_v2_generated_inventory_accounts_for_all_required_english_asset_groups(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('result-en-parity-06-bigfive-v2-en-assets.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('RESULT-EN-PARITY-06', $artifact['pr_id'] ?? null);
+        $this->assertSame('BIG5_OCEAN', $artifact['family'] ?? null);
+        $this->assertSame(
+            'bigfive_result_page_v2_en_parity_draft_ready_for_human_review',
+            $artifact['decision'] ?? null
+        );
+
+        $this->assertTrue((bool) ($artifact['authority']['backend_content_pack_is_authority'] ?? false));
+        $this->assertFalse((bool) ($artifact['authority']['frontend_fallback_is_authority'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['scoring_change'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['selector_change'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['production_mutation'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['cms_mutation'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['deploy'] ?? true));
+        $this->assertFalse((bool) ($artifact['authority']['search_channel_action'] ?? true));
+
+        $assetKeys = array_column($artifact['asset_groups'] ?? [], 'key');
+
+        foreach ($this->requiredAssetKeys() as $key) {
+            $this->assertContains($key, $assetKeys);
+        }
+
+        $this->assertSame([], $artifact['remaining_missing_en_asset_keys'] ?? null);
+        $this->assertEqualsCanonicalizing($this->requiredAssetKeys(), $artifact['remaining_unreviewed_en_asset_keys'] ?? []);
+    }
+
+    public function test_bigfive_v2_english_draft_catalog_is_non_runtime_and_fail_closed(): void
+    {
+        $draft = $this->draftCatalog();
+
+        $this->assertSame('fap.big5.result_page_v2.en_parity_draft.v1', $draft['schema'] ?? null);
+        $this->assertSame('BIG5_OCEAN', $draft['scale_code'] ?? null);
+        $this->assertSame('en', $draft['locale'] ?? null);
+        $this->assertSame('draft_review_only', $draft['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($draft['ready_for_runtime'] ?? true));
+        $this->assertFalse((bool) ($draft['ready_for_production'] ?? true));
+        $this->assertFalse((bool) ($draft['production_use_allowed'] ?? true));
+        $this->assertTrue((bool) ($draft['human_review_required'] ?? false));
+
+        $selectorPolicy = (string) data_get($draft, 'draft_asset_groups.selector_ready_assets.selector_policy');
+
+        $this->assertStringContainsString('must not select zh-CN interpretation copy', $selectorPolicy);
+        $this->assertStringContainsString('fail closed', $selectorPolicy);
+
+        foreach ($draft['draft_asset_groups'] ?? [] as $group => $payload) {
+            $this->assertSame('draft_skeleton', $payload['status'] ?? null, (string) $group);
+            $this->assertFalse((bool) ($payload['ready_for_runtime'] ?? true), (string) $group);
+            $this->assertNotEmpty($payload['keys'] ?? [], (string) $group);
+            $this->assertNotEmpty($payload['deferred'] ?? [], (string) $group);
+        }
+    }
+
+    public function test_bigfive_v2_draft_preserves_trait_vector_workstyle_semantics(): void
+    {
+        $artifact = $this->artifact();
+        $draft = $this->draftCatalog();
+
+        $this->assertSame(
+            'trait_vector_workstyle_behavioral_explanation_only',
+            $artifact['claim_boundary']['semantics'] ?? null
+        );
+
+        $serialized = strtolower(json_encode([$artifact, $draft], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+
+        foreach ([
+            'precise career matching',
+            'hiring fit',
+            'career success prediction',
+            'salary prediction',
+            'turnover prediction',
+            'clinical diagnosis',
+            'treatment advice',
+        ] as $forbidden) {
+            $this->assertContains($forbidden, $artifact['claim_boundary']['forbidden'] ?? []);
+        }
+
+        foreach ([
+            'best career for you',
+            'job fit guarantee',
+            'diagnose you',
+            'treatment plan for you',
+        ] as $unsupportedClaim) {
+            $this->assertStringNotContainsString($unsupportedClaim, $serialized);
+        }
+    }
+
+    public function test_bigfive_v2_draft_seed_coverage_includes_traits_facets_sections_and_scenarios(): void
+    {
+        $artifact = $this->artifact();
+        $draft = $this->draftCatalog();
+
+        $this->assertSame(['O', 'C', 'E', 'A', 'N'], $artifact['draft_seed_coverage']['trait_labels'] ?? null);
+        $this->assertSame(30, $artifact['draft_seed_coverage']['facet_labels'] ?? null);
+        $this->assertSame([
+            'hero_summary',
+            'domains_overview',
+            'domain_deep_dive',
+            'facet_details',
+            'core_portrait',
+            'norms_comparison',
+            'action_plan',
+            'methodology_and_access',
+        ], $artifact['draft_seed_coverage']['section_headlines'] ?? null);
+        $this->assertSame([
+            'workplace',
+            'relationships',
+            'stress_recovery',
+            'personal_growth',
+        ], $artifact['draft_seed_coverage']['scenario_labels'] ?? null);
+
+        $this->assertCount(5, data_get($draft, 'draft_asset_groups.canonical_profiles.trait_label_seed'));
+        $this->assertCount(30, data_get($draft, 'draft_asset_groups.facet_assets.facet_label_seed'));
+        $this->assertCount(8, data_get($draft, 'draft_asset_groups.core_body.section_headlines'));
+        $this->assertCount(4, data_get($draft, 'draft_asset_groups.scenario_action_assets.scenario_labels'));
+    }
+
+    public function test_validation_contract_records_no_scoring_or_selector_change(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue((bool) ($artifact['validation_contract']['generated_json_parses'] ?? false));
+        $this->assertTrue((bool) ($artifact['validation_contract']['draft_catalog_parses'] ?? false));
+        $this->assertTrue((bool) ($artifact['validation_contract']['all_required_v2_groups_accounted_for'] ?? false));
+        $this->assertTrue((bool) ($artifact['validation_contract']['no_zh_fallback_policy_recorded'] ?? false));
+        $this->assertTrue((bool) ($artifact['validation_contract']['selector_source_authority_unchanged'] ?? false));
+        $this->assertTrue((bool) ($artifact['validation_contract']['trait_vector_semantics_preserved'] ?? false));
+        $this->assertTrue((bool) ($artifact['validation_contract']['no_scoring_change'] ?? false));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredAssetKeys(): array
+    {
+        return [
+            'big5.result_page_v2.route_matrix.en',
+            'big5.result_page_v2.coupling_assets.en',
+            'big5.result_page_v2.scenario_action_assets.en',
+            'big5.result_page_v2.facet_assets.en',
+            'big5.result_page_v2.canonical_profiles.en',
+            'big5.result_page_v2.core_body.en',
+            'big5.result_page_v2.selector_ready_assets.en',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function draftCatalog(): array
+    {
+        $path = base_path('content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1776,6 +1776,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_bigfive_v2_en_parity_draft_catalog(): void
+    {
+        $changed = [
+            'backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_allows_bigfive_norm_foundation_data_scope_only(): void
     {
         $allowed = [
@@ -2397,6 +2406,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isBigFiveV2PilotSupportFile($file)) {
+                continue;
+            }
+
+            if ($this->isBigFiveV2EnParityDraftCatalogFile($file)) {
                 continue;
             }
 
@@ -3692,6 +3705,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
             || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
             || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf|Share|History|Compare|Rollout|Observability)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+    }
+
+    private function isBigFiveV2EnParityDraftCatalogFile(string $file): bool
+    {
+        return $file === 'backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json';
     }
 
     private function isBigFiveNormFoundationSchemaFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T07:05:00Z",
+  "updated_at": "2026-05-25T07:45:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -24322,11 +24322,11 @@
   "RESULT-EN-PARITY-05": {
     "repo": "fap-api",
     "branch": "codex/result-en-parity-05-mbti-content-export",
-    "status": "pr_open_github_checks_pending",
+    "status": "merged",
     "depends_on": [
       "RESULT-EN-PARITY-04"
     ],
-    "commit_sha": "27a1fb50302d2eb9e517a8739628a365861c030d",
+    "commit_sha": "c572ca6a9a63b9921efcbd87033caf94d0decf0b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1673",
     "checks": {
       "dependency_result_en_parity_00": {
@@ -24362,14 +24362,18 @@
         "evidence": "Focused ResultEnParity05MbtiContentExport test passed with 5 tests and 79 assertions. route:list exited 0 with 203 routes. Pint passed 3545 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON parse, manifest/state parse, git diff checks, and fap-web reference status passed; fap-web only has pre-existing untracked .playwright-mcp/."
       },
       "github_required_checks": {
-        "status": "pending",
-        "evidence": "PR #1673 opened for RESULT-EN-PARITY-05; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "PR #1673 is MERGED and origin/main contains squash merge c572ca6a9a63b9921efcbd87033caf94d0decf0b; hygiene, supply-chain, Semgrep blocking secrets, verify-mbti-legacy, and verify-mbti-v2 passed."
+      },
+      "post_merge_cleanup": {
+        "status": "pass",
+        "evidence": "origin/main synced to c572ca6a9a63b9921efcbd87033caf94d0decf0b, local main matched origin/main, task branch cleanup completed, and focused post-merge ResultEnParity05MbtiContentExport test passed."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-25T07:03:57Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [],
     "events": [
       {
@@ -24386,6 +24390,84 @@
         "at": "2026-05-25T07:05:00Z",
         "status": "pr_open_github_checks_pending",
         "summary": "Opened PR #1673 for RESULT-EN-PARITY-05 MBTI backend content package export and frontend interpretation de-authoring; waiting for GitHub checks."
+      },
+      {
+        "at": "2026-05-25T07:20:00Z",
+        "status": "merged_reconciled_before_result_en_parity_06",
+        "summary": "Reconciled PR #1673 as merged with required GitHub checks passing, origin/main containing c572ca6a9a63b9921efcbd87033caf94d0decf0b, remote branch deleted, and local cleanup executed before RESULT-EN-PARITY-06."
+      }
+    ]
+  },
+  "RESULT-EN-PARITY-06": {
+    "repo": "fap-api",
+    "branch": "codex/result-en-parity-06-bigfive-v2-en-assets",
+    "status": "pr_opened",
+    "depends_on": [
+      "RESULT-EN-PARITY-05"
+    ],
+    "commit_sha": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1675",
+    "checks": {
+      "dependency_result_en_parity_00": {
+        "status": "pass",
+        "evidence": "PR #1666 is MERGED and origin/main contains merge commit a93345e5a24f1f579495bcfd78f30b4c5984bd1a."
+      },
+      "dependency_result_en_parity_05": {
+        "status": "pass",
+        "evidence": "PR #1673 is MERGED and origin/main contains merge commit c572ca6a9a63b9921efcbd87033caf94d0decf0b."
+      },
+      "scope_boundary": {
+        "status": "pass",
+        "evidence": "Changed files are limited to Big Five V2 EN draft content pack catalog, generated report/artifact, focused SeoIntel test, minimum Big Five runtime-freeze classifier coverage for the draft catalog, and PR-train metadata."
+      },
+      "production_safety": {
+        "status": "pass",
+        "evidence": "No production mutation, CMS mutation, deploy, production migration, URL submission, production user data access, scoring change, selector change, or fap-web commit."
+      },
+      "local_validation": {
+        "status": "pass",
+        "commands": [
+          "cd backend && php artisan test --filter=ResultEnParity06BigFiveV2EnAssets --no-ansi",
+          "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter bigfive_v2_en_parity_draft_catalog --no-ansi",
+          "cd backend && php artisan test --filter=BigFive --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json >/dev/null",
+          "python3 -m json.tool backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json >/dev/null",
+          "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+          "git diff --check",
+          "git diff --cached --check",
+          "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short"
+        ],
+        "evidence": "Focused ResultEnParity06BigFiveV2EnAssets test passed with 5 tests and 93 assertions. Focused Big Five runtime-freeze classifier test passed. php artisan test --filter=BigFive passed with 772 tests and 60954 assertions. route:list exited 0 with 203 routes. Pint passed 3547 files. composer validate --strict passed. composer audit --locked --no-interaction --ignore-unreachable reported no advisories. Generated JSON parse, draft catalog JSON parse, manifest/state parse, diff checks, and fap-web reference status passed; fap-web only has pre-existing untracked .playwright-mcp/."
+      },
+      "github_pr_opened": {
+        "status": "pass",
+        "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1675 from codex/result-en-parity-06-bigfive-v2-en-assets."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "events": [
+      {
+        "at": "2026-05-25T07:20:00Z",
+        "status": "local_files_generated_pending_validation",
+        "summary": "Added Big Five ResultPageV2 non-runtime EN parity draft catalog, generated artifact/report, focused test, and runtime-freeze classifier coverage for the draft catalog path."
+      },
+      {
+        "at": "2026-05-25T07:35:00Z",
+        "status": "local_validation_passed",
+        "summary": "RESULT-EN-PARITY-06 focused test, Big Five sweep, route list, Pint, composer validate, composer audit, JSON parses, manifest/state parse, diff checks, and fap-web reference status passed locally."
+      },
+      {
+        "at": "2026-05-25T07:45:00Z",
+        "status": "pr_opened",
+        "summary": "Opened PR #1675 for RESULT-EN-PARITY-06 Big Five ResultPageV2 EN asset catalog parity."
       }
     ]
   }


### PR DESCRIPTION
## What changed
- Added a non-runtime Big Five ResultPageV2 English parity draft catalog under `backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity`.
- Added generated parity inventory and SEO report for `RESULT-EN-PARITY-06`.
- Added focused SeoIntel tests for required V2 asset group coverage, no-zh-fallback policy, claim boundary, non-runtime draft status, and no scoring/selector changes.
- Added minimum Big Five runtime-freeze classifier coverage for the scoped draft catalog path.
- Reconciled `RESULT-EN-PARITY-05` ledger state as merged.

## Why
`RESULT-EN-PARITY-01` identified Big Five ResultPageV2 EN gaps for route matrix, coupling, scenario actions, facets, canonical profiles, core body, and selector-ready assets. This PR accounts for those keys without publishing unreviewed English prose or changing runtime selection.

## Validation
- `cd backend && php artisan test --filter=ResultEnParity06BigFiveV2EnAssets --no-ansi`
- `cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter bigfive_v2_en_parity_draft_catalog --no-ansi`
- `cd backend && php artisan test --filter=BigFive --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json >/dev/null`
- `python3 -m json.tool backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json >/dev/null`
- `python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'`
- `git diff --check`
- `git diff --cached --check`
- `cd /Users/rainie/Desktop/GitHub/fap-web && git status --short`

## Intentionally deferred
- No runtime selector switch to English assets.
- No reviewed full English prose for all V2 modules in this PR.
- Draft assets remain `draft_review_only`, `ready_for_runtime=false`, `ready_for_production=false`, `production_use_allowed=false`.
- Future PR should convert one asset group at a time into reviewed import packages with checksums and selector fixtures.

## Repository rule impact
Big Five ResultPageV2 interpretation assets remain backend content-pack authoritative. This PR adds a draft backend catalog only and does not transfer authority to frontend fallback or runtime copy.
