### PR TITLE
EN-PARITY-05 career guides English detail completion

### DIFF
--- a/backend/docs/seo/en-parity-05-career-guide-detail-import-package.md
+++ b/backend/docs/seo/en-parity-05-career-guide-detail-import-package.md
@@ -1,0 +1,54 @@
+# EN-PARITY-05 Career Guide English Detail Import Package
+
+## Executive Summary
+
+EN-PARITY-05 lands a repository-backed career guide detail inventory and import-readiness gate. It does not publish career guides, mutate production CMS, submit URLs, deploy, or use fap-web fallback content as authority.
+
+The current career guide baseline contains 36 zh-CN guide rows and 36 en guide rows. The backend authority key is `guide_code`, and the repo baseline has complete EN/ZH guide-code parity. EN-PARITY-00 observed production/runtime discovery gaps for English career guide details, so the remaining work is controlled import/exposure verification rather than mass-generating English guide prose.
+
+## Scope
+
+- Add a generated import-readiness JSON artifact for career guide detail parity.
+- Add a focused test proving EN/ZH career guide baseline detail rows have matching `guide_code` authority keys.
+- Record production/content safety controls for this PR.
+
+## Current Baseline
+
+- English career guide rows: 36
+- Chinese career guide rows: 36
+- Missing English guide-code counterparts in repo baseline: 0
+- Missing Chinese guide-code counterparts in repo baseline: 0
+
+## Authority Boundary
+
+- Backend `career_guides.guide_code` is the counterpart key.
+- Frontend fallback cannot satisfy a missing career guide counterpart.
+- Draft/import candidates must not enter sitemap, llms, hreflang, URL Truth, or public runtime unless backend/CMS authority is published and indexable.
+
+## Controls
+
+- No fap-web files changed.
+- No frontend fallback used as career guide authority.
+- No production CMS mutation performed.
+- No production migration performed.
+- No deploy performed.
+- No Search Channel action or URL submission performed.
+- No mass English career guide generation performed.
+- No auto-publish performed.
+
+## Deferred Work
+
+Production/runtime may still need a controlled operator import, exposure verification, and EN/ZH URL surface validation. That must happen through backend/CMS authority and existing release gates; this PR does not mutate production.
+
+## Validation
+
+- `php artisan test --filter=EnParity05 --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- `python3 -m json.tool backend/docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json >/dev/null`
+
+## Next Task
+
+EN-PARITY-06 should build media asset / alt / og image / locale variant parity inventory and sidecar any human design work. It must not upload or mutate production media.

--- a/backend/docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json
+++ b/backend/docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "en-parity-05-career-guide-detail-import-package.v1",
+  "task": "EN-PARITY-05",
+  "source_authority": "backend_cms_career_guide_baseline",
+  "frontend_fallback_authority_used": false,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "auto_publish_performed": false,
+  "mass_english_generation_performed": false,
+  "substantial_english_prose_generated": false,
+  "fap_web_modified": false,
+  "baseline_sources": [
+    "content_baselines/career_guides/career_guides.en.json",
+    "content_baselines/career_guides/career_guides.zh-CN.json"
+  ],
+  "current_baseline_summary": {
+    "career_guides_en_count": 36,
+    "career_guides_zh_count": 36,
+    "missing_english_counterparts_count": 0,
+    "missing_chinese_counterparts_count": 0,
+    "counterpart_key": "guide_code",
+    "counterpart_lookup_uses_slug_guessing_only": false
+  },
+  "guide_codes_ready_for_controlled_review": [
+    "annual-career-review-system",
+    "big5-for-career-decisions",
+    "build-five-year-career-roadmap",
+    "build-portfolio-for-career-switch",
+    "career-growth-with-manager",
+    "career-risk-management",
+    "career-transition-playbook",
+    "cross-industry-move-strategy",
+    "enfj-career-playbook",
+    "enfp-career-playbook",
+    "entj-career-playbook",
+    "entp-career-playbook",
+    "esfj-career-playbook",
+    "esfp-career-playbook",
+    "estj-career-playbook",
+    "estp-career-playbook",
+    "first-90-days-in-new-role",
+    "from-mbti-to-job-fit",
+    "how-to-choose-college-major",
+    "how-to-find-right-career-direction",
+    "improve-workplace-competitiveness",
+    "infj-career-playbook",
+    "infp-career-playbook",
+    "interview-strategy-by-role",
+    "intj-career-playbook",
+    "intp-career-playbook",
+    "iq-eq-balance-at-work",
+    "isfj-career-playbook",
+    "isfp-career-playbook",
+    "istj-career-playbook",
+    "istp-career-playbook",
+    "leader-track-vs-expert-track",
+    "networking-that-actually-works",
+    "personal-brand-for-professionals",
+    "prevent-burnout-while-growing",
+    "salary-negotiation-framework"
+  ],
+  "import_controls": {
+    "controlled_import_command": "career-guides:import-local-baseline",
+    "production_import_executed": false,
+    "production_publish_executed": false,
+    "requires_operator_review": true,
+    "requires_controlled_publish_workflow": true,
+    "draft_exposure_allowed_in_sitemap_llms": false
+  },
+  "translation_authority_contract": {
+    "entity_type": "career_guide",
+    "source_of_truth": "career_guides",
+    "counterpart_key": "guide_code",
+    "frontend_fallback_can_satisfy_counterpart": false
+  },
+  "deferred_items": [
+    {
+      "id": "en_parity_05_production_import_exposure_verification",
+      "reason": "Runtime observation gaps require controlled backend/CMS import and URL-surface verification outside this no-production-mutation PR."
+    },
+    {
+      "id": "en_parity_07_career_guide_sitemap_llms_gate",
+      "reason": "Career guide URLs must only enter public SEO surfaces after backend/CMS authority is published and indexable."
+    }
+  ],
+  "recommended_next_tasks": [
+    {
+      "id": "EN-PARITY-06",
+      "title": "Media assets alt og image and locale variant parity",
+      "scope": "Inventory media authority and sidecar human design work; do not upload or mutate production media."
+    },
+    {
+      "id": "EN-PARITY-07",
+      "title": "Sitemap llms JSON-LD FAQ grounding parity gate",
+      "scope": "Verify career guide URLs only enter public SEO surfaces when backend authority is published and indexable."
+    }
+  ],
+  "final_decision": "en_parity_05_import_package_landed_career_guides_ready_deferred_production_exposure",
+  "next_task": "EN-PARITY-06 media assets alt og image and locale variant parity"
+}

--- a/backend/tests/Feature/SeoIntel/EnParity05CareerGuideDetailImportPackageTest.php
+++ b/backend/tests/Feature/SeoIntel/EnParity05CareerGuideDetailImportPackageTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class EnParity05CareerGuideDetailImportPackageTest extends TestCase
+{
+    #[Test]
+    public function generated_import_package_records_career_guide_content_controls(): void
+    {
+        $path = base_path('docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('en-parity-05-career-guide-detail-import-package.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('EN-PARITY-05', $payload['task'] ?? null);
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['auto_publish_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['mass_english_generation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['substantial_english_prose_generated'] ?? true));
+        $this->assertFalse((bool) ($payload['fap_web_modified'] ?? true));
+
+        $this->assertSame(36, data_get($payload, 'current_baseline_summary.career_guides_en_count'));
+        $this->assertSame(36, data_get($payload, 'current_baseline_summary.career_guides_zh_count'));
+        $this->assertSame(0, data_get($payload, 'current_baseline_summary.missing_english_counterparts_count'));
+        $this->assertSame(0, data_get($payload, 'current_baseline_summary.missing_chinese_counterparts_count'));
+        $this->assertSame('guide_code', data_get($payload, 'current_baseline_summary.counterpart_key'));
+        $this->assertFalse((bool) data_get($payload, 'current_baseline_summary.counterpart_lookup_uses_slug_guessing_only'));
+        $this->assertFalse((bool) data_get($payload, 'import_controls.production_import_executed'));
+        $this->assertFalse((bool) data_get($payload, 'import_controls.production_publish_executed'));
+    }
+
+    #[Test]
+    public function career_guide_baselines_have_complete_en_zh_guide_code_parity(): void
+    {
+        $en = $this->baselineGuideCodes('content_baselines/career_guides/career_guides.en.json');
+        $zh = $this->baselineGuideCodes('content_baselines/career_guides/career_guides.zh-CN.json');
+
+        $this->assertCount(36, $en);
+        $this->assertCount(36, $zh);
+        $this->assertSame($zh, $en);
+    }
+
+    #[Test]
+    public function generated_package_matches_baseline_guide_code_authority(): void
+    {
+        $payload = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        $this->assertSame(
+            $this->baselineGuideCodes('content_baselines/career_guides/career_guides.en.json'),
+            $payload['guide_codes_ready_for_controlled_review'] ?? [],
+        );
+        $this->assertFalse((bool) data_get($payload, 'translation_authority_contract.frontend_fallback_can_satisfy_counterpart'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function baselineGuideCodes(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents(base_path('../'.$path)), true, 512, JSON_THROW_ON_ERROR);
+        $codes = collect($payload['guides'] ?? [])
+            ->pluck('guide_code')
+            ->map(static fn (mixed $code): string => (string) $code)
+            ->sort()
+            ->values()
+            ->all();
+
+        return $codes;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -8039,7 +8039,7 @@
       "depends_on": [
         "AUDIT-API-ARTICLE-PUBLISH-GATE"
       ],
-      "status": "local_validation_passed",
+      "status": "pr_open_github_checks_pending",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): scope ops release failure audits by org",
@@ -19270,8 +19270,8 @@
       "depends_on": [
         "EN-PARITY-04"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "baebe089",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1676",
       "checks": {
         "dependency_en_parity_04": {
           "status": "pass",
@@ -19324,6 +19324,11 @@
           "at": "2026-05-25T07:36:00Z",
           "status": "local_validation_passed",
           "summary": "EN-PARITY-05 focused test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, and diff checks passed locally."
+        },
+        {
+          "at": "2026-05-25T07:40:00Z",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1676 for EN-PARITY-05 and pushed branch codex/en-parity-05-career-guides; waiting for GitHub checks."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -7922,7 +7922,7 @@
       "depends_on": [
         "AUDIT-API-CAREER-ARTIFACT-READINESS"
       ],
-      "status": "pr_open_github_checks_pending",
+      "status": "merged",
       "train_scope": "security_audit_remediation",
       "risk_level": "medium",
       "title": "fix(security): require editorial approval for controlled article publish",
@@ -19195,7 +19195,7 @@
       "depends_on": [
         "EN-PARITY-03"
       ],
-      "commit_sha": "042f5f45",
+      "commit_sha": "bff0c6a41d7fb5f95f8f006019f20c9f5782f161",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1674",
       "checks": {
         "dependency_en_parity_03": {
@@ -19231,13 +19231,13 @@
           "evidence": "Focused php artisan test --filter=EnParity04 --no-ansi passed; php artisan test --filter=ArticleBaselineImportTest --no-ansi passed; php artisan route:list --no-ansi passed; vendor/bin/pint --test passed; composer validate --strict passed; composer audit --locked --no-interaction --ignore-unreachable passed; generated JSON parsed; PR-train YAML/state JSON parsed; git diff --check and git diff --cached --check passed."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": null
+          "status": "pass",
+          "evidence": "PR #1674 passed hygiene, supply-chain, Semgrep blocking secrets, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2; GitHub mergeStateStatus was CLEAN and PR #1674 was squash-merged as bff0c6a41d7fb5f95f8f006019f20c9f5782f161."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-25T07:18:00Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "sidecar_issues": [],
       "events": [
@@ -19255,6 +19255,75 @@
           "at": "2026-05-25T07:24:00Z",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1674 for EN-PARITY-04 and pushed branch codex/en-parity-04-articles; waiting for GitHub checks."
+        },
+        {
+          "at": "2026-05-25T07:18:00Z",
+          "status": "merged",
+          "summary": "PR #1674 was squash-merged into main as bff0c6a41d7fb5f95f8f006019f20c9f5782f161 and the remote branch was deleted. No post-merge cleanup script exists in this repository."
+        }
+      ]
+    },
+    "EN-PARITY-05": {
+      "repo": "fap-api",
+      "branch": "codex/en-parity-05-career-guides",
+      "status": "local_validation_passed",
+      "depends_on": [
+        "EN-PARITY-04"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency_en_parity_04": {
+          "status": "pass",
+          "evidence": "PR #1674 is MERGED and origin/main contains merge commit bff0c6a41d7fb5f95f8f006019f20c9f5782f161."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Changed files are limited to EN-PARITY-05 report/generated JSON/focused test and current PR-train manifest/state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No production CMS mutation, production migration, deploy, URL submission, Search Channel action, secrets access, or fap-web commit."
+        },
+        "content_generation_boundary": {
+          "status": "pass",
+          "evidence": "EN-PARITY-05 lands an import-readiness package and metadata gate only. Repo baseline already has complete EN/ZH career guide guide_code parity; production exposure remains controlled/deferred."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=EnParity05 --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json >/dev/null",
+            "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "Focused php artisan test --filter=EnParity05 --no-ansi passed; php artisan route:list --no-ansi passed; vendor/bin/pint --test passed; composer validate --strict passed; composer audit --locked --no-interaction --ignore-unreachable passed; generated JSON parsed; PR-train YAML/state JSON parsed; git diff --check and git diff --cached --check passed."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "events": [
+        {
+          "at": "2026-05-25T07:30:00Z",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Started EN-PARITY-05 after EN-PARITY-04 merged. Added career guide detail import-readiness package, focused test, and current manifest/state entry. No production or fap-web mutation performed."
+        },
+        {
+          "at": "2026-05-25T07:36:00Z",
+          "status": "local_validation_passed",
+          "summary": "EN-PARITY-05 focused test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, and diff checks passed locally."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5829,6 +5829,50 @@ prs:
     content_generation_allowed: false
     next_task: EN-PARITY-05
 
+  - id: EN-PARITY-05
+    repo: fap-api
+    depends_on: [EN-PARITY-04]
+    branch: codex/en-parity-05-career-guides
+    base: main
+    title: "EN-PARITY-05 career guides English detail completion"
+    train_scope: en_parity_career_guide_detail_import_package
+    risk_level: p0_career_guide_authority_parity
+    allowed_paths:
+      - backend/docs/seo/en-parity-05-career-guide-detail-import-package.md
+      - backend/docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json
+      - backend/tests/Feature/SeoIntel/EnParity05CareerGuideDetailImportPackageTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Land a repository-backed CareerGuide EN/ZH detail import-readiness package and generated artifact.
+      - Prove committed career guide baselines have complete EN/ZH guide_code parity without relying on frontend fallback.
+      - Keep production import/exposure verification deferred to controlled backend/CMS workflow.
+      - Do not generate substantial English career guide prose or auto-publish content.
+    do_not:
+      - Generate all missing English career guide detail pages or substantial English prose.
+      - Auto-publish, mutate production CMS, run production migration, deploy, or submit URLs.
+      - Modify fap-web or treat frontend fallback as CareerGuide authority.
+      - Modify articles, content pages, media assets, sitemap generator, llms generator, JSON-LD, FAQ, or Search Channel.
+      - Expose draft/import candidates in sitemap, llms, hreflang, URL Truth, or public runtime.
+    validation:
+      - cd backend && php artisan test --filter=EnParity05 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: EN-PARITY-06
+
   - id: RESULT-EN-PARITY-00
     repo: fap-api
     depends_on: [EN-PARITY-00]


### PR DESCRIPTION
## PR id
EN-PARITY-05

## What changed
- Added a Career Guide EN/ZH detail import-readiness report and generated JSON artifact.
- Added focused SeoIntel coverage proving committed career guide baselines have complete EN/ZH `guide_code` parity.
- Added the current EN-PARITY-05 manifest/state entry and reconciled EN-PARITY-04 as merged.

## Why
EN-PARITY-00 observed English career guide detail discovery gaps in production runtime. Repository baseline inspection shows the backend career guide baseline already has 36 EN and 36 zh-CN rows with matching `guide_code`; the remaining gap is controlled import/exposure verification, not permission to mass-generate English guide prose in fap-web.

## Validation
- PASS `cd backend && php artisan test --filter=EnParity05 --no-ansi`
- PASS `cd backend && php artisan route:list --no-ansi`
- PASS `cd backend && vendor/bin/pint --test`
- PASS `cd backend && composer validate --strict`
- PASS `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- PASS `python3 -m json.tool backend/docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json >/dev/null`
- PASS manifest/state YAML/JSON parse
- PASS `git diff --check`
- PASS `git diff --cached --check`

## Safety / do-not confirmation
- No production CMS mutation.
- No production migration.
- No deploy.
- No URL submission or Search Channel action.
- No fap-web commit.
- No frontend fallback treated as CareerGuide authority.
- No mass English career guide generation.
- No auto-publish.

## Intentionally deferred
- Production import/exposure verification remains a controlled backend/CMS operator workflow.
- EN-PARITY-07 must ensure career guide URLs only enter sitemap/llms/JSON-LD when backend authority is published and indexable.

## Repository rule impact
This PR reinforces existing backend CareerGuide authority rules. Career guide detail parity remains owned by backend CareerGuide baseline/CMS authority and controlled import/publish workflow; fap-web fallback is not an authority source.

## Post-merge revalidate plan
- `cd backend && php artisan test --filter=EnParity05 --no-ansi`
- parse generated JSON and PR-train manifest/state

## Next task
EN-PARITY-06 media assets / alt / og image / locale variant parity inventory.
