### PR TITLE
EN-PARITY-06 media assets alt og image and locale variant parity

### DIFF
--- a/backend/docs/seo/en-parity-06-media-assets-parity-inventory.md
+++ b/backend/docs/seo/en-parity-06-media-assets-parity-inventory.md
@@ -1,0 +1,123 @@
+# EN-PARITY-06 Media Assets / Alt / OG Image / Locale Variant Parity
+
+## Executive Summary
+
+EN-PARITY-06 lands a repository-backed media parity inventory for public EN/ZH content surfaces. It does not upload, generate, replace, or publish images.
+
+Decision: `en_parity_06_media_inventory_landed_sidecar_visual_review_required`
+
+The committed authority evidence shows:
+
+- Media baseline assets: 3, all with alt and caption metadata.
+- Article baselines: 20 EN articles and 25 zh-CN articles, all with cover URL, alt, and variants.
+- Existing EN article alt metadata contains no Chinese characters.
+- 19 EN/ZH article pairs share the same cover URL and therefore need human or OCR review before we can claim embedded-text parity.
+- Career guide baselines have complete EN/ZH guide-code parity, but 36 EN and 36 zh-CN guide rows have no `og_image_url` or `twitter_image_url`.
+- Content pages, MBTI topic profiles, and MBTI personality profiles do not currently provide usable public media authority in the inspected baseline fields.
+
+## Scope
+
+This PR is inventory and gate evidence only.
+
+Files landed:
+
+- `backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json`
+- `backend/tests/Feature/SeoIntel/EnParity06MediaAssetsParityInventoryTest.php`
+- `backend/docs/seo/en-parity-06-media-assets-parity-inventory.md`
+- current PR-train manifest/state entry
+
+## Authority Boundary
+
+Backend/CMS Media Library metadata, Article cover metadata, CareerGuide SEO metadata, and repo-backed baseline import packages remain authority.
+
+Frontend fallback content, sitemap, llms, runtime fetches, and visual observation do not become media authority.
+
+## What Was Not Done
+
+- No production CMS mutation.
+- No production media upload.
+- No image generation.
+- No image replacement.
+- No production migration.
+- No deploy.
+- No Search Channel or URL submission.
+- No fap-web commit.
+- No OCR or full human design review was performed.
+
+## Findings
+
+### Article Covers
+
+The EN article baseline has complete cover metadata for all 20 rows:
+
+- `cover_image_url`: 20 / 20
+- `cover_image_alt`: 20 / 20
+- `cover_image_variants`: 20 / 20
+- EN alt text containing Chinese characters: 0
+
+The zh-CN article baseline has complete cover metadata for all 25 rows. Six zh-CN editorial articles remain without EN article counterparts from EN-PARITY-04 and stay deferred.
+
+Nineteen EN/ZH article pairs share cover URLs. This is acceptable as metadata evidence, but it is not enough to prove embedded-text visual parity. Those covers are sidecarized for OCR or human review.
+
+### Career Guide Social Images
+
+Career guide baselines have 36 EN and 36 zh-CN rows with complete `guide_code` parity from EN-PARITY-05. They do not currently carry authority-backed social image fields:
+
+- EN `og_image_url`: 0 / 36
+- zh-CN `og_image_url`: 0 / 36
+- EN `twitter_image_url`: 0 / 36
+- zh-CN `twitter_image_url`: 0 / 36
+
+Career guide public SEO exposure must remain controlled by EN-PARITY-07 until valid authority-backed OG / JSON-LD image policy is enforced.
+
+### Media Library Baseline
+
+`content_baselines/media_assets/default_media_assets.json` contains three default assets:
+
+- `share.mbti.default`
+- `social.wechat.official_qr`
+- `social.wechat.qr`
+
+All three have alt and caption metadata. `share.mbti.default` still needs visual embedded-text review evidence before it can be used as proof of bilingual visual parity.
+
+## Sidecar Items
+
+1. `en_parity_06_shared_article_cover_visual_text_review`
+   - Scope: 19 shared EN/ZH article covers.
+   - Reason: metadata is complete, but embedded text was not OCR/human reviewed.
+
+2. `en_parity_06_career_guide_social_images`
+   - Scope: 36 EN and 36 zh-CN career guide detail rows.
+   - Reason: no authority-backed OG/Twitter image URLs exist yet.
+
+3. `en_parity_06_mbti_default_share_visual_review`
+   - Scope: `share.mbti.default`.
+   - Reason: media metadata exists, but visual text review evidence is not recorded.
+
+## Validation
+
+Required local validation:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=EnParity06 --no-ansi
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd /Users/rainie/Desktop/GitHub/fap-api
+python3 -m json.tool backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json >/dev/null
+python3 - <<'PY'
+import yaml, json
+yaml.safe_load(open('docs/codex/pr-train.yaml'))
+json.load(open('docs/codex/pr-train-state.json'))
+print('manifest/state parse ok')
+PY
+git diff --check
+git diff --cached --check
+```
+
+## Next Task
+
+EN-PARITY-07 should use this inventory to enforce sitemap, llms, JSON-LD, FAQ, canonical, and hreflang gates so public SEO surfaces do not expose draft, placeholder, fallback-only, missing-authority, or broken media/content metadata.

--- a/backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json
+++ b/backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json
@@ -1,0 +1,183 @@
+{
+  "schema_version": "en-parity-06-media-assets-parity-inventory.v1",
+  "task": "EN-PARITY-06",
+  "source_authority": "backend_cms_media_and_content_baselines",
+  "frontend_fallback_authority_used": false,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "auto_publish_performed": false,
+  "media_upload_performed": false,
+  "image_generation_performed": false,
+  "fap_web_modified": false,
+  "visual_ocr_performed": false,
+  "baseline_sources": [
+    "content_baselines/media_assets/default_media_assets.json",
+    "content_baselines/articles/articles.en.json",
+    "content_baselines/articles/articles.zh-CN.json",
+    "content_baselines/career_guides/career_guides.en.json",
+    "content_baselines/career_guides/career_guides.zh-CN.json",
+    "content_baselines/content_pages/content_pages.en.json",
+    "content_baselines/content_pages/content_pages.zh-CN.json",
+    "content_baselines/topics/*.json",
+    "content_baselines/personality/mbti.*.json",
+    "content_baselines/landing_surfaces/*.json"
+  ],
+  "current_baseline_summary": {
+    "media_library_assets_count": 3,
+    "media_library_assets_with_alt_count": 3,
+    "media_library_assets_with_caption_count": 3,
+    "media_library_variants_count": 9,
+    "article_en_count": 20,
+    "article_zh_count": 25,
+    "article_en_cover_url_count": 20,
+    "article_zh_cover_url_count": 25,
+    "article_en_cover_alt_count": 20,
+    "article_zh_cover_alt_count": 25,
+    "article_en_cover_variant_count": 20,
+    "article_zh_cover_variant_count": 25,
+    "article_shared_cover_pair_count": 19,
+    "article_en_missing_cover_alt_count": 0,
+    "article_en_alt_contains_chinese_count": 0,
+    "article_zh_cover_prompt_count": 6,
+    "career_guides_en_count": 36,
+    "career_guides_zh_count": 36,
+    "career_guides_en_og_image_count": 0,
+    "career_guides_zh_og_image_count": 0,
+    "career_guides_missing_og_image_count": 72,
+    "content_pages_media_fields_count": 0,
+    "topic_mbti_cover_image_url_count": 0,
+    "personality_mbti_profile_hero_image_url_count": 0
+  },
+  "authority_contract": {
+    "media_assets_source_of_truth": "Media Library metadata or backend CMS/repo-backed baseline import package",
+    "article_cover_source_of_truth": "Article cover_image_* metadata",
+    "career_guide_social_image_source_of_truth": "CareerGuide seo_meta og_image_url/twitter_image_url",
+    "frontend_fallback_can_satisfy_media_authority": false,
+    "draft_or_placeholder_media_exposure_allowed_in_sitemap_llms": false,
+    "production_media_upload_allowed_in_this_pr": false
+  },
+  "article_cover_parity": {
+    "existing_en_article_covers_have_alt": true,
+    "existing_en_article_alt_text_is_english_metadata": true,
+    "shared_cover_urls_require_visual_text_review": true,
+    "shared_cover_pair_slugs": [
+      "big-five-growth-guide",
+      "big-five-narrative-portrait",
+      "big-five-tool-guide",
+      "clinical-depression-anxiety-pro-growth-guide",
+      "clinical-depression-anxiety-pro-narrative-portrait",
+      "clinical-depression-anxiety-pro-tool-guide",
+      "depression-screening-standard-growth-guide",
+      "depression-screening-standard-narrative-portrait",
+      "depression-screening-standard-tool-guide",
+      "enneagram-test-tool-guide",
+      "eq-test-growth-guide",
+      "eq-test-narrative-portrait",
+      "eq-test-tool-guide",
+      "iq-test-growth-guide",
+      "iq-test-narrative-portrait",
+      "iq-test-tool-guide",
+      "mbti-basics",
+      "mbti-growth-guide",
+      "mbti-narrative-portrait"
+    ],
+    "zh_only_editorial_cover_slugs_deferred_with_articles": [
+      "are-infj-men-rare-or-socially-silenced",
+      "best-valentines-date-by-personality-and-relationship-science",
+      "childhood-dream-job-still-shapes-career-choice",
+      "how-16-personality-types-talk-to-an-ai-coach",
+      "how-personality-shapes-attitude-toward-ai",
+      "which-love-script-fits-you-best"
+    ]
+  },
+  "career_guide_media_parity": {
+    "en_zh_guide_code_parity_ready": true,
+    "og_image_authority_present": false,
+    "twitter_image_authority_present": false,
+    "missing_social_image_policy": "defer_to_human_reviewed_media_variant_package_before_public_exposure",
+    "sitemap_llms_exposure_requires_authority_backed_og_jsonld_image": true
+  },
+  "media_library_inventory": [
+    {
+      "asset_key": "share.mbti.default",
+      "locale_variant_relationship": "shared_default",
+      "has_alt": true,
+      "has_caption": true,
+      "variant_count": 5,
+      "visual_embedded_text_review_status": "pending_human_or_ocr_review"
+    },
+    {
+      "asset_key": "social.wechat.official_qr",
+      "locale_variant_relationship": "zh_social_channel_specific",
+      "has_alt": true,
+      "has_caption": true,
+      "variant_count": 2,
+      "visual_embedded_text_review_status": "channel_specific_not_en_counterpart"
+    },
+    {
+      "asset_key": "social.wechat.qr",
+      "locale_variant_relationship": "legacy_zh_social_channel_specific",
+      "has_alt": true,
+      "has_caption": true,
+      "variant_count": 2,
+      "visual_embedded_text_review_status": "channel_specific_not_en_counterpart"
+    }
+  ],
+  "sidecar_media_review_items": [
+    {
+      "id": "en_parity_06_shared_article_cover_visual_text_review",
+      "asset_scope": "19 EN/ZH shared article cover URLs",
+      "usage_pages": "article detail/index cards for shared EN/ZH article slugs",
+      "reason": "Metadata confirms English alt text and shared URLs, but this PR did not run OCR or human design review to prove images contain no embedded Chinese text.",
+      "owner": "content-design",
+      "follow_up_recommendation": "Run OCR/human visual review and add locale-specific variants if embedded text is detected."
+    },
+    {
+      "id": "en_parity_06_career_guide_social_images",
+      "asset_scope": "36 EN and 36 zh-CN career guide detail rows",
+      "usage_pages": "/en/career/guides/* and /zh/career/guides/* when published",
+      "reason": "Career guide baselines have no og_image_url or twitter_image_url authority yet.",
+      "owner": "content-design",
+      "follow_up_recommendation": "Prepare human-reviewed career guide OG image variant package before public SEO exposure."
+    },
+    {
+      "id": "en_parity_06_mbti_default_share_visual_review",
+      "asset_scope": "share.mbti.default",
+      "usage_pages": "MBTI share/social default placements",
+      "reason": "Default media asset is authority-backed with alt/caption but no OCR/human embedded-text review evidence is recorded.",
+      "owner": "content-design",
+      "follow_up_recommendation": "Add visual-review evidence or locale-specific share variants if text-bearing art is introduced."
+    }
+  ],
+  "deferred_items": [
+    {
+      "id": "en_parity_06_visual_ocr_batch",
+      "reason": "No production media files were downloaded, OCR-scanned, altered, uploaded, or regenerated in this PR."
+    },
+    {
+      "id": "en_parity_06_media_library_importer",
+      "reason": "This PR records inventory and authority contract only. A controlled media metadata importer can follow after human design review."
+    },
+    {
+      "id": "en_parity_07_social_image_surface_gate",
+      "reason": "Sitemap/llms/JSON-LD gates must prevent URLs from exposing draft, placeholder, fallback-only, or missing-authority image metadata."
+    }
+  ],
+  "recommended_next_tasks": [
+    {
+      "id": "EN-PARITY-07",
+      "title": "Sitemap llms JSON-LD FAQ grounding parity gate",
+      "scope": "Use this inventory to ensure public SEO surfaces expose only authority-backed image and content metadata."
+    },
+    {
+      "id": "EN-PARITY-MEDIA-VISUAL-REVIEW-01",
+      "title": "Human or OCR review for shared article and default social covers",
+      "scope": "Inspect shared article/default cover images for embedded Chinese text and prepare locale variants when needed."
+    }
+  ],
+  "final_decision": "en_parity_06_media_inventory_landed_sidecar_visual_review_required",
+  "next_task": "EN-PARITY-07 sitemap llms JSON-LD FAQ grounding parity gate"
+}

--- a/backend/tests/Feature/SeoIntel/EnParity06MediaAssetsParityInventoryTest.php
+++ b/backend/tests/Feature/SeoIntel/EnParity06MediaAssetsParityInventoryTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class EnParity06MediaAssetsParityInventoryTest extends TestCase
+{
+    #[Test]
+    public function generated_media_inventory_records_authority_and_no_mutation_controls(): void
+    {
+        $path = base_path('docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('en-parity-06-media-assets-parity-inventory.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('EN-PARITY-06', $payload['task'] ?? null);
+        $this->assertSame('backend_cms_media_and_content_baselines', $payload['source_authority'] ?? null);
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['auto_publish_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['media_upload_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['image_generation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['fap_web_modified'] ?? true));
+
+        $this->assertSame(3, data_get($payload, 'current_baseline_summary.media_library_assets_count'));
+        $this->assertSame(3, data_get($payload, 'current_baseline_summary.media_library_assets_with_alt_count'));
+        $this->assertSame(3, data_get($payload, 'current_baseline_summary.media_library_assets_with_caption_count'));
+        $this->assertSame(9, data_get($payload, 'current_baseline_summary.media_library_variants_count'));
+        $this->assertSame(20, data_get($payload, 'current_baseline_summary.article_en_count'));
+        $this->assertSame(25, data_get($payload, 'current_baseline_summary.article_zh_count'));
+        $this->assertSame(0, data_get($payload, 'current_baseline_summary.article_en_missing_cover_alt_count'));
+        $this->assertSame(0, data_get($payload, 'current_baseline_summary.article_en_alt_contains_chinese_count'));
+        $this->assertSame(72, data_get($payload, 'current_baseline_summary.career_guides_missing_og_image_count'));
+        $this->assertFalse((bool) data_get($payload, 'authority_contract.frontend_fallback_can_satisfy_media_authority'));
+    }
+
+    #[Test]
+    public function article_cover_metadata_matches_committed_baseline_authority(): void
+    {
+        $enArticles = $this->articles('content_baselines/articles/articles.en.json');
+        $zhArticles = $this->articles('content_baselines/articles/articles.zh-CN.json');
+
+        $this->assertCount(20, $enArticles);
+        $this->assertCount(25, $zhArticles);
+
+        foreach ($enArticles as $article) {
+            $this->assertNotEmpty($article['cover_image_url'] ?? null, (string) ($article['slug'] ?? 'unknown'));
+            $this->assertNotEmpty($article['cover_image_alt'] ?? null, (string) ($article['slug'] ?? 'unknown'));
+            $this->assertIsArray($article['cover_image_variants'] ?? null, (string) ($article['slug'] ?? 'unknown'));
+            $this->assertDoesNotMatchRegularExpression('/\p{Han}/u', (string) ($article['cover_image_alt'] ?? ''));
+        }
+
+        $sharedCoverSlugs = collect($enArticles)
+            ->filter(function (array $article) use ($zhArticles): bool {
+                $zh = collect($zhArticles)->firstWhere('slug', $article['slug'] ?? null);
+
+                return is_array($zh)
+                    && ($zh['cover_image_url'] ?? null) === ($article['cover_image_url'] ?? null);
+            })
+            ->pluck('slug')
+            ->sort()
+            ->values()
+            ->all();
+
+        $payload = $this->generatedPayload();
+        $expected = $payload['article_cover_parity']['shared_cover_pair_slugs'] ?? [];
+        sort($expected);
+
+        $this->assertSame($expected, $sharedCoverSlugs);
+        $this->assertCount(19, $sharedCoverSlugs);
+    }
+
+    #[Test]
+    public function career_guide_social_images_remain_explicitly_missing_not_frontend_fallback(): void
+    {
+        $enGuides = $this->guides('content_baselines/career_guides/career_guides.en.json');
+        $zhGuides = $this->guides('content_baselines/career_guides/career_guides.zh-CN.json');
+
+        $this->assertCount(36, $enGuides);
+        $this->assertCount(36, $zhGuides);
+
+        foreach (array_merge($enGuides, $zhGuides) as $guide) {
+            $seo = $guide['seo_meta'] ?? [];
+            $this->assertEmpty($seo['og_image_url'] ?? null, (string) ($guide['guide_code'] ?? 'unknown'));
+            $this->assertEmpty($seo['twitter_image_url'] ?? null, (string) ($guide['guide_code'] ?? 'unknown'));
+        }
+
+        $payload = $this->generatedPayload();
+        $this->assertFalse((bool) data_get($payload, 'career_guide_media_parity.og_image_authority_present'));
+        $this->assertSame(
+            'defer_to_human_reviewed_media_variant_package_before_public_exposure',
+            data_get($payload, 'career_guide_media_parity.missing_social_image_policy')
+        );
+    }
+
+    #[Test]
+    public function visual_embedded_text_gaps_are_sidecarized_with_asset_scope(): void
+    {
+        $payload = $this->generatedPayload();
+        $sidecarIds = collect($payload['sidecar_media_review_items'] ?? [])
+            ->pluck('id')
+            ->all();
+
+        $this->assertFalse((bool) ($payload['visual_ocr_performed'] ?? true));
+        $this->assertContains('en_parity_06_shared_article_cover_visual_text_review', $sidecarIds);
+        $this->assertContains('en_parity_06_career_guide_social_images', $sidecarIds);
+        $this->assertContains('en_parity_06_mbti_default_share_visual_review', $sidecarIds);
+
+        foreach ($payload['sidecar_media_review_items'] ?? [] as $item) {
+            $this->assertNotEmpty($item['asset_scope'] ?? null);
+            $this->assertNotEmpty($item['usage_pages'] ?? null);
+            $this->assertNotEmpty($item['follow_up_recommendation'] ?? null);
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function articles(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents(base_path('../'.$path)), true, 512, JSON_THROW_ON_ERROR);
+
+        return $payload['articles'] ?? [];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function guides(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents(base_path('../'.$path)), true, 512, JSON_THROW_ON_ERROR);
+
+        return $payload['guides'] ?? [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function generatedPayload(): array
+    {
+        return json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -19266,11 +19266,11 @@
     "EN-PARITY-05": {
       "repo": "fap-api",
       "branch": "codex/en-parity-05-career-guides",
-      "status": "local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "EN-PARITY-04"
       ],
-      "commit_sha": "baebe089",
+      "commit_sha": "51deb80befd82d2138de1f7725b0ae73f5af4a8e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1676",
       "checks": {
         "dependency_en_parity_04": {
@@ -19305,13 +19305,13 @@
           "evidence": "Focused php artisan test --filter=EnParity05 --no-ansi passed; php artisan route:list --no-ansi passed; vendor/bin/pint --test passed; composer validate --strict passed; composer audit --locked --no-interaction --ignore-unreachable passed; generated JSON parsed; PR-train YAML/state JSON parsed; git diff --check and git diff --cached --check passed."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": null
+          "status": "pass",
+          "evidence": "PR #1676 passed hygiene, supply-chain, Semgrep blocking secrets, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2; GitHub mergeStateStatus was CLEAN and PR #1676 was squash-merged as 51deb80befd82d2138de1f7725b0ae73f5af4a8e."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-25T07:30:44Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "sidecar_issues": [],
       "events": [
@@ -19329,6 +19329,96 @@
           "at": "2026-05-25T07:40:00Z",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1676 for EN-PARITY-05 and pushed branch codex/en-parity-05-career-guides; waiting for GitHub checks."
+        },
+        {
+          "at": "2026-05-25T07:30:44Z",
+          "status": "merged",
+          "summary": "PR #1676 was squash-merged into main as 51deb80befd82d2138de1f7725b0ae73f5af4a8e and the remote branch was deleted. No post-merge cleanup script exists in this repository."
+        },
+        {
+          "at": "2026-05-25T07:34:00Z",
+          "status": "post_merge_revalidate_passed",
+          "summary": "Post-merge EN-PARITY-05 focused test, generated JSON parse, manifest/state parse, and clean worktree check passed before starting EN-PARITY-06."
+        }
+      ]
+    },
+    "EN-PARITY-06": {
+      "repo": "fap-api",
+      "branch": "codex/en-parity-06-media-assets",
+      "status": "local_validation_passed",
+      "depends_on": [
+        "EN-PARITY-05"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency_en_parity_05": {
+          "status": "pass",
+          "evidence": "PR #1676 is MERGED and origin/main contains merge commit 51deb80befd82d2138de1f7725b0ae73f5af4a8e."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Changed files are limited to EN-PARITY-06 media inventory report/generated JSON/focused test and current PR-train manifest/state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No production CMS mutation, media upload, image generation, production migration, deploy, URL submission, Search Channel action, secrets access, or fap-web commit."
+        },
+        "media_generation_boundary": {
+          "status": "pass",
+          "evidence": "EN-PARITY-06 lands a media parity inventory and sidecar review list only. Shared covers and CareerGuide social image gaps stay explicit for human/OCR review."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=EnParity06 --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json >/dev/null",
+            "python3 yaml/json parse for docs/codex/pr-train.yaml and docs/codex/pr-train-state.json",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "Focused php artisan test --filter=EnParity06 --no-ansi passed; php artisan route:list --no-ansi passed; vendor/bin/pint --test passed; composer validate --strict passed; composer audit --locked --no-interaction --ignore-unreachable passed; generated JSON parsed; PR-train YAML/state JSON parsed; git diff --check passed."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [
+        {
+          "source_pr": "EN-PARITY-06",
+          "repo": "fap-api",
+          "branch": "codex/en-parity-06-media-assets",
+          "command_or_check": "media embedded-text visual review",
+          "evidence": "Generated inventory records 19 shared EN/ZH article cover URLs and no OCR/human visual-review evidence in repo.",
+          "failure_summary": "Embedded Chinese text cannot be ruled out by metadata alone.",
+          "why_external_to_current_pr": "EN-PARITY-06 is inventory/report/test scope and explicitly forbids image generation, upload, or production media mutation.",
+          "impact_on_current_pr": "No impact on repository media authority inventory; visual proof is deferred to a design/OCR review task.",
+          "owner": "content-design",
+          "follow_up_recommendation": "Run OCR/human visual review and prepare locale-specific media variants only if embedded text is detected.",
+          "required_checks_status": "pending until PR checks complete",
+          "scope_validation_status": "pending until final scope validation",
+          "continue_train_decision": "allowed if local validation, GitHub required checks, and scope validation are green"
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-05-25T07:34:00Z",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Started EN-PARITY-06 after EN-PARITY-05 merged. Added media parity inventory report, generated artifact, focused test, and current manifest/state entry. No production, media upload, image generation, CMS, Search Channel, or fap-web mutation performed."
+        },
+        {
+          "at": "2026-05-25T07:36:00Z",
+          "status": "local_validation_passed",
+          "summary": "EN-PARITY-06 focused test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, and diff check passed locally."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -19345,12 +19345,12 @@
     "EN-PARITY-06": {
       "repo": "fap-api",
       "branch": "codex/en-parity-06-media-assets",
-      "status": "local_validation_passed",
+      "status": "pr_open_github_checks_pending",
       "depends_on": [
         "EN-PARITY-05"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "2edad950a985c66531082cd28f63341a8f1e47cb",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1677",
       "checks": {
         "dependency_en_parity_05": {
           "status": "pass",
@@ -19419,6 +19419,11 @@
           "at": "2026-05-25T07:36:00Z",
           "status": "local_validation_passed",
           "summary": "EN-PARITY-06 focused test, route list, Pint, composer validate, composer audit, generated JSON parse, manifest/state parse, and diff check passed locally."
+        },
+        {
+          "at": "2026-05-25T07:39:00Z",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1677 for EN-PARITY-06 and pushed branch codex/en-parity-06-media-assets; waiting for GitHub checks."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5873,6 +5873,52 @@ prs:
     content_generation_allowed: false
     next_task: EN-PARITY-06
 
+  - id: EN-PARITY-06
+    repo: fap-api
+    depends_on: [EN-PARITY-05]
+    branch: codex/en-parity-06-media-assets
+    base: main
+    title: "EN-PARITY-06 media assets alt og image and locale variant parity"
+    train_scope: en_parity_media_assets_parity_inventory
+    risk_level: p1_media_authority_parity
+    allowed_paths:
+      - backend/docs/seo/en-parity-06-media-assets-parity-inventory.md
+      - backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json
+      - backend/tests/Feature/SeoIntel/EnParity06MediaAssetsParityInventoryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Land a repository-backed media parity inventory for Article, CareerGuide, default Media Library, topic/personality, landing surface, and content page surfaces.
+      - Prove existing EN article cover metadata has alt text and no Chinese characters in EN alt fields without relying on frontend fallback.
+      - Keep shared article covers, default MBTI share image, and missing CareerGuide social images explicit as human/OCR design-review sidecars.
+      - Do not upload, generate, replace, publish, or mutate production media assets.
+    do_not:
+      - Generate production images, upload to CDN/media library, mutate production CMS, run production migration, deploy, or submit URLs.
+      - Modify fap-web or treat frontend fallback as media authority.
+      - Modify articles, career guide bodies, content pages, sitemap generator, llms generator, JSON-LD, FAQ, or Search Channel.
+      - Claim embedded-text visual review is complete without OCR or human review evidence.
+      - Remove images or social metadata to make tests pass.
+    validation:
+      - cd backend && php artisan test --filter=EnParity06 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json >/dev/null
+      - python3 -c 'import yaml, json; yaml.safe_load(open("docs/codex/pr-train.yaml")); json.load(open("docs/codex/pr-train-state.json")); print("manifest/state parse ok")'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    media_upload_allowed: false
+    image_generation_allowed: false
+    content_generation_allowed: false
+    next_task: EN-PARITY-07
+
   - id: RESULT-EN-PARITY-00
     repo: fap-api
     depends_on: [EN-PARITY-00]


### PR DESCRIPTION
## PR id
EN-PARITY-06

## What changed
- Added a repository-backed media assets parity inventory report and generated JSON artifact.
- Added a focused SeoIntel test for media authority, article cover alt metadata, career guide social image gaps, and sidecarized visual-review gaps.
- Registered current EN-PARITY-06 manifest/state entry and reconciled EN-PARITY-05 as merged.

## Why
EN-PARITY-06 must establish media authority evidence before EN-PARITY-07 can enforce sitemap/llms/JSON-LD gates. This PR keeps media parity gaps explicit instead of hiding them behind frontend fallback.

## Validation
- `cd backend && php artisan test --filter=EnParity06 --no-ansi` — PASS
- `cd backend && php artisan route:list --no-ansi` — PASS
- `cd backend && vendor/bin/pint --test` — PASS
- `cd backend && composer validate --strict` — PASS
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` — PASS
- `python3 -m json.tool backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json >/dev/null` — PASS
- `python3` YAML/JSON parse for `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json` — PASS
- `git diff --check` — PASS
- `git diff --cached --check` — PASS

## Scope validation
Changed files are limited to:
- `backend/docs/seo/en-parity-06-media-assets-parity-inventory.md`
- `backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json`
- `backend/tests/Feature/SeoIntel/EnParity06MediaAssetsParityInventoryTest.php`
- `docs/codex/pr-train.yaml`
- `docs/codex/pr-train-state.json`

## Intentionally deferred / sidecar items
- OCR or human visual review for 19 shared EN/ZH article cover URLs.
- Authority-backed career guide OG/Twitter image package for 36 EN and 36 zh-CN guide rows.
- Visual review evidence for `share.mbti.default`.

## Safety
- No production CMS mutation.
- No media upload.
- No image generation.
- No production migration.
- No deploy.
- No URL submission or Search Channel action.
- No fap-web commit.
- Frontend fallback is not treated as media authority.

## Repository rule impact
No repository rule change. This PR reinforces the existing rule that mutable editorial, marketing, social, article, landing page, and SEO images must be Media Library / backend CMS authoritative.
