### PR TITLE
MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00 evaluate marketingskills for FermatMind SEO/GEO/CRO operations

### DIFF
--- a/backend/docs/seo/generated/marketingskills-fermatmind-fit-scan-00.v1.json
+++ b/backend/docs/seo/generated/marketingskills-fermatmind-fit-scan-00.v1.json
@@ -1,0 +1,320 @@
+{
+  "schema_version": "marketingskills-fermatmind-fit-scan-00.v1",
+  "task": "MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00",
+  "final_decision": "marketingskills_fit_scan_completed_ready_for_internal_skill_adaptation",
+  "external_repo": {
+    "url": "https://github.com/coreyhaines31/marketingskills",
+    "temporary_checkout": "/private/tmp/marketingskills-scan",
+    "read_only_scan": true
+  },
+  "external_repo_license": {
+    "license": "MIT",
+    "compatibility": "compatible_for_reference_and_fork_adaptation_with_notice_retention"
+  },
+  "external_repo_skills_scanned": [
+    "product-marketing",
+    "seo-audit",
+    "ai-seo",
+    "schema",
+    "programmatic-seo",
+    "site-architecture",
+    "content-strategy",
+    "cro",
+    "paywalls",
+    "analytics",
+    "emails",
+    "directory-submissions",
+    "competitors",
+    "competitor-profiling",
+    "copywriting",
+    "customer-research",
+    "free-tools"
+  ],
+  "directly_useful_skills": [
+    {
+      "skill": "seo-audit",
+      "fit": "directly_useful",
+      "fermat_use": "URL Truth, sitemap/llms, canonical, hreflang, indexability, and technical SEO review prompts",
+      "required_constraints": ["backend_url_truth_is_authority", "no_runtime_mutation", "no_search_submission"]
+    },
+    {
+      "skill": "ai-seo",
+      "fit": "directly_useful",
+      "fermat_use": "GEO, llms surfaces, Research Hub extractability, and citation-oriented evidence containers",
+      "required_constraints": ["no_ai_bait_content", "visible_content_grounding", "claim_boundary_required"]
+    },
+    {
+      "skill": "schema",
+      "fit": "directly_useful",
+      "fermat_use": "JSON-LD and FAQ grounding gates",
+      "required_constraints": ["schema_matches_visible_content", "cms_backend_authority_only"]
+    },
+    {
+      "skill": "site-architecture",
+      "fit": "directly_useful",
+      "fermat_use": "internal link graph, topic hub, research hub, and page type portfolio planning",
+      "required_constraints": ["no_sitemap_derived_graph_truth", "backend_cms_graph_authority"]
+    },
+    {
+      "skill": "analytics",
+      "fit": "directly_useful",
+      "fermat_use": "CTA attribution, funnel event taxonomy, Search Intelligence, and privacy-safe measurement",
+      "required_constraints": ["no_pii_in_analytics", "backend_revenue_truth"]
+    },
+    {
+      "skill": "cro",
+      "fit": "directly_useful",
+      "fermat_use": "result page, paid report preview, unlock CTA, and My Results conversion review",
+      "required_constraints": ["backend_result_assets_are_authority", "no_frontend_interpretation_authority"]
+    },
+    {
+      "skill": "paywalls",
+      "fit": "directly_useful",
+      "fermat_use": "free result to paid report boundaries and upgrade screen review",
+      "required_constraints": ["no_dark_patterns", "claim_safe_paid_report_copy"]
+    },
+    {
+      "skill": "emails",
+      "fit": "directly_useful",
+      "fermat_use": "result/report recovery and lifecycle email planning",
+      "required_constraints": ["no_pii_leakage", "unsubscribe_required", "no_cms_mutation_in_scan"]
+    }
+  ],
+  "useful_after_adaptation_skills": [
+    {
+      "skill": "product-marketing",
+      "reason": "Useful as the base for Fermat-specific product context, but upstream path and generic SaaS framing must be adapted."
+    },
+    {
+      "skill": "content-strategy",
+      "reason": "Useful for content batches and Research Hub planning after CMS authority and claim gates."
+    },
+    {
+      "skill": "directory-submissions",
+      "reason": "Useful for Digital PR planning only with human-only outreach and tracking."
+    },
+    {
+      "skill": "competitors",
+      "reason": "Useful for comparison strategy and competitor-informed gaps, not auto-generated comparison pages."
+    },
+    {
+      "skill": "competitor-profiling",
+      "reason": "Useful for structured competitor dossiers against 123test, Truity, 16Personalities, CareerExplorer, and Chinese competitors."
+    },
+    {
+      "skill": "copywriting",
+      "reason": "Useful for claim-safe draft review prompts, not direct publishable copy generation."
+    },
+    {
+      "skill": "customer-research",
+      "reason": "Useful for VOC and search-intent research, but personas require real source evidence."
+    },
+    {
+      "skill": "free-tools",
+      "reason": "Useful for product-led SEO and linkable tool thinking; Fermat tests already fit this model."
+    }
+  ],
+  "risky_skills": [
+    {
+      "skill": "programmatic-seo",
+      "risk": "Can encourage scaled page creation before P0 discoverability cleanup, URL Truth, internal link, and claim gates are clean."
+    },
+    {
+      "skill": "directory-submissions",
+      "risk": "Can encourage broad submission before destination pages, tracking, claim review, and human approval are ready."
+    },
+    {
+      "skill": "copywriting",
+      "risk": "Can generate unsupported clinical, career, hiring, salary, treatment, or diagnostic claims if used directly."
+    },
+    {
+      "skill": "competitors",
+      "risk": "Can lead to thin or aggressive competitor pages without verified data and claim review."
+    },
+    {
+      "skill": "ai-seo",
+      "risk": "Can over-prioritize AI files or AI citation tactics over visible helpful content and current P0 cleanup."
+    },
+    {
+      "skill": "schema",
+      "risk": "Can over-markup invisible or non-authoritative content if not constrained by Fermat JSON-LD grounding gates."
+    }
+  ],
+  "not_relevant_now_skills": [
+    "aso",
+    "sms",
+    "ad-creative",
+    "ads",
+    "launch",
+    "referrals",
+    "sales-enablement",
+    "revops",
+    "community-marketing",
+    "co-marketing",
+    "video",
+    "image",
+    "popups",
+    "signup",
+    "onboarding",
+    "pricing",
+    "churn-prevention"
+  ],
+  "fermat_internal_skill_recommendations": [
+    {
+      "skill": "fermat-product-marketing-context",
+      "priority": "P0",
+      "purpose": "Centralize Fermat positioning, audiences, product loops, claim boundaries, and no-go rules."
+    },
+    {
+      "skill": "fermat-seo-ops",
+      "priority": "P0",
+      "purpose": "Wrap SEO audit workflows around URL Truth, Search Channel Queue, CMS authority, and P0 cleanup."
+    },
+    {
+      "skill": "fermat-ai-seo-geo",
+      "priority": "P1",
+      "purpose": "Guide llms/GEO/Research Hub work while forbidding AI-bait and schema stuffing."
+    },
+    {
+      "skill": "fermat-schema-jsonld",
+      "priority": "P1",
+      "purpose": "Ground JSON-LD and FAQ in visible backend/CMS content."
+    },
+    {
+      "skill": "fermat-content-asset-batch",
+      "priority": "P1",
+      "purpose": "Control article, content page, career guide, and result/report content batches through import packages."
+    },
+    {
+      "skill": "fermat-pseo-guard",
+      "priority": "P0",
+      "purpose": "Prevent pSEO until URL Truth, discoverability, content quality, and claim gates pass."
+    },
+    {
+      "skill": "fermat-cro-result-report",
+      "priority": "P1",
+      "purpose": "Improve result/report conversion without frontend interpretation authority."
+    },
+    {
+      "skill": "fermat-digital-pr",
+      "priority": "P1",
+      "purpose": "Run human-only Digital PR with tracking, claim review, and no bulk outreach."
+    },
+    {
+      "skill": "fermat-analytics-attribution",
+      "priority": "P1",
+      "purpose": "Keep funnel attribution privacy-safe and backend revenue authoritative."
+    },
+    {
+      "skill": "fermat-claim-boundary",
+      "priority": "P0",
+      "purpose": "Enforce career, clinical, IQ, RIASEC, Big Five, MBTI, and Research claim boundaries."
+    }
+  ],
+  "pseo_guardrail_recommendations": [
+    "Do not adopt programmatic-seo directly now.",
+    "Block pSEO until sitemap/llms hard-404 exposure and career job discoverability leakage are fixed.",
+    "Require backend entity data, stable entity keys, visible content, FAQ grounding, JSON-LD grounding, and internal links.",
+    "Require claim lint for every generated page class.",
+    "Keep Search Channel Queue human-approved and dry-run-first."
+  ],
+  "seo_ops_recommendations": [
+    "Adapt seo-audit into fermat-seo-ops with URL Truth as authority.",
+    "Use ai-seo only after P0 discoverability cleanup and Research authority grounding.",
+    "Use schema skill principles only through Fermat JSON-LD/FAQ grounding gates.",
+    "Use site-architecture for internal link planning, not automatic CMS link writes."
+  ],
+  "cro_result_report_recommendations": [
+    "Adapt cro and paywalls for result page clarity, paid report preview, unlock CTA, My Results card, and report recovery.",
+    "Keep backend result/report asset catalogs authoritative.",
+    "Fail closed when English interpretation assets are missing.",
+    "Do not use frontend fallback interpretation copy as authority."
+  ],
+  "digital_pr_recommendations": [
+    "Use directory-submissions as a planning reference only.",
+    "Require destination page readiness, claim review, UTM/referral tracking, and manual sender approval.",
+    "No paid backlinks, no bulk outreach, no private email scraping, no transactional backlink asks.",
+    "Treat backlinks and referrals as observation signals, not URL Truth."
+  ],
+  "content_batch_recommendations": [
+    "Use content-strategy for batch planning only after CMS authority is established.",
+    "Use copywriting for review prompts and variants, not direct publishable content.",
+    "Use customer-research only with source-backed evidence and confidence levels.",
+    "Prefer import packages and human review over direct CMS mutation."
+  ],
+  "risk_findings": [
+    {
+      "id": "risk_mass_pseo_generation",
+      "severity": "P0",
+      "finding": "Upstream programmatic-seo can encourage scaled pages before Fermat's P0 discoverability cleanup is complete."
+    },
+    {
+      "id": "risk_unreviewed_copywriting",
+      "severity": "P0",
+      "finding": "Generic copywriting workflows can produce unsupported clinical, career, hiring, salary, treatment, or diagnostic claims."
+    },
+    {
+      "id": "risk_schema_not_grounded",
+      "severity": "P1",
+      "finding": "Schema guidance must be constrained so JSON-LD never marks up invisible or non-authoritative content."
+    },
+    {
+      "id": "risk_frontend_fallback_authority",
+      "severity": "P1",
+      "finding": "Upstream skills do not account for Fermat's rule that fap-web fallback is not authority."
+    },
+    {
+      "id": "risk_search_channel_bypass",
+      "severity": "P0",
+      "finding": "Directory, SEO, and GEO workflows must not enqueue or submit URLs outside Search Channel Queue approval."
+    },
+    {
+      "id": "risk_directory_without_tracking",
+      "severity": "P2",
+      "finding": "Directory submissions without destination readiness and tracking would create vanity backlinks rather than measurable authority."
+    }
+  ],
+  "adoption_phases": [
+    {
+      "phase": 0,
+      "name": "read_only_reference_only",
+      "action": "Keep external repo in /private/tmp or as reference documentation only."
+    },
+    {
+      "phase": 1,
+      "name": "product_marketing_context_draft",
+      "action": "Create Fermat-specific product marketing context from existing Fermat docs and claim boundaries."
+    },
+    {
+      "phase": 2,
+      "name": "fork_adapt_selected_skills",
+      "action": "Adapt selected upstream patterns into Fermat-specific internal skills with authority and no-go rules."
+    },
+    {
+      "phase": 3,
+      "name": "prompt_template_library",
+      "action": "Add Codex prompt templates for SEO Ops, CRO, content batches, and Digital PR review."
+    },
+    {
+      "phase": 4,
+      "name": "pr_train_integration",
+      "action": "Use internal skills only through PR train entries, focused tests, and human approval gates."
+    }
+  ],
+  "do_not_adopt_now": [
+    "Direct installation into .agents/skills",
+    "npx skills install in Fermat repositories",
+    "programmatic-seo direct use",
+    "bulk directory submissions",
+    "auto-generated competitor pages",
+    "unreviewed copywriting for clinical or career pages",
+    "schema changes without visible content grounding",
+    "Search Channel submission or queueing from marketing skills"
+  ],
+  "no_install_performed": true,
+  "no_runtime_code_modified": true,
+  "no_content_generated": true,
+  "no_search_channel_action_performed": true,
+  "no_deploy_performed": true,
+  "recommended_next_task": "FERMAT-MARKETING-SKILLS-ADAPTATION-01"
+}

--- a/backend/docs/seo/marketingskills-fermatmind-fit-scan-00.md
+++ b/backend/docs/seo/marketingskills-fermatmind-fit-scan-00.md
@@ -1,0 +1,246 @@
+# MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00 Report
+
+## 1. Executive Summary
+
+`coreyhaines31/marketingskills` is useful for FermatMind as a reference library and as source material for Fermat-specific internal marketing skills. It should not be installed directly into `.agents/skills` yet.
+
+The repository is strongest for structured SEO audit thinking, AI SEO/GEO content extractability, schema discipline, site architecture, CRO, paywalls, analytics, email lifecycle, directory submissions, competitor research, and product marketing context. Those map well to FermatMind's SEO/GEO/CRO operations, but only after adaptation to FermatMind's backend/CMS authority, URL Truth, Search Channel Queue, claim-boundary, and no-auto-publish rules.
+
+Final decision: `marketingskills_fit_scan_completed_ready_for_internal_skill_adaptation`.
+
+## 2. External Repo Summary
+
+External repository: `https://github.com/coreyhaines31/marketingskills`
+
+Temporary checkout: `/private/tmp/marketingskills-scan`
+
+License: MIT.
+
+The repo is a collection of markdown Agent Skills for marketing workflows. The README positions `product-marketing` as the foundation skill that other skills should read first. The repo also includes installation instructions using `npx skills`, plugin installation, copying skills, or submodules; none of those install paths were executed for FermatMind.
+
+## 3. Relevant Skills Inventory
+
+Scanned skills:
+
+- `product-marketing`
+- `seo-audit`
+- `ai-seo`
+- `schema`
+- `programmatic-seo`
+- `site-architecture`
+- `content-strategy`
+- `cro`
+- `paywalls`
+- `analytics`
+- `emails`
+- `directory-submissions`
+- `competitors`
+- `competitor-profiling`
+- `copywriting`
+- `customer-research`
+- `free-tools`
+
+Directly useful with constraints:
+
+- `seo-audit`
+- `ai-seo`
+- `schema`
+- `site-architecture`
+- `analytics`
+- `cro`
+- `paywalls`
+- `emails`
+
+Useful after adaptation:
+
+- `product-marketing`
+- `content-strategy`
+- `directory-submissions`
+- `competitors`
+- `competitor-profiling`
+- `copywriting`
+- `customer-research`
+- `free-tools`
+
+Risky unless constrained:
+
+- `programmatic-seo`
+- `directory-submissions`
+- `copywriting`
+- `competitors`
+- `ai-seo`
+- `schema`
+
+## 4. FermatMind Current SEO/GEO/Ops Fit
+
+FermatMind already has a stronger governance layer than the upstream skills assume:
+
+- Backend/CMS/URL Truth is authority.
+- fap-web is deterministic runtime, not content authority.
+- sitemap and `llms.txt` are discoverability surfaces, not truth.
+- Search Channel Queue is gated and human-approved.
+- EN/ZH parity and RESULT-EN-PARITY gates are already active.
+- Claim-sensitive areas are bounded for clinical, career, IQ, RIASEC, Big Five, and MBTI surfaces.
+- Current P0 issue is sitemap/llms hard-404 exposure and career job discoverability leakage.
+
+The upstream skills can improve operator reasoning and prompt structure, but they must be wrapped in Fermat-specific gates before use.
+
+## 5. Directly Useful Skills
+
+`seo-audit` maps to existing URL Truth, sitemap/llms, canonical, hreflang, indexability, and CWV-style review. It should be adapted to treat backend URL Truth as source of truth and to forbid direct runtime edits.
+
+`ai-seo` maps to FermatMind GEO, `llms.txt`, Research Hub, and extractable evidence containers. It needs strong limits because Google AI guidance does not require AI-specific files, and FermatMind must avoid AI-bait pages.
+
+`schema` maps to JSON-LD and FAQ grounding gates. It is useful because it emphasizes schema matching visible page content.
+
+`site-architecture` maps to internal link graph and topic/entity navigation, especially after P0 discoverability cleanup.
+
+`analytics` maps to Search Intelligence, funnel event taxonomy, CTA attribution, and privacy boundaries.
+
+`cro` and `paywalls` map to result/report conversion, paid report preview, unlock flow, My Results, and low-friction report recovery.
+
+`emails` maps to result/report lifecycle, but only with PII guardrails.
+
+## 6. Useful After Adaptation
+
+`product-marketing` is useful as the base for a Fermat context file, but the upstream path `.agents/product-marketing.md` should not be added in this PR. The Fermat version should be generated from existing backend SEO docs, product authority rules, claim boundaries, and current growth loops.
+
+`content-strategy` is useful for article counterpart batches and Research Hub planning, but must not produce publishable content directly.
+
+`directory-submissions` is useful for Digital PR Wave 2 planning, but must be human-only, tracked, and claim-safe.
+
+`competitors` and `competitor-profiling` are useful for 123test, Truity, 16Personalities, CareerExplorer, Psychology Today, and Chinese market scans. They must remain research artifacts, not automatic comparison-page generators.
+
+`copywriting` is useful for review prompts and CTA drafts, not direct CMS mutation.
+
+`customer-research` is useful for VOC and search-intent research, but must not invent personas from thin data.
+
+`free-tools` maps well to FermatMind's core product-led SEO model because tests and comparison tools are the product assets.
+
+## 7. Risky / Do Not Adopt Now
+
+Do not directly adopt `programmatic-seo`. FermatMind's pSEO is explicitly blocked until P0 discoverability cleanup, URL Truth, claim boundary, and internal link gates are clean.
+
+Do not directly adopt upstream directory submission playbooks as operational commands. FermatMind requires human approval, no bulk outreach, no paid backlinks, no private email scraping, and no Search Channel side effects.
+
+Do not use upstream copywriting to generate clinical, career, hiring, salary, treatment, or diagnostic claims.
+
+Do not use schema guidance to add JSON-LD for content that is not visibly present or backend-authoritative.
+
+Do not install upstream skills into `.agents/skills` without a Fermat-specific fork and guardrail review.
+
+## 8. Fermat Internal Skill Recommendations
+
+Recommended internal Fermat skills:
+
+- `fermat-product-marketing-context`
+- `fermat-seo-ops`
+- `fermat-ai-seo-geo`
+- `fermat-schema-jsonld`
+- `fermat-content-asset-batch`
+- `fermat-pseo-guard`
+- `fermat-cro-result-report`
+- `fermat-digital-pr`
+- `fermat-analytics-attribution`
+- `fermat-claim-boundary`
+
+These should be Fermat-authored wrappers, not direct copies. Each skill should start with Fermat authority rules, current P0 no-go conditions, and validation requirements.
+
+## 9. pSEO Guardrails
+
+pSEO remains blocked now.
+
+Future pSEO can be considered only when:
+
+- sitemap/llms hard-404 exposure is fixed;
+- career job discoverability leakage is fixed;
+- URL Truth source authority is clean;
+- claim linter is active for the page class;
+- generated page has real backend entity data;
+- visible content, FAQ, JSON-LD, internal links, and CTA are grounded;
+- Search Channel Queue requires human approval;
+- no career or clinical overclaim is possible.
+
+## 10. CRO / Result / Report Funnel Opportunities
+
+The `cro`, `paywalls`, `analytics`, and `emails` skills can support:
+
+- result page next-step clarity;
+- paid report preview framing;
+- unlock CTA testing;
+- My Results card clarity;
+- PDF/email/share lifecycle copy review;
+- article to test to result to paid report attribution;
+- email lookup and report recovery flows with no PII in analytics.
+
+The adaptation must use backend result/report assets as authority and must fail closed when English assets are missing.
+
+## 11. Digital PR / Directory / External Authority Opportunities
+
+Useful patterns from `directory-submissions`, `ai-seo`, and `competitor-profiling`:
+
+- build Research Hub and linkable assets before outreach;
+- track every outreach target manually;
+- vary directory positioning by audience only after claim review;
+- measure backlinks/referrals as observation signals, not truth;
+- use competitor profiles to inform content gaps, not to auto-create pSEO pages.
+
+This maps to MBTI Digital PR Wave 2, Research claim-sensitive preflight, and future authority-building.
+
+## 12. Adoption Phases
+
+Phase 0: read-only reference only.
+
+Phase 1: create a Fermat product marketing context draft from existing Fermat docs.
+
+Phase 2: fork/adapt selected skills into Fermat-specific internal skills.
+
+Phase 3: add Codex prompt templates for SEO Ops, CRO, content batches, and Digital PR review.
+
+Phase 4: integrate into PR train only with strict guardrails, focused tests, and human approval gates.
+
+## 13. Validation
+
+Required validation:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=MarketingSkillsFermatmindFitScan00 --no-ansi
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd /Users/rainie/Desktop/GitHub/fap-api
+python3 -m json.tool backend/docs/seo/generated/marketingskills-fermatmind-fit-scan-00.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 - <<'PY'
+import yaml, pathlib
+yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+print('yaml ok')
+PY
+git diff --check
+git diff --cached --check
+```
+
+## 14. PR / Merge Result
+
+Pending at report generation.
+
+## 15. Sidecar Issues
+
+- fap-web is currently on an active GLOBAL parity branch with local changes; this scan treated fap-web as reference-only and did not modify it.
+- The upstream skills include install instructions; no install command was executed.
+- The upstream skills sometimes assume marketing pages can be created directly; FermatMind requires backend/CMS authority and PR train gates.
+
+## 16. What Was Not Done
+
+No installation, no `.agents` or `.claude` changes, no fap-web commit, no runtime code modification, no CMS mutation, no deploy, no production data access, no raw log read, no Search Channel enqueue/submission, no external search API call, no pSEO generation, and no content asset generation were performed.
+
+## 17. Final Decision
+
+`marketingskills_fit_scan_completed_ready_for_internal_skill_adaptation`
+
+## 18. Recommended Next Task
+
+`FERMAT-MARKETING-SKILLS-ADAPTATION-01`

--- a/backend/tests/Feature/SeoIntel/MarketingSkillsFermatmindFitScan00Test.php
+++ b/backend/tests/Feature/SeoIntel/MarketingSkillsFermatmindFitScan00Test.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class MarketingSkillsFermatmindFitScan00Test extends TestCase
+{
+    public function test_generated_fit_scan_artifact_records_required_safety_contract(): void
+    {
+        $path = base_path('docs/seo/generated/marketingskills-fermatmind-fit-scan-00.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('marketingskills-fermatmind-fit-scan-00.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00', $payload['task'] ?? null);
+
+        $this->assertTrue((bool) ($payload['no_install_performed'] ?? false));
+        $this->assertTrue((bool) ($payload['no_runtime_code_modified'] ?? false));
+        $this->assertTrue((bool) ($payload['no_content_generated'] ?? false));
+        $this->assertTrue((bool) ($payload['no_search_channel_action_performed'] ?? false));
+        $this->assertTrue((bool) ($payload['no_deploy_performed'] ?? false));
+
+        $this->assertIsArray($payload['directly_useful_skills'] ?? null);
+        $this->assertIsArray($payload['useful_after_adaptation_skills'] ?? null);
+        $this->assertIsArray($payload['risk_findings'] ?? null);
+        $this->assertIsArray($payload['adoption_phases'] ?? null);
+
+        $this->assertArrayHasKey('final_decision', $payload);
+        $this->assertArrayHasKey('recommended_next_task', $payload);
+        $this->assertSame(
+            'marketingskills_fit_scan_completed_ready_for_internal_skill_adaptation',
+            $payload['final_decision']
+        );
+        $this->assertSame('FERMAT-MARKETING-SKILLS-ADAPTATION-01', $payload['recommended_next_task']);
+
+        $directSkills = array_column($payload['directly_useful_skills'], 'skill');
+        $this->assertContains('seo-audit', $directSkills);
+        $this->assertContains('ai-seo', $directSkills);
+        $this->assertContains('schema', $directSkills);
+        $this->assertContains('cro', $directSkills);
+
+        $riskIds = array_column($payload['risk_findings'], 'id');
+        $this->assertContains('risk_mass_pseo_generation', $riskIds);
+        $this->assertContains('risk_search_channel_bypass', $riskIds);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T11:43:41Z",
+  "updated_at": "2026-05-25T12:40:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -24893,6 +24893,77 @@
         "at": "2026-05-25T07:45:00Z",
         "status": "pr_opened",
         "summary": "Opened PR #1675 for RESULT-EN-PARITY-06 Big Five ResultPageV2 EN asset catalog parity."
+      }
+    ]
+  },
+  "MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00": {
+    "repo": "fap-api",
+    "branch": "codex/marketingskills-fermatmind-fit-scan-00",
+    "status": "pr_opened",
+    "depends_on": [],
+    "commit_sha": "2d08bb46555389226adf6dbce80dcc9111e2b82a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1680",
+    "checks": {
+      "scope_boundary": {
+        "status": "pass",
+        "evidence": "Changed files are limited to fap-api SEO report, generated fit-scan JSON, focused SeoIntel test, and current task PR-train metadata."
+      },
+      "external_repo_scan": {
+        "status": "pass",
+        "evidence": "coreyhaines31/marketingskills was cloned under /private/tmp/marketingskills-scan and inspected read-only; no install command was executed in FermatMind repos."
+      },
+      "production_safety": {
+        "status": "pass",
+        "evidence": "No production mutation, CMS mutation, deploy, production migration, URL submission, Search Channel enqueue, production user data access, raw log read, pSEO generation, content asset generation, or fap-web commit."
+      },
+      "local_validation": {
+        "status": "pass",
+        "commands": [
+          "cd backend && php artisan test --filter=MarketingSkillsFermatmindFitScan00 --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/docs/seo/generated/marketingskills-fermatmind-fit-scan-00.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 yaml parse for docs/codex/pr-train.yaml",
+          "git diff --check",
+          "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short --branch"
+        ],
+        "evidence": "Focused test passed with 1 test and 22 assertions. route:list exited 0 with 203 routes. Pint passed 3553 files. composer validate --strict passed. composer audit reported no security advisories. Generated JSON, state JSON, manifest YAML parse, and diff check passed. fap-web remained reference-only with pre-existing unrelated GLOBAL parity branch modifications."
+      },
+      "github_pr_opened": {
+        "status": "pass",
+        "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1680 from codex/marketingskills-fermatmind-fit-scan-00."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [
+      {
+        "title": "fap-web reference repo has active unrelated GLOBAL parity branch changes",
+        "repo": "fap-web",
+        "evidence": "git status shows codex/global-en-zh-parity-p0-01-content-help-policy-discoverability with existing modified files; this scan inspected fap-web reference-only and did not modify it.",
+        "why_external_to_current_pr": "Current PR writes fap-api docs/generated/test/state only."
+      }
+    ],
+    "events": [
+      {
+        "at": "2026-05-25T12:00:00Z",
+        "status": "local_files_generated_pending_validation",
+        "summary": "Added read-only marketingskills fit scan report, generated JSON, focused SeoIntel test, and current task PR train metadata."
+      },
+      {
+        "at": "2026-05-25T12:35:00Z",
+        "status": "local_validation_passed",
+        "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parses, diff check, and fap-web reference status passed."
+      },
+      {
+        "at": "2026-05-25T12:40:00Z",
+        "status": "pr_opened",
+        "summary": "Opened PR #1680 for MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -12845,3 +12845,40 @@ prs:
     metabase_deployment: false
     human_review_required: false
     production_approval_required: false
+
+  - id: MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00
+    repo: fap-api
+    depends_on: []
+    branch: codex/marketingskills-fermatmind-fit-scan-00
+    base: main
+    title: "MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00 evaluate marketingskills for FermatMind SEO/GEO/CRO operations"
+    train_scope: read_only_external_repo_local_repo_fit_scan
+    risk_level: low_docs_observation_only
+    allowed_paths:
+      - backend/docs/seo/marketingskills-fermatmind-fit-scan-00.md
+      - backend/docs/seo/generated/marketingskills-fermatmind-fit-scan-00.v1.json
+      - backend/tests/Feature/SeoIntel/MarketingSkillsFermatmindFitScan00Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Clone/read coreyhaines31/marketingskills only under /private/tmp and inspect relevant marketing skills.
+      - Evaluate fit against FermatMind SEO, GEO, CMS ops, CRO, Search Channel, result/report conversion, and pSEO governance.
+      - Add docs/generated artifact and focused SeoIntel test only; do not install skills, modify runtime code, mutate CMS, deploy, submit URLs, or change fap-web.
+    validation:
+      - cd backend && php artisan test --filter=MarketingSkillsFermatmindFitScan00 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/marketingskills-fermatmind-fit-scan-00.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - "python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nprint('yaml ok')\nPY"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    scheduler_activation: false
+    external_api_live_activation: false
+    metabase_deployment: false
+    human_review_required: false
+    production_approval_required: false


### PR DESCRIPTION
## What changed
- Added `MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00` read-only fit scan report for `coreyhaines31/marketingskills`.
- Added generated machine-readable fit scan artifact.
- Added focused SeoIntel test asserting the generated artifact and safety flags.
- Added only the current PR-train manifest/state entry authorized by the user.

## Why
FermatMind needs a constrained assessment of whether upstream marketing skills can support SEO/GEO/CRO/content operations without bypassing backend/CMS authority, URL Truth, Search Channel Queue gates, claim boundaries, or current pSEO no-go rules.

## Validation
- `cd backend && php artisan test --filter=MarketingSkillsFermatmindFitScan00 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/marketingskills-fermatmind-fit-scan-00.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nprint('yaml ok')\nPY`
- `git diff --check`
- `git diff --cached --check`
- `cd /Users/rainie/Desktop/GitHub/fap-web && git status --short --branch`

## Intentionally deferred
- No direct installation into `.agents/skills`.
- No Fermat-specific internal skills created in this PR.
- No prompt library, content generation, pSEO, CMS mutation, Search Channel action, deploy, or fap-web change.
- Recommended next task remains `FERMAT-MARKETING-SKILLS-ADAPTATION-01`.

## Repository rule impact
This is docs/generated/test/state only. It preserves backend/CMS authority, treats fap-web as reference-only, and explicitly rejects direct upstream skill installation or any workflow that bypasses Fermat URL Truth, claim boundaries, and Search Channel gates.
