### PR TITLE
GLOBAL-EN-ZH-PARITY-P0-01 content help policy discoverability cleanup

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-parity-p0-01-content-help-policy-discoverability.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-parity-p0-01-content-help-policy-discoverability.v1.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "global-en-zh-parity-p0-01-content-help-policy-discoverability.v1",
+  "task": "GLOBAL-EN-ZH-PARITY-P0-01",
+  "generated_at": "2026-05-25T12:20:00Z",
+  "final_decision": "p0_01_content_help_policy_cleanup_ready_for_linked_frontend_pr",
+  "repos": [
+    "fap-api",
+    "fap-web"
+  ],
+  "basis": {
+    "source_scan": "GLOBAL-EN-ZH-PARITY-SCAN-00",
+    "source_scan_pr": "https://github.com/fermatmind/fap-api/pull/1679",
+    "source_scan_merge_commit": "87345d16c4b7b22a23ead480925bb1f4c58d2721"
+  },
+  "invalid_sitemap_paths": [
+    "/en/help/about",
+    "/en/help/contact",
+    "/en/help/faq",
+    "/en/help/for-business-and-research",
+    "/en/help/team",
+    "/en/help/used-and-mentioned",
+    "/zh/help/contact",
+    "/zh/help/faq",
+    "/zh/help/for-business-and-research",
+    "/en/method-boundaries",
+    "/zh/method-boundaries",
+    "/zh/policies",
+    "/en/privacy",
+    "/zh/privacy",
+    "/en/support",
+    "/zh/support",
+    "/en/terms",
+    "/zh/terms"
+  ],
+  "invalid_llms_paths": [
+    "/en/support",
+    "/zh/support"
+  ],
+  "classification": {
+    "content_help_policy_paths": "missing_or_unverified_runtime_authority_exclude_from_discoverability_until_backend_cms_authority_and_runtime_route_are_valid",
+    "support_paths": "missing_authority_exclude_from_llms_until_valid_200_authority_exists",
+    "career_job_paths": "deferred_to_GLOBAL-EN-ZH-PARITY-P0-02"
+  },
+  "root_cause": {
+    "backend_authority": "SitemapGenerator emits content_pages only when rows are published, public, indexable, and have non-empty content.",
+    "frontend_discoverability": "fap-web static sitemap authority adapter listed help/support/policy paths and llms routes hardcoded support canonical URLs even when runtime authority was missing."
+  },
+  "fix_plan": {
+    "fap_api": "Record ledger, report, and backend authority guard evidence.",
+    "fap_web": "Remove missing-authority content/help/policy URLs from static sitemap generation and llms primary/next-step exposure without adding frontend fallback content."
+  },
+  "backend_guard": {
+    "content_pages_require_authority": true,
+    "published_required": true,
+    "public_required": true,
+    "indexable_required": true,
+    "body_required": true,
+    "frontend_fallback_authority_used": false
+  },
+  "acceptance": {
+    "no_placeholder_content_created": true,
+    "no_draft_exposure": true,
+    "no_cms_mutation_performed": true,
+    "deploy_performed": false,
+    "search_channel_action_performed": false,
+    "url_submission_performed": false,
+    "external_search_api_call_performed": false,
+    "production_migration_performed": false
+  },
+  "remaining_deferred": [
+    {
+      "task": "GLOBAL-EN-ZH-PARITY-P0-02",
+      "summary": "Investigate and fix career job detail sitemap exposure separately."
+    }
+  ],
+  "next_task": "GLOBAL-EN-ZH-PARITY-P0-02"
+}

--- a/backend/docs/seo/global-en-zh-parity-p0-01-content-help-policy-discoverability.md
+++ b/backend/docs/seo/global-en-zh-parity-p0-01-content-help-policy-discoverability.md
@@ -1,0 +1,64 @@
+# GLOBAL-EN-ZH-PARITY-P0-01 Content / Help / Policy Discoverability Cleanup
+
+## Summary
+
+GLOBAL-EN-ZH-PARITY-SCAN-00 found 18 content/help/policy URLs exposed in `sitemap.xml` that returned hard 404, plus `/en/support` and `/zh/support` exposed in `llms.txt` / `llms-full.txt`.
+
+This PR keeps backend/CMS authority as the source of truth. It does not create placeholder content, does not mutate CMS, does not deploy, and does not submit URLs.
+
+## Invalid URL Set
+
+Sitemap hard-404 paths:
+
+- `/en/help/about`
+- `/en/help/contact`
+- `/en/help/faq`
+- `/en/help/for-business-and-research`
+- `/en/help/team`
+- `/en/help/used-and-mentioned`
+- `/zh/help/contact`
+- `/zh/help/faq`
+- `/zh/help/for-business-and-research`
+- `/en/method-boundaries`
+- `/zh/method-boundaries`
+- `/zh/policies`
+- `/en/privacy`
+- `/zh/privacy`
+- `/en/support`
+- `/zh/support`
+- `/en/terms`
+- `/zh/terms`
+
+LLMS hard-404 overlap:
+
+- `/en/support`
+- `/zh/support`
+
+## Root Cause
+
+Backend `SitemapGenerator` already gates `content_pages` on published, public, indexable authority with non-empty content.
+
+The invalid public exposure comes from the frontend discoverability consumer layer:
+
+- `fap-web/lib/seo/sitemapAuthorityAdapters.cjs` statically generated missing-authority content/help/policy paths.
+- `fap-web/app/llms.txt/route.ts` and `fap-web/app/llms-full.txt/route.ts` hardcoded support canonical URLs as primary entries.
+
+## Current PR Boundary
+
+`fap-api` records the authority evidence and guard test. The linked `fap-web` PR removes the invalid static sitemap/llms exposure. Career job URL exposure remains explicitly deferred to `GLOBAL-EN-ZH-PARITY-P0-02`.
+
+## Safety
+
+- No CMS mutation.
+- No production mutation.
+- No deploy.
+- No URL submission.
+- No Search Channel enqueue.
+- No external search API call.
+- No production migration.
+- No placeholder content.
+- No frontend fallback authority.
+
+## Next Task
+
+`GLOBAL-EN-ZH-PARITY-P0-02` should investigate and clean up career job detail sitemap exposure.

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ContentPage;
+use App\Services\Scale\ScaleRegistry;
+use App\Services\SEO\SitemapGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return list<string>
+     */
+    private static function invalidContentHelpPolicyPaths(): array
+    {
+        return [
+            '/en/help/about',
+            '/en/help/contact',
+            '/en/help/faq',
+            '/en/help/for-business-and-research',
+            '/en/help/team',
+            '/en/help/used-and-mentioned',
+            '/zh/help/contact',
+            '/zh/help/faq',
+            '/zh/help/for-business-and-research',
+            '/en/method-boundaries',
+            '/zh/method-boundaries',
+            '/zh/policies',
+            '/en/privacy',
+            '/zh/privacy',
+            '/en/support',
+            '/zh/support',
+            '/en/terms',
+            '/zh/terms',
+        ];
+    }
+
+    #[Test]
+    public function generated_artifact_records_p0_01_authority_boundary(): void
+    {
+        $path = base_path('docs/seo/generated/global-en-zh-parity-p0-01-content-help-policy-discoverability.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-parity-p0-01-content-help-policy-discoverability.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-P0-01', $payload['task'] ?? null);
+        $this->assertContains('fap-api', $payload['repos'] ?? []);
+        $this->assertContains('fap-web', $payload['repos'] ?? []);
+        $this->assertSame('87345d16c4b7b22a23ead480925bb1f4c58d2721', data_get($payload, 'basis.source_scan_merge_commit'));
+        $this->assertSame(self::invalidContentHelpPolicyPaths(), $payload['invalid_sitemap_paths'] ?? []);
+        $this->assertSame(['/en/support', '/zh/support'], $payload['invalid_llms_paths'] ?? []);
+        $this->assertTrue((bool) data_get($payload, 'backend_guard.content_pages_require_authority'));
+        $this->assertFalse((bool) data_get($payload, 'backend_guard.frontend_fallback_authority_used'));
+        $this->assertTrue((bool) data_get($payload, 'acceptance.no_placeholder_content_created'));
+        $this->assertTrue((bool) data_get($payload, 'acceptance.no_cms_mutation_performed'));
+        $this->assertFalse((bool) data_get($payload, 'acceptance.deploy_performed'));
+        $this->assertFalse((bool) data_get($payload, 'acceptance.search_channel_action_performed'));
+        $this->assertFalse((bool) data_get($payload, 'acceptance.url_submission_performed'));
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-P0-02', $payload['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function backend_sitemap_source_does_not_emit_missing_content_help_policy_urls_without_authority(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $this->app->instance(ScaleRegistry::class, $this->mockScaleRegistry());
+
+        $this->createContentPage([
+            'slug' => 'about',
+            'locale' => 'en',
+            'canonical_path' => '/en/about',
+            'title' => 'About FermatMind',
+        ]);
+
+        $locs = array_map(
+            static fn (array $row): string => (string) ($row['loc'] ?? ''),
+            app(SitemapGenerator::class)->generateUrls()
+        );
+
+        $this->assertContains('https://fermatmind.com/en/about', $locs);
+
+        foreach (self::invalidContentHelpPolicyPaths() as $path) {
+            $this->assertNotContains('https://fermatmind.com'.$path, $locs, $path.' must not be exposed without content_pages authority.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createContentPage(array $overrides = []): ContentPage
+    {
+        return ContentPage::query()->create($overrides + [
+            'org_id' => 0,
+            'slug' => 'about',
+            'path' => '/about',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'about',
+            'title' => 'About FermatMind',
+            'summary' => 'Authority-backed content page.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'en',
+            'translation_group_id' => 'content-page-about',
+            'source_locale' => 'zh-CN',
+            'translation_status' => ContentPage::TRANSLATION_STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'review_state' => 'approved',
+            'content_md' => '## Overview'.PHP_EOL.'Authority-backed body.',
+            'content_html' => '',
+            'seo_title' => 'About FermatMind',
+            'seo_description' => 'Authority-backed content page.',
+            'meta_description' => 'Authority-backed content page.',
+            'canonical_path' => '/en/about',
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    private function mockScaleRegistry(): ScaleRegistry
+    {
+        $registry = \Mockery::mock(ScaleRegistry::class);
+        $registry->shouldReceive('listActivePublic')->andReturn([]);
+
+        return $registry;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T12:35:00Z",
+  "updated_at": "2026-05-25T12:40:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -19711,12 +19711,12 @@
     "GLOBAL-EN-ZH-PARITY-P0-01": {
       "repo": "fap-api",
       "branch": "codex/global-en-zh-parity-p0-01-content-help-policy-discoverability",
-      "status": "local_validation_passed",
+      "status": "pr_open_github_checks_pending",
       "depends_on": [
         "GLOBAL-EN-ZH-PARITY-SCAN-00"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "942ce417813a0632be17fab8b8822d743c6c35d7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1681",
       "checks": {
         "dependency_global_en_zh_parity_scan_00": {
           "status": "pass",
@@ -19749,6 +19749,10 @@
         "github_required_checks": {
           "status": "pending",
           "evidence": null
+        },
+        "github_pr_opened": {
+          "status": "pass",
+          "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1681 linked to fap-web PR https://github.com/fermatmind/fap-web/pull/903."
         }
       },
       "failure_reason": null,
@@ -19771,6 +19775,11 @@
           "at": "2026-05-25T12:35:00Z",
           "status": "scope_validation_passed",
           "summary": "fap-api changed files remain limited to current P0-01 evidence/report/test and current manifest/state reconciliation."
+        },
+        {
+          "at": "2026-05-25T12:40:00Z",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened fap-api PR #1681 and linked fap-web PR #903; waiting for GitHub checks."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-25T11:43:41Z",
+  "updated_at": "2026-05-25T12:35:00Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -19620,9 +19620,9 @@
     "GLOBAL-EN-ZH-PARITY-SCAN-00": {
       "repo": "fap-api",
       "branch": "codex/global-en-zh-parity-scan-00",
-      "status": "pr_open_github_checks_pending",
+      "status": "merged",
       "depends_on": [],
-      "commit_sha": "8a521be11f00fbf85d6c7b6d8c30ce626477f4ce",
+      "commit_sha": "87345d16c4b7b22a23ead480925bb1f4c58d2721",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1679",
       "checks": {
         "scope_boundary": {
@@ -19651,8 +19651,8 @@
           "evidence": "Focused GlobalEnZhParityScan00 test exited 0 with 23 assertions and a PHPUnit warning; php artisan route:list exited 0 with 203 routes; vendor/bin/pint --test passed 3552 files; composer validate --strict passed; composer audit --locked --no-interaction --ignore-unreachable reported no advisories; generated JSON parsed; pr-train state JSON parsed; pr-train YAML parsed; git diff --check and git diff --cached --check passed; fap-web reference git status --short was clean."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": null
+          "status": "pass",
+          "evidence": "PR #1679 is MERGED and origin/main contains merge commit 87345d16c4b7b22a23ead480925bb1f4c58d2721."
         },
         "github_pr_opened": {
           "status": "pass",
@@ -19660,9 +19660,9 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T11:51:00Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [
         {
           "source_pr": "GLOBAL-EN-ZH-PARITY-SCAN-00",
@@ -19675,9 +19675,9 @@
           "impact_on_current_pr": "Scan remains valid and records the visual evidence gap explicitly.",
           "owner": "frontend/seo",
           "follow_up_recommendation": "Run dedicated long-tail Playwright visual/performance pass after GLOBAL-EN-ZH-PARITY-P0-FIX-TRAIN-01.",
-          "required_checks_status": "pending until PR checks complete",
-          "scope_validation_status": "pending until final scope validation",
-          "continue_train_decision": "allowed only if GitHub required checks and scope validation are green"
+          "required_checks_status": "passed after PR #1679 merge",
+          "scope_validation_status": "passed before PR #1679 merge",
+          "continue_train_decision": "allowed; scan PR merged and P0 follow-up train may proceed"
         }
       ],
       "events": [
@@ -19700,6 +19700,77 @@
           "at": "2026-05-25T11:43:41.226250+00:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1679 for GLOBAL-EN-ZH-PARITY-SCAN-00 and pushed branch codex/global-en-zh-parity-scan-00; waiting for GitHub checks."
+        },
+        {
+          "at": "2026-05-25T12:10:55.823326+00:00",
+          "status": "ledger_reconciled_merged",
+          "summary": "Reconciled GLOBAL-EN-ZH-PARITY-SCAN-00 after PR #1679 merged at commit 87345d16c4b7b22a23ead480925bb1f4c58d2721; this bookkeeping unblocks GLOBAL-EN-ZH-PARITY-P0-01."
+        }
+      ]
+    },
+    "GLOBAL-EN-ZH-PARITY-P0-01": {
+      "repo": "fap-api",
+      "branch": "codex/global-en-zh-parity-p0-01-content-help-policy-discoverability",
+      "status": "local_validation_passed",
+      "depends_on": [
+        "GLOBAL-EN-ZH-PARITY-SCAN-00"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency_global_en_zh_parity_scan_00": {
+          "status": "pass",
+          "evidence": "PR #1679 is MERGED and origin/main contains merge commit 87345d16c4b7b22a23ead480925bb1f4c58d2721."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "evidence": "Changed files are limited to backend/docs/seo/global-en-zh-parity-p0-01-content-help-policy-discoverability.md, backend/docs/seo/generated/global-en-zh-parity-p0-01-content-help-policy-discoverability.v1.json, backend/tests/Feature/SeoIntel/GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No deploy, CMS mutation, production migration, Search Channel action, URL submission, external search API call, env/DNS/nginx edit, production data write, or content generation is permitted or performed."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=GlobalEnZhParityP001 --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-en-zh-parity-p0-01-content-help-policy-discoverability.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 yaml parse for docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "Focused P0-01 SeoIntel test passed with 35 assertions; route:list passed with 203 routes; pint passed 3553 files; composer validate and audit passed; generated JSON and pr-train state parsed; pr-train YAML parsed; diff checks passed."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": null
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "sidecar_issues": [],
+      "events": [
+        {
+          "at": "2026-05-25T12:10:55.823326+00:00",
+          "status": "started_manifest_state_initialized",
+          "summary": "Initialized GLOBAL-EN-ZH-PARITY-P0-01 manifest/state entry with explicit user authorization; scope is content/help/policy sitemap/llms hard-404 cleanup only."
+        },
+        {
+          "at": "2026-05-25T12:32:00Z",
+          "status": "local_validation_passed",
+          "summary": "fap-api evidence/ledger/backend guard validation passed for linked GLOBAL-EN-ZH-PARITY-P0-01 PR."
+        },
+        {
+          "at": "2026-05-25T12:35:00Z",
+          "status": "scope_validation_passed",
+          "summary": "fap-api changed files remain limited to current P0-01 evidence/report/test and current manifest/state reconciliation."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -7248,6 +7248,53 @@ prs:
     external_api_live_activation: false
     production_approval_required: false
 
+  - id: GLOBAL-EN-ZH-PARITY-P0-01
+    repo: fap-api
+    depends_on: [GLOBAL-EN-ZH-PARITY-SCAN-00]
+    branch: codex/global-en-zh-parity-p0-01-content-help-policy-discoverability
+    base: main
+    title: "GLOBAL-EN-ZH-PARITY-P0-01 content help policy discoverability cleanup"
+    train_scope: global_en_zh_parity_p0_fix_train
+    risk_level: p0_discoverability_cleanup
+    scope:
+      - Identify the source of sitemap/llms exposure for content, help, policy, and support URLs that currently return hard 404.
+      - Classify invalid content/help/policy URLs by authority status and remove them from sitemap/llms exposure when no valid backend/CMS authority exists.
+      - Add a focused SeoIntel regression test and generated evidence artifact for current P0 content/help/policy discoverability cleanup.
+      - Reconcile GLOBAL-EN-ZH-PARITY-SCAN-00 ledger state because PR #1679 has already merged.
+    allowed_paths:
+      - backend/app/Services/SeoIntel/**
+      - backend/docs/seo/global-en-zh-parity-p0-01-content-help-policy-discoverability.md
+      - backend/docs/seo/generated/global-en-zh-parity-p0-01-content-help-policy-discoverability.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Do not create placeholder content/help/policy pages.
+      - Do not mutate CMS or production data.
+      - Do not deploy.
+      - Do not submit URLs or call external search APIs.
+      - Do not enqueue Search Channel.
+      - Do not run production migrations or edit env/DNS/nginx.
+      - Do not use frontend fallback as authority.
+      - Do not implement GLOBAL-EN-ZH-PARITY-P0-02 or future PR scopes.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhParityP001 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-parity-p0-01-content-help-policy-discoverability.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 yaml parse for docs/codex/pr-train.yaml
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    next_task: GLOBAL-EN-ZH-PARITY-P0-02
+
   - id: SEO-GROWTH-MBTI-ACTION-01D-SCAN-00
     repo: fap-api
     depends_on: []


### PR DESCRIPTION
## PR id
GLOBAL-EN-ZH-PARITY-P0-01

## Repo / branch
- repo: fap-api
- branch: codex/global-en-zh-parity-p0-01-content-help-policy-discoverability
- linked fap-web PR: https://github.com/fermatmind/fap-web/pull/903

## What changed
- Added the current GLOBAL-EN-ZH-PARITY-P0-01 manifest/state entry only.
- Reconciled GLOBAL-EN-ZH-PARITY-SCAN-00 as merged at PR #1679 / 87345d16c4b7b22a23ead480925bb1f4c58d2721.
- Added a read-only P0-01 evidence report and generated JSON classifying the content/help/policy hard-404 exposure.
- Added a focused SeoIntel test proving backend sitemap/content-page source already gates content pages by authority and that the actual exposure source is the linked fap-web static discoverability layer.

## Why
GLOBAL-EN-ZH-PARITY-SCAN-00 found sitemap/llms P0 exposure for missing-authority content/help/policy URLs. This backend PR records the authority-side evidence and ledger state for the linked frontend discoverability cleanup without creating placeholder content or mutating CMS.

## Changed files
- backend/docs/seo/global-en-zh-parity-p0-01-content-help-policy-discoverability.md
- backend/docs/seo/generated/global-en-zh-parity-p0-01-content-help-policy-discoverability.v1.json
- backend/tests/Feature/SeoIntel/GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest.php
- docs/codex/pr-train.yaml
- docs/codex/pr-train-state.json

## Validation
- `php artisan test --filter=GlobalEnZhParityP001 --no-ansi` passed with 35 assertions.
- `php artisan route:list --no-ansi` passed with 203 routes.
- `vendor/bin/pint --test` passed.
- `composer validate --strict` passed.
- `composer audit --locked --no-interaction --ignore-unreachable` passed.
- generated JSON parse passed.
- pr-train state JSON parse passed.
- pr-train YAML parse passed.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Scope / safety
- No deploy.
- No CMS mutation.
- No Search Channel action.
- No URL submission.
- No production migration.
- No env/DNS/nginx edits.
- No content generation or publishing.
- No frontend fallback authority.

## Intentionally deferred
- Career job detail sitemap exposure remains deferred to GLOBAL-EN-ZH-PARITY-P0-02.
- Final P0 closeout/regression artifact remains deferred to GLOBAL-EN-ZH-PARITY-P0-03.

## Rollback
Revert this report/test/ledger PR together with the linked fap-web discoverability cleanup if the P0-01 classification needs to be withdrawn.
