### PR TITLE
GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01 content help policy import package

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json
@@ -1,0 +1,218 @@
+{
+  "schema_version": "global-en-zh-content-asset-batch-01.v1",
+  "task": "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01",
+  "source_authority": "backend_content_pages_repo_backed_import_package",
+  "based_on": [
+    "EN-PARITY-03 content_pages import package",
+    "GLOBAL-EN-ZH-PARITY-SCAN-00",
+    "GLOBAL-EN-ZH-PARITY-P0-01 sitemap/llms hard-404 cleanup"
+  ],
+  "no_mutation_performed": true,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "auto_publish_performed": false,
+  "frontend_fallback_authority_used": false,
+  "substantial_english_prose_generated": false,
+  "draft_pages_exposed_in_sitemap_llms": false,
+  "content_generation_policy": {
+    "mode": "controlled_import_package_only",
+    "auto_publish_allowed": false,
+    "mass_english_generation_allowed": false,
+    "human_review_required_for_new_prose": true,
+    "draft_exposure_allowed_in_sitemap_llms": false,
+    "unsupported_company_legal_or_claim_facts_allowed": false
+  },
+  "target_summary": {
+    "targeted_content_help_policy_items": 12,
+    "authority_backed_pair_or_import_ready": 5,
+    "draft_review_only": 5,
+    "deferred_missing_authority": 2,
+    "published_by_this_pr": 0,
+    "sitemap_llms_exposure_added_by_this_pr": 0
+  },
+  "content_items": [
+    {
+      "entity_key": "about",
+      "family": "company",
+      "zh_path": "/zh/about",
+      "en_path": "/en/about",
+      "state": "authority_backed_pair_or_import_ready",
+      "source": "content_baselines/content_pages",
+      "counterpart_relation": "content-page-about",
+      "sitemap_llms_exposure_eligible": "only_after_runtime_authority_gate",
+      "claim_boundary": "non_diagnostic_company_information_only"
+    },
+    {
+      "entity_key": "support",
+      "family": "support",
+      "zh_path": "/zh/support",
+      "en_path": "/en/support",
+      "state": "deferred_missing_authority",
+      "source": null,
+      "counterpart_relation": null,
+      "sitemap_llms_exposure_eligible": false,
+      "claim_boundary": "requires_human_reviewed_support_authority"
+    },
+    {
+      "entity_key": "brand",
+      "family": "company",
+      "zh_path": "/zh/brand",
+      "en_path": "/en/brand",
+      "state": "draft_review_only",
+      "source": "zh_baseline_only",
+      "counterpart_relation": "content-page-brand",
+      "sitemap_llms_exposure_eligible": false,
+      "claim_boundary": "do_not_invent_brand_claims"
+    },
+    {
+      "entity_key": "charter",
+      "family": "company",
+      "zh_path": "/zh/charter",
+      "en_path": "/en/charter",
+      "state": "draft_review_only",
+      "source": "zh_baseline_only",
+      "counterpart_relation": "content-page-charter",
+      "sitemap_llms_exposure_eligible": false,
+      "claim_boundary": "do_not_invent_legal_or_governance_commitments"
+    },
+    {
+      "entity_key": "foundation",
+      "family": "company",
+      "zh_path": "/zh/foundation",
+      "en_path": "/en/foundation",
+      "state": "draft_review_only",
+      "source": "zh_baseline_only",
+      "counterpart_relation": "content-page-foundation",
+      "sitemap_llms_exposure_eligible": false,
+      "claim_boundary": "do_not_invent_institutional_facts"
+    },
+    {
+      "entity_key": "careers",
+      "family": "company",
+      "zh_path": "/zh/careers",
+      "en_path": "/en/careers",
+      "state": "draft_review_only",
+      "source": "zh_baseline_only",
+      "counterpart_relation": "content-page-careers",
+      "sitemap_llms_exposure_eligible": false,
+      "claim_boundary": "do_not_invent_hiring_or_role_claims"
+    },
+    {
+      "entity_key": "privacy",
+      "family": "policy",
+      "zh_path": "/zh/privacy",
+      "en_path": "/en/privacy",
+      "state": "authority_backed_pair_or_import_ready",
+      "source": "content_baselines/content_pages",
+      "counterpart_relation": "content-page-privacy",
+      "sitemap_llms_exposure_eligible": "only_after_runtime_authority_gate",
+      "claim_boundary": "legal_copy_requires_owner_review_before_public_exposure"
+    },
+    {
+      "entity_key": "terms",
+      "family": "policy",
+      "zh_path": "/zh/terms",
+      "en_path": "/en/terms",
+      "state": "authority_backed_pair_or_import_ready",
+      "source": "content_baselines/content_pages",
+      "counterpart_relation": "content-page-terms",
+      "sitemap_llms_exposure_eligible": "only_after_runtime_authority_gate",
+      "claim_boundary": "legal_copy_requires_owner_review_before_public_exposure"
+    },
+    {
+      "entity_key": "policies",
+      "family": "policy",
+      "zh_path": "/zh/policies",
+      "en_path": "/en/policies",
+      "state": "draft_review_only",
+      "source": "zh_baseline_only",
+      "counterpart_relation": "content-page-policies",
+      "sitemap_llms_exposure_eligible": false,
+      "claim_boundary": "do_not_invent_policy_commitments"
+    },
+    {
+      "entity_key": "help-contact",
+      "family": "help",
+      "zh_path": "/zh/help/contact",
+      "en_path": "/en/help/contact",
+      "state": "authority_backed_pair_or_import_ready",
+      "source": "content_baselines/content_pages",
+      "counterpart_relation": "content-page-help-contact",
+      "sitemap_llms_exposure_eligible": "only_after_runtime_authority_gate",
+      "claim_boundary": "support_instructions_only"
+    },
+    {
+      "entity_key": "help-faq",
+      "family": "help",
+      "zh_path": "/zh/help/faq",
+      "en_path": "/en/help/faq",
+      "state": "authority_backed_pair_or_import_ready",
+      "source": "content_baselines/content_pages",
+      "counterpart_relation": "content-page-help-faq",
+      "sitemap_llms_exposure_eligible": "only_after_runtime_authority_gate",
+      "claim_boundary": "faq_must_be_visible_or_authority_backed"
+    },
+    {
+      "entity_key": "help-about",
+      "family": "help",
+      "zh_path": "/zh/help/about",
+      "en_path": "/en/help/about",
+      "state": "authority_backed_pair_or_import_ready",
+      "source": "content_baselines/content_pages",
+      "counterpart_relation": "content-page-help-about",
+      "sitemap_llms_exposure_eligible": "only_after_runtime_authority_gate",
+      "claim_boundary": "help_explanation_only"
+    }
+  ],
+  "exposure_guard": {
+    "draft_review_only_must_not_enter_sitemap": true,
+    "draft_review_only_must_not_enter_llms": true,
+    "deferred_missing_authority_must_not_enter_sitemap": true,
+    "deferred_missing_authority_must_not_enter_llms": true,
+    "frontend_fallback_must_not_be_counterpart": true,
+    "known_p0_hard_404_exposure_must_stay_closed": true
+  },
+  "forbidden_claim_hits": [],
+  "remaining_gaps": [
+    {
+      "gap": "human_reviewed_english_company_policy_copy",
+      "items": [
+        "brand",
+        "careers",
+        "charter",
+        "foundation",
+        "policies"
+      ],
+      "next_action": "owner-reviewed import package or small review batch"
+    },
+    {
+      "gap": "support_content_authority",
+      "items": [
+        "support"
+      ],
+      "next_action": "create explicit content_page authority or keep retired"
+    },
+    {
+      "gap": "runtime_exposure_gate",
+      "items": [
+        "about",
+        "privacy",
+        "terms",
+        "help-about",
+        "help-contact",
+        "help-faq"
+      ],
+      "next_action": "only expose after runtime 200/canonical/hreflang eligibility is proven"
+    }
+  ],
+  "recommended_next_tasks": [
+    "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01",
+    "Human review for brand/careers/charter/foundation/policies English drafts",
+    "Keep sitemap/llms P0 hard-404 exclusions closed until authority and runtime gates pass"
+  ],
+  "final_decision": "content_asset_batch_import_package_ready_with_human_review_deferred_assets",
+  "next_task": "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01"
+}

--- a/backend/docs/seo/global-en-zh-content-asset-batch-01.md
+++ b/backend/docs/seo/global-en-zh-content-asset-batch-01.md
@@ -1,0 +1,71 @@
+# GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01 Content Help Policy Import Package
+
+## Executive Summary
+
+This PR records the controlled content/help/policy parity batch for the remaining full-site EN/ZH parity train. It does not publish pages, mutate production CMS, deploy, submit URLs, or generate substantial English prose.
+
+The batch confirms that some content/help/policy pages already have repo-backed authority or import-ready pairs, while company and policy gaps that require real English copy stay draft-review-only or deferred.
+
+## Authority Boundary
+
+- Backend `content_pages` remains the authority for company, help, support, and policy pages.
+- `content_baselines/content_pages` is a repo-backed import/recovery package, not frontend runtime authority.
+- fap-web fallback is not accepted as content authority.
+- Draft, missing-authority, fallback-only, hard-404, soft-404, private, or noindex pages must not enter sitemap or llms.
+
+## Batch Classification
+
+Authority-backed or import-ready pairs:
+
+- `about`
+- `privacy`
+- `terms`
+- `help/about`
+- `help/contact`
+- `help/faq`
+
+Draft-review-only English counterparts:
+
+- `brand`
+- `careers`
+- `charter`
+- `foundation`
+- `policies`
+
+Deferred missing authority:
+
+- `support`
+
+## What This PR Does Not Do
+
+- It does not create or publish English body copy.
+- It does not mutate production CMS.
+- It does not expose any draft/import candidate in sitemap, llms, hreflang, URL Truth, or public runtime.
+- It does not change fap-web.
+- It does not submit URLs or run Search Channel actions.
+
+## Validation
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter=GlobalEnZhContentAssetBatch01 --no-ansi
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd /Users/rainie/Desktop/GitHub/fap-api
+python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 - <<'PY'
+import yaml, pathlib
+yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+print('yaml ok')
+PY
+git diff --check
+git diff --cached --check
+```
+
+## Next Task
+
+`GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01`.

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentAssetBatch01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentAssetBatch01Test.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentAssetBatch01Test extends TestCase
+{
+    #[Test]
+    public function generated_content_asset_batch_records_non_mutating_import_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-content-asset-batch-01.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01', $payload['task'] ?? null);
+        $this->assertTrue((bool) ($payload['no_mutation_performed'] ?? false));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['auto_publish_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['substantial_english_prose_generated'] ?? true));
+        $this->assertFalse((bool) ($payload['draft_pages_exposed_in_sitemap_llms'] ?? true));
+    }
+
+    #[Test]
+    public function content_batch_classifies_targets_and_keeps_drafts_out_of_discoverability(): void
+    {
+        $payload = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertSame(12, $payload['target_summary']['targeted_content_help_policy_items'] ?? null);
+        $this->assertSame(5, $payload['target_summary']['draft_review_only'] ?? null);
+        $this->assertSame(2, $payload['target_summary']['deferred_missing_authority'] ?? null);
+        $this->assertSame(0, $payload['target_summary']['published_by_this_pr'] ?? null);
+        $this->assertSame(0, $payload['target_summary']['sitemap_llms_exposure_added_by_this_pr'] ?? null);
+
+        $items = collect($payload['content_items'] ?? [])->keyBy('entity_key');
+
+        foreach (['about', 'privacy', 'terms', 'help-about', 'help-contact', 'help-faq'] as $key) {
+            $this->assertSame('authority_backed_pair_or_import_ready', $items[$key]['state'] ?? null);
+        }
+
+        foreach (['brand', 'careers', 'charter', 'foundation', 'policies'] as $key) {
+            $this->assertSame('draft_review_only', $items[$key]['state'] ?? null);
+            $this->assertFalse((bool) ($items[$key]['sitemap_llms_exposure_eligible'] ?? true));
+        }
+
+        $this->assertSame('deferred_missing_authority', $items['support']['state'] ?? null);
+        $this->assertFalse((bool) ($items['support']['sitemap_llms_exposure_eligible'] ?? true));
+    }
+
+    #[Test]
+    public function claim_and_exposure_guards_remain_closed(): void
+    {
+        $payload = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertSame([], $payload['forbidden_claim_hits'] ?? null);
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.draft_review_only_must_not_enter_sitemap'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.draft_review_only_must_not_enter_llms'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.deferred_missing_authority_must_not_enter_sitemap'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.deferred_missing_authority_must_not_enter_llms'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.frontend_fallback_must_not_be_counterpart'));
+        $this->assertNotEmpty($payload['remaining_gaps'] ?? []);
+        $this->assertNotEmpty($payload['recommended_next_tasks'] ?? []);
+        $this->assertSame(
+            'content_asset_batch_import_package_ready_with_human_review_deferred_assets',
+            $payload['final_decision'] ?? null
+        );
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01', $payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24791,6 +24791,171 @@
           "summary": "Fixed verify-mbti failure with narrow DB migration portability allowlist; local targeted tests and pint pass."
         }
       ]
+    },
+    "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01": {
+      "status": "local_validation_passed",
+      "repo": "fap-api",
+      "branch": "codex/global-en-zh-content-asset-batch-01",
+      "base": "main",
+      "depends_on": [
+        "GLOBAL-EN-ZH-PARITY-P0-01",
+        "GLOBAL-EN-ZH-PARITY-FOOTER-NAV-PARITY-01"
+      ],
+      "title": "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01 content help policy import package",
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "checks": {
+        "dependency": {
+          "status": "passed",
+          "evidence": "GLOBAL-EN-ZH-PARITY-P0-01 is merged in fap-api main; GLOBAL-EN-ZH-PARITY-FOOTER-NAV-PARITY-01 merged in fap-web PR #904 with merge commit f99aa4cf33ccfad763225d86116b7305de4ebce7."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "changed_files": [
+            "backend/docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json",
+            "backend/docs/seo/global-en-zh-content-asset-batch-01.md",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhContentAssetBatch01Test.php",
+            "docs/codex/pr-train-state.json",
+            "docs/codex/pr-train.yaml"
+          ],
+          "evidence": "Changed files are limited to current content asset batch report, generated JSON, focused SeoIntel test, and authorized manifest/state entries."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No deploy, CMS mutation, Search Channel action, URL submission, production migration, fap-web edit, or content publication performed."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "php artisan test --filter=GlobalEnZhContentAssetBatch01 --no-ansi",
+            "php artisan route:list --no-ansi",
+            "vendor/bin/pint --test",
+            "composer validate --strict",
+            "composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 yaml parse for docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "Focused SeoIntel test passed 3 tests / 46 assertions; route:list passed; Pint passed 3555 files; composer validate/audit passed; JSON/YAML parse and diff checks passed."
+        },
+        "github_required_checks": {
+          "status": "pending"
+        }
+      },
+      "history": [
+        {
+          "at": "2026-05-25T21:15:38+08:00",
+          "status": "in_progress",
+          "summary": "Initialized current content/help/policy asset batch PR and added authorized remaining train manifest/state entries without implementing future PR scopes."
+        },
+        {
+          "at": "2026-05-25T21:16:59+08:00",
+          "status": "local_validation_passed",
+          "summary": "Current content/help/policy asset batch passed local validation and scope checks."
+        }
+      ]
+    },
+    "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01": {
+      "status": "planned",
+      "repo": "fap-api",
+      "branch": "codex/global-en-zh-article-counterpart-batch-01",
+      "base": "main",
+      "depends_on": [
+        "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01"
+      ],
+      "title": "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01 article counterpart controlled batch",
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "checks": {},
+      "history": [
+        {
+          "at": "2026-05-25T21:15:38+08:00",
+          "status": "planned",
+          "summary": "Planned manifest/state entry only; no implementation in current PR."
+        }
+      ]
+    },
+    "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01": {
+      "status": "planned",
+      "repo": "fap-api",
+      "branch": "codex/global-en-zh-career-asset-batch-01",
+      "base": "main",
+      "depends_on": [
+        "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01"
+      ],
+      "title": "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01 career guides jobs parity batch",
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "checks": {},
+      "history": [
+        {
+          "at": "2026-05-25T21:15:38+08:00",
+          "status": "planned",
+          "summary": "Planned manifest/state entry only; no implementation in current PR."
+        }
+      ]
+    },
+    "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01": {
+      "status": "planned",
+      "repo": "fap-api",
+      "branch": "codex/global-en-zh-result-media-asset-batch-01",
+      "base": "main",
+      "depends_on": [
+        "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01"
+      ],
+      "title": "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01 result report media parity batch",
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "checks": {},
+      "history": [
+        {
+          "at": "2026-05-25T21:15:38+08:00",
+          "status": "planned",
+          "summary": "Planned manifest/state entry only; no implementation in current PR."
+        }
+      ]
+    },
+    "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01": {
+      "status": "planned",
+      "repo": "fap-api",
+      "branch": "codex/global-en-zh-final-verify-01",
+      "base": "main",
+      "depends_on": [
+        "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01"
+      ],
+      "title": "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01 full site parity verification",
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "checks": {},
+      "history": [
+        {
+          "at": "2026-05-25T21:15:38+08:00",
+          "status": "planned",
+          "summary": "Planned manifest/state entry only; no implementation in current PR."
+        }
+      ]
     }
   },
   "RESULT-EN-PARITY-04": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24793,7 +24793,7 @@
       ]
     },
     "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01": {
-      "status": "local_validation_passed",
+      "status": "pr_open_github_checks_pending",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-content-asset-batch-01",
       "base": "main",
@@ -24802,8 +24802,8 @@
         "GLOBAL-EN-ZH-PARITY-FOOTER-NAV-PARITY-01"
       ],
       "title": "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01 content help policy import package",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "dd822c2b8997ed78b1dcc8bbd0f2e59e6c68012d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1683",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -24858,6 +24858,11 @@
           "at": "2026-05-25T21:16:59+08:00",
           "status": "local_validation_passed",
           "summary": "Current content/help/policy asset batch passed local validation and scope checks."
+        },
+        {
+          "at": "2026-05-25T21:17:47+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened fap-api PR #1683; waiting for GitHub checks."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -12976,3 +12976,202 @@ prs:
     metabase_deployment: false
     human_review_required: false
     production_approval_required: false
+
+  - id: GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-PARITY-P0-01
+      - GLOBAL-EN-ZH-PARITY-FOOTER-NAV-PARITY-01
+    branch: codex/global-en-zh-content-asset-batch-01
+    base: main
+    title: "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01 content help policy import package"
+    train_scope: global_en_zh_remaining_parity_train
+    risk_level: p1_content_asset_batch
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-asset-batch-01.md
+      - backend/docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentAssetBatch01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Prepare controlled content/help/policy parity package for about, support, brand, charter, foundation, careers, privacy, terms, policies, help/contact, help/faq, and help/about.
+      - Classify each item as authority-backed/import-ready, draft-review-only, or deferred missing authority.
+      - Prove no draft, placeholder, fallback-only, or missing-authority page is exposed through sitemap/llms by this PR.
+      - Keep missing counterparts explicit without generating substantial English prose.
+    do_not:
+      - Mutate production CMS, auto-publish, deploy, submit URLs, or enqueue Search Channel.
+      - Generate unsupported company, legal, hiring, diagnostic, salary, or career-success claims.
+      - Modify fap-web, frontend fallback content, runtime routes, sitemap generator, or llms generator.
+      - Implement future article, career, result/media, or final verification PR scopes.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentAssetBatch01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("docs/codex/pr-train.yaml").read_text()); print("yaml ok")'
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01
+
+  - id: GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01
+    branch: codex/global-en-zh-article-counterpart-batch-01
+    base: main
+    title: "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01 article counterpart controlled batch"
+    train_scope: global_en_zh_remaining_parity_train
+    risk_level: p1_article_counterpart_batch
+    allowed_paths:
+      - backend/docs/seo/**
+      - backend/tests/Feature/SeoIntel/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Build a controlled English article counterpart draft/import batch for missing ZH articles.
+      - Keep draft/import-only articles out of sitemap/llms and public runtime exposure.
+      - Preserve explicit claim boundaries and counterpart mapping.
+    do_not:
+      - Publish all missing articles, mutate production CMS, submit URLs, deploy, or use fap-web hardcoded articles as authority.
+      - Create unsupported studies, statistics, citations, diagnosis, treatment, salary, hiring-fit, or career-success claims.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhArticleCounterpartBatch01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01
+
+  - id: GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01
+    branch: codex/global-en-zh-career-asset-batch-01
+    base: main
+    title: "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01 career guides jobs parity batch"
+    train_scope: global_en_zh_remaining_parity_train
+    risk_level: p1_career_asset_batch
+    allowed_paths:
+      - backend/docs/seo/**
+      - backend/tests/Feature/SeoIntel/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Build authority-backed inventory for career guide index/detail, career job detail, and career recommendation pages.
+      - Classify published/indexable, import-ready, draft-review-only, deferred, and excluded-from-sitemap states.
+      - Prevent draft/fallback/404 career URLs from sitemap/llms.
+    do_not:
+      - Create placeholder job pages, publish unreviewed guides, mutate CMS, expose frontend fallback career pages, or claim precise career recommendation.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhCareerAssetBatch01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01
+
+  - id: GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01
+    branch: codex/global-en-zh-result-media-asset-batch-01
+    base: main
+    title: "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01 result report media parity batch"
+    train_scope: global_en_zh_remaining_parity_train
+    risk_level: p1_result_media_asset_batch
+    allowed_paths:
+      - backend/docs/seo/**
+      - backend/tests/Feature/SeoIntel/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Combine remaining RESULT-EN-PARITY deferred assets and media parity gaps into a controlled batch report.
+      - Preserve fail-closed no-zh-fallback behavior.
+      - Classify production-active, draft-review-only, import-ready, deferred-human-review, and blocked-claim-boundary items.
+    do_not:
+      - Mass-generate report prose, expose sensitive or clinical overclaims, mutate CMS, deploy, or edit fap-web.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhResultMediaAssetBatch01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01
+
+  - id: GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01
+    branch: codex/global-en-zh-final-verify-01
+    base: main
+    title: "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01 full site parity verification"
+    train_scope: global_en_zh_remaining_parity_train
+    risk_level: final_verification
+    allowed_paths:
+      - backend/docs/seo/**
+      - backend/tests/Feature/SeoIntel/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Re-run bounded full-site parity verification after previous PRs.
+      - Verify P0 sitemap/llms exposure stays closed and remaining content/article/career/result/media gaps are explicit.
+      - Produce final GO/NO-GO report.
+    do_not:
+      - Mutate CMS, deploy, submit URLs, publish content, or perform implementation fixes beyond report/test corrections.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhFinalVerify01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    search_channel_action: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    content_generation_allowed: false
+    next_task: DEPLOY-READINESS


### PR DESCRIPTION
## PR id
GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01

## What changed
- Adds a controlled content/help/policy parity batch report and generated JSON artifact.
- Classifies target content pages as authority-backed/import-ready, draft-review-only, or deferred missing authority.
- Adds a focused SeoIntel test proving non-mutation, no auto-publish, no frontend fallback authority, and no draft/missing-authority sitemap/llms exposure.
- Adds the remaining GLOBAL EN/ZH parity train manifest/state entries as planned entries only.

## Why
After P0 discoverability cleanup and footer/nav parity, the remaining content/help/policy gaps need an explicit repo-backed import/draft boundary before any content work. This PR keeps missing counterparts explicit without generating or publishing English prose.

## Authority boundary
- Backend `content_pages` remains authority.
- No production CMS mutation.
- No deploy.
- No Search Channel action or URL submission.
- No production migration.
- No fap-web changes.
- No substantial English prose generation.
- Draft/deferred assets are not exposed in sitemap/llms.

## Validation
- `php artisan test --filter=GlobalEnZhContentAssetBatch01 --no-ansi` passed: 3 tests / 46 assertions.
- `php artisan route:list --no-ansi` passed.
- `vendor/bin/pint --test` passed: 3555 files.
- `composer validate --strict` passed.
- `composer audit --locked --no-interaction --ignore-unreachable` passed.
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-asset-batch-01.v1.json >/dev/null` passed.
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` passed.
- YAML parse for `docs/codex/pr-train.yaml` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Intentionally deferred
- Human-reviewed English copy for `brand`, `careers`, `charter`, `foundation`, and `policies`.
- Explicit `support` content authority or retirement decision.
- Runtime/sitemap exposure for import-ready pages until runtime 200/canonical/hreflang eligibility is proven.
- Article counterpart batch, career asset batch, result/media asset batch, and final verification remain future PR scopes.
