### PR TITLE
GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01 article counterpart controlled batch

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-article-counterpart-batch-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-article-counterpart-batch-01.v1.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": "global-en-zh-article-counterpart-batch-01.v1",
+  "task": "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01",
+  "source_authority": "backend_cms_article_baseline",
+  "based_on": [
+    "EN-PARITY-04 article counterpart import package",
+    "GLOBAL-EN-ZH-PARITY-SCAN-00",
+    "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01"
+  ],
+  "no_mutation_performed": true,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "auto_publish_performed": false,
+  "frontend_fallback_authority_used": false,
+  "mass_english_generation_performed": false,
+  "substantial_english_prose_generated": false,
+  "draft_articles_exposed_in_sitemap_llms": false,
+  "batch_policy": {
+    "mode": "controlled_import_package_and_deferred_list",
+    "max_publish_count_by_this_pr": 0,
+    "human_review_required_for_new_prose": true,
+    "draft_exposure_allowed_in_sitemap_llms": false,
+    "unsupported_research_or_stat_claims_allowed": false
+  },
+  "article_summary": {
+    "repo_baseline_en_articles": 20,
+    "repo_baseline_zh_articles": 25,
+    "en_parity_target_counterparts_ready_for_review": 10,
+    "deferred_missing_english_counterparts": 6,
+    "published_by_this_pr": 0,
+    "sitemap_llms_exposure_added_by_this_pr": 0
+  },
+  "import_ready_counterparts": [
+    {
+      "source_zh_slug": "big-five-growth-guide",
+      "proposed_en_slug": "big-five-growth-guide",
+      "counterpart_key": "article:big-five-growth-guide",
+      "status": "import_ready_review_required",
+      "claim_boundary": "non_diagnostic_growth_guidance",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "big-five-narrative-portrait",
+      "proposed_en_slug": "big-five-narrative-portrait",
+      "counterpart_key": "article:big-five-narrative-portrait",
+      "status": "import_ready_review_required",
+      "claim_boundary": "non_diagnostic_trait_description",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "big-five-tool-guide",
+      "proposed_en_slug": "big-five-tool-guide",
+      "counterpart_key": "article:big-five-tool-guide",
+      "status": "import_ready_review_required",
+      "claim_boundary": "tool_explanation_not_diagnosis_or_career_prediction",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "eq-test-tool-guide",
+      "proposed_en_slug": "eq-test-tool-guide",
+      "counterpart_key": "article:eq-test-tool-guide",
+      "status": "import_ready_review_required",
+      "claim_boundary": "self_reflection_not_clinical_assessment",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "iq-test-growth-guide",
+      "proposed_en_slug": "iq-test-growth-guide",
+      "counterpart_key": "article:iq-test-growth-guide",
+      "status": "import_ready_review_required",
+      "claim_boundary": "educational_growth_framing_no_fixed_intelligence_claim",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "iq-test-narrative-portrait",
+      "proposed_en_slug": "iq-test-narrative-portrait",
+      "counterpart_key": "article:iq-test-narrative-portrait",
+      "status": "import_ready_review_required",
+      "claim_boundary": "non_diagnostic_ability_narrative",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "iq-test-tool-guide",
+      "proposed_en_slug": "iq-test-tool-guide",
+      "counterpart_key": "article:iq-test-tool-guide",
+      "status": "import_ready_review_required",
+      "claim_boundary": "tool_guide_no_clinical_or_hiring_claim",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "mbti-basics",
+      "proposed_en_slug": "mbti-basics",
+      "counterpart_key": "article:mbti-basics",
+      "status": "import_ready_review_required",
+      "claim_boundary": "personality_framework_intro_not_diagnosis",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "mbti-growth-guide",
+      "proposed_en_slug": "mbti-growth-guide",
+      "counterpart_key": "article:mbti-growth-guide",
+      "status": "import_ready_review_required",
+      "claim_boundary": "growth_guidance_not_prediction",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    },
+    {
+      "source_zh_slug": "mbti-narrative-portrait",
+      "proposed_en_slug": "mbti-narrative-portrait",
+      "counterpart_key": "article:mbti-narrative-portrait",
+      "status": "import_ready_review_required",
+      "claim_boundary": "narrative_portrait_not_diagnosis_or_fate",
+      "sitemap_llms_exposure_eligible": "only_after_backend_published_indexable_authority"
+    }
+  ],
+  "deferred_missing_english_counterparts": [
+    "are-infj-men-rare-or-socially-silenced",
+    "best-valentines-date-by-personality-and-relationship-science",
+    "childhood-dream-job-still-shapes-career-choice",
+    "how-16-personality-types-talk-to-an-ai-coach",
+    "how-personality-shapes-attitude-toward-ai",
+    "which-love-script-fits-you-best"
+  ],
+  "exposure_guard": {
+    "draft_articles_must_not_enter_sitemap": true,
+    "draft_articles_must_not_enter_llms": true,
+    "frontend_fallback_must_not_be_article_authority": true,
+    "missing_counterparts_must_remain_explicit": true,
+    "published_indexable_authority_required_before_public_exposure": true
+  },
+  "forbidden_claim_hits": [],
+  "remaining_gaps": [
+    {
+      "gap": "six_editorial_articles_need_human_reviewed_english_drafts",
+      "status": "deferred_human_review"
+    },
+    {
+      "gap": "public_exposure_requires_backend_published_indexable_authority",
+      "status": "not_changed_by_this_pr"
+    }
+  ],
+  "recommended_next_tasks": [
+    "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01",
+    "Human-reviewed English draft package for six deferred editorial article counterparts",
+    "Keep draft/import-only article URLs out of sitemap/llms until backend Article authority is published and indexable"
+  ],
+  "final_decision": "article_counterpart_batch_ready_with_deferred_human_review_assets",
+  "next_task": "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01"
+}

--- a/backend/docs/seo/global-en-zh-article-counterpart-batch-01.md
+++ b/backend/docs/seo/global-en-zh-article-counterpart-batch-01.md
@@ -1,0 +1,64 @@
+# GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01 Article Counterpart Controlled Batch
+
+## Executive Summary
+
+This PR records the controlled article counterpart batch for the remaining full-site EN/ZH parity train. It does not publish articles, mutate production CMS, deploy, submit URLs, or generate substantial English prose.
+
+The batch uses the existing EN-PARITY-04 repo-backed Article baseline as authority. Ten target counterparts are import-ready and require review before exposure; six longer editorial counterparts remain deferred for human-reviewed English drafts.
+
+## Authority Boundary
+
+- Backend Article resources remain authority.
+- `content_baselines/articles` is an import/recovery package, not frontend runtime authority.
+- fap-web hardcoded or fallback article content is not authority.
+- Draft/import-only or missing-counterpart article URLs must not enter sitemap, llms, hreflang, URL Truth, or public runtime.
+
+## Import-Ready Target Counterparts
+
+- `big-five-growth-guide`
+- `big-five-narrative-portrait`
+- `big-five-tool-guide`
+- `eq-test-tool-guide`
+- `iq-test-growth-guide`
+- `iq-test-narrative-portrait`
+- `iq-test-tool-guide`
+- `mbti-basics`
+- `mbti-growth-guide`
+- `mbti-narrative-portrait`
+
+These are not published by this PR.
+
+## Deferred Human-Review Drafts
+
+- `are-infj-men-rare-or-socially-silenced`
+- `best-valentines-date-by-personality-and-relationship-science`
+- `childhood-dream-job-still-shapes-career-choice`
+- `how-16-personality-types-talk-to-an-ai-coach`
+- `how-personality-shapes-attitude-toward-ai`
+- `which-love-script-fits-you-best`
+
+## Validation
+
+```bash
+cd /private/tmp/fap-api-global-en-zh-remaining-train/backend
+php artisan test --filter=GlobalEnZhArticleCounterpartBatch01 --no-ansi
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd /private/tmp/fap-api-global-en-zh-remaining-train
+python3 -m json.tool backend/docs/seo/generated/global-en-zh-article-counterpart-batch-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 - <<'PY'
+import yaml, pathlib
+yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+print('yaml ok')
+PY
+git diff --check
+git diff --cached --check
+```
+
+## Next Task
+
+`GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01`.

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhArticleCounterpartBatch01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhArticleCounterpartBatch01Test.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhArticleCounterpartBatch01Test extends TestCase
+{
+    private const TARGET_COUNTERPARTS = [
+        'big-five-growth-guide',
+        'big-five-narrative-portrait',
+        'big-five-tool-guide',
+        'eq-test-tool-guide',
+        'iq-test-growth-guide',
+        'iq-test-narrative-portrait',
+        'iq-test-tool-guide',
+        'mbti-basics',
+        'mbti-growth-guide',
+        'mbti-narrative-portrait',
+    ];
+
+    private const DEFERRED_COUNTERPARTS = [
+        'are-infj-men-rare-or-socially-silenced',
+        'best-valentines-date-by-personality-and-relationship-science',
+        'childhood-dream-job-still-shapes-career-choice',
+        'how-16-personality-types-talk-to-an-ai-coach',
+        'how-personality-shapes-attitude-toward-ai',
+        'which-love-script-fits-you-best',
+    ];
+
+    #[Test]
+    public function generated_article_batch_records_non_mutating_boundaries(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame('global-en-zh-article-counterpart-batch-01.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01', $payload['task'] ?? null);
+        $this->assertTrue((bool) ($payload['no_mutation_performed'] ?? false));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['auto_publish_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['mass_english_generation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['substantial_english_prose_generated'] ?? true));
+        $this->assertFalse((bool) ($payload['draft_articles_exposed_in_sitemap_llms'] ?? true));
+    }
+
+    #[Test]
+    public function article_batch_keeps_counterpart_and_deferred_lists_explicit(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame(20, $payload['article_summary']['repo_baseline_en_articles'] ?? null);
+        $this->assertSame(25, $payload['article_summary']['repo_baseline_zh_articles'] ?? null);
+        $this->assertSame(10, $payload['article_summary']['en_parity_target_counterparts_ready_for_review'] ?? null);
+        $this->assertSame(6, $payload['article_summary']['deferred_missing_english_counterparts'] ?? null);
+        $this->assertSame(0, $payload['article_summary']['published_by_this_pr'] ?? null);
+        $this->assertSame(0, $payload['article_summary']['sitemap_llms_exposure_added_by_this_pr'] ?? null);
+
+        $ready = collect($payload['import_ready_counterparts'] ?? [])->pluck('source_zh_slug')->all();
+        $this->assertSame(self::TARGET_COUNTERPARTS, $ready);
+        $this->assertSame(self::DEFERRED_COUNTERPARTS, $payload['deferred_missing_english_counterparts'] ?? null);
+
+        foreach ($payload['import_ready_counterparts'] ?? [] as $item) {
+            $this->assertSame('import_ready_review_required', $item['status'] ?? null);
+            $this->assertSame(
+                'only_after_backend_published_indexable_authority',
+                $item['sitemap_llms_exposure_eligible'] ?? null
+            );
+            $this->assertNotEmpty($item['claim_boundary'] ?? null);
+        }
+    }
+
+    #[Test]
+    public function claim_and_exposure_guards_remain_closed(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame([], $payload['forbidden_claim_hits'] ?? null);
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.draft_articles_must_not_enter_sitemap'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.draft_articles_must_not_enter_llms'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.frontend_fallback_must_not_be_article_authority'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.missing_counterparts_must_remain_explicit'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_guard.published_indexable_authority_required_before_public_exposure'));
+        $this->assertNotEmpty($payload['remaining_gaps'] ?? []);
+        $this->assertNotEmpty($payload['recommended_next_tasks'] ?? []);
+        $this->assertSame('article_counterpart_batch_ready_with_deferred_human_review_assets', $payload['final_decision'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01', $payload['next_task'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/seo/generated/global-en-zh-article-counterpart-batch-01.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24867,7 +24867,7 @@
       ]
     },
     "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01": {
-      "status": "planned",
+      "status": "local_validation_passed",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-article-counterpart-batch-01",
       "base": "main",
@@ -24881,12 +24881,60 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "passed",
+          "evidence": "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01 merged as fap-api PR #1683 with merge commit ff9b062d72aa3076289c2f8a2d223e9254d85839."
+        },
+        "scope_boundary": {
+          "status": "passed",
+          "changed_files": [
+            "backend/docs/seo/global-en-zh-article-counterpart-batch-01.md",
+            "backend/docs/seo/generated/global-en-zh-article-counterpart-batch-01.v1.json",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhArticleCounterpartBatch01Test.php",
+            "docs/codex/pr-train-state.json"
+          ],
+          "evidence": "Scope is limited to article counterpart controlled batch report, generated JSON, focused test, and current PR ledger state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No deploy, CMS mutation, Search Channel action, URL submission, production migration, fap-web edit, or article publication performed."
+        },
+        "local_validation": {
+          "status": "passed",
+          "commands": [
+            "php artisan test --filter=GlobalEnZhArticleCounterpartBatch01 --no-ansi",
+            "php artisan route:list --no-ansi",
+            "vendor/bin/pint --test",
+            "composer validate --strict",
+            "composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-en-zh-article-counterpart-batch-01.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 YAML parse docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "All local validation commands passed before staging."
+        },
+        "github_required_checks": {
+          "status": "pending"
+        }
+      },
       "history": [
         {
           "at": "2026-05-25T21:15:38+08:00",
           "status": "planned",
           "summary": "Planned manifest/state entry only; no implementation in current PR."
+        },
+        {
+          "at": "2026-05-25T21:39:34+08:00",
+          "status": "in_progress",
+          "summary": "Started controlled article counterpart batch; no article publishing or prose generation."
+        },
+        {
+          "at": "2026-05-25T21:45:48+08:00",
+          "status": "local_validation_passed",
+          "summary": "Article counterpart batch report, generated JSON, and focused test passed local validation; no publishing or CMS mutation performed."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24867,7 +24867,7 @@
       ]
     },
     "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01": {
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-article-counterpart-batch-01",
       "base": "main",
@@ -24875,8 +24875,8 @@
         "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01"
       ],
       "title": "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01 article counterpart controlled batch",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "15abe18b480a48e3c449ea828ae7d170d16f86b2",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1685",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -24917,7 +24917,8 @@
           "evidence": "All local validation commands passed before staging."
         },
         "github_required_checks": {
-          "status": "pending"
+          "status": "pending",
+          "evidence": "PR #1685 opened; GitHub checks pending."
         }
       },
       "history": [
@@ -24935,6 +24936,11 @@
           "at": "2026-05-25T21:45:48+08:00",
           "status": "local_validation_passed",
           "summary": "Article counterpart batch report, generated JSON, and focused test passed local validation; no publishing or CMS mutation performed."
+        },
+        {
+          "at": "2026-05-25T21:47:06+08:00",
+          "status": "pr_open",
+          "summary": "Opened fap-api PR #1685 for article counterpart controlled batch."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Adds a controlled article counterpart batch report for GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01.
- Adds generated JSON for 10 import-ready, human-review-required English article counterpart candidates and 6 deferred article counterparts.
- Adds a focused SeoIntel test covering non-mutation flags, draft/import exposure guards, explicit counterpart mapping, and claim-boundary markers.
- Updates only the current PR ledger state.

## Why
This converts remaining article parity gaps into an explicit backend-owned review/import baseline without using fap-web fallback as authority and without publishing generated prose.

## Validation
- php artisan test --filter=GlobalEnZhArticleCounterpartBatch01 --no-ansi: passed
- php artisan route:list --no-ansi: passed
- vendor/bin/pint --test: passed
- composer validate --strict: passed
- composer audit --locked --no-interaction --ignore-unreachable: passed
- python3 -m json.tool backend/docs/seo/generated/global-en-zh-article-counterpart-batch-01.v1.json >/dev/null: passed
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null: passed
- YAML parse docs/codex/pr-train.yaml: passed
- git diff --check: passed
- git diff --cached --check: passed

## Safety / authority boundaries
- No CMS mutation.
- No production deploy or migration.
- No Search Channel action or URL submission.
- No fap-web change.
- No article publication.
- No substantial English prose generation.
- Draft/import-only items are not exposed in sitemap or llms.

## Intentionally deferred
- Human review and actual import/publication of article counterparts.
- 6 article counterparts that require human review before import readiness.
- Next train task: GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01.