### PR TITLE
GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01 career guides jobs parity batch

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-career-asset-batch-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-career-asset-batch-01.v1.json
@@ -1,0 +1,156 @@
+{
+  "schema_version": "global-en-zh-career-asset-batch-01.v1",
+  "task": "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01",
+  "scanned_at": "2026-05-25T13:57:14Z",
+  "source_authority": "backend_cms_career_baselines_and_previous_global_scan_artifacts",
+  "frontend_fallback_authority_used": false,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "auto_publish_performed": false,
+  "mass_english_generation_performed": false,
+  "substantial_english_prose_generated": false,
+  "fap_web_modified": false,
+  "draft_or_fallback_career_urls_exposed_in_sitemap_llms": false,
+  "baseline_sources": [
+    "content_baselines/career_guides/career_guides.en.json",
+    "content_baselines/career_guides/career_guides.zh-CN.json",
+    "content_baselines/career_jobs/career_jobs.en.json",
+    "content_baselines/career_jobs/career_jobs.zh-CN.json",
+    "backend/docs/seo/generated/en-parity-05-career-guide-detail-import-package.v1.json",
+    "backend/docs/seo/generated/global-en-zh-parity-scan-00.v1.json"
+  ],
+  "career_guide_inventory": {
+    "entity_family": "career_guides",
+    "counterpart_key": "guide_code",
+    "english_authority_count": 36,
+    "chinese_authority_count": 36,
+    "missing_english_counterparts_count": 0,
+    "missing_chinese_counterparts_count": 0,
+    "publication_state": "repo_backed_import_ready_requires_operator_review",
+    "sitemap_llms_exposure_eligibility": "eligible_only_after_backend_cms_import_and_public_indexable_runtime_verification",
+    "frontend_fallback_can_satisfy_counterpart": false
+  },
+  "career_job_inventory": {
+    "entity_family": "career_jobs",
+    "counterpart_key": "job_code",
+    "english_authority_count": 36,
+    "chinese_authority_count": 342,
+    "shared_job_code_counterparts_count": 0,
+    "missing_english_counterparts_count": 342,
+    "missing_chinese_counterparts_count": 36,
+    "english_baseline_scope": "generic_role_profiles",
+    "chinese_baseline_scope": "docx_bls_occupation_batch",
+    "publication_state": "mismatched_authority_sets_require_translation_group_or_import_review",
+    "sitemap_llms_exposure_eligibility": "excluded_until_authority_and_runtime_eligibility_are_proven",
+    "frontend_fallback_can_satisfy_counterpart": false,
+    "previous_sitemap_exposure_url_count": 87,
+    "previous_404_samples": [
+      "/zh/career/jobs/accountants-and-auditors",
+      "/en/career/jobs/accountants-and-auditors",
+      "/zh/career/jobs/actors",
+      "/zh/career/jobs/actuaries",
+      "/zh/career/jobs/computer-support-specialists"
+    ],
+    "missing_english_sample_job_codes": [
+      "accountants-and-auditors",
+      "actors",
+      "actuaries",
+      "administrative-services-managers",
+      "adult-literacy-and-ged-teachers",
+      "advertising-promotions-and-marketing-managers",
+      "advertising-sales-agents",
+      "aerospace-engineering-and-operations-technicians",
+      "aerospace-engineers",
+      "agricultural-and-food-science-technicians",
+      "agricultural-and-food-scientists",
+      "agricultural-engineers"
+    ],
+    "missing_chinese_sample_job_codes": [
+      "backend-engineer",
+      "brand-manager",
+      "business-analyst",
+      "cloud-architect",
+      "content-strategist",
+      "cybersecurity-analyst",
+      "data-analyst",
+      "data-scientist",
+      "digital-marketing-manager",
+      "event-experience-producer",
+      "field-service-engineer",
+      "financial-planner"
+    ]
+  },
+  "career_recommendation_inventory": {
+    "entity_family": "career_recommendations",
+    "publication_state": "decision_support_runtime_snapshots_only",
+    "sitemap_llms_exposure_eligibility": "no_personalized_or_private_recommendation_pages_in_public_sitemap_llms",
+    "claim_boundary": "snapshot-based decision support; not precise recommendation, hiring fit, success prediction, salary guarantee, or diagnosis"
+  },
+  "exposure_gate": {
+    "career_detail_url_must_have_backend_authority": true,
+    "career_detail_url_must_have_public_indexable_status": true,
+    "career_detail_url_must_have_runtime_200_verification": true,
+    "career_detail_url_must_not_be_frontend_fallback_only": true,
+    "career_detail_url_must_not_be_draft_review_only": true,
+    "career_detail_url_must_not_be_placeholder": true,
+    "career_detail_url_must_not_return_404_or_soft_404": true,
+    "draft_exposure_allowed_in_sitemap_llms": false
+  },
+  "claim_boundary": {
+    "forbidden_terms_absent_from_batch_artifact": true,
+    "forbidden_claims": [
+      "precise career recommendation",
+      "best job for you",
+      "hiring fit",
+      "job suitability guarantee",
+      "career success prediction",
+      "salary guarantee",
+      "MBTI determines career",
+      "RIASEC ranks your best career",
+      "Big Five predicts job performance"
+    ],
+    "allowed_framing": [
+      "occupation information",
+      "workstyle tendency",
+      "interest signal",
+      "exploratory guidance",
+      "decision support",
+      "snapshot-based explanation",
+      "non-diagnostic"
+    ]
+  },
+  "deferred_items": [
+    {
+      "id": "career_job_translation_group_review",
+      "status": "deferred_human_review",
+      "reason": "EN 36 generic role profiles and ZH 342 DOCX/BLS occupation rows do not share job_code keys; counterpart mapping must be explicitly designed before public parity exposure."
+    },
+    {
+      "id": "career_job_runtime_exposure_recheck_after_p0_cleanup",
+      "status": "deferred_verification",
+      "reason": "Previously exposed career job detail URLs returned slow hard 404 samples; job detail URLs must remain excluded from sitemap/llms until authority and runtime 200 eligibility are proven."
+    },
+    {
+      "id": "career_guide_operator_import_and_exposure",
+      "status": "import_ready_requires_operator_review",
+      "reason": "Career guide baseline has complete guide_code parity, but production exposure must use controlled backend/CMS import and public indexability verification."
+    }
+  ],
+  "recommended_next_tasks": [
+    {
+      "id": "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01",
+      "title": "Result report media parity batch",
+      "scope": "Batch remaining result/report and media parity assets without activating draft content."
+    },
+    {
+      "id": "CAREER-JOB-TRANSLATION-GROUP-DESIGN-01",
+      "title": "Design career job EN/ZH translation group mapping",
+      "scope": "Map generic EN roles and ZH BLS occupation rows through backend authority, then decide import/publish batches."
+    }
+  ],
+  "final_decision": "career_asset_batch_ready_with_job_counterpart_mapping_deferred",
+  "next_task": "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01"
+}

--- a/backend/docs/seo/global-en-zh-career-asset-batch-01.md
+++ b/backend/docs/seo/global-en-zh-career-asset-batch-01.md
@@ -1,0 +1,64 @@
+# GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01 Career Guides Jobs Parity Batch
+
+## Executive Summary
+
+This PR lands a backend-owned career asset parity batch report. It does not publish career content, create placeholder job pages, mutate production CMS, deploy, submit URLs, or use fap-web fallback content as authority.
+
+Career guides are repo-backed and import-ready: the baseline has 36 English guide rows and 36 Chinese guide rows with complete `guide_code` parity. Career jobs are not parity-ready: the English baseline has 36 generic role profiles, while the Chinese baseline has 342 DOCX/BLS occupation rows, and the two sets currently share no `job_code` counterpart keys.
+
+## Scope
+
+- Build a generated career asset inventory for career guide, career job, and career recommendation surfaces.
+- Classify career guides as import-ready with operator review required.
+- Classify career job detail parity as deferred until translation group / counterpart mapping is designed.
+- Preserve sitemap/llms exposure safety: no draft, fallback-only, placeholder, 404, or soft-404 career URL should be exposed.
+
+## Authority Findings
+
+### Career Guides
+
+- Entity family: `career_guides`
+- Counterpart key: `guide_code`
+- English authority rows: 36
+- Chinese authority rows: 36
+- Missing English counterparts: 0
+- Missing Chinese counterparts: 0
+- State: repo-backed import-ready, but still requires controlled backend/CMS import and runtime exposure verification.
+
+### Career Jobs
+
+- Entity family: `career_jobs`
+- Counterpart key candidate: `job_code`
+- English authority rows: 36
+- Chinese authority rows: 342
+- Shared `job_code` counterparts: 0
+- Missing English counterpart count against the ZH occupation baseline: 342
+- Missing Chinese counterpart count against the EN generic role baseline: 36
+- State: deferred human review. The current authority sets are different families and must not be merged by slug guessing or frontend fallback.
+
+GLOBAL-EN-ZH-PARITY-SCAN-00 previously found 87 career job detail sitemap URLs and sampled slow hard 404s. This batch keeps job detail URL exposure gated until backend authority and runtime 200 eligibility are proven.
+
+## Career Recommendation Boundary
+
+Career recommendation surfaces remain decision-support snapshots only. This batch does not activate personalized recommendation pages in public sitemap/llms and does not introduce claims about precise recommendation, hiring fit, success prediction, salary guarantee, or diagnosis.
+
+## Deferred Work
+
+- Design explicit career job translation group mapping for the EN generic role profiles and ZH BLS/DOCX occupation rows.
+- Re-check career job sitemap/llms exposure after P0 discoverability cleanup and only expose detail URLs that pass authority and runtime eligibility.
+- Run controlled operator import/exposure verification for career guide details.
+
+## Validation
+
+- `php artisan test --filter=GlobalEnZhCareerAssetBatch01 --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-career-asset-batch-01.v1.json >/dev/null`
+- JSON/YAML parse
+- `git diff --check`
+
+## Next Task
+
+`GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01` should batch remaining result/report and media parity assets without activating draft content.

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhCareerAssetBatch01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhCareerAssetBatch01Test.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhCareerAssetBatch01Test extends TestCase
+{
+    #[Test]
+    public function generated_career_asset_batch_records_non_mutating_boundaries(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame('global-en-zh-career-asset-batch-01.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01', $payload['task'] ?? null);
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['auto_publish_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['mass_english_generation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['substantial_english_prose_generated'] ?? true));
+        $this->assertFalse((bool) ($payload['fap_web_modified'] ?? true));
+    }
+
+    #[Test]
+    public function career_guides_are_import_ready_but_career_jobs_remain_explicitly_deferred(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame(36, data_get($payload, 'career_guide_inventory.english_authority_count'));
+        $this->assertSame(36, data_get($payload, 'career_guide_inventory.chinese_authority_count'));
+        $this->assertSame(0, data_get($payload, 'career_guide_inventory.missing_english_counterparts_count'));
+        $this->assertSame(0, data_get($payload, 'career_guide_inventory.missing_chinese_counterparts_count'));
+        $this->assertSame('guide_code', data_get($payload, 'career_guide_inventory.counterpart_key'));
+
+        $this->assertSame(36, data_get($payload, 'career_job_inventory.english_authority_count'));
+        $this->assertSame(342, data_get($payload, 'career_job_inventory.chinese_authority_count'));
+        $this->assertSame(0, data_get($payload, 'career_job_inventory.shared_job_code_counterparts_count'));
+        $this->assertSame(342, data_get($payload, 'career_job_inventory.missing_english_counterparts_count'));
+        $this->assertSame(36, data_get($payload, 'career_job_inventory.missing_chinese_counterparts_count'));
+        $this->assertSame(
+            'mismatched_authority_sets_require_translation_group_or_import_review',
+            data_get($payload, 'career_job_inventory.publication_state'),
+        );
+    }
+
+    #[Test]
+    public function exposure_and_claim_gates_remain_closed_for_draft_fallback_or_overclaim_career_urls(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertFalse((bool) ($payload['draft_or_fallback_career_urls_exposed_in_sitemap_llms'] ?? true));
+        $this->assertTrue((bool) data_get($payload, 'exposure_gate.career_detail_url_must_have_backend_authority'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_gate.career_detail_url_must_have_runtime_200_verification'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_gate.career_detail_url_must_not_be_frontend_fallback_only'));
+        $this->assertTrue((bool) data_get($payload, 'exposure_gate.career_detail_url_must_not_return_404_or_soft_404'));
+        $this->assertFalse((bool) data_get($payload, 'exposure_gate.draft_exposure_allowed_in_sitemap_llms'));
+
+        $this->assertTrue((bool) data_get($payload, 'claim_boundary.forbidden_terms_absent_from_batch_artifact'));
+        $this->assertContains('precise career recommendation', data_get($payload, 'claim_boundary.forbidden_claims'));
+        $this->assertContains('decision support', data_get($payload, 'claim_boundary.allowed_framing'));
+        $this->assertSame(
+            'GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01',
+            $payload['next_task'] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/seo/generated/global-en-zh-career-asset-batch-01.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24867,7 +24867,7 @@
       ]
     },
     "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01": {
-      "status": "pr_open",
+      "status": "merged",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-article-counterpart-batch-01",
       "base": "main",
@@ -24875,12 +24875,12 @@
         "GLOBAL-EN-ZH-PARITY-CONTENT-ASSET-BATCH-01"
       ],
       "title": "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01 article counterpart controlled batch",
-      "commit_sha": "15abe18b480a48e3c449ea828ae7d170d16f86b2",
+      "commit_sha": "630ed5b3a5318d77219d36170f4c382609c9f7e5",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1685",
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T13:54:04Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "checks": {
         "dependency": {
           "status": "passed",
@@ -24917,8 +24917,8 @@
           "evidence": "All local validation commands passed before staging."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR #1685 opened; GitHub checks pending."
+          "status": "passed",
+          "evidence": "GitHub PR #1685 merged with all required checks green and mergeStateStatus CLEAN."
         }
       },
       "history": [
@@ -24941,11 +24941,17 @@
           "at": "2026-05-25T21:47:06+08:00",
           "status": "pr_open",
           "summary": "Opened fap-api PR #1685 for article counterpart controlled batch."
+        },
+        {
+          "at": "2026-05-25T21:58:51+08:00",
+          "status": "merged",
+          "summary": "Reconciled PR #1685 merged state while starting career asset batch PR."
         }
-      ]
+      ],
+      "merge_commit": "0ad3827b7e8771a0de84253854e7cbbe55fcc636"
     },
     "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01": {
-      "status": "planned",
+      "status": "local_validation_passed",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-career-asset-batch-01",
       "base": "main",
@@ -24959,12 +24965,60 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "passed",
+          "evidence": "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01 merged as PR #1685 with merge commit 0ad3827b7e8771a0de84253854e7cbbe55fcc636."
+        },
+        "scope_boundary": {
+          "status": "passed",
+          "changed_files": [
+            "backend/docs/seo/global-en-zh-career-asset-batch-01.md",
+            "backend/docs/seo/generated/global-en-zh-career-asset-batch-01.v1.json",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhCareerAssetBatch01Test.php",
+            "docs/codex/pr-train-state.json"
+          ],
+          "evidence": "Scope is limited to career asset batch report, generated JSON, focused test, and current/reconciled ledger state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No deploy, CMS mutation, Search Channel action, URL submission, production migration, fap-web edit, placeholder career pages, or career publication performed."
+        },
+        "local_validation": {
+          "status": "passed",
+          "commands": [
+            "php artisan test --filter=GlobalEnZhCareerAssetBatch01 --no-ansi",
+            "php artisan route:list --no-ansi",
+            "vendor/bin/pint --test",
+            "composer validate --strict",
+            "composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-en-zh-career-asset-batch-01.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 YAML parse docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "All local validation commands passed before staging."
+        },
+        "github_required_checks": {
+          "status": "pending"
+        }
+      },
       "history": [
         {
           "at": "2026-05-25T21:15:38+08:00",
           "status": "planned",
           "summary": "Planned manifest/state entry only; no implementation in current PR."
+        },
+        {
+          "at": "2026-05-25T21:58:51+08:00",
+          "status": "in_progress",
+          "summary": "Started career guide/job parity batch report and gate; no career content publication or placeholder page creation."
+        },
+        {
+          "at": "2026-05-25T21:59:49+08:00",
+          "status": "local_validation_passed",
+          "summary": "Career asset batch report, generated JSON, and focused test passed local validation; career job counterpart mapping remains deferred."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24951,7 +24951,7 @@
       "merge_commit": "0ad3827b7e8771a0de84253854e7cbbe55fcc636"
     },
     "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01": {
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-career-asset-batch-01",
       "base": "main",
@@ -24959,8 +24959,8 @@
         "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01"
       ],
       "title": "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01 career guides jobs parity batch",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "796fd1523b566a30dbd769e6a2d46b93e6df0e5b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1686",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -25001,7 +25001,8 @@
           "evidence": "All local validation commands passed before staging."
         },
         "github_required_checks": {
-          "status": "pending"
+          "status": "pending",
+          "evidence": "PR #1686 opened; GitHub checks pending."
         }
       },
       "history": [
@@ -25019,6 +25020,11 @@
           "at": "2026-05-25T21:59:49+08:00",
           "status": "local_validation_passed",
           "summary": "Career asset batch report, generated JSON, and focused test passed local validation; career job counterpart mapping remains deferred."
+        },
+        {
+          "at": "2026-05-25T22:01:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened fap-api PR #1686 for career guides/jobs parity batch."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Adds a backend-owned career asset parity batch report and generated JSON.
- Adds a focused SeoIntel test for career guide parity, career job mismatch/deferred state, exposure gates, and claim boundaries.
- Reconciles the previous article batch PR #1685 as merged in the ledger while starting this current PR.

## Why
Career guides are repo-backed and import-ready with complete guide_code parity, but career jobs are not parity-ready: EN has 36 generic role profiles while ZH has 342 DOCX/BLS occupation rows and no shared job_code counterparts. This PR makes that explicit without creating placeholder pages or using fap-web fallback as authority.

## Validation
- php artisan test --filter=GlobalEnZhCareerAssetBatch01 --no-ansi: passed
- php artisan route:list --no-ansi: passed
- vendor/bin/pint --test: passed
- composer validate --strict: passed
- composer audit --locked --no-interaction --ignore-unreachable: passed
- python3 -m json.tool backend/docs/seo/generated/global-en-zh-career-asset-batch-01.v1.json >/dev/null: passed
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null: passed
- YAML parse docs/codex/pr-train.yaml: passed
- git diff --check: passed
- git diff --cached --check: passed

## Safety / authority boundaries
- No CMS mutation.
- No production deploy or migration.
- No Search Channel action or URL submission.
- No fap-web change.
- No career page publication or placeholder page creation.
- No frontend fallback authority.
- No precise career recommendation, hiring fit, success prediction, salary guarantee, or diagnostic claim.

## Intentionally deferred
- Career job EN/ZH translation group design for EN generic role profiles vs ZH BLS occupation rows.
- Runtime exposure re-check after P0 sitemap/llms cleanup.
- Controlled operator import/exposure verification for career guide details.
- Next train task: GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01.