### PR TITLE
GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01 result report media parity batch

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-result-media-asset-batch-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-result-media-asset-batch-01.v1.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": "global-en-zh-result-media-asset-batch-01.v1",
+  "task": "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01",
+  "scanned_at": "2026-05-25T14:11:03Z",
+  "source_authority": "backend_result_asset_catalogs_and_media_parity_artifacts",
+  "frontend_fallback_authority_used": false,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "auto_publish_performed": false,
+  "mass_report_prose_generated": false,
+  "substantial_english_prose_generated": false,
+  "fap_web_modified": false,
+  "zh_fallback_relaxed": false,
+  "draft_assets_runtime_activated": false,
+  "production_user_data_accessed": false,
+  "baseline_sources": [
+    "backend/docs/seo/generated/result-en-parity-00-assessment-result-content-inventory.v1.json",
+    "backend/docs/seo/generated/result-en-parity-01-asset-catalog-gate.v1.json",
+    "backend/docs/seo/generated/result-en-parity-02-riasec-en-assets.v1.json",
+    "backend/docs/seo/generated/result-en-parity-03-iq-locale-safe-labels.v1.json",
+    "backend/docs/seo/generated/result-en-parity-04-clinical-combo-en-paid.v1.json",
+    "backend/docs/seo/generated/result-en-parity-05-mbti-content-export.v1.json",
+    "backend/docs/seo/generated/result-en-parity-06-bigfive-v2-en-assets.v1.json",
+    "backend/docs/seo/generated/en-parity-06-media-assets-parity-inventory.v1.json"
+  ],
+  "result_report_asset_state": {
+    "asset_catalog_gate": {
+      "family_count": 8,
+      "asset_count": 47,
+      "original_missing_en_count": 32,
+      "fail_closed_count": 32
+    },
+    "riasec": {
+      "production_active_en_assets": 0,
+      "draft_review_only_assets": 5,
+      "deferred_human_review_assets": 14,
+      "fail_closed_no_zh_fallback": true,
+      "claim_boundary": "interest signal and exploratory guidance only; not a career recommendation"
+    },
+    "iq": {
+      "locale_safe_label_keys_fixed": true,
+      "claim_boundary": "online estimate and confidence-bound result only; not clinical diagnosis"
+    },
+    "clinical_combo": {
+      "paid_block_en_assets_fixed": true,
+      "claim_boundary": "self-assessment guidance only; not diagnosis, treatment, cure, or emergency protocol"
+    },
+    "mbti": {
+      "missing_en_asset_keys_count": 8,
+      "deferred_assets_count": 6,
+      "fail_closed_no_zh_fallback": true,
+      "frontend_clone_content_is_authority": false,
+      "claim_boundary": "workstyle tendency and exploratory career direction reference only"
+    },
+    "bigfive_v2": {
+      "remaining_missing_en_asset_keys_count": 0,
+      "remaining_unreviewed_en_asset_keys_count": 7,
+      "draft_review_only": true,
+      "fail_closed_no_zh_fallback": true,
+      "claim_boundary": "trait-vector workstyle explanation only"
+    }
+  },
+  "media_asset_state": {
+    "media_library_assets_count": 3,
+    "media_library_assets_with_alt_count": 3,
+    "media_library_assets_with_caption_count": 3,
+    "article_en_missing_cover_alt_count": 0,
+    "article_en_alt_contains_chinese_count": 0,
+    "article_shared_cover_pair_count": 19,
+    "career_guides_missing_og_image_count": 72,
+    "sidecar_media_review_count": 3,
+    "visual_ocr_performed": false,
+    "media_upload_performed": false,
+    "image_generation_performed": false
+  },
+  "deferred_human_review_assets": [
+    {
+      "family": "riasec",
+      "count": 14,
+      "status": "deferred_human_review",
+      "reason": "Deep RIASEC interpretation, examples, near-tie, and action-lab copy require reviewed English content before runtime activation."
+    },
+    {
+      "family": "mbti",
+      "count": 8,
+      "status": "deferred_human_review",
+      "reason": "MBTI external package, generated fallback replacement, share, PDF, email, and My Results summaries require reviewed backend-owned English package."
+    },
+    {
+      "family": "bigfive_v2",
+      "count": 7,
+      "status": "draft_review_only",
+      "reason": "Big Five V2 English route-row, coupling, scenario, facet, profile, body, and selector assets remain review-only."
+    },
+    {
+      "family": "media",
+      "count": 3,
+      "status": "deferred_human_review",
+      "reason": "Shared article covers, career guide social images, and MBTI default share visual require OCR or human design review."
+    }
+  ],
+  "fail_closed_controls": {
+    "no_zh_fallback_relaxation": true,
+    "frontend_clone_content_not_authority": true,
+    "draft_assets_not_runtime_active": true,
+    "private_result_report_data_not_accessed": true,
+    "public_sitemap_llms_not_modified": true
+  },
+  "claim_boundary": {
+    "forbidden_terms_absent_from_batch_artifact": true,
+    "forbidden_claims": [
+      "precise career recommendation",
+      "best career for you",
+      "hiring fit",
+      "career success prediction",
+      "salary prediction",
+      "turnover prediction",
+      "clinical diagnosis",
+      "treatment",
+      "cure"
+    ],
+    "allowed_framing": [
+      "interest signal",
+      "workstyle tendency",
+      "trait tendency",
+      "exploratory guidance",
+      "snapshot-based support",
+      "self-assessment guidance",
+      "non-diagnostic"
+    ]
+  },
+  "recommended_next_tasks": [
+    {
+      "id": "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01",
+      "title": "Full site parity verification",
+      "scope": "Verify remaining P0/P1/P2 state after controlled batch artifacts; do not mutate production."
+    },
+    {
+      "id": "RESULT-ASSET-HUMAN-REVIEW-BATCH-01",
+      "title": "Human-review result/report English assets",
+      "scope": "Review and import selected RIASEC, MBTI, and Big Five English assets through backend authority gates."
+    }
+  ],
+  "final_decision": "result_media_asset_batch_landed_with_deferred_human_review_assets",
+  "next_task": "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01"
+}

--- a/backend/docs/seo/global-en-zh-result-media-asset-batch-01.md
+++ b/backend/docs/seo/global-en-zh-result-media-asset-batch-01.md
@@ -1,0 +1,52 @@
+# GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01 Result Report Media Parity Batch
+
+## Executive Summary
+
+This PR aggregates remaining RESULT-EN-PARITY and media parity gaps into a controlled backend-owned batch report. It does not activate draft assets, relax fail-closed no-ZH-fallback behavior, access production user data, mutate CMS, deploy, submit URLs, edit fap-web, upload media, or generate report prose.
+
+## Result / Report Asset State
+
+- RESULT asset catalog gate covered 8 families and 47 assets. The original gate recorded 32 missing English assets and fail-closed coverage for 32 missing items.
+- RIASEC has 5 prepared English draft authority candidates and 14 deeper assets deferred for human review.
+- IQ label work is locale-safe and bounded to online estimates / confidence-bound labels, not clinical diagnosis.
+- Clinical Combo paid blocks have English coverage under self-assessment / non-medical boundaries.
+- MBTI still records 8 missing English asset keys and 6 deferred assets for backend-owned package, share, PDF, email, and My Results summaries.
+- Big Five V2 has no remaining missing English asset keys, but 7 English asset groups remain review-only before runtime release.
+
+## Media Asset State
+
+- Media library inventory: 3 assets, all with alt and caption metadata.
+- Article English cover alt: 0 missing; English alt metadata does not contain Chinese text.
+- Shared article cover pairs: 19 require OCR or human visual text review.
+- Career guide OG/social images: 72 missing authority-backed image references across EN/ZH rows.
+- Media sidecars: 3, covering shared article covers, career guide social images, and MBTI default share visual review.
+
+## Fail-Closed Controls
+
+- No ZH fallback relaxation.
+- Frontend clone content remains non-authority.
+- Draft assets are not runtime-active.
+- No private result/report user data was accessed.
+- Sitemap/llms were not modified by this PR.
+
+## Deferred Human Review
+
+- RIASEC deep interpretation and action assets.
+- MBTI backend English package / share / PDF / email / My Results assets.
+- Big Five V2 route-row, coupling, scenario, facet, profile, core body, and selector-ready assets.
+- Shared cover OCR/human review and career guide OG image package.
+
+## Validation
+
+- `php artisan test --filter=GlobalEnZhResultMediaAssetBatch01 --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-result-media-asset-batch-01.v1.json >/dev/null`
+- JSON/YAML parse
+- `git diff --check`
+
+## Next Task
+
+`GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01` should re-run final bounded parity verification and provide a clear GO/NO-GO without production mutation.

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhResultMediaAssetBatch01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhResultMediaAssetBatch01Test.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhResultMediaAssetBatch01Test extends TestCase
+{
+    #[Test]
+    public function generated_result_media_batch_records_non_mutating_boundaries(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame('global-en-zh-result-media-asset-batch-01.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01', $payload['task'] ?? null);
+        $this->assertFalse((bool) ($payload['frontend_fallback_authority_used'] ?? true));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['auto_publish_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['mass_report_prose_generated'] ?? true));
+        $this->assertFalse((bool) ($payload['substantial_english_prose_generated'] ?? true));
+        $this->assertFalse((bool) ($payload['fap_web_modified'] ?? true));
+        $this->assertFalse((bool) ($payload['production_user_data_accessed'] ?? true));
+    }
+
+    #[Test]
+    public function result_and_media_gaps_remain_explicit_without_runtime_activation(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame(14, data_get($payload, 'result_report_asset_state.riasec.deferred_human_review_assets'));
+        $this->assertSame(8, data_get($payload, 'result_report_asset_state.mbti.missing_en_asset_keys_count'));
+        $this->assertSame(6, data_get($payload, 'result_report_asset_state.mbti.deferred_assets_count'));
+        $this->assertSame(0, data_get($payload, 'result_report_asset_state.bigfive_v2.remaining_missing_en_asset_keys_count'));
+        $this->assertSame(7, data_get($payload, 'result_report_asset_state.bigfive_v2.remaining_unreviewed_en_asset_keys_count'));
+
+        $this->assertSame(3, data_get($payload, 'media_asset_state.media_library_assets_count'));
+        $this->assertSame(0, data_get($payload, 'media_asset_state.article_en_missing_cover_alt_count'));
+        $this->assertSame(19, data_get($payload, 'media_asset_state.article_shared_cover_pair_count'));
+        $this->assertSame(72, data_get($payload, 'media_asset_state.career_guides_missing_og_image_count'));
+        $this->assertSame(3, data_get($payload, 'media_asset_state.sidecar_media_review_count'));
+    }
+
+    #[Test]
+    public function fail_closed_and_claim_boundaries_remain_enforced(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertFalse((bool) ($payload['zh_fallback_relaxed'] ?? true));
+        $this->assertFalse((bool) ($payload['draft_assets_runtime_activated'] ?? true));
+        $this->assertTrue((bool) data_get($payload, 'fail_closed_controls.no_zh_fallback_relaxation'));
+        $this->assertTrue((bool) data_get($payload, 'fail_closed_controls.frontend_clone_content_not_authority'));
+        $this->assertTrue((bool) data_get($payload, 'fail_closed_controls.draft_assets_not_runtime_active'));
+        $this->assertTrue((bool) data_get($payload, 'claim_boundary.forbidden_terms_absent_from_batch_artifact'));
+        $this->assertContains('clinical diagnosis', data_get($payload, 'claim_boundary.forbidden_claims'));
+        $this->assertContains('non-diagnostic', data_get($payload, 'claim_boundary.allowed_framing'));
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01', $payload['next_task'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/seo/generated/global-en-zh-result-media-asset-batch-01.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -25035,7 +25035,7 @@
       "merge_commit": "e54c5eec171e302fa635aae8bdcafa8497263568"
     },
     "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01": {
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-result-media-asset-batch-01",
       "base": "main",
@@ -25043,8 +25043,8 @@
         "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01"
       ],
       "title": "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01 result report media parity batch",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "333381d0154dfcd166f201a9b00cf154631a6287",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1687",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -25085,7 +25085,8 @@
           "evidence": "All local validation commands passed before staging."
         },
         "github_required_checks": {
-          "status": "pending"
+          "status": "pending",
+          "evidence": "PR #1687 opened; GitHub checks pending."
         }
       },
       "history": [
@@ -25103,6 +25104,11 @@
           "at": "2026-05-25T22:13:33+08:00",
           "status": "local_validation_passed",
           "summary": "Result/media asset batch report, generated JSON, and focused test passed local validation; draft assets remain inactive."
+        },
+        {
+          "at": "2026-05-25T22:14:33+08:00",
+          "status": "pr_open",
+          "summary": "Opened fap-api PR #1687 for result/report and media parity batch."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24951,7 +24951,7 @@
       "merge_commit": "0ad3827b7e8771a0de84253854e7cbbe55fcc636"
     },
     "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01": {
-      "status": "pr_open",
+      "status": "merged",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-career-asset-batch-01",
       "base": "main",
@@ -24959,12 +24959,12 @@
         "GLOBAL-EN-ZH-PARITY-ARTICLE-COUNTERPART-BATCH-01"
       ],
       "title": "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01 career guides jobs parity batch",
-      "commit_sha": "796fd1523b566a30dbd769e6a2d46b93e6df0e5b",
+      "commit_sha": "0ffc2325d50da63387ca8ea827047dd703b2ccb8",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1686",
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T14:08:12Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "checks": {
         "dependency": {
           "status": "passed",
@@ -25001,8 +25001,8 @@
           "evidence": "All local validation commands passed before staging."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR #1686 opened; GitHub checks pending."
+          "status": "passed",
+          "evidence": "GitHub PR #1686 merged with all required checks green and mergeStateStatus CLEAN."
         }
       },
       "history": [
@@ -25025,11 +25025,17 @@
           "at": "2026-05-25T22:01:00+08:00",
           "status": "pr_open",
           "summary": "Opened fap-api PR #1686 for career guides/jobs parity batch."
+        },
+        {
+          "at": "2026-05-25T22:12:28+08:00",
+          "status": "merged",
+          "summary": "Reconciled PR #1686 merged state while starting result/media asset batch PR."
         }
-      ]
+      ],
+      "merge_commit": "e54c5eec171e302fa635aae8bdcafa8497263568"
     },
     "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01": {
-      "status": "planned",
+      "status": "local_validation_passed",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-result-media-asset-batch-01",
       "base": "main",
@@ -25043,12 +25049,60 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "passed",
+          "evidence": "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01 merged as PR #1686 with merge commit e54c5eec171e302fa635aae8bdcafa8497263568."
+        },
+        "scope_boundary": {
+          "status": "passed",
+          "changed_files": [
+            "backend/docs/seo/global-en-zh-result-media-asset-batch-01.md",
+            "backend/docs/seo/generated/global-en-zh-result-media-asset-batch-01.v1.json",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhResultMediaAssetBatch01Test.php",
+            "docs/codex/pr-train-state.json"
+          ],
+          "evidence": "Scope is limited to result/media batch report, generated JSON, focused test, and current/reconciled ledger state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No deploy, CMS mutation, Search Channel action, URL submission, production migration, fap-web edit, private result data access, draft activation, or report prose generation performed."
+        },
+        "local_validation": {
+          "status": "passed",
+          "commands": [
+            "php artisan test --filter=GlobalEnZhResultMediaAssetBatch01 --no-ansi",
+            "php artisan route:list --no-ansi",
+            "vendor/bin/pint --test",
+            "composer validate --strict",
+            "composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-en-zh-result-media-asset-batch-01.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 YAML parse docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "All local validation commands passed before staging."
+        },
+        "github_required_checks": {
+          "status": "pending"
+        }
+      },
       "history": [
         {
           "at": "2026-05-25T21:15:38+08:00",
           "status": "planned",
           "summary": "Planned manifest/state entry only; no implementation in current PR."
+        },
+        {
+          "at": "2026-05-25T22:12:28+08:00",
+          "status": "in_progress",
+          "summary": "Started result/report and media parity batch report; no draft asset activation or zh fallback relaxation."
+        },
+        {
+          "at": "2026-05-25T22:13:33+08:00",
+          "status": "local_validation_passed",
+          "summary": "Result/media asset batch report, generated JSON, and focused test passed local validation; draft assets remain inactive."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Adds a controlled result/report and media parity batch report and generated JSON.
- Adds a focused SeoIntel test for non-mutation boundaries, explicit deferred result/media gaps, fail-closed controls, and claim boundaries.
- Reconciles the previous career batch PR #1686 as merged in the ledger while starting this current PR.

## Why
RESULT-EN-PARITY and media parity artifacts still have deferred review-only assets. This PR batches those gaps without activating drafts, relaxing no-ZH-fallback behavior, or using frontend clone/fallback content as authority.

## Validation
- php artisan test --filter=GlobalEnZhResultMediaAssetBatch01 --no-ansi: passed
- php artisan route:list --no-ansi: passed
- vendor/bin/pint --test: passed
- composer validate --strict: passed
- composer audit --locked --no-interaction --ignore-unreachable: passed
- python3 -m json.tool backend/docs/seo/generated/global-en-zh-result-media-asset-batch-01.v1.json >/dev/null: passed
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null: passed
- YAML parse docs/codex/pr-train.yaml: passed
- git diff --check: passed
- git diff --cached --check: passed

## Safety / authority boundaries
- No CMS mutation.
- No production deploy or migration.
- No Search Channel action or URL submission.
- No fap-web change.
- No production user data access.
- No draft asset runtime activation.
- No zh fallback relaxation.
- No mass report prose generation.
- No clinical/career overclaim expansion.

## Intentionally deferred
- RIASEC deep interpretation/action assets human review.
- MBTI backend English package/share/PDF/email/My Results assets.
- Big Five V2 review-only English asset groups.
- Shared cover OCR/human review and career guide OG image package.
- Next train task: GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01.