### PR TITLE
GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01 full site parity verification

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-final-verify-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-final-verify-01.v1.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "global-en-zh-final-verify-01.v1",
+  "task": "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01",
+  "scanned_at": "2026-05-25T14:22:56Z",
+  "verification_mode": "repo_artifact_and_scope_verification_no_production_mutation",
+  "no_mutation_performed": true,
+  "cms_mutation_performed": false,
+  "production_migration_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "production_user_data_accessed": false,
+  "fap_web_modified": false,
+  "source_artifacts": [
+    "global-en-zh-parity-scan-00.v1.json",
+    "global-en-zh-content-asset-batch-01.v1.json",
+    "global-en-zh-article-counterpart-batch-01.v1.json",
+    "global-en-zh-career-asset-batch-01.v1.json",
+    "global-en-zh-result-media-asset-batch-01.v1.json",
+    "en-parity-06-media-assets-parity-inventory.v1.json"
+  ],
+  "p0_findings_remaining": [],
+  "p1_findings_remaining": [
+    {
+      "id": "p1_content_help_policy_review_import_remaining",
+      "summary": "Content/help/policy pages still include draft-review-only or deferred items that require controlled import/human review before full production parity.",
+      "state": "explicitly_classified"
+    },
+    {
+      "id": "p1_article_human_review_remaining",
+      "summary": "Article parity has 10 import-ready review-required candidates and 6 deferred article counterparts; not auto-published.",
+      "state": "explicitly_classified"
+    },
+    {
+      "id": "p1_career_job_translation_group_remaining",
+      "summary": "Career jobs have EN 36 generic role profiles and ZH 342 BLS/DOCX occupation rows with no shared job_code counterparts; translation group design is deferred.",
+      "state": "explicitly_classified"
+    },
+    {
+      "id": "p1_result_report_review_assets_remaining",
+      "summary": "RIASEC, MBTI, and Big Five V2 result/report assets still include deferred or draft-review-only English assets.",
+      "state": "explicitly_classified"
+    },
+    {
+      "id": "p1_media_visual_review_remaining",
+      "summary": "Shared article covers, career guide OG images, and MBTI share visuals require OCR/human visual review before claiming media parity complete.",
+      "state": "explicitly_classified"
+    }
+  ],
+  "p2_findings_remaining": [
+    {
+      "id": "p2_post_deploy_runtime_visual_longtail",
+      "summary": "A post-deploy long-tail Chrome/Playwright pass is still recommended for lower-priority article/career/content page rhythm."
+    }
+  ],
+  "sitemap_llms_clean": {
+    "repo_gate_state": "p0_invalid_exposure_cleaned_or_gated_by_prior_train",
+    "production_post_deploy_smoke_required": true,
+    "private_or_draft_exposure_detected_in_current_batch": false
+  },
+  "footer_nav_parity_state": {
+    "state": "implemented_in_fap_web_pr_904",
+    "remaining": "post_deploy_visual_spot_check_only"
+  },
+  "content_asset_state": {
+    "import_ready_or_draft_package_landed": true,
+    "auto_publish_performed": false,
+    "remaining_human_review": true
+  },
+  "article_asset_state": {
+    "import_ready_review_required_count": 10,
+    "deferred_human_review_count": 6,
+    "auto_publish_performed": false
+  },
+  "career_asset_state": {
+    "career_guides_guide_code_parity": true,
+    "career_job_shared_counterparts_count": 0,
+    "career_job_translation_group_deferred": true,
+    "placeholder_pages_created": false
+  },
+  "result_report_asset_state": {
+    "fail_closed_no_zh_fallback_preserved": true,
+    "draft_assets_runtime_activated": false,
+    "riasec_deferred_assets": 14,
+    "mbti_missing_en_asset_keys": 8,
+    "bigfive_unreviewed_en_asset_keys": 7
+  },
+  "media_asset_state": {
+    "article_en_missing_cover_alt_count": 0,
+    "career_guides_missing_og_image_count": 72,
+    "sidecar_media_review_count": 3,
+    "visual_ocr_or_human_review_required": true
+  },
+  "claim_boundary_state": {
+    "unsafe_claim_hits_in_current_batch": 0,
+    "forbidden_claims_blocked": true,
+    "career_recommendation_boundary_preserved": true,
+    "clinical_diagnostic_boundary_preserved": true
+  },
+  "visual_parity_state": {
+    "core_h1_overflow_fix_deployed_previously": true,
+    "longtail_visual_scan_required_after_next_deploy": true
+  },
+  "deployment_requirement": {
+    "deploy_required_for_runtime_effects": true,
+    "reason": "This train added repo-backed reports/tests and relies on prior discoverability/code fixes; production runtime parity must be re-smoked after deployment."
+  },
+  "final_go_no_go": "NO_GO_for_claiming_full_english_chinese_parity_until_human_review_imports_and_post_deploy_smoke_complete",
+  "recommended_next_tasks": [
+    {
+      "id": "DEPLOY-READINESS",
+      "title": "Deploy GLOBAL EN/ZH remaining parity fixes",
+      "scope": "Prepare deployment and run post-deploy sitemap/llms/runtime smoke."
+    },
+    {
+      "id": "GLOBAL-EN-ZH-HUMAN-REVIEW-IMPORT-BATCH-01",
+      "title": "Human-reviewed import batch for remaining content/article/result/media assets",
+      "scope": "Import reviewed assets through backend authority without frontend fallback."
+    }
+  ],
+  "final_decision": "global_en_zh_remaining_train_completed_with_deferred_human_review_assets",
+  "next_task": "DEPLOY-READINESS｜Deploy GLOBAL EN/ZH remaining parity fixes"
+}

--- a/backend/docs/seo/global-en-zh-final-verify-01.md
+++ b/backend/docs/seo/global-en-zh-final-verify-01.md
@@ -1,0 +1,43 @@
+# GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01 Full Site Parity Verification
+
+## Executive Summary
+
+This final verification records the remaining EN/ZH parity state after the remaining parity train. It performs no production mutation, CMS mutation, deploy, URL submission, Search Channel action, fap-web edit, or production user data access.
+
+The result is **NO-GO for claiming full English/Chinese parity**. P0 discoverability exposure has been handled by the prior P0 train and current reports keep draft/fallback/private exposure closed, but multiple P1 human-review/import assets remain.
+
+## Current State
+
+- Footer/nav parity: implemented in fap-web PR #904; post-deploy visual spot check remains.
+- Content/help/policy: import/draft package landed; human-review/import remains for draft/deferred items.
+- Articles: 10 import-ready review-required candidates and 6 deferred counterparts; no auto-publish.
+- Career: career guides have 36/36 guide-code parity; career jobs require translation group design because EN 36 generic role profiles and ZH 342 BLS/DOCX occupation rows share no `job_code` counterparts.
+- Result/report: fail-closed no-ZH-fallback remains; RIASEC, MBTI, and Big Five V2 still have deferred/review-only assets.
+- Media: alt metadata is present for current English article covers, but shared cover OCR/human review and career guide OG image work remain.
+
+## P0 / P1 / P2
+
+- P0 remaining: none recorded in current repo artifacts.
+- P1 remaining: content import review, article human review, career job mapping, result/report review assets, media visual review.
+- P2 remaining: long-tail post-deploy visual/rhythm scan.
+
+## GO / NO-GO
+
+Final GO/NO-GO: `NO_GO_for_claiming_full_english_chinese_parity_until_human_review_imports_and_post_deploy_smoke_complete`.
+
+The code/report train is ready for deploy readiness, but the product claim “English site fully aligned with Chinese site” should not be made until reviewed content/result/media imports and post-deploy smoke complete.
+
+## Validation
+
+- `php artisan test --filter=GlobalEnZhFinalVerify01 --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-final-verify-01.v1.json >/dev/null`
+- JSON/YAML parse
+- `git diff --check`
+
+## Next Task
+
+`DEPLOY-READINESS｜Deploy GLOBAL EN/ZH remaining parity fixes`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhFinalVerify01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhFinalVerify01Test.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhFinalVerify01Test extends TestCase
+{
+    #[Test]
+    public function final_verify_report_records_non_mutating_boundaries(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame('global-en-zh-final-verify-01.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01', $payload['task'] ?? null);
+        $this->assertTrue((bool) ($payload['no_mutation_performed'] ?? false));
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_migration_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['url_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['production_user_data_accessed'] ?? true));
+        $this->assertFalse((bool) ($payload['fap_web_modified'] ?? true));
+    }
+
+    #[Test]
+    public function final_verify_keeps_remaining_gaps_explicit(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertIsArray($payload['p0_findings_remaining'] ?? null);
+        $this->assertSame([], $payload['p0_findings_remaining']);
+        $this->assertGreaterThanOrEqual(5, count($payload['p1_findings_remaining'] ?? []));
+        $this->assertGreaterThanOrEqual(1, count($payload['p2_findings_remaining'] ?? []));
+        $this->assertTrue((bool) data_get($payload, 'content_asset_state.remaining_human_review'));
+        $this->assertSame(10, data_get($payload, 'article_asset_state.import_ready_review_required_count'));
+        $this->assertSame(6, data_get($payload, 'article_asset_state.deferred_human_review_count'));
+        $this->assertTrue((bool) data_get($payload, 'career_asset_state.career_job_translation_group_deferred'));
+        $this->assertSame(72, data_get($payload, 'media_asset_state.career_guides_missing_og_image_count'));
+    }
+
+    #[Test]
+    public function final_verify_sets_no_go_until_review_import_and_smoke_complete(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertTrue((bool) data_get($payload, 'result_report_asset_state.fail_closed_no_zh_fallback_preserved'));
+        $this->assertFalse((bool) data_get($payload, 'result_report_asset_state.draft_assets_runtime_activated'));
+        $this->assertTrue((bool) data_get($payload, 'deployment_requirement.deploy_required_for_runtime_effects'));
+        $this->assertSame(
+            'NO_GO_for_claiming_full_english_chinese_parity_until_human_review_imports_and_post_deploy_smoke_complete',
+            $payload['final_go_no_go'] ?? null,
+        );
+        $this->assertSame(
+            'global_en_zh_remaining_train_completed_with_deferred_human_review_assets',
+            $payload['final_decision'] ?? null,
+        );
+        $this->assertSame('DEPLOY-READINESS｜Deploy GLOBAL EN/ZH remaining parity fixes', $payload['next_task'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/seo/generated/global-en-zh-final-verify-01.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -25035,7 +25035,7 @@
       "merge_commit": "e54c5eec171e302fa635aae8bdcafa8497263568"
     },
     "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01": {
-      "status": "pr_open",
+      "status": "merged",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-result-media-asset-batch-01",
       "base": "main",
@@ -25043,12 +25043,12 @@
         "GLOBAL-EN-ZH-PARITY-CAREER-ASSET-BATCH-01"
       ],
       "title": "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01 result report media parity batch",
-      "commit_sha": "333381d0154dfcd166f201a9b00cf154631a6287",
+      "commit_sha": "3c154bd7f9049dfe506fe31e10d15ab1cd215825",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1687",
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T14:21:07Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "checks": {
         "dependency": {
           "status": "passed",
@@ -25085,8 +25085,8 @@
           "evidence": "All local validation commands passed before staging."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR #1687 opened; GitHub checks pending."
+          "status": "passed",
+          "evidence": "GitHub PR #1687 merged with all required checks green and mergeStateStatus CLEAN."
         }
       },
       "history": [
@@ -25109,11 +25109,17 @@
           "at": "2026-05-25T22:14:33+08:00",
           "status": "pr_open",
           "summary": "Opened fap-api PR #1687 for result/report and media parity batch."
+        },
+        {
+          "at": "2026-05-25T22:24:18+08:00",
+          "status": "merged",
+          "summary": "Reconciled PR #1687 merged state while starting final verify PR."
         }
-      ]
+      ],
+      "merge_commit": "757535c7934e43580c951485f9a6867946a1c2c0"
     },
     "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01": {
-      "status": "planned",
+      "status": "local_validation_passed",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-final-verify-01",
       "base": "main",
@@ -25127,12 +25133,60 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "checks": {},
+      "checks": {
+        "dependency": {
+          "status": "passed",
+          "evidence": "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01 merged as PR #1687 with merge commit 757535c7934e43580c951485f9a6867946a1c2c0."
+        },
+        "scope_boundary": {
+          "status": "passed",
+          "changed_files": [
+            "backend/docs/seo/global-en-zh-final-verify-01.md",
+            "backend/docs/seo/generated/global-en-zh-final-verify-01.v1.json",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhFinalVerify01Test.php",
+            "docs/codex/pr-train-state.json"
+          ],
+          "evidence": "Scope is limited to final verification report, generated JSON, focused test, and current/reconciled ledger state."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No deploy, CMS mutation, Search Channel action, URL submission, production migration, fap-web edit, or production user data access performed."
+        },
+        "local_validation": {
+          "status": "passed",
+          "commands": [
+            "php artisan test --filter=GlobalEnZhFinalVerify01 --no-ansi",
+            "php artisan route:list --no-ansi",
+            "vendor/bin/pint --test",
+            "composer validate --strict",
+            "composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-en-zh-final-verify-01.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 YAML parse docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "All local validation commands passed before staging."
+        },
+        "github_required_checks": {
+          "status": "pending"
+        }
+      },
       "history": [
         {
           "at": "2026-05-25T21:15:38+08:00",
           "status": "planned",
           "summary": "Planned manifest/state entry only; no implementation in current PR."
+        },
+        {
+          "at": "2026-05-25T22:24:18+08:00",
+          "status": "in_progress",
+          "summary": "Started final full-site EN/ZH parity verification report; no implementation fixes."
+        },
+        {
+          "at": "2026-05-25T22:25:50+08:00",
+          "status": "local_validation_passed",
+          "summary": "Final verification report, generated JSON, and focused test passed local validation; full parity remains NO-GO pending human review/import and post-deploy smoke."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -25119,7 +25119,7 @@
       "merge_commit": "757535c7934e43580c951485f9a6867946a1c2c0"
     },
     "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01": {
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-final-verify-01",
       "base": "main",
@@ -25127,8 +25127,8 @@
         "GLOBAL-EN-ZH-PARITY-RESULT-MEDIA-ASSET-BATCH-01"
       ],
       "title": "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01 full site parity verification",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "149d4cc80aa07485ee0aa513b8990af0211d8f59",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1688",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -25169,7 +25169,8 @@
           "evidence": "All local validation commands passed before staging."
         },
         "github_required_checks": {
-          "status": "pending"
+          "status": "pending",
+          "evidence": "PR #1688 opened; GitHub checks pending."
         }
       },
       "history": [
@@ -25187,6 +25188,11 @@
           "at": "2026-05-25T22:25:50+08:00",
           "status": "local_validation_passed",
           "summary": "Final verification report, generated JSON, and focused test passed local validation; full parity remains NO-GO pending human review/import and post-deploy smoke."
+        },
+        {
+          "at": "2026-05-25T22:26:47+08:00",
+          "status": "pr_open",
+          "summary": "Opened fap-api PR #1688 for final full-site EN/ZH parity verification."
         }
       ]
     }


### PR DESCRIPTION
## What changed
- Adds final full-site EN/ZH parity verification report and generated JSON.
- Adds a focused SeoIntel test for non-mutation boundaries, explicit remaining P1/P2 gaps, fail-closed controls, and final GO/NO-GO.
- Reconciles previous result/media PR #1687 as merged while starting this final verification PR.

## Why
This closes the remaining parity train with a clear final state: repo-level report/test train completed, but full English/Chinese parity is still NO-GO until human-reviewed imports and post-deploy smoke complete.

## Validation
- php artisan test --filter=GlobalEnZhFinalVerify01 --no-ansi: passed
- php artisan route:list --no-ansi: passed
- vendor/bin/pint --test: passed
- composer validate --strict: passed
- composer audit --locked --no-interaction --ignore-unreachable: passed
- python3 -m json.tool backend/docs/seo/generated/global-en-zh-final-verify-01.v1.json >/dev/null: passed
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null: passed
- YAML parse docs/codex/pr-train.yaml: passed
- git diff --check: passed
- git diff --cached --check: passed

## Safety / authority boundaries
- No CMS mutation.
- No production deploy or migration.
- No Search Channel action or URL submission.
- No fap-web change.
- No production user data access.
- No implementation fix in this PR.

## Final decision
NO-GO for claiming full English/Chinese parity until human review/imports and post-deploy smoke complete.

## Next task
DEPLOY-READINESS｜Deploy GLOBAL EN/ZH remaining parity fixes.