### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01 content help policy English draft package

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-translation-batch-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-translation-batch-01.v1.json
@@ -1,0 +1,138 @@
+{
+  "schema_version": "global-en-zh-content-pages-translation-batch-01.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01",
+  "generated_at": "2026-05-26T01:30:00+08:00",
+  "final_decision": "content_pages_translation_batch_completed_with_deferred_support",
+  "source_matrix_task": "GLOBAL-EN-ZH-FULL-CONTENT-AUTHORITY-TRANSLATION-MATRIX-00",
+  "total_items": 14,
+  "translated_draft_count": 5,
+  "existing_counterpart_review_count": 8,
+  "deferred_count": 1,
+  "human_review_required_count": 14,
+  "draft_import_only_count": 13,
+  "sitemap_eligible_count": 0,
+  "llms_eligible_count": 0,
+  "footer_eligible_count": 0,
+  "translated_asset_keys": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "deferred_items": [
+    {
+      "asset_key": "support",
+      "reason": "No dedicated support content_pages authority source exists in the baseline inventory; help-contact and help-faq exist but must not be substituted as a standalone support page without authority approval."
+    }
+  ],
+  "claim_boundary_findings": [
+    {
+      "asset_key": "brand",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "charter",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "foundation",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "careers",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "policies",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "support",
+      "claim_boundary_state": "blocked_missing_authority",
+      "prohibited_claims": [
+        "unsupported support commitments",
+        "unsupported legal commitments"
+      ]
+    },
+    {
+      "asset_key": "method-boundaries",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "privacy",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "terms",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    }
+  ],
+  "import_package_path": "backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json",
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_pseo_generation": true,
+  "no_frontend_fallback_authority": true,
+  "next_task": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-translation-batch-01.md
+++ b/backend/docs/seo/global-en-zh-content-pages-translation-batch-01.md
@@ -1,0 +1,53 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01 Report
+
+## Executive Summary
+- Final decision: `content_pages_translation_batch_completed_with_deferred_support`.
+- Draft/import package items: 14.
+- New English draft pages generated for human review: 5 (`brand`, `charter`, `foundation`, `careers`, `policies`).
+- Existing English counterparts retained as review-only records: 8.
+- Deferred missing authority items: 1.
+- No CMS mutation, publish, deploy, Search Channel action, URL submission, pSEO generation, or frontend fallback authority was performed.
+
+## Scope
+This batch covers content/help/policy pages using backend baseline authority and prior readiness artifacts. It creates draft/import-only artifacts; it does not modify CMS, runtime, sitemap, llms, footer, nav, or fap-web.
+
+## Generated Draft Items
+- `brand` -> `brand`: `Brand and Usage Guidelines`; claim state `needs_human_review_company_legal_policy_boundary`; human review required.
+- `charter` -> `charter`: `FermatMind Charter`; claim state `needs_human_review_company_legal_policy_boundary`; human review required.
+- `foundation` -> `foundation`: `Fermat Foundation Initiative`; claim state `needs_human_review_company_legal_policy_boundary`; human review required.
+- `careers` -> `careers`: `Careers at FermatMind`; claim state `needs_human_review_company_legal_policy_boundary`; human review required.
+- `policies` -> `policies`: `Additional Policies`; claim state `needs_human_review_company_legal_policy_boundary`; human review required.
+
+## Existing Counterpart Review Records
+- `about`: existing English counterpart recorded as draft review-only; no new prose generated.
+- `help-about`: existing English counterpart recorded as draft review-only; no new prose generated.
+- `help-contact`: existing English counterpart recorded as draft review-only; no new prose generated.
+- `help-faq`: existing English counterpart recorded as draft review-only; no new prose generated.
+- `help-for-business-and-research`: existing English counterpart recorded as draft review-only; no new prose generated.
+- `method-boundaries`: existing English counterpart recorded as draft review-only; no new prose generated.
+- `privacy`: existing English counterpart recorded as draft review-only; no new prose generated.
+- `terms`: existing English counterpart recorded as draft review-only; no new prose generated.
+
+## Deferred Items
+- `support`: `No dedicated support content_pages authority source exists in the baseline inventory; help-contact and help-faq exist but must not be substituted as a standalone support page without authority approval.`
+
+## Eligibility Gates
+- `sitemap_eligible=false` for every item.
+- `llms_eligible=false` for every item.
+- `footer_eligible=false` for every item.
+- `search_channel_eligible=false` for every item.
+
+## Claim Boundary Notes
+- Company, legal, foundation, hiring, policy, and support facts require human owner review before import or publication.
+- The package forbids clinical diagnosis, treatment/cure, hiring-fit, career-success, salary guarantee, and unsupported legal/company commitments.
+
+## Validation
+- `php artisan test --filter=GlobalEnZhContentPagesTranslationBatch01 --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- JSON/YAML parse and diff checks
+
+## Next Task
+`GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02`

--- a/backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json
+++ b/backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json
@@ -1,0 +1,815 @@
+{
+  "schema_version": "global-en-zh-content-pages-translation-batch-01.import.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01",
+  "generated_at": "2026-05-26T01:30:00+08:00",
+  "package_type": "draft_import_only",
+  "source_matrix": "backend/docs/seo/generated/global-en-zh-full-content-authority-translation-matrix-00.v1.json",
+  "source_readiness": "backend/docs/seo/generated/global-en-zh-content-authority-publish-readiness-01.v1.json",
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "runtime_exposure_allowed": false,
+  "sitemap_llms_exposure_allowed": false,
+  "footer_exposure_allowed": false,
+  "search_channel_action_allowed": false,
+  "human_review_required": true,
+  "items": [
+    {
+      "asset_key": "brand",
+      "status": "english_draft_generated_for_human_review",
+      "required_action": "human_review_needed",
+      "zh_source_key": "brand",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": false,
+      "en_slug": "brand",
+      "title_en_draft": "Brand and Usage Guidelines",
+      "description_en_draft": "This page explains how to refer to FermatMind correctly, use our name, content, and visual assets, and identify which uses require permission.",
+      "h1_en_draft": "Brand and Usage Guidelines",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Why brand guidelines matter",
+          "markdown": "For FermatMind, a brand is not only a name, logo, or visual style. It is a promise about trust. When people see “FermatMind,” they should have a clear sense of what it means: a system built around self-understanding, career exploration, and capability growth; a product that emphasizes measurement, interpretation, boundaries, and review; not an entertainment fortune-telling site, and not a tool that any organization can use casually to label people.\n\nBecause the brand carries this trust, we need clear rules for how FermatMind is mentioned, quoted, and used externally. These guidelines are not meant to restrict fair discussion. They are meant to reduce misleading use, avoid unauthorized endorsement, and make sure that when users encounter “FermatMind” in different channels, it still points to the same clear and responsible entity."
+        },
+        {
+          "heading": "Name and official references",
+          "markdown": "The official Chinese name is “费马测试,” and the English name is “FermatMind.” In formal writing or first references, “费马测试（FermatMind）” may be used to help readers connect the two names.\n\n- Do not create unofficial abbreviations, authorization labels, or certification titles that could mislead users.\n- Do not imply an unconfirmed relationship by using phrases such as “official partner,” “official research unit,” or “official certified tool.”\n- Do not register, operate, or use accounts, domains, pages, or materials that can be confused with FermatMind official identity.\n\nIf you are objectively mentioning, reporting on, or commenting on FermatMind, separate authorization is usually not required. If the use would make ordinary users think you represent FermatMind, are endorsed by FermatMind, or are binding FermatMind to your product or service, you need clear permission in advance."
+        },
+        {
+          "heading": "Content quoting and republication",
+          "markdown": "FermatMind welcomes accurate quotation. Third parties may quote articles, explanations, research-oriented content, public policies, and general product descriptions within a reasonable scope, provided that the use follows these rules:\n\n- Preserve the original meaning. Do not quote out of context, modify core conclusions, or remove key boundary statements.\n- Identify the source, including title, platform name, link or traceable source, and access or quotation date.\n- Do not present a partial excerpt as FermatMind’s official support for a person, institution, product, or position.\n- Do not perform bulk mirroring, systematic copying, paid republication, or commercial resale unless written permission has been granted.\n\nFor reasonable quotation in teaching, media reporting, or research discussion, we encourage accurate, restrained, and context-complete use. Summaries, comparison charts, secondary explanations, and translated versions that could affect public understanding should preserve the original boundaries."
+        },
+        {
+          "heading": "How users may share reports and experiences",
+          "markdown": "Users may share their assessment experience, report excerpts, reflections, and growth stories, but they are responsible for what they share. Please consider personal privacy and the privacy of others. Do not expose account information, payment information, full raw answer records, or sensitive content involving other people without consent.\n\n- You may share your own result summary, feelings, reflections, or usage suggestions.\n- You may discuss whether a report helped you understand yourself, but should not present one personal experience as a universal conclusion for everyone.\n- Do not remove source attribution and repackage report content as original content, consulting templates, training materials, or paid products.\n- Do not offer unauthorized services under names such as “FermatMind officially certified” or “FermatMind authorized consulting.”\n\nFermatMind encourages truthful sharing, but opposes using personal results to shame, compare, control, or discriminate against others."
+        },
+        {
+          "heading": "Visual assets and brand presentation",
+          "markdown": "FermatMind logos, wordmarks, graphic elements, screenshots, visual templates, and other brand assets belong to FermatMind or the relevant rights holders. These assets should be used only in official released forms and in a clear, restrained, and non-misleading way.\n\n- Do not stretch, compress, crop, redraw, recolor, or force-combine assets with other marks in a way that creates visual confusion.\n- Do not use brand assets in paid advertising, campaign materials, landing pages, product packaging, or event pages unless written permission has been granted.\n- Do not use FermatMind visual elements in settings that could imply official partnership, official recommendation, or official certification.\n- For media reporting, collaboration demos, or brand materials, request the latest assets and usage notes through official channels."
+        },
+        {
+          "heading": "Allowed uses, uses requiring permission, and prohibited uses",
+          "markdown": "Usually allowed uses:\n\n- Accurate mentions and reasonable quotations in news reports, academic discussion, classroom teaching, or research commentary.\n- Non-misleading user sharing based on personal experience.\n- Partner use of brand names, links, or standardized assets within an approved scope.\n\nUses that usually require written permission:\n\n- Co-publishing, commercial promotion, advertising, offline event materials, courses, or consulting services that display the brand alongside another entity.\n- Large-scale republication, mirroring, translated publication, white-label cooperation, redistribution, or asset-pack use.\n- Binding the FermatMind name or assets to a third-party product, organization, or commercial interest.\n\nClearly prohibited uses:\n\n- Impersonating an official account, partner, certifier, or authorized institution.\n- Using the FermatMind name for fraud, traffic diversion, fees, false promotion, or unauthorized data collection.\n- Packaging assessment results as tools for hiring, admission, elimination, pricing, matching, or other discriminatory decisions.\n- Copying, selling, training on, or redistributing FermatMind content, reports, or brand materials in bulk without permission."
+        },
+        {
+          "heading": "Media, partnership, and permission requests",
+          "markdown": "If you want to formally use the FermatMind name, content, or visual assets in reporting, research, courses, events, product collaboration, channel partnership, or other external projects, contact us through the official channels published on the FermatMind website. Please describe the use case, material format, publication scope, timing, and whether commercial revenue, data processing, or co-branding is involved.\n\nWe evaluate permission requests not only by distribution scale, but also by accuracy, respect for user interests, risk of confusion, fit with the platform’s long-term mission, and boundary safety. We reserve the right to refuse collaborations that could increase public misunderstanding, weaken user trust, or undermine high-risk use boundaries."
+        },
+        {
+          "heading": "Violations and updates",
+          "markdown": "FermatMind reserves the right to protect its brand name, copyrighted content, visual assets, and other intellectual property. For impersonation, misleading use, infringement, bulk republication, illegal resale, false endorsement, or other serious misuse, we may request correction, deletion, or cessation of distribution, and may take further legal action when necessary.\n\nAs products, partnership formats, and public materials change, these guidelines may also be updated. The latest version published on the FermatMind website prevails."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Brand and Usage Guidelines | FermatMind",
+        "description": "How to refer to FermatMind, quote public content, share reports responsibly, and request permission for brand, content, and visual-asset use."
+      },
+      "translation_group_key": "content-page-brand",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "05_品牌与使用规范.docx",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "charter",
+      "status": "english_draft_generated_for_human_review",
+      "required_action": "human_review_needed",
+      "zh_source_key": "charter",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": false,
+      "en_slug": "charter",
+      "title_en_draft": "FermatMind Charter",
+      "description_en_draft": "This charter defines FermatMind’s core principles for assessment, interpretation, career guidance, privacy protection, and long-term product development.",
+      "h1_en_draft": "FermatMind Charter",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Why a charter is necessary",
+          "markdown": "Any tool that can affect how a person understands themselves needs stronger self-restraint than an ordinary content product. Assessment results may change how someone understands their abilities, relationships, and career direction. They may also be used inappropriately in organizational contexts. For that reason, a platform cannot pursue only what looks good, reads easily, or spreads well. It must take responsibility for how it collects information, interprets information, explains boundaries, and prevents misuse.\n\nFermatMind wants assessments to help people, not restrict them; to help people build better self-language, not compress them into a few letters, a score, or a slogan. This charter states our working principles: how we choose when growth conflicts with responsibility, how we write when uncertainty conflicts with commercial expression, and how we refuse use cases that may harm users."
+        },
+        {
+          "heading": "Principle 1: Help users understand themselves, not define them",
+          "markdown": "A person is not four letters, one score, or one chart. Any assessment model is only one window into a person, not the whole person. FermatMind rejects treating assessment results as identity labels, value judgments, or destiny. We care more about whether a result helps users understand preferences, energy allocation, collaboration style, stress response, and growth needs.\n\nWhen we present results, we try to write conclusions as hypotheses that can be understood and tested, rather than final judgments that cannot be challenged. A good result does not classify the user forever. It gives the user more language for self-observation, communication, and choice."
+        },
+        {
+          "heading": "Principle 2: Scientific rigor, not mysticism",
+          "markdown": "FermatMind is built on public research, classic assessment frameworks, psychometric methods, and real usage feedback. We will not package any model as “the most authoritative,” “the most accurate,” or a tool that can directly predict a life. We will not replace evidence and explanation with mysticism, fatalism, or absolute language.\n\nFor users, trust should not come from how surprising a conclusion sounds. It should come from whether the platform clearly explains what it measures, what it cannot measure, which settings it fits, and when caution is required. Scientific rigor does not mean cold or obscure language. It means we are willing to admit limitations and explain complex issues clearly."
+        },
+        {
+          "heading": "Principle 3: Build with professionals, not alone",
+          "markdown": "Personality, emotion, relationships, and career development cannot be fully covered by one discipline alone. FermatMind will continue to work with psychology practitioners, educators, career-development advisors, researchers, and data-governance professionals, bringing outside knowledge into item design, report writing, boundary review, and risk judgment.\n\nWe do not build “professionalism” through closure or mystery. We build it through peer review, real feedback, and continuous correction. External professional collaboration is not packaging. It is the humility a platform needs when dealing with complex human questions."
+        },
+        {
+          "heading": "Principle 4: Explainability and actionability matter more than attractive conclusions",
+          "markdown": "Users do not need a conclusion designed for reposting. They need an explanation they can use in real life. When we design reports and content, we try to answer four questions: what the result means; in which settings it may become a strength; in which settings it may become a risk; and what the user can verify, train, or adjust next.\n\nIf a result cannot help a user learn, collaborate, communicate, manage stress, or plan a career more clearly, it is only a more polished label. For FermatMind, being explainable and actionable is always more important than sounding insightful."
+        },
+        {
+          "heading": "Principle 5: Respect uncertainty and change",
+          "markdown": "People grow, environments change, and measurement contains error. The same person may behave differently across life stages, stress levels, and roles. FermatMind will not present one assessment result as an unchanging essence, and will not encourage users to deny long-term potential because of one current state.\n\nWe try to remind users that results should be understood only within a specific model, condition, and use case. When environment, tasks, relationships, or life stage change significantly, reassessment is often more useful than holding tightly to an old conclusion. Admitting uncertainty does not weaken a tool’s value; it protects the tool’s credibility."
+        },
+        {
+          "heading": "Principle 6: Protect privacy, informed consent, and psychological safety",
+          "markdown": "Information related to personality, emotion, career tendencies, relationship patterns, and answer processes is often more fragile than ordinary account information and easier to misread. FermatMind governs this information with higher sensitivity standards, following principles of minimum necessity, clear purpose, transparent notice, and cautious authorization.\n\nWe also value psychological safety. For content that could trigger anxiety, shame, helplessness, or excessive self-blame, we avoid inflammatory language and absolute judgments. Any conclusion that can affect a user’s sense of self-worth should be expressed carefully."
+        },
+        {
+          "heading": "Principle 7: Avoid high-risk misuse",
+          "markdown": "FermatMind does not encourage any organization or individual to use assessment results as the sole basis for hiring, elimination, compensation, admission, punishment, lending, insurance, medical judgment, or other high-risk decisions. Measures of personality, interests, and behavioral tendencies should not become automated weapons for filtering people.\n\nIf the product enters organizational, school, or research settings, informed consent, purpose limitation, human review, explanation rights, and appeal mechanisms must come before process convenience. The platform has a responsibility to actively limit improper use cases rather than leaving all risk to users."
+        },
+        {
+          "heading": "Principle 8: Long-termism and continuous improvement",
+          "markdown": "FermatMind will not treat any version as final. Item banks, reports, interactions, interpretation language, career mapping, risk notices, and data-governance mechanisms should continue to evolve with research, feedback, and reality.\n\nContinuous improvement does not mean changing standards casually. It means building an open correction capability: acknowledging problems when found, evaluating feedback when received, and, when necessary, updating content, narrowing promises, adding explanations, or adjusting boundaries. A product that deserves long-term trust must care more about correction than short-term completeness."
+        },
+        {
+          "heading": "How this charter takes effect",
+          "markdown": "This charter applies not only to external writing, but also to product design, partnership decisions, organizational governance, and policy making. For FermatMind, when users’ long-term interests, privacy safety, clear explanation, and short-term growth conflict, the former should come first.\n\nWe also welcome continued scrutiny from users, researchers, partners, and professionals. Being questioned does not always mean something is wrong, but being willing to receive public scrutiny is a basic posture for a mission-driven product."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "FermatMind Charter | Assessment Principles and Boundaries",
+        "description": "FermatMind’s charter for assessment interpretation, responsible career guidance, privacy protection, uncertainty, anti-misuse boundaries, and long-term product improvement."
+      },
+      "translation_group_key": "content-page-charter",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "02_费马测试宪章.docx",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "foundation",
+      "status": "english_draft_generated_for_human_review",
+      "required_action": "human_review_needed",
+      "zh_source_key": "foundation",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": false,
+      "en_slug": "foundation",
+      "title_en_draft": "Fermat Foundation Initiative",
+      "description_en_draft": "The Fermat Foundation Initiative focuses on assessment literacy, career education, and youth growth so more people can access reliable self-understanding tools with lower barriers.",
+      "h1_en_draft": "Fermat Foundation Initiative",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Why we are building this initiative",
+          "markdown": "Self-understanding and career exploration should not belong only to people with abundant resources. Many students, young professionals, and career changers are not lacking effort. They lack reliable, low-barrier tools that can be used over time: they have read plenty of self-growth content but lack a structured method; they have taken tests but do not know how to turn results into action; they face career choices with anxiety but lack a framework they can verify.\n\nFermatMind wants to turn part of these basic capabilities into public resources. We call this work the “Fermat Foundation Initiative.” It is not a charity-themed marketing wrapper and not a softer way to say the same promotional message. It starts from a fact: assessment literacy, career information, and growth methods should be more widely accessible."
+        },
+        {
+          "heading": "Public problems we care about",
+          "markdown": "- Insufficient assessment literacy: many people know their test results but do not know how to understand models, boundaries, error, and use cases.\n- Information asymmetry in youth career decisions: many young people facing majors, roles, and industries lack trustworthy path information and judgment frameworks, not motivational slogans.\n- Insufficient basic mental-health literacy: people often encounter relevant knowledge only after a crisis; earlier self-observation and help-seeking education are still scarce.\n- Schools, nonprofit organizations, and frontline workers lack low-barrier tools: they need auxiliary resources that are explainable, deployable, and boundary-aware, not complex systems that cannot be implemented.\n\nThese problems are connected. A person with little assessment literacy is more likely to treat a result as a label. A person without career information is more likely to make rushed decisions in anxiety. A person without basic help-seeking awareness may mistake tools for substitutes for professional support."
+        },
+        {
+          "heading": "What we hope to provide",
+          "markdown": "The Fermat Foundation Initiative will prioritize public resources that are understandable, accessible, and reusable.\n\n- Open content and guides: continued Chinese public content around self-understanding, career exploration, assessment boundaries, and basic mental-health knowledge.\n- Toolkits for campus and nonprofit settings: materials suitable for discussions, workshops, and basic support by schools, youth organizations, nonprofit projects, and counseling supporters.\n- Low-barrier experience and resource support: where conditions allow, free or low-cost assessments and growth resources for specific groups.\n- Partnership projects and research support: collaboration with educational institutions, nonprofit organizations, and researchers to explore more responsible tool use and higher-quality localized expression.\n\nFor FermatMind, public-benefit work does not mean lowering standards. On the contrary, once tools enter public settings, language accuracy, boundary explanation, ethical design, and data governance need even higher standards."
+        },
+        {
+          "heading": "How we work with schools, nonprofit organizations, and researchers",
+          "markdown": "The premise for collaboration is not brand exposure. It is whether the problem is real, the goal is clear, and the boundaries are explicit. We prefer to support projects that truly help young people understand themselves, careers, emotions, and relationship questions, rather than projects that use “assessment” as a packaging step.\n\n- Collaboration goals should be specific, verifiable, and related to public benefit.\n- Personal information processing in collaborations should follow minimum necessity, clear notice, and user-understandable principles.\n- If individual data, research use, or report sharing is involved, clear authorization and withdrawal mechanisms are required.\n- No collaboration setting should use assessment results as a basis for screening, discriminating against, or excluding individuals."
+        },
+        {
+          "heading": "Data and ethical boundaries",
+          "markdown": "Public-benefit purpose does not automatically make an activity legitimate. The Fermat Foundation Initiative will not weaken protection for user data or individual dignity because a project has a public purpose. Information related to assessment answers, personality tendencies, emotional state, career interests, and growth records can have a deep impact on individuals and must be handled carefully.\n\n- Without clear authorization, individual assessment data will not be used for research, publicity, display, or external collaboration.\n- When aggregate or anonymized data can meet the goal, identifiable individual data should not be preferred.\n- When minors are involved, stricter notice, guardian consent, and usage limits should apply.\n- Public-benefit work must not be used to label abilities, label psychology, or conduct hidden screening."
+        },
+        {
+          "heading": "Relationship between the commercial system and the public-benefit system",
+          "markdown": "FermatMind products and services are aimed at long-term growth and decision support. The Fermat Foundation Initiative focuses on broader access to resources, public education, and social collaboration. The two support each other in mission, but should remain governed with clear boundaries. Public-benefit work should not become commercial endorsement, and the commercial system should not use public-benefit language to bypass privacy, authorization, or ethical requirements.\n\nThis boundary helps the platform remain credible: users can tell which resources are services and which are public resources; partners can tell which content can be openly shared and which data needs additional authorization; and the internal team can tell when efficiency should yield to caution."
+        },
+        {
+          "heading": "Our long-term view",
+          "markdown": "As governance, resources, and compliance conditions mature, we hope this initiative can become a more stable, sustained, and reviewable public-impact platform. It could support youth career exploration, assessment-literacy education, basic mental-health education, research-ethics discussion, and more responsible digital growth-tool practice.\n\nIf FermatMind’s commercial system is building personal growth infrastructure, the Fermat Foundation Initiative hopes to make that infrastructure serve more than people who already have resources. Helping more people understand themselves, see careers, and train for the future with lower barriers is the public meaning of this initiative."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Fermat Foundation Initiative | Assessment Literacy and Career Education",
+        "description": "A draft English authority package for FermatMind’s public-benefit initiative around assessment literacy, career education, youth growth, privacy, and ethical boundaries."
+      },
+      "translation_group_key": "content-page-foundation",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "03_费马基金会计划.docx",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "careers",
+      "status": "english_draft_generated_for_human_review",
+      "required_action": "human_review_needed",
+      "zh_source_key": "careers",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": false,
+      "en_slug": "careers",
+      "title_en_draft": "Careers at FermatMind",
+      "description_en_draft": "We are looking for people who want to combine psychometrics, product design, content quality, and engineering systems to build the next generation of personal growth tools.",
+      "h1_en_draft": "Careers at FermatMind",
+      "body_blocks_en_draft": [
+        {
+          "heading": "What we are building",
+          "markdown": "FermatMind is not a project that only builds one-off test pages. We want to build a continuous growth system: helping users understand themselves, understand careers, train capabilities, manage risk, and review their changes over years. Such a system requires long-term collaboration across content, methodology, product, engineering, design, data, and operations. It cannot be completed by one role alone.\n\nThat means joining FermatMind is not only about building features. It is about helping decide how a tool affects people: whether it makes users clearer, better grounded, and more able to act; whether it avoids labeling and anxiety; whether it stays restrained in the face of complex questions; and whether it can keep its boundaries under growth pressure."
+        },
+        {
+          "heading": "Why this work matters",
+          "markdown": "Young people lack high-quality infrastructure at many important decision points: choosing a major, deciding whether to change direction, understanding strengths and weaknesses, managing anxiety and burnout, accumulating evidence of capability, and judging industry risk. The internet has no shortage of content, but tools that are verifiable, reviewable, and clear about boundaries remain scarce.\n\nIf you are willing to treat “helping a person understand themselves more clearly” as serious work rather than content packaging, this is difficult work worth investing in. It requires respect for science, product, language, engineering, and human vulnerability at the same time. It also requires asking at every detail: does this work actually make the user better off, or only make the page look better?"
+        },
+        {
+          "heading": "Who we welcome",
+          "markdown": "Research, methodology, and content:\n\n- People with backgrounds in psychology, psychometrics, education, career development, behavioral science, or related fields.\n- People who can explain complex concepts clearly and turn research logic into language users can understand.\n- People skilled in content research, editing, knowledge architecture, case design, or methodology writing.\n\nProduct, design, and user experience:\n\n- Product managers, interaction designers, visual designers, and user researchers who want to turn abstract theory into a usable real experience.\n- People who care about information hierarchy, interpretation quality, feedback loops, and long-term retention experience.\n\nEngineering, data, and systems:\n\n- Frontend, backend, full-stack, data engineering, algorithm, and AI-related engineers.\n- People who can handle complex flows, data structures, permission boundaries, privacy constraints, and reliability problems.\n\nGrowth, operations, and partnerships:\n\n- People willing to do user growth and long-term operations without manufacturing anxiety or exaggerating promises.\n- People who can build clear boundaries and long-term trust with schools, institutions, and partners."
+        },
+        {
+          "heading": "How we work",
+          "markdown": "FermatMind tends to work with high standards, small teams, strong execution, fast iteration, and repeated review. We prefer clear principles over inefficient process, evidence and results over guesswork, and cross-functional collaboration over isolated execution.\n\n- Look for ways forward before looking for excuses.\n- Respect facts and update judgments quickly instead of clinging to first ideas.\n- Keep creativity, but do not use “inspiration” as a reason to skip validation.\n- Stay sensitive to user feelings, privacy boundaries, and language consequences.\n- Be able to move work forward independently while also refining ideas in dense collaboration.\n\nWe do not pursue obscurity just to sound professional, and we do not encourage excessive control in place of clear responsibility. Effective work often means defining the problem clearly, writing the goal clearly, preserving the evidence clearly, and then iterating."
+        },
+        {
+          "heading": "Qualities we value",
+          "markdown": "- Respect for human complexity instead of rushing to classify and judge.\n- Ability to explain complex ideas clearly instead of using complexity as a barrier.\n- Systems thinking that sees the links between content, product, engineering, data, and governance.\n- Responsibility and ownership, with willingness to carry work through to completion.\n- Sensitivity to privacy, ethics, and high-risk settings, instead of treating “build first, ask later” as the default.\n- Willingness to refine over time, not interest only in short-term attention.\n\nIf you care less about whether a job quickly makes you look impressive and more about whether the work can have long-term value, you are more likely to fit here."
+        },
+        {
+          "heading": "What working here may feel like",
+          "markdown": "You will be close to real user problems. We are not doing purely abstract research, and we are not only building internet features with attractive packaging. You will see how users use these tools when they face career hesitation, relationship confusion, capability anxiety, and stalled growth. You will also see how one imprecise sentence, one vague boundary statement, or one premature conclusion can affect them.\n\nThis makes the work harder, but also more meaningful. You will be expected to have creativity and restraint, to move forward and reflect, to care about completion and consequences. For people willing to carry this level of density, it can be a deeply growth-oriented work experience."
+        },
+        {
+          "heading": "How to apply and how we hire",
+          "markdown": "FermatMind welcomes open applications. Even if no role is publicly open at a given moment, you may submit concise but persuasive materials through official recruiting channels: who you are, what you are good at, why you care about these problems, and which past projects or works show your ability.\n\n- Research and content: include representative writing, research, course design, reports, or case materials.\n- Design and product: include a portfolio and explain how you handle complex information and user decision problems.\n- Engineering and data: include projects, code repositories, system-design notes, or examples of problem decomposition.\n- Growth and operations: include real projects, data reviews, method frameworks, and boundary judgments.\n\nWe aim to build a hiring process that respects differences and equal opportunity. We do not make unfair judgments based on gender, region, age, school label, physical condition, or other factors unrelated to the role. Candidate information submitted during application should also be handled under privacy and minimum-necessity principles."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Careers at FermatMind | Build Assessment and Growth Tools",
+        "description": "How FermatMind works, what kind of people we look for, and how candidates can apply to build assessment, product, content, engineering, and growth systems responsibly."
+      },
+      "translation_group_key": "content-page-careers",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "04_加入费马测试.docx",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "policies",
+      "status": "english_draft_generated_for_human_review",
+      "required_action": "human_review_needed",
+      "zh_source_key": "policies",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": false,
+      "en_slug": "policies",
+      "title_en_draft": "Additional Policies",
+      "description_en_draft": "Additional policies explain refunds, report delivery, enterprise and research use, content quoting, minor protection, and restrictions on high-risk use.",
+      "h1_en_draft": "Additional Policies",
+      "body_blocks_en_draft": [
+        {
+          "heading": "1. Refund, cancellation, and order handling policy",
+          "markdown": "Some FermatMind products are digital content or digital services. Specific pricing, delivered content, access duration, trial availability, auto-renewal status, and refund conditions are determined by the clear information shown on the order page, payment page, and product description page.\n\nUnless an opposite commitment is explicitly stated or mandatory law provides otherwise, digital reports, digital entitlements, assessment unlocks, and online content access are generally considered substantially delivered once they have been generated, delivered, activated, or made accessible. They usually do not support no-reason returns or arbitrary refunds.\n\n- If duplicate charges occur, a system error prevents delivery, payment succeeds but benefits are not granted, or an obvious technical fault makes core content inaccessible, you may request a review through official channels.\n- If an order is for pre-sale, reservation, queued generation, manual verification, or staged delivery, the rules clearly shown on the relevant page apply.\n- If a service includes subscription benefits, you should complete cancellation before the next billing cycle begins. After cancellation, access usually continues until the end of the current cycle.\n\nFermatMind may request necessary information when handling refunds, redelivery, risk review, and abnormal orders in order to verify order authenticity and prevent fraud or duplicate claims."
+        },
+        {
+          "heading": "2. Report delivery and digital content use policy",
+          "markdown": "Digital reports, charts, explanations, courses, tools, or supporting materials delivered by FermatMind are available only within the scope clearly stated on the order page, service description page, or product interface. Access duration, history retention, upgrade methods, and version update strategies may differ across products.\n\n- Use digital content only through the official login, viewing, or download paths. Do not exceed the allowed scope through cracking, scraping, screen recording, bulk export, or account sharing.\n- Reports and digital content are licensed only to the ordering user or the lawful user explicitly stated on the page. Unless the product description allows it, do not resell, sublicense, white-label, or package them for commercial training.\n- If FermatMind updates report expression because of model updates, content revision, boundary optimization, or policy changes, historical display methods, wording details, or accessible content may reasonably change.\n\nIf you believe delivered content is clearly inconsistent with the purchase description, raise the issue through official channels as soon as possible. We will review the order page, feature records, and specific circumstances."
+        },
+        {
+          "heading": "3. Enterprise, school, and research use policy",
+          "markdown": "When FermatMind services are used by enterprises, schools, teams, nonprofit projects, consulting organizations, training institutions, research studies, or other organizational settings, such use should not simply reuse default rules for individual users. Additional agreements should be made according to risk and purpose.\n\n- Before organizational use, the project purpose, participants, data scope, display method, retention period, withdrawal mechanism, appeal path, and division of responsibility should be clear.\n- If an organization intends to access or process individual assessment results, it should obtain necessary authorization through a written agreement, project notice, or other clear method, and explain possible impact to participants.\n- If the goal can be achieved through anonymization, aggregation, or minimization, identifiable individual data should not be preferred.\n- In research settings, publication, case display, external sharing, or secondary data analysis requires additional traceable authorization or strict anonymization.\n\nFermatMind reserves the right to conduct additional review, restrict features, request supplementary materials, set access permissions, or refuse cooperation for organizational projects, especially when they may involve discrimination, high-risk automated judgment, or excessive data processing."
+        },
+        {
+          "heading": "4. Content quotation, republication, and sharing policy",
+          "markdown": "For publicly released FermatMind articles, policy explanations, product descriptions, general methodology content, and public education materials, third parties may quote or discuss them within a reasonable scope while following accuracy, completeness, and source attribution principles.\n\n- Reasonable quotation should preserve the original meaning and must not remove key boundaries, mislead the public, or imply FermatMind’s official endorsement of a third-party viewpoint, product, course, or organization.\n- Large-scale republication, mirroring, full-text translation, content compilation, paid resale, training-data use, white-label integration, and similar uses generally require prior written permission.\n- Users may share their own experiences and result summaries, but should not disclose other people’s information, internal organizational information, or sensitive content without permission.\n\nFor use of names, logos, brand materials, and official references, also refer to the Brand and Usage Guidelines."
+        },
+        {
+          "heading": "5. Supplemental policy for minors",
+          "markdown": "FermatMind recommends that minors use growth-related tools with a guardian’s understanding and guidance. We will try to design content and notices for minors in a clear, restrained, and non-overstimulating way.\n\n- For minors under the age of fourteen, we will require guardian consent in applicable scenarios and apply stricter personal-information processing rules.\n- We do not encourage minors to treat platform results as fixed identities, and do not encourage guardians, schools, or training institutions to use assessment results as the sole evaluation tool.\n- If a guardian believes a minor submitted unnecessary information by mistake, or needs relevant content deleted or display restricted, they may request help through official channels."
+        },
+        {
+          "heading": "6. Restrictions on high-risk use",
+          "markdown": "FermatMind clearly opposes using personality, interest, career tendency, emotional state, relationship pattern, or other growth-related results as the basis for high-risk automated decisions or sole decision-making.\n\n- Results must not be used alone for hiring, admission, elimination, promotion, compensation, performance discipline, or other decisions affecting employment rights.\n- Results must not be used alone for school admission, class placement, rewards or punishment, elimination, funding eligibility, or other decisions affecting educational opportunity.\n- Results must not be used alone for loans, credit, insurance, price discrimination, risk profiles, or other decisions affecting financial rights.\n- Results must not be packaged as medical diagnosis, psychological diagnosis, legal judgment, judicial judgment, crisis-level conclusion, or other high-risk formal opinion.\n- Results must not be used to stigmatize, discriminate against, shame, manipulate, or restrict reasonable opportunities for individuals.\n\nIf FermatMind finds that a service is being used in these settings or carries similar risks, we may restrict permissions, suspend service, request remediation, terminate cooperation, and reserve the right to pursue responsibility."
+        },
+        {
+          "heading": "7. Complaints, appeals, and violation handling policy",
+          "markdown": "If you believe FermatMind has an issue involving content, orders, privacy, authorization, minor protection, brand quotation, or another matter, you may submit complaints, appeals, feedback, or reports through the official channels published on the website.\n\n- Please provide information directly relevant to your issue, such as account information, order number, page link, screenshot, time point, or other verifiable material.\n- FermatMind will review the issue within a reasonable period and respond, correct, redeliver, delete, restrict, restore, or take other appropriate action depending on the nature of the matter.\n- For malicious complaints, forged materials, repeated harassment, attacks under the name of appeal, or violations, FermatMind reserves the right to limit handling.\n\nWhen the platform determines that an account, partner, project, or content involves obvious illegality, infringement, fraud, impersonation, bulk infringing republication, high-risk misuse, or harm to user rights, we may take preliminary measures including but not limited to deleting content, restricting permissions, canceling eligibility, or terminating cooperation."
+        },
+        {
+          "heading": "8. Policy updates",
+          "markdown": "These Additional Policies may be updated as product capabilities, cooperation models, applicable law, and governance requirements change. Updated versions will be published on the FermatMind website or inside the product.\n\nIf this page conflicts with a specific order page, campaign page, or organizational agreement, the special agreement for that scenario applies so long as it does not violate law or basic boundaries. Baseline rules involving privacy protection, high-risk restrictions, intellectual property, and basic user rights should not be weakened by commercial arrangements unless law allows it and there is a clear agreement."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Additional Policies | FermatMind",
+        "description": "FermatMind’s supplemental policies for refunds, report delivery, organizational and research use, content quotation, minors, high-risk restrictions, complaints, and updates."
+      },
+      "translation_group_key": "content-page-policies",
+      "claim_boundary_state": "needs_human_review_company_legal_policy_boundary",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "08_其他政策.docx",
+      "prohibited_claims": [
+        "unsupported company facts",
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction",
+        "salary guarantee"
+      ]
+    },
+    {
+      "asset_key": "support",
+      "status": "deferred_missing_authority",
+      "required_action": "deferred_missing_authority",
+      "zh_source_key": "support",
+      "zh_source_exists": false,
+      "zh_source_authority": null,
+      "en_counterpart_exists_before_batch": false,
+      "en_slug": "support",
+      "title_en_draft": null,
+      "description_en_draft": null,
+      "h1_en_draft": null,
+      "body_blocks_en_draft": [],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": null,
+      "translation_group_key": "content-page-support",
+      "claim_boundary_state": "blocked_missing_authority",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "deferred_missing_authority",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": "No dedicated support content_pages authority source exists in the baseline inventory; help-contact and help-faq exist but must not be substituted as a standalone support page without authority approval.",
+      "source_doc": null,
+      "prohibited_claims": [
+        "unsupported support commitments",
+        "unsupported legal commitments"
+      ]
+    },
+    {
+      "asset_key": "about",
+      "status": "existing_english_counterpart_review_record",
+      "required_action": "human_review_needed",
+      "zh_source_key": "about",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": true,
+      "en_slug": "about",
+      "title_en_draft": "About FermatMind",
+      "description_en_draft": "FermatMind is a self-understanding and growth platform that turns assessments, career exploration, and decision support into a system people can use over time.",
+      "h1_en_draft": "About FermatMind",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Who we are",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Why we exist",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "How we build",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Our boundaries",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "About FermatMind",
+        "description": "FermatMind is a self-understanding and growth platform that turns assessments, career exploration, and decision support into a system people can use over time."
+      },
+      "translation_group_key": "content-page-about",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "human_review_required": true,
+      "owner_review_required": false,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "content_pages.en.baseline",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "help-about",
+      "status": "existing_english_counterpart_review_record",
+      "required_action": "human_review_needed",
+      "zh_source_key": "help-about",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/help_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": true,
+      "en_slug": "help-about",
+      "title_en_draft": "About FermatMind",
+      "description_en_draft": "Who we are, what we build, and the standards behind our assessment product.",
+      "h1_en_draft": "About FermatMind",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Our mission",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Assessment approach",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Privacy and safety boundary",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "About FermatMind",
+        "description": "Who we are, what we build, and the standards behind our assessment product."
+      },
+      "translation_group_key": "content-page-help-about",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "human_review_required": true,
+      "owner_review_required": false,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "helpCenterContent.ts",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "help-contact",
+      "status": "existing_english_counterpart_review_record",
+      "required_action": "human_review_needed",
+      "zh_source_key": "help-contact",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/help_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": true,
+      "en_slug": "help-contact",
+      "title_en_draft": "Contact Support",
+      "description_en_draft": "Share complete context so we can resolve your issue faster.",
+      "h1_en_draft": "Contact Support",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Use these formal paths before support",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "What to include if you still need support",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Response timing",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Contact Support",
+        "description": "Share complete context so we can resolve your issue faster."
+      },
+      "translation_group_key": "content-page-help-contact",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "human_review_required": true,
+      "owner_review_required": false,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "helpCenterContent.ts",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "help-faq",
+      "status": "existing_english_counterpart_review_record",
+      "required_action": "human_review_needed",
+      "zh_source_key": "help-faq",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/help_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": true,
+      "en_slug": "help-faq",
+      "title_en_draft": "Frequently Asked Questions",
+      "description_en_draft": "Common answers for reports, payment, and account-related requests.",
+      "h1_en_draft": "Frequently Asked Questions",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Before you contact support",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Typical support topics",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Frequently asked questions",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Frequently Asked Questions",
+        "description": "Common answers for reports, payment, and account-related requests."
+      },
+      "translation_group_key": "content-page-help-faq",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "human_review_required": true,
+      "owner_review_required": false,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "helpCenterContent.ts",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "help-for-business-and-research",
+      "status": "existing_english_counterpart_review_record",
+      "required_action": "human_review_needed",
+      "zh_source_key": "help-for-business-and-research",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/help_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": true,
+      "en_slug": "help-for-business-and-research",
+      "title_en_draft": "Using FermatMind for Business and Research",
+      "description_en_draft": "Scope, authorization, and compliance notes for organizational usage.",
+      "h1_en_draft": "Using FermatMind for Business and Research",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Usage scope",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Bulk and project access",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Using FermatMind for Business and Research",
+        "description": "Scope, authorization, and compliance notes for organizational usage."
+      },
+      "translation_group_key": "content-page-help-for-business-and-research",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "human_review_required": true,
+      "owner_review_required": false,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "helpCenterContent.ts",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "method-boundaries",
+      "status": "existing_english_counterpart_review_record",
+      "required_action": "human_review_needed",
+      "zh_source_key": "method-boundaries",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": true,
+      "en_slug": "method-boundaries",
+      "title_en_draft": "Assessment Method and Boundaries",
+      "description_en_draft": "How to use FermatMind assessment results responsibly, what they can support, and where their limits begin.",
+      "h1_en_draft": "Assessment Method and Boundaries",
+      "body_blocks_en_draft": [
+        {
+          "heading": "What FermatMind assessments are",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "What results can support",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "What results cannot decide",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Medical and high-stakes limits",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Data and privacy boundaries",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "How to use results responsibly",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Assessment Method and Boundaries",
+        "description": "How to use FermatMind assessment results responsibly, what they can support, and where their limits begin."
+      },
+      "translation_group_key": "content-page-method-boundaries",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "content_pages.en.method_boundaries.baseline",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "privacy",
+      "status": "existing_english_counterpart_review_record",
+      "required_action": "human_review_needed",
+      "zh_source_key": "privacy",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": true,
+      "en_slug": "privacy",
+      "title_en_draft": "Privacy Policy",
+      "description_en_draft": "This privacy baseline explains what data FermatMind may process, why it is processed, and how users can manage privacy requests.",
+      "h1_en_draft": "Privacy Policy",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Information we process",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "How we use information",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "User choices",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Contact",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Privacy Policy",
+        "description": "This privacy baseline explains what data FermatMind may process, why it is processed, and how users can manage privacy requests."
+      },
+      "translation_group_key": "content-page-privacy",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "content_pages.en.baseline",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    },
+    {
+      "asset_key": "terms",
+      "status": "existing_english_counterpart_review_record",
+      "required_action": "human_review_needed",
+      "zh_source_key": "terms",
+      "zh_source_exists": true,
+      "zh_source_authority": "content_baselines/content_pages/content_pages.zh-CN.json",
+      "en_counterpart_exists_before_batch": true,
+      "en_slug": "terms",
+      "title_en_draft": "Terms of Use",
+      "description_en_draft": "These terms describe the baseline rules for using FermatMind products, reports, content, and paid services.",
+      "h1_en_draft": "Terms of Use",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Use of service",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Assessment boundaries",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Paid services",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        },
+        {
+          "heading": "Changes",
+          "markdown": "Existing English counterpart retained for human review; no new prose generated in this batch."
+        }
+      ],
+      "cta_blocks_en_draft": [],
+      "seo_meta_en_draft": {
+        "title": "Terms of Use",
+        "description": "These terms describe the baseline rules for using FermatMind products, reports, content, and paid services."
+      },
+      "translation_group_key": "content-page-terms",
+      "claim_boundary_state": "existing_counterpart_review_required",
+      "human_review_required": true,
+      "owner_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false,
+      "reason_if_deferred": null,
+      "source_doc": "content_pages.en.baseline",
+      "prohibited_claims": [
+        "unsupported legal commitments",
+        "clinical diagnosis",
+        "hiring fit",
+        "career success prediction"
+      ]
+    }
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesTranslationBatch01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesTranslationBatch01Test.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesTranslationBatch01Test extends TestCase
+{
+    #[Test]
+    public function content_pages_translation_package_is_draft_only_and_review_gated(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-translation-batch-01.v1.json');
+        $packagePath = base_path('docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json');
+
+        $this->assertFileExists($generatedPath);
+        $this->assertFileExists($packagePath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+        $package = json_decode((string) file_get_contents($packagePath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-content-pages-translation-batch-01.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01', $generated['task'] ?? null);
+        $this->assertSame('global-en-zh-content-pages-translation-batch-01.import.v1', $package['schema_version'] ?? null);
+        $this->assertSame('draft_import_only', $package['package_type'] ?? null);
+
+        $items = $package['items'] ?? [];
+        $this->assertIsArray($items);
+        $this->assertNotEmpty($items);
+
+        $assetKeys = array_column($items, 'asset_key');
+        foreach ([
+            'brand',
+            'charter',
+            'foundation',
+            'careers',
+            'policies',
+            'support',
+            'about',
+            'help-about',
+            'help-contact',
+            'help-faq',
+            'help-for-business-and-research',
+            'method-boundaries',
+        ] as $expectedAssetKey) {
+            $this->assertContains($expectedAssetKey, $assetKeys);
+        }
+
+        foreach ($items as $item) {
+            $this->assertTrue($item['human_review_required'] ?? false);
+            $this->assertFalse($item['sitemap_eligible'] ?? true);
+            $this->assertFalse($item['llms_eligible'] ?? true);
+            $this->assertFalse($item['footer_eligible'] ?? true);
+            $this->assertFalse($item['search_channel_eligible'] ?? true);
+            $this->assertContains($item['publish_state'] ?? null, ['draft_import_only', 'deferred_missing_authority']);
+        }
+
+        $translatedKeys = $generated['translated_asset_keys'] ?? [];
+        $this->assertContains('brand', $translatedKeys);
+        $this->assertContains('charter', $translatedKeys);
+        $this->assertContains('foundation', $translatedKeys);
+        $this->assertContains('careers', $translatedKeys);
+        $this->assertContains('policies', $translatedKeys);
+
+        $deferredItems = $generated['deferred_items'] ?? [];
+        $this->assertContains('support', array_column($deferredItems, 'asset_key'));
+
+        $this->assertSame(0, $generated['sitemap_eligible_count'] ?? null);
+        $this->assertSame(0, $generated['llms_eligible_count'] ?? null);
+        $this->assertSame(0, $generated['footer_eligible_count'] ?? null);
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_pseo_generation'] ?? false);
+        $this->assertTrue($generated['no_frontend_fallback_authority'] ?? false);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-26T01:05:00+08:00",
+  "updated_at": "2026-05-26T01:50:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -19907,7 +19907,7 @@
       "repo": "fap-api",
       "branch": "codex/global-en-zh-content-pages-translation-batch-01",
       "base": "main",
-      "status": "manifest_registered",
+      "status": "local_validation_passed",
       "depends_on": [
         "GLOBAL-EN-ZH-FULL-CONTENT-AUTHORITY-TRANSLATION-MATRIX-00"
       ],
@@ -19918,6 +19918,39 @@
         "manifest_registration": {
           "status": "pass",
           "evidence": "Registered from GLOBAL-EN-ZH-FULL-CONTENT-AUTHORITY-TRANSLATION-MATRIX-00 recommended PR train; implementation not started."
+        },
+        "scope_boundary": {
+          "status": "pass",
+          "changed_files": [
+            "backend/docs/seo/global-en-zh-content-pages-translation-batch-01.md",
+            "backend/docs/seo/generated/global-en-zh-content-pages-translation-batch-01.v1.json",
+            "backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesTranslationBatch01Test.php",
+            "docs/codex/pr-train-state.json"
+          ],
+          "evidence": "Changed files are limited to Batch-01 report, generated summary, draft/import package, focused SeoIntel test, and current task state ledger."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No CMS mutation, publish, deploy, Search Channel action, URL submission, pSEO generation, fap-web mutation, env/DNS/nginx edit, production migration, raw log read, or production user data access performed."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=GlobalEnZhContentPagesTranslationBatch01 --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-translation-batch-01.v1.json >/dev/null",
+            "python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 YAML parse docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check",
+            "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short"
+          ],
+          "evidence": "Focused test exited 0 with 1 warning from missing isolated backend/.env; no env file was created or edited. route:list exited 0 with 203 routes. Pint passed 3564 files. composer validate --strict passed. composer audit reported no advisories. Generated JSON, import package JSON, state JSON, manifest YAML, diff checks, and fap-web reference status passed."
         }
       },
       "scope": {
@@ -19951,6 +19984,16 @@
           "at": "2026-05-26T01:05:00+08:00",
           "status": "manifest_registered",
           "summary": "Registered content/help/policy translation batch as draft/import-only, human-review-required, no-publish/no-CMS-mutation scope."
+        },
+        {
+          "at": "2026-05-26T01:35:00+08:00",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Generated Batch-01 draft/import package, generated summary, Markdown report, focused test, and current PR state update."
+        },
+        {
+          "at": "2026-05-26T01:50:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Batch-01 focused test, route list, Pint, composer validate/audit, JSON/YAML parses, diff checks, and fap-web reference status passed."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added a draft/import-only English package for content/help/policy surfaces.
- Generated English drafts for `brand`, `charter`, `foundation`, `careers`, and `policies` from ZH baseline authority.
- Recorded existing English counterparts as review-only records and deferred `support` because no standalone authority source exists.
- Added a generated summary and focused SeoIntel contract test.
- Updated only the current PR train state ledger.

## Why
The full EN/ZH matrix showed content/help/policy gaps blocking full English parity. This PR prepares review-gated draft/import artifacts without CMS mutation, publication, runtime exposure, or frontend fallback authority.

## Validation
- `cd backend && php artisan test --filter=GlobalEnZhContentPagesTranslationBatch01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-translation-batch-01.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`
- `cd /Users/rainie/Desktop/GitHub/fap-web && git status --short`

Note: the focused PHPUnit command exited 0 with a warning that this isolated worktree has no `backend/.env`; no env file was created or edited.

## Intentionally deferred
- No CMS mutation or publish.
- No sitemap, llms, footer, nav, Search Channel, URL submission, pSEO, deploy, production migration, raw log read, production user data access, or fap-web runtime change.
- `support` remains `deferred_missing_authority` until a standalone support content authority decision exists.
- All generated English drafts remain `human_review_required=true` and `draft_import_only`.
