### PR TITLE
GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 article English counterpart draft package

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-article-translation-batch-02.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-article-translation-batch-02.v1.json
@@ -1,0 +1,142 @@
+{
+  "schema_version": "global-en-zh-article-translation-batch-02.v1",
+  "task": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02",
+  "generated_at": "2026-05-26T01:44:40+08:00",
+  "final_decision": "article_translation_batch_completed_ready_for_human_review",
+  "source_matrix_task": "GLOBAL-EN-ZH-FULL-CONTENT-AUTHORITY-TRANSLATION-MATRIX-00",
+  "missing_en_article_count": 6,
+  "draft_article_count": 6,
+  "deferred_count": 0,
+  "blocked_count": 0,
+  "human_review_required_count": 6,
+  "claim_review_required_count": 6,
+  "reference_review_required_count": 6,
+  "sitemap_eligible_count": 0,
+  "llms_eligible_count": 0,
+  "footer_or_nav_eligible_count": 0,
+  "search_channel_eligible_count": 0,
+  "draft_article_slugs": [
+    "are-infj-men-rare-or-socially-silenced",
+    "best-valentines-date-by-personality-and-relationship-science",
+    "childhood-dream-job-still-shapes-career-choice",
+    "how-16-personality-types-talk-to-an-ai-coach",
+    "how-personality-shapes-attitude-toward-ai",
+    "which-love-script-fits-you-best"
+  ],
+  "missing_en_counterparts": [
+    {
+      "asset_key": "are-infj-men-rare-or-socially-silenced",
+      "source_zh_slug": "are-infj-men-rare-or-socially-silenced",
+      "proposed_en_slug": "are-infj-men-rare-or-socially-silenced",
+      "required_action": "translate_draft_needed",
+      "draft_status": "created_for_human_review"
+    },
+    {
+      "asset_key": "best-valentines-date-by-personality-and-relationship-science",
+      "source_zh_slug": "best-valentines-date-by-personality-and-relationship-science",
+      "proposed_en_slug": "best-valentines-date-by-personality-and-relationship-science",
+      "required_action": "translate_draft_needed",
+      "draft_status": "created_for_human_review"
+    },
+    {
+      "asset_key": "childhood-dream-job-still-shapes-career-choice",
+      "source_zh_slug": "childhood-dream-job-still-shapes-career-choice",
+      "proposed_en_slug": "childhood-dream-job-still-shapes-career-choice",
+      "required_action": "translate_draft_needed",
+      "draft_status": "created_for_human_review"
+    },
+    {
+      "asset_key": "how-16-personality-types-talk-to-an-ai-coach",
+      "source_zh_slug": "how-16-personality-types-talk-to-an-ai-coach",
+      "proposed_en_slug": "how-16-personality-types-talk-to-an-ai-coach",
+      "required_action": "translate_draft_needed",
+      "draft_status": "created_for_human_review"
+    },
+    {
+      "asset_key": "how-personality-shapes-attitude-toward-ai",
+      "source_zh_slug": "how-personality-shapes-attitude-toward-ai",
+      "proposed_en_slug": "how-personality-shapes-attitude-toward-ai",
+      "required_action": "translate_draft_needed",
+      "draft_status": "created_for_human_review"
+    },
+    {
+      "asset_key": "which-love-script-fits-you-best",
+      "source_zh_slug": "which-love-script-fits-you-best",
+      "proposed_en_slug": "which-love-script-fits-you-best",
+      "required_action": "translate_draft_needed",
+      "draft_status": "created_for_human_review"
+    }
+  ],
+  "claim_boundary_findings": [
+    {
+      "asset_key": "are-infj-men-rare-or-socially-silenced",
+      "claim_boundary_state": "claim_review_required_personality_and_gender_norms",
+      "claim_review_required": true,
+      "notes": [
+        "Do not present INFJ male rarity as a verified population statistic.",
+        "Keep the framing about visibility, social norms, and expression cost rather than diagnostic or deterministic claims."
+      ],
+      "unsupported_claims_added": false
+    },
+    {
+      "asset_key": "best-valentines-date-by-personality-and-relationship-science",
+      "claim_boundary_state": "claim_review_required_relationship_science",
+      "claim_review_required": true,
+      "notes": [
+        "Do not promise relationship success or compatibility outcomes.",
+        "Keep date suggestions framed as exploratory design guidance, not prescriptions."
+      ],
+      "unsupported_claims_added": false
+    },
+    {
+      "asset_key": "childhood-dream-job-still-shapes-career-choice",
+      "claim_boundary_state": "claim_review_required_career_direction_boundary",
+      "claim_review_required": true,
+      "notes": [
+        "Do not claim childhood aspirations predict job success or best-fit careers.",
+        "Use career-direction and person-environment-fit framing only."
+      ],
+      "unsupported_claims_added": false
+    },
+    {
+      "asset_key": "how-16-personality-types-talk-to-an-ai-coach",
+      "claim_boundary_state": "claim_review_required_ai_advice_boundary",
+      "claim_review_required": true,
+      "notes": [
+        "Do not present AI coaching as therapy, diagnosis, treatment, or a substitute for human responsibility.",
+        "Keep 16-type statements as tendencies, not deterministic instructions."
+      ],
+      "unsupported_claims_added": false
+    },
+    {
+      "asset_key": "how-personality-shapes-attitude-toward-ai",
+      "claim_boundary_state": "claim_review_required_ai_and_personality_boundary",
+      "claim_review_required": true,
+      "notes": [
+        "Do not claim personality determines whether someone should use AI.",
+        "Do not present AI as a replacement for professional, legal, clinical, or career judgment."
+      ],
+      "unsupported_claims_added": false
+    },
+    {
+      "asset_key": "which-love-script-fits-you-best",
+      "claim_boundary_state": "claim_review_required_relationship_matching_boundary",
+      "claim_review_required": true,
+      "notes": [
+        "Do not promise perfect matching or relationship outcomes.",
+        "Keep 16-type references as exploratory entry points, not compatibility rules."
+      ],
+      "unsupported_claims_added": false
+    }
+  ],
+  "import_package_path": "backend/docs/seo/import-packages/global-en-zh-article-translation-batch-02.import.v1.json",
+  "generated_markdown_report_path": "backend/docs/seo/global-en-zh-article-translation-batch-02.md",
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_pseo_generation": true,
+  "no_frontend_fallback_authority": true,
+  "next_task": "GLOBAL-EN-ZH-TOPIC-TEST-LANDING-BATCH-03"
+}

--- a/backend/docs/seo/global-en-zh-article-translation-batch-02.md
+++ b/backend/docs/seo/global-en-zh-article-translation-batch-02.md
@@ -1,0 +1,41 @@
+# GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 Report
+
+## Executive Summary
+- Final decision: `article_translation_batch_completed_ready_for_human_review`.
+- Missing EN article counterparts converted to draft/import records: 6.
+- Human-review-required items: 6.
+- Claim-review-required items: 6.
+- No CMS mutation, publish, deploy, Search Channel action, URL submission, pSEO generation, or frontend fallback authority was performed.
+
+## Scope
+This batch creates article English counterpart draft/import assets from backend Chinese article authority. It does not modify article baselines, runtime routes, sitemap, llms, fap-web, CMS, or production state.
+
+## Draft Article Matrix
+- `are-infj-men-rare-or-socially-silenced` -> `are-infj-men-rare-or-socially-silenced`: `Are INFJ Men Rare, or Have Highly Sensitive Men Learned to Stay Silent?`; claim state `claim_review_required_personality_and_gender_norms`; human review required.
+- `best-valentines-date-by-personality-and-relationship-science` -> `best-valentines-date-by-personality-and-relationship-science`: `Stop Chasing Romance Alone: Design a Lower-Friction Valentine Date With Personality and Relationship Science`; claim state `claim_review_required_relationship_science`; human review required.
+- `childhood-dream-job-still-shapes-career-choice` -> `childhood-dream-job-still-shapes-career-choice`: `Why Your Childhood Dream Job Still Shapes Your Career Judgment`; claim state `claim_review_required_career_direction_boundary`; human review required.
+- `how-16-personality-types-talk-to-an-ai-coach` -> `how-16-personality-types-talk-to-an-ai-coach`: `When the 16 Personality Types Talk to an AI Coach: Who Uses It as a Mirror, a Tool, or an Easy Yes`; claim state `claim_review_required_ai_advice_boundary`; human review required.
+- `how-personality-shapes-attitude-toward-ai` -> `how-personality-shapes-attitude-toward-ai`: `How Personality Shapes Your Attitude Toward AI: From Curiosity and Anxiety to Algorithm Trust`; claim state `claim_review_required_ai_and_personality_boundary`; human review required.
+- `which-love-script-fits-you-best` -> `which-love-script-fits-you-best`: `Which Relationship Script Fits You Best? A More Scientific Match Through Seven Love Styles`; claim state `claim_review_required_relationship_matching_boundary`; human review required.
+
+## Eligibility Gates
+- `sitemap_eligible=false` for every draft article.
+- `llms_eligible=false` for every draft article.
+- `footer_or_nav_eligible=false` for every draft article.
+- `search_channel_eligible=false` for every draft article.
+
+## Claim Boundary Notes
+- Personality, relationship, career, and AI advice framing is directional and exploratory only.
+- Drafts do not add studies, citations, statistics, salary data, clinical claims, career-success claims, or product capability claims beyond the Chinese authority source.
+- Source references are preserved for human/reference review; no draft is marked approved or published.
+
+## Validation
+- `php artisan test --filter=GlobalEnZhArticleTranslationBatch02 --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- JSON/YAML parse and diff checks
+
+## Next Task
+`GLOBAL-EN-ZH-TOPIC-TEST-LANDING-BATCH-03`

--- a/backend/docs/seo/import-packages/global-en-zh-article-translation-batch-02.import.v1.json
+++ b/backend/docs/seo/import-packages/global-en-zh-article-translation-batch-02.import.v1.json
@@ -1,0 +1,763 @@
+{
+  "schema_version": "global-en-zh-article-translation-batch-02.import.v1",
+  "task": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02",
+  "generated_at": "2026-05-26T01:44:40+08:00",
+  "package_type": "draft_import_only",
+  "source_matrix_task": "GLOBAL-EN-ZH-FULL-CONTENT-AUTHORITY-TRANSLATION-MATRIX-00",
+  "source_matrix_path": "backend/docs/seo/generated/global-en-zh-full-content-authority-translation-matrix-00.v1.json",
+  "authority_source": "content_baselines/articles/articles.zh-CN.json via backend article baseline/import authority",
+  "items": [
+    {
+      "asset_family": "articles",
+      "asset_key": "are-infj-men-rare-or-socially-silenced",
+      "source_zh_slug": "are-infj-men-rare-or-socially-silenced",
+      "proposed_en_slug": "are-infj-men-rare-or-socially-silenced",
+      "translation_group_key": "article:are-infj-men-rare-or-socially-silenced",
+      "translation_group_exists": false,
+      "zh_source_status": "published",
+      "zh_source_authority": "articles backend baseline import package",
+      "en_counterpart_status": "missing_draft_created_for_review",
+      "title_zh": "“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？",
+      "title_en_draft": "Are INFJ Men Rare, or Have Highly Sensitive Men Learned to Stay Silent?",
+      "description_en_draft": "A source-backed draft on why some men with deep empathy, sensitivity, and value focus may be less visible because masculine norms reward emotional compression.",
+      "h1_en_draft": "Are INFJ Men Rare, or Have Highly Sensitive Men Learned to Stay Silent?",
+      "summary_en_draft": "The useful question is not only whether INFJ-like men are statistically rare, but whether the cost of showing sensitivity makes those traits harder to see.",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Executive Summary",
+          "paragraphs": [
+            "The claim that INFJ men are rare is popular partly because it points toward a recognizable experience: some men who are highly reflective, value-driven, empathic, or internally consistent do not display those traits openly.",
+            "The issue may be less about whether this kind of man is naturally rare and more about how early many men learn to compress, hide, or deny traits that are read as too sensitive.",
+            "FermatMind treats visibility as the more useful question. Some people do not lack these traits; the traits have been trained into something that feels unsafe or unrewarded to show in public."
+          ]
+        },
+        {
+          "heading": "1. What It Means to Learn Silence",
+          "paragraphs": [
+            "Jack and Dill developed the concept of self-silencing to describe patterns in which people suppress thoughts and feelings in order to preserve intimacy, safety, or connection. The idea is also useful for understanding why some people prioritize external harmony, approval, or relational safety at the expense of internal coherence.",
+            "In the context of male socialization, that mechanism becomes more complex. Many boys are taught less to express themselves and more to control themselves, avoid appearing vulnerable, avoid being seen as overly sensitive, and keep emotions from affecting judgment.",
+            "Under that training, emotion does not disappear. It is often converted into humor, distance, rationality, efficiency, silence, or the impression that nothing happened."
+          ]
+        },
+        {
+          "heading": "2. Why Highly Sensitive Men Are Easy to Misread",
+          "paragraphs": [
+            "A man who cares about meaning, relational detail, value consistency, or subtle shifts in group atmosphere can be misread in two common ways. One misread is that he is too slow because he integrates internally before deciding. Another is that he overthinks because he notices relational costs and long-term consequences earlier than others.",
+            "Research on masculine norms repeatedly links strong internalization of emotional control, self-reliance, dominance, and work primacy with poorer mental-health-related outcomes, weaker help-seeking attitudes, and higher interpersonal isolation risk.",
+            "Men who look strong, independent, and quiet are not necessarily steadier. Often, they have become skilled at hiding the movement underneath."
+          ],
+          "evidence_note": "The source article cites meta-analytic work on conformity to masculine norms. This draft does not criticize masculinity itself; it identifies the social cost of not being allowed to express certain traits."
+        },
+        {
+          "heading": "3. Suppression Has Social Costs",
+          "paragraphs": [
+            "Srivastava and colleagues found that expressive suppression is associated with lower social support, less closeness, and lower social satisfaction. In practical terms, when a man repeatedly wraps up real emotion and real need, he may look mature, reliable, or controlled in the short term while becoming harder to understand and harder to support over time.",
+            "This means that the apparent rarity of a certain kind of man can mix two different things: real differences in trait distribution and the social cost of showing those traits. For FermatMind, the second explanation is often more revealing because many groups and relationships do not show who a person is; they show which parts of the person are permitted on stage."
+          ],
+          "bullets": [
+            "He may be harder to understand.",
+            "He may be harder to support.",
+            "He may struggle to build stable, deep connection."
+          ]
+        },
+        {
+          "heading": "4. How FermatMind Reads the INFJ Male Rarity Claim",
+          "paragraphs": [
+            "FermatMind does not treat INFJ male rarity as a simple statistical truth to announce. A more careful version is that some men whose expression resembles the INFJ pattern may be more likely to use masking strategies.",
+            "They may not be absent. In public settings they may train themselves to look more like executors, observers, or problem-solvers while hiding vulnerability, nuance, and value sensitivity. This is why people sometimes say that a man becomes completely different after trust is established. The personality did not suddenly change; permission to express it finally changed."
+          ]
+        },
+        {
+          "heading": "Conclusion",
+          "paragraphs": [
+            "If you want to know whether a type of man is rare, the first question should not be only how many exist. It should be how expensive it is to show those traits.",
+            "In many contexts, silence is itself a result of socialization. The truly rare thing may not be the personality, but an environment where that personality can remain visible without being punished."
+          ]
+        }
+      ],
+      "content_md_en_draft": "# Are INFJ Men Rare, or Have Highly Sensitive Men Learned to Stay Silent?\n\n## Executive Summary\n\nThe claim that INFJ men are rare is popular partly because it points toward a recognizable experience: some men who are highly reflective, value-driven, empathic, or internally consistent do not display those traits openly.\n\nThe issue may be less about whether this kind of man is naturally rare and more about how early many men learn to compress, hide, or deny traits that are read as too sensitive.\n\nFermatMind treats visibility as the more useful question. Some people do not lack these traits; the traits have been trained into something that feels unsafe or unrewarded to show in public.\n\n## 1. What It Means to Learn Silence\n\nJack and Dill developed the concept of self-silencing to describe patterns in which people suppress thoughts and feelings in order to preserve intimacy, safety, or connection. The idea is also useful for understanding why some people prioritize external harmony, approval, or relational safety at the expense of internal coherence.\n\nIn the context of male socialization, that mechanism becomes more complex. Many boys are taught less to express themselves and more to control themselves, avoid appearing vulnerable, avoid being seen as overly sensitive, and keep emotions from affecting judgment.\n\nUnder that training, emotion does not disappear. It is often converted into humor, distance, rationality, efficiency, silence, or the impression that nothing happened.\n\n## 2. Why Highly Sensitive Men Are Easy to Misread\n\nA man who cares about meaning, relational detail, value consistency, or subtle shifts in group atmosphere can be misread in two common ways. One misread is that he is too slow because he integrates internally before deciding. Another is that he overthinks because he notices relational costs and long-term consequences earlier than others.\n\nResearch on masculine norms repeatedly links strong internalization of emotional control, self-reliance, dominance, and work primacy with poorer mental-health-related outcomes, weaker help-seeking attitudes, and higher interpersonal isolation risk.\n\nMen who look strong, independent, and quiet are not necessarily steadier. Often, they have become skilled at hiding the movement underneath.\n\n> **Evidence Note**\n\n> The source article cites meta-analytic work on conformity to masculine norms. This draft does not criticize masculinity itself; it identifies the social cost of not being allowed to express certain traits.\n\n## 3. Suppression Has Social Costs\n\nSrivastava and colleagues found that expressive suppression is associated with lower social support, less closeness, and lower social satisfaction. In practical terms, when a man repeatedly wraps up real emotion and real need, he may look mature, reliable, or controlled in the short term while becoming harder to understand and harder to support over time.\n\nThis means that the apparent rarity of a certain kind of man can mix two different things: real differences in trait distribution and the social cost of showing those traits. For FermatMind, the second explanation is often more revealing because many groups and relationships do not show who a person is; they show which parts of the person are permitted on stage.\n\n- He may be harder to understand.\n\n- He may be harder to support.\n\n- He may struggle to build stable, deep connection.\n\n## 4. How FermatMind Reads the INFJ Male Rarity Claim\n\nFermatMind does not treat INFJ male rarity as a simple statistical truth to announce. A more careful version is that some men whose expression resembles the INFJ pattern may be more likely to use masking strategies.\n\nThey may not be absent. In public settings they may train themselves to look more like executors, observers, or problem-solvers while hiding vulnerability, nuance, and value sensitivity. This is why people sometimes say that a man becomes completely different after trust is established. The personality did not suddenly change; permission to express it finally changed.\n\n## Conclusion\n\nIf you want to know whether a type of man is rare, the first question should not be only how many exist. It should be how expensive it is to show those traits.\n\nIn many contexts, silence is itself a result of socialization. The truly rare thing may not be the personality, but an environment where that personality can remain visible without being punished.\n\nReferences\n\n[1] Jack, D. C., & Dill, D. (1992). The Silencing the Self Scale: Schemas of intimacy associated with depression in women. Psychology of Women Quarterly, 16(1), 97–106. https://doi.org/10.1111/j.1471-6402.1992.tb00242.x\n\n[2] Mahalik, J. R., Locke, B. D., Ludlow, L. H., et al. (2003). Development of the Conformity to Masculine Norms Inventory. Psychology of Men & Masculinity, 4(1), 3–25. https://doi.org/10.1037/1524-9220.4.1.3\n\n[3] Wong, Y. J., Ho, M.-H. R., Wang, S.-Y., & Miller, I. S. K. (2017). Meta-analyses of the relationship between conformity to masculine norms and mental health-related outcomes. Journal of Counseling Psychology, 64(1), 80–93. https://doi.org/10.1037/cou0000176\n\n[4] Mahalik, J. R., Talmadge, W. T., Locke, B. D., & Scott, R. P. J. (2005). Using the Conformity to Masculine Norms Inventory to work with men in a clinical setting. Journal of Clinical Psychology, 61(6), 661–674. https://doi.org/10.1002/jclp.20101\n\n[5] Srivastava, S., Tamir, M., McGonigal, K. M., John, O. P., & Gross, J. J. (2009). The social costs of emotional suppression: A prospective study of the transition to college. Journal of Personality and Social Psychology, 96(4), 883–897. https://doi.org/10.1037/a0014755\n\n[6] Advancing the next generation of research on self-silencing and depression: A narrative review and synthesis of three decades of research. (2025). Sex Roles. https://doi.org/10.1007/s11199-025-01637-8",
+      "related_test_topic_article_links_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "INFJ",
+          "高敏感",
+          "男性规范",
+          "自我沉默",
+          "情绪表达"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "media_references": {
+        "source_cover_image_url": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+        "source_cover_image_alt_zh": "半透明男性轮廓与被压低的声波线条，象征高敏感男性的自我沉默",
+        "cover_image_alt_en_draft": "A translucent male silhouette with lowered sound-wave lines, suggesting self-silencing among highly sensitive men.",
+        "cover_image_width": 1200,
+        "cover_image_height": 675,
+        "cover_image_variants": {
+          "hero": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+          "card": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+          "thumbnail": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+          "og": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+          "preload": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg"
+        },
+        "human_visual_review_required": true
+      },
+      "source_references_preserved": [
+        "[1] Jack, D. C., & Dill, D. (1992). The Silencing the Self Scale: Schemas of intimacy associated with depression in women. Psychology of Women Quarterly, 16(1), 97–106. https://doi.org/10.1111/j.1471-6402.1992.tb00242.x",
+        "[2] Mahalik, J. R., Locke, B. D., Ludlow, L. H., et al. (2003). Development of the Conformity to Masculine Norms Inventory. Psychology of Men & Masculinity, 4(1), 3–25. https://doi.org/10.1037/1524-9220.4.1.3",
+        "[3] Wong, Y. J., Ho, M.-H. R., Wang, S.-Y., & Miller, I. S. K. (2017). Meta-analyses of the relationship between conformity to masculine norms and mental health-related outcomes. Journal of Counseling Psychology, 64(1), 80–93. https://doi.org/10.1037/cou0000176",
+        "[4] Mahalik, J. R., Talmadge, W. T., Locke, B. D., & Scott, R. P. J. (2005). Using the Conformity to Masculine Norms Inventory to work with men in a clinical setting. Journal of Clinical Psychology, 61(6), 661–674. https://doi.org/10.1002/jclp.20101",
+        "[5] Srivastava, S., Tamir, M., McGonigal, K. M., John, O. P., & Gross, J. J. (2009). The social costs of emotional suppression: A prospective study of the transition to college. Journal of Personality and Social Psychology, 96(4), 883–897. https://doi.org/10.1037/a0014755",
+        "[6] Advancing the next generation of research on self-silencing and depression: A narrative review and synthesis of three decades of research. (2025). Sex Roles. https://doi.org/10.1007/s11199-025-01637-8"
+      ],
+      "reference_review_required": true,
+      "claim_boundary_state": "claim_review_required_personality_and_gender_norms",
+      "claim_review_required": true,
+      "claim_review_notes": [
+        "Do not present INFJ male rarity as a verified population statistic.",
+        "Keep the framing about visibility, social norms, and expression cost rather than diagnostic or deterministic claims."
+      ],
+      "unsupported_claims_added": false,
+      "human_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_or_nav_eligible": false,
+      "jsonld_eligible": false,
+      "search_channel_eligible": false,
+      "no_publish": true,
+      "no_cms_mutation": true,
+      "reason_if_deferred": null
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "best-valentines-date-by-personality-and-relationship-science",
+      "source_zh_slug": "best-valentines-date-by-personality-and-relationship-science",
+      "proposed_en_slug": "best-valentines-date-by-personality-and-relationship-science",
+      "translation_group_key": "article:best-valentines-date-by-personality-and-relationship-science",
+      "translation_group_exists": false,
+      "zh_source_status": "published",
+      "zh_source_authority": "articles backend baseline import package",
+      "en_counterpart_status": "missing_draft_created_for_review",
+      "title_zh": "情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会",
+      "title_en_draft": "Stop Chasing Romance Alone: Design a Lower-Friction Valentine Date With Personality and Relationship Science",
+      "description_en_draft": "A source-backed draft on designing dates around novelty, safety, interaction density, and relationship goals rather than cost or spectacle.",
+      "h1_en_draft": "Stop Chasing Romance Alone: Design a Lower-Friction Valentine Date With Personality and Relationship Science",
+      "summary_en_draft": "The best date is not necessarily the biggest one. It is the shared experience that fits both people's pace, stimulation threshold, and relationship goal.",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Executive Summary",
+          "paragraphs": [
+            "A common dating mistake is treating high stimulation as high quality. Relationship research points to a more useful standard: a good shared experience creates some novelty without pushing either person outside psychological safety.",
+            "FermatMind suggests asking a different first question. Instead of asking where to go for Valentine's Day, ask what this date is supposed to accomplish. Is the goal deeper understanding, relief from boredom, renewed closeness, commitment clarification, or simply less friction?",
+            "Different personality styles and relationship stages prioritize those goals differently."
+          ]
+        },
+        {
+          "heading": "1. A Date Is Not Just an Activity. It Is a Relationship Experience",
+          "paragraphs": [
+            "Classic work by Aron and colleagues found that couples who participate in novel and arousing activities can experience improvements in relationship quality, partly through reduced boredom and increased closeness. That does not mean more stimulation is always better.",
+            "Novelty helps when it is experienced as growth, not threat. A practical date design should consider novelty, safety, interaction density, and afterglow."
+          ],
+          "numbered": [
+            "Novelty: Does it introduce something fresh?",
+            "Safety: Does either person feel out of control or forced to perform?",
+            "Interaction density: Does it allow real exchange?",
+            "Afterglow: Do both people leave closer, or simply tired?"
+          ],
+          "evidence_note": "Shared novel activities may support relationship quality when both partners experience them as manageable expansion, not forced endurance."
+        },
+        {
+          "heading": "2. Lower-Friction Dates by Personality Family",
+          "paragraphs": [
+            "Using 16-type language as a practical entry point, FermatMind recommends reading date preferences by broad personality family rather than by single type alone.",
+            "NT styles often do best with themed, discussion-friendly, intellectually fresh experiences such as a small exhibition, a curated bookstore, a quiet bar with room to talk, or a film that invites analysis. The risk is that a scripted or noisy plan can make the date feel like a task.",
+            "NF styles often prefer meaning, emotional movement, and story exchange: a long walk, a gentle hands-on activity, an exhibition followed by conversation, or a quiet dinner. The risk is that a purely functional plan can feel like coordination instead of resonance.",
+            "SJ styles usually appreciate clear structure, reliable details, and stable experience: a well-reserved restaurant, a clear short trip, or an activity that shows preparation. The risk is that sudden plan changes can move attention from connection back to risk management.",
+            "SP styles often respond to sensory participation, immediate feedback, and embodied experience: a night market, a short outdoor activity, live music, a new restaurant, or a compact high-experience event. The risk is that something too static or over-scripted can drain energy quickly."
+          ]
+        },
+        {
+          "heading": "3. The Most Common Valentine Mistakes",
+          "paragraphs": [
+            "Three mistakes appear again and again: mistaking high cost for care, mistaking high stimulation for intimacy, and assuming that what feels good to one person will automatically feel good to the other.",
+            "The source article cites research suggesting that date planning promotes closeness through shared approach goals and self-expansion rather than one-sided drama. A successful date is not measured by whether it is romantic enough, but by whether both people feel closer, less tense, and more willing to continue the next interaction."
+          ]
+        },
+        {
+          "heading": "4. FermatMind Date Design Principles",
+          "paragraphs": [
+            "If the relationship is new, start with low-friction activities that allow conversation. If the relationship is stable but flat, add manageable novelty so the relationship does not become pure efficiency.",
+            "If recent friction has increased, avoid high-stimulation plans and restore safety first. If the relationship is near a commitment decision, choose a setting that reveals how both people make decisions rather than one that only displays romance."
+          ]
+        },
+        {
+          "heading": "Conclusion",
+          "paragraphs": [
+            "Valentine's Day is not a performance contest or a race for romantic intensity. The strongest dates find a workable ratio between freshness and safety, allowing two people to leave habit behind without spending all their energy on the activity itself.",
+            "A high-quality date leaves behind a clearer feeling: I understand who you are a little better, and I want to move closer again."
+          ]
+        }
+      ],
+      "content_md_en_draft": "# Stop Chasing Romance Alone: Design a Lower-Friction Valentine Date With Personality and Relationship Science\n\n## Executive Summary\n\nA common dating mistake is treating high stimulation as high quality. Relationship research points to a more useful standard: a good shared experience creates some novelty without pushing either person outside psychological safety.\n\nFermatMind suggests asking a different first question. Instead of asking where to go for Valentine's Day, ask what this date is supposed to accomplish. Is the goal deeper understanding, relief from boredom, renewed closeness, commitment clarification, or simply less friction?\n\nDifferent personality styles and relationship stages prioritize those goals differently.\n\n## 1. A Date Is Not Just an Activity. It Is a Relationship Experience\n\nClassic work by Aron and colleagues found that couples who participate in novel and arousing activities can experience improvements in relationship quality, partly through reduced boredom and increased closeness. That does not mean more stimulation is always better.\n\nNovelty helps when it is experienced as growth, not threat. A practical date design should consider novelty, safety, interaction density, and afterglow.\n\n1. Novelty: Does it introduce something fresh?\n\n2. Safety: Does either person feel out of control or forced to perform?\n\n3. Interaction density: Does it allow real exchange?\n\n4. Afterglow: Do both people leave closer, or simply tired?\n\n> **Evidence Note**\n\n> Shared novel activities may support relationship quality when both partners experience them as manageable expansion, not forced endurance.\n\n## 2. Lower-Friction Dates by Personality Family\n\nUsing 16-type language as a practical entry point, FermatMind recommends reading date preferences by broad personality family rather than by single type alone.\n\nNT styles often do best with themed, discussion-friendly, intellectually fresh experiences such as a small exhibition, a curated bookstore, a quiet bar with room to talk, or a film that invites analysis. The risk is that a scripted or noisy plan can make the date feel like a task.\n\nNF styles often prefer meaning, emotional movement, and story exchange: a long walk, a gentle hands-on activity, an exhibition followed by conversation, or a quiet dinner. The risk is that a purely functional plan can feel like coordination instead of resonance.\n\nSJ styles usually appreciate clear structure, reliable details, and stable experience: a well-reserved restaurant, a clear short trip, or an activity that shows preparation. The risk is that sudden plan changes can move attention from connection back to risk management.\n\nSP styles often respond to sensory participation, immediate feedback, and embodied experience: a night market, a short outdoor activity, live music, a new restaurant, or a compact high-experience event. The risk is that something too static or over-scripted can drain energy quickly.\n\n## 3. The Most Common Valentine Mistakes\n\nThree mistakes appear again and again: mistaking high cost for care, mistaking high stimulation for intimacy, and assuming that what feels good to one person will automatically feel good to the other.\n\nThe source article cites research suggesting that date planning promotes closeness through shared approach goals and self-expansion rather than one-sided drama. A successful date is not measured by whether it is romantic enough, but by whether both people feel closer, less tense, and more willing to continue the next interaction.\n\n## 4. FermatMind Date Design Principles\n\nIf the relationship is new, start with low-friction activities that allow conversation. If the relationship is stable but flat, add manageable novelty so the relationship does not become pure efficiency.\n\nIf recent friction has increased, avoid high-stimulation plans and restore safety first. If the relationship is near a commitment decision, choose a setting that reveals how both people make decisions rather than one that only displays romance.\n\n## Conclusion\n\nValentine's Day is not a performance contest or a race for romantic intensity. The strongest dates find a workable ratio between freshness and safety, allowing two people to leave habit behind without spending all their energy on the activity itself.\n\nA high-quality date leaves behind a clearer feeling: I understand who you are a little better, and I want to move closer again.\n\nReferences\n\n[1] Aron, A., Norman, C. C., Aron, E. N., McKenna, C., & Heyman, R. E. (2000). Couples’ shared participation in novel and arousing activities and experienced relationship quality. Journal of Personality and Social Psychology, 78(2), 273–284. https://doi.org/10.1037/0022-3514.78.2.273\n\n[2] Schrage, K. M., Impett, E. A., Topal, M. A., Harasymchuk, C., & Muise, A. (2026). Novel and exciting or tried and true? Tailoring shared relationship experiences to insecurely attached partners. Social Psychological and Personality Science. https://doi.org/10.1177/19485506251411438\n\n[3] Raposo, S., Rosen, N. O., & Muise, A. (2020). Self-expansion is associated with greater relationship and sexual well-being for couples coping with low sexual desire. Journal of Social and Personal Relationships, 37(2), 511–533. https://doi.org/10.1177/0265407519875217\n\n[4] Harasymchuk, C., Walker, D. L., Muise, A., & Impett, E. A. (2021). Planning date nights that promote closeness: The roles of relationship goals and self-expansion. Journal of Social and Personal Relationships, 38(5), 1509–1535. https://doi.org/10.1177/02654075211000436\n\n[5] Tomlinson, J. M., Hughes, E. K., Lewandowski, G. W., Aron, A., & Geyer, R. (2019). Do shared self-expanding activities have to be physically arousing? Journal of Social and Personal Relationships, 36(9), 2761–2785. https://doi.org/10.1177/0265407518801095",
+      "related_test_topic_article_links_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "约会设计",
+          "情人节",
+          "人格心理学",
+          "亲密关系",
+          "关系科学"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "media_references": {
+        "source_cover_image_url": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+        "source_cover_image_alt_zh": "抽象路径地图连接两个关系节点，表现低摩擦约会设计",
+        "cover_image_alt_en_draft": "An abstract route map connecting two relationship nodes, representing lower-friction date design.",
+        "cover_image_width": 1200,
+        "cover_image_height": 675,
+        "cover_image_variants": {
+          "hero": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+          "card": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+          "thumbnail": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+          "og": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+          "preload": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg"
+        },
+        "human_visual_review_required": true
+      },
+      "source_references_preserved": [
+        "[1] Aron, A., Norman, C. C., Aron, E. N., McKenna, C., & Heyman, R. E. (2000). Couples’ shared participation in novel and arousing activities and experienced relationship quality. Journal of Personality and Social Psychology, 78(2), 273–284. https://doi.org/10.1037/0022-3514.78.2.273",
+        "[2] Schrage, K. M., Impett, E. A., Topal, M. A., Harasymchuk, C., & Muise, A. (2026). Novel and exciting or tried and true? Tailoring shared relationship experiences to insecurely attached partners. Social Psychological and Personality Science. https://doi.org/10.1177/19485506251411438",
+        "[3] Raposo, S., Rosen, N. O., & Muise, A. (2020). Self-expansion is associated with greater relationship and sexual well-being for couples coping with low sexual desire. Journal of Social and Personal Relationships, 37(2), 511–533. https://doi.org/10.1177/0265407519875217",
+        "[4] Harasymchuk, C., Walker, D. L., Muise, A., & Impett, E. A. (2021). Planning date nights that promote closeness: The roles of relationship goals and self-expansion. Journal of Social and Personal Relationships, 38(5), 1509–1535. https://doi.org/10.1177/02654075211000436",
+        "[5] Tomlinson, J. M., Hughes, E. K., Lewandowski, G. W., Aron, A., & Geyer, R. (2019). Do shared self-expanding activities have to be physically arousing? Journal of Social and Personal Relationships, 36(9), 2761–2785. https://doi.org/10.1177/0265407518801095"
+      ],
+      "reference_review_required": true,
+      "claim_boundary_state": "claim_review_required_relationship_science",
+      "claim_review_required": true,
+      "claim_review_notes": [
+        "Do not promise relationship success or compatibility outcomes.",
+        "Keep date suggestions framed as exploratory design guidance, not prescriptions."
+      ],
+      "unsupported_claims_added": false,
+      "human_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_or_nav_eligible": false,
+      "jsonld_eligible": false,
+      "search_channel_eligible": false,
+      "no_publish": true,
+      "no_cms_mutation": true,
+      "reason_if_deferred": null
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "childhood-dream-job-still-shapes-career-choice",
+      "source_zh_slug": "childhood-dream-job-still-shapes-career-choice",
+      "proposed_en_slug": "childhood-dream-job-still-shapes-career-choice",
+      "translation_group_key": "article:childhood-dream-job-still-shapes-career-choice",
+      "translation_group_exists": false,
+      "zh_source_status": "published",
+      "zh_source_authority": "articles backend baseline import package",
+      "en_counterpart_status": "missing_draft_created_for_review",
+      "title_zh": "你小时候想做的工作，为什么还在影响你今天的职业判断？",
+      "title_en_draft": "Why Your Childhood Dream Job Still Shapes Your Career Judgment",
+      "description_en_draft": "A source-backed draft on why childhood career wishes can reveal preferred work structures without predicting a single future job.",
+      "h1_en_draft": "Why Your Childhood Dream Job Still Shapes Your Career Judgment",
+      "summary_en_draft": "A childhood dream job does not predict your future, but it often exposes the work structure you still value: autonomy, care, order, creativity, exploration, or visibility.",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Executive Summary",
+          "paragraphs": [
+            "Many adults remember childhood dream jobs with a smile: astronaut, teacher, writer, police officer, designer, doctor, entrepreneur. Most people do not actually enter those roles, but that does not make the wishes meaningless.",
+            "Career-development research suggests early occupational aspirations are not random fantasies. They are shaped by self-concept, social evaluation, gender norms, perceived ability, and opportunity structure.",
+            "From this angle, a childhood dream job does not decide what you should do today. It often reveals what you value in work: power, creativity, order, care, exploration, or being seen."
+          ]
+        },
+        {
+          "heading": "1. Childhood Career Wishes Are Often Early Self-Concepts",
+          "paragraphs": [
+            "Gottfredson's theory of circumscription and compromise proposes that children and adolescents gradually exclude occupations that feel inconsistent with who they are or that their environment signals are not for them.",
+            "When a child says what they want to be, they may be saying what kind of position, capability, image, or life they want. A child who wants to be a writer or researcher may want room to explain the world. A child who wants to be a doctor or teacher may want to be useful and trusted. A child who wants to be an entrepreneur, police officer, or pilot may want agency, risk, or visibility.",
+            "That is why childhood occupational wishes are rarely meaningless. They are often early sketches of self-concept."
+          ]
+        },
+        {
+          "heading": "2. Why Many People Move Away From the Childhood Ideal",
+          "paragraphs": [
+            "Moving away from a childhood ideal is not automatically self-betrayal. Occupational aspirations are influenced by gender roles, socioeconomic status, ability feedback, opportunity structure, and practical compromise.",
+            "Many people do not stop liking the underlying work world. They gradually decide that the reward does not fit, the entry threshold is too high, the role may not fit their capabilities, or family and environment have narrowed the available options.",
+            "A more mature approach is not to cling to the childhood title or mock it. It is to translate the wish into the structural preference underneath it and find a sustainable modern expression."
+          ]
+        },
+        {
+          "heading": "3. Person-Environment Fit Matters More Than the Job Name",
+          "paragraphs": [
+            "Career research has long emphasized person-environment fit. The meta-analysis by Kristof-Brown and colleagues found that person-job, person-organization, person-group, and person-supervisor fit all relate to work attitudes, performance, and turnover intentions.",
+            "In practical terms, whether a job can remain livable is not decided only by whether you like its name. It depends on the match between tasks, organization, team style, value structure, and personal preference.",
+            "An adult who once wanted to be an astronaut may not need to work in aerospace, but may still prefer high-autonomy, high-exploration, high-complexity work with long-term meaning. An adult who once wanted to teach may not need a school role, but may still seek work with explanation, development, and social contribution."
+          ],
+          "evidence_note": "The source uses person-environment fit research as a directional framework, not as a promise of job performance or career success."
+        },
+        {
+          "heading": "4. How FermatMind Uses This Signal",
+          "paragraphs": [
+            "FermatMind does not treat childhood dream jobs as career answers. It treats them as early clues. The useful question is: what work structure was I seeking?",
+            "A practical review asks what attracted you to the childhood job, whether the attraction was power, creativity, care, order, risk, being seen, or problem solving, whether you still want those elements, and which modern work structures can provide them without long-term depletion.",
+            "When you ask the question this way, a childhood ideal becomes a career-design signal rather than an immature fantasy."
+          ]
+        },
+        {
+          "heading": "5. From Dream Job to Right Work Structure",
+          "paragraphs": [
+            "Research connecting Big Five traits and RIASEC interest dimensions helps explain why some people remain drawn to certain occupational worlds. Over time, personality and interests can also relate to career stability and mobility.",
+            "This does not turn career choice into a one-time answer. It makes it an ongoing negotiation among personality tendency, interest structure, and real constraints.",
+            "The more mature question is not whether you can still become the person you imagined as a child. It is whether today's world offers a steadier, truer, less costly work structure for the self-concept that appeared early."
+          ]
+        },
+        {
+          "heading": "Conclusion",
+          "paragraphs": [
+            "A childhood dream job is worth revisiting not because it predicted your career, but because it may have revealed the work elements you valued earliest.",
+            "Mature career judgment does not abandon the dream. It translates the job title into a sustainable work structure, so the pursuit becomes less about a childhood position and more about a way of working that still deserves your investment."
+          ]
+        }
+      ],
+      "content_md_en_draft": "# Why Your Childhood Dream Job Still Shapes Your Career Judgment\n\n## Executive Summary\n\nMany adults remember childhood dream jobs with a smile: astronaut, teacher, writer, police officer, designer, doctor, entrepreneur. Most people do not actually enter those roles, but that does not make the wishes meaningless.\n\nCareer-development research suggests early occupational aspirations are not random fantasies. They are shaped by self-concept, social evaluation, gender norms, perceived ability, and opportunity structure.\n\nFrom this angle, a childhood dream job does not decide what you should do today. It often reveals what you value in work: power, creativity, order, care, exploration, or being seen.\n\n## 1. Childhood Career Wishes Are Often Early Self-Concepts\n\nGottfredson's theory of circumscription and compromise proposes that children and adolescents gradually exclude occupations that feel inconsistent with who they are or that their environment signals are not for them.\n\nWhen a child says what they want to be, they may be saying what kind of position, capability, image, or life they want. A child who wants to be a writer or researcher may want room to explain the world. A child who wants to be a doctor or teacher may want to be useful and trusted. A child who wants to be an entrepreneur, police officer, or pilot may want agency, risk, or visibility.\n\nThat is why childhood occupational wishes are rarely meaningless. They are often early sketches of self-concept.\n\n## 2. Why Many People Move Away From the Childhood Ideal\n\nMoving away from a childhood ideal is not automatically self-betrayal. Occupational aspirations are influenced by gender roles, socioeconomic status, ability feedback, opportunity structure, and practical compromise.\n\nMany people do not stop liking the underlying work world. They gradually decide that the reward does not fit, the entry threshold is too high, the role may not fit their capabilities, or family and environment have narrowed the available options.\n\nA more mature approach is not to cling to the childhood title or mock it. It is to translate the wish into the structural preference underneath it and find a sustainable modern expression.\n\n## 3. Person-Environment Fit Matters More Than the Job Name\n\nCareer research has long emphasized person-environment fit. The meta-analysis by Kristof-Brown and colleagues found that person-job, person-organization, person-group, and person-supervisor fit all relate to work attitudes, performance, and turnover intentions.\n\nIn practical terms, whether a job can remain livable is not decided only by whether you like its name. It depends on the match between tasks, organization, team style, value structure, and personal preference.\n\nAn adult who once wanted to be an astronaut may not need to work in aerospace, but may still prefer high-autonomy, high-exploration, high-complexity work with long-term meaning. An adult who once wanted to teach may not need a school role, but may still seek work with explanation, development, and social contribution.\n\n> **Evidence Note**\n\n> The source uses person-environment fit research as a directional framework, not as a promise of job performance or career success.\n\n## 4. How FermatMind Uses This Signal\n\nFermatMind does not treat childhood dream jobs as career answers. It treats them as early clues. The useful question is: what work structure was I seeking?\n\nA practical review asks what attracted you to the childhood job, whether the attraction was power, creativity, care, order, risk, being seen, or problem solving, whether you still want those elements, and which modern work structures can provide them without long-term depletion.\n\nWhen you ask the question this way, a childhood ideal becomes a career-design signal rather than an immature fantasy.\n\n## 5. From Dream Job to Right Work Structure\n\nResearch connecting Big Five traits and RIASEC interest dimensions helps explain why some people remain drawn to certain occupational worlds. Over time, personality and interests can also relate to career stability and mobility.\n\nThis does not turn career choice into a one-time answer. It makes it an ongoing negotiation among personality tendency, interest structure, and real constraints.\n\nThe more mature question is not whether you can still become the person you imagined as a child. It is whether today's world offers a steadier, truer, less costly work structure for the self-concept that appeared early.\n\n## Conclusion\n\nA childhood dream job is worth revisiting not because it predicted your career, but because it may have revealed the work elements you valued earliest.\n\nMature career judgment does not abandon the dream. It translates the job title into a sustainable work structure, so the pursuit becomes less about a childhood position and more about a way of working that still deserves your investment.\n\nReferences\n\n[1] Gottfredson, L. S. (1981). Circumscription and compromise: A developmental theory of occupational aspirations. Journal of Counseling Psychology, 28(6), 545–579. https://doi.org/10.1037/0022-0167.28.6.545\n\n[2] Cochran, D. B., Wang, E. W., Stevenson, S. J., Johnson, L. E., & Crews, C. (2011). Adolescent occupational aspirations: Test of Gottfredson’s theory of circumscription and compromise. The Career Development Quarterly, 59(5), 412–427. https://doi.org/10.1002/j.2161-0045.2011.tb00968.x\n\n[3] Kristof-Brown, A. L., Zimmerman, R. D., & Johnson, E. C. (2005). Consequences of individuals’ fit at work: A meta-analysis of person–job, person–organization, person–group, and person–supervisor fit. Personnel Psychology, 58(2), 281–342. https://doi.org/10.1111/j.1744-6570.2005.00672.x\n\n[4] De Fruyt, F., & Mervielde, I. (1997). The Five-Factor Model of personality and Holland’s RIASEC interest types. Personality and Individual Differences, 23, 87–103. https://doi.org/10.1016/S0191-8869(97)00004-4\n\n[5] Batista, J. S., & Gondim, S. M. G. (2023). Personality and person-work environment fit: A study based on the RIASEC model. International Journal of Environmental Research and Public Health, 20(1), 719. https://doi.org/10.3390/ijerph20010719\n\n[6] Wille, B., De Fruyt, F., & Feys, M. (2010). Vocational interests and Big Five traits as predictors of job instability. Journal of Vocational Behavior, 76(3), 547–558. https://doi.org/10.1016/j.jvb.2010.01.007",
+      "related_test_topic_article_links_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "童年职业",
+          "职业兴趣",
+          "职业判断",
+          "RIASEC",
+          "人职匹配"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "media_references": {
+        "source_cover_image_url": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+        "source_cover_image_alt_zh": "抽象轨迹从童年职业图标延伸到成年职业路径",
+        "cover_image_alt_en_draft": "An abstract path extending from childhood career icons into an adult career route.",
+        "cover_image_width": 1200,
+        "cover_image_height": 675,
+        "cover_image_variants": {
+          "hero": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+          "card": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+          "thumbnail": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+          "og": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+          "preload": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg"
+        },
+        "human_visual_review_required": true
+      },
+      "source_references_preserved": [
+        "[1] Gottfredson, L. S. (1981). Circumscription and compromise: A developmental theory of occupational aspirations. Journal of Counseling Psychology, 28(6), 545–579. https://doi.org/10.1037/0022-0167.28.6.545",
+        "[2] Cochran, D. B., Wang, E. W., Stevenson, S. J., Johnson, L. E., & Crews, C. (2011). Adolescent occupational aspirations: Test of Gottfredson’s theory of circumscription and compromise. The Career Development Quarterly, 59(5), 412–427. https://doi.org/10.1002/j.2161-0045.2011.tb00968.x",
+        "[3] Kristof-Brown, A. L., Zimmerman, R. D., & Johnson, E. C. (2005). Consequences of individuals’ fit at work: A meta-analysis of person–job, person–organization, person–group, and person–supervisor fit. Personnel Psychology, 58(2), 281–342. https://doi.org/10.1111/j.1744-6570.2005.00672.x",
+        "[4] De Fruyt, F., & Mervielde, I. (1997). The Five-Factor Model of personality and Holland’s RIASEC interest types. Personality and Individual Differences, 23, 87–103. https://doi.org/10.1016/S0191-8869(97)00004-4",
+        "[5] Batista, J. S., & Gondim, S. M. G. (2023). Personality and person-work environment fit: A study based on the RIASEC model. International Journal of Environmental Research and Public Health, 20(1), 719. https://doi.org/10.3390/ijerph20010719",
+        "[6] Wille, B., De Fruyt, F., & Feys, M. (2010). Vocational interests and Big Five traits as predictors of job instability. Journal of Vocational Behavior, 76(3), 547–558. https://doi.org/10.1016/j.jvb.2010.01.007"
+      ],
+      "reference_review_required": true,
+      "claim_boundary_state": "claim_review_required_career_direction_boundary",
+      "claim_review_required": true,
+      "claim_review_notes": [
+        "Do not claim childhood aspirations predict job success or best-fit careers.",
+        "Use career-direction and person-environment-fit framing only."
+      ],
+      "unsupported_claims_added": false,
+      "human_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_or_nav_eligible": false,
+      "jsonld_eligible": false,
+      "search_channel_eligible": false,
+      "no_publish": true,
+      "no_cms_mutation": true,
+      "reason_if_deferred": null
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "how-16-personality-types-talk-to-an-ai-coach",
+      "source_zh_slug": "how-16-personality-types-talk-to-an-ai-coach",
+      "proposed_en_slug": "how-16-personality-types-talk-to-an-ai-coach",
+      "translation_group_key": "article:how-16-personality-types-talk-to-an-ai-coach",
+      "translation_group_exists": false,
+      "zh_source_status": "published",
+      "zh_source_authority": "articles backend baseline import package",
+      "en_counterpart_status": "missing_draft_created_for_review",
+      "title_zh": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+      "title_en_draft": "When the 16 Personality Types Talk to an AI Coach: Who Uses It as a Mirror, a Tool, or an Easy Yes",
+      "description_en_draft": "A source-backed draft on how personality styles may shape AI coach use and why smooth agreement should not replace judgment.",
+      "h1_en_draft": "When the 16 Personality Types Talk to an AI Coach: Who Uses It as a Mirror, a Tool, or an Easy Yes",
+      "summary_en_draft": "AI coaching is useful when it helps clarify questions, but risky when its low-friction response is mistaken for reliable judgment.",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Executive Summary",
+          "paragraphs": [
+            "The real value of an AI coach is not that it gives answers. It can change how a person asks questions. The problem is that different personalities do not use it the same way.",
+            "Some people use AI as a structuring assistant. Some use it for brainstorming. Some use it for emotional sorting. Some gradually turn it into a low-friction companion that rarely disagrees at the moment disagreement would matter most.",
+            "FermatMind's position is that the most dangerous part of an AI coach is not only that it might be wrong. It is that it can be too good at going along with you when challenge is needed."
+          ]
+        },
+        {
+          "heading": "1. Why Some People Tell AI the Truth More Easily",
+          "paragraphs": [
+            "Compared with another person, an AI dialogue system can feel low-judgment and low-cost. The source article cites work by Ho, Hancock, and Miner showing that under certain conditions, emotional disclosure to a chatbot can produce subjective outcomes that approach conversation with a person.",
+            "This does not mean AI understands you. It means that when an interaction feels safe and controllable enough, people may treat it as a temporary container.",
+            "That makes AI coaches especially attractive to people who prefer to think before speaking, people who fear being dismissed, and people who value efficiency and structure.",
+            "The boundary is important: a container is not a judge. AI can help you explain yourself, but it does not automatically help you decide well."
+          ]
+        },
+        {
+          "heading": "2. Tool Users, Explorers, and Mirror Users",
+          "paragraphs": [
+            "At least three usage styles appear in personality terms. Structural users treat AI as an organizer, outline builder, and decision draft assistant. Their advantage is efficiency and clearer boundaries; their risk is mistaking structure for correctness.",
+            "Exploratory users treat AI as a brainstorming partner, idea generator, and hypothesis expander. Their advantage is fast option expansion; their risk is more ideas with slower judgment.",
+            "Emotional users treat AI as a mirror that replies immediately, rarely interrupts, and seldom directly rejects them. Their advantage is a lower expression threshold; their risk is confusing being answered with being corrected."
+          ],
+          "evidence_note": "The source article cites human-computer interaction research connecting chatbot anthropomorphism, liking, and self-disclosure. Lower expression friction does not equal human understanding or responsibility."
+        },
+        {
+          "heading": "3. The Feeling of Being Understood Can Be Misread",
+          "paragraphs": [
+            "Research on AI psychotherapy chatbot perception suggests relationships among user liking, anthropomorphism, and self-disclosure. When a system feels like an object that understands me, people may be more willing to say more.",
+            "The risk is that humans often read smooth response as deep understanding and timely feedback as reliable judgment. Algorithm-appreciation research also suggests that people may accept algorithmic advice more readily than expected in some tasks.",
+            "When emotional vulnerability, self-doubt, or relationship conflict is involved, an AI coach can slide from auxiliary tool into substitute judge."
+          ]
+        },
+        {
+          "heading": "4. Common Biases in a 16-Type Frame",
+          "paragraphs": [
+            "Analytical styles may use AI frequently for structured judgment, but should watch for the illusion that logical fluency equals correct decision-making. Idealistic styles may use AI as a mirror for values and feelings, but should watch for comfort without challenge.",
+            "Action-oriented styles may use AI as an instant command center, but should remember that immediate execution does not mean long-term fit. Order-oriented styles may use AI as a normalizing assistant, but should remember that stable advice is not the same as individual fit.",
+            "AI coaching does not evenly amplify every person's strengths. It often amplifies existing preferences first: confirmation, expansion, delay, or control."
+          ]
+        },
+        {
+          "heading": "5. FermatMind Usage Guidance",
+          "paragraphs": [
+            "Use AI to organize, not to decide for you. Use it to expand options, not to rank your values. Use it to clarify a problem, not to take over the question of how you should live.",
+            "If an AI conversation makes you feel more comfortable but no clearer about real constraints, it may have provided psychological pain relief rather than better judgment."
+          ]
+        },
+        {
+          "heading": "Conclusion",
+          "paragraphs": [
+            "The best role for an AI coach is not the final adviser. It is an efficient pre-processing layer that helps name problems, organize structure, and expose possible blind spots.",
+            "It can be a mirror, but it should not be the judge. It can be a tool, but it should not become outsourced personality. Mature use keeps human judgment about reality, relationships, and long-term consequences intact."
+          ]
+        }
+      ],
+      "content_md_en_draft": "# When the 16 Personality Types Talk to an AI Coach: Who Uses It as a Mirror, a Tool, or an Easy Yes\n\n## Executive Summary\n\nThe real value of an AI coach is not that it gives answers. It can change how a person asks questions. The problem is that different personalities do not use it the same way.\n\nSome people use AI as a structuring assistant. Some use it for brainstorming. Some use it for emotional sorting. Some gradually turn it into a low-friction companion that rarely disagrees at the moment disagreement would matter most.\n\nFermatMind's position is that the most dangerous part of an AI coach is not only that it might be wrong. It is that it can be too good at going along with you when challenge is needed.\n\n## 1. Why Some People Tell AI the Truth More Easily\n\nCompared with another person, an AI dialogue system can feel low-judgment and low-cost. The source article cites work by Ho, Hancock, and Miner showing that under certain conditions, emotional disclosure to a chatbot can produce subjective outcomes that approach conversation with a person.\n\nThis does not mean AI understands you. It means that when an interaction feels safe and controllable enough, people may treat it as a temporary container.\n\nThat makes AI coaches especially attractive to people who prefer to think before speaking, people who fear being dismissed, and people who value efficiency and structure.\n\nThe boundary is important: a container is not a judge. AI can help you explain yourself, but it does not automatically help you decide well.\n\n## 2. Tool Users, Explorers, and Mirror Users\n\nAt least three usage styles appear in personality terms. Structural users treat AI as an organizer, outline builder, and decision draft assistant. Their advantage is efficiency and clearer boundaries; their risk is mistaking structure for correctness.\n\nExploratory users treat AI as a brainstorming partner, idea generator, and hypothesis expander. Their advantage is fast option expansion; their risk is more ideas with slower judgment.\n\nEmotional users treat AI as a mirror that replies immediately, rarely interrupts, and seldom directly rejects them. Their advantage is a lower expression threshold; their risk is confusing being answered with being corrected.\n\n> **Evidence Note**\n\n> The source article cites human-computer interaction research connecting chatbot anthropomorphism, liking, and self-disclosure. Lower expression friction does not equal human understanding or responsibility.\n\n## 3. The Feeling of Being Understood Can Be Misread\n\nResearch on AI psychotherapy chatbot perception suggests relationships among user liking, anthropomorphism, and self-disclosure. When a system feels like an object that understands me, people may be more willing to say more.\n\nThe risk is that humans often read smooth response as deep understanding and timely feedback as reliable judgment. Algorithm-appreciation research also suggests that people may accept algorithmic advice more readily than expected in some tasks.\n\nWhen emotional vulnerability, self-doubt, or relationship conflict is involved, an AI coach can slide from auxiliary tool into substitute judge.\n\n## 4. Common Biases in a 16-Type Frame\n\nAnalytical styles may use AI frequently for structured judgment, but should watch for the illusion that logical fluency equals correct decision-making. Idealistic styles may use AI as a mirror for values and feelings, but should watch for comfort without challenge.\n\nAction-oriented styles may use AI as an instant command center, but should remember that immediate execution does not mean long-term fit. Order-oriented styles may use AI as a normalizing assistant, but should remember that stable advice is not the same as individual fit.\n\nAI coaching does not evenly amplify every person's strengths. It often amplifies existing preferences first: confirmation, expansion, delay, or control.\n\n## 5. FermatMind Usage Guidance\n\nUse AI to organize, not to decide for you. Use it to expand options, not to rank your values. Use it to clarify a problem, not to take over the question of how you should live.\n\nIf an AI conversation makes you feel more comfortable but no clearer about real constraints, it may have provided psychological pain relief rather than better judgment.\n\n## Conclusion\n\nThe best role for an AI coach is not the final adviser. It is an efficient pre-processing layer that helps name problems, organize structure, and expose possible blind spots.\n\nIt can be a mirror, but it should not be the judge. It can be a tool, but it should not become outsourced personality. Mature use keeps human judgment about reality, relationships, and long-term consequences intact.\n\nReferences\n\n[1] Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, relational, and emotional effects of self-disclosure after conversations with a chatbot. Journal of Communication, 68(4), 712–733. https://doi.org/10.1093/joc/jqy026\n\n[2] Lee, J., Lee, J.-g., & Lee, D. (2023). User perception and self-disclosure toward an AI psychotherapy chatbot according to the anthropomorphism of its profile picture. Telematics and Informatics, 85, 102052. https://doi.org/10.1016/j.tele.2023.102052\n\n[3] Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm appreciation: People prefer algorithmic to human judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. https://doi.org/10.1016/j.obhdp.2018.12.005\n\n[4] Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human preferences toward algorithmic advice in a word association task. Scientific Reports, 12, 14501. https://doi.org/10.1038/s41598-022-18638-2\n\n[5] Papneja, H., & Yadav, N. (2025). Self-disclosure to conversational AI: A literature review, emergent framework, and directions for future research. Personal and Ubiquitous Computing, 29, 119–151. https://doi.org/10.1007/s00779-024-01823-7",
+      "related_test_topic_article_links_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "AI 教练",
+          "16 型人格",
+          "人机交互",
+          "算法建议",
+          "MBTI"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "media_references": {
+        "source_cover_image_url": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+        "source_cover_image_alt_zh": "抽象对话气泡与镜面结构表现人格与 AI 教练的互动",
+        "cover_image_alt_en_draft": "Abstract dialogue bubbles and a mirror-like structure showing interaction between personality and an AI coach.",
+        "cover_image_width": 1200,
+        "cover_image_height": 675,
+        "cover_image_variants": {
+          "hero": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+          "card": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+          "thumbnail": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+          "og": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+          "preload": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg"
+        },
+        "human_visual_review_required": true
+      },
+      "source_references_preserved": [
+        "[1] Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, relational, and emotional effects of self-disclosure after conversations with a chatbot. Journal of Communication, 68(4), 712–733. https://doi.org/10.1093/joc/jqy026",
+        "[2] Lee, J., Lee, J.-g., & Lee, D. (2023). User perception and self-disclosure toward an AI psychotherapy chatbot according to the anthropomorphism of its profile picture. Telematics and Informatics, 85, 102052. https://doi.org/10.1016/j.tele.2023.102052",
+        "[3] Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm appreciation: People prefer algorithmic to human judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. https://doi.org/10.1016/j.obhdp.2018.12.005",
+        "[4] Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human preferences toward algorithmic advice in a word association task. Scientific Reports, 12, 14501. https://doi.org/10.1038/s41598-022-18638-2",
+        "[5] Papneja, H., & Yadav, N. (2025). Self-disclosure to conversational AI: A literature review, emergent framework, and directions for future research. Personal and Ubiquitous Computing, 29, 119–151. https://doi.org/10.1007/s00779-024-01823-7"
+      ],
+      "reference_review_required": true,
+      "claim_boundary_state": "claim_review_required_ai_advice_boundary",
+      "claim_review_required": true,
+      "claim_review_notes": [
+        "Do not present AI coaching as therapy, diagnosis, treatment, or a substitute for human responsibility.",
+        "Keep 16-type statements as tendencies, not deterministic instructions."
+      ],
+      "unsupported_claims_added": false,
+      "human_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_or_nav_eligible": false,
+      "jsonld_eligible": false,
+      "search_channel_eligible": false,
+      "no_publish": true,
+      "no_cms_mutation": true,
+      "reason_if_deferred": null
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "how-personality-shapes-attitude-toward-ai",
+      "source_zh_slug": "how-personality-shapes-attitude-toward-ai",
+      "proposed_en_slug": "how-personality-shapes-attitude-toward-ai",
+      "translation_group_key": "article:how-personality-shapes-attitude-toward-ai",
+      "translation_group_exists": false,
+      "zh_source_status": "published",
+      "zh_source_authority": "articles backend baseline import package",
+      "en_counterpart_status": "missing_draft_created_for_review",
+      "title_zh": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+      "title_en_draft": "How Personality Shapes Your Attitude Toward AI: From Curiosity and Anxiety to Algorithm Trust",
+      "description_en_draft": "A source-backed draft on how personality, perceived control, and risk interpretation can shape attitudes toward artificial intelligence.",
+      "h1_en_draft": "How Personality Shapes Your Attitude Toward AI: From Curiosity and Anxiety to Algorithm Trust",
+      "summary_en_draft": "AI attitude is not only a technical opinion. It often reflects stable differences in control, risk interpretation, trust, and responsibility.",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Executive Summary",
+          "paragraphs": [
+            "Debates about artificial intelligence often look like debates about technology, but underneath they are frequently debates about personality, control, and risk interpretation.",
+            "Some people see AI as a productivity tool. Some see it as an external cognitive device. Others maintain steady caution. FermatMind reads this not simply as technical literacy or optimism versus pessimism, but as a more stable personality-decision style difference.",
+            "Existing research suggests that Big Five traits, AI anxiety, and demographic factors can jointly shape attitudes toward AI. Conscientiousness may more easily connect AI with efficiency and organization. Higher neuroticism may connect with uncertainty amplification and loss-of-control anxiety. Openness does not automatically mean uncritical adoption; it can also bring stronger scrutiny of authenticity and replacement risk."
+          ],
+          "evidence_note": "The source cites research by Kaya and colleagues. Personality does not decide whether someone should use AI; it can influence how risk, trust, and control are interpreted."
+        },
+        {
+          "heading": "1. Liking AI Is Not One Question",
+          "paragraphs": [
+            "Public discussion often divides people into supporters and opponents of AI. Behaviorally, that is too crude. It is more useful to split AI attitude into three layers: functional judgment, control judgment, and value judgment.",
+            "Functional judgment asks whether the tool helps finish work faster. Control judgment asks whether the person still owns the final decision. Value judgment asks whether AI erodes creativity, responsibility, or authenticity.",
+            "For highly conscientious people, AI may first enter an efficiency and organization frame. If it reduces repetitive labor and stabilizes output, it becomes easier to accept. For highly open people, the question may not be whether it is new, but what it is replacing. Writers, designers, and other creators may be especially sensitive to what remains of originality, authorship, and taste when text, images, and judgments can be produced at scale."
+          ]
+        },
+        {
+          "heading": "2. Algorithm Trust Is Conditional",
+          "paragraphs": [
+            "Research does not support a single answer to whether people trust humans or algorithms more. Logg, Minson, and Moore describe algorithm appreciation: in some predictive tasks, people may be more willing to use algorithmic advice than expected.",
+            "But this does not mean unlimited trust. In associative, creative, and ambiguous tasks, people may use algorithmic advice while preserving room to revise it.",
+            "For FermatMind, mature AI use is neither total reliance nor total rejection. AI can provide candidate answers, but it should not automatically take final interpretive authority."
+          ]
+        },
+        {
+          "heading": "3. Why Some People Talk to AI",
+          "paragraphs": [
+            "Some people use AI as a tool. Others use it as a lower-risk dialogue partner. Chatbot research suggests that people may experience AI disclosure in ways that resemble interpersonal disclosure, including easier expression of sensitive material, immediate pressure relief, or a subjective feeling of being understood.",
+            "This does not mean AI truly understands a person. It means that when a system feels socially present, predictable, and low in judgment threat, users may treat it as a usable emotional container.",
+            "That convenience has a boundary risk. For people who need outside confirmation while still wanting control, AI can become a high-frequency, low-friction echo wall. It gives advice quickly, but it cannot carry the consequences of that advice."
+          ]
+        },
+        {
+          "heading": "4. FermatMind's Judgment",
+          "paragraphs": [
+            "If you are strongly optimistic about AI, the useful question is not only what else it can do for you. It is where you may be outsourcing judgment too quickly.",
+            "If you are strongly cautious about AI, the useful question is whether you are responding to the risk itself or to the discomfort of losing a familiar mode of control.",
+            "Personality will not decide whether you should use AI, but it can shape how you define risk, distribute trust, and decide how much thinking sovereignty you are willing to hand over."
+          ],
+          "bullets": [
+            "Do you know why you trust it?",
+            "Do you know why you doubt it?",
+            "Do you keep a final layer of judgment?"
+          ]
+        },
+        {
+          "heading": "Conclusion",
+          "paragraphs": [
+            "AI is not only a technical issue. It is a mirror that amplifies personality differences. It may make conscientious people more efficient and vigilant people more anxious. It may help some people act faster while forcing others to debate authenticity and boundaries more carefully.",
+            "FermatMind is less interested in whether you like AI than in whether you can use it while keeping judgment, responsibility, and a long-term professional moat intact."
+          ]
+        }
+      ],
+      "content_md_en_draft": "# How Personality Shapes Your Attitude Toward AI: From Curiosity and Anxiety to Algorithm Trust\n\n## Executive Summary\n\nDebates about artificial intelligence often look like debates about technology, but underneath they are frequently debates about personality, control, and risk interpretation.\n\nSome people see AI as a productivity tool. Some see it as an external cognitive device. Others maintain steady caution. FermatMind reads this not simply as technical literacy or optimism versus pessimism, but as a more stable personality-decision style difference.\n\nExisting research suggests that Big Five traits, AI anxiety, and demographic factors can jointly shape attitudes toward AI. Conscientiousness may more easily connect AI with efficiency and organization. Higher neuroticism may connect with uncertainty amplification and loss-of-control anxiety. Openness does not automatically mean uncritical adoption; it can also bring stronger scrutiny of authenticity and replacement risk.\n\n> **Evidence Note**\n\n> The source cites research by Kaya and colleagues. Personality does not decide whether someone should use AI; it can influence how risk, trust, and control are interpreted.\n\n## 1. Liking AI Is Not One Question\n\nPublic discussion often divides people into supporters and opponents of AI. Behaviorally, that is too crude. It is more useful to split AI attitude into three layers: functional judgment, control judgment, and value judgment.\n\nFunctional judgment asks whether the tool helps finish work faster. Control judgment asks whether the person still owns the final decision. Value judgment asks whether AI erodes creativity, responsibility, or authenticity.\n\nFor highly conscientious people, AI may first enter an efficiency and organization frame. If it reduces repetitive labor and stabilizes output, it becomes easier to accept. For highly open people, the question may not be whether it is new, but what it is replacing. Writers, designers, and other creators may be especially sensitive to what remains of originality, authorship, and taste when text, images, and judgments can be produced at scale.\n\n## 2. Algorithm Trust Is Conditional\n\nResearch does not support a single answer to whether people trust humans or algorithms more. Logg, Minson, and Moore describe algorithm appreciation: in some predictive tasks, people may be more willing to use algorithmic advice than expected.\n\nBut this does not mean unlimited trust. In associative, creative, and ambiguous tasks, people may use algorithmic advice while preserving room to revise it.\n\nFor FermatMind, mature AI use is neither total reliance nor total rejection. AI can provide candidate answers, but it should not automatically take final interpretive authority.\n\n## 3. Why Some People Talk to AI\n\nSome people use AI as a tool. Others use it as a lower-risk dialogue partner. Chatbot research suggests that people may experience AI disclosure in ways that resemble interpersonal disclosure, including easier expression of sensitive material, immediate pressure relief, or a subjective feeling of being understood.\n\nThis does not mean AI truly understands a person. It means that when a system feels socially present, predictable, and low in judgment threat, users may treat it as a usable emotional container.\n\nThat convenience has a boundary risk. For people who need outside confirmation while still wanting control, AI can become a high-frequency, low-friction echo wall. It gives advice quickly, but it cannot carry the consequences of that advice.\n\n## 4. FermatMind's Judgment\n\nIf you are strongly optimistic about AI, the useful question is not only what else it can do for you. It is where you may be outsourcing judgment too quickly.\n\nIf you are strongly cautious about AI, the useful question is whether you are responding to the risk itself or to the discomfort of losing a familiar mode of control.\n\nPersonality will not decide whether you should use AI, but it can shape how you define risk, distribute trust, and decide how much thinking sovereignty you are willing to hand over.\n\n- Do you know why you trust it?\n\n- Do you know why you doubt it?\n\n- Do you keep a final layer of judgment?\n\n## Conclusion\n\nAI is not only a technical issue. It is a mirror that amplifies personality differences. It may make conscientious people more efficient and vigilant people more anxious. It may help some people act faster while forcing others to debate authenticity and boundaries more carefully.\n\nFermatMind is less interested in whether you like AI than in whether you can use it while keeping judgment, responsibility, and a long-term professional moat intact.\n\nReferences\n\n[1] Kaya, F., Aydın, F., Schepman, A., Rodway, P., Yetişensoy, O., & Demir Kaya, M. (2024). The roles of personality traits, AI anxiety, and demographic factors in attitudes toward artificial intelligence. International Journal of Human-Computer Interaction. https://doi.org/10.1080/10447318.2022.2151730\n\n[2] Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm appreciation: People prefer algorithmic to human judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. https://doi.org/10.1016/j.obhdp.2018.12.005\n\n[3] Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human preferences toward algorithmic advice in a word association task. Scientific Reports, 12, 14501. https://doi.org/10.1038/s41598-022-18638-2\n\n[4] Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, relational, and emotional effects of self-disclosure after conversations with a chatbot. Journal of Communication, 68(4), 712–733. https://doi.org/10.1093/joc/jqy026\n\n[5] Papneja, H., & Yadav, N. (2025). Self-disclosure to conversational AI: A literature review, emergent framework, and directions for future research. Personal and Ubiquitous Computing, 29, 119–151. https://doi.org/10.1007/s00779-024-01823-7",
+      "related_test_topic_article_links_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "人格心理学",
+          "AI",
+          "算法信任",
+          "人机交互",
+          "MBTI"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "media_references": {
+        "source_cover_image_url": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+        "source_cover_image_alt_zh": "抽象人脸轮廓与 AI 节点网络交织，表现人格差异如何影响算法信任",
+        "cover_image_alt_en_draft": "An abstract face outline woven with AI network nodes, showing how personality differences can affect algorithm trust.",
+        "cover_image_width": 1200,
+        "cover_image_height": 675,
+        "cover_image_variants": {
+          "hero": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+          "card": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+          "thumbnail": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+          "og": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+          "preload": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg"
+        },
+        "human_visual_review_required": true
+      },
+      "source_references_preserved": [
+        "[1] Kaya, F., Aydın, F., Schepman, A., Rodway, P., Yetişensoy, O., & Demir Kaya, M. (2024). The roles of personality traits, AI anxiety, and demographic factors in attitudes toward artificial intelligence. International Journal of Human-Computer Interaction. https://doi.org/10.1080/10447318.2022.2151730",
+        "[2] Logg, J. M., Minson, J. A., & Moore, D. A. (2019). Algorithm appreciation: People prefer algorithmic to human judgment. Organizational Behavior and Human Decision Processes, 151, 90–103. https://doi.org/10.1016/j.obhdp.2018.12.005",
+        "[3] Bogert, E., Lauharatanahirun, N., & Schecter, A. (2022). Human preferences toward algorithmic advice in a word association task. Scientific Reports, 12, 14501. https://doi.org/10.1038/s41598-022-18638-2",
+        "[4] Ho, A., Hancock, J., & Miner, A. S. (2018). Psychological, relational, and emotional effects of self-disclosure after conversations with a chatbot. Journal of Communication, 68(4), 712–733. https://doi.org/10.1093/joc/jqy026",
+        "[5] Papneja, H., & Yadav, N. (2025). Self-disclosure to conversational AI: A literature review, emergent framework, and directions for future research. Personal and Ubiquitous Computing, 29, 119–151. https://doi.org/10.1007/s00779-024-01823-7"
+      ],
+      "reference_review_required": true,
+      "claim_boundary_state": "claim_review_required_ai_and_personality_boundary",
+      "claim_review_required": true,
+      "claim_review_notes": [
+        "Do not claim personality determines whether someone should use AI.",
+        "Do not present AI as a replacement for professional, legal, clinical, or career judgment."
+      ],
+      "unsupported_claims_added": false,
+      "human_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_or_nav_eligible": false,
+      "jsonld_eligible": false,
+      "search_channel_eligible": false,
+      "no_publish": true,
+      "no_cms_mutation": true,
+      "reason_if_deferred": null
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "which-love-script-fits-you-best",
+      "source_zh_slug": "which-love-script-fits-you-best",
+      "proposed_en_slug": "which-love-script-fits-you-best",
+      "translation_group_key": "article:which-love-script-fits-you-best",
+      "translation_group_exists": false,
+      "zh_source_status": "published",
+      "zh_source_authority": "articles backend baseline import package",
+      "en_counterpart_status": "missing_draft_created_for_review",
+      "title_zh": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+      "title_en_draft": "Which Relationship Script Fits You Best? A More Scientific Match Through Seven Love Styles",
+      "description_en_draft": "A source-backed draft on using love styles and relationship structure to reduce mismatch without turning personality labels into destiny.",
+      "h1_en_draft": "Which Relationship Script Fits You Best? A More Scientific Match Through Seven Love Styles",
+      "summary_en_draft": "The question is not only who matches you, but which relationship structure you are seeking: passion, intimacy, stability, realism, care, play, or anxious intensity.",
+      "body_blocks_en_draft": [
+        {
+          "heading": "Executive Summary",
+          "paragraphs": [
+            "When people talk about a suitable partner, they are often not only describing who they want. They are describing the kind of intimate relationship script they want to enter.",
+            "Some people want passion and novelty. Some want stability and cooperation. Some want to be understood. Others want shared responsibility in real life.",
+            "FermatMind's view is simple: instead of asking who you are most compatible with, first ask which love structure you are actually seeking. That is closer to relationship science than turning personality labels into entertainment-style matching."
+          ]
+        },
+        {
+          "heading": "1. Love Is Not One Thing",
+          "paragraphs": [
+            "Sternberg's triangular theory describes love through three components: intimacy, passion, and commitment. Different combinations create different relationship structures.",
+            "Hendrick and Hendrick, building on Lee's color wheel of love, described love styles such as Eros, Ludus, Storge, Pragma, Mania, and Agape. One framework explains structure; the other explains style.",
+            "Compressed into a practical frame, FermatMind names seven common relationship scripts: intense-passion, intimacy-growth, stable-partner, practical-negotiation, self-sacrificing, playful-testing, and anxious-possessive.",
+            "No script is automatically superior, but each demands something different. Placing someone who wants safety into a playful-testing script, or someone who wants high passion into a low-variation stability script, can create long-term mismatch."
+          ]
+        },
+        {
+          "heading": "2. What More Scientific Matching Means",
+          "paragraphs": [
+            "A more scientific match does not assume a destined partner exists. It identifies three things: your preferred intimacy rhythm, your way of handling commitment, and your definition of being loved.",
+            "Do you need high stimulation or high predictability? Do you commit first and calibrate later, or observe first and commit slowly? Does being loved mean being understood, pursued, held, or joined in practical responsibility?",
+            "Research suggests links between love styles and relationship quality. Eros and Agape are more often aligned with positive relationship-quality indicators, Ludus is often associated with lower satisfaction and higher ambivalence, and Pragma may support practical long-term compatibility even if it feels less romantic."
+          ],
+          "evidence_note": "Love-style research suggests relationship quality depends not only on whether people like each other, but on how both people understand intimacy, passion, and commitment. Strong attraction does not guarantee long-term stability."
+        },
+        {
+          "heading": "3. Use 16 Types as an Entry Point, Not an Answer",
+          "paragraphs": [
+            "If you already use 16-type language to understand yourself, the frame can help, as long as it stays an entry point rather than a final answer.",
+            "Intuitive and ideal-driven people may be more drawn to intimacy based on being understood. Executive and structured personalities may prioritize cooperative long-term relationships. Action-oriented and extraverted personalities may prefer high-interaction, high-experience-density scripts.",
+            "These are tendencies, not commands. The real standard is what you want from a relationship and whether you can carry the costs attached to that structure."
+          ]
+        },
+        {
+          "heading": "4. FermatMind's Suggestion",
+          "paragraphs": [
+            "If you keep feeling disappointed in relationships, the problem may not be that you have not met the right person. It may be that you are using the wrong script to evaluate someone who could have been right in another structure.",
+            "For example, you may want long-term stability while repeatedly being pulled toward intense-passion relationships. You may need understanding and empathy while misreading execution-oriented partners as not loving enough. You may treat emotional intensity as intimacy and receive volatility rather than connection.",
+            "FermatMind does not turn matching into entertainment. The stricter question is what relationship structure can meet your core needs without placing you in chronic depletion."
+          ]
+        },
+        {
+          "heading": "Conclusion",
+          "paragraphs": [
+            "The most suitable partner is not simply the person most similar to you or the person who ignites you most quickly.",
+            "A more mature judgment asks which person and which structure can form a stable long-term rhythm across intimacy, passion, and commitment. Identify the love script first; then ask who can participate in it with you. That is the safer way to reduce mismatch."
+          ]
+        }
+      ],
+      "content_md_en_draft": "# Which Relationship Script Fits You Best? A More Scientific Match Through Seven Love Styles\n\n## Executive Summary\n\nWhen people talk about a suitable partner, they are often not only describing who they want. They are describing the kind of intimate relationship script they want to enter.\n\nSome people want passion and novelty. Some want stability and cooperation. Some want to be understood. Others want shared responsibility in real life.\n\nFermatMind's view is simple: instead of asking who you are most compatible with, first ask which love structure you are actually seeking. That is closer to relationship science than turning personality labels into entertainment-style matching.\n\n## 1. Love Is Not One Thing\n\nSternberg's triangular theory describes love through three components: intimacy, passion, and commitment. Different combinations create different relationship structures.\n\nHendrick and Hendrick, building on Lee's color wheel of love, described love styles such as Eros, Ludus, Storge, Pragma, Mania, and Agape. One framework explains structure; the other explains style.\n\nCompressed into a practical frame, FermatMind names seven common relationship scripts: intense-passion, intimacy-growth, stable-partner, practical-negotiation, self-sacrificing, playful-testing, and anxious-possessive.\n\nNo script is automatically superior, but each demands something different. Placing someone who wants safety into a playful-testing script, or someone who wants high passion into a low-variation stability script, can create long-term mismatch.\n\n## 2. What More Scientific Matching Means\n\nA more scientific match does not assume a destined partner exists. It identifies three things: your preferred intimacy rhythm, your way of handling commitment, and your definition of being loved.\n\nDo you need high stimulation or high predictability? Do you commit first and calibrate later, or observe first and commit slowly? Does being loved mean being understood, pursued, held, or joined in practical responsibility?\n\nResearch suggests links between love styles and relationship quality. Eros and Agape are more often aligned with positive relationship-quality indicators, Ludus is often associated with lower satisfaction and higher ambivalence, and Pragma may support practical long-term compatibility even if it feels less romantic.\n\n> **Evidence Note**\n\n> Love-style research suggests relationship quality depends not only on whether people like each other, but on how both people understand intimacy, passion, and commitment. Strong attraction does not guarantee long-term stability.\n\n## 3. Use 16 Types as an Entry Point, Not an Answer\n\nIf you already use 16-type language to understand yourself, the frame can help, as long as it stays an entry point rather than a final answer.\n\nIntuitive and ideal-driven people may be more drawn to intimacy based on being understood. Executive and structured personalities may prioritize cooperative long-term relationships. Action-oriented and extraverted personalities may prefer high-interaction, high-experience-density scripts.\n\nThese are tendencies, not commands. The real standard is what you want from a relationship and whether you can carry the costs attached to that structure.\n\n## 4. FermatMind's Suggestion\n\nIf you keep feeling disappointed in relationships, the problem may not be that you have not met the right person. It may be that you are using the wrong script to evaluate someone who could have been right in another structure.\n\nFor example, you may want long-term stability while repeatedly being pulled toward intense-passion relationships. You may need understanding and empathy while misreading execution-oriented partners as not loving enough. You may treat emotional intensity as intimacy and receive volatility rather than connection.\n\nFermatMind does not turn matching into entertainment. The stricter question is what relationship structure can meet your core needs without placing you in chronic depletion.\n\n## Conclusion\n\nThe most suitable partner is not simply the person most similar to you or the person who ignites you most quickly.\n\nA more mature judgment asks which person and which structure can form a stable long-term rhythm across intimacy, passion, and commitment. Identify the love script first; then ask who can participate in it with you. That is the safer way to reduce mismatch.\n\nReferences\n\n[1] Sternberg, R. J. (1986). A triangular theory of love. Psychological Review, 93(2), 119–135. https://doi.org/10.1037/0033-295X.93.2.119\n\n[2] Hendrick, C., & Hendrick, S. (1986). A theory and method of love. Journal of Personality and Social Psychology, 50(2), 392–402. https://doi.org/10.1037/0022-3514.50.2.392\n\n[3] Davis, K. E., & Latty-Mann, H. (1987). Love styles and relationship quality: A contribution to validation. Journal of Social and Personal Relationships, 4(4), 409–428. https://doi.org/10.1177/0265407587044002\n\n[4] Taraban, C. B., & Hendrick, C. (1995). Personality perceptions associated with six styles of love. Journal of Social and Personal Relationships, 12(3), 451–464. https://doi.org/10.1177/0265407595123008\n\n[5] Acker, M., & Davis, M. H. (1992). Intimacy, passion and commitment in adult romantic relationships: A test of the triangular theory of love. Journal of Social and Personal Relationships, 9(1), 21–50. https://doi.org/10.1177/0265407592091002",
+      "related_test_topic_article_links_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "爱情风格",
+          "亲密关系",
+          "关系科学",
+          "MBTI",
+          "依恋与亲密"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "media_references": {
+        "source_cover_image_url": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+        "source_cover_image_alt_zh": "抽象关系网络中呈现七种爱情脚本的几何路径",
+        "cover_image_alt_en_draft": "An abstract relationship network showing geometric paths for seven love scripts.",
+        "cover_image_width": 1200,
+        "cover_image_height": 675,
+        "cover_image_variants": {
+          "hero": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+          "card": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+          "thumbnail": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+          "og": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+          "preload": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg"
+        },
+        "human_visual_review_required": true
+      },
+      "source_references_preserved": [
+        "[1] Sternberg, R. J. (1986). A triangular theory of love. Psychological Review, 93(2), 119–135. https://doi.org/10.1037/0033-295X.93.2.119",
+        "[2] Hendrick, C., & Hendrick, S. (1986). A theory and method of love. Journal of Personality and Social Psychology, 50(2), 392–402. https://doi.org/10.1037/0022-3514.50.2.392",
+        "[3] Davis, K. E., & Latty-Mann, H. (1987). Love styles and relationship quality: A contribution to validation. Journal of Social and Personal Relationships, 4(4), 409–428. https://doi.org/10.1177/0265407587044002",
+        "[4] Taraban, C. B., & Hendrick, C. (1995). Personality perceptions associated with six styles of love. Journal of Social and Personal Relationships, 12(3), 451–464. https://doi.org/10.1177/0265407595123008",
+        "[5] Acker, M., & Davis, M. H. (1992). Intimacy, passion and commitment in adult romantic relationships: A test of the triangular theory of love. Journal of Social and Personal Relationships, 9(1), 21–50. https://doi.org/10.1177/0265407592091002"
+      ],
+      "reference_review_required": true,
+      "claim_boundary_state": "claim_review_required_relationship_matching_boundary",
+      "claim_review_required": true,
+      "claim_review_notes": [
+        "Do not promise perfect matching or relationship outcomes.",
+        "Keep 16-type references as exploratory entry points, not compatibility rules."
+      ],
+      "unsupported_claims_added": false,
+      "human_review_required": true,
+      "publish_state": "draft_import_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_or_nav_eligible": false,
+      "jsonld_eligible": false,
+      "search_channel_eligible": false,
+      "no_publish": true,
+      "no_cms_mutation": true,
+      "reason_if_deferred": null
+    }
+  ],
+  "policy": {
+    "human_review_required": true,
+    "publish_state": "draft_import_only",
+    "no_cms_mutation": true,
+    "no_publish": true,
+    "no_deploy": true,
+    "no_search_channel_action": true,
+    "no_url_submission": true,
+    "no_pseo_generation": true,
+    "no_frontend_fallback_authority": true,
+    "drafts_do_not_enter_sitemap_or_llms": true
+  }
+}

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhArticleTranslationBatch02Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhArticleTranslationBatch02Test.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhArticleTranslationBatch02Test extends TestCase
+{
+    #[Test]
+    public function article_translation_package_is_draft_only_and_review_gated(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-article-translation-batch-02.v1.json');
+        $packagePath = base_path('docs/seo/import-packages/global-en-zh-article-translation-batch-02.import.v1.json');
+
+        $this->assertFileExists($generatedPath);
+        $this->assertFileExists($packagePath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+        $package = json_decode((string) file_get_contents($packagePath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-article-translation-batch-02.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02', $generated['task'] ?? null);
+        $this->assertSame('global-en-zh-article-translation-batch-02.import.v1', $package['schema_version'] ?? null);
+        $this->assertSame('draft_import_only', $package['package_type'] ?? null);
+
+        $items = $package['items'] ?? [];
+        $this->assertIsArray($items);
+        $this->assertCount(6, $items);
+
+        $expectedSlugs = [
+            'are-infj-men-rare-or-socially-silenced',
+            'best-valentines-date-by-personality-and-relationship-science',
+            'childhood-dream-job-still-shapes-career-choice',
+            'how-16-personality-types-talk-to-an-ai-coach',
+            'how-personality-shapes-attitude-toward-ai',
+            'which-love-script-fits-you-best',
+        ];
+
+        $this->assertEqualsCanonicalizing($expectedSlugs, array_column($items, 'source_zh_slug'));
+        $this->assertEqualsCanonicalizing($expectedSlugs, array_column($items, 'proposed_en_slug'));
+
+        foreach ($items as $item) {
+            $this->assertSame('articles', $item['asset_family'] ?? null);
+            $this->assertTrue($item['human_review_required'] ?? false);
+            $this->assertTrue($item['claim_review_required'] ?? false);
+            $this->assertTrue($item['reference_review_required'] ?? false);
+            $this->assertFalse($item['unsupported_claims_added'] ?? true);
+            $this->assertSame('draft_import_only', $item['publish_state'] ?? null);
+            $this->assertFalse($item['sitemap_eligible'] ?? true);
+            $this->assertFalse($item['llms_eligible'] ?? true);
+            $this->assertFalse($item['footer_or_nav_eligible'] ?? true);
+            $this->assertFalse($item['jsonld_eligible'] ?? true);
+            $this->assertFalse($item['search_channel_eligible'] ?? true);
+            $this->assertNotEmpty($item['title_en_draft'] ?? '');
+            $this->assertNotEmpty($item['description_en_draft'] ?? '');
+            $this->assertNotEmpty($item['h1_en_draft'] ?? '');
+            $this->assertNotEmpty($item['summary_en_draft'] ?? '');
+            $this->assertNotEmpty($item['body_blocks_en_draft'] ?? []);
+            $this->assertNotEmpty($item['content_md_en_draft'] ?? '');
+            $this->assertNotEmpty($item['source_references_preserved'] ?? []);
+        }
+
+        $this->assertSame(6, $generated['missing_en_article_count'] ?? null);
+        $this->assertSame(6, $generated['draft_article_count'] ?? null);
+        $this->assertSame(0, $generated['deferred_count'] ?? null);
+        $this->assertSame(0, $generated['blocked_count'] ?? null);
+        $this->assertSame(6, $generated['human_review_required_count'] ?? null);
+        $this->assertSame(6, $generated['claim_review_required_count'] ?? null);
+        $this->assertSame(0, $generated['sitemap_eligible_count'] ?? null);
+        $this->assertSame(0, $generated['llms_eligible_count'] ?? null);
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_pseo_generation'] ?? false);
+        $this->assertTrue($generated['no_frontend_fallback_authority'] ?? false);
+        $this->assertSame('GLOBAL-EN-ZH-TOPIC-TEST-LANDING-BATCH-03', $generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -20010,13 +20010,13 @@
       "repo": "fap-api",
       "branch": "codex/global-en-zh-article-translation-batch-02",
       "base": "main",
-      "status": "local_validation_passed",
+      "status": "pr_opened",
       "depends_on": [
         "GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01"
       ],
       "title": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 article English counterpart draft package",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "955a08a1e4722211c5f192de699b027980b59d01",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1693",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -20055,6 +20055,10 @@
             "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short"
           ],
           "evidence": "Focused test exited 0 with 1 warning from missing isolated backend/.env; no env file was created or edited. route:list exited 0 with 203 routes. Pint passed 3565 files. composer validate --strict passed. composer audit reported no advisories. Generated JSON, import package JSON, state JSON, manifest YAML, diff checks, and fap-web reference status passed."
+        },
+        "pr_opened": {
+          "status": "pass",
+          "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1693 from codex/global-en-zh-article-translation-batch-02 after local validation passed."
         }
       },
       "scope": {
@@ -20098,6 +20102,11 @@
           "at": "2026-05-26T01:45:52+08:00",
           "status": "local_validation_passed",
           "summary": "Batch-02 focused test, route list, Pint, composer validate/audit, JSON/YAML parses, diff checks, and fap-web reference status passed."
+        },
+        {
+          "at": "2026-05-26T01:47:36+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1693 for Batch-02 after local validation passed."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -19907,13 +19907,13 @@
       "repo": "fap-api",
       "branch": "codex/global-en-zh-content-pages-translation-batch-01",
       "base": "main",
-      "status": "local_validation_passed",
+      "status": "merged",
       "depends_on": [
         "GLOBAL-EN-ZH-FULL-CONTENT-AUTHORITY-TRANSLATION-MATRIX-00"
       ],
       "title": "GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01 human-reviewed content/help/policy English translation batch",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "9f239b8df69878664de145e6d60122efaeda93f2",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1692",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -19951,6 +19951,10 @@
             "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short"
           ],
           "evidence": "Focused test exited 0 with 1 warning from missing isolated backend/.env; no env file was created or edited. route:list exited 0 with 203 routes. Pint passed 3564 files. composer validate --strict passed. composer audit reported no advisories. Generated JSON, import package JSON, state JSON, manifest YAML, diff checks, and fap-web reference status passed."
+        },
+        "github_checks": {
+          "status": "pass",
+          "evidence": "PR #1692 merged after required GitHub checks succeeded and mergeStateStatus was CLEAN; origin/main contains merge commit 9f239b8df69878664de145e6d60122efaeda93f2."
         }
       },
       "scope": {
@@ -19974,9 +19978,9 @@
         "frontend_fallback_authority": false
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-25T17:35:54Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02",
       "events": [
@@ -19994,6 +19998,11 @@
           "at": "2026-05-26T01:50:00+08:00",
           "status": "local_validation_passed",
           "summary": "Batch-01 focused test, route list, Pint, composer validate/audit, JSON/YAML parses, diff checks, and fap-web reference status passed."
+        },
+        {
+          "at": "2026-05-26T01:44:40+08:00",
+          "status": "merged_reconciled",
+          "summary": "Reconciled Batch-01 after PR #1692 merge; remote branch deleted and local task branch cleanup completed before Batch-02 continued."
         }
       ]
     },
@@ -20001,17 +20010,51 @@
       "repo": "fap-api",
       "branch": "codex/global-en-zh-article-translation-batch-02",
       "base": "main",
-      "status": "manifest_registered",
+      "status": "local_validation_passed",
       "depends_on": [
         "GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01"
       ],
-      "title": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 human-reviewed article counterpart translation batch",
+      "title": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 article English counterpart draft package",
       "commit_sha": null,
       "pr_url": null,
       "checks": {
         "manifest_registration": {
           "status": "pass",
           "evidence": "Registered from GLOBAL-EN-ZH-FULL-CONTENT-AUTHORITY-TRANSLATION-MATRIX-00 recommended PR train; implementation not started."
+        },
+        "scope_boundary": {
+          "status": "pending_validation",
+          "changed_files": [
+            "backend/docs/seo/global-en-zh-article-translation-batch-02.md",
+            "backend/docs/seo/generated/global-en-zh-article-translation-batch-02.v1.json",
+            "backend/docs/seo/import-packages/global-en-zh-article-translation-batch-02.import.v1.json",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhArticleTranslationBatch02Test.php",
+            "docs/codex/pr-train.yaml",
+            "docs/codex/pr-train-state.json"
+          ],
+          "evidence": "Generated Batch-02 report, generated summary, draft/import package, focused SeoIntel test, and current task state ledger only."
+        },
+        "production_safety": {
+          "status": "pass",
+          "evidence": "No CMS mutation, publish, deploy, Search Channel action, URL submission, pSEO generation, fap-web mutation, env/DNS/nginx edit, production migration, raw log read, or production user data access performed."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=GlobalEnZhArticleTranslationBatch02 --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-en-zh-article-translation-batch-02.v1.json >/dev/null",
+            "python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-article-translation-batch-02.import.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 YAML parse docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check",
+            "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short"
+          ],
+          "evidence": "Focused test exited 0 with 1 warning from missing isolated backend/.env; no env file was created or edited. route:list exited 0 with 203 routes. Pint passed 3565 files. composer validate --strict passed. composer audit reported no advisories. Generated JSON, import package JSON, state JSON, manifest YAML, diff checks, and fap-web reference status passed."
         }
       },
       "scope": {
@@ -20045,6 +20088,16 @@
           "at": "2026-05-26T01:05:00+08:00",
           "status": "manifest_registered",
           "summary": "Registered article translation batch as draft/import-only, human-review-required, no-publish/no-CMS-mutation scope."
+        },
+        {
+          "at": "2026-05-26T01:44:40+08:00",
+          "status": "local_files_generated_pending_validation",
+          "summary": "Generated Batch-02 article draft/import package, generated summary, Markdown report, focused test, and Batch-01 merge reconciliation."
+        },
+        {
+          "at": "2026-05-26T01:45:52+08:00",
+          "status": "local_validation_passed",
+          "summary": "Batch-02 focused test, route list, Pint, composer validate/audit, JSON/YAML parses, diff checks, and fap-web reference status passed."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -13366,7 +13366,7 @@ prs:
       - GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01
     branch: codex/global-en-zh-article-translation-batch-02
     base: main
-    title: "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 human-reviewed article counterpart translation batch"
+    title: "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 article English counterpart draft package"
     train_scope: global_en_zh_article_translation_batch
     risk_level: p1_editorial_draft_translation
     allowed_paths:


### PR DESCRIPTION
## What changed
- Added the Batch-02 article English counterpart draft/import package for the 6 missing EN article counterparts from the EN/ZH authority matrix.
- Added generated summary/report artifacts and a focused SeoIntel test.
- Reconciled Batch-01 ledger state after PR #1692 merged and aligned the Batch-02 manifest title with this scoped PR.

## Why
- Full EN/ZH content parity requires repo-backed draft/import assets before any human review/import step.
- These article drafts stay human-review-required and draft-import-only, with no sitemap/llms/search exposure.

## Validation
- `php artisan test --filter=GlobalEnZhArticleTranslationBatch02 --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-article-translation-batch-02.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-article-translation-batch-02.import.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3` YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`
- `cd /Users/rainie/Desktop/GitHub/fap-web && git status --short`

Note: the focused Laravel test exited 0 with one warning from the isolated worktree missing `backend/.env`; no env file was created or edited.

## Intentionally deferred
- No CMS mutation, publish, deploy, Search Channel action, URL submission, pSEO generation, or fap-web runtime change.
- Human/editorial/reference review remains required before any import or publication.
- Drafts do not enter sitemap, llms, footer/nav, JSON-LD, or Search Channel surfaces.
