### PR TITLE
GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02 article review decisions

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-article-human-review-import-02.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-article-human-review-import-02.v1.json
@@ -1,0 +1,435 @@
+{
+  "schema_version": "global-en-zh-article-human-review-import-02.v1",
+  "task": "GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02",
+  "generated_at": "2026-05-26T21:35:53+08:00",
+  "final_decision": "article_review_decision_packet_created_ready_for_human_review",
+  "source_import_package": "backend/docs/seo/import-packages/global-en-zh-article-translation-batch-02.import.v1.json",
+  "source_review_queue": "backend/docs/seo/generated/global-en-zh-human-review-import-queue-00.v1.json",
+  "browser_cms_read_only_evidence": {
+    "public_site_observations": [
+      {
+        "url": "https://fermatmind.com/en/articles",
+        "status": "observed_read_only",
+        "summary": "EN article index rendered with public article cards; runtime observation only."
+      }
+    ],
+    "cms_ops_observations": [
+      {
+        "url": "CMS article records",
+        "status": "not_opened_for_write",
+        "summary": "No CMS article edit/save/publish/import action was performed."
+      }
+    ],
+    "cms_mutation_performed": false,
+    "browser_write_actions_performed": false,
+    "private_user_data_accessed": false
+  },
+  "summary": {
+    "total_articles": 6,
+    "go_human_review": 6,
+    "claim_review_required": 6,
+    "factual_citation_review_required": 6,
+    "media_visual_review_required": 6,
+    "publish_ready": 0,
+    "blocked": 0
+  },
+  "review_decisions": [
+    {
+      "asset_family": "articles",
+      "asset_key": "are-infj-men-rare-or-socially-silenced",
+      "source_zh_article": "are-infj-men-rare-or-socially-silenced",
+      "en_draft_package_key": "are-infj-men-rare-or-socially-silenced",
+      "proposed_en_slug": "are-infj-men-rare-or-socially-silenced",
+      "translation_group_key": "article:are-infj-men-rare-or-socially-silenced",
+      "translation_group_exists": false,
+      "cms_current_state": "article_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "public runtime spot check: /en/articles returned Articles page with article cards and Page 1 of 1.",
+      "draft_exists": true,
+      "title_en_draft": "Are INFJ Men Rare, or Have Highly Sensitive Men Learned to Stay Silent?",
+      "claim_risk": "medium",
+      "claim_boundary_state": "claim_review_required_personality_and_gender_norms",
+      "claim_review_required": true,
+      "factual_citation_risk": "review_required",
+      "reference_review_required": true,
+      "media_alt_risk": "visual_review_required",
+      "media_alt_draft": "A translucent male silhouette with lowered sound-wave lines, suggesting self-silencing among highly sensitive men.",
+      "internal_link_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "INFJ",
+          "高敏感",
+          "男性规范",
+          "自我沉默",
+          "情绪表达"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "internal_link_review_required": true,
+      "publish_readiness_after_human_review": "controlled_import_candidate_after_claim_fact_media_link_review",
+      "sitemap_llms_eligibility_only_after_publish": true,
+      "human_review_required": true,
+      "import_ready": true,
+      "publish_ready": false,
+      "blocked": false,
+      "deferred": false,
+      "required_review_risks": [
+        "claim_boundary_review",
+        "factual_citation_review",
+        "media_alt_visual_review"
+      ],
+      "required_reviewer_roles": [
+        "SEO_GEO_review",
+        "claim_boundary_review",
+        "technical_import_review",
+        "visual_media_review"
+      ],
+      "recommended_import_wave": "wave_2_articles_after_content_pages",
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "footer_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "notes": [
+        "No invented studies/statistics/citations may be added during review.",
+        "Sitemap/llms eligibility only after CMS publish and runtime verification."
+      ]
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "best-valentines-date-by-personality-and-relationship-science",
+      "source_zh_article": "best-valentines-date-by-personality-and-relationship-science",
+      "en_draft_package_key": "best-valentines-date-by-personality-and-relationship-science",
+      "proposed_en_slug": "best-valentines-date-by-personality-and-relationship-science",
+      "translation_group_key": "article:best-valentines-date-by-personality-and-relationship-science",
+      "translation_group_exists": false,
+      "cms_current_state": "article_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "public runtime spot check: /en/articles returned Articles page with article cards and Page 1 of 1.",
+      "draft_exists": true,
+      "title_en_draft": "Stop Chasing Romance Alone: Design a Lower-Friction Valentine Date With Personality and Relationship Science",
+      "claim_risk": "high",
+      "claim_boundary_state": "claim_review_required_relationship_science",
+      "claim_review_required": true,
+      "factual_citation_risk": "review_required",
+      "reference_review_required": true,
+      "media_alt_risk": "visual_review_required",
+      "media_alt_draft": "An abstract route map connecting two relationship nodes, representing lower-friction date design.",
+      "internal_link_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "约会设计",
+          "情人节",
+          "人格心理学",
+          "亲密关系",
+          "关系科学"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "internal_link_review_required": true,
+      "publish_readiness_after_human_review": "controlled_import_candidate_after_claim_fact_media_link_review",
+      "sitemap_llms_eligibility_only_after_publish": true,
+      "human_review_required": true,
+      "import_ready": true,
+      "publish_ready": false,
+      "blocked": false,
+      "deferred": false,
+      "required_review_risks": [
+        "claim_boundary_review",
+        "factual_citation_review",
+        "media_alt_visual_review",
+        "relationship_claim_review"
+      ],
+      "required_reviewer_roles": [
+        "SEO_GEO_review",
+        "claim_boundary_review",
+        "technical_import_review",
+        "visual_media_review"
+      ],
+      "recommended_import_wave": "wave_2_articles_after_content_pages",
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "footer_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "notes": [
+        "No invented studies/statistics/citations may be added during review.",
+        "Sitemap/llms eligibility only after CMS publish and runtime verification."
+      ]
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "childhood-dream-job-still-shapes-career-choice",
+      "source_zh_article": "childhood-dream-job-still-shapes-career-choice",
+      "en_draft_package_key": "childhood-dream-job-still-shapes-career-choice",
+      "proposed_en_slug": "childhood-dream-job-still-shapes-career-choice",
+      "translation_group_key": "article:childhood-dream-job-still-shapes-career-choice",
+      "translation_group_exists": false,
+      "cms_current_state": "article_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "public runtime spot check: /en/articles returned Articles page with article cards and Page 1 of 1.",
+      "draft_exists": true,
+      "title_en_draft": "Why Your Childhood Dream Job Still Shapes Your Career Judgment",
+      "claim_risk": "high",
+      "claim_boundary_state": "claim_review_required_career_direction_boundary",
+      "claim_review_required": true,
+      "factual_citation_risk": "review_required",
+      "reference_review_required": true,
+      "media_alt_risk": "visual_review_required",
+      "media_alt_draft": "An abstract path extending from childhood career icons into an adult career route.",
+      "internal_link_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "童年职业",
+          "职业兴趣",
+          "职业判断",
+          "RIASEC",
+          "人职匹配"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "internal_link_review_required": true,
+      "publish_readiness_after_human_review": "controlled_import_candidate_after_claim_fact_media_link_review",
+      "sitemap_llms_eligibility_only_after_publish": true,
+      "human_review_required": true,
+      "import_ready": true,
+      "publish_ready": false,
+      "blocked": false,
+      "deferred": false,
+      "required_review_risks": [
+        "career_claim_review",
+        "claim_boundary_review",
+        "factual_citation_review",
+        "media_alt_visual_review"
+      ],
+      "required_reviewer_roles": [
+        "SEO_GEO_review",
+        "career_claim_review",
+        "claim_boundary_review",
+        "technical_import_review",
+        "visual_media_review"
+      ],
+      "recommended_import_wave": "wave_2_articles_after_content_pages",
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "footer_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "notes": [
+        "No invented studies/statistics/citations may be added during review.",
+        "Sitemap/llms eligibility only after CMS publish and runtime verification."
+      ]
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "how-16-personality-types-talk-to-an-ai-coach",
+      "source_zh_article": "how-16-personality-types-talk-to-an-ai-coach",
+      "en_draft_package_key": "how-16-personality-types-talk-to-an-ai-coach",
+      "proposed_en_slug": "how-16-personality-types-talk-to-an-ai-coach",
+      "translation_group_key": "article:how-16-personality-types-talk-to-an-ai-coach",
+      "translation_group_exists": false,
+      "cms_current_state": "article_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "public runtime spot check: /en/articles returned Articles page with article cards and Page 1 of 1.",
+      "draft_exists": true,
+      "title_en_draft": "When the 16 Personality Types Talk to an AI Coach: Who Uses It as a Mirror, a Tool, or an Easy Yes",
+      "claim_risk": "high",
+      "claim_boundary_state": "claim_review_required_ai_advice_boundary",
+      "claim_review_required": true,
+      "factual_citation_risk": "review_required",
+      "reference_review_required": true,
+      "media_alt_risk": "visual_review_required",
+      "media_alt_draft": "Abstract dialogue bubbles and a mirror-like structure showing interaction between personality and an AI coach.",
+      "internal_link_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "AI 教练",
+          "16 型人格",
+          "人机交互",
+          "算法建议",
+          "MBTI"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "internal_link_review_required": true,
+      "publish_readiness_after_human_review": "controlled_import_candidate_after_claim_fact_media_link_review",
+      "sitemap_llms_eligibility_only_after_publish": true,
+      "human_review_required": true,
+      "import_ready": true,
+      "publish_ready": false,
+      "blocked": false,
+      "deferred": false,
+      "required_review_risks": [
+        "ai_advice_boundary_review",
+        "claim_boundary_review",
+        "factual_citation_review",
+        "media_alt_visual_review"
+      ],
+      "required_reviewer_roles": [
+        "SEO_GEO_review",
+        "claim_boundary_review",
+        "technical_import_review",
+        "visual_media_review"
+      ],
+      "recommended_import_wave": "wave_2_articles_after_content_pages",
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "footer_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "notes": [
+        "No invented studies/statistics/citations may be added during review.",
+        "Sitemap/llms eligibility only after CMS publish and runtime verification."
+      ]
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "how-personality-shapes-attitude-toward-ai",
+      "source_zh_article": "how-personality-shapes-attitude-toward-ai",
+      "en_draft_package_key": "how-personality-shapes-attitude-toward-ai",
+      "proposed_en_slug": "how-personality-shapes-attitude-toward-ai",
+      "translation_group_key": "article:how-personality-shapes-attitude-toward-ai",
+      "translation_group_exists": false,
+      "cms_current_state": "article_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "public runtime spot check: /en/articles returned Articles page with article cards and Page 1 of 1.",
+      "draft_exists": true,
+      "title_en_draft": "How Personality Shapes Your Attitude Toward AI: From Curiosity and Anxiety to Algorithm Trust",
+      "claim_risk": "high",
+      "claim_boundary_state": "claim_review_required_ai_and_personality_boundary",
+      "claim_review_required": true,
+      "factual_citation_risk": "review_required",
+      "reference_review_required": true,
+      "media_alt_risk": "visual_review_required",
+      "media_alt_draft": "An abstract face outline woven with AI network nodes, showing how personality differences can affect algorithm trust.",
+      "internal_link_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "人格心理学",
+          "AI",
+          "算法信任",
+          "人机交互",
+          "MBTI"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "internal_link_review_required": true,
+      "publish_readiness_after_human_review": "controlled_import_candidate_after_claim_fact_media_link_review",
+      "sitemap_llms_eligibility_only_after_publish": true,
+      "human_review_required": true,
+      "import_ready": true,
+      "publish_ready": false,
+      "blocked": false,
+      "deferred": false,
+      "required_review_risks": [
+        "ai_advice_boundary_review",
+        "claim_boundary_review",
+        "factual_citation_review",
+        "media_alt_visual_review"
+      ],
+      "required_reviewer_roles": [
+        "SEO_GEO_review",
+        "claim_boundary_review",
+        "technical_import_review",
+        "visual_media_review"
+      ],
+      "recommended_import_wave": "wave_2_articles_after_content_pages",
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "footer_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "notes": [
+        "No invented studies/statistics/citations may be added during review.",
+        "Sitemap/llms eligibility only after CMS publish and runtime verification."
+      ]
+    },
+    {
+      "asset_family": "articles",
+      "asset_key": "which-love-script-fits-you-best",
+      "source_zh_article": "which-love-script-fits-you-best",
+      "en_draft_package_key": "which-love-script-fits-you-best",
+      "proposed_en_slug": "which-love-script-fits-you-best",
+      "translation_group_key": "article:which-love-script-fits-you-best",
+      "translation_group_exists": false,
+      "cms_current_state": "article_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "public runtime spot check: /en/articles returned Articles page with article cards and Page 1 of 1.",
+      "draft_exists": true,
+      "title_en_draft": "Which Relationship Script Fits You Best? A More Scientific Match Through Seven Love Styles",
+      "claim_risk": "high",
+      "claim_boundary_state": "claim_review_required_relationship_matching_boundary",
+      "claim_review_required": true,
+      "factual_citation_risk": "review_required",
+      "reference_review_required": true,
+      "media_alt_risk": "visual_review_required",
+      "media_alt_draft": "An abstract relationship network showing geometric paths for seven love scripts.",
+      "internal_link_intent": {
+        "related_test_slug": null,
+        "tags_zh": [
+          "爱情风格",
+          "亲密关系",
+          "关系科学",
+          "MBTI",
+          "依恋与亲密"
+        ],
+        "linking_notes": "Preserve article-to-topic/test intent only when backend authority can resolve the linked destination; do not expose draft URLs."
+      },
+      "internal_link_review_required": true,
+      "publish_readiness_after_human_review": "controlled_import_candidate_after_claim_fact_media_link_review",
+      "sitemap_llms_eligibility_only_after_publish": true,
+      "human_review_required": true,
+      "import_ready": true,
+      "publish_ready": false,
+      "blocked": false,
+      "deferred": false,
+      "required_review_risks": [
+        "claim_boundary_review",
+        "factual_citation_review",
+        "media_alt_visual_review",
+        "relationship_claim_review"
+      ],
+      "required_reviewer_roles": [
+        "SEO_GEO_review",
+        "claim_boundary_review",
+        "technical_import_review",
+        "visual_media_review"
+      ],
+      "recommended_import_wave": "wave_2_articles_after_content_pages",
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "footer_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "notes": [
+        "No invented studies/statistics/citations may be added during review.",
+        "Sitemap/llms eligibility only after CMS publish and runtime verification."
+      ]
+    }
+  ],
+  "claim_boundary_items": [
+    "are-infj-men-rare-or-socially-silenced",
+    "best-valentines-date-by-personality-and-relationship-science",
+    "childhood-dream-job-still-shapes-career-choice",
+    "how-16-personality-types-talk-to-an-ai-coach",
+    "how-personality-shapes-attitude-toward-ai",
+    "which-love-script-fits-you-best"
+  ],
+  "factual_citation_review_items": [
+    "are-infj-men-rare-or-socially-silenced",
+    "best-valentines-date-by-personality-and-relationship-science",
+    "childhood-dream-job-still-shapes-career-choice",
+    "how-16-personality-types-talk-to-an-ai-coach",
+    "how-personality-shapes-attitude-toward-ai",
+    "which-love-script-fits-you-best"
+  ],
+  "media_review_items": [
+    "are-infj-men-rare-or-socially-silenced",
+    "best-valentines-date-by-personality-and-relationship-science",
+    "childhood-dream-job-still-shapes-career-choice",
+    "how-16-personality-types-talk-to-an-ai-coach",
+    "how-personality-shapes-attitude-toward-ai",
+    "which-love-script-fits-you-best"
+  ],
+  "not_done": [
+    "No CMS mutation/import/publish.",
+    "No sitemap/llms/Search Channel exposure.",
+    "No article auto approval and no invented citations or studies."
+  ],
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_pseo_generation": true,
+  "no_frontend_fallback_authority": true,
+  "next_task": "GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03"
+}

--- a/backend/docs/seo/global-en-zh-article-human-review-import-02.md
+++ b/backend/docs/seo/global-en-zh-article-human-review-import-02.md
@@ -1,0 +1,43 @@
+# GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02
+
+## Executive Summary
+This PR creates a decision-only review packet for six English article counterpart drafts. It does not import, publish, edit CMS records, submit URLs, enqueue Search Channel, or expose drafts in sitemap/llms.
+
+## Read-Only Evidence
+- Public article index observed at `https://fermatmind.com/en/articles`.
+- No CMS article edit/save/import/publish action was performed.
+
+## Summary
+- `total_articles`: 6
+- `go_human_review`: 6
+- `claim_review_required`: 6
+- `factual_citation_review_required`: 6
+- `media_visual_review_required`: 6
+- `publish_ready`: 0
+- `blocked`: 0
+
+## Article Decisions
+| Article | Claim Risk | Citation Review | Media Review | Import Later | Required Review |
+| --- | --- | --- | --- | --- | --- |
+| `are-infj-men-rare-or-socially-silenced` | medium | true | visual_review_required | true | SEO_GEO_review, claim_boundary_review, technical_import_review, visual_media_review |
+| `best-valentines-date-by-personality-and-relationship-science` | high | true | visual_review_required | true | SEO_GEO_review, claim_boundary_review, technical_import_review, visual_media_review |
+| `childhood-dream-job-still-shapes-career-choice` | high | true | visual_review_required | true | SEO_GEO_review, career_claim_review, claim_boundary_review, technical_import_review, visual_media_review |
+| `how-16-personality-types-talk-to-an-ai-coach` | high | true | visual_review_required | true | SEO_GEO_review, claim_boundary_review, technical_import_review, visual_media_review |
+| `how-personality-shapes-attitude-toward-ai` | high | true | visual_review_required | true | SEO_GEO_review, claim_boundary_review, technical_import_review, visual_media_review |
+| `which-love-script-fits-you-best` | high | true | visual_review_required | true | SEO_GEO_review, claim_boundary_review, technical_import_review, visual_media_review |
+
+## Gates
+- `publish_ready=false` for every article.
+- `sitemap_eligible_after_import=false` and `llms_eligible_after_import=false` for every article.
+- Human review must verify claims, citations, internal links, and media/alt text before any controlled CMS import/publish task.
+
+## What Was Not Done
+- No CMS mutation/import/publish.
+- No sitemap/llms/Search Channel exposure.
+- No article auto approval and no invented citations or studies.
+
+## Final Decision
+`article_review_decision_packet_created_ready_for_human_review`
+
+## Next Task
+`GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhArticleHumanReviewImport02Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhArticleHumanReviewImport02Test.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhArticleHumanReviewImport02Test extends TestCase
+{
+    #[Test]
+    public function article_review_decision_packet_is_decision_only(): void
+    {
+        $reportPath = base_path('docs/seo/global-en-zh-article-human-review-import-02.md');
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-article-human-review-import-02.v1.json');
+
+        $this->assertFileExists($reportPath);
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-article-human-review-import-02.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02', $generated['task'] ?? null);
+        $this->assertSame('article_review_decision_packet_created_ready_for_human_review', $generated['final_decision'] ?? null);
+
+        $decisions = $generated['review_decisions'] ?? [];
+        $this->assertCount(6, $decisions);
+
+        foreach ($decisions as $decision) {
+            foreach ([
+                'source_zh_article',
+                'en_draft_package_key',
+                'claim_risk',
+                'factual_citation_risk',
+                'media_alt_risk',
+                'internal_link_intent',
+                'publish_readiness_after_human_review',
+                'sitemap_llms_eligibility_only_after_publish',
+                'required_reviewer_roles',
+            ] as $requiredKey) {
+                $this->assertArrayHasKey($requiredKey, $decision);
+            }
+
+            $this->assertTrue($decision['human_review_required'] ?? false);
+            $this->assertTrue($decision['claim_review_required'] ?? false);
+            $this->assertTrue($decision['reference_review_required'] ?? false);
+            $this->assertTrue($decision['internal_link_review_required'] ?? false);
+            $this->assertFalse($decision['publish_ready'] ?? true);
+            $this->assertFalse($decision['sitemap_eligible_after_import'] ?? true);
+            $this->assertFalse($decision['llms_eligible_after_import'] ?? true);
+            $this->assertFalse($decision['search_channel_eligible_after_import'] ?? true);
+            $this->assertTrue($decision['sitemap_llms_eligibility_only_after_publish'] ?? false);
+        }
+
+        $this->assertSame(6, $generated['summary']['claim_review_required'] ?? null);
+        $this->assertSame(6, $generated['summary']['factual_citation_review_required'] ?? null);
+        $this->assertSame(0, $generated['summary']['publish_ready'] ?? null);
+
+        $evidence = $generated['browser_cms_read_only_evidence'] ?? [];
+        $this->assertFalse($evidence['cms_mutation_performed'] ?? true);
+        $this->assertFalse($evidence['browser_write_actions_performed'] ?? true);
+        $this->assertFalse($evidence['private_user_data_accessed'] ?? true);
+
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_pseo_generation'] ?? false);
+        $this->assertTrue($generated['no_frontend_fallback_authority'] ?? false);
+        $this->assertSame('GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03', $generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26245,7 +26245,7 @@
       "merge_commit_sha": "acf26cb4c155d6ec387acea81db2f9a4f366f3c9"
     },
     "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVIEW-IMPORT-01": {
-      "status": "pr_opened",
+      "status": "merged",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-content-pages-human-review-import-01",
       "base": "main",
@@ -26253,12 +26253,12 @@
         "GLOBAL-EN-ZH-HUMAN-REVIEW-IMPORT-QUEUE-00"
       ],
       "title": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVIEW-IMPORT-01 content page review decisions",
-      "commit_sha": "886dc8be",
+      "commit_sha": "41e684bf",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1700",
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-26T13:33:34Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "checks": {
         "preflight": {
           "status": "passed",
@@ -26313,6 +26313,15 @@
           "status": "passed",
           "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
           "evidence": "No fap-web changes."
+        },
+        "github_required_checks": {
+          "status": "passed",
+          "evidence": "PR #1700 checks green and mergeStateStatus CLEAN before squash merge."
+        },
+        "post_merge_focused_test": {
+          "status": "passed",
+          "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanReviewImport01 --no-ansi",
+          "evidence": "1 test passed, 330 assertions after PR #1700 merge."
         }
       },
       "history": [
@@ -26340,11 +26349,22 @@
           "at": "2026-05-26T21:24:26+08:00",
           "status": "pr_opened",
           "summary": "Opened PR #1700 after local validation; waiting for GitHub required checks."
+        },
+        {
+          "at": "2026-05-26T21:35:53+08:00",
+          "status": "merged",
+          "summary": "PR #1700 squash-merged; merge commit 40cb182fbbe8ff521eb78b698c17c2ef67e9798b verified on origin/main."
+        },
+        {
+          "at": "2026-05-26T21:35:53+08:00",
+          "status": "post_merge_cleanup_done",
+          "summary": "Remote task branch deleted by merge; local task branch deleted; post-merge focused test passed."
         }
-      ]
+      ],
+      "merge_commit_sha": "40cb182fbbe8ff521eb78b698c17c2ef67e9798b"
     },
     "GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02": {
-      "status": "planned",
+      "status": "local_checks_passed",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-article-human-review-import-02",
       "base": "main",
@@ -26358,12 +26378,77 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "checks": {},
+      "checks": {
+        "preflight": {
+          "status": "passed",
+          "evidence": "Started from origin/main at 40cb182fbbe8ff521eb78b698c17c2ef67e9798b in isolated worktree; dependency PR #1700 merged."
+        },
+        "browser_read_only_evidence": {
+          "status": "passed",
+          "evidence": "Public /en/articles index observed read-only; no CMS article write action."
+        },
+        "focused_test": {
+          "status": "passed",
+          "command": "cd backend && php artisan test --filter=GlobalEnZhArticleHumanReviewImport02 --no-ansi",
+          "evidence": "1 test passed, 128 assertions."
+        },
+        "route_list": {
+          "status": "passed",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "203 routes listed."
+        },
+        "pint": {
+          "status": "passed",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "3573 files passed."
+        },
+        "composer_validate": {
+          "status": "passed",
+          "command": "cd backend && composer validate --strict"
+        },
+        "composer_audit": {
+          "status": "passed",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "passed",
+          "evidence": "Generated JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+        },
+        "scope_validation": {
+          "status": "passed",
+          "changed_files": [
+            "backend/docs/seo/generated/global-en-zh-article-human-review-import-02.v1.json",
+            "backend/docs/seo/global-en-zh-article-human-review-import-02.md",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhArticleHumanReviewImport02Test.php",
+            "docs/codex/pr-train-state.json"
+          ]
+        },
+        "diff_check": {
+          "status": "passed",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "fap_web_reference_check": {
+          "status": "passed",
+          "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+          "evidence": "No fap-web changes."
+        }
+      },
       "history": [
         {
           "at": "2026-05-26T11:02:25+08:00",
           "status": "planned",
           "summary": "Authorized browser-assisted human review train entry; no CMS mutation, publish, deploy, URL submission, Search Channel action, or pSEO generation."
+        },
+        {
+          "at": "2026-05-26T21:35:53+08:00",
+          "status": "in_progress",
+          "summary": "Started article human-review decision packet from Batch-02 article import package and read-only article index evidence."
+        },
+        {
+          "at": "2026-05-26T21:36:52+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, fap-web reference check, and scope validation passed."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26364,7 +26364,7 @@
       "merge_commit_sha": "40cb182fbbe8ff521eb78b698c17c2ef67e9798b"
     },
     "GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02": {
-      "status": "local_checks_passed",
+      "status": "pr_opened",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-article-human-review-import-02",
       "base": "main",
@@ -26372,8 +26372,8 @@
         "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVIEW-IMPORT-01"
       ],
       "title": "GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02 article review decisions",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "33ed329f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1701",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -26449,6 +26449,11 @@
           "at": "2026-05-26T21:36:52+08:00",
           "status": "local_checks_passed",
           "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, fap-web reference check, and scope validation passed."
+        },
+        {
+          "at": "2026-05-26T21:37:37+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1701 after local validation; waiting for GitHub required checks."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the article human-review decision packet for `GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02`.
- Generated a decision-only JSON artifact for 6 EN article counterpart drafts, including claim, citation, media/alt, internal-link, reviewer-role, and import-wave decisions.
- Added a focused PHPUnit test and updated the PR train state ledger, including PR #1700 post-merge bookkeeping.

## Why
This prepares human review/import decisions for article counterpart drafts while preserving CMS authority and keeping all generated content out of publish, sitemap, llms, and Search Channel surfaces.

## Validation
- `cd backend && php artisan test --filter=GlobalEnZhArticleHumanReviewImport02 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-article-human-review-import-02.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check && git diff --cached --check`
- fap-web reference check: clean

## Intentionally deferred
- No CMS import, save, publish, or approval.
- No sitemap/llms/Search Channel exposure or URL submission.
- No invented studies, citations, statistics, unsupported clinical/career claims, or article auto approval.

Repository rule impact: decision-only backend docs/generated/test/state artifacts; no content ownership or runtime authority change.
