### PR TITLE
docs(seo-intel): add ZH MBTI IndexNow 24h review

### DIFF
--- a/backend/docs/seo/generated/search-channel-live-zh-mbti-02-24h-review.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-zh-mbti-02-24h-review.v1.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "v1",
+  "task": "SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW",
+  "final_decision": "search_channel_live_zh_mbti_02_24h_review_completed_stable_ready_for_seo_ops",
+  "queue_item_id": 3,
+  "target_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+  "channel": "indexnow",
+  "review_window": {
+    "required_elapsed_hours": 24,
+    "earliest_valid_review_time": "2026-05-26T04:09:44Z"
+  },
+  "live_submission_time": "2026-05-25T04:09:44Z",
+  "review_started_at": "2026-05-26T13:28:30Z",
+  "elapsed_hours": 33.31,
+  "elapsed_window_passed": true,
+  "queue_item_state": {
+    "exists": true,
+    "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "locale": "zh-CN",
+    "page_entity_type": "test_detail",
+    "source_authority": "scale_catalog",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "eligibility_state": "eligible",
+    "claim_boundary_state": "claim_safe",
+    "private_flow": false
+  },
+  "event_counts": {
+    "queue_item_planned": 1,
+    "live_submission_approved": 1,
+    "live_submission_response": 1
+  },
+  "live_response_state": {
+    "event_present": true,
+    "endpoint_host": "api.indexnow.org",
+    "http_status": 200,
+    "submission_status": "accepted",
+    "exception_class": null
+  },
+  "queue_item_2_state": {
+    "queue_item_id": 2,
+    "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+    "channel": "indexnow",
+    "approval_state": "approved",
+    "execution_state": "submitted",
+    "unchanged": true
+  },
+  "duplicate_check": {
+    "target_url_channel_count": 1,
+    "duplicate_active_queue_item_detected": false,
+    "research_submitted_count": 0,
+    "bulk_submit_event_count_since_submission": 0
+  },
+  "retry_check": {
+    "live_submission_response_count": 1,
+    "retry_storm_detected": false
+  },
+  "gate_state": {
+    "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED": false,
+    "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED": false,
+    "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED": false,
+    "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED": false
+  },
+  "public_runtime_check": {
+    "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "http_status": 200,
+    "final_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "canonical": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "robots_meta": "index, follow",
+    "noindex_detected": false,
+    "staging_canonical_detected": false,
+    "private_flow_marker_detected": false,
+    "stale_slug_marker_detected": false,
+    "used_as_url_truth": false
+  },
+  "issue_queue_check": {
+    "available": true,
+    "table": "seo_issue_queue",
+    "target_issue_count": 0,
+    "private_flow_leak_detected": false,
+    "forbidden_authority_detected": false,
+    "claim_unsafe_detected": false,
+    "duplicate_search_channel_issue_detected": false
+  },
+  "crawler_aggregate_observation": {
+    "available": false,
+    "tables_checked": [
+      "seo_crawler_log_daily_aggregates",
+      "seo_crawler_daily_aggregates"
+    ],
+    "raw_nginx_logs_read": false,
+    "crawler_visit_claimed": false,
+    "sidecar": "crawler aggregate table not detected"
+  },
+  "external_search_visibility_observation": {
+    "checked": false,
+    "external_search_api_called": false,
+    "serp_observation_performed": false,
+    "indexing_claimed": false,
+    "ranking_claimed": false,
+    "sidecar": "not checked by scope"
+  },
+  "staging_sidecar": {
+    "checked": true,
+    "url": "https://staging.fermatmind.com/",
+    "http_status": 200,
+    "x_robots_tag": "noindex, nofollow, noarchive",
+    "robots_meta": "noindex, nofollow, noarchive, nocache",
+    "canonical": "https://fermatmind.com",
+    "baidu_stale_result_sidecar": true,
+    "blocks_zh_mbti_review": false
+  },
+  "no_indexing_claim": true,
+  "no_ranking_claim": true,
+  "no_live_submission_performed": true,
+  "no_external_search_api_call": true,
+  "no_search_channel_enqueue": true,
+  "no_cms_mutation": true,
+  "no_deploy": true,
+  "next_task": "SEO-OPS-MBTI-FIRST-7D-RUN-01"
+}

--- a/backend/docs/seo/search-channel-live-zh-mbti-02-24h-review.md
+++ b/backend/docs/seo/search-channel-live-zh-mbti-02-24h-review.md
@@ -1,0 +1,184 @@
+# SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW
+
+## 1. Executive Summary
+The T+24h read-only review window was met and the ZH MBTI IndexNow live submission remains stable.
+
+Final decision:
+
+`search_channel_live_zh_mbti_02_24h_review_completed_stable_ready_for_seo_ops`
+
+No production writes, no Search Channel enqueue, no live URL submission, no external search API calls, no CMS mutation, no deploy, and no raw Nginx access log reads occurred during this review.
+
+## 2. Review Window Verification
+- Live submission response time: `2026-05-25T04:09:44Z`
+- Earliest valid review time: `2026-05-26T04:09:44Z`
+- Review started at: `2026-05-26T13:28:30Z`
+- Elapsed time: `33.31` hours
+
+The review was started after the required 24h gate.
+
+## 3. Queue Item 3 State
+Read-only production DB verification confirmed queue item `3` still exists and matches the target:
+
+- canonical_url: `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- channel: `indexnow`
+- locale: `zh-CN`
+- page_entity_type: `test_detail`
+- source_authority: `scale_catalog`
+- approval_state: `approved`
+- execution_state: `submitted`
+- eligibility_state: `eligible`
+- claim_boundary_state: `claim_safe`
+- private_flow: `false`
+
+## 4. Event / Response State
+Read-only production DB verification confirmed the expected event trail:
+
+- `queue_item_planned`: `1`
+- `live_submission_approved`: `1`
+- `live_submission_response`: `1`
+
+The latest `live_submission_response` payload records:
+
+- endpoint_host: `api.indexnow.org`
+- http_status: `200`
+- submission_status: `accepted`
+- exception_class: `null`
+
+## 5. Gate State
+Read-only Laravel config verification confirmed persistent production gates remain closed:
+
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`
+- `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false`
+
+## 6. Duplicate / Retry Check
+No duplicate, retry, or bulk anomaly was detected.
+
+- Exact ZH MBTI URL/channel queue rows: `1`
+- `live_submission_response` events for queue item `3`: `1`
+- bulk event count since submission: `0`
+- submitted Research queue item count: `0`
+
+## 7. Queue Item 2 Protection
+EN MBTI queue item `2` remained unchanged:
+
+- canonical_url: `https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types`
+- channel: `indexnow`
+- approval_state: `approved`
+- execution_state: `submitted`
+
+## 8. Public URL Runtime Check
+Safe public read confirmed:
+
+- URL: `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- HTTP status: `200`
+- canonical: `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- robots meta: `index, follow`
+- no `noindex`
+- no staging canonical
+- no private-flow marker
+- no stale slug marker
+
+Public runtime was used only as observation, not URL Truth.
+
+## 9. Issue Queue Check
+Read-only `seo_issue_queue` verification found:
+
+- target URL issue count: `0`
+- no private-flow leak issue detected
+- no forbidden-authority issue detected
+- no claim-unsafe issue detected
+- no duplicate Search Channel issue detected
+
+## 10. Crawler Aggregate Observation
+No crawler aggregate table was available in production for this bounded review:
+
+- `seo_crawler_log_daily_aggregates`: unavailable
+- `seo_crawler_daily_aggregates`: unavailable
+
+No raw Nginx access logs were read. No crawler visit, indexing, or ranking inference is made.
+
+## 11. External Search Visibility Observation
+External search visibility was not checked.
+
+No GSC, Baidu, Bing, 360, Sogou, Shenma, or IndexNow live endpoint was called. No indexing or ranking claim is made.
+
+## 12. Staging / Baidu Sidecar
+Safe public staging check confirmed containment remains active:
+
+- `https://staging.fermatmind.com/` returned HTTP `200`
+- `X-Robots-Tag: noindex, nofollow, noarchive`
+- HTML robots: `noindex, nofollow, noarchive, nocache`
+- canonical points to production apex
+
+The known Baidu stale staging result remains a sidecar and does not block this ZH MBTI review.
+
+## 13. Indexing / Ranking Claim Boundary
+IndexNow `accepted` means the endpoint accepted a URL update signal.
+
+It does not prove:
+
+- indexing
+- ranking improvement
+- crawler visit
+- search visibility change
+
+No crawler visit is claimed because crawler aggregate evidence is unavailable.
+
+## 14. Validation
+Required local validation commands for this PR:
+
+```bash
+cd /private/tmp/fap-api-search-channel-live-zh-mbti-02-24h-review/backend
+php artisan test --filter=SeoIntelSearchChannelLiveZhMbti02TwentyFourHourReview --no-ansi
+php artisan route:list --no-ansi
+vendor/bin/pint --test
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+
+cd /private/tmp/fap-api-search-channel-live-zh-mbti-02-24h-review
+python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-02-24h-review.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 - <<'PY'
+import yaml, pathlib
+yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+print('yaml ok')
+PY
+git diff --check
+git diff --cached --check
+```
+
+## 15. PR / Merge Result
+Pending for this PR.
+
+## 16. Sidecar Issues
+- `crawler_aggregate_table_unavailable`: crawler aggregate tables were not available, so no crawler visit or indexing inference is made.
+- `external_search_visibility_not_checked`: public SERP observation and webmaster tools were not checked by scope.
+- `ops_seo_visibility_not_checked`: authenticated `/ops/seo` UI visibility was not checked; direct read-only production DB evidence was used.
+- `baidu_staging_stale_result_sidecar`: known stale staging result remains separate from this ZH MBTI live submission review.
+
+## 17. What Was Not Done
+- No deployment.
+- No production env, DNS, or nginx edit.
+- No migration.
+- No collector write.
+- No scheduler activation.
+- No Search Channel enqueue.
+- No URL submission.
+- No IndexNow live endpoint call.
+- No GSC, Baidu, Bing, 360, Sogou, or Shenma call.
+- No raw Nginx access log read.
+- No CMS mutation.
+- No article publication.
+- No internal link creation.
+- No Digital PR.
+- No pSEO.
+- No indexing or ranking claim.
+
+## 18. Final Decision
+`search_channel_live_zh_mbti_02_24h_review_completed_stable_ready_for_seo_ops`
+
+## 19. Next Task
+`SEO-OPS-MBTI-FIRST-7D-RUN-01`

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti02TwentyFourHourReviewTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti02TwentyFourHourReviewTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelLiveZhMbti02TwentyFourHourReviewTest extends TestCase
+{
+    public function test_generated_artifact_exists_and_locks_twenty_four_hour_review_boundary(): void
+    {
+        $path = base_path('docs/seo/generated/search-channel-live-zh-mbti-02-24h-review.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(3, $payload['queue_item_id']);
+        $this->assertSame(
+            'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types',
+            $payload['target_url']
+        );
+        $this->assertSame('indexnow', $payload['channel']);
+        $this->assertArrayHasKey('elapsed_window_passed', $payload);
+        $this->assertArrayHasKey('queue_item_state', $payload);
+        $this->assertArrayHasKey('gate_state', $payload);
+        $this->assertArrayHasKey('live_response_state', $payload);
+        $this->assertTrue($payload['no_indexing_claim']);
+        $this->assertTrue($payload['no_ranking_claim']);
+        $this->assertTrue($payload['no_live_submission_performed']);
+        $this->assertTrue($payload['no_external_search_api_call']);
+        $this->assertTrue($payload['no_search_channel_enqueue']);
+        $this->assertTrue($payload['no_cms_mutation']);
+        $this->assertTrue($payload['no_deploy']);
+        $this->assertSame(1, $payload['event_counts']['live_submission_response'] ?? null);
+        $this->assertSame('accepted', $payload['live_response_state']['submission_status'] ?? null);
+        $this->assertFalse($payload['duplicate_check']['duplicate_active_queue_item_detected'] ?? true);
+        $this->assertNotEmpty($payload['final_decision'] ?? null);
+        $this->assertNotEmpty($payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15043,7 +15043,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-enqueue",
-      "status": "commit_created",
+      "status": "pr_open_github_checks_pending",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01A"
       ],
@@ -18460,8 +18460,8 @@
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-ZH-MBTI-02"
       ],
-      "commit_sha": "f72e0f3b",
-      "pr_url": null,
+      "commit_sha": "d33dfb5e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1702",
       "checks": {
         "review_window": {
           "status": "pass",
@@ -18521,7 +18521,12 @@
         {
           "at": "2026-05-26T21:43:00+08:00",
           "status": "commit_created",
-          "summary": "Created scoped commit f72e0f3b for the ZH MBTI 24h review report."
+          "summary": "Created scoped commit d33dfb5e for the ZH MBTI 24h review report."
+        },
+        {
+          "at": "2026-05-26T21:47:00+08:00",
+          "status": "pr_open_github_checks_pending",
+          "summary": "Opened PR #1702 for the ZH MBTI 24h review report. GitHub checks are pending."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15043,7 +15043,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B": {
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01b-enqueue",
-      "status": "local_checks_passed",
+      "status": "commit_created",
       "depends_on": [
         "SEO-GROWTH-MBTI-ACTION-01A"
       ],
@@ -18450,6 +18450,78 @@
           "at": "2026-05-25T12:31:00+08:00",
           "status": "pr_open_github_checks_pending",
           "summary": "Opened PR #1664 for the ZH MBTI live submission report. GitHub checks are pending."
+        }
+      ]
+    },
+    "SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW": {
+      "repo": "fap-api",
+      "branch": "codex/search-channel-live-zh-mbti-02-24h-review",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "SEARCH-CHANNEL-LIVE-ZH-MBTI-02"
+      ],
+      "commit_sha": "3b61d5aa",
+      "pr_url": null,
+      "checks": {
+        "review_window": {
+          "status": "pass",
+          "evidence": "Live response time was 2026-05-25T04:09:44Z; review started at 2026-05-26T13:28:30Z; elapsed_hours=33.31."
+        },
+        "production_read_only": {
+          "queue_item_3_state": "passed: queue item 3 exists with exact ZH MBTI URL, channel=indexnow, locale=zh-CN, page_entity_type=test_detail, source_authority=scale_catalog, approval_state=approved, execution_state=submitted, eligibility_state=eligible, claim_boundary_state=claim_safe, private_flow=false.",
+          "event_response_state": "passed: queue_item_planned=1, live_submission_approved=1, live_submission_response=1; latest response records endpoint_host=api.indexnow.org, http_status=200, submission_status=accepted.",
+          "duplicate_retry_bulk": "passed: exact ZH URL/channel queue count=1, live_submission_response count=1, bulk event count since submission=0, submitted Research queue item count=0.",
+          "queue_item_2": "passed: EN MBTI queue item 2 remains approved/submitted for the exact EN MBTI URL/channel.",
+          "gate_state": "passed: queue write, live submission, external API, and IndexNow live API gates are false in Laravel config state.",
+          "public_runtime": "passed: ZH MBTI public URL returned HTTP 200 with exact apex canonical, robots index/follow, no noindex, no staging canonical, no private-flow marker, and no stale slug marker.",
+          "issue_queue": "passed: seo_issue_queue exists and target URL issue count is 0.",
+          "crawler_aggregate": "sidecar: crawler aggregate tables were unavailable; no raw Nginx access logs were read and no crawler/indexing inference was made.",
+          "external_search_visibility": "not_checked_by_scope: no GSC/Baidu/Bing/360/Sogou/Shenma APIs, no IndexNow live endpoint, no SERP observation, and no indexing/ranking claim.",
+          "staging_sidecar": "passed: staging public check still shows X-Robots-Tag noindex/nofollow/noarchive, HTML robots noindex/nofollow/noarchive/nocache, and production apex canonical."
+        },
+        "local": {
+          "focused_twenty_four_hour_review_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveZhMbti02TwentyFourHourReview --no-ansi (1 test, 20 assertions)",
+          "route_list": "passed: php artisan route:list --no-ansi (203 routes)",
+          "pint": "passed: vendor/bin/pint --test (3572 files)",
+          "composer_validate": "passed: composer validate --strict",
+          "composer_audit": "passed: composer audit --locked --no-interaction --ignore-unreachable",
+          "json_artifact": "passed: python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-02-24h-review.v1.json",
+          "json_state": "passed: python3 -m json.tool docs/codex/pr-train-state.json",
+          "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
+          "git_diff_check": "passed: git diff --check",
+          "git_diff_cached_check": "passed: git diff --cached --check",
+          "fap_web_reference_status": "passed: git status --short returned clean in /Users/rainie/Desktop/GitHub/fap-web"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_deploy_allowed": false,
+      "production_migration_execution_allowed": false,
+      "external_api_credentials_required": false,
+      "scheduler_activation": false,
+      "next_pr": "SEO-OPS-MBTI-FIRST-7D-RUN-01",
+      "history": [
+        {
+          "at": "2026-05-26T21:28:30+08:00",
+          "status": "review_window_passed",
+          "summary": "Confirmed more than 24 hours elapsed since queue item 3 live_submission_response at 2026-05-25T04:09:44Z."
+        },
+        {
+          "at": "2026-05-26T21:29:00+08:00",
+          "status": "production_read_only_review_completed",
+          "summary": "Read-only production checks confirmed queue item 3 remains approved/submitted, expected events are present, gates are closed, queue item 2 is unchanged, no duplicate/retry/bulk anomaly exists, public runtime is healthy, and no Research URL was submitted."
+        },
+        {
+          "at": "2026-05-26T21:42:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused 24h review test, route list, Pint, composer validate, composer audit, generated JSON/state parse, manifest parse, fap-web reference status, and diff checks passed."
+        },
+        {
+          "at": "2026-05-26T21:43:00+08:00",
+          "status": "commit_created",
+          "summary": "Created scoped commit 3b61d5aa for the ZH MBTI 24h review report."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -18460,7 +18460,7 @@
       "depends_on": [
         "SEARCH-CHANNEL-LIVE-ZH-MBTI-02"
       ],
-      "commit_sha": "3b61d5aa",
+      "commit_sha": "f72e0f3b",
       "pr_url": null,
       "checks": {
         "review_window": {
@@ -18521,7 +18521,7 @@
         {
           "at": "2026-05-26T21:43:00+08:00",
           "status": "commit_created",
-          "summary": "Created scoped commit 3b61d5aa for the ZH MBTI 24h review report."
+          "summary": "Created scoped commit f72e0f3b for the ZH MBTI 24h review report."
         }
       ]
     },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -12417,6 +12417,51 @@ prs:
     live_external_submission_allowed: true
     next_task: SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW
 
+  - id: SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW
+    repo: fap-api
+    depends_on:
+      - SEARCH-CHANNEL-LIVE-ZH-MBTI-02
+    branch: codex/search-channel-live-zh-mbti-02-24h-review
+    base: main
+    title: "docs(seo-intel): add ZH MBTI IndexNow 24h review"
+    name: "24h review for ZH MBTI IndexNow live submission"
+    train_scope: seo_intel_search_channel_live_submission
+    risk_level: read_only_production_verification
+    type: docs_generated_test
+    scope:
+      - Perform a read-only T+24h technical review of queue item 3 after the ZH MBTI IndexNow live submission.
+      - Verify queue item state, event/response state, duplicate/retry safety, gate closure, queue item 2 protection, public runtime, issue queue, crawler aggregate availability, staging sidecar, and claim boundaries.
+      - Make no indexing, ranking, or crawler-visit claim unless aggregate evidence exists.
+    allowed_paths:
+      - backend/docs/seo/search-channel-live-zh-mbti-02-24h-review.md
+      - backend/docs/seo/generated/search-channel-live-zh-mbti-02-24h-review.v1.json
+      - backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveZhMbti02TwentyFourHourReviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, deploy files, production env, DNS, nginx, migrations, scheduler, collectors, CMS content, articles, internal links, URL Truth, seo_urls, seo_url_entities, sitemap, llms, Metabase, emails, DMs, Digital PR outreach, pSEO, business DB / Tencent RDS / Node2 DB, or frontend fallback authority.
+      - Enqueue Search Channel items, submit URLs, call IndexNow live endpoint, call GSC/Baidu/Bing/360/Sogou/Shenma, read raw Nginx access logs, mutate production data, or claim IndexNow acceptance as indexing/ranking proof.
+    validation:
+      - cd backend && php artisan test --filter=SeoIntelSearchChannelLiveZhMbti02TwentyFourHourReview --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-02-24h-review.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_deploy_allowed: false
+    production_migration_execution_allowed: false
+    scheduler_activation: false
+    live_external_submission_allowed: false
+    next_task: SEO-OPS-MBTI-FIRST-7D-RUN-01
+
   - id: OPS-ADMIN-UI-01
     repo: fap-api
     branch: codex/ops-admin-ui-01-table-toolbar


### PR DESCRIPTION
## What changed
- Added the SEARCH-CHANNEL-LIVE-ZH-MBTI-02-24H-REVIEW read-only report.
- Recorded queue item 3 state, event response state, gate closure, duplicate/retry checks, queue item 2 protection, public runtime observation, issue queue status, crawler aggregate sidecar, and staging sidecar.
- Added generated JSON, focused artifact test, and the authorized current task manifest/state entry only.

## Why
- Queue item 3 completed the ZH MBTI IndexNow live submission and needed a T+24h technical review without making indexing or ranking claims.

## Validation
- cd backend && php artisan test --filter=SeoIntelSearchChannelLiveZhMbti02TwentyFourHourReview --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/search-channel-live-zh-mbti-02-24h-review.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
print('yaml ok')
PY
- git diff --check
- git diff --cached --check
- cd /Users/rainie/Desktop/GitHub/fap-web && git status --short

## Intentionally deferred
- No live submission, enqueue, external search API call, deploy, CMS mutation, crawler raw log read, content creation, pSEO, or future task manifest entry.
- No indexing/ranking/crawler-visit claim.