### PR TITLE
GLOBAL-EN-ZH-RESEARCH-CLAIM-HUMAN-REVIEW-04 research claim review decisions

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-research-claim-human-review-04.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-research-claim-human-review-04.v1.json
@@ -1,0 +1,291 @@
+{
+  "schema_version": "global-en-zh-research-claim-human-review-04.v1",
+  "task": "GLOBAL-EN-ZH-RESEARCH-CLAIM-HUMAN-REVIEW-04",
+  "generated_at": "2026-05-26T22:35:47+08:00",
+  "final_decision": "research_claim_review_decision_packet_created_with_blockers",
+  "source_import_package": "backend/docs/seo/import-packages/global-en-zh-research-claim-review-batch-04.import.v1.json",
+  "browser_cms_read_only_evidence": {
+    "public_site_observations": [
+      {
+        "url": "https://fermatmind.com/en/research",
+        "status": "not_mutated_observation_only",
+        "summary": "Research runtime was not activated or changed by this packet."
+      }
+    ],
+    "cms_ops_observations": [
+      {
+        "url": "CMS research records",
+        "status": "not_opened_for_write",
+        "summary": "No CMS research edit/save/import/publish action was performed."
+      }
+    ],
+    "cms_mutation_performed": false,
+    "browser_write_actions_performed": false,
+    "private_user_data_accessed": false
+  },
+  "summary": {
+    "total_research_items": 2,
+    "blocked": 2,
+    "claim_review_required": 2,
+    "dataset_schema_eligible": 0,
+    "article_schema_eligible": 0,
+    "publish_ready": 0
+  },
+  "review_decisions": [
+    {
+      "asset_family": "research_pages",
+      "source_key": "mbti-salary-turnover-report",
+      "zh_source_status": "missing",
+      "en_counterpart_status": "candidate_frozen_draft",
+      "cms_current_state": "research_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "research_runtime_not_activated_by_this_packet",
+      "claim_risk": "critical",
+      "visible_grounding": false,
+      "visible_grounding_requirements": [
+        "methodology",
+        "sample_disclaimer",
+        "claim_boundary_statement",
+        "references",
+        "author_name",
+        "reviewer_name",
+        "last_reviewed_at",
+        "downloadable_asset_or_dataset_decision"
+      ],
+      "dataset_schema_eligible": false,
+      "article_schema_eligible": false,
+      "schema_activation_allowed": false,
+      "forbidden_claim_hits": [
+        "MBTI predicts individual salary",
+        "MBTI predicts individual turnover",
+        "individual-level hiring or retention prediction",
+        "salary guarantee",
+        "turnover guarantee",
+        "job suitability guarantee",
+        "career success prediction",
+        "diagnosis",
+        "treatment",
+        "cure"
+      ],
+      "required_caveats": [
+        "Research findings, if later approved, must be presented as aggregate-level, modeled, directional, and for reference only. They must not be used for individual hiring, retention, salary prediction, diagnosis, treatment, or career-success decisions."
+      ],
+      "publish_readiness": "blocked_deferred_claim_review",
+      "blocked": true,
+      "deferred": true,
+      "blocked_deferred_reason": "Candidate remains blocked until methodology, sample disclaimer, references, author/reviewer, last_reviewed_at, dataset decision, and claim review pass.",
+      "human_review_required": true,
+      "claim_review_required": true,
+      "required_reviewer_roles": [
+        "claim_boundary_review",
+        "SEO_GEO_review",
+        "technical_import_review"
+      ],
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "digital_pr_eligible_after_import": false,
+      "pseo_eligible_after_import": false,
+      "notes": [
+        "No MBTI salary/turnover individual prediction allowed.",
+        "Only aggregate/model/directional language can be considered after methodology and caveat review."
+      ]
+    },
+    {
+      "asset_family": "research_pages",
+      "source_key": "research-report-catalog",
+      "zh_source_status": "missing",
+      "en_counterpart_status": "missing",
+      "cms_current_state": "research_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "research_runtime_not_activated_by_this_packet",
+      "claim_risk": "high",
+      "visible_grounding": false,
+      "visible_grounding_requirements": [
+        "methodology",
+        "sample_disclaimer",
+        "claim_boundary_statement",
+        "references",
+        "author_name",
+        "reviewer_name",
+        "last_reviewed_at",
+        "downloadable_asset_or_dataset_decision"
+      ],
+      "dataset_schema_eligible": false,
+      "article_schema_eligible": false,
+      "schema_activation_allowed": false,
+      "forbidden_claim_hits": [
+        "MBTI predicts individual salary",
+        "MBTI predicts individual turnover",
+        "individual-level hiring or retention prediction",
+        "salary guarantee",
+        "turnover guarantee",
+        "job suitability guarantee",
+        "career success prediction",
+        "diagnosis",
+        "treatment",
+        "cure"
+      ],
+      "required_caveats": [
+        "Research findings, if later approved, must be presented as aggregate-level, modeled, directional, and for reference only. They must not be used for individual hiring, retention, salary prediction, diagnosis, treatment, or career-success decisions."
+      ],
+      "publish_readiness": "blocked_deferred_missing_authority",
+      "blocked": true,
+      "deferred": true,
+      "blocked_deferred_reason": "No backend research report authority source exists for this catalog surface; do not create placeholder research pages or schema.",
+      "human_review_required": true,
+      "claim_review_required": true,
+      "required_reviewer_roles": [
+        "claim_boundary_review",
+        "SEO_GEO_review",
+        "technical_import_review"
+      ],
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "digital_pr_eligible_after_import": false,
+      "pseo_eligible_after_import": false,
+      "notes": [
+        "No MBTI salary/turnover individual prediction allowed.",
+        "Only aggregate/model/directional language can be considered after methodology and caveat review."
+      ]
+    }
+  ],
+  "blocked_items": [
+    {
+      "asset_family": "research_pages",
+      "source_key": "mbti-salary-turnover-report",
+      "zh_source_status": "missing",
+      "en_counterpart_status": "candidate_frozen_draft",
+      "cms_current_state": "research_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "research_runtime_not_activated_by_this_packet",
+      "claim_risk": "critical",
+      "visible_grounding": false,
+      "visible_grounding_requirements": [
+        "methodology",
+        "sample_disclaimer",
+        "claim_boundary_statement",
+        "references",
+        "author_name",
+        "reviewer_name",
+        "last_reviewed_at",
+        "downloadable_asset_or_dataset_decision"
+      ],
+      "dataset_schema_eligible": false,
+      "article_schema_eligible": false,
+      "schema_activation_allowed": false,
+      "forbidden_claim_hits": [
+        "MBTI predicts individual salary",
+        "MBTI predicts individual turnover",
+        "individual-level hiring or retention prediction",
+        "salary guarantee",
+        "turnover guarantee",
+        "job suitability guarantee",
+        "career success prediction",
+        "diagnosis",
+        "treatment",
+        "cure"
+      ],
+      "required_caveats": [
+        "Research findings, if later approved, must be presented as aggregate-level, modeled, directional, and for reference only. They must not be used for individual hiring, retention, salary prediction, diagnosis, treatment, or career-success decisions."
+      ],
+      "publish_readiness": "blocked_deferred_claim_review",
+      "blocked": true,
+      "deferred": true,
+      "blocked_deferred_reason": "Candidate remains blocked until methodology, sample disclaimer, references, author/reviewer, last_reviewed_at, dataset decision, and claim review pass.",
+      "human_review_required": true,
+      "claim_review_required": true,
+      "required_reviewer_roles": [
+        "claim_boundary_review",
+        "SEO_GEO_review",
+        "technical_import_review"
+      ],
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "digital_pr_eligible_after_import": false,
+      "pseo_eligible_after_import": false,
+      "notes": [
+        "No MBTI salary/turnover individual prediction allowed.",
+        "Only aggregate/model/directional language can be considered after methodology and caveat review."
+      ]
+    },
+    {
+      "asset_family": "research_pages",
+      "source_key": "research-report-catalog",
+      "zh_source_status": "missing",
+      "en_counterpart_status": "missing",
+      "cms_current_state": "research_records_not_mutated_read_only_review_packet",
+      "public_runtime_state": "research_runtime_not_activated_by_this_packet",
+      "claim_risk": "high",
+      "visible_grounding": false,
+      "visible_grounding_requirements": [
+        "methodology",
+        "sample_disclaimer",
+        "claim_boundary_statement",
+        "references",
+        "author_name",
+        "reviewer_name",
+        "last_reviewed_at",
+        "downloadable_asset_or_dataset_decision"
+      ],
+      "dataset_schema_eligible": false,
+      "article_schema_eligible": false,
+      "schema_activation_allowed": false,
+      "forbidden_claim_hits": [
+        "MBTI predicts individual salary",
+        "MBTI predicts individual turnover",
+        "individual-level hiring or retention prediction",
+        "salary guarantee",
+        "turnover guarantee",
+        "job suitability guarantee",
+        "career success prediction",
+        "diagnosis",
+        "treatment",
+        "cure"
+      ],
+      "required_caveats": [
+        "Research findings, if later approved, must be presented as aggregate-level, modeled, directional, and for reference only. They must not be used for individual hiring, retention, salary prediction, diagnosis, treatment, or career-success decisions."
+      ],
+      "publish_readiness": "blocked_deferred_missing_authority",
+      "blocked": true,
+      "deferred": true,
+      "blocked_deferred_reason": "No backend research report authority source exists for this catalog surface; do not create placeholder research pages or schema.",
+      "human_review_required": true,
+      "claim_review_required": true,
+      "required_reviewer_roles": [
+        "claim_boundary_review",
+        "SEO_GEO_review",
+        "technical_import_review"
+      ],
+      "sitemap_eligible_after_import": false,
+      "llms_eligible_after_import": false,
+      "search_channel_eligible_after_import": false,
+      "digital_pr_eligible_after_import": false,
+      "pseo_eligible_after_import": false,
+      "notes": [
+        "No MBTI salary/turnover individual prediction allowed.",
+        "Only aggregate/model/directional language can be considered after methodology and caveat review."
+      ]
+    }
+  ],
+  "forbidden_claim_policy": [
+    "no MBTI predicts salary",
+    "no MBTI predicts turnover",
+    "no individual-level prediction",
+    "no hiring or retention decision framing",
+    "aggregate/model/directional only after grounding approval"
+  ],
+  "not_done": [
+    "No publish.",
+    "No Dataset/Article schema activation.",
+    "No Search Channel, URL submission, Digital PR, or pSEO action.",
+    "No CMS mutation/import/save."
+  ],
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_pseo_generation": true,
+  "no_frontend_fallback_authority": true,
+  "next_task": "GLOBAL-EN-ZH-CAREER-HUMAN-REVIEW-IMPORT-05"
+}

--- a/backend/docs/seo/global-en-zh-research-claim-human-review-04.md
+++ b/backend/docs/seo/global-en-zh-research-claim-human-review-04.md
@@ -1,0 +1,30 @@
+# GLOBAL-EN-ZH-RESEARCH-CLAIM-HUMAN-REVIEW-04
+
+## Executive Summary
+This PR creates a decision-only claim review packet for research surfaces. Both research items remain blocked/deferred; no Dataset/Article schema, publish, Search Channel, Digital PR, URL submission, or CMS mutation is allowed.
+
+## Summary
+- `total_research_items`: 2
+- `blocked`: 2
+- `claim_review_required`: 2
+- `dataset_schema_eligible`: 0
+- `article_schema_eligible`: 0
+- `publish_ready`: 0
+
+## Research Decisions
+| Research Item | Claim Risk | Publish Readiness | Dataset Schema | Article Schema | Reason |
+| --- | --- | --- | --- | --- | --- |
+| `mbti-salary-turnover-report` | critical | blocked_deferred_claim_review | false | false | Candidate remains blocked until methodology, sample disclaimer, references, author/reviewer, last_reviewed_at, dataset decision, and claim review pass. |
+| `research-report-catalog` | high | blocked_deferred_missing_authority | false | false | No backend research report authority source exists for this catalog surface; do not create placeholder research pages or schema. |
+
+## Claim Boundaries
+- Do not imply MBTI predicts salary.
+- Do not imply MBTI predicts turnover.
+- Do not imply individual-level hiring, retention, suitability, salary, or career-success prediction.
+- Salary/turnover framing, if ever approved later, must be aggregate, modeled, directional, caveated, and visibly grounded.
+
+## Final Decision
+`research_claim_review_decision_packet_created_with_blockers`
+
+## Next Task
+`GLOBAL-EN-ZH-CAREER-HUMAN-REVIEW-IMPORT-05`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhResearchClaimHumanReview04Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhResearchClaimHumanReview04Test.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhResearchClaimHumanReview04Test extends TestCase
+{
+    #[Test]
+    public function research_claim_review_packet_blocks_schema_and_publish(): void
+    {
+        $reportPath = base_path('docs/seo/global-en-zh-research-claim-human-review-04.md');
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-research-claim-human-review-04.v1.json');
+
+        $this->assertFileExists($reportPath);
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('global-en-zh-research-claim-human-review-04.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-RESEARCH-CLAIM-HUMAN-REVIEW-04', $generated['task'] ?? null);
+        $this->assertSame('research_claim_review_decision_packet_created_with_blockers', $generated['final_decision'] ?? null);
+
+        $decisions = $generated['review_decisions'] ?? [];
+        $this->assertCount(2, $decisions);
+
+        foreach ($decisions as $decision) {
+            $this->assertTrue($decision['human_review_required'] ?? false);
+            $this->assertTrue($decision['claim_review_required'] ?? false);
+            $this->assertTrue($decision['blocked'] ?? false);
+            $this->assertTrue($decision['deferred'] ?? false);
+            $this->assertFalse($decision['dataset_schema_eligible'] ?? true);
+            $this->assertFalse($decision['article_schema_eligible'] ?? true);
+            $this->assertFalse($decision['schema_activation_allowed'] ?? true);
+            $this->assertFalse($decision['sitemap_eligible_after_import'] ?? true);
+            $this->assertFalse($decision['llms_eligible_after_import'] ?? true);
+            $this->assertFalse($decision['search_channel_eligible_after_import'] ?? true);
+            $this->assertFalse($decision['digital_pr_eligible_after_import'] ?? true);
+            $this->assertFalse($decision['pseo_eligible_after_import'] ?? true);
+            $this->assertNotEmpty($decision['forbidden_claim_hits'] ?? []);
+            $this->assertNotEmpty($decision['required_caveats'] ?? []);
+        }
+
+        $this->assertSame(2, $generated['summary']['blocked'] ?? null);
+        $this->assertSame(0, $generated['summary']['publish_ready'] ?? null);
+        $this->assertContains('no MBTI predicts salary', $generated['forbidden_claim_policy'] ?? []);
+        $this->assertContains('no MBTI predicts turnover', $generated['forbidden_claim_policy'] ?? []);
+
+        $evidence = $generated['browser_cms_read_only_evidence'] ?? [];
+        $this->assertFalse($evidence['cms_mutation_performed'] ?? true);
+        $this->assertFalse($evidence['browser_write_actions_performed'] ?? true);
+        $this->assertFalse($evidence['private_user_data_accessed'] ?? true);
+
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_pseo_generation'] ?? false);
+        $this->assertTrue($generated['no_frontend_fallback_authority'] ?? false);
+        $this->assertSame('GLOBAL-EN-ZH-CAREER-HUMAN-REVIEW-IMPORT-05', $generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26690,7 +26690,7 @@
       "merge_commit_sha": "137096cb47ee8adfe6056f22d0aba62b2cfbb248"
     },
     "GLOBAL-EN-ZH-RESEARCH-CLAIM-HUMAN-REVIEW-04": {
-      "status": "local_checks_passed",
+      "status": "pr_opened",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-research-claim-human-review-04",
       "base": "main",
@@ -26698,8 +26698,8 @@
         "GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03"
       ],
       "title": "GLOBAL-EN-ZH-RESEARCH-CLAIM-HUMAN-REVIEW-04 research claim review decisions",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "278e3d9e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1705",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -26771,6 +26771,11 @@
           "at": "2026-05-26T22:36:57+08:00",
           "status": "local_checks_passed",
           "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, fap-web reference check, and scope validation passed."
+        },
+        {
+          "at": "2026-05-26T22:38:04+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1705 after local validation; waiting for GitHub required checks."
         }
       ]
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26555,7 +26555,7 @@
       "merge_commit_sha": "2071cc060295a2b62d700a77bf41460ca9b601d0"
     },
     "GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03": {
-      "status": "pr_opened_rerun_after_supply_chain_remediation",
+      "status": "merged",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-topic-test-landing-human-review-import-03",
       "base": "main",
@@ -26563,12 +26563,12 @@
         "GLOBAL-EN-ZH-ARTICLE-HUMAN-REVIEW-IMPORT-02"
       ],
       "title": "GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03 topic test landing review decisions",
-      "commit_sha": "da3cfe4b",
+      "commit_sha": "2789b9b8",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1703",
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-26T14:33:58Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "checks": {
         "preflight": {
           "status": "passed",
@@ -26625,10 +26625,8 @@
           "evidence": "No fap-web changes."
         },
         "github_required_checks": {
-          "status": "failed_external_blocker",
-          "failed_check": "supply-chain",
-          "evidence": "composer audit --locked --no-interaction --ignore-unreachable reports CVE-2026-46644 for symfony/polyfill-intl-idn v1.37.0; affected >=1.17.1,<1.38.1.",
-          "details_url": "https://github.com/fermatmind/fap-api/actions/runs/26452487510/job/77877106624"
+          "status": "passed",
+          "evidence": "PR #1703 checks green and mergeStateStatus CLEAN after supply-chain remediation PR #1704."
         },
         "local_composer_audit_recheck": {
           "status": "passed",
@@ -26640,6 +26638,11 @@
           "pr_url": "https://github.com/fermatmind/fap-api/pull/1704",
           "merge_commit_sha": "73d27d05452dfa2d255101bfb5d54345c7853138",
           "evidence": "symfony/polyfill-intl-idn upgraded to v1.38.1 on main; composer audit now reports no security vulnerability advisories."
+        },
+        "post_merge_focused_test": {
+          "status": "passed",
+          "command": "cd backend && php artisan test --filter=GlobalEnZhTopicTestLandingHumanReviewImport03 --no-ansi",
+          "evidence": "1 test passed, 337 assertions after PR #1703 merge."
         }
       },
       "history": [
@@ -26672,11 +26675,22 @@
           "at": "2026-05-26T22:25:37+08:00",
           "status": "pr_opened_rerun_after_supply_chain_remediation",
           "summary": "PR #1703 rebased onto origin/main after supply-chain remediation PR #1704 merged; local composer audit and PR4 validations pass; rerunning GitHub checks."
+        },
+        {
+          "at": "2026-05-26T22:35:47+08:00",
+          "status": "merged",
+          "summary": "PR #1703 squash-merged after #1704 supply-chain remediation; merge commit 137096cb47ee8adfe6056f22d0aba62b2cfbb248 verified on origin/main."
+        },
+        {
+          "at": "2026-05-26T22:35:47+08:00",
+          "status": "post_merge_cleanup_done",
+          "summary": "Remote task branch deleted by merge; local task branch deleted; post-merge focused test passed."
         }
-      ]
+      ],
+      "merge_commit_sha": "137096cb47ee8adfe6056f22d0aba62b2cfbb248"
     },
     "GLOBAL-EN-ZH-RESEARCH-CLAIM-HUMAN-REVIEW-04": {
-      "status": "planned",
+      "status": "local_checks_passed",
       "repo": "fap-api",
       "branch": "codex/global-en-zh-research-claim-human-review-04",
       "base": "main",
@@ -26690,12 +26704,73 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "checks": {},
+      "checks": {
+        "preflight": {
+          "status": "passed",
+          "evidence": "Started from origin/main at 137096cb47ee8adfe6056f22d0aba62b2cfbb248 in isolated worktree; dependency PR #1703 merged."
+        },
+        "focused_test": {
+          "status": "passed",
+          "command": "cd backend && php artisan test --filter=GlobalEnZhResearchClaimHumanReview04 --no-ansi",
+          "evidence": "1 test passed, 49 assertions."
+        },
+        "route_list": {
+          "status": "passed",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "203 routes listed."
+        },
+        "pint": {
+          "status": "passed",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "3576 files passed."
+        },
+        "composer_validate": {
+          "status": "passed",
+          "command": "cd backend && composer validate --strict"
+        },
+        "composer_audit": {
+          "status": "passed",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "passed",
+          "evidence": "Generated JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+        },
+        "scope_validation": {
+          "status": "passed",
+          "changed_files": [
+            "backend/docs/seo/generated/global-en-zh-research-claim-human-review-04.v1.json",
+            "backend/docs/seo/global-en-zh-research-claim-human-review-04.md",
+            "backend/tests/Feature/SeoIntel/GlobalEnZhResearchClaimHumanReview04Test.php",
+            "docs/codex/pr-train-state.json"
+          ]
+        },
+        "diff_check": {
+          "status": "passed",
+          "command": "git diff --check && git diff --cached --check"
+        },
+        "fap_web_reference_check": {
+          "status": "passed",
+          "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+          "evidence": "No fap-web changes."
+        }
+      },
       "history": [
         {
           "at": "2026-05-26T11:02:25+08:00",
           "status": "planned",
           "summary": "Authorized browser-assisted human review train entry; no CMS mutation, publish, deploy, URL submission, Search Channel action, or pSEO generation."
+        },
+        {
+          "at": "2026-05-26T22:35:47+08:00",
+          "status": "in_progress",
+          "summary": "Started research claim human-review decision packet from Batch-04 research claim review package."
+        },
+        {
+          "at": "2026-05-26T22:36:57+08:00",
+          "status": "local_checks_passed",
+          "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, fap-web reference check, and scope validation passed."
         }
       ]
     },


### PR DESCRIPTION
## What changed
- Added the research claim human-review decision packet for `GLOBAL-EN-ZH-RESEARCH-CLAIM-HUMAN-REVIEW-04`.
- Generated a decision-only JSON artifact for 2 research items, explicitly blocking publish/schema/search actions until methodology, caveats, references, author/reviewer, and claim review are complete.
- Added a focused PHPUnit test and updated the PR train state ledger, including PR #1703 post-merge bookkeeping and the resolved #1704 supply-chain blocker.

## Why
Research content is claim-sensitive. This packet prevents MBTI salary/turnover content from implying individual prediction, hiring/retention decisions, salary guarantees, or career-success claims.

## Validation
- `cd backend && php artisan test --filter=GlobalEnZhResearchClaimHumanReview04 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-research-claim-human-review-04.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check && git diff --cached --check`
- fap-web reference check: clean

## Intentionally deferred
- No CMS import, save, publish, or approval.
- No Dataset/Article schema activation.
- No Search Channel, URL submission, Digital PR, deploy, or pSEO action.
- Research items remain blocked/deferred pending claim and authority review.

Repository rule impact: decision-only backend docs/generated/test/state artifacts; no content ownership or runtime authority change.
