### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01 controlled CMS import for Wave 1 content pages

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-controlled-cms-import-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-controlled-cms-import-01.v1.json
@@ -1,0 +1,361 @@
+{
+  "schema_version": "global-en-zh-content-pages-controlled-cms-import-01.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01",
+  "final_decision": "content_pages_controlled_cms_import_completed_with_sidecars",
+  "approval_phrase_verified": true,
+  "mode": "controlled_cms_import_dry_run_first",
+  "production_context": {
+    "backend_sha": "f21280b1d22045d97a1ea360fe08d5859a81e35f",
+    "frontend_node1_sha": "55ba93638d9a1818117898b2cf2632ef95406d5e"
+  },
+  "input_artifacts": [
+    "backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json",
+    "backend/docs/seo/generated/global-en-zh-human-review-import-queue-00.v1.json",
+    "backend/docs/seo/generated/global-en-zh-content-pages-human-review-import-01.v1.json"
+  ],
+  "allowed_target_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies",
+    "about",
+    "help-about",
+    "help-contact",
+    "help-faq",
+    "help-for-business-and-research",
+    "method-boundaries",
+    "support"
+  ],
+  "import_attempted_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies",
+    "about",
+    "help-about",
+    "help-contact",
+    "help-faq",
+    "help-for-business-and-research",
+    "method-boundaries"
+  ],
+  "excluded_items": [
+    {
+      "asset_key": "support",
+      "reason": "blocked/deferred in source package: deferred_missing_authority"
+    },
+    {
+      "asset_key": "privacy",
+      "reason": "out of current Wave 1 allowed target list"
+    },
+    {
+      "asset_key": "terms",
+      "reason": "out of current Wave 1 allowed target list"
+    }
+  ],
+  "preflight": {
+    "package_exists_and_parses": true,
+    "review_packet_exists_and_parses": true,
+    "every_import_target_in_allowed_scope": true,
+    "blocked_or_deferred_items_excluded": true,
+    "publish_will_not_occur": true,
+    "sitemap_eligible_true_count": 0,
+    "llms_eligible_true_count": 0,
+    "footer_eligible_true_count": 0,
+    "search_channel_action_planned": false,
+    "out_of_scope_cms_write_planned": false,
+    "official_import_runtime": "content-pages:import-local-baseline",
+    "official_import_runtime_supports_dry_run": true,
+    "upsert_disabled_to_protect_existing_published_records": true
+  },
+  "dry_run": {
+    "passed": true,
+    "command": "php artisan content-pages:import-local-baseline --dry-run --status=draft --source-dir=<scoped-temp-dir>",
+    "output": [
+      "baseline_source_dir=/tmp/fap-content-pages-controlled-cms-import-01-20260527074715",
+      "dry_run=1",
+      "upsert=0",
+      "status_mode=draft",
+      "files_found=1",
+      "pages_found=11",
+      "will_create=5",
+      "will_update=0",
+      "will_skip=6",
+      "dry-run complete"
+    ],
+    "summary": {
+      "files_found": 1,
+      "pages_found": 11,
+      "will_create": 5,
+      "will_update": 0,
+      "will_skip": 6
+    }
+  },
+  "controlled_import": {
+    "performed": true,
+    "command": "php artisan content-pages:import-local-baseline --status=draft --source-dir=<scoped-temp-dir>",
+    "output": [
+      "baseline_source_dir=/tmp/fap-content-pages-controlled-cms-import-01-20260527074715",
+      "dry_run=0",
+      "upsert=0",
+      "status_mode=draft",
+      "files_found=1",
+      "pages_found=11",
+      "will_create=5",
+      "will_update=0",
+      "will_skip=6",
+      "import complete"
+    ],
+    "summary": {
+      "files_found": 1,
+      "pages_found": 11,
+      "will_create": 5,
+      "will_update": 0,
+      "will_skip": 6
+    }
+  },
+  "created_draft_records": [
+    "brand",
+    "careers",
+    "charter",
+    "foundation",
+    "policies"
+  ],
+  "skipped_existing_records": [
+    "about",
+    "help-about",
+    "help-contact",
+    "help-faq",
+    "help-for-business-and-research",
+    "method-boundaries"
+  ],
+  "post_import_records": [
+    {
+      "slug": "about",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "translation_status": "published",
+      "review_state": "approved",
+      "path": "/about"
+    },
+    {
+      "slug": "brand",
+      "locale": "en",
+      "status": "draft",
+      "is_public": false,
+      "is_indexable": false,
+      "translation_status": "draft",
+      "review_state": "draft",
+      "path": "/brand"
+    },
+    {
+      "slug": "careers",
+      "locale": "en",
+      "status": "draft",
+      "is_public": false,
+      "is_indexable": false,
+      "translation_status": "draft",
+      "review_state": "draft",
+      "path": "/careers"
+    },
+    {
+      "slug": "charter",
+      "locale": "en",
+      "status": "draft",
+      "is_public": false,
+      "is_indexable": false,
+      "translation_status": "draft",
+      "review_state": "draft",
+      "path": "/charter"
+    },
+    {
+      "slug": "foundation",
+      "locale": "en",
+      "status": "draft",
+      "is_public": false,
+      "is_indexable": false,
+      "translation_status": "draft",
+      "review_state": "draft",
+      "path": "/foundation"
+    },
+    {
+      "slug": "help-about",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "translation_status": "published",
+      "review_state": "approved",
+      "path": "/help/about"
+    },
+    {
+      "slug": "help-contact",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "translation_status": "published",
+      "review_state": "approved",
+      "path": "/help/contact"
+    },
+    {
+      "slug": "help-faq",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "translation_status": "published",
+      "review_state": "approved",
+      "path": "/help/faq"
+    },
+    {
+      "slug": "help-for-business-and-research",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "translation_status": "published",
+      "review_state": "approved",
+      "path": "/help/for-business-and-research"
+    },
+    {
+      "slug": "method-boundaries",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "translation_status": "published",
+      "review_state": "approved",
+      "path": "/method-boundaries"
+    },
+    {
+      "slug": "policies",
+      "locale": "en",
+      "status": "draft",
+      "is_public": false,
+      "is_indexable": false,
+      "translation_status": "draft",
+      "review_state": "draft",
+      "path": "/policies"
+    }
+  ],
+  "post_import_verification": {
+    "created_records_exist": true,
+    "created_records_not_published": true,
+    "created_records_not_public": true,
+    "created_records_not_indexable": true,
+    "created_records_translation_status_draft": true,
+    "created_records_review_state_draft": true,
+    "existing_published_records_not_mutated_by_upsert": true,
+    "public_runtime_new_draft_paths": [
+      {
+        "path": "/en/brand",
+        "http_status": 404
+      },
+      {
+        "path": "/en/charter",
+        "http_status": 404
+      },
+      {
+        "path": "/en/foundation",
+        "http_status": 404
+      },
+      {
+        "path": "/en/careers",
+        "http_status": 404
+      },
+      {
+        "path": "/en/policies",
+        "http_status": 404
+      }
+    ],
+    "new_draft_public_runtime_not_200": true,
+    "sitemap_eligible_false_for_created": true,
+    "llms_eligible_false_for_created": true,
+    "footer_eligible_false_for_created": true,
+    "search_channel_unchanged": true,
+    "gates_closed": true
+  },
+  "sidecars": [
+    {
+      "type": "existing_published_records_skipped",
+      "asset_keys": [
+        "about",
+        "help-about",
+        "help-contact",
+        "help-faq",
+        "help-for-business-and-research",
+        "method-boundaries"
+      ],
+      "reason": "Existing English CMS records were already published before this task; import ran with upsert disabled and did not mutate them."
+    },
+    {
+      "type": "blocked_deferred_item_not_imported",
+      "asset_keys": [
+        "support"
+      ],
+      "reason": "Source package marks support deferred_missing_authority."
+    },
+    {
+      "type": "out_of_scope_items_not_imported",
+      "asset_keys": [
+        "privacy",
+        "terms"
+      ],
+      "reason": "Not in current approval target list."
+    }
+  ],
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_sitemap_llms_footer_exposure": true,
+  "no_pseo_generation": true,
+  "no_production_user_data_access": true,
+  "no_frontend_fallback_authority": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01",
+  "generated_at": "2026-05-27T07:50:00+08:00",
+  "validation": {
+    "focused_test": {
+      "status": "passed",
+      "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesControlledCmsImport01 --no-ansi",
+      "evidence": "1 test passed, 69 assertions."
+    },
+    "route_list": {
+      "status": "passed",
+      "command": "cd backend && php artisan route:list --no-ansi",
+      "evidence": "203 routes listed."
+    },
+    "pint": {
+      "status": "passed",
+      "command": "cd backend && vendor/bin/pint --test",
+      "evidence": "3580 files passed."
+    },
+    "composer_validate": {
+      "status": "passed",
+      "command": "cd backend && composer validate --strict",
+      "evidence": "composer.json is valid."
+    },
+    "composer_audit": {
+      "status": "passed",
+      "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+      "evidence": "No security vulnerability advisories found."
+    },
+    "json_yaml_parse": {
+      "status": "passed",
+      "evidence": "Generated JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+    },
+    "diff_check": {
+      "status": "passed",
+      "command": "git diff --check && git diff --cached --check"
+    },
+    "fap_web_reference_check": {
+      "status": "passed",
+      "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+      "evidence": "No fap-web changes."
+    }
+  }
+}

--- a/backend/docs/seo/global-en-zh-content-pages-controlled-cms-import-01.md
+++ b/backend/docs/seo/global-en-zh-content-pages-controlled-cms-import-01.md
@@ -1,0 +1,101 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01 Report
+
+## Executive Summary
+The exact approval phrase was present. The official CMS importer `content-pages:import-local-baseline` was used with dry-run first, `--status=draft`, and no `--upsert`.
+
+Dry-run passed with `will_create=5`, `will_update=0`, and `will_skip=6`. Controlled import then created five draft-only English content pages: brand, charter, foundation, careers, and policies.
+
+Six scoped pages already existed as published English CMS records before this task, so they were skipped without mutation: about, help-about, help-contact, help-faq, help-for-business-and-research, and method-boundaries.
+
+## Scope
+Wave 1 content/help/policy pages only. Articles, topics, test landing pages, research, career jobs, career recommendations, result/report assets, media assets, UI runtime, Search Channel, sitemap/llms/footer exposure, publish, deploy, and pSEO were not touched.
+
+## Preflight
+- Import package parsed: pass
+- Human-review decision packet parsed: pass
+- Official import runtime available: `content-pages:import-local-baseline`
+- Blocked/deferred items excluded: pass
+- Out-of-scope items excluded: privacy, terms
+- Publish disabled: pass
+- Sitemap/llms/footer/Search Channel exposure disabled: pass
+- Upsert disabled to protect existing published records: pass
+
+## Dry-Run Result
+```text
+baseline_source_dir=/tmp/fap-content-pages-controlled-cms-import-01-20260527074715
+dry_run=1
+upsert=0
+status_mode=draft
+files_found=1
+pages_found=11
+will_create=5
+will_update=0
+will_skip=6
+dry-run complete
+```
+
+## Controlled Import Result
+```text
+baseline_source_dir=/tmp/fap-content-pages-controlled-cms-import-01-20260527074715
+dry_run=0
+upsert=0
+status_mode=draft
+files_found=1
+pages_found=11
+will_create=5
+will_update=0
+will_skip=6
+import complete
+```
+
+## Created Draft Records
+- brand: draft, non-public, non-indexable
+- charter: draft, non-public, non-indexable
+- foundation: draft, non-public, non-indexable
+- careers: draft, non-public, non-indexable
+- policies: draft, non-public, non-indexable
+
+## Skipped Existing Records
+These were already existing English published CMS records and were not mutated because `--upsert` was not used:
+- about
+- help-about
+- help-contact
+- help-faq
+- help-for-business-and-research
+- method-boundaries
+
+## Not Imported
+- support: blocked/deferred because the source package marks it `deferred_missing_authority`
+- privacy: out of this approval scope
+- terms: out of this approval scope
+
+## Post-Import Verification
+New draft public runtime checks returned non-200:
+- /en/brand: 404
+- /en/charter: 404
+- /en/foundation: 404
+- /en/careers: 404
+- /en/policies: 404
+
+No Search Channel command was run. No URL submission was run. No deployment was run.
+
+## Sidecars
+- Existing published English records were skipped and should be handled only by a later explicit review/update approval.
+- Support remains blocked until a dedicated support authority source exists.
+- Privacy and terms remain outside this import scope.
+
+## Validation
+- `php artisan test --filter=GlobalEnZhContentPagesControlledCmsImport01 --no-ansi`: passed, 1 test / 69 assertions
+- `php artisan route:list --no-ansi`: passed, 203 routes listed
+- `vendor/bin/pint --test`: passed, 3580 files
+- `composer validate --strict`: passed
+- `composer audit --locked --no-interaction --ignore-unreachable`: passed, no advisories
+- JSON/YAML parse: passed
+- `git diff --check && git diff --cached --check`: passed
+- fap-web reference status: clean
+
+## Final Decision
+`content_pages_controlled_cms_import_completed_with_sidecars`
+
+## Next Task
+`GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledCmsImport01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledCmsImport01Test.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesControlledCmsImport01Test extends TestCase
+{
+    #[Test]
+    public function controlled_content_page_import_report_preserves_gates(): void
+    {
+        $reportPath = base_path('docs/seo/global-en-zh-content-pages-controlled-cms-import-01.md');
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-controlled-cms-import-01.v1.json');
+
+        $this->assertFileExists($reportPath);
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-content-pages-controlled-cms-import-01.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01', $generated['task'] ?? null);
+        $this->assertSame('content_pages_controlled_cms_import_completed_with_sidecars', $generated['final_decision'] ?? null);
+        $this->assertTrue($generated['approval_phrase_verified'] ?? false);
+
+        $preflight = $generated['preflight'] ?? [];
+        $this->assertTrue($preflight['package_exists_and_parses'] ?? false);
+        $this->assertTrue($preflight['review_packet_exists_and_parses'] ?? false);
+        $this->assertTrue($preflight['every_import_target_in_allowed_scope'] ?? false);
+        $this->assertTrue($preflight['blocked_or_deferred_items_excluded'] ?? false);
+        $this->assertTrue($preflight['publish_will_not_occur'] ?? false);
+        $this->assertSame(0, $preflight['sitemap_eligible_true_count'] ?? null);
+        $this->assertSame(0, $preflight['llms_eligible_true_count'] ?? null);
+        $this->assertSame(0, $preflight['footer_eligible_true_count'] ?? null);
+        $this->assertFalse($preflight['search_channel_action_planned'] ?? true);
+        $this->assertFalse($preflight['out_of_scope_cms_write_planned'] ?? true);
+        $this->assertSame('content-pages:import-local-baseline', $preflight['official_import_runtime'] ?? null);
+        $this->assertTrue($preflight['official_import_runtime_supports_dry_run'] ?? false);
+        $this->assertTrue($preflight['upsert_disabled_to_protect_existing_published_records'] ?? false);
+
+        $this->assertTrue($generated['dry_run']['passed'] ?? false);
+        $this->assertSame(5, $generated['dry_run']['summary']['will_create'] ?? null);
+        $this->assertSame(0, $generated['dry_run']['summary']['will_update'] ?? null);
+        $this->assertSame(6, $generated['dry_run']['summary']['will_skip'] ?? null);
+
+        $this->assertTrue($generated['controlled_import']['performed'] ?? false);
+        $this->assertSame(5, $generated['controlled_import']['summary']['will_create'] ?? null);
+        $this->assertSame(0, $generated['controlled_import']['summary']['will_update'] ?? null);
+        $this->assertSame(6, $generated['controlled_import']['summary']['will_skip'] ?? null);
+
+        $createdDraftRecords = $generated['created_draft_records'] ?? [];
+        sort($createdDraftRecords);
+        $this->assertSame([
+            'brand',
+            'careers',
+            'charter',
+            'foundation',
+            'policies',
+        ], $createdDraftRecords);
+
+        $skippedExistingRecords = $generated['skipped_existing_records'] ?? [];
+        sort($skippedExistingRecords);
+        $this->assertSame([
+            'about',
+            'help-about',
+            'help-contact',
+            'help-faq',
+            'help-for-business-and-research',
+            'method-boundaries',
+        ], $skippedExistingRecords);
+
+        $excluded = array_column($generated['excluded_items'] ?? [], 'asset_key');
+        $this->assertContains('support', $excluded);
+        $this->assertContains('privacy', $excluded);
+        $this->assertContains('terms', $excluded);
+
+        $verification = $generated['post_import_verification'] ?? [];
+        $this->assertTrue($verification['created_records_exist'] ?? false);
+        $this->assertTrue($verification['created_records_not_published'] ?? false);
+        $this->assertTrue($verification['created_records_not_public'] ?? false);
+        $this->assertTrue($verification['created_records_not_indexable'] ?? false);
+        $this->assertTrue($verification['created_records_translation_status_draft'] ?? false);
+        $this->assertTrue($verification['created_records_review_state_draft'] ?? false);
+        $this->assertTrue($verification['existing_published_records_not_mutated_by_upsert'] ?? false);
+        $this->assertTrue($verification['new_draft_public_runtime_not_200'] ?? false);
+        $this->assertTrue($verification['sitemap_eligible_false_for_created'] ?? false);
+        $this->assertTrue($verification['llms_eligible_false_for_created'] ?? false);
+        $this->assertTrue($verification['footer_eligible_false_for_created'] ?? false);
+        $this->assertTrue($verification['search_channel_unchanged'] ?? false);
+        $this->assertTrue($verification['gates_closed'] ?? false);
+
+        foreach ($generated['post_import_records'] ?? [] as $record) {
+            if (in_array($record['slug'] ?? '', $generated['created_draft_records'] ?? [], true)) {
+                $this->assertSame('draft', $record['status'] ?? null);
+                $this->assertFalse($record['is_public'] ?? true);
+                $this->assertFalse($record['is_indexable'] ?? true);
+            }
+        }
+
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_sitemap_llms_footer_exposure'] ?? false);
+        $this->assertTrue($generated['no_pseo_generation'] ?? false);
+        $this->assertTrue($generated['no_production_user_data_access'] ?? false);
+        $this->assertTrue($generated['no_frontend_fallback_authority'] ?? false);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01', $generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-26T23:25:45+08:00",
+  "updated_at": "2026-05-27T08:10:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -27517,6 +27517,145 @@
         "at": "2026-05-25T22:00:00+08:00",
         "status": "pr_opened",
         "summary": "Opened PR #1684 for FERMAT-MARKETING-SKILLS-ADAPTATION-02."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01": {
+    "status": "github_checks_passed",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-controlled-cms-import-01",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVIEW-IMPORT-01"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01 controlled CMS import for Wave 1 content pages",
+    "commit_sha": "a1ff7cc1ef84f022530f83d975d8d344876aeb22",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1709",
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "approval_phrase": {
+        "status": "passed",
+        "evidence": "Exact approval phrase was present in the user request."
+      },
+      "preflight": {
+        "status": "passed",
+        "evidence": "Import package and review packet parsed; support/privacy/terms excluded; scoped targets only; publish, sitemap, llms, footer, URL submission, and Search Channel gates remained closed."
+      },
+      "official_import_runtime": {
+        "status": "passed",
+        "evidence": "content-pages:import-local-baseline exists and supports --dry-run, --status=draft, and --source-dir."
+      },
+      "dry_run": {
+        "status": "passed",
+        "command": "php artisan content-pages:import-local-baseline --dry-run --status=draft --source-dir=<scoped-temp-dir>",
+        "evidence": "files_found=1, pages_found=11, will_create=5, will_update=0, will_skip=6, upsert=0."
+      },
+      "controlled_import": {
+        "status": "passed",
+        "command": "php artisan content-pages:import-local-baseline --status=draft --source-dir=<scoped-temp-dir>",
+        "evidence": "Created five missing draft-only records and skipped six existing records; will_update=0."
+      },
+      "post_import_verification": {
+        "status": "passed",
+        "evidence": "Created records are draft, non-public, non-indexable, translation_status=draft, review_state=draft; /en/brand, /en/charter, /en/foundation, /en/careers, and /en/policies returned 404."
+      },
+      "search_channel": {
+        "status": "passed",
+        "evidence": "No Search Channel command, URL submission, or external search API call was run."
+      },
+      "remote_temp_cleanup": {
+        "status": "passed",
+        "evidence": "Scoped remote temporary import directory was removed after import."
+      },
+      "local_validation": {
+        "status": "pending"
+      },
+      "github_required_checks": {
+        "status": "passed",
+        "evidence": "PR #1709 required checks passed and mergeStateStatus was CLEAN."
+      },
+      "focused_test": {
+        "status": "passed",
+        "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesControlledCmsImport01 --no-ansi",
+        "evidence": "1 test passed, 69 assertions."
+      },
+      "route_list": {
+        "status": "passed",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "203 routes listed."
+      },
+      "pint": {
+        "status": "passed",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "3580 files passed."
+      },
+      "composer_validate": {
+        "status": "passed",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "passed",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "passed",
+        "evidence": "Generated JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+      },
+      "scope_validation": {
+        "status": "passed",
+        "changed_files": [
+          "backend/docs/seo/global-en-zh-content-pages-controlled-cms-import-01.md",
+          "backend/docs/seo/generated/global-en-zh-content-pages-controlled-cms-import-01.v1.json",
+          "backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledCmsImport01Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "diff_check": {
+        "status": "passed",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "fap_web_reference_check": {
+        "status": "passed",
+        "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+        "evidence": "No fap-web changes."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T07:55:00+08:00",
+        "status": "planned",
+        "summary": "Authorized controlled CMS import for Wave 1 content/help/policy pages only, dry-run first, no publish, no deploy, no Search Channel, no URL submission."
+      },
+      {
+        "at": "2026-05-27T07:55:00+08:00",
+        "status": "dry_run_passed",
+        "summary": "Official importer dry-run passed with will_create=5, will_update=0, will_skip=6, upsert disabled."
+      },
+      {
+        "at": "2026-05-27T07:55:00+08:00",
+        "status": "controlled_import_completed",
+        "summary": "Created five draft-only non-public/non-indexable records; skipped six existing English published records without mutation; sidecars recorded."
+      },
+      {
+        "at": "2026-05-27T07:59:00+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, fap-web reference check, and scope validation passed."
+      },
+      {
+        "at": "2026-05-27T08:02:00+08:00",
+        "status": "pr_opened",
+        "summary": "Opened PR #1709 after local validation; waiting for GitHub required checks."
+      },
+      {
+        "at": "2026-05-27T08:10:00+08:00",
+        "status": "github_checks_passed",
+        "summary": "GitHub required checks passed and mergeStateStatus was CLEAN before final ledger update."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -13868,6 +13868,52 @@ prs:
     pseo_generation_allowed: false
     frontend_fallback_authority: false
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVIEW-IMPORT-01
+    branch: codex/global-en-zh-content-pages-controlled-cms-import-01
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01 controlled CMS import for Wave 1 content pages"
+    train_scope: global_en_zh_controlled_cms_import
+    risk_level: p0_scoped_cms_write_dry_run_first
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-controlled-cms-import-01.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-controlled-cms-import-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledCmsImport01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Perform dry-run first using the official content page import runtime.
+      - Import only Wave 1 content/help/policy pages that are in scope, unblocked, and approved by the human-review packet.
+      - Keep all imported records draft-only, non-public, non-indexable, and excluded from sitemap, llms, footer, Search Channel, and URL submission.
+      - Do not publish, deploy, create pSEO pages, access production user data, or mutate out-of-scope CMS assets.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesControlledCmsImport01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-controlled-cms-import-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    production_write_scope: content_pages_wave_1_draft_import_only
+    cms_mutation: scoped_draft_import_only
+    dry_run_required: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Recorded the controlled CMS import for Wave 1 content/help/policy pages.
- Added the generated import evidence JSON, Markdown report, focused SeoIntel test, and PR-train manifest/state entry.
- Used the official `content-pages:import-local-baseline` runtime with dry-run first, `--status=draft`, and no `--upsert`.

## Why
This captures the approved production CMS write in repo-backed evidence and keeps the next import verification task auditable.

## Import result
- Dry-run: `will_create=5`, `will_update=0`, `will_skip=6`, `upsert=0`.
- Import: created `brand`, `charter`, `foundation`, `careers`, and `policies` as draft-only, non-public, non-indexable records.
- Skipped existing published English records without mutation: `about`, `help-about`, `help-contact`, `help-faq`, `help-for-business-and-research`, `method-boundaries`.

## Intentionally deferred
- `support`: blocked/deferred because source authority is missing.
- `privacy` and `terms`: outside this approval scope.
- No publish, deploy, Search Channel, URL submission, sitemap/llms/footer exposure, pSEO, or production user data access.

## Validation
- `cd backend && php artisan test --filter=GlobalEnZhContentPagesControlledCmsImport01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-controlled-cms-import-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse
- `git diff --check && git diff --cached --check`
- fap-web reference status clean
