### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01 verify Wave 1 content page import safety

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-import-verify-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-import-verify-01.v1.json
@@ -1,0 +1,562 @@
+{
+  "schema_version": "global-en-zh-content-pages-import-verify-01.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01",
+  "final_decision": "content_pages_import_verify_completed_ready_for_publish_readiness",
+  "import_pr": {
+    "url": "https://github.com/fermatmind/fap-api/pull/1709",
+    "merge_commit": "a0895313fc16f0aa000916e4da29c1cb07fe0a9c",
+    "final_decision": "content_pages_controlled_cms_import_completed_with_sidecars"
+  },
+  "imported_records": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "cms_record_state": {
+    "checked_at": "2026-05-27T00:17:10.929135Z",
+    "records": [
+      {
+        "slug": "brand",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "translation_status": "draft",
+        "review_state": "draft",
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "path": "/brand",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      },
+      {
+        "slug": "charter",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "translation_status": "draft",
+        "review_state": "draft",
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "path": "/charter",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      },
+      {
+        "slug": "foundation",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "translation_status": "draft",
+        "review_state": "draft",
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "path": "/foundation",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      },
+      {
+        "slug": "careers",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "translation_status": "draft",
+        "review_state": "draft",
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "path": "/careers",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      },
+      {
+        "slug": "policies",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "translation_status": "draft",
+        "review_state": "draft",
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "path": "/policies",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      }
+    ],
+    "all_exist": true,
+    "all_draft_only": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_published_at_null": true,
+    "all_import_marker_present": true
+  },
+  "existing_published_records_check": {
+    "records": [
+      {
+        "slug": "about",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "translation_status": "published",
+        "review_state": "approved",
+        "published_at": "2026-04-21T00:00:00.000000Z",
+        "source_doc": "content_pages.en.baseline",
+        "path": "/about",
+        "created_at": "2026-04-21T05:43:25.000000Z",
+        "updated_at": "2026-05-25T09:29:44.000000Z"
+      },
+      {
+        "slug": "help-about",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "translation_status": "published",
+        "review_state": "approved",
+        "published_at": "2026-04-19T00:00:00.000000Z",
+        "source_doc": "helpCenterContent.ts",
+        "path": "/help/about",
+        "created_at": "2026-04-20T03:36:10.000000Z",
+        "updated_at": "2026-05-25T09:29:45.000000Z"
+      },
+      {
+        "slug": "help-contact",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "translation_status": "published",
+        "review_state": "approved",
+        "published_at": "2026-04-19T00:00:00.000000Z",
+        "source_doc": "helpCenterContent.ts",
+        "path": "/help/contact",
+        "created_at": "2026-04-20T03:36:10.000000Z",
+        "updated_at": "2026-05-25T09:29:45.000000Z"
+      },
+      {
+        "slug": "help-faq",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "translation_status": "published",
+        "review_state": "approved",
+        "published_at": "2026-04-19T00:00:00.000000Z",
+        "source_doc": "helpCenterContent.ts",
+        "path": "/help/faq",
+        "created_at": "2026-04-20T03:36:10.000000Z",
+        "updated_at": "2026-05-25T09:29:45.000000Z"
+      },
+      {
+        "slug": "help-for-business-and-research",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "translation_status": "published",
+        "review_state": "approved",
+        "published_at": "2026-04-19T00:00:00.000000Z",
+        "source_doc": "helpCenterContent.ts",
+        "path": "/help/for-business-and-research",
+        "created_at": "2026-04-20T03:36:10.000000Z",
+        "updated_at": "2026-05-25T09:29:45.000000Z"
+      },
+      {
+        "slug": "method-boundaries",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "translation_status": "published",
+        "review_state": "approved",
+        "published_at": "2026-05-08T00:00:00.000000Z",
+        "source_doc": "content_pages.en.method_boundaries.baseline",
+        "path": "/method-boundaries",
+        "created_at": "2026-05-08T08:40:03.000000Z",
+        "updated_at": "2026-05-25T09:29:44.000000Z"
+      }
+    ],
+    "all_exist": true,
+    "all_still_published_public_indexable": true,
+    "import_marker_absent_from_existing_records": true,
+    "mutation_detected": false,
+    "notes": "Existing records retain published/public/indexable states and non-import source_doc markers; no upsert mutation was detected by this read-only check."
+  },
+  "public_runtime_check": {
+    "checked_at": "2026-05-27T00:18:04Z",
+    "checks": [
+      {
+        "path": "/en/brand",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/charter",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/foundation",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/careers",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/policies",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/about",
+        "status": 200,
+        "live_200": true
+      },
+      {
+        "path": "/en/privacy",
+        "status": 200,
+        "live_200": true
+      },
+      {
+        "path": "/en/terms",
+        "status": 200,
+        "live_200": true
+      }
+    ],
+    "surface_status": {
+      "/en/brand": {
+        "status": 404,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 19627
+      },
+      "/en/charter": {
+        "status": 404,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 19631
+      },
+      "/en/foundation": {
+        "status": 404,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 19637
+      },
+      "/en/careers": {
+        "status": 404,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 19631
+      },
+      "/en/policies": {
+        "status": 404,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 19633
+      },
+      "/en/about": {
+        "status": 200,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 65850
+      },
+      "/en/privacy": {
+        "status": 200,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 65066
+      },
+      "/en/terms": {
+        "status": 200,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 64738
+      },
+      "/sitemap.xml": {
+        "status": 200,
+        "content_type": "application/xml",
+        "bytes": 13368
+      },
+      "/llms.txt": {
+        "status": 200,
+        "content_type": "text/plain; charset=utf-8",
+        "bytes": 6903
+      },
+      "/llms-full.txt": {
+        "status": 200,
+        "content_type": "text/plain; charset=utf-8",
+        "bytes": 61037
+      },
+      "/en": {
+        "status": 200,
+        "content_type": "text/html; charset=utf-8",
+        "bytes": 108778
+      }
+    },
+    "all_draft_paths_not_200": true,
+    "all_known_live_pages_200": true
+  },
+  "sitemap_check": {
+    "source": "https://fermatmind.com/sitemap.xml",
+    "status": 200,
+    "draft_paths_absent": true,
+    "exposure": {
+      "/en/brand": false,
+      "/en/charter": false,
+      "/en/foundation": false,
+      "/en/careers": false,
+      "/en/policies": false
+    }
+  },
+  "llms_check": {
+    "llms_txt": {
+      "source": "https://fermatmind.com/llms.txt",
+      "status": 200,
+      "draft_paths_absent": true,
+      "exposure": {
+        "/en/brand": false,
+        "/en/charter": false,
+        "/en/foundation": false,
+        "/en/careers": false,
+        "/en/policies": false
+      }
+    },
+    "llms_full_txt": {
+      "source": "https://fermatmind.com/llms-full.txt",
+      "status": 200,
+      "draft_paths_absent": true,
+      "exposure": {
+        "/en/brand": false,
+        "/en/charter": false,
+        "/en/foundation": false,
+        "/en/careers": false,
+        "/en/policies": false
+      }
+    }
+  },
+  "footer_nav_check": {
+    "source": "https://fermatmind.com/en",
+    "status": 200,
+    "draft_links_absent": true,
+    "items": {
+      "/en/brand": {
+        "label": "Brand",
+        "href_present": false,
+        "label_present": false
+      },
+      "/en/charter": {
+        "label": "Charter",
+        "href_present": false,
+        "label_present": false
+      },
+      "/en/foundation": {
+        "label": "Foundation",
+        "href_present": false,
+        "label_present": false
+      },
+      "/en/careers": {
+        "label": "Careers",
+        "href_present": false,
+        "label_present": false
+      },
+      "/en/policies": {
+        "label": "Policies",
+        "href_present": false,
+        "label_present": false
+      }
+    }
+  },
+  "search_channel_check": {
+    "checked_at": "2026-05-27T00:17:10.929135Z",
+    "counts": {
+      "seo_search_channel_queue_items": 3,
+      "seo_search_channel_queue_batches": 3,
+      "seo_search_channel_queue_events": 12,
+      "seo_indexnow_submissions": 0,
+      "seo_domestic_submission_logs": 0
+    },
+    "draft_page_queue_items": [],
+    "queue_items_2_3": [
+      {
+        "id": 2,
+        "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+        "locale": "en",
+        "page_entity_type": "test_detail",
+        "source_authority": "scale_catalog",
+        "channel": "indexnow",
+        "approval_state": "approved",
+        "execution_state": "submitted",
+        "indexability_state": "indexable",
+        "updated_at": "2026-05-23 05:18:45"
+      },
+      {
+        "id": 3,
+        "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "locale": "zh-CN",
+        "page_entity_type": "test_detail",
+        "source_authority": "scale_catalog",
+        "channel": "indexnow",
+        "approval_state": "approved",
+        "execution_state": "submitted",
+        "indexability_state": "indexable",
+        "updated_at": "2026-05-25 04:09:44"
+      }
+    ],
+    "live_submission_events_recent": [
+      {
+        "id": 12,
+        "queue_item_id": 3,
+        "batch_id": 3,
+        "event_type": "live_submission_response",
+        "created_at": "2026-05-25 04:09:44"
+      },
+      {
+        "id": 11,
+        "queue_item_id": 3,
+        "batch_id": 3,
+        "event_type": "live_submission_approved",
+        "created_at": "2026-05-25 04:09:42"
+      },
+      {
+        "id": 8,
+        "queue_item_id": 2,
+        "batch_id": 2,
+        "event_type": "live_submission_response",
+        "created_at": "2026-05-23 05:18:45"
+      },
+      {
+        "id": 7,
+        "queue_item_id": 2,
+        "batch_id": 2,
+        "event_type": "live_submission_approved",
+        "created_at": "2026-05-23 05:18:44"
+      },
+      {
+        "id": 4,
+        "queue_item_id": 1,
+        "batch_id": 1,
+        "event_type": "live_submission_response",
+        "created_at": "2026-05-21 15:27:37"
+      },
+      {
+        "id": 3,
+        "queue_item_id": 1,
+        "batch_id": 1,
+        "event_type": "live_submission_approved",
+        "created_at": "2026-05-21 15:27:36"
+      }
+    ],
+    "config_gates": {
+      "indexnow_enabled": false,
+      "indexnow_live_api_enabled": false,
+      "search_channel_queue_no_live_submission": true,
+      "real_url_submission_allowed": false,
+      "draft_url_submission_allowed": false
+    },
+    "no_queue_items_for_imported_drafts": true,
+    "no_live_submission_tables": true,
+    "queue_item_2_en_mbti_present": true,
+    "queue_item_3_zh_mbti_present": true,
+    "gates_closed": true
+  },
+  "gate_state": {
+    "cms_import_gate_closed": true,
+    "publish_gate_closed": true,
+    "sitemap_gate_closed": true,
+    "llms_gate_closed": true,
+    "footer_nav_gate_closed": true,
+    "search_channel_gate_closed": true,
+    "url_submission_gate_closed": true,
+    "deploy_gate_closed": true
+  },
+  "sidecar_issues": [
+    {
+      "type": "inherited_non_blocking",
+      "key": "support",
+      "status": "deferred_missing_authority",
+      "notes": "Standalone support page was not imported because authority source remains missing."
+    },
+    {
+      "type": "inherited_non_blocking",
+      "key": "existing_published_records_skipped",
+      "status": "requires_separate_update_scope",
+      "asset_keys": [
+        "about",
+        "help-about",
+        "help-contact",
+        "help-faq",
+        "help-for-business-and-research",
+        "method-boundaries"
+      ]
+    },
+    {
+      "type": "inherited_non_blocking",
+      "key": "privacy_terms_out_of_scope",
+      "status": "requires_legal_policy_scope",
+      "asset_keys": [
+        "privacy",
+        "terms"
+      ]
+    }
+  ],
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_sitemap_llms_exposure": true,
+  "no_footer_nav_exposure": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01",
+  "generated_at": "2026-05-27T08:20:00+08:00",
+  "validation": {
+    "composer_install": {
+      "status": "passed",
+      "command": "cd backend && composer install --no-interaction --no-progress",
+      "evidence": "Installed dependencies in isolated worktree only; ignored generated vendor/public/cache artifacts were not staged."
+    },
+    "focused_test": {
+      "status": "passed",
+      "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesImportVerify01 --no-ansi",
+      "evidence": "1 test passed, 28 assertions."
+    },
+    "route_list": {
+      "status": "passed",
+      "command": "cd backend && php artisan route:list --no-ansi",
+      "evidence": "203 routes listed."
+    },
+    "pint": {
+      "status": "passed",
+      "command": "cd backend && vendor/bin/pint --test",
+      "evidence": "3581 files passed."
+    },
+    "composer_validate": {
+      "status": "passed",
+      "command": "cd backend && composer validate --strict",
+      "evidence": "composer.json is valid."
+    },
+    "composer_audit": {
+      "status": "passed",
+      "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+      "evidence": "No security vulnerability advisories found."
+    },
+    "json_yaml_parse": {
+      "status": "passed",
+      "evidence": "Generated JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+    },
+    "diff_check": {
+      "status": "passed",
+      "command": "git diff --check && git diff --cached --check"
+    },
+    "fap_web_reference_check": {
+      "status": "passed",
+      "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+      "evidence": "No fap-web changes."
+    }
+  }
+}

--- a/backend/docs/seo/global-en-zh-content-pages-import-verify-01.md
+++ b/backend/docs/seo/global-en-zh-content-pages-import-verify-01.md
@@ -1,0 +1,100 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01 Report
+
+## 1. Executive Summary
+Read-only verification completed for the Wave 1 content/help/policy CMS draft import from PR #1709. The five imported English records exist and remain draft-only, non-public, non-indexable, and unpublished. Public runtime, sitemap, llms surfaces, footer/nav, and Search Channel checks did not expose the draft pages.
+
+Final decision: `content_pages_import_verify_completed_ready_for_publish_readiness`.
+
+## 2. Imported Draft Records Verification
+Verified CMS records:
+
+| slug | status | public | indexable | published_at | source_doc |
+| --- | --- | --- | --- | --- | --- |
+| `brand` | `draft` | `false` | `false` | `None` | `global-en-zh-content-pages-translation-batch-01.import.v1.json` |
+| `charter` | `draft` | `false` | `false` | `None` | `global-en-zh-content-pages-translation-batch-01.import.v1.json` |
+| `foundation` | `draft` | `false` | `false` | `None` | `global-en-zh-content-pages-translation-batch-01.import.v1.json` |
+| `careers` | `draft` | `false` | `false` | `None` | `global-en-zh-content-pages-translation-batch-01.import.v1.json` |
+| `policies` | `draft` | `false` | `false` | `None` | `global-en-zh-content-pages-translation-batch-01.import.v1.json` |
+
+All five records were created in the import window and retain the import source marker.
+
+## 3. Existing Published Records Check
+Existing English records remain published/public/indexable and do not carry the Wave 1 import source marker:
+
+| slug | status | public | indexable | source_doc | updated_at |
+| --- | --- | --- | --- | --- | --- |
+| `about` | `published` | `true` | `true` | `content_pages.en.baseline` | `2026-05-25T09:29:44.000000Z` |
+| `help-about` | `published` | `true` | `true` | `helpCenterContent.ts` | `2026-05-25T09:29:45.000000Z` |
+| `help-contact` | `published` | `true` | `true` | `helpCenterContent.ts` | `2026-05-25T09:29:45.000000Z` |
+| `help-faq` | `published` | `true` | `true` | `helpCenterContent.ts` | `2026-05-25T09:29:45.000000Z` |
+| `help-for-business-and-research` | `published` | `true` | `true` | `helpCenterContent.ts` | `2026-05-25T09:29:45.000000Z` |
+| `method-boundaries` | `published` | `true` | `true` | `content_pages.en.method_boundaries.baseline` | `2026-05-25T09:29:44.000000Z` |
+
+No upsert mutation was detected for these records.
+
+## 4. Public Runtime Check
+Draft paths were not public 200 pages:
+
+| path | status |
+| --- | --- |
+| `/en/brand` | `404` |
+| `/en/charter` | `404` |
+| `/en/foundation` | `404` |
+| `/en/careers` | `404` |
+| `/en/policies` | `404` |
+
+Known live pages still returned 200:
+
+| path | status |
+| --- | --- |
+| `/en/about` | `200` |
+| `/en/privacy` | `200` |
+| `/en/terms` | `200` |
+
+## 5. Sitemap / llms Exposure Check
+- `/sitemap.xml`: draft paths absent = `True`
+- `/llms.txt`: draft paths absent = `True`
+- `/llms-full.txt`: draft paths absent = `True`
+
+## 6. Footer / Nav Exposure Check
+English homepage footer/nav did not contain links to `/en/brand`, `/en/charter`, `/en/foundation`, `/en/careers`, or `/en/policies`.
+
+## 7. Search Channel Safety
+- Queue items for imported draft pages: `0`
+- `seo_indexnow_submissions`: `0`
+- `seo_domestic_submission_logs`: `0`
+- Queue item 2 EN MBTI present: `True`
+- Queue item 3 ZH MBTI present: `True`
+- Search Channel gates closed: `True`
+
+## 8. Gate State
+Publish, import, sitemap, llms, footer/nav, Search Channel, URL submission, and deploy gates remained closed during this read-only verification.
+
+## 9. Validation
+- `composer install --no-interaction --no-progress`: passed in isolated worktree only
+- `php artisan test --filter=GlobalEnZhContentPagesImportVerify01 --no-ansi`: passed, 1 test / 28 assertions
+- `php artisan route:list --no-ansi`: passed, 203 routes listed
+- `vendor/bin/pint --test`: passed, 3581 files
+- `composer validate --strict`: passed
+- `composer audit --locked --no-interaction --ignore-unreachable`: passed, no advisories
+- JSON/YAML parse: passed
+- `git diff --check && git diff --cached --check`: passed
+- fap-web reference status: clean
+
+## 10. PR / Merge Result
+Pending.
+
+## 11. Sidecar Issues
+Inherited non-blocking sidecars remain:
+- `support`: deferred_missing_authority.
+- Existing published English records need a separate update scope if content changes are desired.
+- `privacy` and `terms` need a separate legal/policy scope.
+
+## 12. What Was Not Done
+No import, publish, CMS mutation, deploy, Search Channel action, URL submission, external search API call, production migration, raw log read, production user data access, or fap-web modification was performed.
+
+## 13. Final Decision
+`content_pages_import_verify_completed_ready_for_publish_readiness`
+
+## 14. Next Task
+`GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesImportVerify01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesImportVerify01Test.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesImportVerify01Test extends TestCase
+{
+    #[Test]
+    public function content_page_import_verify_artifact_preserves_closed_gates(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-import-verify-01.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-import-verify-01.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-content-pages-import-verify-01.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01', $generated['task'] ?? null);
+
+        $importedRecords = $generated['imported_records'] ?? [];
+        sort($importedRecords);
+
+        $this->assertSame([
+            'brand',
+            'careers',
+            'charter',
+            'foundation',
+            'policies',
+        ], $importedRecords);
+
+        $this->assertNotEmpty($generated['final_decision'] ?? null);
+        $this->assertNotEmpty($generated['next_task'] ?? null);
+
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_sitemap_llms_exposure'] ?? false);
+        $this->assertTrue($generated['no_footer_nav_exposure'] ?? false);
+
+        $this->assertTrue($generated['cms_record_state']['all_exist'] ?? false);
+        $this->assertTrue($generated['cms_record_state']['all_draft_only'] ?? false);
+        $this->assertTrue($generated['cms_record_state']['all_non_public'] ?? false);
+        $this->assertTrue($generated['cms_record_state']['all_non_indexable'] ?? false);
+        $this->assertTrue($generated['cms_record_state']['all_published_at_null'] ?? false);
+        $this->assertTrue($generated['existing_published_records_check']['all_still_published_public_indexable'] ?? false);
+        $this->assertFalse($generated['existing_published_records_check']['mutation_detected'] ?? true);
+        $this->assertTrue($generated['public_runtime_check']['all_draft_paths_not_200'] ?? false);
+        $this->assertTrue($generated['sitemap_check']['draft_paths_absent'] ?? false);
+        $this->assertTrue($generated['llms_check']['llms_txt']['draft_paths_absent'] ?? false);
+        $this->assertTrue($generated['llms_check']['llms_full_txt']['draft_paths_absent'] ?? false);
+        $this->assertTrue($generated['footer_nav_check']['draft_links_absent'] ?? false);
+        $this->assertTrue($generated['search_channel_check']['no_queue_items_for_imported_drafts'] ?? false);
+        $this->assertTrue($generated['search_channel_check']['gates_closed'] ?? false);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T08:10:00+08:00",
+  "updated_at": "2026-05-27T08:34:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -27654,6 +27654,139 @@
       },
       {
         "at": "2026-05-27T08:10:00+08:00",
+        "status": "github_checks_passed",
+        "summary": "GitHub required checks passed and mergeStateStatus was CLEAN before final ledger update."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01": {
+    "status": "github_checks_passed",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-import-verify-01",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01 verify Wave 1 content page import safety",
+    "commit_sha": "b534cb6d5b9448a5279cd8c82f65331b6e301354",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1710",
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "preflight": {
+        "status": "passed",
+        "evidence": "Started from origin/main at a0895313fc16f0aa000916e4da29c1cb07fe0a9c in isolated worktree; dependency PR #1709 merged."
+      },
+      "cms_record_state": {
+        "status": "passed",
+        "evidence": "Five imported records exist and remain draft, non-public, non-indexable, published_at null, with import source marker."
+      },
+      "existing_published_records": {
+        "status": "passed",
+        "evidence": "about/help/method-boundaries records remain published/public/indexable and do not carry the Wave 1 import source marker."
+      },
+      "public_runtime": {
+        "status": "passed",
+        "evidence": "/en/brand, /en/charter, /en/foundation, /en/careers, and /en/policies returned 404; /en/about, /en/privacy, /en/terms returned 200."
+      },
+      "sitemap_llms": {
+        "status": "passed",
+        "evidence": "Imported draft paths absent from /sitemap.xml, /llms.txt, and /llms-full.txt."
+      },
+      "footer_nav": {
+        "status": "passed",
+        "evidence": "English homepage footer/nav did not link to imported draft paths."
+      },
+      "search_channel": {
+        "status": "passed",
+        "evidence": "No queue items for imported drafts; no IndexNow/domestic submissions; Search Channel gates closed; queue items 2 and 3 MBTI present."
+      },
+      "local_validation": {
+        "status": "pending"
+      },
+      "github_required_checks": {
+        "status": "passed",
+        "evidence": "PR #1710 required checks passed and mergeStateStatus was CLEAN."
+      },
+      "composer_install": {
+        "status": "passed",
+        "command": "cd backend && composer install --no-interaction --no-progress",
+        "evidence": "Installed dependencies in isolated worktree only; ignored generated vendor/public/cache artifacts were not staged."
+      },
+      "focused_test": {
+        "status": "passed",
+        "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesImportVerify01 --no-ansi",
+        "evidence": "1 test passed, 28 assertions."
+      },
+      "route_list": {
+        "status": "passed",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "203 routes listed."
+      },
+      "pint": {
+        "status": "passed",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "3581 files passed."
+      },
+      "composer_validate": {
+        "status": "passed",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "passed",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "passed",
+        "evidence": "Generated JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+      },
+      "scope_validation": {
+        "status": "passed",
+        "changed_files": [
+          "backend/docs/seo/global-en-zh-content-pages-import-verify-01.md",
+          "backend/docs/seo/generated/global-en-zh-content-pages-import-verify-01.v1.json",
+          "backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesImportVerify01Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "diff_check": {
+        "status": "passed",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "fap_web_reference_check": {
+        "status": "passed",
+        "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+        "evidence": "No fap-web changes."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T08:20:00+08:00",
+        "status": "planned",
+        "summary": "Authorized current read-only import verification task entry only; no publish, CMS mutation, deploy, Search Channel action, URL submission, or fap-web modification."
+      },
+      {
+        "at": "2026-05-27T08:20:00+08:00",
+        "status": "in_progress",
+        "summary": "Completed read-only CMS, runtime, sitemap/llms, footer/nav, and Search Channel verification; local validation pending."
+      },
+      {
+        "at": "2026-05-27T08:28:00+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, fap-web reference check, and scope validation passed."
+      },
+      {
+        "at": "2026-05-27T08:31:00+08:00",
+        "status": "pr_opened",
+        "summary": "Opened PR #1710 after local validation; waiting for GitHub required checks."
+      },
+      {
+        "at": "2026-05-27T08:34:00+08:00",
         "status": "github_checks_passed",
         "summary": "GitHub required checks passed and mergeStateStatus was CLEAN before final ledger update."
       }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -13914,6 +13914,51 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-CMS-IMPORT-01
+    branch: codex/global-en-zh-content-pages-import-verify-01
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01 verify Wave 1 content page import safety"
+    train_scope: global_en_zh_controlled_cms_import
+    risk_level: p0_read_only_post_import_verification
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-import-verify-01.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-import-verify-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesImportVerify01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Verify Wave 1 imported content/help/policy records exist and remain draft-only, non-public, non-indexable, and unpublished.
+      - Verify public runtime, sitemap, llms, footer/nav, Search Channel, and URL submission gates did not expose imported drafts.
+      - Verify existing published English records were not upsert-mutated by the controlled import.
+      - Keep verification strictly read-only with no CMS mutation, publish, deploy, Search Channel action, URL submission, external search API call, production migration, raw log read, production user data access, or fap-web modification.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesImportVerify01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-import-verify-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added read-only verification report and generated JSON for Wave 1 content/help/policy CMS draft import safety.
- Added focused SeoIntel test for the verification artifact.
- Added only the current PR-train manifest/state entry authorized by the goal.

## Why
PR #1709 performed a controlled CMS draft import. This PR records post-import verification that the imported records stayed draft-only, non-public, non-indexable, and unexposed across runtime, sitemap, llms, footer/nav, and Search Channel surfaces.

## Verification summary
- Imported draft records exist: `brand`, `charter`, `foundation`, `careers`, `policies`.
- All five remain `status=draft`, `is_public=false`, `is_indexable=false`, `published_at=null`.
- Public runtime draft paths return 404.
- `/sitemap.xml`, `/llms.txt`, and `/llms-full.txt` do not contain draft paths.
- EN footer/nav does not link draft paths.
- Search Channel has no queue items for imported draft paths; URL submission gates remain closed.
- Existing published English records remain published/public/indexable and were not upsert-mutated.

## Intentionally deferred
- No import, publish, CMS mutation, deploy, Search Channel action, URL submission, external search API call, production migration, raw log read, production user data access, or fap-web modification.
- Inherited sidecars remain: `support` missing authority, existing published English records require separate update scope, `privacy`/`terms` require separate legal/policy scope.

## Validation
- `cd backend && composer install --no-interaction --no-progress`
- `cd backend && php artisan test --filter=GlobalEnZhContentPagesImportVerify01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-import-verify-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse
- `git diff --check && git diff --cached --check`
- fap-web reference status clean
