### PR TITLE
fix(results): require actor-bound email lookup

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php
@@ -29,6 +29,44 @@ final class ResultEmailLookupController extends Controller
             (string) $payload['email'],
             (int) $this->orgContext->orgId(),
             $payload['locale'] ?? null,
+            $this->orgContext->userId(),
+            $this->orgContext->anonId(),
+            $this->resolveClientAnonId($request),
         ));
+    }
+
+    private function resolveClientAnonId(ResultEmailLookupRequest $request): ?string
+    {
+        $candidates = [
+            $request->attributes->get('client_anon_id'),
+            $request->header('X-Anon-Id'),
+            $request->cookie('fap_anonymous_id_v1'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_string($candidate) && ! is_numeric($candidate)) {
+                continue;
+            }
+
+            $normalized = trim((string) $candidate);
+            if ($normalized === '' || strlen($normalized) > 128) {
+                continue;
+            }
+
+            $lower = mb_strtolower($normalized, 'UTF-8');
+            $isPlaceholder = false;
+            foreach (['todo', 'placeholder', 'fixme', 'tbd', '填这里'] as $bad) {
+                if (mb_strpos($lower, $bad) !== false) {
+                    $isPlaceholder = true;
+                    break;
+                }
+            }
+
+            if (! $isPlaceholder) {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/app/Services/Results/ResultEmailLookupService.php
+++ b/backend/app/Services/Results/ResultEmailLookupService.php
@@ -35,7 +35,69 @@ final class ResultEmailLookupService
     /**
      * @return array{ok:bool,items:list<array<string,mixed>>,email_verification_required:bool,message:string}
      */
-    public function lookup(string $email, int $orgId, ?string $locale = null): array
+    public function lookup(
+        string $email,
+        int $orgId,
+        ?string $locale = null,
+        ?int $userId = null,
+        mixed $tokenAnonId = null,
+        mixed $clientAnonId = null
+    ): array {
+        $emailHash = $this->emailHash($email);
+        $ownerUserId = $userId !== null && $userId > 0 ? (string) $userId : null;
+        $ownerAnonIds = $this->ownerAnonIds($tokenAnonId, $clientAnonId);
+
+        if ($emailHash === null || ($ownerUserId === null && $ownerAnonIds === [])) {
+            return $this->verificationRequiredResponse();
+        }
+
+        $bindings = AttemptEmailBinding::query()
+            ->where('org_id', max(0, $orgId))
+            ->where('email_hash', $emailHash)
+            ->where('status', AttemptEmailBinding::STATUS_ACTIVE)
+            ->where(function ($query) use ($ownerUserId, $ownerAnonIds): void {
+                if ($ownerUserId !== null) {
+                    $query->orWhere('bound_user_id', $ownerUserId);
+                }
+
+                foreach ($ownerAnonIds as $anonId) {
+                    $query->orWhere('bound_anon_id', $anonId);
+                }
+            })
+            ->orderByDesc('updated_at')
+            ->orderByDesc('created_at')
+            ->limit(25)
+            ->get();
+
+        $items = [];
+        foreach ($bindings as $binding) {
+            if (! $binding instanceof AttemptEmailBinding) {
+                continue;
+            }
+
+            $item = $this->lookupItemForBinding($binding, $locale);
+            if ($item === null) {
+                continue;
+            }
+
+            $items[] = $item;
+            if (count($items) >= 10) {
+                break;
+            }
+        }
+
+        return [
+            'ok' => true,
+            'items' => $items,
+            'email_verification_required' => false,
+            'message' => 'Saved results are listed only when the email and current session match an active binding.',
+        ];
+    }
+
+    /**
+     * @return array{ok:bool,items:list<array<string,mixed>>,email_verification_required:bool,message:string}
+     */
+    private function verificationRequiredResponse(): array
     {
         return [
             'ok' => true,
@@ -148,5 +210,42 @@ final class ResultEmailLookupService
         $separator = str_contains($base, '?') ? '&' : '?';
 
         return $base.$separator.'access_token='.rawurlencode($token).$fragment;
+    }
+
+    private function emailHash(string $email): ?string
+    {
+        $normalized = $this->piiCipher->normalizeEmail($email);
+        if ($normalized === '') {
+            return null;
+        }
+
+        return $this->piiCipher->emailHash($normalized);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function ownerAnonIds(mixed ...$values): array
+    {
+        $normalized = [];
+        foreach ($values as $value) {
+            $owner = $this->normalizeOwnerString($value);
+            if ($owner !== null) {
+                $normalized[$owner] = true;
+            }
+        }
+
+        return array_keys($normalized);
+    }
+
+    private function normalizeOwnerString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
     }
 }

--- a/backend/tests/Feature/ResultEmailLookupTest.php
+++ b/backend/tests/Feature/ResultEmailLookupTest.php
@@ -11,6 +11,7 @@ use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -18,7 +19,7 @@ final class ResultEmailLookupTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_lookup_by_email_requires_verification_before_listing_saved_results(): void
+    public function test_lookup_by_email_lists_only_results_bound_to_current_anonymous_actor(): void
     {
         $email = 'Owner@Example.Test';
         $firstAttemptId = $this->seedAttemptWithResult('anon_lookup_a', 'MBTI', 'INTJ-A', now()->subMinutes(5));
@@ -26,14 +27,46 @@ final class ResultEmailLookupTest extends TestCase
         $this->seedBinding($firstAttemptId, $email, 'anon_lookup_a');
         $this->seedBinding($secondAttemptId, $email, 'anon_lookup_b');
 
-        $response = $this->postJson('/api/v0.3/results/lookup-by-email', [
-            'email' => ' owner@example.test ',
-            'locale' => 'zh-CN',
-        ]);
+        $response = $this->withHeader('X-Anon-Id', 'anon_lookup_a')
+            ->postJson('/api/v0.3/results/lookup-by-email', [
+                'email' => ' owner@example.test ',
+                'locale' => 'zh-CN',
+            ]);
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('email_verification_required', true);
+        $response->assertJsonPath('email_verification_required', false);
+        $response->assertJsonCount(1, 'items');
+        $response->assertJsonPath('items.0.attempt_id', $firstAttemptId);
+        $response->assertJsonStructure([
+            'items' => [
+                [
+                    'result_access_token',
+                    'result_access_token_expires_at',
+                ],
+            ],
+        ]);
+        $this->assertStringContainsString('/zh/result/'.$firstAttemptId.'?access_token=', (string) $response->json('items.0.result_url'));
+        $this->assertStringNotContainsString($secondAttemptId, $response->getContent());
+    }
+
+    public function test_lookup_by_email_does_not_list_results_for_other_anonymous_actor(): void
+    {
+        $email = 'Owner@Example.Test';
+        $firstAttemptId = $this->seedAttemptWithResult('anon_lookup_a', 'MBTI', 'INTJ-A', now()->subMinutes(5));
+        $secondAttemptId = $this->seedAttemptWithResult('anon_lookup_b', 'BIG5_OCEAN', 'OCEAN-HIGH', now()->subMinute());
+        $this->seedBinding($firstAttemptId, $email, 'anon_lookup_a');
+        $this->seedBinding($secondAttemptId, $email, 'anon_lookup_b');
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_lookup_other')
+            ->postJson('/api/v0.3/results/lookup-by-email', [
+                'email' => ' owner@example.test ',
+                'locale' => 'zh-CN',
+            ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('email_verification_required', false);
         $response->assertJsonCount(0, 'items');
         $response->assertJsonMissingPath('items.0.result_access_token');
         $this->assertStringNotContainsString($firstAttemptId, $response->getContent());
@@ -53,7 +86,7 @@ final class ResultEmailLookupTest extends TestCase
         $response->assertJsonCount(0, 'items');
     }
 
-    public function test_lookup_ignores_inactive_and_sensitive_bindings(): void
+    public function test_lookup_ignores_inactive_and_sensitive_bindings_for_current_actor(): void
     {
         $email = 'owner@example.test';
         $activeAttemptId = $this->seedAttemptWithResult('anon_lookup_active', 'MBTI', 'ENFP-A', now()->subMinutes(3));
@@ -63,15 +96,16 @@ final class ResultEmailLookupTest extends TestCase
         $this->seedBinding($inactiveAttemptId, $email, 'anon_lookup_inactive', 'pending');
         $this->seedBinding($sensitiveAttemptId, $email, 'anon_lookup_sds');
 
-        $response = $this->postJson('/api/v0.3/results/lookup-by-email', [
-            'email' => $email,
-            'locale' => 'en',
-        ]);
+        $response = $this->withHeader('X-Anon-Id', 'anon_lookup_active')
+            ->postJson('/api/v0.3/results/lookup-by-email', [
+                'email' => $email,
+                'locale' => 'en',
+            ]);
 
         $response->assertOk();
-        $response->assertJsonPath('email_verification_required', true);
-        $response->assertJsonCount(0, 'items');
-        $this->assertStringNotContainsString($activeAttemptId, $response->getContent());
+        $response->assertJsonPath('email_verification_required', false);
+        $response->assertJsonCount(1, 'items');
+        $response->assertJsonPath('items.0.attempt_id', $activeAttemptId);
         $this->assertStringNotContainsString($inactiveAttemptId, $response->getContent());
         $this->assertStringNotContainsString($sensitiveAttemptId, $response->getContent());
     }
@@ -81,16 +115,23 @@ final class ResultEmailLookupTest extends TestCase
         Cache::flush();
         config([
             'fap.rate_limits.bypass_in_test_env' => false,
+            'fap.rate_limits.api_public_per_minute' => 120,
             'fap.rate_limits.api_result_lookup_per_minute' => 1,
         ]);
 
         $email = 'ratelimit_'.Str::lower(Str::random(12)).'@example.test';
+        $server = ['REMOTE_ADDR' => '198.51.100.77'];
+        foreach (['127.0.0.1', '198.51.100.77'] as $ip) {
+            RateLimiter::clear('ip:'.$ip);
+            RateLimiter::clear('api_result_lookup|ip:'.$ip.'|org:0|route:api/v0.3/results/lookup-by-email');
+            RateLimiter::clear('api_result_lookup|ip:'.$ip.'|org:0|route:v0.3/results/lookup-by-email');
+        }
 
-        $this->postJson('/api/v0.3/results/lookup-by-email', [
+        $this->withServerVariables($server)->postJson('/api/v0.3/results/lookup-by-email', [
             'email' => $email,
         ])->assertOk();
 
-        $this->postJson('/api/v0.3/results/lookup-by-email', [
+        $this->withServerVariables($server)->postJson('/api/v0.3/results/lookup-by-email', [
             'email' => $email,
         ])
             ->assertStatus(429)


### PR DESCRIPTION
## What changed
- Restores result email lookup only when the submitted email matches an active attempt email binding owned by the current user/token anon/client anon session.
- Issues existing short-lived result access tokens only for matched bindings.
- Keeps email-only lookups empty and excludes inactive/sensitive bindings.

## Why
The lookup endpoint was hard-closed, so users could not recover saved results by email. Returning all results for an email would expose result metadata to anyone who knows the address, so this PR limits listing to the current verified actor/session.

## Validation
- php artisan test --filter=ResultEmailLookupTest --no-ansi
- php artisan test --filter=ResultEmailGatedReadTest --no-ansi
- php artisan test --filter=ResultEmail --no-ansi
- php artisan route:list --path=lookup-by-email --no-ansi -vv
- php artisan route:list --no-ansi
- vendor/bin/pint --test
- git diff --check

## Deferred
- Cross-device email verification link flow.
- Frontend copy/interaction changes for the lookup page.