### PR TITLE
docs(commerce): record order grant projection readonly check

### DIFF
--- a/backend/docs/commerce/generated/order-grant-projection-readonly-ord-1093b7e6.v1.json
+++ b/backend/docs/commerce/generated/order-grant-projection-readonly-ord-1093b7e6.v1.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "commerce.order_grant_projection_readonly.v1",
+  "task": "ORDER-GRANT-PROJECTION-READONLY-ORD-1093B7E6",
+  "final_decision": "order_grant_projection_readonly_completed_payment_pending_no_grant",
+  "order_no": "ord_1093b7e6-073a-4d93-b26d-4a68a819fa23",
+  "production_readonly_verification": true,
+  "no_write_performed": true,
+  "no_env_edit": true,
+  "no_migration": true,
+  "no_grant_created": true,
+  "no_projection_write": true,
+  "no_repair_command_run": true,
+  "public_order_endpoint_invoked": false,
+  "builder_repair_invoked": false,
+  "order_state": {
+    "status": "pending",
+    "payment_state": "pending",
+    "grant_state": "not_started",
+    "provider": "alipay",
+    "target_attempt_id_present": true,
+    "paid_at_present": false,
+    "fulfilled_at_present": false,
+    "last_reconciled_at_present": false
+  },
+  "payment_attempts": {
+    "count": 1,
+    "latest_state": "client_presented",
+    "external_trade_no_present": false,
+    "provider_trade_no_present": false,
+    "latest_payment_event_id_present": false,
+    "callback_received_at_present": false,
+    "verified_at_present": false,
+    "finalized_at_present": false,
+    "last_error_code": null
+  },
+  "payment_events": {
+    "count": 0
+  },
+  "benefit_grants": {
+    "count": 0,
+    "active_count": 0
+  },
+  "unified_access_projection": {
+    "exists": false
+  },
+  "exact_result_entry_readonly_inference": {
+    "result_exists": true,
+    "access_state": "locked",
+    "report_state": "ready",
+    "pdf_state": "missing",
+    "reason_code": "projection_missing_result_ready",
+    "ready_to_enter": false,
+    "builder_repair_not_invoked": true
+  },
+  "sidecars": [
+    {
+      "id": "payment_attempt_schema_retry",
+      "summary": "The first read-only payment_attempts query used a non-existent status column and was retried with the production schema's state column."
+    }
+  ],
+  "next_task": "PAYMENT-ALIPAY-RETURN-VERIFY-01"
+}

--- a/backend/docs/commerce/order-grant-projection-readonly-ord-1093b7e6.md
+++ b/backend/docs/commerce/order-grant-projection-readonly-ord-1093b7e6.md
@@ -1,0 +1,93 @@
+# Order Grant / Projection Read-only Check
+
+Task: `ORDER-GRANT-PROJECTION-READONLY-ORD-1093B7E6`
+
+Order checked:
+
+- `ord_1093b7e6-073a-4d93-b26d-4a68a819fa23`
+
+## Summary
+
+Production read-only verification shows this order is not currently paid.
+
+- `orders.status`: `pending`
+- `orders.payment_state`: `pending`
+- `orders.grant_state`: `not_started`
+- `benefit_grants`: `0`
+- `unified_access_projections`: missing for the order attempt
+- `exact_result_entry.reason_code` read-only inference: `projection_missing_result_ready`
+- `exact_result_entry.ready_to_enter` read-only inference: `false`
+
+The order wait page behavior is consistent with the backend state: payment has not been confirmed into `paid`, no grant has been issued, and no unified access projection is ready.
+
+## Read-only Evidence
+
+The production checks used SELECT-only Laravel query builder reads through the production application context. No public order endpoint was called because that endpoint can invoke projection repair when a result exists.
+
+Observed order state:
+
+```json
+{
+  "status": "pending",
+  "payment_state": "pending",
+  "grant_state": "not_started",
+  "provider": "alipay",
+  "target_attempt_id_present": true,
+  "paid_at_present": false,
+  "fulfilled_at_present": false,
+  "last_reconciled_at_present": false
+}
+```
+
+Observed payment state:
+
+```json
+{
+  "payment_attempts_count": 1,
+  "latest_payment_attempt_state": "client_presented",
+  "external_trade_no_present": false,
+  "provider_trade_no_present": false,
+  "callback_received_at_present": false,
+  "verified_at_present": false,
+  "finalized_at_present": false,
+  "payment_events_count": 0
+}
+```
+
+Observed grant/projection state:
+
+```json
+{
+  "benefit_grants_count": 0,
+  "unified_access_projection_exists": false,
+  "result_exists": true,
+  "access_state": "locked",
+  "report_state": "ready",
+  "pdf_state": "missing",
+  "reason_code": "projection_missing_result_ready",
+  "ready_to_enter": false
+}
+```
+
+## Interpretation
+
+This is not a paid-no-grant case at the time of verification. It is a pending Alipay client-presented order with no provider trade number, no callback, no verified payment attempt, and no payment event.
+
+Because `payment_state` remains `pending`, the backend must not grant benefits or mark the unified access projection ready. A full result redirect after payment requires payment confirmation first, then grant/projection readiness.
+
+## What Was Not Done
+
+- No production write was performed.
+- No env value was edited.
+- No migration was run.
+- No collector, scheduler, or repair command was run.
+- No benefit grant was created.
+- No unified access projection was written.
+- No order state was changed.
+- No public order endpoint or builder repair path was invoked.
+
+## Next Step
+
+Recommended next task:
+
+`PAYMENT-ALIPAY-RETURN-VERIFY-01` - investigate why this Alipay order remained `client_presented` / `payment_state=pending` after the user believed payment completed, using read-only provider-safe evidence first.

--- a/backend/tests/Feature/Commerce/OrderGrantProjectionReadonlyOrd1093b7e6Test.php
+++ b/backend/tests/Feature/Commerce/OrderGrantProjectionReadonlyOrd1093b7e6Test.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use Tests\TestCase;
+
+final class OrderGrantProjectionReadonlyOrd1093b7e6Test extends TestCase
+{
+    public function test_generated_report_locks_readonly_order_grant_projection_state(): void
+    {
+        $path = base_path('docs/commerce/generated/order-grant-projection-readonly-ord-1093b7e6.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('ord_1093b7e6-073a-4d93-b26d-4a68a819fa23', $payload['order_no']);
+        $this->assertTrue($payload['production_readonly_verification']);
+        $this->assertTrue($payload['no_write_performed']);
+        $this->assertTrue($payload['no_env_edit']);
+        $this->assertTrue($payload['no_migration']);
+        $this->assertTrue($payload['no_grant_created']);
+        $this->assertTrue($payload['no_projection_write']);
+        $this->assertFalse($payload['public_order_endpoint_invoked']);
+        $this->assertFalse($payload['builder_repair_invoked']);
+        $this->assertSame('pending', $payload['order_state']['payment_state']);
+        $this->assertSame('not_started', $payload['order_state']['grant_state']);
+        $this->assertSame(0, $payload['benefit_grants']['count']);
+        $this->assertFalse($payload['unified_access_projection']['exists']);
+        $this->assertSame(
+            'projection_missing_result_ready',
+            $payload['exact_result_entry_readonly_inference']['reason_code']
+        );
+        $this->assertFalse($payload['exact_result_entry_readonly_inference']['ready_to_enter']);
+        $this->assertNotEmpty($payload['final_decision']);
+        $this->assertNotEmpty($payload['next_task']);
+    }
+}


### PR DESCRIPTION
## What changed
- Adds a read-only production diagnostic report for order ord_1093b7e6-073a-4d93-b26d-4a68a819fa23.
- Adds generated JSON locking payment/grant/projection state and no-write boundaries.
- Adds a focused test asserting the report artifact and safety flags.

## Why
The user-visible payment wait flow depends on paid order state, benefit grant creation, and unified access projection readiness. This report records the current backend truth for the specific order without invoking repair or mutation paths.

## Result
- The order is currently payment_state=pending, not paid.
- grant_state=not_started.
- benefit_grants count is 0.
- unified_access_projection is missing.
- readonly exact_result_entry reason inference is projection_missing_result_ready and ready_to_enter=false.

## Validation
- php artisan test --filter=OrderGrantProjectionReadonlyOrd1093b7e6 --no-ansi
- python3 -m json.tool backend/docs/commerce/generated/order-grant-projection-readonly-ord-1093b7e6.v1.json >/dev/null
- vendor/bin/pint --test tests/Feature/Commerce/OrderGrantProjectionReadonlyOrd1093b7e6Test.php
- php artisan route:list --no-ansi
- vendor/bin/pint --test
- git diff --check

## Deferred
- Alipay return/provider verification investigation.
- Any order repair, grant creation, projection refresh, env edit, migration, or deploy.