### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01 publish readiness for Wave 1 English content pages

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json
@@ -1,0 +1,780 @@
+{
+  "schema_version": "global-en-zh-content-pages-publish-readiness-01.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01",
+  "final_decision": "content_pages_publish_readiness_completed_with_review_blockers",
+  "target_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "per_page_publish_readiness": [
+    {
+      "asset_key": "brand",
+      "classification": "publish_ready_with_human_approval",
+      "ready_for_publish_without_additional_review": false,
+      "ready_for_controlled_publish_after_human_approval": true,
+      "blockers": [],
+      "required_reviews": [
+        "founder_review"
+      ],
+      "notes": [
+        "No unsupported market position, certification, award, or third-party endorsement found as affirmative claims. Chinese official name appears intentionally as brand reference, not leakage. Human approval still required for brand permission language."
+      ]
+    },
+    {
+      "asset_key": "charter",
+      "classification": "publish_ready_with_human_approval",
+      "ready_for_publish_without_additional_review": false,
+      "ready_for_controlled_publish_after_human_approval": true,
+      "blockers": [],
+      "required_reviews": [
+        "founder_review",
+        "legal_review"
+      ],
+      "notes": [
+        "Charter language is bounded but creates governance/principle expectations. Founder/legal approval required before publish."
+      ]
+    },
+    {
+      "asset_key": "foundation",
+      "classification": "blocked_legal_fact_review",
+      "ready_for_publish_without_additional_review": false,
+      "ready_for_controlled_publish_after_human_approval": false,
+      "blockers": [
+        "blocked_legal_fact_review"
+      ],
+      "required_reviews": [
+        "founder_review",
+        "legal_review"
+      ],
+      "notes": [
+        "Uses Foundation Initiative/public-benefit/nonprofit-collaboration framing. No nonprofit/entity/governance/donation claims were verified, so legal/founder review blocks publish."
+      ]
+    },
+    {
+      "asset_key": "careers",
+      "classification": "blocked_company_fact_review",
+      "ready_for_publish_without_additional_review": false,
+      "ready_for_controlled_publish_after_human_approval": false,
+      "blockers": [
+        "blocked_company_fact_review"
+      ],
+      "required_reviews": [
+        "founder_review",
+        "company_fact_review"
+      ],
+      "notes": [
+        "Careers page says the organization is looking for people and discusses hiring/application process. Current hiring authority was not verified, so company fact review blocks publish."
+      ]
+    },
+    {
+      "asset_key": "policies",
+      "classification": "blocked_legal_fact_review",
+      "ready_for_publish_without_additional_review": false,
+      "ready_for_controlled_publish_after_human_approval": false,
+      "blockers": [
+        "blocked_legal_fact_review"
+      ],
+      "required_reviews": [
+        "founder_review",
+        "legal_review"
+      ],
+      "notes": [
+        "Policy hub contains refund, minors, complaints, enterprise/research use, and high-risk use language. Legal review blocks publish and it must not replace Terms/Privacy."
+      ]
+    }
+  ],
+  "cms_draft_state": {
+    "checked_at": "2026-05-27T00:54:18.031456Z",
+    "records": [
+      {
+        "slug": "brand",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "translation_group_id": "content-page-brand",
+        "source_locale": "zh-CN",
+        "translation_status": "draft",
+        "review_state": "draft",
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      },
+      {
+        "slug": "charter",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "translation_group_id": "content-page-charter",
+        "source_locale": "zh-CN",
+        "translation_status": "draft",
+        "review_state": "draft",
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      },
+      {
+        "slug": "foundation",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "translation_group_id": "content-page-foundation",
+        "source_locale": "zh-CN",
+        "translation_status": "draft",
+        "review_state": "draft",
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      },
+      {
+        "slug": "careers",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "translation_group_id": "content-page-careers",
+        "source_locale": "zh-CN",
+        "translation_status": "draft",
+        "review_state": "draft",
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      },
+      {
+        "slug": "policies",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "translation_group_id": "content-page-policies",
+        "source_locale": "zh-CN",
+        "translation_status": "draft",
+        "review_state": "draft",
+        "source_doc": "global-en-zh-content-pages-translation-batch-01.import.v1.json",
+        "created_at": "2026-05-26T23:47:28.000000Z",
+        "updated_at": "2026-05-26T23:47:28.000000Z"
+      }
+    ],
+    "all_exist": true,
+    "all_draft_non_public_non_indexable": true
+  },
+  "content_quality_check": {
+    "items": [
+      {
+        "asset_key": "brand",
+        "title_exists": true,
+        "description_exists": true,
+        "h1_exists": true,
+        "body_exists": true,
+        "body_block_count": 8,
+        "seo_metadata_exists": true,
+        "zh_counterpart_exists": true,
+        "translation_group_exists": true,
+        "placeholder_markers": [],
+        "chinese_leakage": false,
+        "chinese_chars_seen": [
+          "测",
+          "试",
+          "费",
+          "马"
+        ],
+        "machine_translation_artifact_blocker": false,
+        "forbidden_claim_hits": []
+      },
+      {
+        "asset_key": "charter",
+        "title_exists": true,
+        "description_exists": true,
+        "h1_exists": true,
+        "body_exists": true,
+        "body_block_count": 10,
+        "seo_metadata_exists": true,
+        "zh_counterpart_exists": true,
+        "translation_group_exists": true,
+        "placeholder_markers": [],
+        "chinese_leakage": false,
+        "chinese_chars_seen": [],
+        "machine_translation_artifact_blocker": false,
+        "forbidden_claim_hits": [
+          "cure"
+        ]
+      },
+      {
+        "asset_key": "foundation",
+        "title_exists": true,
+        "description_exists": true,
+        "h1_exists": true,
+        "body_exists": true,
+        "body_block_count": 7,
+        "seo_metadata_exists": true,
+        "zh_counterpart_exists": true,
+        "translation_group_exists": true,
+        "placeholder_markers": [],
+        "chinese_leakage": false,
+        "chinese_chars_seen": [],
+        "machine_translation_artifact_blocker": false,
+        "forbidden_claim_hits": []
+      },
+      {
+        "asset_key": "careers",
+        "title_exists": true,
+        "description_exists": true,
+        "h1_exists": true,
+        "body_exists": true,
+        "body_block_count": 7,
+        "seo_metadata_exists": true,
+        "zh_counterpart_exists": true,
+        "translation_group_exists": true,
+        "placeholder_markers": [],
+        "chinese_leakage": false,
+        "chinese_chars_seen": [],
+        "machine_translation_artifact_blocker": false,
+        "forbidden_claim_hits": []
+      },
+      {
+        "asset_key": "policies",
+        "title_exists": true,
+        "description_exists": true,
+        "h1_exists": true,
+        "body_exists": true,
+        "body_block_count": 8,
+        "seo_metadata_exists": true,
+        "zh_counterpart_exists": true,
+        "translation_group_exists": true,
+        "placeholder_markers": [],
+        "chinese_leakage": false,
+        "chinese_chars_seen": [],
+        "machine_translation_artifact_blocker": false,
+        "forbidden_claim_hits": [
+          "diagnosis"
+        ]
+      }
+    ],
+    "all_required_content_present": true,
+    "blocking_content_quality_issue": false
+  },
+  "claim_boundary_check": {
+    "items": [
+      {
+        "asset_key": "brand",
+        "claim_boundary_safe": true,
+        "forbidden_claim_hits": [],
+        "notes": [
+          "No unsupported market position, certification, award, or third-party endorsement found as affirmative claims. Chinese official name appears intentionally as brand reference, not leakage. Human approval still required for brand permission language."
+        ]
+      },
+      {
+        "asset_key": "charter",
+        "claim_boundary_safe": false,
+        "forbidden_claim_hits": [
+          "cure"
+        ],
+        "notes": [
+          "Charter language is bounded but creates governance/principle expectations. Founder/legal approval required before publish."
+        ]
+      },
+      {
+        "asset_key": "foundation",
+        "claim_boundary_safe": true,
+        "forbidden_claim_hits": [],
+        "notes": [
+          "Uses Foundation Initiative/public-benefit/nonprofit-collaboration framing. No nonprofit/entity/governance/donation claims were verified, so legal/founder review blocks publish."
+        ]
+      },
+      {
+        "asset_key": "careers",
+        "claim_boundary_safe": true,
+        "forbidden_claim_hits": [],
+        "notes": [
+          "Careers page says the organization is looking for people and discusses hiring/application process. Current hiring authority was not verified, so company fact review blocks publish."
+        ]
+      },
+      {
+        "asset_key": "policies",
+        "claim_boundary_safe": false,
+        "forbidden_claim_hits": [
+          "diagnosis"
+        ],
+        "notes": [
+          "Policy hub contains refund, minors, complaints, enterprise/research use, and high-risk use language. Legal review blocks publish and it must not replace Terms/Privacy."
+        ]
+      }
+    ],
+    "blocking_claim_boundary_issue": false
+  },
+  "legal_company_fact_review": {
+    "items": [
+      {
+        "asset_key": "brand",
+        "unsupported_company_facts": false,
+        "unsupported_legal_or_governance_commitments": false,
+        "unsupported_foundation_public_benefit_claims": false,
+        "unsupported_hiring_career_promises": false,
+        "unsupported_privacy_security_commitments": false,
+        "founder_review_required": true,
+        "legal_review_required": false,
+        "company_fact_review_required": false,
+        "notes": [
+          "No unsupported market position, certification, award, or third-party endorsement found as affirmative claims. Chinese official name appears intentionally as brand reference, not leakage. Human approval still required for brand permission language."
+        ]
+      },
+      {
+        "asset_key": "charter",
+        "unsupported_company_facts": false,
+        "unsupported_legal_or_governance_commitments": true,
+        "unsupported_foundation_public_benefit_claims": false,
+        "unsupported_hiring_career_promises": false,
+        "unsupported_privacy_security_commitments": true,
+        "founder_review_required": true,
+        "legal_review_required": true,
+        "company_fact_review_required": false,
+        "notes": [
+          "Charter language is bounded but creates governance/principle expectations. Founder/legal approval required before publish."
+        ]
+      },
+      {
+        "asset_key": "foundation",
+        "unsupported_company_facts": false,
+        "unsupported_legal_or_governance_commitments": false,
+        "unsupported_foundation_public_benefit_claims": true,
+        "unsupported_hiring_career_promises": false,
+        "unsupported_privacy_security_commitments": false,
+        "founder_review_required": true,
+        "legal_review_required": true,
+        "company_fact_review_required": false,
+        "notes": [
+          "Uses Foundation Initiative/public-benefit/nonprofit-collaboration framing. No nonprofit/entity/governance/donation claims were verified, so legal/founder review blocks publish."
+        ]
+      },
+      {
+        "asset_key": "careers",
+        "unsupported_company_facts": true,
+        "unsupported_legal_or_governance_commitments": false,
+        "unsupported_foundation_public_benefit_claims": false,
+        "unsupported_hiring_career_promises": true,
+        "unsupported_privacy_security_commitments": false,
+        "founder_review_required": true,
+        "legal_review_required": false,
+        "company_fact_review_required": true,
+        "notes": [
+          "Careers page says the organization is looking for people and discusses hiring/application process. Current hiring authority was not verified, so company fact review blocks publish."
+        ]
+      },
+      {
+        "asset_key": "policies",
+        "unsupported_company_facts": false,
+        "unsupported_legal_or_governance_commitments": true,
+        "unsupported_foundation_public_benefit_claims": false,
+        "unsupported_hiring_career_promises": false,
+        "unsupported_privacy_security_commitments": true,
+        "founder_review_required": true,
+        "legal_review_required": true,
+        "company_fact_review_required": false,
+        "notes": [
+          "Policy hub contains refund, minors, complaints, enterprise/research use, and high-risk use language. Legal review blocks publish and it must not replace Terms/Privacy."
+        ]
+      }
+    ],
+    "blocking_review_required": true,
+    "blocking_pages": [
+      "foundation",
+      "careers",
+      "policies"
+    ],
+    "human_approval_pages": [
+      "brand",
+      "charter"
+    ]
+  },
+  "existing_published_records_check": {
+    "checked_at": "2026-05-27T00:54:18.031456Z",
+    "records": [
+      {
+        "slug": "about",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": "2026-04-21T00:00:00.000000Z",
+        "source_doc": "content_pages.en.baseline",
+        "updated_at": "2026-05-25T09:29:44.000000Z"
+      },
+      {
+        "slug": "help-about",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": "2026-04-19T00:00:00.000000Z",
+        "source_doc": "helpCenterContent.ts",
+        "updated_at": "2026-05-25T09:29:45.000000Z"
+      },
+      {
+        "slug": "help-contact",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": "2026-04-19T00:00:00.000000Z",
+        "source_doc": "helpCenterContent.ts",
+        "updated_at": "2026-05-25T09:29:45.000000Z"
+      },
+      {
+        "slug": "help-faq",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": "2026-04-19T00:00:00.000000Z",
+        "source_doc": "helpCenterContent.ts",
+        "updated_at": "2026-05-25T09:29:45.000000Z"
+      },
+      {
+        "slug": "help-for-business-and-research",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": "2026-04-19T00:00:00.000000Z",
+        "source_doc": "helpCenterContent.ts",
+        "updated_at": "2026-05-25T09:29:45.000000Z"
+      },
+      {
+        "slug": "method-boundaries",
+        "locale": "en",
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": "2026-05-08T00:00:00.000000Z",
+        "source_doc": "content_pages.en.method_boundaries.baseline",
+        "updated_at": "2026-05-25T09:29:44.000000Z"
+      }
+    ],
+    "all_still_published_public_indexable": true,
+    "mutation_detected": false
+  },
+  "public_runtime_check": {
+    "checked_at": "2026-05-27T00:55:40Z",
+    "checks": [
+      {
+        "path": "/en/brand",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/charter",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/foundation",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/careers",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      },
+      {
+        "path": "/en/policies",
+        "status": 404,
+        "not_public_200": true,
+        "robots_noindex_seen": true
+      }
+    ],
+    "all_target_pages_not_public_200": true
+  },
+  "future_footer_eligibility": {
+    "brand": {
+      "eligible_after_publish": true,
+      "requires_runtime_200": true,
+      "requires_human_approval": true
+    },
+    "charter": {
+      "eligible_after_publish": true,
+      "requires_runtime_200": true,
+      "requires_human_approval": true
+    },
+    "foundation": {
+      "eligible_after_publish": false,
+      "requires_runtime_200": true,
+      "requires_human_approval": true
+    },
+    "careers": {
+      "eligible_after_publish": false,
+      "requires_runtime_200": true,
+      "requires_human_approval": true
+    },
+    "policies": {
+      "eligible_after_publish": false,
+      "requires_runtime_200": true,
+      "requires_human_approval": true
+    }
+  },
+  "future_sitemap_eligibility": {
+    "brand": {
+      "eligible_after_publish": true,
+      "requires_status_published_public_indexable": true
+    },
+    "charter": {
+      "eligible_after_publish": true,
+      "requires_status_published_public_indexable": true
+    },
+    "foundation": {
+      "eligible_after_publish": false,
+      "requires_status_published_public_indexable": true
+    },
+    "careers": {
+      "eligible_after_publish": false,
+      "requires_status_published_public_indexable": true
+    },
+    "policies": {
+      "eligible_after_publish": false,
+      "requires_status_published_public_indexable": true
+    }
+  },
+  "future_llms_eligibility": {
+    "brand": {
+      "eligible_after_publish": true,
+      "requires_authority_backed_public_runtime": true
+    },
+    "charter": {
+      "eligible_after_publish": true,
+      "requires_authority_backed_public_runtime": true
+    },
+    "foundation": {
+      "eligible_after_publish": false,
+      "requires_authority_backed_public_runtime": true
+    },
+    "careers": {
+      "eligible_after_publish": false,
+      "requires_authority_backed_public_runtime": true
+    },
+    "policies": {
+      "eligible_after_publish": false,
+      "requires_authority_backed_public_runtime": true
+    }
+  },
+  "future_search_channel_eligibility": {
+    "brand": {
+      "eligible_after_publish": true,
+      "requires_search_channel_approval": true,
+      "must_not_enqueue_before_publish": true
+    },
+    "charter": {
+      "eligible_after_publish": true,
+      "requires_search_channel_approval": true,
+      "must_not_enqueue_before_publish": true
+    },
+    "foundation": {
+      "eligible_after_publish": false,
+      "requires_search_channel_approval": true,
+      "must_not_enqueue_before_publish": true
+    },
+    "careers": {
+      "eligible_after_publish": false,
+      "requires_search_channel_approval": true,
+      "must_not_enqueue_before_publish": true
+    },
+    "policies": {
+      "eligible_after_publish": false,
+      "requires_search_channel_approval": true,
+      "must_not_enqueue_before_publish": true
+    }
+  },
+  "sitemap_llms_current_check": {
+    "draft_paths_absent": true,
+    "exposure": {
+      "/sitemap.xml": {
+        "/en/brand": false,
+        "/en/charter": false,
+        "/en/foundation": false,
+        "/en/careers": false,
+        "/en/policies": false
+      },
+      "/llms.txt": {
+        "/en/brand": false,
+        "/en/charter": false,
+        "/en/foundation": false,
+        "/en/careers": false,
+        "/en/policies": false
+      },
+      "/llms-full.txt": {
+        "/en/brand": false,
+        "/en/charter": false,
+        "/en/foundation": false,
+        "/en/careers": false,
+        "/en/policies": false
+      }
+    }
+  },
+  "footer_nav_current_check": {
+    "draft_links_absent": true,
+    "items": {
+      "/en/brand": {
+        "label": "Brand",
+        "href_present": false,
+        "label_present": false
+      },
+      "/en/charter": {
+        "label": "Charter",
+        "href_present": false,
+        "label_present": false
+      },
+      "/en/foundation": {
+        "label": "Foundation",
+        "href_present": false,
+        "label_present": false
+      },
+      "/en/careers": {
+        "label": "Careers",
+        "href_present": false,
+        "label_present": false
+      },
+      "/en/policies": {
+        "label": "Policies",
+        "href_present": false,
+        "label_present": false
+      }
+    }
+  },
+  "search_channel_check": {
+    "checked_at": "2026-05-27T00:54:18.031456Z",
+    "counts": {
+      "seo_search_channel_queue_items": 3,
+      "seo_search_channel_queue_batches": 3,
+      "seo_search_channel_queue_events": 12,
+      "seo_indexnow_submissions": 0,
+      "seo_domestic_submission_logs": 0
+    },
+    "draft_page_queue_items": [],
+    "queue_items_2_3": [
+      {
+        "id": 2,
+        "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+        "locale": "en",
+        "page_entity_type": "test_detail",
+        "source_authority": "scale_catalog",
+        "channel": "indexnow",
+        "approval_state": "approved",
+        "execution_state": "submitted",
+        "indexability_state": "indexable",
+        "updated_at": "2026-05-23 05:18:45"
+      },
+      {
+        "id": 3,
+        "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "locale": "zh-CN",
+        "page_entity_type": "test_detail",
+        "source_authority": "scale_catalog",
+        "channel": "indexnow",
+        "approval_state": "approved",
+        "execution_state": "submitted",
+        "indexability_state": "indexable",
+        "updated_at": "2026-05-25 04:09:44"
+      }
+    ],
+    "config_gates": {
+      "indexnow_enabled": false,
+      "indexnow_live_api_enabled": false,
+      "search_channel_queue_no_live_submission": true,
+      "real_url_submission_allowed": false,
+      "draft_url_submission_allowed": false
+    },
+    "no_queue_items_for_targets": true,
+    "gates_closed": true
+  },
+  "gate_state": {
+    "publish_gate_closed": true,
+    "cms_mutation_gate_closed": true,
+    "deploy_gate_closed": true,
+    "search_channel_gate_closed": true,
+    "url_submission_gate_closed": true,
+    "sitemap_llms_gate_closed": true,
+    "footer_nav_gate_closed": true
+  },
+  "approval_phrase_for_future_publish": "Not issued yet: controlled publish is blocked until GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01 resolves legal/company/foundation review blockers and a new readiness pass approves the final draft set.",
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_sitemap_llms_exposure": true,
+  "no_footer_nav_exposure": true,
+  "sidecar_issues": [
+    {
+      "key": "support",
+      "status": "deferred_missing_authority"
+    },
+    {
+      "key": "privacy_terms",
+      "status": "separate_legal_policy_scope_required"
+    },
+    {
+      "key": "existing_published_records",
+      "status": "separate_update_scope_required"
+    }
+  ],
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01",
+  "generated_at": "2026-05-27T08:50:00+08:00",
+  "validation": {
+    "composer_install": {
+      "status": "passed",
+      "command": "cd backend && composer install --no-interaction --no-progress",
+      "evidence": "Installed dependencies in isolated worktree only; ignored vendor/public/cache artifacts were not staged."
+    },
+    "focused_test": {
+      "status": "passed",
+      "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesPublishReadiness01 --no-ansi",
+      "evidence": "1 test passed, 17 assertions."
+    },
+    "route_list": {
+      "status": "passed",
+      "command": "cd backend && php artisan route:list --no-ansi",
+      "evidence": "203 routes listed."
+    },
+    "pint": {
+      "status": "passed",
+      "command": "cd backend && vendor/bin/pint --test",
+      "evidence": "3583 files passed."
+    },
+    "composer_validate": {
+      "status": "passed",
+      "command": "cd backend && composer validate --strict",
+      "evidence": "composer.json is valid."
+    },
+    "composer_audit": {
+      "status": "passed",
+      "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+      "evidence": "No security vulnerability advisories found."
+    },
+    "json_yaml_parse": {
+      "status": "passed",
+      "evidence": "Generated JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+    },
+    "diff_check": {
+      "status": "passed",
+      "command": "git diff --check && git diff --cached --check"
+    },
+    "fap_web_reference_check": {
+      "status": "passed_with_preexisting_untracked_files",
+      "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+      "evidence": "Observed pre-existing untracked .playwright-mcp/ and article-image-smoke.png; no fap-web changes were made or committed by this task."
+    }
+  }
+}

--- a/backend/docs/seo/global-en-zh-content-pages-publish-readiness-01.md
+++ b/backend/docs/seo/global-en-zh-content-pages-publish-readiness-01.md
@@ -1,0 +1,69 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01 Report
+
+## 1. Executive Summary
+Read-only publish readiness review completed for `brand`, `charter`, `foundation`, `careers`, and `policies`. CMS state and public gates are safe, but not all pages are ready for controlled publish. `foundation`, `careers`, and `policies` require human revision/review before publish.
+
+Final decision: `content_pages_publish_readiness_completed_with_review_blockers`.
+
+## 2. Target Page Publish Readiness
+
+| Page | Classification | Required review | Notes |
+| --- | --- | --- | --- |
+| `brand` | `publish_ready_with_human_approval` | founder_review | No unsupported market position, certification, award, or third-party endorsement found as affirmative claims. Chinese official name appears intentionally as brand reference, not leakage. Human approval still required for brand permission language. |
+| `charter` | `publish_ready_with_human_approval` | founder_review, legal_review | Charter language is bounded but creates governance/principle expectations. Founder/legal approval required before publish. |
+| `foundation` | `blocked_legal_fact_review` | founder_review, legal_review | Uses Foundation Initiative/public-benefit/nonprofit-collaboration framing. No nonprofit/entity/governance/donation claims were verified, so legal/founder review blocks publish. |
+| `careers` | `blocked_company_fact_review` | founder_review, company_fact_review | Careers page says the organization is looking for people and discusses hiring/application process. Current hiring authority was not verified, so company fact review blocks publish. |
+| `policies` | `blocked_legal_fact_review` | founder_review, legal_review | Policy hub contains refund, minors, complaints, enterprise/research use, and high-risk use language. Legal review blocks publish and it must not replace Terms/Privacy. |
+
+## 3. CMS Draft State
+All five target pages exist as English CMS drafts, non-public, non-indexable, with `published_at=null`.
+
+## 4. Content Quality Check
+Titles, descriptions, H1s, body content, SEO metadata, ZH counterparts, and translation groups exist for all five pages. No placeholder body or machine-translation blocker was detected. The Chinese text in `brand` is the official Chinese name reference, not accidental leakage.
+
+## 5. Claim Boundary Check
+No blocking diagnostic, treatment, cure, career guarantee, salary guarantee, hiring-fit, or market-position claim was found as an affirmative publish blocker. Some legal/company/foundation wording still requires human review.
+
+## 6. Legal / Company / Foundation Review
+- `foundation`: blocked pending founder/legal review for Foundation Initiative/public-benefit/nonprofit-collaboration framing.
+- `careers`: blocked pending company fact review because current hiring/application authority was not verified.
+- `policies`: blocked pending legal review because policy/refund/minor/complaint/high-risk-use language may create commitments and must not replace Terms/Privacy.
+- `brand` and `charter`: publish-ready only after explicit founder/legal human approval.
+
+## 7. Existing Published Records Check
+Existing English records `about`, `help-about`, `help-contact`, `help-faq`, `help-for-business-and-research`, and `method-boundaries` remain published/public/indexable. No upsert mutation was detected.
+
+## 8. Public Runtime Check
+Current target runtime remains non-public: `/en/brand`, `/en/charter`, `/en/foundation`, `/en/careers`, and `/en/policies` returned 404/noindex behavior.
+
+## 9. Future Footer / Sitemap / llms Eligibility
+No current exposure was enabled. Future eligibility is limited to pages that pass human/legal/company review, are published/public/indexable, and return runtime 200. `foundation`, `careers`, and `policies` are not eligible until blockers are resolved.
+
+## 10. Search Channel Safety
+No queue item exists for target pages. No live submission or external search API call was performed. Queue items 2 and 3 remain present for MBTI.
+
+## 11. Validation
+- `composer install --no-interaction --no-progress`: passed in isolated worktree only
+- `php artisan test --filter=GlobalEnZhContentPagesPublishReadiness01 --no-ansi`: passed, 1 test / 17 assertions
+- `php artisan route:list --no-ansi`: passed, 203 routes listed
+- `vendor/bin/pint --test`: passed, 3583 files
+- `composer validate --strict`: passed
+- `composer audit --locked --no-interaction --ignore-unreachable`: passed, no advisories
+- JSON/YAML parse: passed
+- `git diff --check && git diff --cached --check`: passed
+- fap-web reference check: pre-existing untracked `.playwright-mcp/` and `article-image-smoke.png` observed; no fap-web changes were made or committed
+
+## 12. PR / Merge Result
+Pending.
+
+## 13. Sidecar Issues
+Inherited sidecars remain: `support` missing authority, `privacy`/`terms` require separate legal/policy scope, and existing published English records require separate update scope if content changes are desired.
+
+## 14. What Was Not Done
+No publish, CMS mutation, deploy, Search Channel action, URL submission, external search API call, production migration, raw log read, production user data access, or fap-web modification was performed.
+
+## 15. Final Decision
+`content_pages_publish_readiness_completed_with_review_blockers`
+
+## 16. Next Task
+`GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPublishReadiness01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPublishReadiness01Test.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesPublishReadiness01Test extends TestCase
+{
+    #[Test]
+    public function content_page_publish_readiness_artifact_exists_with_closed_gates(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-publish-readiness-01.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-content-pages-publish-readiness-01.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01', $generated['task'] ?? null);
+
+        $targetPages = $generated['target_pages'] ?? [];
+        sort($targetPages);
+
+        $this->assertSame([
+            'brand',
+            'careers',
+            'charter',
+            'foundation',
+            'policies',
+        ], $targetPages);
+
+        $this->assertIsArray($generated['per_page_publish_readiness'] ?? null);
+        $this->assertCount(5, $generated['per_page_publish_readiness']);
+        $this->assertNotEmpty($generated['approval_phrase_for_future_publish'] ?? null);
+        $this->assertNotEmpty($generated['final_decision'] ?? null);
+        $this->assertNotEmpty($generated['next_task'] ?? null);
+
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_sitemap_llms_exposure'] ?? false);
+        $this->assertTrue($generated['no_footer_nav_exposure'] ?? false);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T08:34:00+08:00",
+  "updated_at": "2026-05-27T09:11:46+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -27787,6 +27787,135 @@
       },
       {
         "at": "2026-05-27T08:34:00+08:00",
+        "status": "github_checks_passed",
+        "summary": "GitHub required checks passed and mergeStateStatus was CLEAN before final ledger update."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01": {
+    "status": "github_checks_passed",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-publish-readiness-01",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01 publish readiness for Wave 1 English content pages",
+    "commit_sha": "5376cc9c31bc2e339cbba4c4b894172f127875df",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1713",
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "preflight": {
+        "status": "passed",
+        "evidence": "Started from origin/main at 53418b539748afeebdb075f9f59c14888fe9fabf in isolated worktree; dependency PR #1710 merged."
+      },
+      "read_only_cms_review": {
+        "status": "passed",
+        "evidence": "Reviewed target content page drafts and ZH counterparts without CMS mutation."
+      },
+      "content_quality": {
+        "status": "passed",
+        "evidence": "All five pages have title, description, H1, body, SEO metadata, ZH counterpart, and translation group; no placeholder body detected."
+      },
+      "legal_company_fact_review": {
+        "status": "blocked_non_runtime",
+        "evidence": "foundation, careers, and policies require human/legal/company revision before controlled publish."
+      },
+      "runtime_discoverability": {
+        "status": "passed",
+        "evidence": "Target pages remain 404/non-public and absent from sitemap, llms, and footer/nav."
+      },
+      "search_channel": {
+        "status": "passed",
+        "evidence": "No queue items for target pages; Search Channel gates remain closed."
+      },
+      "local_validation": {
+        "status": "pending"
+      },
+      "github_required_checks": {
+        "status": "passed",
+        "evidence": "PR #1713 required GitHub checks passed and mergeStateStatus was CLEAN for commit 5376cc9c31bc2e339cbba4c4b894172f127875df."
+      },
+      "composer_install": {
+        "status": "passed",
+        "command": "cd backend && composer install --no-interaction --no-progress",
+        "evidence": "Installed dependencies in isolated worktree only; ignored vendor/public/cache artifacts were not staged."
+      },
+      "focused_test": {
+        "status": "passed",
+        "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesPublishReadiness01 --no-ansi",
+        "evidence": "1 test passed, 17 assertions."
+      },
+      "route_list": {
+        "status": "passed",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "203 routes listed."
+      },
+      "pint": {
+        "status": "passed",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "3583 files passed."
+      },
+      "composer_validate": {
+        "status": "passed",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "passed",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "passed",
+        "evidence": "Generated JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+      },
+      "scope_validation": {
+        "status": "passed",
+        "changed_files": [
+          "backend/docs/seo/global-en-zh-content-pages-publish-readiness-01.md",
+          "backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json",
+          "backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPublishReadiness01Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "diff_check": {
+        "status": "passed",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "fap_web_reference_check": {
+        "status": "passed_with_preexisting_untracked_files",
+        "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+        "evidence": "Observed pre-existing untracked .playwright-mcp/ and article-image-smoke.png; no fap-web changes were made or committed by this task."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T08:50:00+08:00",
+        "status": "planned",
+        "summary": "Authorized current publish readiness task entry only; no publish, CMS mutation, deploy, Search Channel action, URL submission, or fap-web modification."
+      },
+      {
+        "at": "2026-05-27T08:50:00+08:00",
+        "status": "in_progress",
+        "summary": "Completed read-only CMS/content/runtime/discoverability/Search Channel readiness review; local validation pending."
+      },
+      {
+        "at": "2026-05-27T09:00:00+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, fap-web reference check, and scope validation passed."
+      },
+      {
+        "at": "2026-05-27T09:03:00+08:00",
+        "status": "pr_opened",
+        "summary": "Opened PR #1713 after local validation; waiting for GitHub required checks."
+      },
+      {
+        "at": "2026-05-27T09:11:46+08:00",
         "status": "github_checks_passed",
         "summary": "GitHub required checks passed and mergeStateStatus was CLEAN before final ledger update."
       }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -13959,6 +13959,50 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-IMPORT-VERIFY-01
+    branch: codex/global-en-zh-content-pages-publish-readiness-01
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01 publish readiness for Wave 1 English content pages"
+    train_scope: global_en_zh_controlled_cms_import
+    risk_level: p0_read_only_publish_readiness
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-publish-readiness-01.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPublishReadiness01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Review publish readiness for Wave 1 English content/help/policy draft pages.
+      - Verify CMS draft state, content quality, claim boundaries, legal/company/foundation review needs, runtime safety, discoverability gates, and Search Channel safety.
+      - Keep verification strictly read-only with no publish, CMS mutation, deploy, URL submission, Search Channel action, external search API call, production migration, raw log read, production user data access, or fap-web modification.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesPublishReadiness01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added read-only publish readiness review for Wave 1 English content pages: `brand`, `charter`, `foundation`, `careers`, `policies`.
- Added generated JSON, Markdown report, focused SeoIntel test, and the authorized current manifest/state entry.

## Why
The Wave 1 CMS draft import and import verification passed. This PR determines whether those drafts are ready for a future controlled publish without mutating CMS or opening any public/search gates.

## Readiness result
- CMS draft state is safe for all five pages: draft, non-public, non-indexable, `published_at=null`.
- Content quality basics pass: title, description, H1, body, SEO metadata, ZH counterpart, and translation group exist.
- Current runtime/discoverability gates remain closed: target pages return 404 and are absent from sitemap, llms, footer/nav, and Search Channel.
- Final decision: `content_pages_publish_readiness_completed_with_review_blockers`.

## Review blockers
- `foundation`: requires founder/legal review for Foundation Initiative/public-benefit/nonprofit-collaboration framing.
- `careers`: requires company fact review because current hiring/application authority was not verified.
- `policies`: requires legal review because refund/minor/complaint/high-risk-use policy language may create commitments and must not replace Terms/Privacy.
- `brand` and `charter`: publish-ready only after explicit founder/legal human approval.

## Intentionally deferred
- No publish, CMS mutation, deploy, Search Channel action, URL submission, external search API call, production migration, raw log read, production user data access, or fap-web modification.
- No future publish/deploy/Search Channel task entries were added.

## Validation
- `cd backend && composer install --no-interaction --no-progress`
- `cd backend && php artisan test --filter=GlobalEnZhContentPagesPublishReadiness01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse
- `git diff --check && git diff --cached --check`
- fap-web reference check observed pre-existing untracked `.playwright-mcp/` and `article-image-smoke.png`; no fap-web changes were made or committed
