### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01 revise Wave 1 English content page drafts

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "global-en-zh-content-pages-human-revision-01.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01",
+  "final_decision": "content_pages_human_revision_completed_ready_for_cms_draft_update",
+  "target_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "per_page_revision_status": [
+    {
+      "page_key": "brand",
+      "original_status_from_publish_readiness": "publish_ready_with_human_approval",
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "remaining_review_requirements": [
+        "founder_review",
+        "brand_owner_review"
+      ]
+    },
+    {
+      "page_key": "charter",
+      "original_status_from_publish_readiness": "publish_ready_with_human_approval",
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ]
+    },
+    {
+      "page_key": "foundation",
+      "original_status_from_publish_readiness": "blocked_legal_fact_review",
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ]
+    },
+    {
+      "page_key": "careers",
+      "original_status_from_publish_readiness": "blocked_company_fact_review",
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "remaining_review_requirements": [
+        "founder_review",
+        "company_fact_review"
+      ]
+    },
+    {
+      "page_key": "policies",
+      "original_status_from_publish_readiness": "blocked_legal_fact_review",
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ]
+    }
+  ],
+  "revised_pages": [
+    {
+      "page_key": "brand",
+      "revised_title_en": "Brand and Usage Guidelines",
+      "revised_description_en": "A practical guide for referring to FermatMind accurately, using public brand references responsibly, and avoiding misleading endorsement or affiliation claims.",
+      "revised_h1_en": "Brand and Usage Guidelines",
+      "body_block_count": 6,
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval"
+    },
+    {
+      "page_key": "charter",
+      "revised_title_en": "FermatMind Editorial Charter",
+      "revised_description_en": "A plain-language statement of FermatMind editorial principles for assessment content, interpretation boundaries, privacy-aware wording, and responsible use.",
+      "revised_h1_en": "FermatMind Editorial Charter",
+      "body_block_count": 6,
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval"
+    },
+    {
+      "page_key": "foundation",
+      "revised_title_en": "Public-Benefit Direction",
+      "revised_description_en": "FermatMind’s public-benefit direction describes educational and research-oriented aspirations around assessment literacy, career exploration, and responsible self-understanding tools.",
+      "revised_h1_en": "Public-Benefit Direction",
+      "body_block_count": 6,
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval"
+    },
+    {
+      "page_key": "careers",
+      "revised_title_en": "Work With FermatMind",
+      "revised_description_en": "A cautious overview of the kinds of work FermatMind may need over time, without announcing current openings, hiring timelines, employment terms, or an active recruiting process.",
+      "revised_h1_en": "Work With FermatMind",
+      "body_block_count": 5,
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval"
+    },
+    {
+      "page_key": "policies",
+      "revised_title_en": "Policy Overview",
+      "revised_description_en": "A navigation-oriented overview that helps users find FermatMind policy information without replacing the Terms, Privacy Policy, order pages, or product notices.",
+      "revised_h1_en": "Policy Overview",
+      "body_block_count": 6,
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval"
+    }
+  ],
+  "remaining_blockers": [],
+  "remaining_review_requirements": {
+    "brand": [
+      "founder_review",
+      "brand_owner_review"
+    ],
+    "charter": [
+      "founder_review",
+      "legal_review"
+    ],
+    "foundation": [
+      "founder_review",
+      "legal_review"
+    ],
+    "careers": [
+      "founder_review",
+      "company_fact_review"
+    ],
+    "policies": [
+      "founder_review",
+      "legal_review"
+    ]
+  },
+  "claim_boundary_check": {
+    "blocking_claim_boundary_issue": false,
+    "notes": [
+      "Revised copy avoids diagnosis, treatment, cure, salary guarantee, career success guarantee, hiring fit, precise career recommendation, MBTI income/turnover prediction, and unsupported privacy/security/legal commitments.",
+      "High-risk use statements remain boundary statements and do not activate new procedures or legal commitments."
+    ]
+  },
+  "legal_company_fact_check": {
+    "blocking_legal_company_fact_risk_after_revision": false,
+    "notes": [
+      "Foundation copy now states it is not a separate legal foundation, nonprofit, donation program, grant program, board, or legal entity claim.",
+      "Careers copy now states it does not announce current openings, hiring, employment terms, or an active recruiting process.",
+      "Policies copy now states it is a policy overview and does not replace Terms, Privacy Policy, order terms, product notices, or specific agreements."
+    ]
+  },
+  "cms_update_required": true,
+  "future_cms_draft_update_required": true,
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_sitemap_llms_exposure": true,
+  "no_footer_nav_exposure": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01",
+  "generated_at": "2026-05-27T09:33:37+08:00"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-human-revision-01.md
+++ b/backend/docs/seo/global-en-zh-content-pages-human-revision-01.md
@@ -1,0 +1,89 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01 Report
+
+## 1. Executive Summary
+Created a human revision package for the five Wave 1 English content/help/policy pages: `brand`, `charter`, `foundation`, `careers`, and `policies`. The package revises risky company/legal/foundation/careers/policies wording into bounded draft copy for a later controlled CMS draft update.
+
+No CMS mutation, publish, deploy, Search Channel action, URL submission, sitemap/llms/footer exposure, production migration, raw log read, production user data access, or fap-web modification was performed.
+
+Final decision: `content_pages_human_revision_completed_ready_for_cms_draft_update`.
+
+## 2. Target Pages
+- `brand`
+- `charter`
+- `foundation`
+- `careers`
+- `policies`
+
+## 3. Revisions by Page
+
+| Page | Previous readiness | Recommended after revision | Remaining review |
+| --- | --- | --- | --- |
+| `brand` | `publish_ready_with_human_approval` | `publish_ready_with_human_approval` | founder_review, brand_owner_review |
+| `charter` | `publish_ready_with_human_approval` | `publish_ready_with_human_approval` | founder_review, legal_review |
+| `foundation` | `blocked_legal_fact_review` | `publish_ready_with_human_approval` | founder_review, legal_review |
+| `careers` | `blocked_company_fact_review` | `publish_ready_with_human_approval` | founder_review, company_fact_review |
+| `policies` | `blocked_legal_fact_review` | `publish_ready_with_human_approval` | founder_review, legal_review |
+
+### `brand`
+Kept the page as factual brand and usage guidance. The revised copy avoids implying certification, partnership, market status, awards, or third-party endorsement.
+
+### `charter`
+Renamed the page to an editorial charter and explicitly states it is not a legal governance document, board-approved constitution, fiduciary commitment, or Terms/Privacy substitute.
+
+### `foundation`
+Reframed the page as `Public-Benefit Direction` and explicitly states it is not a separate registered foundation, nonprofit, donation program, grant program, board, or legal entity claim.
+
+### `careers`
+Reframed the page as `Work With FermatMind` and explicitly states it does not announce current job openings, guarantee hiring, describe employment terms, or create a recruiting process.
+
+### `policies`
+Reframed the page as `Policy Overview` and explicitly states it is a navigation aid that does not replace Terms, Privacy Policy, order terms, product notices, or specific agreements.
+
+## 4. Claims Removed or Softened
+- `brand`: Softened broad intellectual-property enforcement language into correction/removal language.
+- `brand`: Avoided statements that could imply existing partner, certification, or authorization programs.
+- `charter`: Softened “commitment” language into editorial/product principles.
+- `charter`: Removed phrasing that could imply binding institutional governance.
+- `charter`: Removed potentially flagged cure/treatment wording.
+- `foundation`: Removed implication of registered foundation or nonprofit status.
+- `foundation`: Removed donation handling, grant, board, and legal public-benefit implications.
+- `foundation`: Softened active program language into possible future collaboration themes.
+- `careers`: Removed currently hiring implication.
+- `careers`: Removed open applications and official recruiting channel instruction.
+- `careers`: Removed statements that could imply employment terms, timelines, or role availability.
+- `policies`: Removed refund/cancellation rule details.
+- `policies`: Removed complaint response/correction/deletion procedure promises.
+- `policies`: Removed standalone minors policy language.
+- `policies`: Removed privacy/security commitments beyond references to published authorities.
+
+## 5. Remaining Review Requirements
+All five pages remain `human_review_required=true`. Remaining reviews are founder/brand/legal/company fact approval before any later publish readiness R2 or controlled publish.
+
+No remaining blocker is recorded for a controlled CMS draft update because the package is draft-only and designed to update the existing non-public CMS drafts for another readiness pass.
+
+## 6. CMS Draft Update Requirement
+`cms_update_required=true` and `future_cms_draft_update_required=true` for all five pages. The next task must update the existing draft CMS records only, keep them unpublished/non-indexable, and then run publish readiness R2.
+
+## 7. Sitemap / llms / Footer Safety
+The revision package keeps all items `sitemap_eligible=false`, `llms_eligible=false`, `footer_eligible=false`, and `search_channel_eligible=false`. It does not expose pages in runtime, sitemap, llms, footer, nav, or Search Channel.
+
+## 8. Validation
+Pending.
+
+## 9. PR / Merge Result
+Pending.
+
+## 10. Sidecar Issues
+Inherited sidecars remain out of scope:
+- `support` still needs authority before import/revision.
+- `privacy` and `terms` require a separate legal-policy scope.
+- Existing published English records require a separate update scope if their content should be revised.
+
+## 11. What Was Not Done
+No CMS update, CMS publish, production deployment, Search Channel action, URL submission, external search API call, sitemap/llms/footer/nav exposure, production migration, raw log read, production user data access, or fap-web modification was performed.
+
+## 12. Final Decision
+`content_pages_human_revision_completed_ready_for_cms_draft_update`
+
+## 13. Next Task
+`GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01`

--- a/backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json
+++ b/backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json
@@ -1,0 +1,288 @@
+{
+  "schema_version": "global-en-zh-content-pages-human-revision-01.revision.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01",
+  "generated_at": "2026-05-27T09:33:37+08:00",
+  "package_type": "human_revision_package",
+  "source_publish_readiness_pr": "https://github.com/fermatmind/fap-api/pull/1713",
+  "source_publish_readiness_merge_commit": "b820f2b74e26c09961a159e9d8fcc56830908d46",
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "runtime_exposure_allowed": false,
+  "human_review_required": true,
+  "items": [
+    {
+      "page_key": "brand",
+      "original_status_from_publish_readiness": "publish_ready_with_human_approval",
+      "revised_title_en": "Brand and Usage Guidelines",
+      "revised_description_en": "A practical guide for referring to FermatMind accurately, using public brand references responsibly, and avoiding misleading endorsement or affiliation claims.",
+      "revised_h1_en": "Brand and Usage Guidelines",
+      "revised_body_blocks_en": [
+        {
+          "heading": "Purpose of these guidelines",
+          "markdown": "These guidelines explain how to refer to FermatMind in a clear and non-misleading way. They are intended to protect users from confusion about official identity, source attribution, and endorsement. They do not create a certification program, partnership status, or permission to use FermatMind materials beyond the scope stated here."
+        },
+        {
+          "heading": "Name and identity",
+          "markdown": "Use “FermatMind” for the English product name. The Chinese name “费马测试” may be shown when a bilingual reference is needed. Do not create unofficial abbreviations, authorization labels, certification titles, partner badges, or account names that could be confused with FermatMind official channels."
+        },
+        {
+          "heading": "Accurate references and quotation",
+          "markdown": "Public discussion, commentary, and limited quotation should preserve the original meaning, include source attribution where appropriate, and keep important boundary statements intact. Do not present an excerpt as FermatMind endorsement of a person, organization, course, product, or viewpoint."
+        },
+        {
+          "heading": "Visual and product references",
+          "markdown": "Screenshots, logos, wordmarks, and product visuals should be used only in ways that are accurate, restrained, and not likely to imply official cooperation. Do not alter visual assets or combine them with another mark in a way that suggests sponsorship, certification, or partnership."
+        },
+        {
+          "heading": "Permission-sensitive uses",
+          "markdown": "Commercial promotion, co-branded pages, courses, events, large-scale republication, translated redistribution, white-label use, or asset-pack use may require written permission through official channels. This page does not approve any third-party use by default."
+        },
+        {
+          "heading": "Misleading use",
+          "markdown": "Do not use FermatMind names, content, or visuals to impersonate official services, sell unauthorized copies, imply a verified relationship, or remove attribution. FermatMind may ask for correction or removal when public confusion or rights issues arise."
+        }
+      ],
+      "risk_reductions": [
+        "Removed stronger legal-enforcement framing from the default text.",
+        "Kept brand rules factual and avoided certification, award, market-position, or endorsement claims.",
+        "Clarified that permission-sensitive uses are not approved by default."
+      ],
+      "removed_or_softened_claims": [
+        "Softened broad intellectual-property enforcement language into correction/removal language.",
+        "Avoided statements that could imply existing partner, certification, or authorization programs."
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "brand_owner_review"
+      ],
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "publish_state": "draft_revision_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    },
+    {
+      "page_key": "charter",
+      "original_status_from_publish_readiness": "publish_ready_with_human_approval",
+      "revised_title_en": "FermatMind Editorial Charter",
+      "revised_description_en": "A plain-language statement of FermatMind editorial principles for assessment content, interpretation boundaries, privacy-aware wording, and responsible use.",
+      "revised_h1_en": "FermatMind Editorial Charter",
+      "revised_body_blocks_en": [
+        {
+          "heading": "What this charter is",
+          "markdown": "This charter describes editorial and product principles used when FermatMind explains assessment results and related content. It is not a legal governance document, board-approved constitution, fiduciary commitment, or substitute for the Terms or Privacy Policy."
+        },
+        {
+          "heading": "Help people understand themselves, not define them",
+          "markdown": "Assessment results should be treated as structured signals, not permanent identity labels. FermatMind writing should help users observe preferences, workstyle tendencies, stress patterns, and growth needs while leaving room for context, change, and personal judgment."
+        },
+        {
+          "heading": "Use evidence-aware and bounded language",
+          "markdown": "FermatMind should avoid mystical, fatalistic, or absolute language. Content should explain what a model is intended to describe, what it cannot describe, and where caution is needed. Results should not promise life outcomes, salary outcomes, diagnosis, treatment, or hiring suitability."
+        },
+        {
+          "heading": "Make interpretation useful without overclaiming",
+          "markdown": "Good interpretation gives users practical language for reflection, communication, and planning. It should not pressure users into a single career, relationship, or life decision. Where content offers suggestions, those suggestions should be framed as exploratory guidance or decision support."
+        },
+        {
+          "heading": "Respect uncertainty, privacy, and psychological safety",
+          "markdown": "People change, measurement has limits, and sensitive self-knowledge can be misread. FermatMind content should avoid shaming, alarming, or overly deterministic statements. Privacy-related statements should remain consistent with the published Privacy Policy and product notices."
+        },
+        {
+          "heading": "Avoid high-risk misuse",
+          "markdown": "FermatMind does not support using assessment results as the sole basis for hiring, admission, compensation, discipline, lending, insurance, medical, or other high-risk decisions. Organizational or research use requires clear purpose, consent, human review, and separate agreements where applicable."
+        }
+      ],
+      "risk_reductions": [
+        "Renamed page to Editorial Charter to reduce formal governance implication.",
+        "Explicitly states the page is not a legal governance document or substitute for Terms/Privacy.",
+        "Removed treatment/cure wording and uses non-diagnostic, non-deterministic framing."
+      ],
+      "removed_or_softened_claims": [
+        "Softened “commitment” language into editorial/product principles.",
+        "Removed phrasing that could imply binding institutional governance.",
+        "Removed potentially flagged cure/treatment wording."
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ],
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "publish_state": "draft_revision_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    },
+    {
+      "page_key": "foundation",
+      "original_status_from_publish_readiness": "blocked_legal_fact_review",
+      "revised_title_en": "Public-Benefit Direction",
+      "revised_description_en": "FermatMind’s public-benefit direction describes educational and research-oriented aspirations around assessment literacy, career exploration, and responsible self-understanding tools.",
+      "revised_h1_en": "Public-Benefit Direction",
+      "revised_body_blocks_en": [
+        {
+          "heading": "A direction, not a separate legal foundation",
+          "markdown": "This page describes a public-benefit direction for FermatMind. It does not state that a separate registered foundation, nonprofit organization, donation program, grant program, board, or public-benefit legal entity currently exists. Any future formal program would need separate governance, legal review, and public documentation."
+        },
+        {
+          "heading": "Why this direction matters",
+          "markdown": "Assessment literacy and career exploration should be easier to understand and use responsibly. Many students, early-career users, and career changers need clear explanations of models, boundaries, uncertainty, and practical next steps rather than deterministic labels or motivational slogans."
+        },
+        {
+          "heading": "Areas we may support over time",
+          "markdown": "FermatMind may create educational resources about self-understanding, career exploration, assessment boundaries, and responsible tool use. These resources should remain practical, source-aware, and clear about what they can and cannot do. They should not be presented as diagnosis, treatment, career guarantees, or institutional endorsement."
+        },
+        {
+          "heading": "Possible collaboration themes",
+          "markdown": "Future collaborations may focus on education, assessment literacy, youth career exploration, or responsible research discussion when purpose, boundaries, consent, and data handling are clear. This page does not announce an active donation, grant, nonprofit, school partnership, or research program."
+        },
+        {
+          "heading": "Data and participant boundaries",
+          "markdown": "Public-interest intent does not reduce the need for privacy and consent. Any project involving personal data, assessment answers, minors, research use, or public display would require separate authorization, purpose limitation, and review before it begins."
+        },
+        {
+          "heading": "Long-term aspiration",
+          "markdown": "The long-term aspiration is to make responsible self-understanding and career exploration resources more accessible. This remains an aspiration unless and until a specific program is formally announced through official materials."
+        }
+      ],
+      "risk_reductions": [
+        "Removed “Foundation Initiative” as a formal-sounding title.",
+        "Added explicit non-entity/nonprofit/non-donation/non-grant disclaimer.",
+        "Changed public-benefit language from commitment to aspiration/direction.",
+        "Removed implied active collaborations with schools, nonprofits, and researchers."
+      ],
+      "removed_or_softened_claims": [
+        "Removed implication of registered foundation or nonprofit status.",
+        "Removed donation handling, grant, board, and legal public-benefit implications.",
+        "Softened active program language into possible future collaboration themes."
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ],
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "publish_state": "draft_revision_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    },
+    {
+      "page_key": "careers",
+      "original_status_from_publish_readiness": "blocked_company_fact_review",
+      "revised_title_en": "Work With FermatMind",
+      "revised_description_en": "A cautious overview of the kinds of work FermatMind may need over time, without announcing current openings, hiring timelines, employment terms, or an active recruiting process.",
+      "revised_h1_en": "Work With FermatMind",
+      "revised_body_blocks_en": [
+        {
+          "heading": "About this page",
+          "markdown": "This page describes the kinds of work FermatMind may need as the product develops. It does not announce current job openings, guarantee hiring, describe employment terms, or create a recruiting process. Official opportunities, if available, should be confirmed only through current official channels."
+        },
+        {
+          "heading": "The work we care about",
+          "markdown": "FermatMind works on assessment interpretation, career exploration, product systems, content quality, and user-facing decision support. The work requires careful language, product judgment, engineering reliability, privacy awareness, and respect for the limits of assessment tools."
+        },
+        {
+          "heading": "Possible collaboration areas",
+          "markdown": "Depending on future needs, relevant areas may include research and methodology, content and editing, product design, user research, frontend and backend engineering, data analysis, quality assurance, operations, and responsible growth. This list is descriptive and does not mean any role is currently open."
+        },
+        {
+          "heading": "What we value in collaborators",
+          "markdown": "We value clarity, careful reasoning, respect for human complexity, strong execution, and willingness to revise work when evidence changes. We also value sensitivity to privacy, psychological safety, and high-risk settings where assessment results can be misused."
+        },
+        {
+          "heading": "Future contact and official channels",
+          "markdown": "If FermatMind opens formal roles or collaboration channels, the relevant information should appear through official public channels. Until then, this page should be read as a directional overview, not as an invitation, job advertisement, hiring promise, or application instruction."
+        }
+      ],
+      "risk_reductions": [
+        "Removed “we are looking for people” and open-application language.",
+        "Added explicit no-current-opening/no-hiring/no-process disclaimer.",
+        "Reframed role lists as future possible collaboration areas, not available jobs.",
+        "Removed application-material instructions and hiring-process details."
+      ],
+      "removed_or_softened_claims": [
+        "Removed currently hiring implication.",
+        "Removed open applications and official recruiting channel instruction.",
+        "Removed statements that could imply employment terms, timelines, or role availability."
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "company_fact_review"
+      ],
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "publish_state": "draft_revision_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    },
+    {
+      "page_key": "policies",
+      "original_status_from_publish_readiness": "blocked_legal_fact_review",
+      "revised_title_en": "Policy Overview",
+      "revised_description_en": "A navigation-oriented overview that helps users find FermatMind policy information without replacing the Terms, Privacy Policy, order pages, or product notices.",
+      "revised_h1_en": "Policy Overview",
+      "revised_body_blocks_en": [
+        {
+          "heading": "How to use this page",
+          "markdown": "This page is a policy overview and navigation aid. It does not replace the Terms, Privacy Policy, order page terms, product notices, or any specific agreement. If a dedicated legal or product page applies to a topic, that page should be treated as the controlling source."
+        },
+        {
+          "heading": "Core policy sources",
+          "markdown": "For account, service, payment, privacy, data, and product-use questions, users should refer to the published Terms, Privacy Policy, order pages, product descriptions, and in-product notices. This overview should not be used to create new refund rules, data-retention rules, security commitments, dispute procedures, or compliance claims."
+        },
+        {
+          "heading": "Responsible use boundaries",
+          "markdown": "FermatMind assessment and content surfaces are intended for self-understanding, career exploration, and decision support. They should not be used as the sole basis for diagnosis, treatment, hiring, admission, compensation, lending, insurance, or other high-risk decisions."
+        },
+        {
+          "heading": "Organizational or research use",
+          "markdown": "Enterprise, school, nonprofit, consulting, or research use may require separate review and agreements depending on purpose, participants, data scope, consent, and risk. This overview does not approve organizational access to individual results or data by default."
+        },
+        {
+          "heading": "Minors and sensitive contexts",
+          "markdown": "When minors or sensitive contexts are involved, users should follow the published Privacy Policy, Terms, product notices, and applicable law. This overview does not create a standalone minors policy or additional legal procedure."
+        },
+        {
+          "heading": "Updates and conflicts",
+          "markdown": "Policy information may change as products and requirements evolve. If this overview conflicts with published Terms, Privacy Policy, order terms, product notices, or a signed agreement, the more specific authority should control unless law requires otherwise."
+        }
+      ],
+      "risk_reductions": [
+        "Converted detailed legal-policy text into a navigation-oriented overview.",
+        "Removed operational refund, complaint, deletion, retention, and minors commitments.",
+        "Explicitly states this page does not replace Terms/Privacy or create new legal obligations.",
+        "Kept high-risk use boundaries without activating new procedures."
+      ],
+      "removed_or_softened_claims": [
+        "Removed refund/cancellation rule details.",
+        "Removed complaint response/correction/deletion procedure promises.",
+        "Removed standalone minors policy language.",
+        "Removed privacy/security commitments beyond references to published authorities."
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ],
+      "recommended_publish_readiness_after_revision": "publish_ready_with_human_approval",
+      "human_review_required": true,
+      "cms_update_required": true,
+      "publish_state": "draft_revision_only",
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    }
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevision01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevision01Test.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesHumanRevision01Test extends TestCase
+{
+    #[Test]
+    public function content_page_human_revision_artifacts_exist_with_closed_gates(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json');
+        $revisionPackagePath = base_path('docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-human-revision-01.md'));
+        $this->assertFileExists($generatedPath);
+        $this->assertFileExists($revisionPackagePath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+        $revisionPackage = json_decode((string) file_get_contents($revisionPackagePath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('global-en-zh-content-pages-human-revision-01.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01', $generated['task'] ?? null);
+        $this->assertSame('global-en-zh-content-pages-human-revision-01.revision.v1', $revisionPackage['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01', $revisionPackage['task'] ?? null);
+
+        $targetPages = $generated['target_pages'] ?? [];
+        sort($targetPages);
+
+        $this->assertSame([
+            'brand',
+            'careers',
+            'charter',
+            'foundation',
+            'policies',
+        ], $targetPages);
+
+        $this->assertIsArray($generated['per_page_revision_status'] ?? null);
+        $this->assertCount(5, $generated['per_page_revision_status']);
+        $this->assertIsArray($revisionPackage['items'] ?? null);
+        $this->assertCount(5, $revisionPackage['items']);
+
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_sitemap_llms_exposure'] ?? false);
+        $this->assertTrue($generated['no_footer_nav_exposure'] ?? false);
+        $this->assertTrue($generated['future_cms_draft_update_required'] ?? false);
+        $this->assertNotEmpty($generated['final_decision'] ?? null);
+        $this->assertNotEmpty($generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T09:11:46+08:00",
+  "updated_at": "2026-05-27T09:46:10+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -27916,6 +27916,128 @@
       },
       {
         "at": "2026-05-27T09:11:46+08:00",
+        "status": "github_checks_passed",
+        "summary": "GitHub required checks passed and mergeStateStatus was CLEAN before final ledger update."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01": {
+    "status": "github_checks_passed",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-human-revision-01",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01 revise Wave 1 English content page drafts",
+    "commit_sha": "12c9e34db8e720d66276684e4270cacd7a06a276",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1714",
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "preflight": {
+        "status": "passed",
+        "evidence": "Started from origin/main at b820f2b74e26c09961a159e9d8fcc56830908d46 in isolated worktree; dependency PR #1713 merged."
+      },
+      "revision_package": {
+        "status": "passed",
+        "evidence": "Created draft-only human revision package for brand, charter, foundation, careers, and policies."
+      },
+      "claim_boundary": {
+        "status": "passed",
+        "evidence": "Revised copy avoids forbidden diagnosis, treatment, cure, salary guarantee, career guarantee, hiring fit, precise career recommendation, MBTI income/turnover prediction, and unsupported legal/privacy/security claims."
+      },
+      "legal_company_fact_review": {
+        "status": "passed_for_draft_update",
+        "evidence": "Foundation, careers, and policies blockers were converted into bounded draft copy; human review remains required before publish."
+      },
+      "local_validation": {
+        "status": "passed"
+      },
+      "github_required_checks": {
+        "status": "passed",
+        "evidence": "PR #1714 required GitHub checks passed and mergeStateStatus was CLEAN for commit 12c9e34db8e720d66276684e4270cacd7a06a276."
+      },
+      "composer_install": {
+        "status": "passed",
+        "command": "cd backend && composer install --no-interaction --no-progress",
+        "evidence": "Installed dependencies in isolated worktree only; ignored vendor/public/cache artifacts were not staged."
+      },
+      "focused_test": {
+        "status": "passed",
+        "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevision01 --no-ansi",
+        "evidence": "1 test passed, 22 assertions."
+      },
+      "route_list": {
+        "status": "passed",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "203 routes listed."
+      },
+      "pint": {
+        "status": "passed",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "3584 files passed."
+      },
+      "composer_validate": {
+        "status": "passed",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "passed",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "passed",
+        "evidence": "Generated JSON, revision package JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+      },
+      "scope_validation": {
+        "status": "passed",
+        "changed_files": [
+          "backend/docs/seo/global-en-zh-content-pages-human-revision-01.md",
+          "backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json",
+          "backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json",
+          "backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevision01Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "diff_check": {
+        "status": "passed",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "fap_web_reference_check": {
+        "status": "passed_with_preexisting_untracked_files",
+        "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+        "evidence": "Observed pre-existing untracked .playwright-mcp/ and article-image-smoke.png; no fap-web changes were made or committed by this task."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T09:33:37+08:00",
+        "status": "planned",
+        "summary": "Authorized current human revision task entry only; no CMS mutation, publish, deploy, Search Channel action, URL submission, or fap-web modification."
+      },
+      {
+        "at": "2026-05-27T09:33:37+08:00",
+        "status": "in_progress",
+        "summary": "Generated draft-only human revision package; local validation pending."
+      },
+      {
+        "at": "2026-05-27T09:38:01+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, fap-web reference check, and scope validation passed."
+      },
+      {
+        "at": "2026-05-27T09:39:09+08:00",
+        "status": "pr_opened",
+        "summary": "Opened PR #1714 after local validation; waiting for GitHub required checks."
+      },
+      {
+        "at": "2026-05-27T09:46:10+08:00",
         "status": "github_checks_passed",
         "summary": "GitHub required checks passed and mergeStateStatus was CLEAN before final ledger update."
       }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14003,6 +14003,52 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-01
+    branch: codex/global-en-zh-content-pages-human-revision-01
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01 revise Wave 1 English content page drafts"
+    train_scope: global_en_zh_controlled_cms_import
+    risk_level: p0_draft_revision_package_only
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-human-revision-01.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json
+      - backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevision01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Create a human revision package for Wave 1 English content/help/policy draft pages.
+      - Revise brand, charter, foundation, careers, and policies copy to remove or soften unsupported company, legal, foundation, hiring, privacy, security, and policy claims.
+      - Keep all generated content draft-only for a later controlled CMS draft update; do not publish, mutate production CMS, deploy, expose in sitemap/llms/footer/nav, submit URLs, trigger Search Channel, access production user data, or modify fap-web.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevision01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added a human revision package for Wave 1 English content/help/policy pages: `brand`, `charter`, `foundation`, `careers`, and `policies`.
- Added generated readiness summary JSON and Markdown report for the revision package.
- Added a focused artifact test for the revision package and closed-gate flags.
- Added the authorized current task entry to `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json`.

## Why
Publish readiness PR #1713 found `foundation`, `careers`, and `policies` blocked by legal/company/foundation fact review, while `brand` and `charter` still required human approval. This PR creates safer draft copy for a later controlled CMS draft update without publishing or mutating CMS.

## Revision result
- `brand`: remains factual brand usage guidance; avoids certification, endorsement, partnership, award, or market-position claims.
- `charter`: reframed as an editorial charter, not a binding legal governance document.
- `foundation`: reframed as public-benefit direction, explicitly not a separate foundation/nonprofit/donation/grant/board/legal-entity claim.
- `careers`: reframed as future collaboration direction, explicitly not current openings, hiring, employment terms, or recruiting process.
- `policies`: reframed as policy overview/navigation, explicitly not a Terms/Privacy/order/product-notice replacement.

## Validation
- `cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevision01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check && git diff --cached --check`
- `git -C /Users/rainie/Desktop/GitHub/fap-web status --short` observed pre-existing untracked `.playwright-mcp/` and `article-image-smoke.png`; no fap-web changes were made.

## Intentionally deferred
- No CMS draft update, publish, deploy, Search Channel action, URL submission, sitemap/llms/footer/nav exposure, production migration, raw log read, production user data access, or fap-web modification.
- Human/founder/legal/company fact review remains required before any later publish decision.
- Next task: `GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01`.
