### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE reconcile foundation governance facts

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01a-foundation-governance.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01a-foundation-governance.v1.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "global-en-zh-content-pages-human-revision-01a-foundation-governance.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE",
+  "final_decision": "foundation_governance_fact_reconciled_with_legal_review_required",
+  "foundation_fact_state": "planned_public_benefit_shareholding",
+  "evidence_summary": {
+    "primary_deck": "/Users/rainie/Desktop/费马测试20260524_增加股权结构页.pptx",
+    "supporting_decks": [
+      "/Users/rainie/Desktop/费马资料文件/创业大赛/费马测试.pptx",
+      "/Users/rainie/Desktop/费马资料文件/创业大赛/费马测试——信息文件/费马测试.pptx"
+    ],
+    "repo_artifacts_reviewed": [
+      "backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json",
+      "backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json",
+      "backend/docs/seo/global-en-zh-content-pages-human-revision-01.md",
+      "backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json",
+      "backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json"
+    ],
+    "evidence_supports": [
+      "public benefit as a brand trust mechanism",
+      "youth-first governance principles",
+      "clear data-boundary principles",
+      "social responsibility written into governance",
+      "public-benefit mission vehicle / foundation shareholding plan"
+    ],
+    "evidence_does_not_prove": [
+      "registered foundation",
+      "nonprofit legal status",
+      "charity registration",
+      "completed equity transfer",
+      "exact ownership percentage",
+      "formal board governance",
+      "donation program",
+      "grant program"
+    ]
+  },
+  "pages_reconciled": [
+    "foundation",
+    "charter",
+    "policies",
+    "brand"
+  ],
+  "revised_foundation_guidance": {
+    "recommended_title_en": "Public-Benefit Mission and Governance",
+    "recommended_h1_en": "Public-Benefit Mission and Governance",
+    "fact_state": "planned_public_benefit_shareholding",
+    "core_language": "planned public-benefit shareholding arrangement",
+    "guidance": "Preserve public-benefit shareholding and governance as a core trust mechanism, but do not claim charitable registration, nonprofit legal status, donation handling, grant activity, board governance, exact ownership terms, or completed equity transfer unless formal documents prove them."
+  },
+  "revised_charter_guidance": {
+    "guidance": "Tie editorial, data, and claim boundaries to the public-benefit governance design while preserving the statement that the charter is not a legal charter, board charter, fiduciary commitment, or Terms/Privacy substitute unless formal documents prove that status."
+  },
+  "revised_policies_guidance": {
+    "guidance": "Keep the page as a policy overview and mention that privacy, consent, and data-boundary choices align with public-benefit governance principles without creating new commitments beyond Terms, Privacy Policy, product notices, or signed agreements."
+  },
+  "revised_brand_guidance": {
+    "guidance": "Optionally connect brand trust to youth-first boundaries and public-benefit governance, while avoiding certification, partnership, charity, endorsement, or market-position claims."
+  },
+  "allowed_claims": [
+    "FermatMind is pursuing a public-benefit governance path.",
+    "Public-benefit governance is intended as a trust mechanism.",
+    "The governance direction prioritizes youth interests, clear data boundaries, and responsible use of assessment results.",
+    "A planned public-benefit shareholding arrangement may be described as a direction or path pending formal founder/legal confirmation.",
+    "The foundation page may state that donation and grant programs are not launched unless separately announced."
+  ],
+  "forbidden_claims": [
+    "registered foundation",
+    "nonprofit legal status",
+    "charity registration",
+    "donation program",
+    "grant program",
+    "formal board governance",
+    "legal fiduciary duty",
+    "exact ownership percentage",
+    "completed equity transfer",
+    "completed foundation holding",
+    "public fundraising eligibility",
+    "tax-deductible donation status"
+  ],
+  "remaining_founder_legal_review_required": true,
+  "cms_update_required": true,
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_sitemap_llms_exposure": true,
+  "no_footer_nav_exposure": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-human-revision-01a-foundation-governance.md
+++ b/backend/docs/seo/global-en-zh-content-pages-human-revision-01a-foundation-governance.md
@@ -1,0 +1,105 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE Report
+
+## 1. Executive Summary
+This addendum reconciles the Wave 1 English content-page revision package with the founder-provided public-benefit governance direction. It does not update CMS drafts, publish content, deploy code, expose pages in sitemap/llms/footer/nav, enqueue Search Channel items, or submit URLs.
+
+The prior revision package correctly removed unsupported claims of a registered foundation, nonprofit, donation program, grant program, board, or completed legal entity. However, the newer deck evidence supports a stronger public-benefit governance narrative than the phrase `Public-Benefit Direction` alone. The recommended foundation page direction is now `Public-Benefit Mission and Governance`, using a bounded phrase such as `planned public-benefit shareholding arrangement` until founder/legal documents confirm a completed structure.
+
+Final decision: `foundation_governance_fact_reconciled_with_legal_review_required`.
+
+## 2. Foundation / Shareholding Fact State
+Classification: `planned_public_benefit_shareholding`.
+
+Rationale:
+
+- The local deck `/Users/rainie/Desktop/费马测试20260524_增加股权结构页.pptx` contains the phrases `公益不是宣传，而是品牌信任机制`, `青年利益优先`, `数据边界清晰`, `社会责任写进治理`, and `公益使命载体 / 公益基金会持股计划`.
+- The same deck also discusses future financing and equity release, which supports a governance planning context.
+- No formal legal/equity document was found in the inspected repository artifacts or local deck evidence proving a completed equity transfer, registered foundation, charity registration, nonprofit status, legal fiduciary duty, formal board governance, exact ownership percentage, donation program, or grant program.
+
+## 3. Evidence Summary
+Evidence used:
+
+- `backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json`
+- `backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01.v1.json`
+- `backend/docs/seo/global-en-zh-content-pages-human-revision-01.md`
+- `backend/docs/seo/import-packages/global-en-zh-content-pages-translation-batch-01.import.v1.json`
+- `backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-01.v1.json`
+- `/Users/rainie/Desktop/费马测试20260524_增加股权结构页.pptx`
+- `/Users/rainie/Desktop/费马资料文件/创业大赛/费马测试.pptx`
+- `/Users/rainie/Desktop/费马资料文件/创业大赛/费马测试——信息文件/费马测试.pptx`
+
+The strongest direct evidence is the deck page that frames public benefit as a trust mechanism and names a foundation shareholding plan. The inspected evidence supports public-benefit governance intent and planning, not completed legal status.
+
+## 4. Revision Impact
+### foundation
+Rename the direction from `Public-Benefit Direction` to `Public-Benefit Mission and Governance`. The page should treat public-benefit shareholding/governance as a core trust mechanism, but should use `planned public-benefit shareholding arrangement` until legal/equity documents confirm implementation.
+
+The page should avoid saying `not a foundation` in a way that erases the intended foundation-holding direction. Instead, it should say that the page does not claim charitable registration, donation handling, grant activity, nonprofit legal status, board governance, exact ownership terms, or completed equity transfer unless those are supported by formal documents.
+
+### charter
+Tie editorial, data, and claim boundaries to the governance design. Keep the charter non-legal unless formal documents prove board-approved or fiduciary status.
+
+### policies
+Keep as a policy overview. Mention that privacy, consent, and data boundaries align with public-benefit governance principles, without creating new legal commitments beyond Terms, Privacy Policy, product notices, or signed agreements.
+
+### brand
+Optionally connect brand trust to youth-first boundaries and public-benefit governance, while avoiding certification, partnership, charity, or market-position claims.
+
+## 5. Allowed Claims
+- FermatMind is pursuing a public-benefit governance path.
+- Public-benefit governance is intended as a trust mechanism, not a marketing decoration.
+- The governance direction prioritizes youth interests, clear data boundaries, and responsible use of assessment results.
+- A planned public-benefit shareholding arrangement may be described as a direction or path, pending formal founder/legal confirmation.
+- The foundation page can say it does not handle donations or grants unless a separate formal program is launched.
+
+## 6. Forbidden Claims
+Do not claim any of the following unless a formal source document proves it:
+
+- registered foundation
+- nonprofit legal status
+- charity registration
+- donation program
+- grant program
+- formal board governance
+- legal fiduciary duty
+- exact ownership percentage
+- completed equity transfer
+- completed foundation holding
+- public fundraising eligibility
+- tax-deductible donation status
+
+## 7. Remaining Founder / Legal Review
+Founder/legal review remains required before publish. Review must confirm:
+
+- whether the public-benefit shareholding arrangement is planned, approved pending implementation, or already completed;
+- whether any foundation, public-benefit entity, trust, or holding vehicle exists legally;
+- whether any ownership percentage, transfer condition, or governance control can be stated publicly;
+- whether donation, grant, charity, or nonprofit language is permitted.
+
+## 8. CMS Draft Update Requirement
+CMS draft update is required because the prior foundation draft is now too weak on the public-benefit governance direction. The update should remain draft-only and non-public until founder/legal review completes.
+
+## 9. Validation
+Required validation for this addendum:
+
+- `php artisan test --filter=GlobalEnZhContentPagesHumanRevision01aFoundationGovernance --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- JSON parse for generated report and addendum package
+- YAML parse for `docs/codex/pr-train.yaml`
+- `git diff --check`
+- `git diff --cached --check`
+
+## 10. PR / Merge Result
+Pending.
+
+## 11. What Was Not Done
+No CMS update, publish, deploy, Search Channel action, URL submission, search-engine API call, env/DNS/nginx edit, production migration, production user data access, fap-web modification, sitemap/llms exposure, footer/nav exposure, donation setup, grant setup, or legal status claim was performed.
+
+## 12. Final Decision
+`foundation_governance_fact_reconciled_with_legal_review_required`
+
+## 13. Next Task
+`GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01`

--- a/backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json
+++ b/backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE",
+  "package_type": "revision_addendum_only",
+  "source_revision_package": "backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json",
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "runtime_exposure_allowed": false,
+  "items": [
+    {
+      "page_key": "foundation",
+      "revised_title_en": "Public-Benefit Mission and Governance",
+      "revised_description_en": "FermatMind's public-benefit mission and governance path describes youth-first assessment boundaries, clear data responsibilities, and a planned public-benefit shareholding arrangement without claiming completed legal status.",
+      "revised_h1_en": "Public-Benefit Mission and Governance",
+      "patch_blocks_en": [
+        {
+          "operation": "replace_page_direction",
+          "target": "Public-Benefit Direction",
+          "replacement": "Public-Benefit Mission and Governance"
+        },
+        {
+          "heading": "Public benefit as governance, not promotion",
+          "markdown": "FermatMind treats public-benefit work as part of long-term trust. The direction is youth-first: assessment results should not become permanent labels, hiring shortcuts, or deterministic judgments. Data boundaries should remain clear, consent-aware, and consistent with published privacy and product notices."
+        },
+        {
+          "heading": "Planned public-benefit shareholding arrangement",
+          "markdown": "FermatMind is pursuing a planned public-benefit shareholding arrangement as part of its governance path. Until formal founder and legal review confirms implementation details, this page should not claim a registered foundation, nonprofit legal status, charity registration, formal board governance, exact ownership percentage, completed equity transfer, donation program, or grant program."
+        },
+        {
+          "heading": "What this page does and does not claim",
+          "markdown": "This page may describe the public-benefit mission, youth-first boundaries, data-boundary principles, and governance direction. It does not claim charitable registration, donation handling, grant activity, public fundraising eligibility, tax-deductible donation status, legal fiduciary duty, or completed foundation holding unless those facts are supported by formal documents."
+        }
+      ],
+      "foundation_governance_language": "Use planned public-benefit shareholding arrangement until founder/legal documents confirm completed implementation. Do not erase the foundation/shareholding direction; bound it as a governance path.",
+      "fact_state": "planned_public_benefit_shareholding",
+      "evidence_needed_before_publish": [
+        "founder confirmation of exact public-benefit shareholding status",
+        "legal/equity document confirming whether any transfer or holding vehicle is completed",
+        "review of whether foundation, nonprofit, charity, donation, grant, board, or fiduciary wording is legally allowed",
+        "confirmation of whether ownership percentage or governance terms can be stated publicly"
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ],
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    },
+    {
+      "page_key": "charter",
+      "revised_title_en": "FermatMind Editorial Charter",
+      "revised_description_en": "A plain-language statement of FermatMind editorial principles for assessment content, interpretation boundaries, data-aware wording, and responsible use.",
+      "revised_h1_en": "FermatMind Editorial Charter",
+      "patch_blocks_en": [
+        {
+          "operation": "add_governance_alignment_note",
+          "markdown": "Editorial, data, and claim-boundary principles should align with FermatMind's public-benefit governance path, while the page remains non-legal and should not be described as a board charter or fiduciary commitment unless formal documents prove that status."
+        }
+      ],
+      "foundation_governance_language": "Connect assessment-boundary discipline to public-benefit governance principles without creating legal governance claims.",
+      "fact_state": "planned_public_benefit_shareholding",
+      "evidence_needed_before_publish": [
+        "founder/legal confirmation that governance alignment language is acceptable",
+        "confirmation that no legal charter or board-charter implication is introduced"
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ],
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    },
+    {
+      "page_key": "policies",
+      "revised_title_en": "Policy Overview",
+      "revised_description_en": "A navigation-oriented overview that helps users find FermatMind policy information without replacing Terms, Privacy Policy, order pages, or product notices.",
+      "revised_h1_en": "Policy Overview",
+      "patch_blocks_en": [
+        {
+          "operation": "add_governance_alignment_note",
+          "markdown": "Privacy, consent, and data-boundary choices may be described as aligned with FermatMind's public-benefit governance principles, but the page must not create new legal commitments beyond the Terms, Privacy Policy, product notices, order terms, or signed agreements."
+        }
+      ],
+      "foundation_governance_language": "Policies can reference governance principles only as alignment, not as new legal duties or completed public-benefit entity status.",
+      "fact_state": "planned_public_benefit_shareholding",
+      "evidence_needed_before_publish": [
+        "legal review that policy overview language does not create new commitments",
+        "confirmation that Terms/Privacy remain the controlling authorities"
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "legal_review"
+      ],
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    },
+    {
+      "page_key": "brand",
+      "revised_title_en": "Brand and Usage Guidelines",
+      "revised_description_en": "A practical guide for referring to FermatMind accurately, using public brand references responsibly, and avoiding misleading endorsement or affiliation claims.",
+      "revised_h1_en": "Brand and Usage Guidelines",
+      "patch_blocks_en": [
+        {
+          "operation": "optional_brand_trust_note",
+          "markdown": "Brand trust may be connected to youth-first boundaries, clear data boundaries, and public-benefit governance principles, without implying certification, partnership, charity status, third-party endorsement, or market leadership."
+        }
+      ],
+      "foundation_governance_language": "Brand language can acknowledge public-benefit governance as a trust principle while avoiding unsupported external status claims.",
+      "fact_state": "planned_public_benefit_shareholding",
+      "evidence_needed_before_publish": [
+        "founder/brand owner confirmation that public-benefit governance language belongs on brand guidance",
+        "legal check that no charity, partnership, endorsement, or certification implication is introduced"
+      ],
+      "remaining_review_requirements": [
+        "founder_review",
+        "brand_owner_review",
+        "legal_review_if_public_benefit_language_is_added"
+      ],
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "footer_eligible": false,
+      "search_channel_eligible": false
+    }
+  ],
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01"
+}

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevision01aFoundationGovernanceTest.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevision01aFoundationGovernanceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesHumanRevision01aFoundationGovernanceTest extends TestCase
+{
+    #[Test]
+    public function foundation_governance_addendum_exists_with_bounded_public_benefit_direction(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-human-revision-01a-foundation-governance.v1.json');
+        $addendumPath = base_path('docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-human-revision-01a-foundation-governance.md'));
+        $this->assertFileExists($generatedPath);
+        $this->assertFileExists($addendumPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+        $addendum = json_decode((string) file_get_contents($addendumPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE', $generated['task'] ?? null);
+        $this->assertNotEmpty($generated['foundation_fact_state'] ?? null);
+
+        $foundationGuidance = json_encode($generated['revised_foundation_guidance'] ?? [], JSON_THROW_ON_ERROR);
+        $this->assertStringContainsString('public-benefit', $foundationGuidance);
+        $this->assertStringContainsString('shareholding', $foundationGuidance);
+
+        $foundationItem = collect($addendum['items'] ?? [])->firstWhere('page_key', 'foundation');
+
+        $this->assertIsArray($foundationItem);
+        $this->assertSame('planned_public_benefit_shareholding', $foundationItem['fact_state'] ?? null);
+        $this->assertStringContainsString('public-benefit shareholding', $foundationItem['foundation_governance_language'] ?? '');
+        $this->assertFalse($foundationItem['sitemap_eligible'] ?? true);
+        $this->assertFalse($foundationItem['llms_eligible'] ?? true);
+        $this->assertFalse($foundationItem['footer_eligible'] ?? true);
+        $this->assertFalse($foundationItem['search_channel_eligible'] ?? true);
+
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertNotEmpty($generated['final_decision'] ?? null);
+        $this->assertNotEmpty($generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T10:23:33+08:00",
+  "updated_at": "2026-05-27T10:31:10+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28052,7 +28052,7 @@
       "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01"
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE reconcile foundation governance facts",
-    "commit_sha": "79402718e95bb4c360f9a72d6acf27440eb639ea",
+    "commit_sha": "a320b69289cf2175b5f25db52af978a4047a2a77",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -28146,6 +28146,11 @@
         "at": "2026-05-27T10:23:33+08:00",
         "status": "committed",
         "summary": "Committed scoped revision addendum artifacts for foundation governance fact reconciliation."
+      },
+      {
+        "at": "2026-05-27T10:31:10+08:00",
+        "status": "ledger_commit_sha_recorded",
+        "summary": "Recorded scoped artifact commit SHA before PR creation."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T09:46:10+08:00",
+  "updated_at": "2026-05-27T10:23:33+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28040,6 +28040,112 @@
         "at": "2026-05-27T09:46:10+08:00",
         "status": "github_checks_passed",
         "summary": "GitHub required checks passed and mergeStateStatus was CLEAN before final ledger update."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE": {
+    "status": "local_checks_passed",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-human-revision-01a-foundation-governance",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE reconcile foundation governance facts",
+    "commit_sha": "79402718e95bb4c360f9a72d6acf27440eb639ea",
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "preflight": {
+        "status": "passed",
+        "evidence": "Started from latest origin/main at 3255e661b659b8ea018a8b6d2cd85c3ba7090262 in isolated worktree; user authorized only current task manifest/state entry."
+      },
+      "evidence_review": {
+        "status": "passed",
+        "evidence": "Reviewed prior revision/readiness artifacts and local deck evidence. Classified foundation fact state as planned_public_benefit_shareholding because deck supports a foundation shareholding plan but no formal legal/equity completion document was available."
+      },
+      "scope_boundary": {
+        "status": "passed",
+        "evidence": "Revision addendum only; no CMS mutation, publish, deploy, Search Channel action, URL submission, sitemap/llms/footer/nav exposure, or fap-web modification."
+      },
+      "composer_install": {
+        "status": "passed",
+        "command": "cd backend && composer install --no-interaction --no-progress --prefer-dist",
+        "evidence": "Installed dependencies in isolated worktree only; ignored vendor/public/cache artifacts were not staged."
+      },
+      "focused_test": {
+        "status": "passed",
+        "command": "cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevision01aFoundationGovernance --no-ansi",
+        "evidence": "1 test passed, 21 assertions."
+      },
+      "route_list": {
+        "status": "passed",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "203 routes listed."
+      },
+      "pint": {
+        "status": "passed",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "3585 files passed."
+      },
+      "composer_validate": {
+        "status": "passed",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "passed",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "passed",
+        "evidence": "Generated JSON, addendum package JSON, pr-train-state.json, and pr-train.yaml parse successfully."
+      },
+      "scope_validation": {
+        "status": "passed",
+        "changed_files": [
+          "backend/docs/seo/global-en-zh-content-pages-human-revision-01a-foundation-governance.md",
+          "backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01a-foundation-governance.v1.json",
+          "backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json",
+          "backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevision01aFoundationGovernanceTest.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "diff_check": {
+        "status": "passed",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "fap_web_reference_check": {
+        "status": "passed_with_preexisting_untracked_files",
+        "command": "git -C /Users/rainie/Desktop/GitHub/fap-web status --short",
+        "evidence": "Observed pre-existing untracked fap-web files; no fap-web changes were made or committed by this task."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T10:23:33+08:00",
+        "status": "planned",
+        "summary": "Authorized current foundation governance fact reconcile task entry only."
+      },
+      {
+        "at": "2026-05-27T10:23:33+08:00",
+        "status": "in_progress",
+        "summary": "Created draft-only addendum artifacts and focused test; local validation pending."
+      },
+      {
+        "at": "2026-05-27T10:23:33+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, Pint, composer validate/audit, JSON/YAML parse, fap-web reference check, and diff checks passed."
+      },
+      {
+        "at": "2026-05-27T10:23:33+08:00",
+        "status": "committed",
+        "summary": "Committed scoped revision addendum artifacts for foundation governance fact reconciliation."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T10:31:10+08:00",
+  "updated_at": "2026-05-27T10:32:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28044,7 +28044,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE": {
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-human-revision-01a-foundation-governance",
     "base": "main",
@@ -28053,7 +28053,7 @@
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE reconcile foundation governance facts",
     "commit_sha": "a320b69289cf2175b5f25db52af978a4047a2a77",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1715",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -28151,6 +28151,11 @@
         "at": "2026-05-27T10:31:10+08:00",
         "status": "ledger_commit_sha_recorded",
         "summary": "Recorded scoped artifact commit SHA before PR creation."
+      },
+      {
+        "at": "2026-05-27T10:32:30+08:00",
+        "status": "pr_opened",
+        "summary": "Opened PR #1715 after local validation; waiting for GitHub required checks."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14049,6 +14049,52 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01
+    branch: codex/global-en-zh-content-pages-human-revision-01a-foundation-governance
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE reconcile foundation governance facts"
+    train_scope: global_en_zh_controlled_cms_import
+    risk_level: p0_revision_addendum_only
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-human-revision-01a-foundation-governance.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01a-foundation-governance.v1.json
+      - backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevision01aFoundationGovernanceTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Create a revision addendum that reconciles foundation/shareholding governance facts before any CMS draft update.
+      - Classify foundation/shareholding evidence state and preserve public-benefit governance direction without claiming registered foundation, nonprofit status, donation/grant program, formal board governance, legal fiduciary duty, exact ownership percentage, or completed equity transfer unless formal documents prove them.
+      - Keep the addendum draft-only with no CMS mutation, publish, deploy, sitemap/llms/footer/nav exposure, Search Channel action, URL submission, production migration, production user data access, or fap-web modification.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevision01aFoundationGovernance --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01a-foundation-governance.v1.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added a revision addendum report for foundation/shareholding governance fact reconciliation.
- Added generated JSON and an import-package addendum that preserves public-benefit governance/shareholding direction while bounding unsupported legal claims.
- Added a focused SeoIntel artifact test.
- Added only the authorized current task entry to the PR train manifest/state.

## Why
The previous revision softened the foundation page too far after removing unsupported foundation/nonprofit implications. New deck evidence supports a planned public-benefit shareholding governance path, but not completed legal status. This PR reconciles that fact boundary before any later CMS draft update.

## Validation
- cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevision01aFoundationGovernance --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-human-revision-01a-foundation-governance.v1.json >/dev/null
- python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- YAML parse for docs/codex/pr-train.yaml
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No CMS draft update.
- No publish or deploy.
- No sitemap/llms/footer/nav exposure.
- No Search Channel enqueue or URL submission.
- No fap-web modification.
- Formal founder/legal confirmation remains required before publish.