### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01 update Wave 1 English CMS draft records

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-cms-draft-update-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-cms-draft-update-01.v1.json
@@ -1,0 +1,255 @@
+{
+  "schema_version": "global-en-zh-content-pages-cms-draft-update-01.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01",
+  "final_decision": "content_pages_cms_draft_update_completed_with_sidecars",
+  "approval_phrase_verified": true,
+  "target_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "preflight_result": {
+    "passed": true,
+    "official_cms_draft_update_runtime": "content-pages:import-local-baseline",
+    "official_runtime_supports_dry_run": true,
+    "official_runtime_supports_upsert": true,
+    "target_draft_records_found": 5,
+    "all_targets_locale_en": true,
+    "all_targets_draft_non_public_non_indexable": true,
+    "all_targets_published_at_null": true,
+    "revision_package_parsed": true,
+    "foundation_governance_addendum_parsed": true,
+    "foundation_addendum_superseded_prior_foundation_framing": true,
+    "no_target_publish_planned": true,
+    "no_target_indexable_planned": true,
+    "no_sitemap_llms_footer_exposure_planned": true,
+    "no_search_channel_action_planned": true,
+    "no_deploy_planned": true,
+    "protected_published_records_excluded": [
+      "about",
+      "help-about",
+      "help-contact",
+      "help-faq",
+      "help-for-business-and-research",
+      "method-boundaries",
+      "privacy",
+      "terms"
+    ]
+  },
+  "dry_run_result": {
+    "passed": true,
+    "command": "php artisan content-pages:import-local-baseline --dry-run --upsert --status=draft --source-dir=/tmp/fap-content-pages-cms-draft-update-01-source",
+    "target_count": 5,
+    "would_update_count": 5,
+    "would_create_count": 0,
+    "would_skip_count": 0,
+    "blocked_count": 0,
+    "target_keys": [
+      "brand",
+      "charter",
+      "foundation",
+      "careers",
+      "policies"
+    ],
+    "before_status": {
+      "brand": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      },
+      "charter": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      },
+      "foundation": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      },
+      "careers": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      },
+      "policies": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      }
+    },
+    "after_status": {
+      "brand": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      },
+      "charter": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      },
+      "foundation": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      },
+      "careers": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      },
+      "policies": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null
+      }
+    },
+    "no_publish": true,
+    "no_indexable": true,
+    "no_sitemap_llms_footer_exposure": true,
+    "no_search_channel_action": true,
+    "raw_output": [
+      "baseline_source_dir=/tmp/fap-content-pages-cms-draft-update-01-source",
+      "dry_run=1",
+      "upsert=1",
+      "status_mode=draft",
+      "files_found=1",
+      "pages_found=5",
+      "will_create=0",
+      "will_update=5",
+      "will_skip=0",
+      "dry-run complete"
+    ]
+  },
+  "update_result": {
+    "performed": true,
+    "command": "php artisan content-pages:import-local-baseline --upsert --status=draft --source-dir=/tmp/fap-content-pages-cms-draft-update-01-source",
+    "target_count": 5,
+    "updated_count": 5,
+    "created_count": 0,
+    "skipped_count": 0,
+    "raw_output": [
+      "baseline_source_dir=/tmp/fap-content-pages-cms-draft-update-01-source",
+      "dry_run=0",
+      "upsert=1",
+      "status_mode=draft",
+      "files_found=1",
+      "pages_found=5",
+      "will_create=0",
+      "will_update=5",
+      "will_skip=0",
+      "import complete"
+    ],
+    "temporary_source_removed": true
+  },
+  "post_update_verification": {
+    "records": [
+      {
+        "slug": "brand",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "title": "Brand and Usage Guidelines"
+      },
+      {
+        "slug": "careers",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "title": "Work With FermatMind"
+      },
+      {
+        "slug": "charter",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "title": "FermatMind Editorial Charter"
+      },
+      {
+        "slug": "foundation",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "title": "Public-Benefit Mission and Governance"
+      },
+      {
+        "slug": "policies",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "title": "Policy Overview"
+      }
+    ],
+    "all_five_updated": true,
+    "all_remain_draft_non_public_non_indexable": true,
+    "public_runtime": {
+      "/en/brand": {
+        "status": 404,
+        "non_public": true
+      },
+      "/en/charter": {
+        "status": 404,
+        "non_public": true
+      },
+      "/en/foundation": {
+        "status": 404,
+        "non_public": true
+      },
+      "/en/careers": {
+        "status": 404,
+        "non_public": true
+      },
+      "/en/policies": {
+        "status": 404,
+        "non_public": true
+      }
+    },
+    "sitemap_contains_targets": false,
+    "llms_txt_contains_targets": false,
+    "llms_full_txt_contains_targets": false,
+    "footer_nav_homepage_contains_targets": false,
+    "protected_published_records_not_targeted": true,
+    "search_channel_tables_available_on_checked_connection": false,
+    "search_channel_sidecar": "seo_search_channel_queue_* tables were not detected on the checked production default/seo_intel connection, so queue item 2/3 state could not be re-read in this task. No Search Channel command was run, all live/queue gates read as false, and no content_page queue items could be detected on this connection."
+  },
+  "foundation_fact_state": "planned_public_benefit_shareholding",
+  "foundation_governance_language_used": "Public-Benefit Mission and Governance; planned public-benefit shareholding arrangement",
+  "forbidden_foundation_claims_absent": true,
+  "forbidden_foundation_claims_absent_scope": "No affirmative claims of registered foundation, nonprofit legal status, charity registration, donation/grant program, formal board governance, legal fiduciary duty, exact ownership percentage, completed equity transfer, or completed foundation holding were introduced. The draft uses denial/boundary language where those terms appear.",
+  "cms_records_updated": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "sidecar_issues": [
+    "Search Channel queue tables were unavailable on the checked production connection; queue item 2/3 unchanged verification could not be completed from that connection. No Search Channel action was performed."
+  ],
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_sitemap_llms_exposure": true,
+  "no_footer_nav_exposure": true,
+  "no_public_runtime_exposure": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-cms-draft-update-01.md
+++ b/backend/docs/seo/global-en-zh-content-pages-cms-draft-update-01.md
@@ -1,0 +1,112 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01 Report
+
+## 1. Executive Summary
+The exact approval phrase was present. The existing English CMS draft records for `brand`, `charter`, `foundation`, `careers`, and `policies` were updated using the merged human revision package and the 01A foundation governance addendum.
+
+The official CMS importer `content-pages:import-local-baseline` was used with dry-run first and then controlled `--upsert --status=draft`. No new pages were created. No page was published or made indexable.
+
+Final decision: `content_pages_cms_draft_update_completed_with_sidecars`.
+
+## 2. Approval Verification
+Approval phrase verified: true.
+
+## 3. Target Pages
+- `brand`
+- `charter`
+- `foundation`
+- `careers`
+- `policies`
+
+Protected published records were excluded: `about`, `help-about`, `help-contact`, `help-faq`, `help-for-business-and-research`, `method-boundaries`, `privacy`, and `terms`.
+
+## 4. Preflight Result
+Preflight passed. All five target records existed in production as English draft records, non-public, non-indexable, and `published_at=null`.
+
+The 01 revision package and 01A foundation governance addendum both existed and parsed. The foundation update used `planned_public_benefit_shareholding` and `Public-Benefit Mission and Governance` framing.
+
+## 5. Dry-run Result
+Dry-run command:
+
+```text
+php artisan content-pages:import-local-baseline --dry-run --upsert --status=draft --source-dir=/tmp/fap-content-pages-cms-draft-update-01-source
+```
+
+Result:
+
+```text
+files_found=1
+pages_found=5
+will_create=0
+will_update=5
+will_skip=0
+dry-run complete
+```
+
+## 6. CMS Draft Update Result
+Controlled update command:
+
+```text
+php artisan content-pages:import-local-baseline --upsert --status=draft --source-dir=/tmp/fap-content-pages-cms-draft-update-01-source
+```
+
+Result:
+
+```text
+files_found=1
+pages_found=5
+will_create=0
+will_update=5
+will_skip=0
+import complete
+```
+
+The temporary source package was removed after execution.
+
+## 7. Foundation Governance Reconciliation
+Foundation now uses `Public-Benefit Mission and Governance` with `planned public-benefit shareholding arrangement` language.
+
+No affirmative claim was introduced for registered foundation, nonprofit legal status, charity registration, donation program, grant program, formal board governance, legal fiduciary duty, exact ownership percentage, completed equity transfer, or completed foundation holding. Terms may appear only inside denial/boundary language.
+
+## 8. Post-update Verification
+All five records remain:
+
+- draft
+- non-public
+- non-indexable
+- `published_at=null`
+
+Updated titles:
+
+- `brand`: Brand and Usage Guidelines
+- `charter`: FermatMind Editorial Charter
+- `foundation`: Public-Benefit Mission and Governance
+- `careers`: Work With FermatMind
+- `policies`: Policy Overview
+
+Public runtime checks for `/en/brand`, `/en/charter`, `/en/foundation`, `/en/careers`, and `/en/policies` returned 404/non-public behavior.
+
+## 9. Sitemap / llms / Footer Safety
+`sitemap.xml`, `llms.txt`, `llms-full.txt`, and the public English homepage did not include the five draft target paths.
+
+## 10. Search Channel Safety
+No Search Channel command was run, no URL was submitted, and all checked live/queue gates read as false.
+
+Sidecar: `seo_search_channel_queue_*` tables were not detected on the checked production default/seo_intel connection, so queue item 2/3 unchanged verification could not be completed from that connection.
+
+## 11. Validation
+Pending local validation in this PR.
+
+## 12. PR / Merge Result
+Pending.
+
+## 13. Sidecar Issues
+Search Channel queue tables were unavailable on the checked production connection; queue item 2/3 state could not be re-read in this task. No Search Channel action was performed.
+
+## 14. What Was Not Done
+No publish, deploy, Search Channel enqueue, URL submission, external search API call, sitemap/llms/footer/nav exposure, fap-web modification, env/DNS/nginx edit, production migration, raw log read, or production user-data access was performed.
+
+## 15. Final Decision
+`content_pages_cms_draft_update_completed_with_sidecars`
+
+## 16. Next Task
+`GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesCmsDraftUpdate01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesCmsDraftUpdate01Test.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesCmsDraftUpdate01Test extends TestCase
+{
+    #[Test]
+    public function content_pages_cms_draft_update_report_exists_with_closed_publication_boundaries(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-cms-draft-update-01.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-cms-draft-update-01.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01', $generated['task'] ?? null);
+
+        $targetPages = $generated['target_pages'] ?? [];
+        sort($targetPages);
+
+        $this->assertSame([
+            'brand',
+            'careers',
+            'charter',
+            'foundation',
+            'policies',
+        ], $targetPages);
+
+        $this->assertSame('planned_public_benefit_shareholding', $generated['foundation_fact_state'] ?? null);
+        $this->assertTrue($generated['approval_phrase_verified'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_sitemap_llms_exposure'] ?? false);
+        $this->assertTrue($generated['no_footer_nav_exposure'] ?? false);
+        $this->assertTrue($generated['no_public_runtime_exposure'] ?? false);
+        $this->assertNotEmpty($generated['final_decision'] ?? null);
+        $this->assertNotEmpty($generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28160,7 +28160,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01": {
-    "status": "local_checks_passed",
+    "status": "committed",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-cms-draft-update-01",
     "base": "main",
@@ -28169,7 +28169,7 @@
       "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE"
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01 update Wave 1 English CMS draft records",
-    "commit_sha": null,
+    "commit_sha": "8be84d8e670132d3c87c8c009df655dfec2308ea",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -28256,6 +28256,11 @@
         "at": "2026-05-27T10:59:58+08:00",
         "status": "local_checks_passed",
         "summary": "Focused test, route list, pint, composer validate/audit, JSON/YAML parsing, and diff checks passed."
+      },
+      {
+        "at": "2026-05-27T11:00:51+08:00",
+        "status": "committed",
+        "summary": "Committed CMS draft update report artifacts and focused test."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21014,7 +21014,7 @@
     "next_pr": "OPS-CI-CODESCAN-WEB-01"
   },
   "OPS-CI-CODESCAN-API-02": {
-    "status": "pr_open",
+    "status": "github_checks_passed",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/ops-ci-codescan-api-02",
@@ -28239,6 +28239,10 @@
       "fap_web_reference_check": {
         "status": "passed_with_sidecar",
         "evidence": "Reference-only fap-web working tree had pre-existing tracked and untracked changes; no fap-web files were modified by this task."
+      },
+      "github_checks": {
+        "status": "passed",
+        "evidence": "PR #1716 checks passed and mergeStateStatus was CLEAN."
       }
     },
     "history": [
@@ -28266,6 +28270,11 @@
         "at": "2026-05-27T11:01:39+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1716 for the scoped CMS draft update report."
+      },
+      {
+        "at": "2026-05-27T11:09:10+08:00",
+        "status": "github_checks_passed",
+        "summary": "GitHub checks passed for PR #1716 and merge state was CLEAN."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28160,7 +28160,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01": {
-    "status": "committed",
+    "status": "pr_open",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-cms-draft-update-01",
     "base": "main",
@@ -28170,7 +28170,7 @@
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01 update Wave 1 English CMS draft records",
     "commit_sha": "8be84d8e670132d3c87c8c009df655dfec2308ea",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1716",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -28261,6 +28261,11 @@
         "at": "2026-05-27T11:00:51+08:00",
         "status": "committed",
         "summary": "Committed CMS draft update report artifacts and focused test."
+      },
+      {
+        "at": "2026-05-27T11:01:39+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1716 for the scoped CMS draft update report."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T10:32:30+08:00",
+  "updated_at": "2026-05-27T10:55:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28156,6 +28156,106 @@
         "at": "2026-05-27T10:32:30+08:00",
         "status": "pr_opened",
         "summary": "Opened PR #1715 after local validation; waiting for GitHub required checks."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01": {
+    "status": "local_checks_passed",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-cms-draft-update-01",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01",
+      "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01 update Wave 1 English CMS draft records",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "approval_phrase": {
+        "status": "passed",
+        "evidence": "Exact approval phrase was present in the task prompt."
+      },
+      "preflight": {
+        "status": "passed",
+        "evidence": "Five target English CMS draft records existed and were draft/non-public/non-indexable with published_at=null."
+      },
+      "official_runtime": {
+        "status": "passed",
+        "evidence": "Used content-pages:import-local-baseline with --dry-run, --upsert, --status=draft, and scoped source-dir."
+      },
+      "dry_run": {
+        "status": "passed",
+        "evidence": "Dry-run reported pages_found=5, will_update=5, will_create=0, will_skip=0."
+      },
+      "controlled_update": {
+        "status": "passed",
+        "evidence": "Controlled update reported pages_found=5, will_update=5, will_create=0, will_skip=0; all five remained draft/non-public/non-indexable."
+      },
+      "public_exposure": {
+        "status": "passed",
+        "evidence": "Public runtime returned 404 for all five target /en paths; sitemap, llms, llms-full, and homepage did not include target paths."
+      },
+      "search_channel": {
+        "status": "passed_with_sidecar",
+        "evidence": "No Search Channel command was run and checked gates read false; seo_search_channel_queue_* tables were unavailable on the checked production connection, so queue item 2/3 unchanged verification was recorded as sidecar."
+      },
+      "focused_test": {
+        "status": "passed",
+        "command": "php artisan test --filter=GlobalEnZhContentPagesCmsDraftUpdate01 --no-ansi",
+        "evidence": "1 passed, 15 assertions."
+      },
+      "route_list": {
+        "status": "passed",
+        "command": "php artisan route:list --no-ansi"
+      },
+      "pint": {
+        "status": "passed",
+        "command": "vendor/bin/pint --test",
+        "evidence": "3586 files passed."
+      },
+      "composer_validate": {
+        "status": "passed",
+        "command": "composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "passed",
+        "command": "composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "passed",
+        "evidence": "Generated JSON, pr-train-state JSON, and pr-train YAML parsed successfully."
+      },
+      "diff_check": {
+        "status": "passed",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "fap_web_reference_check": {
+        "status": "passed_with_sidecar",
+        "evidence": "Reference-only fap-web working tree had pre-existing tracked and untracked changes; no fap-web files were modified by this task."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T10:55:00+08:00",
+        "status": "planned",
+        "summary": "Authorized current CMS draft update task entry only; no future publish/deploy/Search Channel tasks added."
+      },
+      {
+        "at": "2026-05-27T10:55:00+08:00",
+        "status": "controlled_update_completed",
+        "summary": "Dry-run passed and existing English CMS draft records were updated draft-only using merged revision packages."
+      },
+      {
+        "at": "2026-05-27T10:59:58+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, pint, composer validate/audit, JSON/YAML parsing, and diff checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14095,6 +14095,51 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01
+      - GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE
+    branch: codex/global-en-zh-content-pages-cms-draft-update-01
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01 update Wave 1 English CMS draft records"
+    train_scope: global_en_zh_controlled_cms_import
+    risk_level: p0_controlled_cms_draft_update
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-cms-draft-update-01.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-cms-draft-update-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesCmsDraftUpdate01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Dry-run first and then update only the existing English CMS draft records for brand, charter, foundation, careers, and policies using the merged human revision packages.
+      - Use the foundation governance 01A addendum where applicable and keep the foundation fact state bounded as planned_public_benefit_shareholding.
+      - Do not publish, deploy, submit URLs, enqueue Search Channel, expose sitemap/llms/footer/nav, edit fap-web, run production migrations, read raw logs, or access production user data.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesCmsDraftUpdate01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-cms-draft-update-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    cms_mutation: draft_only_existing_records
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Recorded the controlled CMS draft update for the five Wave 1 English content pages: `brand`, `charter`, `foundation`, `careers`, and `policies`.
- Added the generated evidence JSON and focused regression test for `GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01`.
- Added the current task entry/state to the PR train ledger only.

## Why
- The existing English draft-only CMS records were updated using the merged human revision package and the 01A foundation governance addendum.
- The foundation framing now uses planned public-benefit shareholding language while avoiding unsupported legal, nonprofit, donation, grant, board, fiduciary, ownership percentage, or completed transfer claims.

## Validation
- `php artisan test --filter=GlobalEnZhContentPagesCmsDraftUpdate01 --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-cms-draft-update-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No publish action.
- No deploy.
- No Search Channel enqueue or submission.
- No sitemap, llms, footer, or nav exposure.
- Search Channel queue item 2/3 unchanged verification remains a sidecar because the checked production connection did not expose the `seo_search_channel_queue_*` tables; no Search Channel command was run and gates read closed.
