### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2 publish readiness recheck for Wave 1 English content pages

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-r2.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-r2.v1.json
@@ -1,0 +1,220 @@
+{
+  "schema_version": "global-en-zh-content-pages-publish-readiness-r2.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2",
+  "final_decision": "content_pages_publish_readiness_r2_completed_ready_for_controlled_publish",
+  "target_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "per_page_publish_readiness": {
+    "brand": {
+      "classification": "publish_ready_with_founder_approval",
+      "reason": "Brand usage copy is complete, bounded, and avoids unsupported certification, partnership, endorsement, market-position, and legal-status claims."
+    },
+    "charter": {
+      "classification": "publish_ready_with_legal_approval",
+      "reason": "Editorial charter copy is complete and explicitly states it is not a legal governance document, board charter, fiduciary commitment, or Terms/Privacy substitute."
+    },
+    "foundation": {
+      "classification": "publish_ready_with_legal_approval",
+      "reason": "Foundation copy uses planned public-benefit shareholding language only and avoids affirmative completed legal, nonprofit, charity, donation, grant, board, fiduciary, ownership-percentage, or completed-transfer claims."
+    },
+    "careers": {
+      "classification": "publish_ready_with_company_fact_approval",
+      "reason": "Careers copy is complete and avoids current opening, hiring timeline, employment term, equal opportunity, or active recruiting claims; company/founder approval is still required before publish."
+    },
+    "policies": {
+      "classification": "publish_ready_with_legal_approval",
+      "reason": "Policy overview copy is complete and states it does not replace Terms, Privacy Policy, product notices, order terms, or signed agreements."
+    }
+  },
+  "cms_draft_state": {
+    "checked_at": "2026-05-27T11:52:00+08:00",
+    "source": "production Laravel read-only query",
+    "all_targets_exist": true,
+    "all_locale_en": true,
+    "all_status_draft": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_published_at_null": true,
+    "all_source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages",
+    "target_titles": {
+      "brand": "Brand and Usage Guidelines",
+      "charter": "FermatMind Editorial Charter",
+      "foundation": "Public-Benefit Mission and Governance",
+      "careers": "Work With FermatMind",
+      "policies": "Policy Overview"
+    }
+  },
+  "content_completeness_check": {
+    "all_titles_present": true,
+    "all_descriptions_present": true,
+    "all_h1_present": true,
+    "all_body_blocks_present": true,
+    "all_seo_metadata_present": true,
+    "all_zh_counterparts_present": true,
+    "all_translation_groups_present": true,
+    "placeholder_content_detected": false,
+    "obvious_machine_translation_blocker_detected": false,
+    "obvious_chinese_leakage_detected": false,
+    "notes": [
+      "The brand page includes the Chinese product name as an intentional bilingual naming reference, not leaked untranslated body copy."
+    ]
+  },
+  "claim_boundary_check": {
+    "global_forbidden_claims_detected": false,
+    "diagnosis_treatment_cure_claim_detected": false,
+    "salary_or_career_success_guarantee_detected": false,
+    "hiring_fit_guarantee_detected": false,
+    "precise_career_recommendation_claim_detected": false,
+    "mbti_income_or_turnover_prediction_claim_detected": false,
+    "unsupported_privacy_security_legal_commitment_detected": false,
+    "unsupported_company_foundation_fact_detected": false,
+    "negative_boundary_mentions_are_not_affirmative_claims": true
+  },
+  "legal_company_fact_check": {
+    "brand": {
+      "unsupported_awards_certifications_endorsements_partnerships_market_position_or_legal_status": false,
+      "remaining_approval": "founder_approval"
+    },
+    "charter": {
+      "legal_charter_or_board_charter_claim": false,
+      "terms_privacy_substitute_claim": false,
+      "legal_fiduciary_language": false,
+      "remaining_approval": "legal_approval"
+    },
+    "foundation": {
+      "registered_foundation_claim": false,
+      "nonprofit_legal_status_claim": false,
+      "charity_registration_claim": false,
+      "donation_or_grant_program_claim": false,
+      "formal_board_governance_claim": false,
+      "legal_fiduciary_duty_claim": false,
+      "exact_ownership_percentage_claim": false,
+      "completed_equity_transfer_or_foundation_holding_claim": false,
+      "remaining_approval": "legal_approval"
+    },
+    "careers": {
+      "current_hiring_claim": false,
+      "open_roles_claim": false,
+      "hiring_timeline_or_process_claim": false,
+      "employment_terms_or_equal_opportunity_policy_claim": false,
+      "remaining_approval": "company_fact_approval"
+    },
+    "policies": {
+      "terms_or_privacy_replacement_claim": false,
+      "new_refund_dispute_privacy_retention_security_minors_compliance_or_legal_obligation_claim": false,
+      "remaining_approval": "legal_approval"
+    }
+  },
+  "foundation_fact_state": "planned_public_benefit_shareholding",
+  "foundation_governance_language": {
+    "title": "Public-Benefit Mission and Governance",
+    "required_phrase_present": "planned public-benefit shareholding arrangement",
+    "completed_status_not_claimed": true,
+    "legal_review_required_before_publish": true
+  },
+  "existing_published_records_check": {
+    "source": "production Laravel read-only query plus public runtime GET checks",
+    "records_checked": [
+      "about",
+      "help-about",
+      "help-contact",
+      "help-faq",
+      "help-for-business-and-research",
+      "method-boundaries",
+      "privacy",
+      "terms"
+    ],
+    "all_status_published": true,
+    "all_public": true,
+    "all_indexable": true,
+    "public_runtime_200": true
+  },
+  "public_runtime_check": {
+    "target_pages_currently_public": false,
+    "target_paths": {
+      "https://fermatmind.com/en/brand": 404,
+      "https://fermatmind.com/en/charter": 404,
+      "https://fermatmind.com/en/foundation": 404,
+      "https://fermatmind.com/en/careers": 404,
+      "https://fermatmind.com/en/policies": 404
+    },
+    "indexable_public_runtime_exposure_detected": false
+  },
+  "future_footer_eligibility": {
+    "brand": false,
+    "charter": false,
+    "foundation": false,
+    "careers": false,
+    "policies": false,
+    "reason": "Footer/nav placement remains a separate IA decision and must not be enabled by publish readiness alone."
+  },
+  "future_sitemap_eligibility": {
+    "brand": "eligible_after_controlled_publish_and_runtime_200",
+    "charter": "eligible_after_controlled_publish_and_runtime_200",
+    "foundation": "eligible_after_controlled_publish_and_runtime_200",
+    "careers": "eligible_after_controlled_publish_and_runtime_200",
+    "policies": "eligible_after_controlled_publish_and_runtime_200"
+  },
+  "future_llms_eligibility": {
+    "brand": "eligible_after_controlled_publish_and_runtime_200",
+    "charter": "eligible_after_controlled_publish_and_runtime_200",
+    "foundation": "eligible_after_controlled_publish_and_runtime_200",
+    "careers": "eligible_after_controlled_publish_and_runtime_200",
+    "policies": "eligible_after_controlled_publish_and_runtime_200"
+  },
+  "future_search_channel_eligibility": {
+    "brand": false,
+    "charter": false,
+    "foundation": false,
+    "careers": false,
+    "policies": false,
+    "reason": "Current Search Channel allowed page_entity_type set does not include content_page; Search Channel remains out of scope for these pages."
+  },
+  "search_channel_safety_check": {
+    "source": "production seo_intel Laravel connection, read-only",
+    "queue_tables_visible": true,
+    "content_page_queue_items_found": 0,
+    "content_page_live_submissions_found": 0,
+    "queue_item_2_state": {
+      "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    },
+    "queue_item_3_state": {
+      "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    },
+    "no_search_channel_action_performed": true
+  },
+  "gate_state": {
+    "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED": false,
+    "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED": false,
+    "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED": false,
+    "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED": false
+  },
+  "staging_discoverability_check": {
+    "checked": true,
+    "staging_home_x_robots_tag": "noindex, nofollow, noarchive",
+    "staging_sitemap_status": 410,
+    "staging_llms_status": 410,
+    "draft_leakage_detected": false
+  },
+  "publish_scope_recommendation": "all_five_pages",
+  "approval_phrase_for_future_publish": "I explicitly approve GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01 to publish the existing English CMS draft records for brand, charter, foundation, careers, and policies after founder/legal/company fact approval. Do not deploy. Do not enqueue Search Channel. Do not submit URLs. Do not change footer or navigation.",
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_sitemap_llms_exposure": true,
+  "no_footer_nav_exposure": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-publish-readiness-r2.md
+++ b/backend/docs/seo/global-en-zh-content-pages-publish-readiness-r2.md
@@ -1,0 +1,211 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2
+
+## Executive Summary
+
+This read-only R2 review rechecked the five Wave 1 English content page drafts after `GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01`.
+
+Final decision: `content_pages_publish_readiness_r2_completed_ready_for_controlled_publish`.
+
+All five target pages are ready for a later controlled publish with explicit human approval and page-specific approval boundaries:
+
+| Page | Readiness | Approval boundary |
+| --- | --- | --- |
+| `brand` | `publish_ready_with_founder_approval` | Founder/brand approval |
+| `charter` | `publish_ready_with_legal_approval` | Legal approval |
+| `foundation` | `publish_ready_with_legal_approval` | Legal approval for planned public-benefit shareholding language |
+| `careers` | `publish_ready_with_company_fact_approval` | Company/founder fact approval |
+| `policies` | `publish_ready_with_legal_approval` | Legal approval |
+
+No CMS mutation, publish, deploy, URL submission, Search Channel action, sitemap/llms/footer exposure, raw log read, production user data access, or fap-web modification was performed.
+
+## Target Page Publish Readiness
+
+- `brand`: ready with founder approval. The page avoids unsupported award, certification, endorsement, partnership, market-position, and legal-status claims.
+- `charter`: ready with legal approval. The page explicitly states it is not a legal governance document, board charter, fiduciary commitment, or Terms/Privacy substitute.
+- `foundation`: ready with legal approval. The page uses `planned public-benefit shareholding arrangement` and does not claim completed foundation holding or completed legal implementation.
+- `careers`: ready with company fact approval. The page does not claim current openings, open roles, hiring timelines, hiring process, employment terms, or equal opportunity policy.
+- `policies`: ready with legal approval. The page is a policy overview and does not replace Terms, Privacy Policy, product notices, order terms, or signed agreements.
+
+Recommended publish scope: `all_five_pages`.
+
+## CMS Draft State
+
+Production Laravel read-only query confirmed all five target records:
+
+- exist in `content_pages`
+- `locale=en`
+- `status=draft`
+- `is_public=false`
+- `is_indexable=false`
+- `published_at=null`
+- `source_doc=global-en-zh-content-pages-cms-draft-update-01 from human revision packages`
+
+Updated target titles:
+
+- `brand`: `Brand and Usage Guidelines`
+- `charter`: `FermatMind Editorial Charter`
+- `foundation`: `Public-Benefit Mission and Governance`
+- `careers`: `Work With FermatMind`
+- `policies`: `Policy Overview`
+
+## Content Completeness Check
+
+All five records include:
+
+- title
+- summary / description
+- H1 / headings
+- body markdown
+- SEO title
+- meta description
+- canonical path
+- translation group
+- zh-CN counterpart
+
+No placeholder body, obvious machine-translation blocker, or accidental Chinese body leakage was found. The brand page includes `费马测试` only as an intentional bilingual product-name reference.
+
+## Claim Boundary Check
+
+No affirmative unsupported claim was found for:
+
+- diagnosis, treatment, or cure
+- salary guarantee
+- career success guarantee
+- hiring-fit guarantee
+- precise career recommendation
+- MBTI predicting income or turnover
+- unsupported privacy, security, legal, company, or foundation commitments
+
+Some forbidden legal/foundation terms appear only as explicit negative boundaries, not as affirmative claims.
+
+## Legal / Company / Foundation Review
+
+Remaining approvals before publish:
+
+- `brand`: founder/brand approval
+- `charter`: legal approval
+- `foundation`: legal approval
+- `careers`: company/founder fact approval
+- `policies`: legal approval
+
+No further copy revision is required before a controlled publish task if those approvals are granted in the future task.
+
+## Foundation Governance Fact State
+
+Foundation fact state: `planned_public_benefit_shareholding`.
+
+Approved framing:
+
+- `Public-Benefit Mission and Governance`
+- `planned public-benefit shareholding arrangement`
+
+Not claimed:
+
+- registered foundation
+- nonprofit legal status
+- charity registration
+- donation program
+- grant program
+- formal board governance
+- legal fiduciary duty
+- exact ownership percentage
+- completed equity transfer
+- completed foundation holding
+
+## Existing Published Records Check
+
+Production read-only checks confirmed existing English published records remain published/public/indexable:
+
+- `about`
+- `help-about`
+- `help-contact`
+- `help-faq`
+- `help-for-business-and-research`
+- `method-boundaries`
+- `privacy`
+- `terms`
+
+Safe public runtime GET checks returned 200 for their expected English public routes.
+
+## Public Runtime Check
+
+The five target pages are still not public:
+
+- `https://fermatmind.com/en/brand` -> 404
+- `https://fermatmind.com/en/charter` -> 404
+- `https://fermatmind.com/en/foundation` -> 404
+- `https://fermatmind.com/en/careers` -> 404
+- `https://fermatmind.com/en/policies` -> 404
+
+No indexable public runtime exposure was detected.
+
+## Future Footer / Sitemap / llms Eligibility
+
+Future footer/nav eligibility: false for all five until a separate IA/footer/nav approval.
+
+Future sitemap/llms eligibility: eligible only after a later controlled publish succeeds and public runtime returns 200 for each page.
+
+Future Search Channel eligibility: false under the current Search Channel allow-list because `content_page` is not an allowed Search Channel page entity type.
+
+## Search Channel Safety
+
+Production `seo_intel` connection exposed Search Channel queue tables.
+
+Read-only check found:
+
+- no Search Channel queue item for `brand`, `charter`, `foundation`, `careers`, or `policies`
+- no content page live submission
+- queue item 2 remains EN MBTI `approved/submitted`
+- queue item 3 remains ZH MBTI `approved/submitted`
+- queue/write/live/external gates read closed
+
+No Search Channel command was run and no Search Channel action was performed.
+
+## Staging / Discoverability Sidecar
+
+Safe public staging checks remained stable:
+
+- staging home sends `X-Robots-Tag: noindex, nofollow, noarchive`
+- staging sitemap returns 410
+- staging llms returns 410
+- no target draft leakage was observed
+
+## Future Approval Phrase
+
+Future controlled publish phrase:
+
+`I explicitly approve GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01 to publish the existing English CMS draft records for brand, charter, foundation, careers, and policies after founder/legal/company fact approval. Do not deploy. Do not enqueue Search Channel. Do not submit URLs. Do not change footer or navigation.`
+
+## Validation
+
+Required validation for this report PR:
+
+- `php artisan test --filter=GlobalEnZhContentPagesPublishReadinessR2 --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+- JSON/YAML parse checks
+- `git diff --check`
+- `git diff --cached --check`
+
+## What Was Not Done
+
+- No CMS mutation.
+- No publish.
+- No deploy.
+- No Search Channel enqueue.
+- No URL submission.
+- No external search API call.
+- No sitemap/llms/footer/nav exposure.
+- No raw log read.
+- No production user data access.
+- No fap-web modification.
+
+## Final Decision
+
+`content_pages_publish_readiness_r2_completed_ready_for_controlled_publish`
+
+## Next Task
+
+`GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPublishReadinessR2Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPublishReadinessR2Test.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesPublishReadinessR2Test extends TestCase
+{
+    public function test_publish_readiness_r2_report_exists_with_closed_action_boundaries(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-publish-readiness-r2.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-publish-readiness-r2.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true);
+
+        $this->assertIsArray($generated);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2', $generated['task'] ?? null);
+        $this->assertSame(
+            ['brand', 'charter', 'foundation', 'careers', 'policies'],
+            $generated['target_pages'] ?? null,
+        );
+
+        $this->assertIsArray($generated['per_page_publish_readiness'] ?? null);
+        $this->assertArrayHasKey('brand', $generated['per_page_publish_readiness']);
+        $this->assertArrayHasKey('charter', $generated['per_page_publish_readiness']);
+        $this->assertArrayHasKey('foundation', $generated['per_page_publish_readiness']);
+        $this->assertArrayHasKey('careers', $generated['per_page_publish_readiness']);
+        $this->assertArrayHasKey('policies', $generated['per_page_publish_readiness']);
+
+        $this->assertSame('planned_public_benefit_shareholding', $generated['foundation_fact_state'] ?? null);
+        $this->assertArrayHasKey('publish_scope_recommendation', $generated);
+        $this->assertArrayHasKey('approval_phrase_for_future_publish', $generated);
+
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_sitemap_llms_exposure'] ?? false);
+        $this->assertTrue($generated['no_footer_nav_exposure'] ?? false);
+
+        $this->assertArrayHasKey('final_decision', $generated);
+        $this->assertArrayHasKey('next_task', $generated);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28277,5 +28277,99 @@
         "summary": "GitHub checks passed for PR #1716 and merge state was CLEAN."
       }
     ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2": {
+    "status": "local_checks_passed",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-publish-readiness-r2",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2 publish readiness recheck for Wave 1 English content pages",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "dependency_verification": {
+        "status": "passed",
+        "evidence": "GitHub showed PR #1716 merged at 2026-05-27T03:16:01Z with merge commit 0a57dbf2ef7f0354f85cd0a894491ff09faf2882; local main and origin/main match that commit."
+      },
+      "cms_draft_state": {
+        "status": "passed",
+        "evidence": "Production read-only Laravel query confirmed brand, charter, foundation, careers, and policies exist as en draft records with is_public=false, is_indexable=false, and published_at=null."
+      },
+      "content_completeness": {
+        "status": "passed",
+        "evidence": "All five target records include title, summary/description, H1/body headings, content_md, SEO title, meta description, canonical path, translation group, and zh-CN counterpart."
+      },
+      "claim_boundary": {
+        "status": "passed",
+        "evidence": "No affirmative unsupported diagnosis, treatment, salary, career guarantee, MBTI income/turnover, hiring-fit, legal, foundation, donation, grant, board, or completed shareholding claims were found."
+      },
+      "public_runtime": {
+        "status": "passed",
+        "evidence": "Public runtime returned 404 for /en/brand, /en/charter, /en/foundation, /en/careers, and /en/policies."
+      },
+      "sitemap_llms_footer": {
+        "status": "passed",
+        "evidence": "sitemap.xml, llms.txt, llms-full.txt, and /en homepage did not contain target page paths."
+      },
+      "search_channel": {
+        "status": "passed",
+        "evidence": "Production seo_intel connection exposed Search Channel queue tables; only MBTI queue items 2 and 3 matched checked URLs, and no content page queue item was present. Gates read closed."
+      },
+      "focused_test": {
+        "status": "passed",
+        "command": "php artisan test --filter=GlobalEnZhContentPagesPublishReadinessR2 --no-ansi",
+        "evidence": "1 passed, 23 assertions."
+      },
+      "route_list": {
+        "status": "passed",
+        "command": "php artisan route:list --no-ansi"
+      },
+      "pint": {
+        "status": "passed",
+        "command": "vendor/bin/pint --test",
+        "evidence": "3587 files passed."
+      },
+      "composer_validate": {
+        "status": "passed",
+        "command": "composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "passed",
+        "command": "composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "passed",
+        "evidence": "Generated JSON, pr-train-state JSON, and pr-train YAML parsed successfully."
+      },
+      "diff_check": {
+        "status": "passed",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "fap_web_reference_check": {
+        "status": "passed_with_sidecar",
+        "evidence": "Reference-only fap-web working tree had pre-existing tracked and untracked changes; no fap-web files were modified by this task."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T11:54:41+08:00",
+        "status": "read_only_checks_completed",
+        "summary": "Completed production read-only publish readiness recheck for Wave 1 English content page drafts."
+      },
+      {
+        "at": "2026-05-27T12:01:05+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, pint, composer validate/audit, JSON/YAML parsing, and diff checks passed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28279,7 +28279,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2": {
-    "status": "local_checks_passed",
+    "status": "committed",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-publish-readiness-r2",
     "base": "main",
@@ -28287,7 +28287,7 @@
       "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01"
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2 publish readiness recheck for Wave 1 English content pages",
-    "commit_sha": null,
+    "commit_sha": "3422f4d8c4995cbce259df22c427787368c95796",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -28369,6 +28369,11 @@
         "at": "2026-05-27T12:01:05+08:00",
         "status": "local_checks_passed",
         "summary": "Focused test, route list, pint, composer validate/audit, JSON/YAML parsing, and diff checks passed."
+      },
+      {
+        "at": "2026-05-27T12:01:48+08:00",
+        "status": "committed",
+        "summary": "Committed publish readiness R2 report artifacts and focused test."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28279,7 +28279,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2": {
-    "status": "committed",
+    "status": "pr_open",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-publish-readiness-r2",
     "base": "main",
@@ -28288,7 +28288,7 @@
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2 publish readiness recheck for Wave 1 English content pages",
     "commit_sha": "3422f4d8c4995cbce259df22c427787368c95796",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1717",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -28374,6 +28374,11 @@
         "at": "2026-05-27T12:01:48+08:00",
         "status": "committed",
         "summary": "Committed publish readiness R2 report artifacts and focused test."
+      },
+      {
+        "at": "2026-05-27T12:02:33+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1717 for the scoped publish readiness R2 report."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28160,7 +28160,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01": {
-    "status": "pr_open",
+    "status": "github_checks_passed",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-cms-draft-update-01",
     "base": "main",
@@ -28357,6 +28357,10 @@
       "fap_web_reference_check": {
         "status": "passed_with_sidecar",
         "evidence": "Reference-only fap-web working tree had pre-existing tracked and untracked changes; no fap-web files were modified by this task."
+      },
+      "github_checks": {
+        "status": "passed",
+        "evidence": "PR #1717 checks passed and mergeStateStatus was CLEAN."
       }
     },
     "history": [
@@ -28379,6 +28383,11 @@
         "at": "2026-05-27T12:02:33+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1717 for the scoped publish readiness R2 report."
+      },
+      {
+        "at": "2026-05-27T12:09:07+08:00",
+        "status": "github_checks_passed",
+        "summary": "GitHub checks passed for PR #1717 and merge state was CLEAN."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14140,6 +14140,50 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-01
+    branch: codex/global-en-zh-content-pages-publish-readiness-r2
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2 publish readiness recheck for Wave 1 English content pages"
+    train_scope: global_en_zh_controlled_cms_import
+    risk_level: p0_read_only_publish_readiness
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-publish-readiness-r2.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-r2.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPublishReadinessR2Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Re-run publish readiness after the controlled CMS draft update for brand, charter, foundation, careers, and policies.
+      - Verify CMS draft state, content completeness, claim boundaries, legal/company/foundation review needs, runtime non-exposure, future discoverability eligibility, and Search Channel safety.
+      - Keep verification strictly read-only with no publish, CMS mutation, deploy, URL submission, Search Channel action, external search API call, production migration, raw log read, production user data access, or fap-web modification.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesPublishReadinessR2 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-r2.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the read-only publish readiness R2 report for the Wave 1 English content page drafts: `brand`, `charter`, `foundation`, `careers`, and `policies`.
- Added generated JSON evidence and a focused test for `GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2`.
- Added only the current PR train manifest/state entry authorized by the task.

## Why
- Rechecked the actual production CMS draft state after the controlled draft update in PR #1716.
- Classified all five pages as ready for later controlled publish with explicit page-specific founder/legal/company fact approvals.
- Confirmed current public runtime remains non-public and no sitemap, llms, footer, Search Channel, or URL submission exposure occurred.

## Validation
- `php artisan test --filter=GlobalEnZhContentPagesPublishReadinessR2 --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-publish-readiness-r2.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No publish.
- No CMS mutation.
- No deploy.
- No Search Channel enqueue or submission.
- No URL submission.
- No footer/nav changes.
- Controlled publish remains a separate explicitly approved task.
