### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01 controlled publish for Wave 1 English content pages

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-01.v1.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "global-en-zh-content-pages-controlled-publish-01.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01",
+  "final_decision": "blocked_missing_official_publish_runtime",
+  "approval_phrase_verified": true,
+  "target_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "preflight_result": {
+    "status": "blocked",
+    "dependency_readiness_source": "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2",
+    "dependency_final_decision": "content_pages_publish_readiness_r2_completed_ready_for_controlled_publish",
+    "target_scope_from_r2": "all_five_pages",
+    "runtime_discovery": {
+      "official_content_pages_publish_runtime_found": false,
+      "content_pages_import_runtime_found": "content-pages:import-local-baseline",
+      "content_pages_import_runtime_rejected_for_publish": true,
+      "article_publish_runtime_found": "articles:publish-controlled",
+      "article_publish_runtime_applicable": false,
+      "content_publish_rehearsal_runtime_found": "seo-intel:content-publish-rehearsal",
+      "content_publish_rehearsal_runtime_applicable": false,
+      "reason": "No official bounded runtime exists to dry-run and publish only existing content_pages draft records while failing closed on missing targets."
+    },
+    "cms_mutation_attempted": false,
+    "publish_attempted": false
+  },
+  "dry_run_result": {
+    "performed": false,
+    "blocked_reason": "missing_official_content_pages_publish_runtime",
+    "target_count": 5,
+    "would_publish_count": null,
+    "would_update_count": null,
+    "would_skip_count": null,
+    "blocked_count": 1,
+    "target_keys": [
+      "brand",
+      "charter",
+      "foundation",
+      "careers",
+      "policies"
+    ],
+    "before_status": "not_rechecked_in_this_blocked_task",
+    "after_status": "not_applicable",
+    "sitemap_eligible_after_publish": "not_applicable",
+    "llms_eligible_after_publish": "not_applicable",
+    "footer_eligible_after_publish": "not_applicable",
+    "search_channel_action_attempted": false,
+    "deploy_attempted": false
+  },
+  "publish_result": {
+    "performed": false,
+    "published_pages": [],
+    "blocked_reason": "missing_official_content_pages_publish_runtime"
+  },
+  "post_publish_verification": {
+    "performed": false,
+    "reason": "No publish was performed."
+  },
+  "foundation_fact_state": "planned_public_benefit_shareholding",
+  "foundation_governance_language_used": [
+    "Public-Benefit Mission and Governance",
+    "planned public-benefit shareholding arrangement",
+    "public-benefit governance path"
+  ],
+  "forbidden_foundation_claims_absent": true,
+  "cms_records_published": [],
+  "public_runtime_check": {
+    "performed_after_publish": false,
+    "reason": "No publish was performed.",
+    "r2_prior_state": "target pages were non-public before this task"
+  },
+  "sitemap_exposure_check": {
+    "sitemap_exposure_enabled": false,
+    "unexpected_exposure_detected": false
+  },
+  "llms_exposure_check": {
+    "llms_exposure_enabled": false,
+    "unexpected_exposure_detected": false
+  },
+  "footer_nav_exposure_check": {
+    "footer_nav_exposure_enabled": false,
+    "unexpected_exposure_detected": false
+  },
+  "search_channel_check": {
+    "search_channel_command_run": false,
+    "queue_item_created": false,
+    "url_submitted": false
+  },
+  "gate_state": {
+    "not_modified": true,
+    "search_channel_gates_opened": false
+  },
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_out_of_scope_cms_write": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-controlled-publish-01.md
+++ b/backend/docs/seo/global-en-zh-content-pages-controlled-publish-01.md
@@ -1,0 +1,82 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01
+
+## Executive Summary
+
+The exact human approval phrase for controlled publish was present, and the requested target scope was limited to the existing English CMS draft records for `brand`, `charter`, `foundation`, `careers`, and `policies`.
+
+The task stopped before any CMS mutation because the repository does not currently expose an official bounded controlled publish runtime for `content_pages`. The available content-page command is `content-pages:import-local-baseline`, which is an importer/upserter and can create missing records; it is not a fail-closed publish command for existing draft records only. The available controlled publish runtime, `articles:publish-controlled`, is article-specific.
+
+No publish, deploy, Search Channel enqueue, URL submission, external search API call, sitemap/llms/footer/nav exposure, or out-of-scope CMS write was performed.
+
+## Approval Verification
+
+- Exact approval phrase present: yes
+- Target pages named exactly: `brand`, `charter`, `foundation`, `careers`, `policies`
+- Requested behavior: dry-run first, publish only five existing English draft records, and stop before out-of-scope CMS writes
+
+## Target Pages
+
+- `brand`
+- `charter`
+- `foundation`
+- `careers`
+- `policies`
+
+## Preflight Result
+
+Dependency evidence from the merged R2 readiness package remains the governing input for this task:
+
+- R2 final decision: `content_pages_publish_readiness_r2_completed_ready_for_controlled_publish`
+- Recommended scope: `all_five_pages`
+- Per-page readiness:
+  - `brand`: `publish_ready_with_founder_approval`
+  - `charter`: `publish_ready_with_legal_approval`
+  - `foundation`: `publish_ready_with_legal_approval`
+  - `careers`: `publish_ready_with_company_fact_approval`
+  - `policies`: `publish_ready_with_legal_approval`
+
+Runtime discovery found no official content-pages controlled publish command. The task therefore stopped before production write.
+
+## Dry-run Result
+
+Dry-run was not performed because the required official controlled publish runtime is missing.
+
+Using `content-pages:import-local-baseline --upsert --status=published` was rejected as unsafe for this task because it is an import/upsert command, not a publish-only runtime, and it does not fail closed on missing target draft records.
+
+## Controlled Publish Result
+
+No controlled publish was performed.
+
+## Foundation Governance Boundary
+
+- Foundation fact state remains `planned_public_benefit_shareholding`.
+- Approved framing remains `Public-Benefit Mission and Governance` and `planned public-benefit shareholding arrangement`.
+- Forbidden foundation claims remain absent by prior R2 evidence:
+  - registered foundation
+  - nonprofit legal status
+  - charity registration
+  - donation program
+  - grant program
+  - formal board governance
+  - legal fiduciary duty
+  - exact ownership percentage
+  - completed equity transfer
+  - completed foundation holding
+
+## Public Runtime Verification
+
+No post-publish runtime verification was performed because no publish occurred. R2 evidence showed the target pages were still non-public before this task.
+
+## Sitemap / llms / Footer Exposure Check
+
+No sitemap, llms, footer, or navigation exposure was enabled. No related generator or frontend files were modified.
+
+## Search Channel Safety
+
+No Search Channel command was run, no queue item was created, and no URL was submitted.
+
+## Decision
+
+Final decision: `blocked_missing_official_publish_runtime`
+
+Required next task: `GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublish01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublish01Test.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesControlledPublish01Test extends TestCase
+{
+    public function test_controlled_publish_report_exists_with_closed_boundaries(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-controlled-publish-01.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-controlled-publish-01.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true);
+
+        $this->assertIsArray($generated);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01', $generated['task'] ?? null);
+        $this->assertSame(
+            ['brand', 'charter', 'foundation', 'careers', 'policies'],
+            $generated['target_pages'] ?? null,
+        );
+
+        $this->assertSame('planned_public_benefit_shareholding', $generated['foundation_fact_state'] ?? null);
+        $this->assertTrue($generated['approval_phrase_verified'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_external_search_api_call'] ?? false);
+        $this->assertTrue($generated['no_out_of_scope_cms_write'] ?? false);
+
+        $this->assertArrayHasKey('final_decision', $generated);
+        $this->assertArrayHasKey('next_task', $generated);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28392,7 +28392,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01": {
-    "status": "local_checks_passed_blocked_missing_official_publish_runtime",
+    "status": "pr_open_blocked_missing_official_publish_runtime",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-controlled-publish-01",
     "base": "main",
@@ -28400,8 +28400,8 @@
       "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2"
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01 controlled publish for Wave 1 English content pages",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "6b2fb19c68364c918537552c0d9ca08fc5752b89",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1718",
     "failure_reason": "No official bounded controlled publish runtime exists for content_pages; content-pages:import-local-baseline is an import/upsert runtime and can create missing records, so it was rejected for this publish-only scope.",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -28474,6 +28474,11 @@
         "at": "2026-05-27T12:58:00+08:00",
         "status": "local_checks_passed",
         "summary": "Focused test, route list, pint, composer validate/audit, JSON/YAML parsing, and diff checks passed."
+      },
+      {
+        "at": "2026-05-27T13:02:00+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1718 for the scoped blocked-runtime report."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28390,5 +28390,91 @@
         "summary": "GitHub checks passed for PR #1717 and merge state was CLEAN."
       }
     ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01": {
+    "status": "local_checks_passed_blocked_missing_official_publish_runtime",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-controlled-publish-01",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01 controlled publish for Wave 1 English content pages",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": "No official bounded controlled publish runtime exists for content_pages; content-pages:import-local-baseline is an import/upsert runtime and can create missing records, so it was rejected for this publish-only scope.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "approval_phrase": {
+        "status": "passed",
+        "evidence": "Exact approval phrase was present in the user request."
+      },
+      "dependency_verification": {
+        "status": "passed",
+        "evidence": "GitHub shows PR #1717 merged at 2026-05-27T04:17:22Z with merge commit 56c5db23283412a9791b79ac6cf91305dea4709a. Merged R2 readiness package on main reports content_pages_publish_readiness_r2_completed_ready_for_controlled_publish and all_five_pages scope."
+      },
+      "official_publish_runtime": {
+        "status": "blocked",
+        "evidence": "Repository runtime inspection and php artisan list found articles:publish-controlled for articles and content-pages:import-local-baseline for imports, but no content-pages controlled publish runtime with dry-run and existing-record-only fail-closed behavior."
+      },
+      "cms_publish": {
+        "status": "not_performed",
+        "evidence": "No CMS mutation was performed because the official content-pages publish runtime is missing."
+      },
+      "search_channel": {
+        "status": "not_performed",
+        "evidence": "No Search Channel command was run."
+      },
+      "focused_test": {
+        "status": "passed",
+        "command": "php artisan test --filter=GlobalEnZhContentPagesControlledPublish01 --no-ansi",
+        "evidence": "1 passed, 14 assertions."
+      },
+      "route_list": {
+        "status": "passed",
+        "command": "php artisan route:list --no-ansi"
+      },
+      "pint": {
+        "status": "passed",
+        "command": "vendor/bin/pint --test",
+        "evidence": "3588 files passed."
+      },
+      "composer_validate": {
+        "status": "passed",
+        "command": "composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "passed",
+        "command": "composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "passed",
+        "evidence": "Generated JSON, pr-train-state JSON, and pr-train YAML parsed successfully."
+      },
+      "diff_check": {
+        "status": "passed",
+        "command": "git diff --check && git diff --cached --check"
+      },
+      "fap_web_reference_check": {
+        "status": "passed_with_sidecar",
+        "evidence": "Reference-only fap-web working tree has pre-existing untracked files; no fap-web files were modified by this task."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T12:45:00+08:00",
+        "status": "blocked_missing_official_publish_runtime",
+        "summary": "Stopped before CMS publish because no official bounded content_pages publish runtime exists."
+      },
+      {
+        "at": "2026-05-27T12:58:00+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, pint, composer validate/audit, JSON/YAML parsing, and diff checks passed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14184,6 +14184,50 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2
+    branch: codex/global-en-zh-content-pages-controlled-publish-01
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01 controlled publish for Wave 1 English content pages"
+    train_scope: global_en_zh_controlled_cms_publish
+    risk_level: p0_controlled_cms_publish
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-controlled-publish-01.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublish01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Dry-run first and publish only the existing English CMS draft records for brand, charter, foundation, careers, and policies if an official bounded content-pages publish runtime exists.
+      - Stop fail-closed if the official publish runtime is missing, a target draft record is missing, dry-run fails, foundation boundaries are overclaimed, or sitemap/llms/footer/Search Channel exposure changes unexpectedly.
+      - Do not deploy, submit URLs, enqueue Search Channel, call external search APIs, enable sitemap/llms/footer/nav exposure, edit fap-web, run production migrations, read raw logs, access production user data, or write out-of-scope CMS records.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesControlledPublish01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    cms_mutation: controlled_publish_existing_records_only
+    publish_allowed: true
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the controlled publish report and generated JSON for GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01.
- Added a focused SeoIntel fixture test for the generated artifact.
- Added the scoped PR train manifest/state entry.

## Why
- The approved publish task was evaluated fail-closed because no official bounded content-pages controlled publish runtime exists.
- `content-pages:import-local-baseline` was rejected for this publish-only scope because it is import/upsert oriented and can create missing records.

## Validation
- `php artisan test --filter=GlobalEnZhContentPagesControlledPublish01 --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No CMS publish was performed.
- No Search Channel enqueue, URL submission, external search API call, deploy, sitemap/llms/footer/nav exposure, or fap-web change was performed.
- Next required task: `GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01`.
