### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02 execute controlled publish for Wave 1 English content pages

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-02.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-02.v1.json
@@ -1,0 +1,197 @@
+{
+  "schema_version": "global-en-zh-content-pages-controlled-publish-02.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02",
+  "final_decision": "blocked_foundation_fact_overclaim",
+  "approval_phrase_verified": true,
+  "backend_revision_verified": {
+    "verified": true,
+    "expected_sha": "76a326807b38b43c807d6fb6348c2684ea5e8aae",
+    "actual_sha": "76a326807b38b43c807d6fb6348c2684ea5e8aae",
+    "release": "prod-20260527-76a32680"
+  },
+  "command_verified": true,
+  "target_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "preflight_result": {
+    "status": "passed_until_dry_run_claim_guard",
+    "production_runtime": "content-pages:publish-controlled",
+    "command_help_checked": true,
+    "target_records_exist": true,
+    "target_records_before_state": {
+      "brand": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages"
+      },
+      "charter": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages"
+      },
+      "foundation": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages"
+      },
+      "careers": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages"
+      },
+      "policies": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_at": null,
+        "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages"
+      }
+    },
+    "r2_readiness_artifact_required": true,
+    "no_search_channel_command_planned": true,
+    "no_deploy_planned": true,
+    "no_out_of_scope_cms_record_planned": true
+  },
+  "dry_run_result": {
+    "performed": true,
+    "ok": false,
+    "dry_run": true,
+    "writes_committed": false,
+    "target_count": 5,
+    "would_publish_count": 0,
+    "would_update_count": 0,
+    "would_create_count": 0,
+    "blocked_count": 1,
+    "target_keys": [
+      "brand",
+      "charter",
+      "foundation",
+      "careers",
+      "policies"
+    ],
+    "error_codes": [
+      "foundation_overclaim_detected"
+    ],
+    "foundation_fact_state": "planned_public_benefit_shareholding",
+    "forbidden_foundation_claims_absent": false,
+    "search_channel_action_attempted": false,
+    "url_submission_attempted": false,
+    "external_search_api_call_attempted": false,
+    "deploy_attempted": false,
+    "sitemap_llms_footer_explicit_enablement": false,
+    "no_record_creation": true,
+    "no_upsert_missing": true,
+    "no_out_of_scope_cms_write": true
+  },
+  "publish_result": {
+    "performed": false,
+    "reason": "Production dry-run failed fail-closed with foundation_overclaim_detected.",
+    "published_pages": [],
+    "writes_committed": false,
+    "cms_records_published": []
+  },
+  "post_publish_verification": {
+    "performed": false,
+    "reason": "No publish was performed because dry-run blocked on foundation_overclaim_detected.",
+    "draft_records_still_draft": true,
+    "public_runtime_still_non_public": true
+  },
+  "foundation_fact_state": "planned_public_benefit_shareholding",
+  "forbidden_foundation_claims_absent": false,
+  "foundation_claim_guard_observation": {
+    "runtime_error_code": "foundation_overclaim_detected",
+    "matched_negative_boundary_text": [
+      "formal board governance",
+      "completed equity transfer"
+    ],
+    "classification": "dry_run_claim_guard_blocked_publish",
+    "note": "The matched phrases appeared inside a negative boundary sentence describing claims the page does not make. The deployed runtime still treats those exact phrases as forbidden and blocks publish."
+  },
+  "cms_records_published": [],
+  "public_runtime_check": {
+    "performed": true,
+    "results": {
+      "https://fermatmind.com/en/brand": {
+        "http_status": 404,
+        "robots": "noindex"
+      },
+      "https://fermatmind.com/en/charter": {
+        "http_status": 404,
+        "robots": "noindex"
+      },
+      "https://fermatmind.com/en/foundation": {
+        "http_status": 404,
+        "robots": "noindex"
+      },
+      "https://fermatmind.com/en/careers": {
+        "http_status": 404,
+        "robots": "noindex"
+      },
+      "https://fermatmind.com/en/policies": {
+        "http_status": 404,
+        "robots": "noindex"
+      }
+    }
+  },
+  "sitemap_exposure_check": {
+    "performed": true,
+    "sitemap_status": 200,
+    "target_page_hits": []
+  },
+  "llms_exposure_check": {
+    "performed": true,
+    "llms_txt_status": 200,
+    "llms_full_txt_status": 200,
+    "target_page_hits": []
+  },
+  "footer_nav_exposure_check": {
+    "performed": true,
+    "checked_public_home_locales": [
+      "/en",
+      "/zh"
+    ],
+    "target_page_hits": []
+  },
+  "search_channel_check": {
+    "performed": true,
+    "content_page_queue_count": 0,
+    "queue_item_2_state": {
+      "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    },
+    "queue_item_3_state": {
+      "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    },
+    "queue_item_created": false,
+    "live_submission_performed": false
+  },
+  "gate_state": {
+    "SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED": false,
+    "SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED": false,
+    "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED": false,
+    "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED": false
+  },
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_out_of_scope_cms_write": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-controlled-publish-02.md
+++ b/backend/docs/seo/global-en-zh-content-pages-controlled-publish-02.md
@@ -1,0 +1,137 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02
+
+## Executive Summary
+
+The exact approval phrase was present, the deployed backend revision matched `76a326807b38b43c807d6fb6348c2684ea5e8aae`, and production exposed the official `content-pages:publish-controlled` runtime.
+
+The production dry-run failed closed before publish. No CMS records were published. The runtime blocked the `foundation` draft with `foundation_overclaim_detected`, so the execute command was not run.
+
+## Approval Verification
+
+- Exact approval phrase present: yes
+- Approved target pages: `brand`, `charter`, `foundation`, `careers`, `policies`
+- Approved mode: dry-run first, publish only the five existing English CMS draft records, no deploy, no Search Channel, no URL submission
+
+## Runtime / Revision Verification
+
+- Production backend revision: `76a326807b38b43c807d6fb6348c2684ea5e8aae`
+- Release: `prod-20260527-76a32680`
+- Runtime command verified: `content-pages:publish-controlled`
+
+## Target Pages
+
+The five target CMS records exist and remain:
+
+- `status=draft`
+- `is_public=false`
+- `is_indexable=false`
+- `published_at=null`
+- `source_doc=global-en-zh-content-pages-cms-draft-update-01 from human revision packages`
+
+## Preflight Result
+
+Preflight passed until the official runtime claim guard evaluated the foundation draft during dry-run.
+
+The foundation page retained the expected `planned_public_benefit_shareholding` fact state and `Public-Benefit Mission and Governance` title.
+
+## Dry-run Result
+
+Command:
+
+```bash
+php artisan content-pages:publish-controlled \
+  --locale=en \
+  --keys=brand,charter,foundation,careers,policies \
+  --dry-run \
+  --json
+```
+
+Result:
+
+- `ok=false`
+- `dry_run=true`
+- `writes_committed=false`
+- `target_count=5`
+- `would_create_count=0`
+- `blocked_count=1`
+- Error: `foundation_overclaim_detected`
+- Search Channel action attempted: false
+- URL submission attempted: false
+- External search API attempted: false
+- Deploy attempted: false
+
+## Controlled Publish Result
+
+No execute command was run because dry-run failed.
+
+Published pages: none.
+
+## Foundation Governance Boundary
+
+The blocker is inside the foundation page claim guard. The runtime matched the phrases:
+
+- `formal board governance`
+- `completed equity transfer`
+
+Those phrases appeared in a negative boundary sentence saying the page does not claim those items. The deployed runtime is intentionally conservative and still blocks exact forbidden phrases.
+
+## Public Runtime Verification
+
+Because no publish occurred, the five pages remain non-public:
+
+- `/en/brand`: 404, `noindex`
+- `/en/charter`: 404, `noindex`
+- `/en/foundation`: 404, `noindex`
+- `/en/careers`: 404, `noindex`
+- `/en/policies`: 404, `noindex`
+
+## Sitemap / llms / Footer Exposure Check
+
+No target page appeared in:
+
+- `/sitemap.xml`
+- `/llms.txt`
+- `/llms-full.txt`
+- `/en`
+- `/zh`
+
+## Search Channel Safety
+
+- No Search Channel queue item was created for the five content pages.
+- Queue item 2 remains EN MBTI approved/submitted.
+- Queue item 3 remains ZH MBTI approved/submitted.
+- Search Channel gates remain closed.
+
+## Validation
+
+Validation is recorded in the generated JSON and focused test for this blocked publish attempt.
+
+## PR / Merge Result
+
+Pending at report creation.
+
+## Sidecar Issues
+
+The current foundation copy or claim guard needs a follow-up. The safest remediation is either:
+
+- revise the foundation draft so the boundary sentence avoids exact forbidden phrases, or
+- update the runtime claim guard to recognize explicit negative boundary language without allowing positive overclaims.
+
+## What Was Not Done
+
+- No publish execute command was run.
+- No CMS record was published.
+- No deploy was performed.
+- No Search Channel enqueue was performed.
+- No URL was submitted.
+- No external search API was called.
+- No sitemap, llms, footer, or nav exposure was enabled.
+- No fap-web file was modified.
+
+## Final Decision
+
+`blocked_foundation_fact_overclaim`
+
+## Next Task
+
+`GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublish02Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublish02Test.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesControlledPublish02Test extends TestCase
+{
+    public function test_controlled_publish_02_report_exists_with_closed_boundaries(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-controlled-publish-02.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-controlled-publish-02.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true);
+
+        $this->assertIsArray($generated);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02', $generated['task'] ?? null);
+        $this->assertSame(
+            ['brand', 'charter', 'foundation', 'careers', 'policies'],
+            $generated['target_pages'] ?? null,
+        );
+
+        $this->assertSame('planned_public_benefit_shareholding', $generated['foundation_fact_state'] ?? null);
+        $this->assertTrue($generated['approval_phrase_verified'] ?? false);
+        $this->assertTrue($generated['command_verified'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_external_search_api_call'] ?? false);
+        $this->assertTrue($generated['no_out_of_scope_cms_write'] ?? false);
+
+        $this->assertArrayHasKey('final_decision', $generated);
+        $this->assertArrayHasKey('next_task', $generated);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -22490,7 +22490,7 @@
       "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00"
     ],
     "commit_sha": "401099d481c71c1afaf77a9e5458b7c6dad3f462",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1720",
     "checks": {
       "scope_validation": {
         "status": "pass",
@@ -28564,6 +28564,14 @@
         "status": "created",
         "sha": "401099d481c71c1afaf77a9e5458b7c6dad3f462",
         "message": "docs(content-pages): record controlled publish block"
+      },
+      "push": {
+        "status": "pushed",
+        "branch": "codex/global-en-zh-content-pages-controlled-publish-02"
+      },
+      "pull_request": {
+        "status": "open",
+        "url": "https://github.com/fermatmind/fap-api/pull/1720"
       }
     },
     "history": [
@@ -28682,6 +28690,11 @@
         "at": "2026-05-27T14:09:57+08:00",
         "status": "committed",
         "summary": "Created scoped report commit 401099d4."
+      },
+      {
+        "at": "2026-05-27T14:09:57+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1720 for the blocked controlled-publish dry-run report."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -22489,7 +22489,7 @@
     "depends_on": [
       "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00"
     ],
-    "commit_sha": "4b273eef9fdffcebc564740bdc9dad7e7098097e",
+    "commit_sha": "401099d481c71c1afaf77a9e5458b7c6dad3f462",
     "pr_url": null,
     "checks": {
       "scope_validation": {
@@ -28562,7 +28562,7 @@
       },
       "commit": {
         "status": "created",
-        "sha": "4b273eef9fdffcebc564740bdc9dad7e7098097e",
+        "sha": "401099d481c71c1afaf77a9e5458b7c6dad3f462",
         "message": "docs(content-pages): record controlled publish block"
       }
     },
@@ -28681,7 +28681,7 @@
       {
         "at": "2026-05-27T14:09:57+08:00",
         "status": "committed",
-        "summary": "Created scoped report commit 4b273eef."
+        "summary": "Created scoped report commit 401099d4."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -22489,7 +22489,7 @@
     "depends_on": [
       "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00"
     ],
-    "commit_sha": null,
+    "commit_sha": "4b273eef9fdffcebc564740bdc9dad7e7098097e",
     "pr_url": null,
     "checks": {
       "scope_validation": {
@@ -28483,7 +28483,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01": {
-    "status": "local_checks_passed_after_ci_fix",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-controlled-publish-runtime-01",
     "base": "main",
@@ -28491,11 +28491,11 @@
       "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-01"
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01 content pages controlled publish runtime",
-    "commit_sha": "c4daaa7f275971e734f782564999266cd0772c4e",
+    "commit_sha": "76a326807b38b43c807d6fb6348c2684ea5e8aae",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1719",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-05-27T05:22:00Z",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "checks": {
       "dependency_verification": {
@@ -28532,7 +28532,7 @@
         "branch": "codex/global-en-zh-content-pages-controlled-publish-runtime-01"
       },
       "pull_request": {
-        "status": "open",
+        "status": "merged",
         "url": "https://github.com/fermatmind/fap-api/pull/1719"
       },
       "github_checks": {
@@ -28559,6 +28559,11 @@
           "git diff --check",
           "git diff --cached --check"
         ]
+      },
+      "commit": {
+        "status": "created",
+        "sha": "4b273eef9fdffcebc564740bdc9dad7e7098097e",
+        "message": "docs(content-pages): record controlled publish block"
       }
     },
     "history": [
@@ -28596,6 +28601,87 @@
         "at": "2026-05-27T13:14:11+08:00",
         "status": "local_checks_passed_after_ci_fix",
         "summary": "CI freeze-boundary fix validated locally with runtime and BigFive freeze classifier suites."
+      },
+      {
+        "at": "2026-05-27T14:09:57+08:00",
+        "status": "merged",
+        "summary": "Reconciled ledger: GitHub PR #1719 is merged, origin/main contains merge commit 76a326807b38b43c807d6fb6348c2684ea5e8aae, and the remote branch is deleted."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02": {
+    "status": "blocked_foundation_fact_overclaim",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-controlled-publish-02",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02 execute controlled publish for Wave 1 English content pages",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": "Production dry-run failed fail-closed with foundation_overclaim_detected; no execute command was run.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "approval_verification": {
+        "status": "passed",
+        "evidence": "Exact approval phrase was present."
+      },
+      "runtime_revision_verification": {
+        "status": "passed",
+        "evidence": "Production backend REVISION matched 76a326807b38b43c807d6fb6348c2684ea5e8aae and content-pages:publish-controlled --help succeeded."
+      },
+      "production_dry_run": {
+        "status": "failed_closed",
+        "command": "php artisan content-pages:publish-controlled --locale=en --keys=brand,charter,foundation,careers,policies --dry-run --json",
+        "evidence": "Dry-run returned ok=false, writes_committed=false, blocked_count=1, error code foundation_overclaim_detected."
+      },
+      "execute": {
+        "status": "skipped",
+        "evidence": "Execute was not run because dry-run failed."
+      },
+      "safety_verification": {
+        "status": "passed",
+        "evidence": "Target records remain draft/non-public/non-indexable; public runtime remains 404/noindex; sitemap/llms/footer show no target page hits; Search Channel gates are closed and no content-page queue items exist."
+      },
+      "local_validation": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test --filter=GlobalEnZhContentPagesControlledPublish02 --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-02.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<'PY' ... yaml.safe_load(...) ... PY",
+          "git diff --check",
+          "git diff --cached --check"
+        ]
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T14:09:57+08:00",
+        "status": "production_dry_run_failed_closed",
+        "summary": "Ran official production dry-run; runtime blocked foundation with foundation_overclaim_detected."
+      },
+      {
+        "at": "2026-05-27T14:09:57+08:00",
+        "status": "execute_skipped",
+        "summary": "Did not run --execute because dry-run failed."
+      },
+      {
+        "at": "2026-05-27T14:09:57+08:00",
+        "status": "local_checks_passed",
+        "summary": "Generated blocked publish report and passed required local validation."
+      },
+      {
+        "at": "2026-05-27T14:09:57+08:00",
+        "status": "committed",
+        "summary": "Created scoped report commit 4b273eef."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14279,6 +14279,50 @@ prs:
     frontend_fallback_authority: false
     next_task: BACKEND-DEPLOY-READINESS｜Deploy content pages controlled publish runtime
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01
+    branch: codex/global-en-zh-content-pages-controlled-publish-02
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02 execute controlled publish for Wave 1 English content pages"
+    train_scope: global_en_zh_controlled_cms_publish_execution
+    risk_level: p0_production_cms_publish_bounded
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-controlled-publish-02.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-02.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublish02Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Run the deployed content-pages:publish-controlled runtime for the exact five English content_pages records brand, charter, foundation, careers, and policies.
+      - Dry-run first; execute only if dry-run passes; record the outcome in docs/generated/test artifacts.
+      - Avoid deploy, Search Channel enqueue, URL submission, external search APIs, sitemap/llms/footer/nav enablement, raw logs, production user data, fap-web changes, and out-of-scope CMS writes.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesControlledPublish02 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-02.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    cms_mutation: true
+    publish_allowed: true
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Recorded GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02 production dry-run outcome.
- Added generated JSON, markdown report, focused test, and scoped PR train metadata.
- Reconciled the already-merged runtime PR ledger entry needed for this train item.

## Why
- The official deployed `content-pages:publish-controlled` runtime failed closed on the foundation draft with `foundation_overclaim_detected`.
- No publish execute command was run, and the five target pages remain draft/non-public/non-indexable.

## Validation
- `cd backend && php artisan test --filter=GlobalEnZhContentPagesControlledPublish02 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-controlled-publish-02.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No CMS publish execute after dry-run failed.
- No deploy, Search Channel action, URL submission, external search API call, sitemap/llms/footer/nav exposure, fap-web mutation, or production user-data access.
- Follow-up should revise foundation boundary copy or make the claim guard negation-aware before retrying controlled publish.