### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2 remove foundation forbidden exact phrases

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-human-revision-r2.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-human-revision-r2.v1.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "global-en-zh-content-pages-human-revision-r2.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2",
+  "final_decision": "content_pages_human_revision_r2_completed_ready_for_cms_draft_update",
+  "blocker_from_previous_task": "foundation_overclaim_detected",
+  "target_pages": [
+    "foundation"
+  ],
+  "revised_pages": [
+    "foundation"
+  ],
+  "foundation_fact_state": "planned_public_benefit_shareholding",
+  "previous_blocker_summary": {
+    "source_task": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02",
+    "source_pr": "https://github.com/fermatmind/fap-api/pull/1720",
+    "source_merge_commit": "9d9004bab3f1d909207adcdf4e485f2b71ad9393",
+    "dry_run_error_code": "foundation_overclaim_detected",
+    "reason": "The foundation draft contained exact guard phrases inside negative boundary language. The controlled publish runtime blocks exact guarded text regardless of negation."
+  },
+  "evidence_summary": {
+    "public_benefit_direction_supported_by_user_deck": true,
+    "supported_themes": [
+      "public benefit is a trust mechanism rather than promotion",
+      "youth interests first",
+      "clear data boundaries",
+      "social responsibility written into governance",
+      "public-benefit mission carrier / public-benefit foundation shareholding plan"
+    ],
+    "completed_legal_status_not_evidenced": true
+  },
+  "revision_strategy": {
+    "scope": "foundation wording only",
+    "approach": "Replace enumerated negative disclaimers with generalized boundary language that avoids exact guarded tokens while keeping the planned public-benefit shareholding direction.",
+    "source_addendum_superseded_for_foundation_text": "backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json"
+  },
+  "forbidden_foundation_phrases_removed": true,
+  "forbidden_foundation_phrase_hits_after_revision": 0,
+  "public_benefit_governance_preserved": true,
+  "cms_update_required": true,
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_sitemap_llms_exposure": true,
+  "no_footer_nav_exposure": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-R2"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-human-revision-r2.md
+++ b/backend/docs/seo/global-en-zh-content-pages-human-revision-r2.md
@@ -1,0 +1,93 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2
+
+## Executive Summary
+
+`GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02` stopped fail-closed during the production dry-run because the foundation draft still contained exact guarded phrases inside negative boundary language.
+
+This R2 package revises only the foundation page wording. It preserves `planned_public_benefit_shareholding`, `Public-Benefit Mission and Governance`, youth-first boundaries, data-boundary principles, responsible assessment use, and the long-term governance direction. It removes the exact guarded terms from the future public draft body by replacing enumerated disclaimers with generalized legal-completion boundary language.
+
+No CMS record was updated. No publish, deploy, Search Channel action, URL submission, sitemap/llms/footer/nav exposure, or fap-web change was performed.
+
+## Previous Blocker
+
+Previous task: `GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02`
+
+Previous PR: https://github.com/fermatmind/fap-api/pull/1720
+
+Merge commit: `9d9004bab3f1d909207adcdf4e485f2b71ad9393`
+
+Dry-run blocker: `foundation_overclaim_detected`
+
+Cause: exact guarded phrases appeared inside negative boundary language. The runtime correctly treats exact guarded text as a fail-closed condition, regardless of whether the sentence says the page does not claim those facts.
+
+## Revision Scope
+
+Target page:
+
+- `foundation`
+
+No revision was made to:
+
+- `brand`
+- `charter`
+- `careers`
+- `policies`
+- articles, topics, tests, research, careers jobs, result/report assets, media assets, UI i18n, footer/nav, sitemap/llms, or Search Channel
+
+## Foundation Wording Changes
+
+The revised package keeps:
+
+- title: `Public-Benefit Mission and Governance`
+- fact state: `planned_public_benefit_shareholding`
+- the planned public-benefit shareholding arrangement
+- youth-first assessment boundaries
+- clear data boundaries
+- responsible assessment use
+- the statement that specific implementation details still require founder and legal confirmation
+
+The future public body now uses generalized boundary language:
+
+> This page describes a planned governance direction. It does not present that direction as already legally completed, and it should be read together with FermatMind's Terms and Privacy Policy.
+
+## Forbidden Phrase Removal
+
+The R2 public draft body has zero exact guarded phrase hits after revision.
+
+The previous enumerated negative disclaimer style was replaced because it was too brittle for the controlled publish runtime. The R2 text avoids listing guarded terms in the body while preserving the same claim boundary.
+
+## Public-Benefit Governance Preservation
+
+The revision does not erase the public-benefit governance direction. It keeps the trust mechanism supported by the user's deck:
+
+- public benefit as a brand trust mechanism, not promotion
+- youth interests first
+- clear data boundaries
+- social responsibility inside governance
+- a planned public-benefit mission/shareholding path
+
+The package does not claim that the planned path is already legally completed.
+
+## CMS Draft Update Requirement
+
+`cms_update_required=true`
+
+The next task should update the existing foundation CMS draft from the R2 revision package only. It should not publish and should keep the page draft/non-public/non-indexable until a later controlled publish retry.
+
+## Safety Boundary
+
+- `no_cms_mutation=true`
+- `no_publish=true`
+- `no_deploy=true`
+- `no_search_channel_action=true`
+- `no_url_submission=true`
+- `no_sitemap_llms_exposure=true`
+- `no_footer_nav_exposure=true`
+
+## Final Decision
+
+`content_pages_human_revision_r2_completed_ready_for_cms_draft_update`
+
+## Next Task
+
+`GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-R2`

--- a/backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-r2.foundation.v1.json
+++ b/backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-r2.foundation.v1.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "global-en-zh-content-pages-human-revision-r2.foundation.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2",
+  "package_type": "foundation_revision_only",
+  "source_blocker_task": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02",
+  "source_revision_packages": [
+    "backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01.revision.v1.json",
+    "backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-01a-foundation-governance.addendum.v1.json"
+  ],
+  "page_key": "foundation",
+  "revised_title_en": "Public-Benefit Mission and Governance",
+  "revised_description_en": "FermatMind's public-benefit mission and governance path describes youth-first assessment boundaries, clear data responsibilities, and a planned public-benefit shareholding arrangement without presenting the direction as already legally completed.",
+  "revised_h1_en": "Public-Benefit Mission and Governance",
+  "revised_body_blocks_en": [
+    {
+      "heading": "Public benefit as governance, not promotion",
+      "markdown": "FermatMind treats public-benefit work as part of long-term trust. The direction is youth-first: assessment results should not become permanent labels, hiring shortcuts, or deterministic judgments. Data boundaries should remain clear, consent-aware, and consistent with published privacy and product notices."
+    },
+    {
+      "heading": "Planned public-benefit shareholding arrangement",
+      "markdown": "FermatMind is building a planned public-benefit shareholding arrangement as part of its governance path. The purpose is to keep youth interests, clear data boundaries, and responsible assessment use inside the company's long-term operating principles. Specific implementation details require founder and legal confirmation before public statements go beyond this planned direction."
+    },
+    {
+      "heading": "Youth-first assessment boundaries",
+      "markdown": "The governance direction supports a simple product rule: assessment content should help people explore work styles, strengths, risks, and next-step questions without turning a result into a fixed identity or a single life outcome. Public-benefit language should strengthen responsible use rather than increase pressure on users."
+    },
+    {
+      "heading": "How to read this page",
+      "markdown": "This page describes a planned governance direction. It does not present that direction as already legally completed, and it should be read together with FermatMind's Terms and Privacy Policy."
+    }
+  ],
+  "removed_phrases": [
+    "registered foundation",
+    "nonprofit legal status",
+    "charity registration",
+    "donation program",
+    "grant program",
+    "formal board governance",
+    "legal fiduciary duty",
+    "exact ownership percentage",
+    "completed equity transfer",
+    "completed foundation holding"
+  ],
+  "replacement_strategy": "Removed enumerated negative disclaimers and replaced them with generalized legally-completed boundary language that does not contain exact guarded phrases or close guarded variants.",
+  "foundation_fact_state": "planned_public_benefit_shareholding",
+  "remaining_review_requirements": [
+    "founder_review",
+    "legal_review",
+    "cms_draft_update_r2"
+  ],
+  "cms_update_required": true,
+  "publish_state": "draft_revision_only",
+  "sitemap_eligible": false,
+  "llms_eligible": false,
+  "footer_eligible": false,
+  "search_channel_eligible": false,
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true
+}

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevisionR2Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevisionR2Test.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesHumanRevisionR2Test extends TestCase
+{
+    #[Test]
+    public function revision_r2_package_removes_foundation_guarded_phrases_without_erasing_governance_direction(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-human-revision-r2.v1.json');
+        $packagePath = base_path('docs/seo/import-packages/global-en-zh-content-pages-human-revision-r2.foundation.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-human-revision-r2.md'));
+        $this->assertFileExists($generatedPath);
+        $this->assertFileExists($packagePath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+        $package = json_decode((string) file_get_contents($packagePath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2', $generated['task'] ?? null);
+        $this->assertSame('planned_public_benefit_shareholding', $generated['foundation_fact_state'] ?? null);
+        $this->assertTrue($generated['forbidden_foundation_phrases_removed'] ?? false);
+        $this->assertSame(0, $generated['forbidden_foundation_phrase_hits_after_revision'] ?? null);
+        $this->assertTrue($generated['public_benefit_governance_preserved'] ?? false);
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertNotEmpty($generated['final_decision'] ?? null);
+        $this->assertNotEmpty($generated['next_task'] ?? null);
+
+        $this->assertSame('foundation', $package['page_key'] ?? null);
+        $this->assertSame('planned_public_benefit_shareholding', $package['foundation_fact_state'] ?? null);
+        $this->assertTrue($package['cms_update_required'] ?? false);
+        $this->assertSame('draft_revision_only', $package['publish_state'] ?? null);
+        $this->assertFalse($package['sitemap_eligible'] ?? true);
+        $this->assertFalse($package['llms_eligible'] ?? true);
+        $this->assertFalse($package['footer_eligible'] ?? true);
+        $this->assertFalse($package['search_channel_eligible'] ?? true);
+
+        $revisionText = strtolower(json_encode([
+            $package['revised_title_en'] ?? '',
+            $package['revised_description_en'] ?? '',
+            $package['revised_h1_en'] ?? '',
+            $package['revised_body_blocks_en'] ?? [],
+        ], JSON_THROW_ON_ERROR));
+
+        foreach ($this->guardedPhrases() as $phrase) {
+            $this->assertStringNotContainsString($phrase, $revisionText);
+        }
+
+        $this->assertStringContainsString('public-benefit', $revisionText);
+        $this->assertStringContainsString('planned public-benefit shareholding arrangement', $revisionText);
+        $this->assertStringContainsString('youth', $revisionText);
+        $this->assertStringContainsString('data boundaries', $revisionText);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function guardedPhrases(): array
+    {
+        return [
+            'registered foundation',
+            'nonprofit legal status',
+            'charity registration',
+            'donation program',
+            'grant program',
+            'formal board governance',
+            'legal fiduciary duty',
+            'exact ownership percentage',
+            'completed equity transfer',
+            'completed foundation holding',
+            'formal board',
+            'board governance',
+            'equity transfer',
+            'ownership percentage',
+            'completed holding',
+            'registered charity',
+            'nonprofit status',
+            'fiduciary',
+        ];
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28704,7 +28704,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2": {
-    "status": "committed",
+    "status": "pr_open",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-human-revision-r2",
     "base": "main",
@@ -28713,7 +28713,7 @@
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2 remove foundation forbidden exact phrases",
     "commit_sha": "d62ad4eeefb58b42d660fc04db6d953943ac2baf",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1721",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -28746,6 +28746,10 @@
       "reference_only_fap_web": {
         "status": "passed",
         "evidence": "git status --short in /Users/rainie/Desktop/GitHub/fap-web returned clean; no fap-web files were committed."
+      },
+      "pull_request": {
+        "status": "open",
+        "url": "https://github.com/fermatmind/fap-api/pull/1721"
       }
     },
     "history": [
@@ -28763,6 +28767,11 @@
         "at": "2026-05-27T14:45:50+08:00",
         "status": "committed",
         "summary": "Created scoped R2 revision commit d62ad4ee."
+      },
+      {
+        "at": "2026-05-27T14:47:23+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1721 for the foundation wording R2 revision package."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28279,7 +28279,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-PUBLISH-READINESS-R2": {
-    "status": "pr_open",
+    "status": "github_checks_passed",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-publish-readiness-r2",
     "base": "main",
@@ -28750,6 +28750,10 @@
       "pull_request": {
         "status": "open",
         "url": "https://github.com/fermatmind/fap-api/pull/1721"
+      },
+      "github_checks": {
+        "status": "passed",
+        "evidence": "PR #1721 checks passed and mergeStateStatus was CLEAN before recording this ledger transition."
       }
     },
     "history": [
@@ -28772,6 +28776,11 @@
         "at": "2026-05-27T14:47:23+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1721 for the foundation wording R2 revision package."
+      },
+      {
+        "at": "2026-05-27T14:54:36+08:00",
+        "status": "github_checks_passed",
+        "summary": "GitHub checks passed for PR #1721 and mergeStateStatus was CLEAN."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28712,7 +28712,7 @@
       "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02"
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2 remove foundation forbidden exact phrases",
-    "commit_sha": "74f1d4dfc6bd9537f92febdaca176c3743b99e42",
+    "commit_sha": "d62ad4eeefb58b42d660fc04db6d953943ac2baf",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -28762,7 +28762,7 @@
       {
         "at": "2026-05-27T14:45:50+08:00",
         "status": "committed",
-        "summary": "Created scoped R2 revision commit 74f1d4df."
+        "summary": "Created scoped R2 revision commit d62ad4ee."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28618,7 +28618,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02": {
-    "status": "blocked_foundation_fact_overclaim",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-controlled-publish-02",
     "base": "main",
@@ -28626,12 +28626,12 @@
       "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01"
     ],
     "title": "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02 execute controlled publish for Wave 1 English content pages",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9d9004bab3f1d909207adcdf4e485f2b71ad9393",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1720",
     "failure_reason": "Production dry-run failed fail-closed with foundation_overclaim_detected; no execute command was run.",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-27T06:28:18Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "approval_verification": {
         "status": "passed",
@@ -28695,6 +28695,74 @@
         "at": "2026-05-27T14:09:57+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1720 for the blocked controlled-publish dry-run report."
+      },
+      {
+        "at": "2026-05-27T14:38:18+08:00",
+        "status": "merged",
+        "summary": "Reconciled ledger: GitHub PR #1720 is merged, origin/main contains merge commit 9d9004bab3f1d909207adcdf4e485f2b71ad9393, and the remote branch is deleted. The task final decision remains blocked_foundation_fact_overclaim in its report artifacts."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2": {
+    "status": "committed",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-human-revision-r2",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2 remove foundation forbidden exact phrases",
+    "commit_sha": "74f1d4dfc6bd9537f92febdaca176c3743b99e42",
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "dependency_reconciliation": {
+        "status": "passed",
+        "evidence": "GitHub PR #1720 is merged and origin/main contains merge commit 9d9004bab3f1d909207adcdf4e485f2b71ad9393."
+      },
+      "scope": {
+        "status": "passed",
+        "evidence": "Current changes are limited to the R2 report, generated JSON, foundation revision package, focused test, and PR train metadata."
+      },
+      "local_validation": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevisionR2 --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-human-revision-r2.v1.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-r2.foundation.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<'PY' ... yaml.safe_load(...) ... PY",
+          "git diff --check",
+          "git diff --cached --check"
+        ]
+      },
+      "reference_only_fap_web": {
+        "status": "passed",
+        "evidence": "git status --short in /Users/rainie/Desktop/GitHub/fap-web returned clean; no fap-web files were committed."
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T14:38:18+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started foundation-only R2 revision package to remove exact guarded phrases from future public draft text while preserving planned public-benefit shareholding governance direction."
+      },
+      {
+        "at": "2026-05-27T14:45:00+08:00",
+        "status": "local_checks_passed",
+        "summary": "Created R2 artifacts and passed focused test, route list, Pint, Composer validation/audit, JSON/YAML parsing, diff checks, and reference-only fap-web status."
+      },
+      {
+        "at": "2026-05-27T14:45:50+08:00",
+        "status": "committed",
+        "summary": "Created scoped R2 revision commit 74f1d4df."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14323,6 +14323,53 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02
+    branch: codex/global-en-zh-content-pages-human-revision-r2
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2 remove foundation forbidden exact phrases"
+    train_scope: global_en_zh_content_pages_foundation_revision_r2
+    risk_level: p1_revision_package_only
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-human-revision-r2.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-human-revision-r2.v1.json
+      - backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-r2.foundation.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesHumanRevisionR2Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Create a foundation-only R2 revision package after controlled publish dry-run blocked on exact guarded phrases.
+      - Preserve planned_public_benefit_shareholding, Public-Benefit Mission and Governance, youth-first boundaries, clear data boundaries, responsible assessment use, and long-term governance design.
+      - Remove exact guarded foundation phrases from the future public draft body while keeping the same claim boundary through generalized wording.
+      - Record the revision package, report, generated artifact, focused test, and PR train state only.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevisionR2 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-human-revision-r2.v1.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-r2.foundation.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-R2
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2 report and generated JSON.
- Added a foundation-only R2 revision package that preserves planned_public_benefit_shareholding and Public-Benefit Mission and Governance while removing guarded exact phrases from future public draft text.
- Added a focused SeoIntel test covering the generated JSON, revision package, no-mutation boundaries, and zero guarded phrase hits in revised public draft text.
- Added the scoped PR train manifest/state entry and reconciled the prior controlled-publish PR #1720 as merged.

## Why
- GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02 failed closed during dry-run with foundation_overclaim_detected because the draft contained exact guarded phrases inside negative boundary language.
- This revision avoids enumerated forbidden wording while preserving the same public-benefit governance meaning.

## Validation
- cd backend && php artisan test --filter=GlobalEnZhContentPagesHumanRevisionR2 --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-human-revision-r2.v1.json >/dev/null
- python3 -m json.tool backend/docs/seo/import-packages/global-en-zh-content-pages-human-revision-r2.foundation.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- YAML parse for docs/codex/pr-train.yaml
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No CMS draft update.
- No publish.
- No deploy.
- No Search Channel enqueue or submission.
- No sitemap, llms, footer, or nav exposure.