### PR TITLE
[codex] Repair career runtime cohort and detail APIs

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace App\Domain\Career\Publish;
 
 use App\Console\Commands\CareerPublicResolutionTypeMatrix;
-use Illuminate\Contracts\Container\Container;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Support\Facades\Cache;
 
 final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublishProjectionVisibility
 {
@@ -20,7 +21,6 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
     private ?array $itemsBySlug = null;
 
     public function __construct(
-        private readonly Container $container,
         private readonly CareerRuntimePublishProjectionService $projectionService,
     ) {}
 
@@ -159,13 +159,7 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
         }
 
         if ($projection === null) {
-            try {
-                $projection = $this->container
-                    ->make(CareerRuntimePublishProjectionExporter::class)
-                    ->build();
-            } catch (\Throwable) {
-                return;
-            }
+            $projection = $this->projectionFromCachedDatasetHub();
         }
 
         if ($projection === []) {
@@ -191,6 +185,81 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
             $this->itemsBySlugLocale[$slug.'|'.$locale] = $item;
             $this->itemsBySlug[$slug] ??= $item;
         }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function projectionFromCachedDatasetHub(): ?array
+    {
+        $payload = Cache::get(PublicCareerAuthorityResponseCache::DATASET_HUB_CACHE_KEY);
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        $members = array_values(array_filter(
+            (array) ($payload['members'] ?? []),
+            static fn (mixed $member): bool => is_array($member)
+        ));
+
+        if ($members === []) {
+            return null;
+        }
+
+        $items = [];
+        foreach ($members as $member) {
+            $slug = $this->normalizeSlug((string) ($member['canonical_slug'] ?? ''));
+            if ($slug === null) {
+                continue;
+            }
+
+            $included = ($member['included_in_public_dataset'] ?? false) === true;
+            $releaseCohort = strtolower(trim((string) ($member['release_cohort'] ?? '')));
+            $publicIndexState = strtolower(trim((string) ($member['public_index_state'] ?? '')));
+            $strongIndexDecision = strtolower(trim((string) ($member['strong_index_decision'] ?? '')));
+            $published = $included
+                && $releaseCohort === 'public_detail_indexable'
+                && in_array($publicIndexState, ['indexable', 'index'], true)
+                && in_array($strongIndexDecision, ['strong_index_ready', 'runtime_publish_projection_visible'], true);
+
+            foreach (CareerRuntimePublishProjectionService::LOCALES as $locale) {
+                $items[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'public_resolution_type' => $published
+                        ? CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB
+                        : CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+                    'runtime_publish_state' => $published
+                        ? CareerRuntimePublishProjectionService::STATE_PUBLISHED
+                        : CareerRuntimePublishProjectionService::STATE_BLOCKED,
+                    'detail_route_enabled' => $published,
+                    'dataset_visible' => $published,
+                    'search_visible' => $published,
+                    'sitemap_live' => $published,
+                    'llms_live' => $published,
+                    'llms_full_live' => $published,
+                    'canonical_url' => $published
+                        ? 'https://fermatmind.com/'.$locale.'/career/jobs/'.$slug
+                        : null,
+                    'canonical_self' => $published,
+                    'robots_indexable' => $published,
+                    'release_gate_pass' => $published,
+                    'blockers' => $published ? [] : ['dataset_cache_projection_not_public_indexable'],
+                    'projection_source' => 'cached_dataset_hub_fallback',
+                ];
+            }
+        }
+
+        if ($items === []) {
+            return null;
+        }
+
+        return [
+            'projection_kind' => CareerRuntimePublishProjectionService::PROJECTION_KIND,
+            'projection_version' => CareerRuntimePublishProjectionService::PROJECTION_VERSION,
+            'source_authority' => 'cached_dataset_hub',
+            'items' => $items,
+        ];
     }
 
     private function normalizeSlug(string $slug): ?string

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -58,6 +58,9 @@ final class CareerJobListBundleBuilder
     public function build(bool $includeNonIndexable = false): array
     {
         $compileRunId = $this->latestCompletedJobListCompileRunId();
+        $runtimeDetailItems = $this->runtimePublishProjection->publicDetailItems();
+        $runtimeDetailSlugs = $this->runtimeProjectionSlugSet($runtimeDetailItems);
+        $hasRuntimeDetailAuthority = $runtimeDetailSlugs !== [];
 
         $snapshotQuery = RecommendationSnapshot::query()
             ->with([
@@ -87,6 +90,12 @@ final class CareerJobListBundleBuilder
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
             ->limit(self::MAX_PUBLIC_COMPILED_ROWS);
+
+        if ($hasRuntimeDetailAuthority) {
+            $snapshotQuery->whereHas('occupation', static function ($query) use ($runtimeDetailSlugs): void {
+                $query->whereIn('canonical_slug', array_keys($runtimeDetailSlugs));
+            });
+        }
 
         if ($compileRunId !== null) {
             $snapshotQuery->where('compile_run_id', $compileRunId);
@@ -137,7 +146,10 @@ final class CareerJobListBundleBuilder
             ->filter()
             ->all();
 
-        $docxItems = $this->buildPublishedDocxCareerJobItems($compiledSlugs);
+        $docxItems = $this->buildPublishedDocxCareerJobItems(
+            $compiledSlugs,
+            $hasRuntimeDetailAuthority ? $runtimeDetailSlugs : null,
+        );
         if ($docxItems !== []) {
             $items = $items->concat($docxItems)->values();
         }
@@ -146,7 +158,10 @@ final class CareerJobListBundleBuilder
             ->map(static fn (CareerJobListItemBundle $item): string => (string) ($item->identity['canonical_slug'] ?? ''))
             ->filter()
             ->all();
-        $directoryDraftItems = $this->buildDirectoryDraftCareerJobItems($visibleSlugs);
+        $directoryDraftItems = $this->buildDirectoryDraftCareerJobItems(
+            $visibleSlugs,
+            $hasRuntimeDetailAuthority ? $runtimeDetailSlugs : null,
+        );
         if ($directoryDraftItems !== []) {
             $items = $items->concat($directoryDraftItems)->values();
         }
@@ -155,7 +170,11 @@ final class CareerJobListBundleBuilder
             ->map(static fn (CareerJobListItemBundle $item): string => (string) ($item->identity['canonical_slug'] ?? ''))
             ->filter()
             ->all();
-        $runtimeProjectionItems = $this->buildRuntimeProjectionCareerJobItems($visibleSlugs, $includeNonIndexable);
+        $runtimeProjectionItems = $this->buildRuntimeProjectionCareerJobItems(
+            $visibleSlugs,
+            $includeNonIndexable,
+            $runtimeDetailItems,
+        );
         if ($runtimeProjectionItems !== []) {
             $items = $items->concat($runtimeProjectionItems)->values();
         }
@@ -171,13 +190,14 @@ final class CareerJobListBundleBuilder
 
     /**
      * @param  list<string>  $excludedSlugs
+     * @param  array<string, true>|null  $allowedSlugs
      * @return list<CareerJobListItemBundle>
      */
-    private function buildPublishedDocxCareerJobItems(array $excludedSlugs): array
+    private function buildPublishedDocxCareerJobItems(array $excludedSlugs, ?array $allowedSlugs = null): array
     {
         $excluded = array_flip(array_filter($excludedSlugs));
 
-        return CareerJob::query()
+        $query = CareerJob::query()
             ->withoutGlobalScope(TenantScope::class)
             ->with('seoMeta')
             ->where('org_id', 0)
@@ -190,8 +210,13 @@ final class CareerJobListBundleBuilder
             })
             ->orderBy('subtitle')
             ->orderBy('slug')
-            ->limit(self::MAX_PUBLIC_DOCX_ROWS)
-            ->get()
+            ->limit(self::MAX_PUBLIC_DOCX_ROWS);
+
+        if ($allowedSlugs !== null) {
+            $query->whereIn('slug', array_keys($allowedSlugs));
+        }
+
+        return $query->get()
             ->filter(fn (CareerJob $job): bool => ! isset($excluded[(string) $job->slug])
                 && $this->isDocxCareerJob($job)
                 && $this->runtimePublishProjection->datasetVisible((string) $job->slug))
@@ -202,19 +227,25 @@ final class CareerJobListBundleBuilder
 
     /**
      * @param  list<string>  $excludedSlugs
+     * @param  array<string, true>|null  $allowedSlugs
      * @return list<CareerJobListItemBundle>
      */
-    private function buildDirectoryDraftCareerJobItems(array $excludedSlugs): array
+    private function buildDirectoryDraftCareerJobItems(array $excludedSlugs, ?array $allowedSlugs = null): array
     {
         $excluded = array_flip(array_filter($excludedSlugs));
 
-        return Occupation::query()
+        $query = Occupation::query()
             ->with(['crosswalks', 'displayAssets'])
             ->where('crosswalk_mode', self::DIRECTORY_DRAFT_CROSSWALK_MODE)
             ->orderBy('canonical_title_en')
             ->orderBy('canonical_slug')
-            ->limit(self::MAX_PUBLIC_DIRECTORY_DRAFT_ROWS)
-            ->get()
+            ->limit(self::MAX_PUBLIC_DIRECTORY_DRAFT_ROWS);
+
+        if ($allowedSlugs !== null) {
+            $query->whereIn('canonical_slug', array_keys($allowedSlugs));
+        }
+
+        return $query->get()
             ->filter(fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug])
                 && $this->runtimePublishProjection->datasetVisible((string) $occupation->canonical_slug))
             ->values()
@@ -224,14 +255,18 @@ final class CareerJobListBundleBuilder
 
     /**
      * @param  list<string>  $excludedSlugs
+     * @param  list<array<string, mixed>>|null  $runtimeDetailItems
      * @return list<CareerJobListItemBundle>
      */
-    private function buildRuntimeProjectionCareerJobItems(array $excludedSlugs, bool $includeNonIndexable): array
-    {
+    private function buildRuntimeProjectionCareerJobItems(
+        array $excludedSlugs,
+        bool $includeNonIndexable,
+        ?array $runtimeDetailItems = null
+    ): array {
         $excluded = array_flip(array_filter($excludedSlugs));
         $projectionItemsBySlug = [];
 
-        foreach ($this->runtimePublishProjection->publicDetailItems() as $item) {
+        foreach (($runtimeDetailItems ?? $this->runtimePublishProjection->publicDetailItems()) as $item) {
             $slug = trim((string) ($item['slug'] ?? ''));
             if ($slug === '' || isset($excluded[$slug])) {
                 continue;
@@ -259,6 +294,24 @@ final class CareerJobListBundleBuilder
                 $projectionItemsBySlug[(string) $occupation->canonical_slug] ?? [],
             ))
             ->all();
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, true>
+     */
+    private function runtimeProjectionSlugSet(array $items): array
+    {
+        $slugs = [];
+
+        foreach ($items as $item) {
+            $slug = strtolower(trim((string) ($item['slug'] ?? '')));
+            if ($slug !== '') {
+                $slugs[$slug] = true;
+            }
+        }
+
+        return $slugs;
     }
 
     private function compareSnapshots(RecommendationSnapshot $left, RecommendationSnapshot $right, bool $includeNonIndexable): int

--- a/backend/docs/career/career-runtime-cohort-and-detail-repair-2026-05-27.md
+++ b/backend/docs/career/career-runtime-cohort-and-detail-repair-2026-05-27.md
@@ -1,0 +1,88 @@
+# Career Runtime Cohort and Detail Repair
+
+Task: `GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01`
+
+Date: 2026-05-27
+
+## Scope
+
+Backend-first runtime diagnosis and scoped repair for the public career jobs cohort, job list timeout, and detail 404/504 behavior.
+
+This work did not mutate CMS data, did not publish the 2289 excluded records, did not generate pSEO pages, did not add sitemap or `llms.txt` exposure, and did not add fap-web fallback authority.
+
+## Production Evidence
+
+Observed through public runtime requests:
+
+| Surface | Observation | Meaning |
+|---|---|---|
+| `/api/v0.5/career/datasets/occupations?locale=zh-CN` | `200`, `member_count=30`, `included_count=30`, `excluded_count=2289`, `public_detail_indexable_count=30` | Current cached dataset hub exposes a 30-item public runtime cohort. |
+| Dataset manifest | `career.dataset_authority.runtime_projection_plus_legacy_342.v2` | Dataset builder is the runtime projection plus legacy 342 authority layer, not raw frontend content. |
+| Dataset tracking | `expected_total_occupations=30`, `tracked_total_occupations=30`, `missing_occupations=0` | The cached runtime authority currently treats 30 as the active published cohort. |
+| `/api/v0.5/career/jobs?locale=zh-CN` | `504 Gateway Time-out` after about 30 seconds | Job index runtime work exceeded the gateway budget. |
+| `/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN` | `504 Gateway Time-out` | Non-current-cohort detail resolution was timing out instead of failing closed quickly. |
+| `/api/v0.5/career/jobs/software-developers?locale=zh-CN` | `504 Gateway Time-out` | Manual-hold detail resolution was timing out instead of failing closed quickly. |
+| fap-web detail route | `fetchCareerJobBundle()` returns `null` for API errors; page route calls `notFound()` | Backend 504 can surface to users as frontend 404. |
+
+## Cohort Meanings
+
+`30` is the current runtime-published, public detail/indexable cohort from the cached dataset hub response. It is the only cohort this repair treats as actively public.
+
+`342` is the legacy B71X/DOCX `career_all_342` baseline. The codebase defines it from batch manifests: `30` batch 2 members, `80` batch 3 members, `222` batch 4 members, plus `10` excluded first-wave slugs. It is a governed baseline, not automatic public runtime exposure.
+
+`2289` is the current excluded count reported by the runtime dataset authority. Based on the code path, these are authority/candidate records excluded by runtime projection and release gates. They are not public jobs, and this repair does not publish them.
+
+## Root Cause
+
+Primary root cause:
+
+`CareerRuntimePublishProjectionLookup` could fall back to building the full runtime projection through `CareerRuntimePublishProjectionExporter` during a public request when a materialized projection artifact was not available. That path can rebuild ledger/projection authority and is too expensive for public list/detail requests.
+
+Secondary root cause:
+
+`CareerJobListBundleBuilder` assembled list candidates from compiled snapshots, DOCX jobs, directory drafts, and runtime projection items before narrowing to the active runtime projection. That allowed work to scale toward legacy/raw cohorts even when the public runtime cohort was only 30.
+
+Frontend 404 behavior:
+
+The frontend route currently treats a failed or null career job API bundle as `notFound()`. Therefore backend timeout/null can appear as a 404 detail page. This repair keeps the authority fix in the backend and does not add frontend fallback data.
+
+## Implemented Repair
+
+1. `CareerRuntimePublishProjectionLookup`
+   - Keeps materialized runtime projection as the first authority.
+   - Keeps materialized release ledger projection as the second authority.
+   - Adds a fast cached dataset hub fallback using `PublicCareerAuthorityResponseCache::DATASET_HUB_CACHE_KEY`.
+   - Removes synchronous exporter rebuild from the public lookup fallback path.
+   - Fails closed when no materialized projection, ledger, or cached dataset hub authority exists.
+
+2. `CareerJobListBundleBuilder`
+   - Reads runtime detail authority once.
+   - Builds a release-gate slug set from `publicDetailItems()`.
+   - When runtime detail authority exists, constrains compiled snapshot, DOCX, directory draft, and runtime projection list sources to that slug set.
+   - Preserves legacy behavior for tests/dev contexts without explicit runtime projection authority.
+
+## Expected Runtime Behavior After Deploy
+
+| URL | Expected |
+|---|---|
+| `/api/v0.5/career/jobs?locale=zh-CN` | `200` within gateway budget, limited to runtime release-gate jobs. |
+| `/api/v0.5/career/jobs/actuaries?locale=zh-CN` | `200` if content/display authority requirements pass for the current 30 cohort. |
+| `/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN` | Fast `404` unless Product/SEO promotes it into runtime projection. |
+| `/api/v0.5/career/jobs/software-developers?locale=zh-CN` | Fast `404`; current code treats it as a manual hold. |
+| `/zh/career/jobs` | Should stop showing detail-ready count `0` caused by job index timeout once backend list endpoint recovers. |
+
+## Tests Added
+
+- `CareerRuntimePublishProjectionLookupTest::test_it_falls_back_to_cached_dataset_hub_without_rebuilding_projection`
+- `CareerJobListApiTest::test_runtime_projection_limits_public_job_index_to_release_gate_slugs`
+
+## Still Needs Product/SEO Confirmation
+
+- Whether `30` is the intended current public cohort or only a temporary launch cohort.
+- Whether and when the legacy `342` baseline should become public.
+- Whether any of the `2289` excluded records should move into a future release queue.
+- Whether frontend should distinguish backend timeout from true `404` in user-facing career detail routes.
+
+## Decision
+
+`career_runtime_cohort_repair_completed_ready_for_deploy_readiness`

--- a/backend/docs/career/generated/career-runtime-cohort-diagnosis-2026-05-27.json
+++ b/backend/docs/career/generated/career-runtime-cohort-diagnosis-2026-05-27.json
@@ -1,0 +1,76 @@
+{
+  "task_id": "GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01",
+  "generated_at": "2026-05-27",
+  "mode": "backend_first_runtime_diagnosis_and_scoped_repair",
+  "production_observations": {
+    "base_url": "https://fermatmind.com",
+    "dataset_endpoint": {
+      "url": "/api/v0.5/career/datasets/occupations?locale=zh-CN",
+      "status": 200,
+      "member_count": 30,
+      "included_count": 30,
+      "excluded_count": 2289,
+      "public_detail_indexable_count": 30,
+      "public_detail_conservative_count": 0,
+      "manifest_version": "career.dataset_authority.runtime_projection_plus_legacy_342.v2",
+      "selection_policy_version": "career_full_release_ledger",
+      "tracking_counts": {
+        "expected_total_occupations": 30,
+        "tracked_total_occupations": 30,
+        "missing_occupations": 0
+      }
+    },
+    "jobs_endpoint": {
+      "url": "/api/v0.5/career/jobs?locale=zh-CN",
+      "status": 504,
+      "gateway": "openresty",
+      "observed_timeout_seconds": 30
+    },
+    "detail_endpoints": [
+      {
+        "url": "/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN",
+        "status": 504,
+        "expected_after_repair": "fast 404 unless this slug enters runtime publish projection"
+      },
+      {
+        "url": "/api/v0.5/career/jobs/software-developers?locale=zh-CN",
+        "status": 504,
+        "expected_after_repair": "fast 404 because software-developers is a manual hold"
+      },
+      {
+        "url": "/api/v0.5/career/jobs/actuaries?locale=zh-CN",
+        "status": "not rechecked in this artifact",
+        "expected_after_repair": "200 if cached dataset hub remains authoritative and backend content/display shell requirements pass"
+      }
+    ]
+  },
+  "cohort_meanings": {
+    "30": "Current runtime-published public detail/indexable cohort exposed by the cached dataset hub response.",
+    "342": "Legacy B71X/DOCX career_all_342 coverage baseline: 30 batch_2 + 80 batch_3 + 222 batch_4 + 10 excluded first-wave slugs.",
+    "2289": "Runtime-excluded occupation records/candidates seen by the authority builder but not in the current public runtime dataset; they must not be published by this repair."
+  },
+  "root_cause_assessment": {
+    "primary": "CareerRuntimePublishProjectionLookup could synchronously rebuild the full runtime projection authority when no materialized projection artifact was available, causing public jobs/detail requests to exceed the 30s gateway budget.",
+    "secondary": "CareerJobListBundleBuilder scanned broad compiled, DOCX, and directory-draft sources before narrowing to runtime projection slugs, so public list work could scale toward legacy/raw cohorts instead of the active public release cohort.",
+    "frontend_404_chain": "fap-web fetchCareerJobBundle returns null for API failures, and app/(localized)/[locale]/career/jobs/[slug]/page.tsx calls notFound() when no bundle is returned."
+  },
+  "implemented_repair": {
+    "projection_lookup": "Use materialized projection first, then materialized release ledger, then cached dataset hub fallback. Public request path no longer invokes CareerRuntimePublishProjectionExporter as a synchronous fallback.",
+    "job_list": "When runtime detail authority exists, constrain compiled, DOCX, directory-draft, and runtime projection list sources to the release-gate slug set.",
+    "cms_mutation": false,
+    "frontend_fallback_authority_added": false,
+    "pseo_generation": false,
+    "sitemap_or_llms_exposure_added": false
+  },
+  "focused_tests": [
+    "Tests\\Unit\\Services\\Career\\CareerRuntimePublishProjectionLookupTest::test_it_falls_back_to_cached_dataset_hub_without_rebuilding_projection",
+    "Tests\\Feature\\Career\\CareerJobListApiTest::test_runtime_projection_limits_public_job_index_to_release_gate_slugs"
+  ],
+  "decision": "career_runtime_cohort_repair_completed_ready_for_deploy_readiness",
+  "pending_verification": [
+    "After deployment, verify /api/v0.5/career/jobs?locale=zh-CN returns 200 within gateway budget.",
+    "After deployment, verify current 30 runtime cohort detail pages return 200 where content/display authority passes.",
+    "After deployment, verify non-cohort slugs such as accountants-and-auditors and software-developers return fast 404, not 504.",
+    "Product/SEO must confirm when, if ever, the 342 legacy cohort should be promoted beyond the current runtime projection."
+  ]
+}

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -301,6 +301,48 @@ final class CareerJobListApiTest extends TestCase
         $this->assertContains('runtime_published_navigation_shell', $response->json('items.0.seo_contract.reason_codes'));
     }
 
+    public function test_runtime_projection_limits_public_job_index_to_release_gate_slugs(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(items: [
+                'actuaries' => [
+                    'slug' => 'actuaries',
+                    'runtime_publish_state' => 'published',
+                    'dataset_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                    'canonical_path' => '/career/jobs/actuaries',
+                    'reason_codes' => ['cached_dataset_hub_fallback'],
+                ],
+            ]),
+        );
+
+        $this->createDirectoryDraftOccupation([
+            'canonical_slug' => 'actuaries',
+            'canonical_title_en' => 'Actuaries',
+            'canonical_title_zh' => '精算师',
+            'search_h1_zh' => '精算师',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+        ]);
+        $this->createDirectoryDraftOccupation([
+            'canonical_slug' => 'accountants-and-auditors',
+            'canonical_title_en' => 'Accountants and Auditors',
+            'canonical_title_zh' => '会计师和审计师',
+            'search_h1_zh' => '会计师和审计师',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'actuaries')
+            ->assertJsonMissing(['canonical_slug' => 'accountants-and-auditors']);
+    }
+
     public function test_directory_draft_runtime_projection_requires_published_state_before_list_upgrade(): void
     {
         $this->app->instance(

--- a/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\Services\Career;
 
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionLookup;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
@@ -112,6 +114,44 @@ final class CareerRuntimePublishProjectionLookupTest extends TestCase
         $this->assertTrue($lookup->searchVisible('architectural-and-civil-drafters'));
         $this->assertTrue($lookup->robotsIndexable('architectural-and-civil-drafters'));
         $this->assertTrue($lookup->releaseGatePass('architectural-and-civil-drafters'));
+    }
+
+    public function test_it_falls_back_to_cached_dataset_hub_without_rebuilding_projection(): void
+    {
+        Cache::put(PublicCareerAuthorityResponseCache::DATASET_HUB_CACHE_KEY, [
+            'members' => [
+                [
+                    'canonical_slug' => 'actuaries',
+                    'release_cohort' => 'public_detail_indexable',
+                    'public_index_state' => 'indexable',
+                    'strong_index_decision' => 'strong_index_ready',
+                    'included_in_public_dataset' => true,
+                ],
+                [
+                    'canonical_slug' => 'accountants-and-auditors',
+                    'release_cohort' => 'review_needed',
+                    'public_index_state' => 'noindex',
+                    'strong_index_decision' => 'review_needed',
+                    'included_in_public_dataset' => false,
+                ],
+            ],
+        ]);
+
+        $lookup = app(CareerRuntimePublishProjectionLookup::class);
+
+        $this->assertTrue($lookup->detailRouteEnabled('actuaries'));
+        $this->assertTrue($lookup->datasetVisible('actuaries'));
+        $this->assertTrue($lookup->searchVisible('actuaries'));
+        $this->assertTrue($lookup->robotsIndexable('actuaries'));
+        $this->assertTrue($lookup->releaseGatePass('actuaries'));
+        $this->assertSame(['actuaries'], array_column($lookup->publicDatasetItems(), 'slug'));
+        $this->assertSame(['actuaries'], array_column($lookup->publicDetailItems(), 'slug'));
+
+        $this->assertFalse($lookup->detailRouteEnabled('accountants-and-auditors'));
+        $this->assertFalse($lookup->datasetVisible('accountants-and-auditors'));
+        $this->assertFalse($lookup->searchVisible('accountants-and-auditors'));
+        $this->assertFalse($lookup->robotsIndexable('accountants-and-auditors'));
+        $this->assertFalse($lookup->releaseGatePass('accountants-and-auditors'));
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## What changed

This PR repairs the public career runtime path for the current release cohort and job detail behavior.

- Removes the synchronous runtime projection rebuild fallback from public career visibility lookup.
- Adds a cached dataset hub fallback for runtime projection visibility when materialized projection artifacts are unavailable.
- Restricts the career job list builder to the runtime public detail cohort before reading compiled snapshots, DOCX jobs, directory drafts, or runtime projection shells.
- Adds focused tests for cached dataset hub fallback and release-gate slug limiting.
- Adds a diagnosis report and generated JSON artifact documenting the observed production cohort counts and timeout behavior.

## Why

Production showed `/api/v0.5/career/jobs?locale=zh-CN` and career job detail endpoints timing out with 504s. The frontend then converts failed/null career job bundles into `notFound()`, so users see detail pages as unavailable/404-like.

The observed cohort numbers mean:

- `30`: current runtime-published public detail/indexable cohort.
- `342`: legacy governed baseline from prior career batches, not automatically all public.
- `2289`: excluded candidates/assets outside the current public release authority, not publishable by this PR.

## Root cause

When no materialized runtime projection artifact was available, the public visibility lookup could fall back to building the runtime projection synchronously inside a public request. The job list builder also loaded broad candidate sets before narrowing to runtime-published items, which increased the request cost and timeout risk.

## Validation

Passed locally:

```bash
cd backend && php artisan route:list --path=api/v0.5/career
cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend
cd backend && ./vendor/bin/pint --test app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php app/Services/Career/Bundles/CareerJobListBundleBuilder.php tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php tests/Feature/Career/CareerJobListApiTest.php
cd backend && php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php
cd backend && bash scripts/ci_verify_mbti.sh
git diff --check
```

Focused career tests passed: 22 tests, 277 assertions.

Note: `cd backend && php artisan migrate --pretend` against the local default `.env` MySQL failed because local `root@localhost` has no password access. The testing SQLite migration dry-run passed.

## Intentionally deferred

- No deploy in this PR.
- No CMS mutation.
- No pSEO generation.
- No sitemap or llms exposure changes.
- No frontend fallback authority.
- Does not publish the 2289 excluded candidates.
- Does not promote the legacy 342 baseline to public detail/indexable.
- Does not change career recommendation claim boundaries.
- Frontend timeout-vs-true-404 UX remains a follow-up decision.

## Post-merge smoke checks

After backend deploy readiness and deployment, verify:

```bash
curl -i 'https://fermatmind.com/api/v0.5/career/datasets/occupations?locale=zh-CN'
curl -i 'https://fermatmind.com/api/v0.5/career/jobs?locale=zh-CN'
curl -i 'https://fermatmind.com/api/v0.5/career/jobs/actuaries?locale=zh-CN'
curl -i 'https://fermatmind.com/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN'
curl -i 'https://fermatmind.com/api/v0.5/career/jobs/software-developers?locale=zh-CN'
```
