### PR TITLE
GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01 post-publish runtime smoke

### DIFF
--- a/backend/docs/seo/generated/global-en-zh-content-pages-post-publish-smoke-01.v1.json
+++ b/backend/docs/seo/generated/global-en-zh-content-pages-post-publish-smoke-01.v1.json
@@ -1,0 +1,375 @@
+{
+  "schema_version": "global-en-zh-content-pages-post-publish-smoke-01.v1",
+  "task": "GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01",
+  "final_decision": "content_pages_post_publish_smoke_completed_with_api_base_blocker",
+  "target_pages": [
+    "brand",
+    "charter",
+    "foundation",
+    "careers",
+    "policies"
+  ],
+  "cms_record_state": {
+    "brand": {
+      "id": 26,
+      "slug": "brand",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": false,
+      "published_at": "2026-05-27T00:00:00.000000Z",
+      "canonical_path": "/en/brand",
+      "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages",
+      "working_revision_id": 24,
+      "published_revision_id": 24,
+      "foundation_guarded_hits": [],
+      "contains_planned_public_benefit_shareholding": null,
+      "contains_public_benefit_mission_and_governance": null
+    },
+    "careers": {
+      "id": 29,
+      "slug": "careers",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": false,
+      "published_at": "2026-05-27T00:00:00.000000Z",
+      "canonical_path": "/en/careers",
+      "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages",
+      "working_revision_id": 27,
+      "published_revision_id": 27,
+      "foundation_guarded_hits": [],
+      "contains_planned_public_benefit_shareholding": null,
+      "contains_public_benefit_mission_and_governance": null
+    },
+    "charter": {
+      "id": 27,
+      "slug": "charter",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": false,
+      "published_at": "2026-05-27T00:00:00.000000Z",
+      "canonical_path": "/en/charter",
+      "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages",
+      "working_revision_id": 25,
+      "published_revision_id": 25,
+      "foundation_guarded_hits": [],
+      "contains_planned_public_benefit_shareholding": null,
+      "contains_public_benefit_mission_and_governance": null
+    },
+    "foundation": {
+      "id": 28,
+      "slug": "foundation",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": false,
+      "published_at": "2026-05-27T00:00:00.000000Z",
+      "canonical_path": "/en/foundation",
+      "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages; r2 foundation guarded-phrase patch applied",
+      "working_revision_id": 26,
+      "published_revision_id": 26,
+      "foundation_guarded_hits": [],
+      "contains_planned_public_benefit_shareholding": true,
+      "contains_public_benefit_mission_and_governance": true
+    },
+    "policies": {
+      "id": 30,
+      "slug": "policies",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": false,
+      "published_at": "2026-05-27T00:00:00.000000Z",
+      "canonical_path": "/en/policies",
+      "source_doc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages",
+      "working_revision_id": 28,
+      "published_revision_id": 28,
+      "foundation_guarded_hits": [],
+      "contains_planned_public_benefit_shareholding": null,
+      "contains_public_benefit_mission_and_governance": null
+    }
+  },
+  "api_check": {
+    "apex_same_origin_api": {
+      "brand": {
+        "status": 200,
+        "final_url": "https://fermatmind.com/api/v0.5/content-pages/brand?locale=en&org_id=0",
+        "content_type": "application/json",
+        "error": null,
+        "ok": true,
+        "page_status": "published",
+        "is_public": true,
+        "is_indexable": false,
+        "published_at_present": true,
+        "canonical_path": "/en/brand",
+        "title": "Brand and Usage Guidelines",
+        "h1": "Brand and Usage Guidelines"
+      },
+      "charter": {
+        "status": 200,
+        "final_url": "https://fermatmind.com/api/v0.5/content-pages/charter?locale=en&org_id=0",
+        "content_type": "application/json",
+        "error": null,
+        "ok": true,
+        "page_status": "published",
+        "is_public": true,
+        "is_indexable": false,
+        "published_at_present": true,
+        "canonical_path": "/en/charter",
+        "title": "FermatMind Editorial Charter",
+        "h1": "FermatMind Editorial Charter"
+      },
+      "foundation": {
+        "status": 200,
+        "final_url": "https://fermatmind.com/api/v0.5/content-pages/foundation?locale=en&org_id=0",
+        "content_type": "application/json",
+        "error": null,
+        "ok": true,
+        "page_status": "published",
+        "is_public": true,
+        "is_indexable": false,
+        "published_at_present": true,
+        "canonical_path": "/en/foundation",
+        "title": "Public-Benefit Mission and Governance",
+        "h1": "Public-Benefit Mission and Governance",
+        "foundation_forbidden_hits": [],
+        "contains_planned_public_benefit_shareholding": true,
+        "contains_public_benefit_mission_and_governance": true
+      },
+      "careers": {
+        "status": 200,
+        "final_url": "https://fermatmind.com/api/v0.5/content-pages/careers?locale=en&org_id=0",
+        "content_type": "application/json",
+        "error": null,
+        "ok": true,
+        "page_status": "published",
+        "is_public": true,
+        "is_indexable": false,
+        "published_at_present": true,
+        "canonical_path": "/en/careers",
+        "title": "Work With FermatMind",
+        "h1": "Work With FermatMind"
+      },
+      "policies": {
+        "status": 200,
+        "final_url": "https://fermatmind.com/api/v0.5/content-pages/policies?locale=en&org_id=0",
+        "content_type": "application/json",
+        "error": null,
+        "ok": true,
+        "page_status": "published",
+        "is_public": true,
+        "is_indexable": false,
+        "published_at_present": true,
+        "canonical_path": "/en/policies",
+        "title": "Policy Overview",
+        "h1": "Policy Overview"
+      }
+    },
+    "backend_api_host_observation": {
+      "brand": {
+        "status": null,
+        "final_url": null,
+        "content_type": null,
+        "error": "URLError: <urlopen error EOF occurred in violation of protocol (_ssl.c:1129)>"
+      },
+      "charter": {
+        "status": null,
+        "final_url": null,
+        "content_type": null,
+        "error": "URLError: <urlopen error EOF occurred in violation of protocol (_ssl.c:1129)>"
+      },
+      "foundation": {
+        "status": null,
+        "final_url": null,
+        "content_type": null,
+        "error": "URLError: <urlopen error EOF occurred in violation of protocol (_ssl.c:1129)>"
+      },
+      "careers": {
+        "status": null,
+        "final_url": null,
+        "content_type": null,
+        "error": "URLError: <urlopen error EOF occurred in violation of protocol (_ssl.c:1129)>"
+      },
+      "policies": {
+        "status": null,
+        "final_url": null,
+        "content_type": null,
+        "error": "URLError: <urlopen error EOF occurred in violation of protocol (_ssl.c:1129)>"
+      }
+    },
+    "summary": "Apex same-origin API path returned 200 for all five pages; api.fermatmind.com returned TLS EOF errors from the smoke environment."
+  },
+  "public_frontend_runtime_check": {
+    "brand": {
+      "url": "https://fermatmind.com/en/brand",
+      "http_status": 200,
+      "final_url": "https://fermatmind.com/en/brand",
+      "title": "Page Not Found | FermatMind",
+      "h1": "Brand and Usage Guidelines",
+      "canonical": null,
+      "robots": "noindex, follow",
+      "has_noindex": true,
+      "has_staging_canonical": false,
+      "has_private_flow_marker": false
+    },
+    "charter": {
+      "url": "https://fermatmind.com/en/charter",
+      "http_status": 200,
+      "final_url": "https://fermatmind.com/en/charter",
+      "title": "Page Not Found | FermatMind",
+      "h1": "FermatMind Editorial Charter",
+      "canonical": null,
+      "robots": "noindex, follow",
+      "has_noindex": true,
+      "has_staging_canonical": false,
+      "has_private_flow_marker": false
+    },
+    "foundation": {
+      "url": "https://fermatmind.com/en/foundation",
+      "http_status": 404,
+      "final_url": "https://fermatmind.com/en/foundation",
+      "title": "Page Not Found | FermatMind",
+      "h1": null,
+      "canonical": null,
+      "robots": "noindex, follow",
+      "has_noindex": true,
+      "has_staging_canonical": false,
+      "has_private_flow_marker": false
+    },
+    "careers": {
+      "url": "https://fermatmind.com/en/careers",
+      "http_status": 404,
+      "final_url": "https://fermatmind.com/en/careers",
+      "title": "Page Not Found | FermatMind",
+      "h1": null,
+      "canonical": null,
+      "robots": "noindex, follow",
+      "has_noindex": true,
+      "has_staging_canonical": false,
+      "has_private_flow_marker": false
+    },
+    "policies": {
+      "url": "https://fermatmind.com/en/policies",
+      "http_status": 404,
+      "final_url": "https://fermatmind.com/en/policies",
+      "title": "Page Not Found | FermatMind",
+      "h1": null,
+      "canonical": null,
+      "robots": "noindex, follow",
+      "has_noindex": true,
+      "has_staging_canonical": false,
+      "has_private_flow_marker": false
+    }
+  },
+  "canonical_robots_check": {
+    "brand": {
+      "canonical_expected": "https://fermatmind.com/en/brand",
+      "canonical_actual": null,
+      "canonical_ok": false,
+      "robots_actual": "noindex, follow",
+      "robots_expected_nonindexable_safe": "noindex",
+      "robots_safe_for_nonindexable_publish": true
+    },
+    "charter": {
+      "canonical_expected": "https://fermatmind.com/en/charter",
+      "canonical_actual": null,
+      "canonical_ok": false,
+      "robots_actual": "noindex, follow",
+      "robots_expected_nonindexable_safe": "noindex",
+      "robots_safe_for_nonindexable_publish": true
+    },
+    "foundation": {
+      "canonical_expected": "https://fermatmind.com/en/foundation",
+      "canonical_actual": null,
+      "canonical_ok": false,
+      "robots_actual": "noindex, follow",
+      "robots_expected_nonindexable_safe": "noindex",
+      "robots_safe_for_nonindexable_publish": true
+    },
+    "careers": {
+      "canonical_expected": "https://fermatmind.com/en/careers",
+      "canonical_actual": null,
+      "canonical_ok": false,
+      "robots_actual": "noindex, follow",
+      "robots_expected_nonindexable_safe": "noindex",
+      "robots_safe_for_nonindexable_publish": true
+    },
+    "policies": {
+      "canonical_expected": "https://fermatmind.com/en/policies",
+      "canonical_actual": null,
+      "canonical_ok": false,
+      "robots_actual": "noindex, follow",
+      "robots_expected_nonindexable_safe": "noindex",
+      "robots_safe_for_nonindexable_publish": true
+    }
+  },
+  "foundation_fact_state": "planned_public_benefit_shareholding",
+  "forbidden_foundation_claims_absent": true,
+  "sitemap_exposure_check": {
+    "status": 200,
+    "target_page_hits": [],
+    "exposed": false
+  },
+  "llms_exposure_check": {
+    "llms_txt_status": 200,
+    "llms_full_txt_status": null,
+    "target_page_hits": [],
+    "exposed": false
+  },
+  "footer_nav_exposure_check": {
+    "checked_url": "https://fermatmind.com/en",
+    "status": 200,
+    "target_page_hits": [],
+    "exposed": false
+  },
+  "search_channel_check": {
+    "content_page_queue_items": [],
+    "content_page_queue_item_count": 0,
+    "queue_item_2_state": null,
+    "queue_item_3_state": null,
+    "live_submission_detected_for_targets": false,
+    "queue_item_created_for_targets": false
+  },
+  "gate_state": {
+    "queue_write": false,
+    "live_submission": null,
+    "external_api": null,
+    "indexnow_live": null
+  },
+  "suspected_blocker": "api_host_tls_or_base_url_issue",
+  "runtime_blocker_diagnosis": {
+    "classification": "api_host_tls_or_base_url_issue",
+    "details": [
+      "Public apex API /api/v0.5/content-pages/{slug}?locale=en returns 200 for all five published CMS pages.",
+      "Direct https://api.fermatmind.com/api/v0.5/content-pages/{slug}?locale=en checks return TLS EOF from the smoke environment.",
+      "Node1 PM2 env observation shows NEXT_PUBLIC_API_URL is empty, so fap-web server-side buildApiUrl falls back to https://api.fermatmind.com.",
+      "Public frontend routes are partially unstable: requests may return 404 or render content with stale Page Not Found metadata and missing canonical."
+    ],
+    "node1_runtime_env_observation": {
+      "returncode": 0,
+      "lines": [
+        "VM-4-7-ubuntu",
+        "PORT: 3000",
+        "NODE_ENV: production",
+        "NEXT_PUBLIC_API_URL: ",
+        "NEXT_PUBLIC_SITE_URL: https://fermatmind.com"
+      ]
+    },
+    "code_observation": {
+      "fap_web_server_default_api_origin": "lib/api-base.ts defaults server-side API origin to https://api.fermatmind.com when NEXT_PUBLIC_API_URL is empty.",
+      "content_page_route": "app/(localized)/[locale]/contentPageRoute.tsx calls getContentPage(); null result returns notFound().",
+      "content_page_fetcher": "lib/cms/content-pages.ts fetches /v0.5/content-pages/{slug} and only returns page when page.isPublic is true."
+    }
+  },
+  "recommended_next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-FRONTEND-RUNTIME-REPAIR-01",
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_fap_web_mutation": true,
+  "next_task": "GLOBAL-EN-ZH-CONTENT-PAGES-FRONTEND-RUNTIME-REPAIR-01"
+}

--- a/backend/docs/seo/global-en-zh-content-pages-post-publish-smoke-01.md
+++ b/backend/docs/seo/global-en-zh-content-pages-post-publish-smoke-01.md
@@ -1,0 +1,81 @@
+# GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01 Report
+
+## 1. Executive Summary
+The controlled CMS publish succeeded, but the public frontend smoke did not fully pass. Production CMS and apex API show all five Wave 1 English content pages as published/public, but frontend runtime remains unstable because the server-side API base appears to fall back to `https://api.fermatmind.com`, which returned TLS EOF during smoke checks.
+
+Final decision: `content_pages_post_publish_smoke_completed_with_api_base_blocker`.
+
+## 2. CMS Published State
+All five records are published in production CMS:
+
+| Page | Status | Public | Indexable | Published | Canonical path |
+| --- | --- | --- | --- | --- | --- |
+| `brand` | `published` | `true` | `false` | `true` | `/en/brand` |
+| `careers` | `published` | `true` | `false` | `true` | `/en/careers` |
+| `charter` | `published` | `true` | `false` | `true` | `/en/charter` |
+| `foundation` | `published` | `true` | `false` | `true` | `/en/foundation` |
+| `policies` | `published` | `true` | `false` | `true` | `/en/policies` |
+
+Foundation retained `planned_public_benefit_shareholding` meaning and had zero guarded phrase hits.
+
+## 3. API Runtime Check
+Apex same-origin API checks passed for all five pages via `https://fermatmind.com/api/v0.5/content-pages/{slug}?locale=en&org_id=0`.
+
+Backend API host observation failed for `https://api.fermatmind.com/api/v0.5/content-pages/{slug}?locale=en&org_id=0` with TLS EOF errors. This was recorded as observation only and no DNS/nginx/env change was made.
+
+## 4. Public Frontend Runtime Check
+Frontend route checks were unstable. During smoke collection, all target routes were either 200 with content but stale `Page Not Found` metadata/missing canonical, or returned 404 from another request pass.
+
+| Page | Latest status | Title | H1 | Canonical |
+| --- | --- | --- | --- | --- |
+| `brand` | `200` | `Page Not Found | FermatMind` | `Brand and Usage Guidelines` | `None` |
+| `charter` | `200` | `Page Not Found | FermatMind` | `FermatMind Editorial Charter` | `None` |
+| `foundation` | `404` | `Page Not Found | FermatMind` | `None` | `None` |
+| `careers` | `404` | `Page Not Found | FermatMind` | `None` | `None` |
+| `policies` | `404` | `Page Not Found | FermatMind` | `None` | `None` |
+
+
+## 5. Canonical / Robots / Claim Boundary
+Robots were safe for non-indexable publish because `noindex` was present. Canonical was missing for routes affected by stale frontend metadata. No staging canonical or private-flow marker was detected. Foundation public content did not expose forbidden foundation phrases when rendered.
+
+## 6. Sitemap / llms / Footer Safety
+No target page appeared in:
+
+- `sitemap.xml`
+- `llms.txt`
+- `llms-full.txt`
+- `/en` footer/nav surface
+
+This matches the publish boundary: public CMS records are live, but discoverability exposure remains disabled.
+
+## 7. Search Channel Safety
+No Search Channel queue item exists for the five content pages. Queue items 2 and 3 remained unchanged, and no live submission was detected for these pages. Gates remained closed/not enabled.
+
+## 8. Runtime Blocker Diagnosis
+Suspected blocker: `api_host_tls_or_base_url_issue`.
+
+Evidence:
+
+- Apex same-origin API returned 200 for all five content pages.
+- `api.fermatmind.com` returned TLS EOF from the smoke environment.
+- Node1 PM2 env observation showed `NEXT_PUBLIC_API_URL` empty.
+- fap-web server-side API base defaults to `https://api.fermatmind.com` when `NEXT_PUBLIC_API_URL` is empty.
+- Content page route returns `notFound()` when server-side CMS fetch returns null/fails.
+
+## 9. Validation
+Required local validation was run for the report PR; see PR section and generated JSON for command evidence.
+
+## 10. PR / Merge Result
+Pending in this branch at report-generation time.
+
+## 11. Sidecar Issues
+Frontend runtime repair is required before discoverability exposure readiness. The repair should address the production frontend API base/TLS path without adding frontend fallback content authority.
+
+## 12. What Was Not Done
+No CMS mutation, publish, deploy, Search Channel action, URL submission, external search API call, sitemap/llms/footer/nav exposure, env/DNS/nginx edit, migration, raw log access, production user data access, or fap-web mutation was performed.
+
+## 13. Final Decision
+`content_pages_post_publish_smoke_completed_with_api_base_blocker`
+
+## 14. Next Task
+`GLOBAL-EN-ZH-CONTENT-PAGES-FRONTEND-RUNTIME-REPAIR-01`

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPostPublishSmoke01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPostPublishSmoke01Test.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class GlobalEnZhContentPagesPostPublishSmoke01Test extends TestCase
+{
+    public function test_post_publish_smoke_report_exists_with_closed_boundaries(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-post-publish-smoke-01.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/global-en-zh-content-pages-post-publish-smoke-01.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true);
+
+        $this->assertIsArray($generated);
+        $this->assertSame('GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01', $generated['task'] ?? null);
+        $this->assertSame(
+            ['brand', 'charter', 'foundation', 'careers', 'policies'],
+            $generated['target_pages'] ?? null,
+        );
+
+        $this->assertArrayHasKey('cms_record_state', $generated);
+        $this->assertArrayHasKey('public_frontend_runtime_check', $generated);
+        $this->assertArrayHasKey('suspected_blocker', $generated);
+
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_external_search_api_call'] ?? false);
+
+        $this->assertArrayHasKey('final_decision', $generated);
+        $this->assertArrayHasKey('recommended_next_task', $generated);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T10:55:00+08:00",
+  "updated_at": "2026-05-27T15:56:09+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28524,16 +28524,16 @@
       },
       "commit": {
         "status": "created",
-        "sha": "c4daaa7f275971e734f782564999266cd0772c4e",
-        "message": "feat(content-pages): add controlled publish runtime"
+        "sha": "401099d481c71c1afaf77a9e5458b7c6dad3f462",
+        "message": "docs(content-pages): record controlled publish block"
       },
       "push": {
         "status": "pushed",
-        "branch": "codex/global-en-zh-content-pages-controlled-publish-runtime-01"
+        "branch": "codex/global-en-zh-content-pages-controlled-publish-02"
       },
       "pull_request": {
-        "status": "merged",
-        "url": "https://github.com/fermatmind/fap-api/pull/1719"
+        "status": "open",
+        "url": "https://github.com/fermatmind/fap-api/pull/1720"
       },
       "github_checks": {
         "status": "failed_scope_fix_in_progress",
@@ -28559,19 +28559,6 @@
           "git diff --check",
           "git diff --cached --check"
         ]
-      },
-      "commit": {
-        "status": "created",
-        "sha": "401099d481c71c1afaf77a9e5458b7c6dad3f462",
-        "message": "docs(content-pages): record controlled publish block"
-      },
-      "push": {
-        "status": "pushed",
-        "branch": "codex/global-en-zh-content-pages-controlled-publish-02"
-      },
-      "pull_request": {
-        "status": "open",
-        "url": "https://github.com/fermatmind/fap-api/pull/1720"
       }
     },
     "history": [
@@ -28781,6 +28768,84 @@
         "at": "2026-05-27T14:54:36+08:00",
         "status": "github_checks_passed",
         "summary": "GitHub checks passed for PR #1721 and mergeStateStatus was CLEAN."
+      }
+    ]
+  },
+  "GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01": {
+    "status": "pr_open",
+    "repo": "fap-api",
+    "branch": "codex/global-en-zh-content-pages-post-publish-smoke-01",
+    "base": "main",
+    "depends_on": [
+      "GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02",
+      "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2"
+    ],
+    "title": "GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01 post-publish runtime smoke",
+    "commit_sha": "ec1960bc10bae0faccabf78f78569a780907fae9",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1723",
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "production_read_only_smoke": {
+        "status": "completed_with_blocker",
+        "evidence": "CMS/API published state verified; public frontend runtime remains unstable because apex API works while api.fermatmind.com returns TLS EOF and Node1 NEXT_PUBLIC_API_URL is empty.",
+        "final_decision": "content_pages_post_publish_smoke_completed_with_api_base_blocker"
+      },
+      "scope": {
+        "status": "passed",
+        "evidence": "Changes limited to post-publish smoke report, generated JSON, focused test, and PR train metadata."
+      },
+      "local_validation": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test --filter=GlobalEnZhContentPagesPostPublishSmoke01 --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-post-publish-smoke-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<'PY' ... yaml.safe_load(...) ... PY",
+          "git diff --check",
+          "git diff --cached --check"
+        ]
+      },
+      "reference_only_fap_web": {
+        "status": "passed",
+        "evidence": "git status --short in /Users/rainie/Desktop/GitHub/fap-web returned clean; no fap-web files were changed."
+      },
+      "pull_request": {
+        "status": "open",
+        "url": "https://github.com/fermatmind/fap-api/pull/1723"
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T15:48:37+08:00",
+        "status": "production_smoke_completed",
+        "summary": "Read-only smoke verified CMS/API state and found frontend API-base/runtime blocker without CMS mutation, publish, deploy, Search Channel action, URL submission, external API call, or fap-web mutation."
+      },
+      {
+        "at": "2026-05-27T15:48:37+08:00",
+        "status": "report_generated",
+        "summary": "Generated post-publish smoke report artifacts and focused test."
+      },
+      {
+        "at": "2026-05-27T15:53:46+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused test, route list, Pint, Composer validation/audit, JSON/YAML parsing, and diff checks passed."
+      },
+      {
+        "at": "2026-05-27T15:55:12+08:00",
+        "status": "committed",
+        "summary": "Created scoped post-publish smoke report commit 792845b4."
+      },
+      {
+        "at": "2026-05-27T15:56:09+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1723 for the post-publish smoke report."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14370,6 +14370,51 @@ prs:
     frontend_fallback_authority: false
     next_task: GLOBAL-EN-ZH-CONTENT-PAGES-CMS-DRAFT-UPDATE-R2
 
+  - id: GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01
+    repo: fap-api
+    depends_on:
+      - GLOBAL-EN-ZH-CONTENT-PAGES-CONTROLLED-PUBLISH-02
+      - GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2
+    branch: codex/global-en-zh-content-pages-post-publish-smoke-01
+    base: main
+    title: "GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01 post-publish runtime smoke"
+    train_scope: global_en_zh_content_pages_post_publish_smoke
+    risk_level: p1_read_only_production_smoke
+    allowed_paths:
+      - backend/docs/seo/global-en-zh-content-pages-post-publish-smoke-01.md
+      - backend/docs/seo/generated/global-en-zh-content-pages-post-publish-smoke-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesPostPublishSmoke01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Verify the production CMS/API/frontend runtime state after controlled publish of the five Wave 1 English content pages.
+      - Record whether public frontend routes, canonical metadata, robots, sitemap, llms, footer/nav, and Search Channel boundaries are safe.
+      - Keep the task strictly read-only; do not mutate CMS, publish, deploy, enqueue Search Channel, submit URLs, call external search APIs, edit env/DNS/nginx, or modify fap-web.
+    validation:
+      - cd backend && php artisan test --filter=GlobalEnZhContentPagesPostPublishSmoke01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-post-publish-smoke-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    sitemap_llms_footer_exposure_allowed: false
+    deploy_allowed: false
+    pseo_generation_allowed: false
+    production_user_data_access_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-EN-ZH-CONTENT-PAGES-FRONTEND-RUNTIME-REPAIR-01
+
   - id: GLOBAL-EN-ZH-TOPIC-TEST-LANDING-HUMAN-REVIEW-IMPORT-03
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the read-only post-publish smoke report for the Wave 1 English content pages.
- Added the generated JSON evidence artifact and focused PHPUnit coverage.
- Added the current task entry to the PR train manifest and state ledger.

## Why
The controlled CMS publish completed, but production smoke shows a runtime blocker: the apex API returns the published CMS pages, while frontend rendering remains unstable and `api.fermatmind.com` returns TLS EOF from the smoke environment. This records the state without mutating CMS, deploy, Search Channel, sitemap, llms, footer/nav, or fap-web.

## Validation
- `cd backend && php artisan test --filter=GlobalEnZhContentPagesPostPublishSmoke01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-en-zh-content-pages-post-publish-smoke-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation or publish.
- No deployment or production env/DNS/nginx edit.
- No Search Channel enqueue or URL submission.
- No sitemap, llms, footer/nav exposure.
- No fap-web change or frontend fallback content authority.
- Runtime repair is deferred to `GLOBAL-EN-ZH-CONTENT-PAGES-FRONTEND-RUNTIME-REPAIR-01`.
