### PR TITLE
fix(api): audit career detail-ready 1048 candidates

### DIFF
--- a/backend/app/Console/Commands/CareerAuditDetailReady1048Candidates.php
+++ b/backend/app/Console/Commands/CareerAuditDetailReady1048Candidates.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Audit\CareerDetailReadyPublicationCandidateScanner;
+use Illuminate\Console\Command;
+
+final class CareerAuditDetailReady1048Candidates extends Command
+{
+    protected $signature = 'career:audit-detail-ready-1048-candidates
+        {--json : Emit JSON output}
+        {--output= : Optional output path for the scan artifact}';
+
+    protected $description = 'Read-only scan for Career detail-ready 1048 publication candidates.';
+
+    public function handle(CareerDetailReadyPublicationCandidateScanner $scanner): int
+    {
+        $payload = $scanner->scan();
+
+        $output = $this->option('output');
+        if (is_string($output) && trim($output) !== '') {
+            $path = trim($output);
+            $dir = dirname($path);
+            if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+                throw new \RuntimeException('Unable to create output directory: '.$dir);
+            }
+            file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+            $payload['output_path'] = $path;
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('schema_version='.$payload['schema_version']);
+            $this->line('target_key='.$payload['target_key']);
+            $this->line('current_public_detail='.$payload['counts']['current_public_detail']);
+            $this->line('union_detail_ready='.$payload['counts']['union_detail_ready']);
+            $this->line('ready_not_currently_public='.$payload['counts']['ready_not_currently_public']);
+            $this->line('writes_database=false');
+            $this->line('next_required_action='.$payload['next_required_action']);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -18,6 +18,7 @@ use App\Console\Commands\CareerAlignSelectedAuthorityCrosswalks;
 use App\Console\Commands\CareerAlignSelectedOnetCrosswalks;
 use App\Console\Commands\CareerApplyOccupationDirectoryReviewDecisions;
 use App\Console\Commands\CareerAuditCanonicalEligibility;
+use App\Console\Commands\CareerAuditDetailReady1048Candidates;
 use App\Console\Commands\CareerCloseoutCanonicalProgressiveCohort;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCompileRecommendationSubjects;
@@ -211,6 +212,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerApplyOccupationDirectoryReviewDecisions::class,
         CareerAuditCanonicalEligibility::class,
+        CareerAuditDetailReady1048Candidates::class,
         CareerCloseoutCanonicalProgressiveCohort::class,
         CareerAlignActorsAuthorityOccupation::class,
         CareerAlignCareerAuthorityBatch::class,

--- a/backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php
+++ b/backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+use App\Domain\Career\Publish\CareerFullReleaseLedgerProjectionService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerJob;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\RecommendationSnapshot;
+use App\Models\Scopes\TenantScope;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class CareerDetailReadyPublicationCandidateScanner
+{
+    private const SCHEMA_VERSION = 'career_detail_ready_publication_candidates.v1';
+
+    private const TARGET_KEY = 'detail_ready_1048';
+
+    private const MANUAL_HOLD_SLUGS = [
+        'software-developers',
+    ];
+
+    private const DISPLAY_SURFACE_VERSION = 'display.surface.v1';
+
+    private const DISPLAY_ASSET_VERSION = 'v4.2';
+
+    private const DISPLAY_ASSET_TYPE = 'career_job_public_display';
+
+    private const DISPLAY_READY_STATUS = 'ready_for_pilot';
+
+    private const DISPLAY_COMPONENT_ORDER_COUNT = 24;
+
+    public function __construct(
+        private readonly CareerRuntimePublishProjectionVisibility $runtimeProjection,
+        private readonly CareerFullReleaseLedgerProjectionService $fullReleaseLedgerProjectionService,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function scan(): array
+    {
+        $currentPublicSlugs = $this->currentPublicDetailSlugs();
+        $docxReadySlugs = $this->docxReadySlugs();
+        $displayAssetReadySlugs = $this->displayAssetReadySlugs();
+        $compiledReadySlugs = $this->compiledReadySlugs();
+        $unionReadySlugs = $this->sortedUnique([
+            ...$docxReadySlugs,
+            ...$displayAssetReadySlugs,
+            ...$compiledReadySlugs,
+        ]);
+        $readyNotPublicSlugs = $this->diff($unionReadySlugs, $currentPublicSlugs);
+        $manualHoldReadySlugs = $this->intersect($unionReadySlugs, self::MANUAL_HOLD_SLUGS);
+        $ledger = $this->ledgerSummary();
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'target_key' => self::TARGET_KEY,
+            'generated_at' => now()->toISOString(),
+            'writes_database' => false,
+            'apply_allowed' => false,
+            'rollout_allowed' => false,
+            'deploy_allowed' => false,
+            'cms_mutation_allowed' => false,
+            'fap_web_fallback_authority_allowed' => false,
+            'product_visible_claim_boundary' => [
+                'target' => 'all currently backend-authoritative detail-ready Career jobs',
+                'not_a_2786_partition_accounting_claim' => true,
+                'do_not_claim_all_2786_visible' => true,
+                'raw_occupation_assets_are_not_publication_authority' => true,
+            ],
+            'counts' => [
+                'current_public_detail' => count($currentPublicSlugs),
+                'docx_ready' => count($docxReadySlugs),
+                'display_asset_ready' => count($displayAssetReadySlugs),
+                'compiled_snapshot_ready' => count($compiledReadySlugs),
+                'union_detail_ready' => count($unionReadySlugs),
+                'ready_not_currently_public' => count($readyNotPublicSlugs),
+                'manual_hold_ready' => count($manualHoldReadySlugs),
+                'raw_occupation_assets' => Occupation::query()->count(),
+                'career_job_rows' => CareerJob::query()->withoutGlobalScope(TenantScope::class)->count(),
+                'display_asset_rows' => CareerJobDisplayAsset::query()->count(),
+            ],
+            'current_public_30' => [
+                'count' => count($currentPublicSlugs),
+                'slugs' => $currentPublicSlugs,
+            ],
+            'ready_not_public_1018' => [
+                'count' => count($readyNotPublicSlugs),
+                'slugs' => $readyNotPublicSlugs,
+            ],
+            'sources' => [
+                'docx_ready' => [
+                    'count' => count($docxReadySlugs),
+                    'slugs' => $docxReadySlugs,
+                ],
+                'display_asset_ready' => [
+                    'count' => count($displayAssetReadySlugs),
+                    'slugs' => $displayAssetReadySlugs,
+                ],
+                'compiled_ready' => [
+                    'count' => count($compiledReadySlugs),
+                    'slugs' => $compiledReadySlugs,
+                ],
+                'union_detail_ready' => [
+                    'count' => count($unionReadySlugs),
+                    'slugs' => $unionReadySlugs,
+                ],
+            ],
+            'manual_hold' => [
+                'policy' => 'do_not_force_enable_without_explicit_manual_hold_release_decision',
+                'configured_slugs' => self::MANUAL_HOLD_SLUGS,
+                'ready_slugs' => $manualHoldReadySlugs,
+            ],
+            'ledger_classification' => $ledger,
+            'row_counts' => [
+                'career_jobs_by_locale' => $this->careerJobRowsByLocale(),
+            ],
+            'next_required_action' => 'REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function currentPublicDetailSlugs(): array
+    {
+        return $this->sortedUnique(array_map(
+            static fn (array $item): string => strtolower(trim((string) ($item['slug'] ?? ''))),
+            $this->runtimeProjection->publicDetailItems(),
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function docxReadySlugs(): array
+    {
+        return CareerJob::query()
+            ->withoutGlobalScope(TenantScope::class)
+            ->with('seoMeta')
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('status', CareerJob::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->get()
+            ->filter(static fn (CareerJob $job): bool => is_string(data_get($job->seoMeta?->jsonld_overrides_json, 'source_docx'))
+                && data_get($job->market_demand_json, 'source_refs.0.url') !== null)
+            ->pluck('slug')
+            ->map(static fn (mixed $slug): string => strtolower(trim((string) $slug)))
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function displayAssetReadySlugs(): array
+    {
+        return Occupation::query()
+            ->with(['crosswalks', 'displayAssets'])
+            ->get()
+            ->filter(fn (Occupation $occupation): bool => $this->hasValidDisplayAssetDetailAuthority($occupation))
+            ->pluck('canonical_slug')
+            ->map(static fn (mixed $slug): string => strtolower(trim((string) $slug)))
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function compiledReadySlugs(): array
+    {
+        return RecommendationSnapshot::query()
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('occupation', static function ($query): void {
+                $query->whereIn('crosswalk_mode', ['exact', 'trust_inheritance', 'direct_match']);
+            })
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave')
+                    ->whereNull('projection_payload->recommendation_subject_meta');
+            })
+            ->whereHas('compileRun', static function ($query): void {
+                $query->where('status', 'completed')
+                    ->where('dry_run', false);
+            })
+            ->with('occupation:id,canonical_slug')
+            ->get()
+            ->map(static fn (RecommendationSnapshot $snapshot): string => strtolower(trim((string) $snapshot->occupation?->canonical_slug)))
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+    }
+
+    private function hasValidDisplayAssetDetailAuthority(Occupation $occupation): bool
+    {
+        $slug = strtolower(trim((string) $occupation->canonical_slug));
+        if ($slug === '' || in_array($slug, self::MANUAL_HOLD_SLUGS, true)) {
+            return false;
+        }
+
+        foreach (['us_soc', 'onet_soc_2019'] as $sourceSystem) {
+            $rows = $occupation->crosswalks
+                ->filter(static fn (OccupationCrosswalk $crosswalk): bool => strtolower((string) $crosswalk->source_system) === $sourceSystem)
+                ->values();
+
+            if ($rows->count() !== 1 || trim((string) $rows->first()?->source_code) === '') {
+                return false;
+            }
+        }
+
+        $assets = $occupation->displayAssets
+            ->where('canonical_slug', $slug)
+            ->where('surface_version', self::DISPLAY_SURFACE_VERSION)
+            ->where('asset_version', self::DISPLAY_ASSET_VERSION)
+            ->where('template_version', self::DISPLAY_ASSET_VERSION)
+            ->where('status', self::DISPLAY_READY_STATUS)
+            ->where('asset_type', self::DISPLAY_ASSET_TYPE)
+            ->values();
+
+        if ($assets->count() !== 1) {
+            return false;
+        }
+
+        $asset = $assets->first();
+        if (! $asset instanceof CareerJobDisplayAsset) {
+            return false;
+        }
+
+        $componentOrder = is_array($asset->component_order_json) ? array_values($asset->component_order_json) : [];
+        $pages = is_array($asset->page_payload_json) ? $asset->page_payload_json : [];
+        $localizedPages = is_array($pages['page'] ?? null) ? $pages['page'] : $pages;
+
+        return count($componentOrder) === self::DISPLAY_COMPONENT_ORDER_COUNT
+            && is_array($localizedPages['zh'] ?? null)
+            && is_array($localizedPages['en'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function ledgerSummary(): array
+    {
+        try {
+            $ledger = $this->fullReleaseLedgerProjectionService->build()[CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME] ?? [];
+        } catch (\Throwable $exception) {
+            return [
+                'available' => false,
+                'error' => $exception->getMessage(),
+            ];
+        }
+
+        $members = collect((array) ($ledger['members'] ?? []))
+            ->filter(static fn (mixed $member): bool => is_array($member))
+            ->values();
+
+        return [
+            'available' => true,
+            'release_counts' => $ledger['counts']['release_counts'] ?? $ledger['release_counts'] ?? [],
+            'tracking_counts' => $ledger['tracking_counts'] ?? [],
+            'release_cohort_counts' => $this->countBy($members, 'release_cohort'),
+            'blocker_reason_counts' => $this->blockerReasonCounts($members),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $members
+     * @return array<string, int>
+     */
+    private function countBy(Collection $members, string $field): array
+    {
+        return $members
+            ->map(static fn (array $member): string => trim((string) ($member[$field] ?? '__missing__')))
+            ->filter()
+            ->countBy()
+            ->sortDesc()
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $members
+     * @return array<string, int>
+     */
+    private function blockerReasonCounts(Collection $members): array
+    {
+        $counts = [];
+        foreach ($members as $member) {
+            foreach ((array) ($member['blocker_reasons'] ?? []) as $reason) {
+                $key = trim((string) $reason);
+                if ($key === '') {
+                    continue;
+                }
+                $counts[$key] = (int) ($counts[$key] ?? 0) + 1;
+            }
+        }
+        arsort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return list<array{locale: string, count: int}>
+     */
+    private function careerJobRowsByLocale(): array
+    {
+        return CareerJob::query()
+            ->withoutGlobalScope(TenantScope::class)
+            ->select('locale', DB::raw('count(*) as count'))
+            ->groupBy('locale')
+            ->orderBy('locale')
+            ->get()
+            ->map(static fn (mixed $row): array => [
+                'locale' => (string) $row->locale,
+                'count' => (int) $row->count,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  list<list<string>|string>  $groups
+     * @return list<string>
+     */
+    private function sortedUnique(array $groups): array
+    {
+        $slugs = [];
+        foreach ($groups as $group) {
+            foreach ((array) $group as $slug) {
+                $normalized = strtolower(trim((string) $slug));
+                if ($normalized !== '') {
+                    $slugs[$normalized] = true;
+                }
+            }
+        }
+
+        $keys = array_keys($slugs);
+        sort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * @param  list<string>  $left
+     * @param  list<string>  $right
+     * @return list<string>
+     */
+    private function diff(array $left, array $right): array
+    {
+        $rightSet = array_fill_keys($right, true);
+
+        return array_values(array_filter($left, static fn (string $slug): bool => ! isset($rightSet[$slug])));
+    }
+
+    /**
+     * @param  list<string>  $left
+     * @param  list<string>  $right
+     * @return list<string>
+     */
+    private function intersect(array $left, array $right): array
+    {
+        $rightSet = array_fill_keys($right, true);
+
+        return array_values(array_filter($left, static fn (string $slug): bool => isset($rightSet[$slug])));
+    }
+}

--- a/backend/docs/career/audits/detail_ready_1048_publication_scan.md
+++ b/backend/docs/career/audits/detail_ready_1048_publication_scan.md
@@ -1,0 +1,43 @@
+# Career Detail-Ready 1048 Publication Scan
+
+`career:audit-detail-ready-1048-candidates` is a read-only scanner for the
+Career detail-ready publication train.
+
+The scan distinguishes product-visible detail-page publication from 2786
+partition accounting. It does not publish jobs, mutate CMS content, run runtime
+candidate preparation, run rollout, deploy, submit URLs, or generate pSEO pages.
+
+## Authority Inputs
+
+- Current runtime projection public detail slugs.
+- Published public indexable `CareerJob` DOCX baseline rows with source evidence.
+- Valid `career_job_display_assets` rows with required SOC/O*NET crosswalks.
+- Compiled first-wave recommendation snapshot candidates.
+- Full release ledger classification when available.
+
+## Output Contract
+
+The command emits `career_detail_ready_publication_candidates.v1` with:
+
+- `current_public_30`
+- `ready_not_public_1018`
+- `sources.docx_ready`
+- `sources.display_asset_ready`
+- `sources.compiled_ready`
+- `sources.union_detail_ready`
+- `manual_hold`
+- `ledger_classification`
+- mutation guard fields: `writes_database=false`, `apply_allowed=false`,
+  `rollout_allowed=false`, `deploy_allowed=false`
+
+The output is an audit artifact only. Later PRs must define target authority,
+candidate preparation, artifact refresh, rollout gate, and live acceptance before
+any production apply or deploy.
+
+## Example
+
+```bash
+php artisan career:audit-detail-ready-1048-candidates \
+  --json \
+  --output=/tmp/career-detail-ready-1048-scan.json
+```

--- a/backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerAuditDetailReady1048Candidates;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerImportRun;
+use App\Models\CareerJob;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
+use Tests\TestCase;
+
+final class CareerAuditDetailReady1048CandidatesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const DISPLAY_COMPONENT_ORDER = [
+        'breadcrumb',
+        'hero',
+        'fermat_decision_card',
+        'primary_cta',
+        'career_snapshot_primary_locale',
+        'career_snapshot_secondary_locale',
+        'fit_decision_checklist',
+        'riasec_fit_block',
+        'personality_fit_block',
+        'definition_block',
+        'responsibilities_block',
+        'work_context_block',
+        'market_signal_card',
+        'adjacent_career_comparison_table',
+        'ai_impact_table',
+        'career_risk_cards',
+        'contract_project_risk_block',
+        'next_steps_block',
+        'faq_block',
+        'related_next_pages',
+        'source_card',
+        'methodology_note',
+        'trust_footer',
+        'schema_anchor',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(CareerAuditDetailReady1048Candidates::class),
+        );
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('career:audit-detail-ready-1048-candidates', Artisan::all());
+    }
+
+    public function test_it_scans_detail_ready_candidates_without_mutation(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                items: [
+                    [
+                        'slug' => 'currently-public-actuary',
+                        'locale' => 'en',
+                        'detail_route_enabled' => true,
+                        'dataset_visible' => true,
+                        'search_visible' => true,
+                        'robots_indexable' => true,
+                        'release_gate_pass' => true,
+                        'runtime_publish_state' => 'published',
+                    ],
+                ],
+            ),
+        );
+
+        $this->createDocxCareerJob('currently-public-actuary');
+        $this->createDocxCareerJob('accountants-and-auditors');
+        $this->createDocxCareerJob('software-developers');
+        $this->createDisplayAssetReadyOccupation('actors');
+
+        $output = sys_get_temp_dir().'/career-detail-ready-1048-test-'.bin2hex(random_bytes(4)).'.json';
+
+        $exitCode = Artisan::call('career:audit-detail-ready-1048-candidates', [
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $payload = json_decode((string) file_get_contents($output), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('career_detail_ready_publication_candidates.v1', $payload['schema_version']);
+        $this->assertSame('detail_ready_1048', $payload['target_key']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertFalse($payload['apply_allowed']);
+        $this->assertFalse($payload['rollout_allowed']);
+        $this->assertFalse($payload['deploy_allowed']);
+        $this->assertTrue($payload['product_visible_claim_boundary']['not_a_2786_partition_accounting_claim']);
+        $this->assertSame(1, $payload['counts']['current_public_detail']);
+        $this->assertSame(3, $payload['counts']['docx_ready']);
+        $this->assertSame(1, $payload['counts']['display_asset_ready']);
+        $this->assertSame(4, $payload['counts']['union_detail_ready']);
+        $this->assertSame(3, $payload['counts']['ready_not_currently_public']);
+        $this->assertContains('accountants-and-auditors', $payload['ready_not_public_1018']['slugs']);
+        $this->assertContains('actors', $payload['ready_not_public_1018']['slugs']);
+        $this->assertContains('software-developers', $payload['manual_hold']['ready_slugs']);
+        $this->assertFileExists($output);
+
+        @unlink($output);
+    }
+
+    private function createDocxCareerJob(string $slug): CareerJob
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => $slug,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => ucfirst(str_replace('-', ' ', $slug)),
+            'subtitle' => ucfirst(str_replace('-', ' ', $slug)),
+            'excerpt' => 'Read-only fixture.',
+            'market_demand_json' => [
+                'source_refs' => [
+                    ['url' => 'https://example.test/source'],
+                ],
+            ],
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+            'schema_version' => 'v1',
+        ]);
+        $job->seoMeta()->create([
+            'jsonld_overrides_json' => [
+                'source_docx' => 'fixture.docx',
+            ],
+        ]);
+
+        return $job->refresh();
+    }
+
+    private function createDisplayAssetReadyOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'family-'.$slug,
+            'title_en' => 'Fixture Family',
+            'title_zh' => '测试职业族',
+        ]);
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'directory_draft',
+            'canonical_title_en' => ucfirst(str_replace('-', ' ', $slug)),
+            'canonical_title_zh' => '测试职业',
+            'search_h1_zh' => '测试职业',
+        ]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'display_asset_crosswalks',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'display-asset-crosswalks-'.$slug,
+            'scope_mode' => 'display_asset_backed_directory_draft',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+
+        foreach ([['us_soc', '27-2011'], ['onet_soc_2019', '27-2011.00']] as [$system, $code]) {
+            OccupationCrosswalk::query()->create([
+                'occupation_id' => $occupation->id,
+                'source_system' => $system,
+                'source_code' => $code,
+                'source_title' => (string) $occupation->canonical_title_en,
+                'mapping_type' => 'direct_match',
+                'confidence_score' => 1,
+                'import_run_id' => $importRun->id,
+                'row_fingerprint' => hash('sha256', $system.'-'.$slug),
+            ]);
+        }
+
+        CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => $slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => self::DISPLAY_COMPONENT_ORDER,
+            'page_payload_json' => [
+                'zh' => ['hero' => ['title' => '测试职业']],
+                'en' => ['hero' => ['title' => 'Fixture Job']],
+            ],
+            'seo_payload_json' => [],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+        ]);
+
+        return $occupation->refresh();
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -207,6 +207,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_detail_ready_1048_audit_scanner_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_cms_article_report_correctness_changes(): void
     {
         $changed = [
@@ -2384,6 +2393,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerDetailReady1048AuditFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
                 continue;
             }
@@ -3720,6 +3733,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Audit/Career2786FullAuditArtifact.php',
             'backend/app/Domain/Career/Audit/Career2786FullAuditArtifactBuilder.php',
         ], true);
+    }
+
+    private function isCareerDetailReady1048AuditFile(string $file): bool
+    {
+        return $file === 'backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php';
     }
 
     private function isBigFiveV2PilotSupportFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T16:23:16+08:00",
+  "updated_at": "2026-05-27T16:36:19+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28850,13 +28850,13 @@
     ]
   },
   "AUDIT-CAREER-DETAIL-READY-1048-SCAN-1": {
-    "status": "implementation_in_progress",
+    "status": "pr_open",
     "repo": "fap-api",
     "branch": "codex/audit-career-detail-ready-1048-scan-1",
     "base": "main",
     "title": "fix(api): audit career detail-ready 1048 candidates",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "e4c6f26b06711fccd88fcdc817c956282d403447",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1724",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -28864,7 +28864,7 @@
     "checks": {
       "scope": {
         "status": "passed",
-        "evidence": "Changed files are limited to the read-only career detail-ready scanner, command registration, focused test, audit doc, and PR train metadata."
+        "evidence": "Changed files are limited to the read-only career detail-ready scanner, command registration, focused test, audit doc, Big Five runtime-freeze classifier test guard, and PR train metadata."
       },
       "local_validation": {
         "status": "passed",
@@ -28873,13 +28873,20 @@
           "php -l backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php",
           "php -l backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php",
           "cd backend && php artisan test tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php --no-ansi",
+          "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze_classifier_ignores_career_detail_ready_1048_audit_scanner_changes --no-ansi",
+          "cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --no-ansi",
           "cd backend && php artisan route:list --no-ansi",
-          "cd backend && vendor/bin/pint --test app/Console/Commands/CareerAuditDetailReady1048Candidates.php app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/CareerAuditDetailReady1048Candidates.php app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
           "python3 - <<'PY' ... yaml.safe_load(open('docs/codex/pr-train.yaml')) ... PY",
           "git diff --check",
           "cd backend && bash scripts/ci_verify_mbti.sh"
         ]
+      },
+      "github_checks": {
+        "status": "rerun_pending_after_scoped_fix",
+        "initial_failure": "verify-mbti legacy/v2 failed because BigFiveResultPageV2CoreBodyPreviewTest runtime freeze guard flagged backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php.",
+        "fix": "Added an explicit Career detail-ready 1048 audit scanner classifier case to the runtime freeze guard test."
       }
     },
     "history": [
@@ -28902,6 +28909,11 @@
         "at": "2026-05-27T16:23:16+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1724 for the read-only detail-ready 1048 candidate scanner."
+      },
+      {
+        "at": "2026-05-27T16:36:19+08:00",
+        "status": "github_checks_fix_ready",
+        "summary": "Fixed current-scope CI failure by classifying the read-only Career 1048 audit scanner as non-MBTI-impacting in the runtime freeze guard; focused guard test, full guard test, scanner test, route list, Pint, JSON/YAML, diff check, and backend CI master chain passed locally."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T16:36:19+08:00",
+  "updated_at": "2026-05-27T16:43:56+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28855,7 +28855,7 @@
     "branch": "codex/audit-career-detail-ready-1048-scan-1",
     "base": "main",
     "title": "fix(api): audit career detail-ready 1048 candidates",
-    "commit_sha": "e4c6f26b06711fccd88fcdc817c956282d403447",
+    "commit_sha": "9d7f67d2dab71ae981dcad290a49a7ee9de527b3",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1724",
     "failure_reason": null,
     "merged_at": null,
@@ -28884,9 +28884,10 @@
         ]
       },
       "github_checks": {
-        "status": "rerun_pending_after_scoped_fix",
+        "status": "passed",
         "initial_failure": "verify-mbti legacy/v2 failed because BigFiveResultPageV2CoreBodyPreviewTest runtime freeze guard flagged backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php.",
-        "fix": "Added an explicit Career detail-ready 1048 audit scanner classifier case to the runtime freeze guard test."
+        "fix": "Added an explicit Career detail-ready 1048 audit scanner classifier case to the runtime freeze guard test.",
+        "evidence": "PR #1724 checks passed after scoped fix: hygiene, supply-chain, Semgrep, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "history": [
@@ -28914,6 +28915,11 @@
         "at": "2026-05-27T16:36:19+08:00",
         "status": "github_checks_fix_ready",
         "summary": "Fixed current-scope CI failure by classifying the read-only Career 1048 audit scanner as non-MBTI-impacting in the runtime freeze guard; focused guard test, full guard test, scanner test, route list, Pint, JSON/YAML, diff check, and backend CI master chain passed locally."
+      },
+      {
+        "at": "2026-05-27T16:43:56+08:00",
+        "status": "github_checks_passed",
+        "summary": "GitHub checks passed for PR #1724 after the scoped runtime-freeze classifier fix."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T16:21:24+08:00",
+  "updated_at": "2026-05-27T16:23:16+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -22586,8 +22586,8 @@
     "depends_on": [
       "SEARCH-CHANNEL-LIVE-00"
     ],
-    "commit_sha": "d823de28682fe718fa9382b1d1bf14204956bef6",
-    "pr_url": null,
+    "commit_sha": "6fe4c4a4c94601eac1f8327e91a70d7652b6af02",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1724",
     "checks": {
       "dependency": {
         "status": "pass",
@@ -28896,7 +28896,12 @@
       {
         "at": "2026-05-27T16:21:24+08:00",
         "status": "committed",
-        "summary": "Created scoped audit scanner commit d823de28."
+        "summary": "Created scoped audit scanner commit 6fe4c4a4."
+      },
+      {
+        "at": "2026-05-27T16:23:16+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1724 for the read-only detail-ready 1048 candidate scanner."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T15:56:09+08:00",
+  "updated_at": "2026-05-27T16:21:24+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -22586,7 +22586,7 @@
     "depends_on": [
       "SEARCH-CHANNEL-LIVE-00"
     ],
-    "commit_sha": null,
+    "commit_sha": "d823de28682fe718fa9382b1d1bf14204956bef6",
     "pr_url": null,
     "checks": {
       "dependency": {
@@ -28848,5 +28848,146 @@
         "summary": "Opened PR #1723 for the post-publish smoke report."
       }
     ]
+  },
+  "AUDIT-CAREER-DETAIL-READY-1048-SCAN-1": {
+    "status": "implementation_in_progress",
+    "repo": "fap-api",
+    "branch": "codex/audit-career-detail-ready-1048-scan-1",
+    "base": "main",
+    "title": "fix(api): audit career detail-ready 1048 candidates",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "scope": {
+        "status": "passed",
+        "evidence": "Changed files are limited to the read-only career detail-ready scanner, command registration, focused test, audit doc, and PR train metadata."
+      },
+      "local_validation": {
+        "status": "passed",
+        "commands": [
+          "php -l backend/app/Console/Commands/CareerAuditDetailReady1048Candidates.php",
+          "php -l backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php",
+          "php -l backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php",
+          "cd backend && php artisan test tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/CareerAuditDetailReady1048Candidates.php app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<'PY' ... yaml.safe_load(open('docs/codex/pr-train.yaml')) ... PY",
+          "git diff --check",
+          "cd backend && bash scripts/ci_verify_mbti.sh"
+        ]
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T16:11:06+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Initialized read-only detail-ready 1048 candidate scan PR and added the six-item PR train entries from the user-provided goal."
+      },
+      {
+        "at": "2026-05-27T16:19:16+08:00",
+        "status": "local_checks_passed",
+        "summary": "Focused scanner test, route list, Pint, JSON/YAML parsing, diff check, and backend CI master chain passed."
+      },
+      {
+        "at": "2026-05-27T16:21:24+08:00",
+        "status": "committed",
+        "summary": "Created scoped audit scanner commit d823de28."
+      }
+    ]
+  },
+  "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1": {
+    "status": "planned",
+    "repo": "fap-api",
+    "branch": "codex/repair-career-detail-ready-target-authority-1",
+    "base": "main",
+    "depends_on": [
+      "AUDIT-CAREER-DETAIL-READY-1048-SCAN-1"
+    ],
+    "title": "fix(api): define career detail-ready 1048 authority",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {},
+    "history": []
+  },
+  "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1": {
+    "status": "planned",
+    "repo": "fap-api",
+    "branch": "codex/repair-career-detail-ready-candidate-prep-1",
+    "base": "main",
+    "depends_on": [
+      "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1"
+    ],
+    "title": "fix(api): plan career detail-ready 1018 candidate prep",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {},
+    "history": []
+  },
+  "REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1": {
+    "status": "planned",
+    "repo": "fap-api",
+    "branch": "codex/repair-career-detail-ready-runtime-artifact-refresh-1",
+    "base": "main",
+    "depends_on": [
+      "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1"
+    ],
+    "title": "fix(api): refresh career detail-ready 1048 artifacts",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {},
+    "history": []
+  },
+  "REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1": {
+    "status": "planned",
+    "repo": "fap-api",
+    "branch": "codex/repair-career-detail-ready-rollout-gate-1",
+    "base": "main",
+    "depends_on": [
+      "REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1"
+    ],
+    "title": "fix(api): gate career detail-ready 1048 rollout",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {},
+    "history": []
+  },
+  "REPAIR-CAREER-DETAIL-READY-LIVE-ACCEPTANCE-CLOSEOUT-1": {
+    "status": "planned",
+    "repo": "fap-api",
+    "branch": "codex/repair-career-detail-ready-live-acceptance-closeout-1",
+    "base": "main",
+    "depends_on": [
+      "REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1"
+    ],
+    "title": "fix(api): accept career detail-ready 1048 closeout",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {},
+    "history": []
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5232,6 +5232,7 @@ prs:
       - backend/app/Console/Kernel.php
       - backend/app/Domain/Career/Audit/**
       - backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - backend/docs/career/audits/**
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
@@ -5247,6 +5248,7 @@ prs:
       - php artisan test tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php --no-ansi
       - php artisan route:list --no-ansi
       - vendor/bin/pint --test app/Console/Commands/CareerAuditDetailReady1048Candidates.php app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php
+      - php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze_classifier_ignores_career_detail_ready_1048_audit_scanner_changes --no-ansi
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - JSON/YAML parse
       - bash backend/scripts/ci_verify_mbti.sh

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5216,6 +5216,263 @@ prs:
       github_checks_required: true
       squash: true
 
+  - id: AUDIT-CAREER-DETAIL-READY-1048-SCAN-1
+    repo: fap-api
+    branch: codex/audit-career-detail-ready-1048-scan-1
+    base: main
+    title: "fix(api): audit career detail-ready 1048 candidates"
+    name: "Audit all currently detail-ready Career publication candidates"
+    train_scope: career_detail_ready_1048_publication
+    scope:
+      - Add a read-only scanner and JSON artifact contract for current detail-ready Career publication candidates.
+      - Classify current_public_30, ready_not_public_1018, docx_ready, display_asset_ready, compiled_ready, manual_hold, blocked, review_needed, and family_handoff evidence.
+      - Keep the scan separate from candidate preparation, rollout, deploy, CMS mutation, and fap-web fallback authority.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerAuditDetailReady1048Candidates.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Domain/Career/Audit/**
+      - backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish 2289 excluded/raw assets.
+      - Publish all 2786 occupations.
+      - Generate pSEO pages.
+      - Add fap-web fallback authority.
+      - Mutate production DB or CMS.
+      - Run candidate prep apply, rollout apply, deploy, backfill, rollback, or quarantine.
+      - Force-enable software-developers.
+    validation:
+      - php artisan test tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test app/Console/Commands/CareerAuditDetailReady1048Candidates.php app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by AUDIT-CAREER-DETAIL-READY-1048-SCAN-1
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1
+    repo: fap-api
+    depends_on:
+      - AUDIT-CAREER-DETAIL-READY-1048-SCAN-1
+    branch: codex/repair-career-detail-ready-target-authority-1
+    base: main
+    title: "fix(api): define career detail-ready 1048 authority"
+    name: "Define detail-ready 1048 product-visible publication authority"
+    train_scope: career_detail_ready_1048_publication
+    scope:
+      - Add backend authority semantics for target detail_ready_1048.
+      - Keep detail_ready_1048 separate from 2786 partition accounting.
+      - Preserve manual hold and CN proxy policies.
+      - Add product-visible claim guardrails for 1048 detail pages.
+    allowed_paths:
+      - backend/app/Console/Commands/Career*
+      - backend/app/Domain/Career/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production mutation, candidate prep apply, rollout apply, deploy, backfill, rollback, or quarantine.
+      - Touch fap-web or generate pSEO pages.
+      - Weaken CN proxy or software-developers manual hold policy.
+    validation:
+      - php artisan test --filter=CareerDetailReady --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1
+    branch: codex/repair-career-detail-ready-candidate-prep-1
+    base: main
+    title: "fix(api): plan career detail-ready 1018 candidate prep"
+    name: "Plan runtime candidate preparation for the detail-ready 1018 delta"
+    train_scope: career_detail_ready_1048_publication
+    scope:
+      - Extend runtime candidate preparation planning for the 1018 detail-ready delta.
+      - Support chunked explicit slug artifacts when needed.
+      - Preserve review, family, blocked, CN proxy, and manual-hold gates.
+      - Keep implementation planner/dry-run only.
+    allowed_paths:
+      - backend/app/Console/Commands/Career*
+      - backend/app/Domain/Career/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production candidate prep apply.
+      - Run rollout apply, deploy, backfill, rollback, quarantine, CMS mutation, or fap-web changes.
+    validation:
+      - php artisan test --filter=CareerDetailReady --no-ansi
+      - php artisan test --filter=CareerRuntimeCandidate --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1
+    branch: codex/repair-career-detail-ready-runtime-artifact-refresh-1
+    base: main
+    title: "fix(api): refresh career detail-ready 1048 artifacts"
+    name: "Support candidate-aware runtime artifacts for detail-ready 1048"
+    train_scope: career_detail_ready_1048_publication
+    scope:
+      - Extend candidate-aware projection, truth, and ledger refresh for detail_ready_1048.
+      - Ensure dataset, jobs API, detail route, sitemap, llms, and llms-full consume one authority.
+      - Keep implementation read-only/planner-only without production export or apply.
+    allowed_paths:
+      - backend/app/Console/Commands/Career*
+      - backend/app/Domain/Career/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production artifact export/apply, rollout apply, deploy, CMS mutation, or fap-web changes.
+    validation:
+      - php artisan test --filter=CareerDetailReady --no-ansi
+      - php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1
+    branch: codex/repair-career-detail-ready-rollout-gate-1
+    base: main
+    title: "fix(api): gate career detail-ready 1048 rollout"
+    name: "Add rollout manifest gate for the detail-ready 1018 delta"
+    train_scope: career_detail_ready_1048_publication
+    scope:
+      - Add rollout manifest and rollback-group support for the 1018 detail-ready delta.
+      - Reject partial promotion, unready slugs, CN proxy rows, manual holds, and stale artifacts.
+      - Keep implementation dry-run/gate-only without rollout apply.
+    allowed_paths:
+      - backend/app/Console/Commands/Career*
+      - backend/app/Domain/Career/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run rollout apply, candidate prep apply, production mutation, deploy, CMS mutation, or fap-web changes.
+    validation:
+      - php artisan test --filter=CareerDetailReady --no-ansi
+      - php artisan test --filter=CareerDeltaRollout --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
+  - id: REPAIR-CAREER-DETAIL-READY-LIVE-ACCEPTANCE-CLOSEOUT-1
+    repo: fap-api
+    depends_on:
+      - REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1
+    branch: codex/repair-career-detail-ready-live-acceptance-closeout-1
+    base: main
+    title: "fix(api): accept career detail-ready 1048 closeout"
+    name: "Add live acceptance and closeout support for detail-ready 1048"
+    train_scope: career_detail_ready_1048_publication
+    scope:
+      - Add live acceptance and closeout support for target total 1048.
+      - Verify product-visible counts rather than partition accounting.
+      - Require dataset member_count, jobs item count, detail-ready count, locale-row count, sitemap, llms, and noindex/404/redirect-source consistency.
+      - Keep live crawl disabled unless separately approved.
+    allowed_paths:
+      - backend/app/Console/Commands/Career*
+      - backend/app/Domain/Career/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/Domain/Career/**
+      - backend/docs/career/audits/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run live crawl without explicit approval.
+      - Run production mutation, rollout apply, deploy, CMS mutation, Search Channel action, URL submission, or fap-web changes.
+    validation:
+      - php artisan test --filter=CareerDetailReady --no-ansi
+      - php artisan test --filter=CareerLiveAcceptance --no-ansi
+      - php artisan route:list --no-ansi
+      - vendor/bin/pint --test
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+    scope_validation:
+      continue_train_when_external_blocker:
+        - blocker is not introduced by REPAIR-CAREER-DETAIL-READY-LIVE-ACCEPTANCE-CLOSEOUT-1
+        - GitHub required checks are green
+        - scoped validation is green
+      record_external_blocker_as_sidecar: true
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
   - id: PUBLISH-API-MEDIA-ORIGIN-READYNESS
     repo: fap-api
     branch: codex/publish-api-media-origin-readyness


### PR DESCRIPTION
## What changed
- Added a read-only `career:audit-detail-ready-1048-candidates` command.
- Added `CareerDetailReadyPublicationCandidateScanner` to classify current public detail slugs, DOCX-ready jobs, display-asset-ready jobs, compiled-ready jobs, union detail-ready candidates, ready-not-public candidates, manual holds, and ledger classification.
- Added a focused feature test for command registration, mutation guards, claim-boundary guards, source classification, and manual hold handling.
- Added the six-item Career detail-ready 1048 PR train manifest/state entries.
- Added a short audit contract doc for the scanner output.

## Why
This is the first AUDIT PR in the backend-first train for `detail_ready_1048`. It creates a non-mutating scanner/artifact contract so later PRs can define target authority, candidate prep, runtime artifact refresh, rollout gates, and acceptance without mixing scopes.

## Validation commands
- `php -l backend/app/Console/Commands/CareerAuditDetailReady1048Candidates.php`
- `php -l backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php`
- `php -l backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php`
- `cd backend && php artisan test tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/CareerAuditDetailReady1048Candidates.php app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(open('docs/codex/pr-train.yaml')) ... PY`
- `git diff --check`
- `git diff --cached --check`
- `cd backend && bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No production DB mutation.
- No CMS mutation.
- No candidate prep apply.
- No runtime artifact export/apply.
- No rollout apply.
- No deploy.
- No Search Channel, URL submission, pSEO generation, or fap-web fallback authority.
- No publication of 2289 excluded/raw assets or all 2786 occupations.
- No force-enable for `software-developers`.

## Sidecar blockers
None identified in this PR scope.
