### PR TITLE
fix(api): define career detail-ready 1048 authority

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php
+++ b/backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php
@@ -38,6 +38,7 @@ final class CareerDetailReadyPublicationCandidateScanner
     public function __construct(
         private readonly CareerRuntimePublishProjectionVisibility $runtimeProjection,
         private readonly CareerFullReleaseLedgerProjectionService $fullReleaseLedgerProjectionService,
+        private readonly CareerDetailReadyTargetAuthority $targetAuthority,
     ) {}
 
     /**
@@ -68,6 +69,7 @@ final class CareerDetailReadyPublicationCandidateScanner
             'deploy_allowed' => false,
             'cms_mutation_allowed' => false,
             'fap_web_fallback_authority_allowed' => false,
+            'target_authority' => $this->targetAuthority->target(),
             'product_visible_claim_boundary' => [
                 'target' => 'all currently backend-authoritative detail-ready Career jobs',
                 'not_a_2786_partition_accounting_claim' => true,

--- a/backend/app/Domain/Career/Audit/CareerDetailReadyTargetAuthority.php
+++ b/backend/app/Domain/Career/Audit/CareerDetailReadyTargetAuthority.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Audit;
+
+final class CareerDetailReadyTargetAuthority
+{
+    public const SCHEMA_VERSION = 'career_detail_ready_1048_target_authority.v1';
+
+    public const TARGET_KEY = 'detail_ready_1048';
+
+    public const CURRENT_PUBLIC_DETAIL_TOTAL = 30;
+
+    public const TARGET_PUBLIC_TOTAL = 1048;
+
+    public const READY_NOT_PUBLIC_DELTA = 1018;
+
+    public const RAW_OCCUPATION_ASSET_TOTAL = 2786;
+
+    public const EXCLUDED_RAW_ASSET_TOTAL = 2289;
+
+    public const MANUAL_HOLD_SLUGS = [
+        'software-developers',
+    ];
+
+    /**
+     * @param  list<string>  $locales
+     * @return array<string, mixed>
+     */
+    public function target(array $locales = ['en', 'zh']): array
+    {
+        $locales = $this->normalizeLocales($locales);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'target_key' => self::TARGET_KEY,
+            'target_public_total' => self::TARGET_PUBLIC_TOTAL,
+            'current_public_detail_total' => self::CURRENT_PUBLIC_DETAIL_TOTAL,
+            'ready_not_currently_public_delta' => self::READY_NOT_PUBLIC_DELTA,
+            'locale_policy' => [
+                'locales' => $locales,
+                'expected_locale_rows' => self::TARGET_PUBLIC_TOTAL * count($locales),
+            ],
+            'publication_scope' => [
+                'product_visible_detail_pages' => true,
+                'public_runtime_authority_required' => true,
+                'sitemap_llms_authority_required' => true,
+                'runtime_projection_artifact_required' => true,
+                'candidate_prep_apply_allowed' => false,
+                'rollout_apply_allowed' => false,
+                'production_deploy_allowed' => false,
+            ],
+            'partition_boundary' => [
+                'is_2786_partition_accounting' => false,
+                'raw_occupation_asset_total' => self::RAW_OCCUPATION_ASSET_TOTAL,
+                'excluded_raw_asset_total' => self::EXCLUDED_RAW_ASSET_TOTAL,
+                'raw_assets_are_not_publication_authority' => true,
+                'do_not_claim_2786_visible_jobs' => true,
+                'do_not_publish_excluded_raw_assets' => true,
+            ],
+            'manual_hold_policy' => [
+                'slugs' => self::MANUAL_HOLD_SLUGS,
+                'release_requires_explicit_decision_artifact' => true,
+                'must_not_force_enable' => true,
+                'must_not_enter_candidate_prep_without_release_decision' => true,
+                'must_not_enter_sitemap_llms_or_public_routes_without_release_decision' => true,
+            ],
+            'cn_proxy_policy' => [
+                'cn_proxy_rows_are_not_detail_ready_publication_authority' => true,
+                'preserve_noindex_noncanonical_policy' => true,
+                'must_not_count_toward_product_visible_detail_claim' => true,
+            ],
+            'claim_guardrails' => [
+                'claim_policy_version' => 'career_detail_ready_1048_product_visible_claim.v1',
+                'visible_detail_claim_requires' => [
+                    'dataset_member_count' => self::TARGET_PUBLIC_TOTAL,
+                    'career_jobs_api_item_count' => self::TARGET_PUBLIC_TOTAL,
+                    'detail_ready_count' => self::TARGET_PUBLIC_TOTAL,
+                    'public_detail_indexable_count' => self::TARGET_PUBLIC_TOTAL,
+                    'expected_locale_rows' => self::TARGET_PUBLIC_TOTAL * count($locales),
+                    'no_noindex_404_or_redirect_source_urls_in_sitemap_llms' => true,
+                ],
+                'unsafe_claims' => [
+                    'all_2786_jobs_are_public',
+                    'all_2786_detail_pages_are_indexable',
+                    'excluded_raw_assets_are_public',
+                    'software_developers_is_public_without_release_decision',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @param  list<string>  $locales
+     * @return array<string, mixed>
+     */
+    public function productVisibleClaim(array $evidence, array $locales = ['en', 'zh']): array
+    {
+        $locales = $this->normalizeLocales($locales);
+        $expectedLocaleRows = self::TARGET_PUBLIC_TOTAL * count($locales);
+        $datasetMemberCount = $this->intAtAny($evidence, [
+            'dataset.member_count',
+            'collection_summary.member_count',
+            'product_surface.directory_member_count',
+            'observed_public_directory_member_count',
+        ]);
+        $careerJobsItemCount = $this->intAtAny($evidence, [
+            'career_jobs.item_count',
+            'career_job_list.item_count',
+            'product_surface.career_jobs_item_count',
+            'observed_job_items_count',
+        ]);
+        $detailReadyCount = $this->intAtAny($evidence, [
+            'detail_ready.count',
+            'product_surface.detail_ready_count',
+            'public_detail_indexable_count',
+            'observed_detail_ready_count',
+        ]);
+        $publicDetailIndexableCount = $this->intAtAny($evidence, [
+            'product_surface.public_detail_indexable_count',
+            'collection_summary.public_detail_indexable_count',
+            'public_detail_indexable_count',
+        ]);
+        $foundPublishedLocaleRows = $this->intAtAny($evidence, [
+            'found_published',
+            'acceptance_summary.found_published',
+            'canonical_public_locale_rows',
+        ]);
+        $releaseGatePassCount = $this->intAtAny($evidence, [
+            'release_gate.pass_count',
+            'release_gate_pass_count',
+            'acceptance_summary.release_gate_pass_count',
+        ]);
+        $badUrlCount = $this->intAtAny($evidence, [
+            'sitemap_llms.bad_url_count',
+            'bad_url_count',
+            'acceptance_summary.bad_url_count',
+        ]) ?? 0;
+        $partitionAccountingTotal = $this->intAtAny($evidence, [
+            'partition_accounting.final_public_accounted_total',
+            'final_public_accounted_total',
+        ]);
+
+        $visibleDetailClaimAllowed = $datasetMemberCount === self::TARGET_PUBLIC_TOTAL
+            && $careerJobsItemCount === self::TARGET_PUBLIC_TOTAL
+            && $detailReadyCount === self::TARGET_PUBLIC_TOTAL
+            && $publicDetailIndexableCount === self::TARGET_PUBLIC_TOTAL
+            && $foundPublishedLocaleRows === $expectedLocaleRows
+            && $releaseGatePassCount === $expectedLocaleRows
+            && $badUrlCount === 0;
+
+        return [
+            'claim_policy_version' => 'career_detail_ready_1048_product_visible_claim.v1',
+            'target_key' => self::TARGET_KEY,
+            'visible_detail_claim_allowed' => $visibleDetailClaimAllowed,
+            'partition_accounting_claim_allowed' => false,
+            'safe_claim_scope' => $visibleDetailClaimAllowed
+                ? 'product_visible_detail_ready_1048'
+                : ($partitionAccountingTotal === self::RAW_OCCUPATION_ASSET_TOTAL
+                    ? 'partition_accounted_not_product_visible'
+                    : 'insufficient_product_visible_evidence'),
+            'claimable_counts' => [
+                'dataset_member_count' => $datasetMemberCount,
+                'career_jobs_item_count' => $careerJobsItemCount,
+                'detail_ready_count' => $detailReadyCount,
+                'public_detail_indexable_count' => $publicDetailIndexableCount,
+                'found_published_locale_rows' => $foundPublishedLocaleRows,
+                'release_gate_pass_count' => $releaseGatePassCount,
+                'bad_url_count' => $badUrlCount,
+                'partition_accounting_total' => $partitionAccountingTotal,
+            ],
+        ];
+    }
+
+    public function supportsTarget(string $targetKey): bool
+    {
+        return $targetKey === self::TARGET_KEY;
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return list<string>
+     */
+    private function normalizeLocales(array $locales): array
+    {
+        $normalized = [];
+        foreach ($locales as $locale) {
+            $value = strtolower(trim($locale));
+            if ($value !== '') {
+                $normalized[$value] = true;
+            }
+        }
+
+        $keys = array_keys($normalized);
+        sort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $paths
+     */
+    private function intAtAny(array $payload, array $paths): ?int
+    {
+        foreach ($paths as $path) {
+            $value = data_get($payload, $path);
+            if (is_int($value)) {
+                return $value;
+            }
+            if (is_numeric($value)) {
+                return (int) $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/docs/career/audits/detail_ready_1048_target_authority.md
+++ b/backend/docs/career/audits/detail_ready_1048_target_authority.md
@@ -1,0 +1,32 @@
+# Career Detail-Ready 1048 Target Authority
+
+`CareerDetailReadyTargetAuthority` defines the backend authority semantics for
+the `detail_ready_1048` target.
+
+This target means 1048 product-visible Career detail pages, not 2786 partition
+accounting. It preserves the current public 30 cohort, identifies the planned
+1018 delta, and keeps raw/excluded occupation assets out of publication
+authority.
+
+## Guardrails
+
+- No production mutation, CMS mutation, candidate-prep apply, rollout apply, or
+  deploy is allowed by this target authority.
+- `software-developers` remains a manual-hold slug and must not be force-enabled.
+- CN proxy rows remain outside product-visible detail-page authority and must
+  preserve noindex/noncanonical policy.
+- A visible 1048 claim requires dataset, jobs API, detail-ready,
+  public-detail-indexable, locale-row, release-gate, sitemap, and llms evidence.
+- 2786 partition accounting never proves a 1048 visible-detail claim.
+
+## Acceptance Shape
+
+For the default `en` + `zh` locale policy, acceptance must eventually prove:
+
+- dataset member count: 1048
+- career jobs API item count: 1048
+- detail-ready count: 1048
+- public detail indexable count: 1048
+- published locale rows: 2096
+- release gate pass rows: 2096
+- no noindex, 404, or redirect-source URLs in sitemap / llms surfaces

--- a/backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php
@@ -103,6 +103,10 @@ final class CareerAuditDetailReady1048CandidatesCommandTest extends TestCase
         $this->assertFalse($payload['apply_allowed']);
         $this->assertFalse($payload['rollout_allowed']);
         $this->assertFalse($payload['deploy_allowed']);
+        $this->assertSame('detail_ready_1048', $payload['target_authority']['target_key']);
+        $this->assertSame(1048, $payload['target_authority']['target_public_total']);
+        $this->assertFalse($payload['target_authority']['partition_boundary']['is_2786_partition_accounting']);
+        $this->assertTrue($payload['target_authority']['manual_hold_policy']['must_not_force_enable']);
         $this->assertTrue($payload['product_visible_claim_boundary']['not_a_2786_partition_accounting_claim']);
         $this->assertSame(1, $payload['counts']['current_public_detail']);
         $this->assertSame(3, $payload['counts']['docx_ready']);

--- a/backend/tests/Unit/Domain/Career/Audit/CareerDetailReadyTargetAuthorityTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerDetailReadyTargetAuthorityTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\CareerDetailReadyTargetAuthority;
+use PHPUnit\Framework\TestCase;
+
+final class CareerDetailReadyTargetAuthorityTest extends TestCase
+{
+    public function test_target_authority_separates_1048_from_2786_partition_accounting(): void
+    {
+        $authority = new CareerDetailReadyTargetAuthority;
+        $target = $authority->target();
+
+        $this->assertSame('career_detail_ready_1048_target_authority.v1', $target['schema_version']);
+        $this->assertSame('detail_ready_1048', $target['target_key']);
+        $this->assertSame(30, $target['current_public_detail_total']);
+        $this->assertSame(1048, $target['target_public_total']);
+        $this->assertSame(1018, $target['ready_not_currently_public_delta']);
+        $this->assertSame(2096, $target['locale_policy']['expected_locale_rows']);
+        $this->assertFalse($target['partition_boundary']['is_2786_partition_accounting']);
+        $this->assertTrue($target['partition_boundary']['raw_assets_are_not_publication_authority']);
+        $this->assertTrue($target['partition_boundary']['do_not_publish_excluded_raw_assets']);
+        $this->assertContains('software-developers', $target['manual_hold_policy']['slugs']);
+        $this->assertTrue($target['manual_hold_policy']['must_not_force_enable']);
+        $this->assertTrue($target['cn_proxy_policy']['preserve_noindex_noncanonical_policy']);
+        $this->assertTrue($authority->supportsTarget('detail_ready_1048'));
+        $this->assertFalse($authority->supportsTarget('2786'));
+    }
+
+    public function test_product_visible_claim_requires_all_1048_runtime_counts(): void
+    {
+        $authority = new CareerDetailReadyTargetAuthority;
+
+        $claim = $authority->productVisibleClaim([
+            'dataset' => ['member_count' => 1048],
+            'career_jobs' => ['item_count' => 1048],
+            'detail_ready' => ['count' => 1048],
+            'product_surface' => ['public_detail_indexable_count' => 1048],
+            'found_published' => 2096,
+            'release_gate' => ['pass_count' => 2096],
+            'sitemap_llms' => ['bad_url_count' => 0],
+        ]);
+
+        $this->assertTrue($claim['visible_detail_claim_allowed']);
+        $this->assertFalse($claim['partition_accounting_claim_allowed']);
+        $this->assertSame('product_visible_detail_ready_1048', $claim['safe_claim_scope']);
+    }
+
+    public function test_2786_partition_accounting_does_not_allow_1048_visible_claim(): void
+    {
+        $authority = new CareerDetailReadyTargetAuthority;
+
+        $claim = $authority->productVisibleClaim([
+            'partition_accounting' => [
+                'final_public_accounted_total' => 2786,
+            ],
+        ]);
+
+        $this->assertFalse($claim['visible_detail_claim_allowed']);
+        $this->assertFalse($claim['partition_accounting_claim_allowed']);
+        $this->assertSame('partition_accounted_not_product_visible', $claim['safe_claim_scope']);
+        $this->assertSame(2786, $claim['claimable_counts']['partition_accounting_total']);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -211,6 +211,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php',
+            'backend/app/Domain/Career/Audit/CareerDetailReadyTargetAuthority.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -3737,7 +3738,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isCareerDetailReady1048AuditFile(string $file): bool
     {
-        return $file === 'backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php';
+        return in_array($file, [
+            'backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php',
+            'backend/app/Domain/Career/Audit/CareerDetailReadyTargetAuthority.php',
+        ], true);
     }
 
     private function isBigFiveV2PilotSupportFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T16:43:56+08:00",
+  "updated_at": "2026-05-27T17:04:43+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28850,7 +28850,7 @@
     ]
   },
   "AUDIT-CAREER-DETAIL-READY-1048-SCAN-1": {
-    "status": "pr_open",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/audit-career-detail-ready-1048-scan-1",
     "base": "main",
@@ -28858,8 +28858,8 @@
     "commit_sha": "9d7f67d2dab71ae981dcad290a49a7ee9de527b3",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1724",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-05-27T16:45:00+08:00",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "checks": {
       "scope": {
@@ -28920,11 +28920,16 @@
         "at": "2026-05-27T16:43:56+08:00",
         "status": "github_checks_passed",
         "summary": "GitHub checks passed for PR #1724 after the scoped runtime-freeze classifier fix."
+      },
+      {
+        "at": "2026-05-27T16:55:03+08:00",
+        "status": "merged",
+        "summary": "PR #1724 was squash merged into main at 6e576fcf; remote branch was deleted. Repository has no scripts/post_merge_cleanup.sh, so scripted local cleanup was not executed."
       }
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1": {
-    "status": "planned",
+    "status": "local_checks_passed",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-target-authority-1",
     "base": "main",
@@ -28932,14 +28937,60 @@
       "AUDIT-CAREER-DETAIL-READY-1048-SCAN-1"
     ],
     "title": "fix(api): define career detail-ready 1048 authority",
-    "commit_sha": null,
+    "commit_sha": "3c21241f565a11cbf1f0849cd8b531abe1a161ad",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "checks": {},
-    "history": []
+    "checks": {
+      "local": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test --filter=CareerDetailReady --no-ansi",
+          "cd backend && php artisan test tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && bash scripts/ci_verify_mbti.sh"
+        ],
+        "notes": "The MBTI CI chain regenerated BIG5_OCEAN compiled artifacts as a local side effect; those generated diffs were restored because they are outside this PR scope."
+      },
+      "scope": {
+        "status": "passed",
+        "changed_files": [
+          "backend/app/Domain/Career/Audit/CareerDetailReadyPublicationCandidateScanner.php",
+          "backend/app/Domain/Career/Audit/CareerDetailReadyTargetAuthority.php",
+          "backend/docs/career/audits/detail_ready_1048_target_authority.md",
+          "backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php",
+          "backend/tests/Unit/Domain/Career/Audit/CareerDetailReadyTargetAuthorityTest.php",
+          "docs/codex/pr-train-state.json"
+        ],
+        "outside_scope": []
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T16:55:03+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started backend authority semantics PR for detail_ready_1048 after AUDIT PR merge."
+      },
+      {
+        "at": "2026-05-27T17:04:43+08:00",
+        "status": "local_checks_passed",
+        "summary": "CareerDetailReady tests, scanner feature test, route list, testing sqlite migrate pretend, full Pint, and backend MBTI CI master chain passed locally."
+      },
+      {
+        "at": "2026-05-27T17:04:43+08:00",
+        "status": "scope_validation_passed",
+        "summary": "Changed files are within the target-authority PR allowed paths."
+      },
+      {
+        "at": "2026-05-27T17:04:43+08:00",
+        "status": "local_commit_created",
+        "summary": "Created local commit 3c21241f565a11cbf1f0849cd8b531abe1a161ad for target authority PR."
+      }
+    ]
   },
   "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1": {
     "status": "planned",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28937,7 +28937,7 @@
       "AUDIT-CAREER-DETAIL-READY-1048-SCAN-1"
     ],
     "title": "fix(api): define career detail-ready 1048 authority",
-    "commit_sha": "3c21241f565a11cbf1f0849cd8b531abe1a161ad",
+    "commit_sha": "2207629e257c9544a6d1ab240025747771065e04",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -28988,7 +28988,7 @@
       {
         "at": "2026-05-27T17:04:43+08:00",
         "status": "local_commit_created",
-        "summary": "Created local commit 3c21241f565a11cbf1f0849cd8b531abe1a161ad for target authority PR."
+        "summary": "Created local commit 2207629e257c9544a6d1ab240025747771065e04 for target authority PR."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T17:08:20+08:00",
+  "updated_at": "2026-05-27T17:18:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28963,10 +28963,21 @@
           "backend/app/Domain/Career/Audit/CareerDetailReadyTargetAuthority.php",
           "backend/docs/career/audits/detail_ready_1048_target_authority.md",
           "backend/tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "backend/tests/Unit/Domain/Career/Audit/CareerDetailReadyTargetAuthorityTest.php",
+          "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
         "outside_scope": []
+      },
+      "github": {
+        "status": "failed_then_scoped_fix_applied",
+        "failed_checks": [
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "failure_reason": "BigFive runtime freeze classifier did not yet classify backend/app/Domain/Career/Audit/CareerDetailReadyTargetAuthority.php as Career detail-ready 1048 audit/authority scope.",
+        "fix": "Extended the existing Career detail-ready 1048 audit classifier and focused guard test to include CareerDetailReadyTargetAuthority.php; updated PR manifest allowed paths and validation command."
       }
     },
     "history": [
@@ -28994,6 +29005,11 @@
         "at": "2026-05-27T17:08:20+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1725 for detail_ready_1048 target authority semantics."
+      },
+      {
+        "at": "2026-05-27T17:18:30+08:00",
+        "status": "github_checks_failed_scoped_fix_applied",
+        "summary": "GitHub MBTI checks failed because the new CareerDetailReadyTargetAuthority.php file was not classified by the Big Five runtime freeze guard. Added a scoped guard-test classifier update and reran focused tests, route list, targeted Pint, and backend MBTI CI locally."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T17:04:43+08:00",
+  "updated_at": "2026-05-27T17:08:20+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28929,7 +28929,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1": {
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-target-authority-1",
     "base": "main",
@@ -28938,7 +28938,7 @@
     ],
     "title": "fix(api): define career detail-ready 1048 authority",
     "commit_sha": "2207629e257c9544a6d1ab240025747771065e04",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1725",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -28989,6 +28989,11 @@
         "at": "2026-05-27T17:04:43+08:00",
         "status": "local_commit_created",
         "summary": "Created local commit 2207629e257c9544a6d1ab240025747771065e04 for target authority PR."
+      },
+      {
+        "at": "2026-05-27T17:08:20+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1725 for detail_ready_1048 target authority semantics."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5283,6 +5283,7 @@ prs:
       - backend/app/Domain/Career/**
       - backend/tests/Feature/Console/**
       - backend/tests/Unit/Domain/Career/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - backend/docs/career/audits/**
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
@@ -5292,6 +5293,7 @@ prs:
       - Weaken CN proxy or software-developers manual hold policy.
     validation:
       - php artisan test --filter=CareerDetailReady --no-ansi
+      - php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_freeze_classifier_ignores_career_detail_ready_1048_audit_scanner_changes --no-ansi
       - php artisan route:list --no-ansi
       - vendor/bin/pint --test
       - bash backend/scripts/ci_verify_mbti.sh


### PR DESCRIPTION
## What changed
- Added backend target authority semantics for `detail_ready_1048` under the Career audit domain.
- Attached the authority payload to the existing read-only detail-ready scanner output.
- Added focused unit coverage for product-visible claim guardrails and the 1048-vs-2786 boundary.
- Extended the scanner feature test to assert target authority guardrails.
- Added a short audit doc for the target authority contract.
- Updated the PR train ledger for this scoped item.

## Why
This PR defines the product-visible publication target before later train items prepare candidates, refresh runtime artifacts, add rollout gates, or add live acceptance. It keeps the 1048 detail-ready target separate from 2786 raw/partition accounting and preserves manual hold / CN proxy policies.

## Validation commands
```bash
cd backend && php artisan test --filter=CareerDetailReady --no-ansi
cd backend && php artisan test tests/Feature/Console/CareerAuditDetailReady1048CandidatesCommandTest.php --no-ansi
cd backend && php artisan route:list --no-ansi
cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
cd backend && vendor/bin/pint --test
cd backend && bash scripts/ci_verify_mbti.sh
git diff --check
git diff --cached --check
```

## Intentionally deferred
- No candidate prep apply.
- No rollout apply.
- No production DB mutation.
- No deploy.
- No sitemap/llms exposure changes.
- No fap-web fallback authority.
- No publication of 2289 excluded/raw assets or all 2786 occupations.
- No forced enablement of `software-developers` without an explicit manual-hold release decision artifact.

## Sidecar blockers
None introduced by this PR. Runtime publication, candidate prep, artifact refresh, rollout, and live acceptance remain in later train items.

## Repository rule impact
Career publication authority remains backend-authoritative. This PR adds authority semantics only; it does not create a new content surface, mutate CMS content, or change runtime public exposure.
