### PR TITLE
fix(api): plan career detail-ready 1018 candidate prep

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php
@@ -21,6 +21,7 @@ final class CareerPlanCanonicalRuntimeCandidatePrep extends Command
         {--truth= : Optional runtime truth JSON artifact}
         {--ledger= : Optional full release ledger JSON artifact}
         {--locales=en,zh : Comma-separated locales to prepare}
+        {--chunk-size=250 : Maximum slugs per embedded explicit slug artifact}
         {--json : Emit JSON output}
         {--output= : Optional output path for runtime candidate preparation plan JSON}';
 
@@ -38,6 +39,7 @@ final class CareerPlanCanonicalRuntimeCandidatePrep extends Command
                 locales: $this->localesOption(),
                 targetPublicTotal: $this->nullablePositiveIntOption('target-total'),
                 cohort: $this->nullableStringOption('cohort'),
+                chunkSize: $this->positiveIntOption('chunk-size', CareerRuntimeCandidatePrepPlanner::DEFAULT_CHUNK_SIZE),
             )->toArray();
 
             return $this->finish($payload, ($payload['status'] ?? null) === 'planned' ? self::SUCCESS : self::FAILURE);
@@ -83,6 +85,21 @@ final class CareerPlanCanonicalRuntimeCandidatePrep extends Command
         $raw = $this->option($name);
         if ($raw === null || trim((string) $raw) === '') {
             return null;
+        }
+
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if (! is_int($value) || $value < 1) {
+            throw new RuntimeException(str_replace('-', '_', $name).'_invalid');
+        }
+
+        return $value;
+    }
+
+    private function positiveIntOption(string $name, int $default): int
+    {
+        $raw = $this->option($name);
+        if ($raw === null || trim((string) $raw) === '') {
+            return $default;
         }
 
         $value = filter_var($raw, FILTER_VALIDATE_INT);

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
@@ -10,6 +10,8 @@ final class CareerRuntimeCandidatePrepPlanner
 {
     public const SCHEMA_VERSION = 'career_runtime_candidate_prep_plan.v1';
 
+    public const DEFAULT_CHUNK_SIZE = 250;
+
     /**
      * @param  array<string, mixed>  $targetDeltaPlan
      * @param  array<string, mixed>|null  $projection
@@ -25,13 +27,16 @@ final class CareerRuntimeCandidatePrepPlanner
         array $locales = ['en', 'zh'],
         ?int $targetPublicTotal = null,
         ?string $cohort = null,
+        int $chunkSize = self::DEFAULT_CHUNK_SIZE,
     ): CareerRuntimeCandidatePrepResult {
         $deltaSlugs = $this->deltaSlugs($targetDeltaPlan);
         $locales = CareerRuntimeArtifactRefreshPlanner::normalizeLocaleList($locales, 'locale');
+        $chunkSize = $this->chunkSize($chunkSize);
         $artifactTargetPublicTotal = $this->artifactTargetPublicTotal($targetDeltaPlan);
         $currentPublicTotal = $this->artifactCurrentPublicTotal($targetDeltaPlan);
         $targetPublicTotal ??= $artifactTargetPublicTotal ?? 80;
         $cohort = $this->cohortValue($cohort, $targetPublicTotal, $currentPublicTotal);
+        $targetAuthority = $this->targetAuthority($targetDeltaPlan);
 
         $projectionBySlugLocale = $this->rowsBySlugLocale($this->artifactRows($projection, ['items', 'rows']));
         $truthBySlugLocale = $this->rowsBySlugLocale($this->artifactRows($truth, ['items', 'rows']));
@@ -115,8 +120,9 @@ final class CareerRuntimeCandidatePrepPlanner
             $slugRows[] = $slugEvidence;
         }
 
-        $blockers = $this->blockers($targetDeltaPlan, $deltaSlugs, $targetPublicTotal, $artifactTargetPublicTotal);
+        $blockers = $this->blockers($targetDeltaPlan, $deltaSlugs, $targetPublicTotal, $artifactTargetPublicTotal, $targetAuthority);
         $status = $blockers === [] ? 'planned' : 'blocked';
+        $chunkedSlugArtifacts = $this->chunkedSlugArtifacts($deltaSlugs, $locales, $cohort, $targetPublicTotal, $chunkSize);
 
         return new CareerRuntimeCandidatePrepResult([
             'schema_version' => self::SCHEMA_VERSION,
@@ -132,6 +138,8 @@ final class CareerRuntimeCandidatePrepPlanner
             'expected_delta_locale_rows' => count($deltaSlugs) * count($locales),
             'planned_candidate_rows_count' => count($plannedRows),
             'planned_candidate_rows' => $plannedRows,
+            'target_authority' => $targetAuthority,
+            'chunked_slug_artifacts' => $chunkedSlugArtifacts,
             'slug_rows' => $slugRows,
             'context_summary' => [
                 'ledger_member_missing_count' => count(array_unique($missingLedger)),
@@ -164,6 +172,7 @@ final class CareerRuntimeCandidatePrepPlanner
     {
         $slugs = $targetDeltaPlan['recommended_rollout_delta_slugs']
             ?? $targetDeltaPlan['delta_promotion_slugs']
+            ?? data_get($targetDeltaPlan, 'ready_not_public_1018.slugs')
             ?? $targetDeltaPlan['slugs']
             ?? null;
 
@@ -341,10 +350,75 @@ final class CareerRuntimeCandidatePrepPlanner
 
     /**
      * @param  array<string, mixed>  $targetDeltaPlan
+     * @return array<string, mixed>
+     */
+    private function targetAuthority(array $targetDeltaPlan): array
+    {
+        $embedded = data_get($targetDeltaPlan, 'target_authority');
+        if (is_array($embedded) && ! array_is_list($embedded)) {
+            return $embedded;
+        }
+
+        if (($targetDeltaPlan['target_key'] ?? null) === CareerDetailReadyTargetAuthority::TARGET_KEY) {
+            return (new CareerDetailReadyTargetAuthority)->target();
+        }
+
+        return [
+            'target_key' => $targetDeltaPlan['target_key'] ?? null,
+            'candidate_prep_apply_allowed' => false,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $deltaSlugs
+     * @param  list<string>  $locales
+     * @return list<array<string, mixed>>
+     */
+    private function chunkedSlugArtifacts(array $deltaSlugs, array $locales, string $cohort, int $targetPublicTotal, int $chunkSize): array
+    {
+        $chunks = array_chunk($deltaSlugs, $chunkSize);
+        $artifacts = [];
+
+        foreach ($chunks as $index => $chunk) {
+            $payload = [
+                'schema_version' => 'career_runtime_candidate_prep_slug_chunk.v1',
+                'target' => $cohort,
+                'target_public_total' => $targetPublicTotal,
+                'chunk_index' => $index + 1,
+                'chunk_count' => count($chunks),
+                'slug_count' => count($chunk),
+                'locales' => $locales,
+                'expected_locale_rows' => count($chunk) * count($locales),
+                'slugs' => array_values($chunk),
+                'writes_database' => false,
+                'apply_allowed' => false,
+            ];
+
+            $encoded = json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            $artifacts[] = [
+                ...$payload,
+                'sha256' => hash('sha256', $encoded),
+            ];
+        }
+
+        return $artifacts;
+    }
+
+    private function chunkSize(int $chunkSize): int
+    {
+        if ($chunkSize < 1) {
+            throw new RuntimeException('chunk_size_invalid');
+        }
+
+        return $chunkSize;
+    }
+
+    /**
+     * @param  array<string, mixed>  $targetDeltaPlan
      * @param  list<string>  $deltaSlugs
      * @return list<array<string, mixed>>
      */
-    private function blockers(array $targetDeltaPlan, array $deltaSlugs, int $targetPublicTotal, ?int $artifactTargetPublicTotal): array
+    private function blockers(array $targetDeltaPlan, array $deltaSlugs, int $targetPublicTotal, ?int $artifactTargetPublicTotal, array $targetAuthority): array
     {
         $blockers = [];
         if (($targetDeltaPlan['status'] ?? null) !== 'pass') {
@@ -377,6 +451,106 @@ final class CareerRuntimeCandidatePrepPlanner
             ];
         }
 
+        if (($targetDeltaPlan['target_key'] ?? data_get($targetAuthority, 'target_key')) === CareerDetailReadyTargetAuthority::TARGET_KEY) {
+            if ($targetPublicTotal !== CareerDetailReadyTargetAuthority::TARGET_PUBLIC_TOTAL) {
+                $blockers[] = [
+                    'reason' => 'detail_ready_1048_target_public_total_mismatch',
+                    'message' => 'detail_ready_1048 candidate preparation must target exactly 1048 public detail pages.',
+                    'evidence' => [
+                        'requested' => $targetPublicTotal,
+                        'expected' => CareerDetailReadyTargetAuthority::TARGET_PUBLIC_TOTAL,
+                    ],
+                ];
+            }
+
+            if (count($deltaSlugs) !== CareerDetailReadyTargetAuthority::READY_NOT_PUBLIC_DELTA) {
+                $blockers[] = [
+                    'reason' => 'detail_ready_1048_delta_count_mismatch',
+                    'message' => 'detail_ready_1048 candidate preparation must preserve the 1018 ready-not-public delta.',
+                    'evidence' => [
+                        'actual' => count($deltaSlugs),
+                        'expected' => CareerDetailReadyTargetAuthority::READY_NOT_PUBLIC_DELTA,
+                    ],
+                ];
+            }
+        }
+
+        $blockedSets = [
+            'manual_hold' => $this->slugSetAtAny($targetDeltaPlan, [
+                'manual_hold.ready_slugs',
+                'manual_hold.slugs',
+            ]),
+            'review_needed' => $this->slugSetAtAny($targetDeltaPlan, [
+                'review_needed.slugs',
+                'review_needed.ready_slugs',
+            ]),
+            'family_handoff' => $this->slugSetAtAny($targetDeltaPlan, [
+                'family_handoff.slugs',
+                'family_handoff.ready_slugs',
+            ]),
+            'blocked' => $this->slugSetAtAny($targetDeltaPlan, [
+                'blocked.slugs',
+                'blocked.ready_slugs',
+            ]),
+            'cn_proxy' => $this->slugSetAtAny($targetDeltaPlan, [
+                'cn_proxy.slugs',
+                'cn_proxy.ready_slugs',
+                'cn_proxy_policy_asset.slugs',
+            ]),
+        ];
+
+        foreach ($blockedSets as $reason => $slugs) {
+            $intersect = array_values(array_intersect($deltaSlugs, $slugs));
+            if ($intersect === []) {
+                continue;
+            }
+
+            $blockers[] = [
+                'reason' => 'delta_contains_'.$reason.'_slugs',
+                'message' => 'Runtime candidate preparation cannot include gated '.$reason.' slugs.',
+                'evidence' => [
+                    'count' => count($intersect),
+                    'sample_slugs' => array_slice($intersect, 0, 20),
+                ],
+            ];
+        }
+
+        $manualHoldPolicySlugs = data_get($targetAuthority, 'manual_hold_policy.slugs');
+        if (is_array($manualHoldPolicySlugs) && array_is_list($manualHoldPolicySlugs)) {
+            $manualHoldIntersect = array_values(array_intersect(
+                $deltaSlugs,
+                $this->normalizedUniqueStrings($manualHoldPolicySlugs, 'manual_hold_policy_slug', allowEmpty: true)
+            ));
+
+            if ($manualHoldIntersect !== []) {
+                $blockers[] = [
+                    'reason' => 'delta_contains_manual_hold_policy_slugs',
+                    'message' => 'Runtime candidate preparation cannot include manual-hold policy slugs without an explicit release decision.',
+                    'evidence' => [
+                        'count' => count($manualHoldIntersect),
+                        'sample_slugs' => array_slice($manualHoldIntersect, 0, 20),
+                    ],
+                ];
+            }
+        }
+
         return $blockers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $paths
+     * @return list<string>
+     */
+    private function slugSetAtAny(array $payload, array $paths): array
+    {
+        foreach ($paths as $path) {
+            $value = data_get($payload, $path);
+            if (is_array($value) && array_is_list($value)) {
+                return $this->normalizedUniqueStrings($value, str_replace('.', '_', $path), allowEmpty: true);
+            }
+        }
+
+        return [];
     }
 }

--- a/backend/docs/career/audits/runtime_candidate_prep.md
+++ b/backend/docs/career/audits/runtime_candidate_prep.md
@@ -1,6 +1,6 @@
 # Career Runtime Candidate Preparation Plan
 
-`career:plan-canonical-runtime-candidate-prep` is a read-only planner for the Career 80 delta path. It consumes the target-delta artifact that separates the 29 already-published baseline slugs from the 51 delta promotion slugs, then emits the `published_candidate` runtime rows that a later approval-gated preparation step would need.
+`career:plan-canonical-runtime-candidate-prep` is a read-only planner for explicit Career publication deltas. It consumes either the original Career 80 target-delta artifact or a later detail-ready publication scan artifact, then emits the `published_candidate` runtime rows that a later approval-gated preparation step would need.
 
 The command does not write the database, run rollout, run rollout dry-run, publish occupations, or generate rollout manifests.
 
@@ -15,6 +15,20 @@ php artisan career:plan-canonical-runtime-candidate-prep \
   --locales=en,zh \
   --json \
   --output=/tmp/career_80_delta_runtime_candidate_prep_plan.json
+```
+
+Detail-ready 1048 planning uses the read-only publication scan from
+`career:audit-detail-ready-1048-candidates` and keeps the 1048 product-visible
+target separate from 2786 partition accounting:
+
+```bash
+php artisan career:plan-canonical-runtime-candidate-prep \
+  --target-delta=/tmp/career-detail-ready-1048-scan.json \
+  --target-total=1048 \
+  --cohort=detail_ready_1048 \
+  --chunk-size=250 \
+  --json \
+  --output=/tmp/career_detail_ready_1048_runtime_candidate_prep_plan.json
 ```
 
 The projection, truth, and ledger inputs are optional for local planning, but supplying them gives the plan useful context counts for missing ledger members, missing projection rows, missing truth rows, and candidate state repairs.
@@ -32,9 +46,24 @@ Key fields:
 - `delta_slug_count`: expected to be 51 for the first delta.
 - `expected_locale_rows`: `delta_slug_count * locale_count`, expected to be 102 for 51 slugs and `en,zh`.
 - `planned_candidate_rows`: the planned `published_candidate` rows.
+- `target_authority`: target guardrails when supplied by the detail-ready scan,
+  including manual-hold and CN proxy policy boundaries.
+- `chunked_slug_artifacts`: embedded explicit slug chunks for later reviewed
+  dry-run/apply gates. These chunks are artifacts, not writes; each chunk has
+  `writes_database=false` and `apply_allowed=false`.
 - `context_summary`: counts for missing ledger/projection/truth and candidate state repair needs.
 - `apply_allowed`: always `false`.
 - `next_required_action`: `RUNTIME_CANDIDATE_PREP_DRY_RUN` when planned.
+
+For `detail_ready_1048`, the planner requires:
+
+- target total `1048`;
+- ready-not-public delta `1018`;
+- no `manual_hold`, `review_needed`, `family_handoff`, `blocked`, or CN proxy
+  slugs inside the runtime candidate prep delta.
+
+The planner does not unlock `software-developers`, does not publish 2786 raw
+occupation assets, and does not weaken CN proxy noindex/noncanonical policy.
 
 ## Non-goals
 

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php
@@ -88,6 +88,45 @@ final class CareerPlanCanonicalRuntimeCandidatePrepCommandTest extends TestCase
         $this->assertSame(440, $payload['planned_candidate_rows_count']);
     }
 
+    public function test_generates_detail_ready_1048_prep_plan_from_publication_scan_with_chunk_guard(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeDetailReadyScan($this->slugs('ready', 1018)),
+            '--target-total' => 1048,
+            '--cohort' => 'detail_ready_1048',
+            '--chunk-size' => 500,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('detail_ready_1048', $payload['target']);
+        $this->assertSame(30, $payload['current_public_total']);
+        $this->assertSame(1048, $payload['target_public_total']);
+        $this->assertSame(1018, $payload['delta_slug_count']);
+        $this->assertSame(2036, $payload['expected_locale_rows']);
+        $this->assertSame([500, 500, 18], array_column($payload['chunked_slug_artifacts'], 'slug_count'));
+        $this->assertFalse($payload['chunked_slug_artifacts'][0]['apply_allowed']);
+    }
+
+    public function test_detail_ready_1048_blocks_manual_hold_slug(): void
+    {
+        $slugs = $this->slugs('ready', 1017);
+        $slugs[] = 'software-developers';
+
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeDetailReadyScan($slugs, manualHoldSlugs: ['software-developers']),
+            '--target-total' => 1048,
+            '--cohort' => 'detail_ready_1048',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('delta_contains_manual_hold_slugs', array_column($payload['blockers'], 'reason'));
+        $this->assertFalse($payload['apply_allowed']);
+    }
+
     public function test_blocks_progressive_target_total_mismatch(): void
     {
         $exitCode = $this->callCommand([
@@ -198,6 +237,28 @@ final class CareerPlanCanonicalRuntimeCandidatePrepCommandTest extends TestCase
             'delta_promotion_count' => count($slugs),
             'delta_slug_count' => count($slugs),
             'recommended_rollout_delta_slugs' => $slugs,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $manualHoldSlugs
+     */
+    private function writeDetailReadyScan(array $slugs, array $manualHoldSlugs = []): string
+    {
+        return $this->writeJson('detail-ready-scan', [
+            'schema_version' => 'career_detail_ready_publication_candidates.v1',
+            'status' => 'pass',
+            'target_key' => 'detail_ready_1048',
+            'current_public_total' => 30,
+            'target_public_total' => 1048,
+            'ready_not_public_1018' => [
+                'count' => count($slugs),
+                'slugs' => $slugs,
+            ],
+            'manual_hold' => [
+                'ready_slugs' => $manualHoldSlugs,
+            ],
         ]);
     }
 

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
@@ -71,6 +71,89 @@ final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
         $this->assertSame(3972, $full['expected_delta_locale_rows']);
     }
 
+    public function test_plans_detail_ready_1048_delta_from_publication_scan_with_chunks(): void
+    {
+        $slugs = $this->slugs('ready', 1018);
+
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: [
+                'schema_version' => 'career_detail_ready_publication_candidates.v1',
+                'status' => 'pass',
+                'target_key' => 'detail_ready_1048',
+                'current_public_total' => 30,
+                'target_public_total' => 1048,
+                'ready_not_public_1018' => [
+                    'count' => 1018,
+                    'slugs' => $slugs,
+                ],
+                'manual_hold' => [
+                    'ready_slugs' => [],
+                ],
+            ],
+            targetPublicTotal: 1048,
+            cohort: 'detail_ready_1048',
+            chunkSize: 400,
+        )->toArray();
+
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('detail_ready_1048', $payload['target']);
+        $this->assertSame(30, $payload['current_public_total']);
+        $this->assertSame(1048, $payload['target_public_total']);
+        $this->assertSame(1018, $payload['delta_slug_count']);
+        $this->assertSame(2036, $payload['expected_delta_locale_rows']);
+        $this->assertSame('detail_ready_1048', $payload['target_authority']['target_key']);
+        $this->assertCount(3, $payload['chunked_slug_artifacts']);
+        $this->assertSame([400, 400, 218], array_column($payload['chunked_slug_artifacts'], 'slug_count'));
+        $this->assertFalse($payload['chunked_slug_artifacts'][0]['writes_database']);
+        $this->assertFalse($payload['chunked_slug_artifacts'][0]['apply_allowed']);
+    }
+
+    public function test_detail_ready_1048_blocks_gated_slugs(): void
+    {
+        $slugs = $this->slugs('ready', 1017);
+        $slugs[] = 'software-developers';
+
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: [
+                'schema_version' => 'career_detail_ready_publication_candidates.v1',
+                'status' => 'pass',
+                'target_key' => 'detail_ready_1048',
+                'current_public_total' => 30,
+                'target_public_total' => 1048,
+                'ready_not_public_1018' => [
+                    'count' => 1018,
+                    'slugs' => $slugs,
+                ],
+                'manual_hold' => [
+                    'ready_slugs' => ['software-developers'],
+                ],
+                'review_needed' => [
+                    'slugs' => ['ready-001'],
+                ],
+                'family_handoff' => [
+                    'slugs' => ['ready-002'],
+                ],
+                'blocked' => [
+                    'slugs' => ['ready-003'],
+                ],
+                'cn_proxy' => [
+                    'slugs' => ['ready-004'],
+                ],
+            ],
+            targetPublicTotal: 1048,
+            cohort: 'detail_ready_1048',
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $reasons = array_column($payload['blockers'], 'reason');
+        $this->assertContains('delta_contains_manual_hold_slugs', $reasons);
+        $this->assertContains('delta_contains_manual_hold_policy_slugs', $reasons);
+        $this->assertContains('delta_contains_review_needed_slugs', $reasons);
+        $this->assertContains('delta_contains_family_handoff_slugs', $reasons);
+        $this->assertContains('delta_contains_blocked_slugs', $reasons);
+        $this->assertContains('delta_contains_cn_proxy_slugs', $reasons);
+    }
+
     public function test_blocks_target_delta_plan_that_did_not_pass(): void
     {
         $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
@@ -151,6 +234,8 @@ final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
             'expected_delta_locale_rows',
             'planned_candidate_rows_count',
             'planned_candidate_rows',
+            'target_authority',
+            'chunked_slug_artifacts',
             'slug_rows',
             'context_summary',
             'context_slug_sets',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29022,7 +29022,7 @@
     "local_cleanup_note": "scripts/post_merge_cleanup.sh not present in fap-api; local main fast-forwarded to origin/main and task branch was not present locally after merge."
   },
   "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1": {
-    "status": "github_checks_failed",
+    "status": "github_checks_green",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-candidate-prep-1",
     "base": "main",
@@ -29030,9 +29030,9 @@
       "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1"
     ],
     "title": "fix(api): plan career detail-ready 1018 candidate prep",
-    "commit_sha": "7e2685f1b5786a8c33d2c41b83ad930375487610",
+    "commit_sha": "b7ddae6de5feb950b46ec89bae64e7029e26fbd2",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1726",
-    "failure_reason": "Required GitHub CI supply-chain check failed on composer audit due to newly reported Symfony advisories: symfony/html-sanitizer CVE-2026-48761 and CVE-2026-48760, symfony/http-foundation CVE-2026-48736, symfony/routing CVE-2026-48784. This is outside the current Career candidate-prep scope, but required checks are not green, so train progression is blocked.",
+    "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -29066,19 +29066,20 @@
         "outside_scope": []
       },
       "github": {
-        "status": "failed",
-        "head_sha": "7e2685f1b5786a8c33d2c41b83ad930375487610",
-        "failed_checks": [
-          "supply-chain"
+        "status": "passed",
+        "head_sha": "b7ddae6de5feb950b46ec89bae64e7029e26fbd2",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "Semgrep blocking secrets",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
         ],
-        "failed_jobs": [
-          "https://github.com/fermatmind/fap-api/actions/runs/26503477496/job/78049796376",
-          "https://github.com/fermatmind/fap-api/actions/runs/26503474750/job/78049773809"
-        ],
-        "failure_reason": "composer audit found 4 advisories affecting 3 Symfony packages: symfony/html-sanitizer, symfony/http-foundation, symfony/routing.",
-        "external_to_current_pr_scope": true,
-        "merge_blocked": true,
-        "train_progression_blocked": true
+        "merge_state": "CLEAN",
+        "failure_reason": null,
+        "external_blocker_resolved_by": "https://github.com/fermatmind/fap-api/pull/1727",
+        "merge_blocked": false,
+        "train_progression_blocked": false
       }
     },
     "history": [
@@ -29111,6 +29112,16 @@
         "at": "2026-05-27T17:43:47+08:00",
         "status": "github_checks_failed",
         "summary": "Required GitHub supply-chain check failed on Composer audit advisories external to this Career planner PR scope; stopping train before merge or next PR."
+      },
+      {
+        "at": "2026-05-27T18:21:24+08:00",
+        "status": "external_blocker_resolved",
+        "summary": "Merged sidecar PR #1727 to clear the required Symfony Composer audit blocker."
+      },
+      {
+        "at": "2026-05-27T18:29:06+08:00",
+        "status": "github_checks_green",
+        "summary": "After rebasing onto origin/main with PR #1727, PR #1726 required GitHub checks passed and merge state is CLEAN."
       }
     ],
     "sidecar_blockers": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29022,7 +29022,7 @@
     "local_cleanup_note": "scripts/post_merge_cleanup.sh not present in fap-api; local main fast-forwarded to origin/main and task branch was not present locally after merge."
   },
   "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1": {
-    "status": "local_commit_created",
+    "status": "pr_open",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-candidate-prep-1",
     "base": "main",
@@ -29030,8 +29030,8 @@
       "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1"
     ],
     "title": "fix(api): plan career detail-ready 1018 candidate prep",
-    "commit_sha": "bd3b804222d5dc58be809e3c3faed518f6e7298f",
-    "pr_url": null,
+    "commit_sha": "7aeddd1f722382e54fcb2f804417154459670be2",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1726",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -29086,6 +29086,11 @@
         "at": "2026-05-27T17:38:41+08:00",
         "status": "local_commit_created",
         "summary": "Created local commit bd3b804222d5dc58be809e3c3faed518f6e7298f for detail-ready 1018 runtime candidate prep planning."
+      },
+      {
+        "at": "2026-05-27T17:40:09+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1726 for detail_ready_1048 runtime candidate preparation planning."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -28929,7 +28929,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1": {
-    "status": "pr_open",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-target-authority-1",
     "base": "main",
@@ -28937,11 +28937,11 @@
       "AUDIT-CAREER-DETAIL-READY-1048-SCAN-1"
     ],
     "title": "fix(api): define career detail-ready 1048 authority",
-    "commit_sha": "2207629e257c9544a6d1ab240025747771065e04",
+    "commit_sha": "b55c3668fc4419c8502ca4b7abcfe93acb71d885",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1725",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-05-27T17:32:30+08:00",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "checks": {
       "local": {
@@ -28971,13 +28971,15 @@
         "outside_scope": []
       },
       "github": {
-        "status": "failed_then_scoped_fix_applied",
+        "status": "passed",
         "failed_checks": [
           "verify-mbti-legacy",
           "verify-mbti-v2"
         ],
         "failure_reason": "BigFive runtime freeze classifier did not yet classify backend/app/Domain/Career/Audit/CareerDetailReadyTargetAuthority.php as Career detail-ready 1048 audit/authority scope.",
-        "fix": "Extended the existing Career detail-ready 1048 audit classifier and focused guard test to include CareerDetailReadyTargetAuthority.php; updated PR manifest allowed paths and validation command."
+        "fix": "Extended the existing Career detail-ready 1048 audit classifier and focused guard test to include CareerDetailReadyTargetAuthority.php; updated PR manifest allowed paths and validation command.",
+        "head_sha": "f8286724ed7ce409121199c99d78361ff445a9bd",
+        "merge_state": "CLEAN"
       }
     },
     "history": [
@@ -29010,11 +29012,17 @@
         "at": "2026-05-27T17:18:30+08:00",
         "status": "github_checks_failed_scoped_fix_applied",
         "summary": "GitHub MBTI checks failed because the new CareerDetailReadyTargetAuthority.php file was not classified by the Big Five runtime freeze guard. Added a scoped guard-test classifier update and reran focused tests, route list, targeted Pint, and backend MBTI CI locally."
+      },
+      {
+        "at": "2026-05-27T17:32:30+08:00",
+        "status": "merged",
+        "summary": "PR #1725 squash-merged; origin/main contains b55c3668fc4419c8502ca4b7abcfe93acb71d885; remote task branch deleted; no post_merge_cleanup.sh exists in fap-api."
       }
-    ]
+    ],
+    "local_cleanup_note": "scripts/post_merge_cleanup.sh not present in fap-api; local main fast-forwarded to origin/main and task branch was not present locally after merge."
   },
   "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1": {
-    "status": "planned",
+    "status": "local_commit_created",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-candidate-prep-1",
     "base": "main",
@@ -29022,14 +29030,64 @@
       "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1"
     ],
     "title": "fix(api): plan career detail-ready 1018 candidate prep",
-    "commit_sha": null,
+    "commit_sha": "bd3b804222d5dc58be809e3c3faed518f6e7298f",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "checks": {},
-    "history": []
+    "checks": {
+      "local": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test --filter=CareerDetailReady --no-ansi",
+          "cd backend && php artisan test --filter=CareerRuntimeCandidate --no-ansi",
+          "cd backend && php artisan test tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+          "cd backend && vendor/bin/pint --test",
+          "bash backend/scripts/ci_verify_mbti.sh",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        ],
+        "notes": "The MBTI CI chain regenerated BIG5_OCEAN compiled artifacts as a local side effect; those generated diffs were restored because they are outside this PR scope."
+      },
+      "scope": {
+        "status": "passed",
+        "changed_files": [
+          "backend/app/Console/Commands/CareerPlanCanonicalRuntimeCandidatePrep.php",
+          "backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php",
+          "backend/docs/career/audits/runtime_candidate_prep.md",
+          "backend/tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php",
+          "backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php",
+          "docs/codex/pr-train-state.json"
+        ],
+        "outside_scope": []
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T17:32:30+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started detail_ready_1048 runtime candidate preparation planning PR from latest main after target authority merge."
+      },
+      {
+        "at": "2026-05-27T17:38:11+08:00",
+        "status": "local_checks_passed",
+        "summary": "CareerDetailReady, CareerRuntimeCandidate, focused command tests, route list, migrate pretend, full Pint, backend MBTI CI, diff check, and JSON/YAML parse passed locally."
+      },
+      {
+        "at": "2026-05-27T17:38:11+08:00",
+        "status": "scope_validation_passed",
+        "summary": "Changed files are within the candidate-prep PR allowed paths; generated BIG5_OCEAN compiled artifacts were restored as out-of-scope CI side effects."
+      },
+      {
+        "at": "2026-05-27T17:38:41+08:00",
+        "status": "local_commit_created",
+        "summary": "Created local commit bd3b804222d5dc58be809e3c3faed518f6e7298f for detail-ready 1018 runtime candidate prep planning."
+      }
+    ]
   },
   "REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1": {
     "status": "planned",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29022,7 +29022,7 @@
     "local_cleanup_note": "scripts/post_merge_cleanup.sh not present in fap-api; local main fast-forwarded to origin/main and task branch was not present locally after merge."
   },
   "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1": {
-    "status": "pr_open",
+    "status": "github_checks_failed",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-candidate-prep-1",
     "base": "main",
@@ -29030,9 +29030,9 @@
       "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1"
     ],
     "title": "fix(api): plan career detail-ready 1018 candidate prep",
-    "commit_sha": "7aeddd1f722382e54fcb2f804417154459670be2",
+    "commit_sha": "7e2685f1b5786a8c33d2c41b83ad930375487610",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1726",
-    "failure_reason": null,
+    "failure_reason": "Required GitHub CI supply-chain check failed on composer audit due to newly reported Symfony advisories: symfony/html-sanitizer CVE-2026-48761 and CVE-2026-48760, symfony/http-foundation CVE-2026-48736, symfony/routing CVE-2026-48784. This is outside the current Career candidate-prep scope, but required checks are not green, so train progression is blocked.",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -29064,6 +29064,21 @@
           "docs/codex/pr-train-state.json"
         ],
         "outside_scope": []
+      },
+      "github": {
+        "status": "failed",
+        "head_sha": "7e2685f1b5786a8c33d2c41b83ad930375487610",
+        "failed_checks": [
+          "supply-chain"
+        ],
+        "failed_jobs": [
+          "https://github.com/fermatmind/fap-api/actions/runs/26503477496/job/78049796376",
+          "https://github.com/fermatmind/fap-api/actions/runs/26503474750/job/78049773809"
+        ],
+        "failure_reason": "composer audit found 4 advisories affecting 3 Symfony packages: symfony/html-sanitizer, symfony/http-foundation, symfony/routing.",
+        "external_to_current_pr_scope": true,
+        "merge_blocked": true,
+        "train_progression_blocked": true
       }
     },
     "history": [
@@ -29091,6 +29106,25 @@
         "at": "2026-05-27T17:40:09+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1726 for detail_ready_1048 runtime candidate preparation planning."
+      },
+      {
+        "at": "2026-05-27T17:43:47+08:00",
+        "status": "github_checks_failed",
+        "summary": "Required GitHub supply-chain check failed on Composer audit advisories external to this Career planner PR scope; stopping train before merge or next PR."
+      }
+    ],
+    "sidecar_blockers": [
+      {
+        "at": "2026-05-27T17:43:47+08:00",
+        "kind": "required_github_check_failure_external_to_scope",
+        "check": "supply-chain",
+        "summary": "Composer audit fails on Symfony advisories reported 2026-05-26; resolving requires dependency/security scope, not Career candidate-prep planner scope.",
+        "advisories": [
+          "CVE-2026-48761",
+          "CVE-2026-48760",
+          "CVE-2026-48736",
+          "CVE-2026-48784"
+        ]
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Extended the read-only Career runtime candidate prep planner to consume the `career_detail_ready_publication_candidates.v1` scan artifact and its `ready_not_public_1018.slugs` list.
- Added `detail_ready_1048` target guards: target total must be 1048, delta count must be 1018, and gated manual-hold/review/family/blocked/CN proxy slugs block planning.
- Added embedded chunked explicit-slug artifacts for later reviewed dry-run/apply gates; chunks are read-only and carry `writes_database=false` / `apply_allowed=false`.
- Updated command docs and focused tests for 1018 delta planning and manual-hold blocking.
- Reconciled the prior target-authority PR ledger as merged.

## Why
This is the planner-only step for publishing all backend-authoritative detail-ready Career jobs. It prepares the 1018 ready-not-public delta for a later explicit approval gate without publishing, rolling out, mutating CMS, deploying, or treating 2786 raw occupations as public authority.

## Validation commands
- `cd backend && php artisan test --filter=CareerDetailReady --no-ansi`
- `cd backend && php artisan test --filter=CareerRuntimeCandidate --no-ansi`
- `cd backend && php artisan test tests/Feature/Console/CareerPlanCanonicalRuntimeCandidatePrepCommandTest.php --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `cd backend && vendor/bin/pint --test`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`

## Intentionally deferred
- No production candidate prep apply.
- No rollout dry-run or rollout apply.
- No production DB or CMS mutation.
- No backend or frontend deploy.
- No fap-web fallback authority.
- No pSEO generation, sitemap/llms exposure, or URL submission.
- No publication of 2289 excluded/raw assets or all 2786 occupations.
- No `software-developers` release without an explicit manual-hold release decision artifact.

## Sidecar blockers
None introduced by this PR.

## Repository rule impact
Career publication remains backend-authoritative. This PR adds planner/dry-run artifact semantics only; it does not change runtime public exposure, content ownership, CMS authority, or frontend fallback behavior.
