### PR TITLE
fix(deps): unblock Symfony Composer audit

### DIFF
--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -6188,16 +6188,16 @@
         },
         {
             "name": "symfony/html-sanitizer",
-            "version": "v7.4.12",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/html-sanitizer.git",
-                "reference": "51cb4f68195883f7ac403abb58ecf7adc74e0f9e"
+                "reference": "761f6c49dfd103ee08b3cd09ece588b069e18ec9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/51cb4f68195883f7ac403abb58ecf7adc74e0f9e",
-                "reference": "51cb4f68195883f7ac403abb58ecf7adc74e0f9e",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/761f6c49dfd103ee08b3cd09ece588b069e18ec9",
+                "reference": "761f6c49dfd103ee08b3cd09ece588b069e18ec9",
                 "shasum": ""
             },
             "require": {
@@ -6238,7 +6238,7 @@
                 "sanitizer"
             ],
             "support": {
-                "source": "https://github.com/symfony/html-sanitizer/tree/v7.4.12"
+                "source": "https://github.com/symfony/html-sanitizer/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6258,20 +6258,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
@@ -6320,7 +6320,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6340,7 +6340,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -7213,16 +7213,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+                "reference": "8339098cae28673c15cce00d80734af0453054e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
+                "reference": "8339098cae28673c15cce00d80734af0453054e2",
                 "shasum": ""
             },
             "require": {
@@ -7269,7 +7269,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7289,7 +7289,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
@@ -7688,16 +7688,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.12",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204",
-                "reference": "3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -7749,7 +7749,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.12"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7769,7 +7769,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29049,6 +29049,64 @@
     "checks": {},
     "history": []
   },
+  "SUPPLY-CHAIN-SYMFONY-AUDIT-UNBLOCK-20260527": {
+    "status": "implementation_in_progress",
+    "repo": "fap-api",
+    "branch": "codex/supply-chain-symfony-audit-unblock-20260527",
+    "base": "main",
+    "unblocks": [
+      "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1"
+    ],
+    "title": "fix(deps): unblock Symfony Composer audit",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "local": {
+        "status": "passed",
+        "commands": [
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+          "cd backend && vendor/bin/pint --test",
+          "bash backend/scripts/ci_verify_mbti.sh",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+        ],
+        "notes": "Composer audit reports no advisories after updating the affected Symfony lock entries. The backend MBTI CI chain regenerated BIG5_OCEAN compiled artifacts as a local side effect; those generated diffs were restored because they are outside this supply-chain sidecar scope."
+      },
+      "scope": {
+        "status": "passed",
+        "changed_files": [
+          "backend/composer.lock",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "outside_scope": []
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T18:02:53+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started sidecar supply-chain unblocker from latest main to clear required Composer audit advisories blocking PR #1726."
+      },
+      {
+        "at": "2026-05-27T18:08:22+08:00",
+        "status": "local_checks_passed",
+        "summary": "Composer audit, route list, migrate pretend, Pint, backend MBTI CI, diff check, JSON parse, and YAML parse passed locally."
+      },
+      {
+        "at": "2026-05-27T18:08:22+08:00",
+        "status": "scope_validation_passed",
+        "summary": "Changed files are limited to backend/composer.lock and train metadata; generated BIG5_OCEAN compiled artifacts were restored as out-of-scope CI side effects."
+      }
+    ]
+  },
   "REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1": {
     "status": "planned",
     "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -22675,7 +22675,7 @@
     "depends_on": [
       "GSC-LIVE-00"
     ],
-    "commit_sha": null,
+    "commit_sha": "b7833e07220c885ab9af12696323000c253a7a0b",
     "pr_url": null,
     "checks": {
       "dependency": {
@@ -29104,6 +29104,11 @@
         "at": "2026-05-27T18:08:22+08:00",
         "status": "scope_validation_passed",
         "summary": "Changed files are limited to backend/composer.lock and train metadata; generated BIG5_OCEAN compiled artifacts were restored as out-of-scope CI side effects."
+      },
+      {
+        "at": "2026-05-27T18:08:22+08:00",
+        "status": "local_commit_created",
+        "summary": "Created local commit b7833e07220c885ab9af12696323000c253a7a0b for the Symfony Composer audit sidecar unblocker."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -22675,7 +22675,7 @@
     "depends_on": [
       "GSC-LIVE-00"
     ],
-    "commit_sha": "b7833e07220c885ab9af12696323000c253a7a0b",
+    "commit_sha": null,
     "pr_url": null,
     "checks": {
       "dependency": {
@@ -29058,8 +29058,8 @@
       "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1"
     ],
     "title": "fix(deps): unblock Symfony Composer audit",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "b7833e07220c885ab9af12696323000c253a7a0b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1727",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -29109,6 +29109,11 @@
         "at": "2026-05-27T18:08:22+08:00",
         "status": "local_commit_created",
         "summary": "Created local commit b7833e07220c885ab9af12696323000c253a7a0b for the Symfony Composer audit sidecar unblocker."
+      },
+      {
+        "at": "2026-05-27T18:12:27+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1727 for the Symfony Composer audit sidecar unblocker."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -5393,6 +5393,41 @@ prs:
       github_checks_required: true
       squash: true
 
+  - id: SUPPLY-CHAIN-SYMFONY-AUDIT-UNBLOCK-20260527
+    repo: fap-api
+    branch: codex/supply-chain-symfony-audit-unblock-20260527
+    base: main
+    title: "fix(deps): unblock Symfony Composer audit"
+    name: "Unblock required supply-chain Composer audit"
+    train_scope: supply_chain_unblocker
+    unblocks:
+      - REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1
+    scope:
+      - Update backend Composer lock dependencies only as needed to clear current Symfony Composer audit advisories.
+      - Keep this sidecar PR separate from the Career detail-ready 1048 candidate-prep scope.
+      - Do not change backend runtime behavior, Career authority semantics, CMS data, production DB, or deployment state.
+    allowed_paths:
+      - backend/composer.lock
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify Career runtime code, candidate prep code, routes, migrations, controllers, services, CMS content, or fap-web.
+      - Run production migration, production deploy, production DB mutation, CMS mutation, rollout apply, or candidate prep apply.
+      - Broaden Composer updates beyond the packages Composer requires to clear the active audit advisories.
+    validation:
+      - composer audit --locked --no-interaction --ignore-unreachable
+      - php artisan route:list --no-ansi
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
+      - vendor/bin/pint --test
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+      - git diff --cached --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"
+    merge_policy:
+      github_checks_required: true
+      squash: true
+
   - id: REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Updated `backend/composer.lock` to move the affected Symfony packages to Composer audit-safe versions:
  - `symfony/html-sanitizer` `v7.4.12 -> v7.4.13`
  - `symfony/http-foundation` `v7.4.8 -> v7.4.13`
  - `symfony/routing` `v7.4.12 -> v7.4.13`
  - Composer-required polyfill lock updates:
    - `symfony/polyfill-php83` `v1.37.0 -> v1.38.1`
    - `symfony/polyfill-mbstring` `v1.37.0 -> v1.38.1`
    - `symfony/polyfill-intl-idn` `v1.37.0 -> v1.38.1`
    - `symfony/polyfill-intl-normalizer` `v1.37.0 -> v1.38.0`
- Added a sidecar PR-train manifest/state entry for `SUPPLY-CHAIN-SYMFONY-AUDIT-UNBLOCK-20260527`.

## Why
- PR #1726 is blocked by the required GitHub `supply-chain` check.
- The failure is a Composer audit failure from Symfony advisories, not a Career runtime or candidate-prep code failure.
- This PR keeps the dependency/security unblock separate from the Career detail-ready 1048 PR train scope.

## Validation commands
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `cd backend && vendor/bin/pint --test`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`

## Intentionally deferred
- No Career runtime behavior changes.
- No Career candidate-prep changes.
- No production deploy.
- No production DB or CMS mutation.
- No fap-web changes.

## Sidecar blockers
- This PR is intended to clear the external required `supply-chain` blocker currently preventing PR #1726 from merging.

## Repository rule impact
- Content authority unchanged.
- No CMS/runtime content surface changes.
- No deployment readiness or production mutation changes.
