### PR TITLE
fix(api): refresh career detail-ready 1048 artifacts

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php
@@ -25,7 +25,7 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
         {--projection-output=/tmp/career_80_delta_runtime_projection_candidate_aware.json : Candidate-aware projection output path}
         {--truth-output=/tmp/career_80_delta_runtime_truth_candidate_aware.json : Candidate-aware truth output path}
         {--ledger-output=/tmp/career_80_delta_full_release_ledger_candidate_aware.json : Candidate-aware ledger output path}
-        {--expect-slug-count=51 : Expected verified candidate prep apply slug count in candidate-aware mode}
+        {--expect-slug-count= : Expected verified candidate prep apply slug count in candidate-aware mode}
         {--json : Emit JSON output}
         {--output= : Optional output path for runtime artifact refresh plan JSON}';
 
@@ -80,8 +80,8 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
         $projectionOutputPath = $this->requiredPathOption('projection-output');
         $truthOutputPath = $this->requiredPathOption('truth-output');
         $ledgerOutputPath = $this->requiredPathOption('ledger-output');
-        $expectedSlugCount = $this->positiveIntOption('expect-slug-count', 51);
         $target = trim((string) ($this->option('target') ?? 'career_80_delta')) ?: 'career_80_delta';
+        $expectedSlugCount = $this->positiveIntOption('expect-slug-count', $this->defaultExpectedSlugCount($target));
 
         try {
             $result = app(CareerRuntimeCandidateAwareArtifactRefresh::class)->build(
@@ -210,6 +210,16 @@ final class CareerPlanCanonicalRuntimeArtifactRefresh extends Command
         }
 
         return $value;
+    }
+
+    private function defaultExpectedSlugCount(string $target): int
+    {
+        $normalized = strtolower(trim($target));
+        $key = preg_replace('/[^a-z0-9]+/', '_', $normalized) ?? $normalized;
+
+        return trim($key, '_') === CareerRuntimeArtifactRefreshPlanner::TARGET_DETAIL_READY_1048
+            ? 1018
+            : 51;
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php
@@ -10,17 +10,17 @@ final class CareerRuntimeArtifactRefreshPlanner
 
     public const CANONICAL_LOCALES = ['en', 'zh'];
 
-    private const TARGET = 'career_80_delta';
+    public const TARGET_CAREER_80_DELTA = 'career_80_delta';
 
-    private const DELTA_SLUG_COUNT = 51;
+    public const TARGET_DETAIL_READY_1048 = CareerDetailReadyTargetAuthority::TARGET_KEY;
 
-    private const PROJECTION_OUTPUT = '/tmp/career_80_delta_runtime_projection_after_candidate_prep.json';
+    private const DELTA_SLUG_COUNT_51 = 51;
 
-    private const TRUTH_OUTPUT = '/tmp/career_80_delta_runtime_truth_after_candidate_prep.json';
+    private const DELTA_SLUG_COUNT_DETAIL_READY_1048 = CareerDetailReadyTargetAuthority::READY_NOT_PUBLIC_DELTA;
 
-    private const LEDGER_OUTPUT = '/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json';
+    private const TARGET_PUBLIC_TOTAL_80 = 80;
 
-    private const SUMMARY_OUTPUT = '/tmp/career_80_delta_runtime_artifact_refresh_summary.json';
+    private const TARGET_PUBLIC_TOTAL_DETAIL_READY_1048 = CareerDetailReadyTargetAuthority::TARGET_PUBLIC_TOTAL;
 
     /**
      * @param  list<mixed>  $values
@@ -71,29 +71,40 @@ final class CareerRuntimeArtifactRefreshPlanner
      * @param  array<string, mixed>|null  $candidatePrepApply
      */
     public function plan(
-        string $target = self::TARGET,
+        string $target = self::TARGET_CAREER_80_DELTA,
         ?array $deltaPlan = null,
         ?array $candidatePrepPlan = null,
         ?array $candidatePrepApply = null,
     ): CareerRuntimeArtifactRefreshResult {
+        $target = $this->normalizeTarget($target);
+        $targetConfig = $this->targetConfig($target);
         $blockers = [];
 
-        if ($target !== self::TARGET) {
-            $blockers[] = $this->blocker('target_unsupported', 'Only the Career 80 delta artifact refresh target is supported.', [
+        if ($targetConfig === null) {
+            $targetConfig = $this->targetConfig(self::TARGET_CAREER_80_DELTA);
+            $blockers[] = $this->blocker('target_unsupported', 'Only supported Career runtime artifact refresh targets can be planned.', [
                 'target' => $target,
+                'supported_targets' => [
+                    self::TARGET_CAREER_80_DELTA,
+                    self::TARGET_DETAIL_READY_1048,
+                ],
             ]);
         }
 
         if ($deltaPlan === null) {
-            $blockers[] = $this->blocker('target_delta_plan_missing', 'The Career 80 target delta plan is required for runtime artifact refresh planning.', []);
+            $blockers[] = $this->blocker('target_delta_plan_missing', 'The target delta plan is required for runtime artifact refresh planning.', [
+                'target' => $target,
+            ]);
         }
 
         if ($candidatePrepPlan === null) {
-            $blockers[] = $this->blocker('candidate_prep_plan_missing', 'The runtime candidate preparation plan is required for runtime artifact refresh planning.', []);
+            $blockers[] = $this->blocker('candidate_prep_plan_missing', 'The runtime candidate preparation plan is required for runtime artifact refresh planning.', [
+                'target' => $target,
+            ]);
         }
 
-        $deltaValidation = $this->validateDeltaPlan($deltaPlan);
-        $candidatePlanValidation = $this->validateCandidatePrepPlan($candidatePrepPlan);
+        $deltaValidation = $this->validateDeltaPlan($deltaPlan, $targetConfig);
+        $candidatePlanValidation = $this->validateCandidatePrepPlan($candidatePrepPlan, $targetConfig);
         $deltaSlugCount = $candidatePlanValidation['delta_slug_count'] ?? $deltaValidation['delta_slug_count'] ?? 0;
         $blockers = [
             ...$blockers,
@@ -101,10 +112,11 @@ final class CareerRuntimeArtifactRefreshPlanner
             ...$candidatePlanValidation['blockers'],
         ];
 
-        if ($deltaSlugCount !== self::DELTA_SLUG_COUNT) {
-            $blockers[] = $this->blocker('delta_slug_count_not_51', 'The runtime artifact refresh plan is scoped to exactly 51 delta slugs.', [
+        if ($deltaSlugCount !== $targetConfig['expected_delta_slug_count']) {
+            $blockers[] = $this->blocker($targetConfig['delta_count_blocker'], 'The runtime artifact refresh plan must preserve the expected target delta slug count.', [
                 'delta_slug_count' => $deltaSlugCount,
-                'expected' => self::DELTA_SLUG_COUNT,
+                'expected' => $targetConfig['expected_delta_slug_count'],
+                'target' => $targetConfig['target'],
             ]);
         }
 
@@ -126,27 +138,32 @@ final class CareerRuntimeArtifactRefreshPlanner
         return new CareerRuntimeArtifactRefreshResult([
             'schema_version' => self::SCHEMA_VERSION,
             'status' => $status,
-            'target' => self::TARGET,
+            'target' => $targetConfig['target'],
             'phase' => $phase,
             'delta_slug_count' => $deltaSlugCount,
+            'target_public_total' => $targetConfig['target_public_total'],
+            'expected_locale_rows' => $deltaSlugCount * count(self::CANONICAL_LOCALES),
             'candidate_prep_required' => true,
             'candidate_prep_apply_required' => true,
             'writes_database' => false,
             'read_only' => true,
-            'required_inputs' => $this->requiredInputs($deltaPlan, $candidatePrepPlan, $candidatePrepApply),
-            'required_outputs' => $this->requiredOutputs(),
-            'commands' => $this->commands(),
+            'target_authority' => $this->targetAuthority($targetConfig['target']),
+            'runtime_authority_contract' => $this->runtimeAuthorityContract($targetConfig['target']),
+            'required_inputs' => $this->requiredInputs($targetConfig, $deltaPlan, $candidatePrepPlan, $candidatePrepApply),
+            'required_outputs' => $this->requiredOutputs($targetConfig),
+            'commands' => $this->commands($targetConfig),
             'blockers' => $blockers,
-            'approval_gates' => $this->approvalGates($status, $phase),
-            'next_required_action' => $this->nextRequiredAction($status, $phase),
+            'approval_gates' => $this->approvalGates($status, $phase, $targetConfig),
+            'next_required_action' => $this->nextRequiredAction($status, $phase, $targetConfig),
         ]);
     }
 
     /**
      * @param  array<string, mixed>|null  $deltaPlan
+     * @param  array<string, mixed>  $targetConfig
      * @return array{delta_slug_count: int|null, blockers: list<array<string, mixed>>}
      */
-    private function validateDeltaPlan(?array $deltaPlan): array
+    private function validateDeltaPlan(?array $deltaPlan, array $targetConfig): array
     {
         if ($deltaPlan === null) {
             return ['delta_slug_count' => null, 'blockers' => []];
@@ -159,14 +176,25 @@ final class CareerRuntimeArtifactRefreshPlanner
             ]);
         }
 
-        if (($deltaPlan['schema_version'] ?? null) !== 'career_80_target_delta.v1') {
-            $blockers[] = $this->blocker('target_delta_plan_schema_invalid', 'Target delta plan schema_version must be career_80_target_delta.v1 for this refresh target.', [
+        if (! in_array(($deltaPlan['schema_version'] ?? null), $targetConfig['accepted_delta_plan_schemas'], true)) {
+            $blockers[] = $this->blocker('target_delta_plan_schema_invalid', 'Target delta plan schema_version is not supported for this refresh target.', [
                 'schema_version' => $deltaPlan['schema_version'] ?? null,
+                'accepted' => $targetConfig['accepted_delta_plan_schemas'],
             ]);
         }
 
-        $slugs = $this->slugList($deltaPlan, ['recommended_rollout_delta_slugs', 'delta_promotion_slugs', 'slugs']);
+        if ($targetConfig['target'] === self::TARGET_DETAIL_READY_1048 && ($deltaPlan['target_key'] ?? null) !== self::TARGET_DETAIL_READY_1048) {
+            $blockers[] = $this->blocker('target_delta_plan_target_key_invalid', 'detail_ready_1048 artifact refresh requires a matching target_key.', [
+                'target_key' => $deltaPlan['target_key'] ?? null,
+                'expected' => self::TARGET_DETAIL_READY_1048,
+            ]);
+        }
+
+        $slugs = $this->slugList($deltaPlan, ['recommended_rollout_delta_slugs', 'delta_promotion_slugs', 'ready_not_public_1018.slugs', 'slugs']);
         $declaredCount = $this->declaredCount($deltaPlan, ['delta_promotion_count', 'delta_slug_count']);
+        if ($declaredCount === null && $targetConfig['target'] === self::TARGET_DETAIL_READY_1048) {
+            $declaredCount = $this->declaredCount((array) ($deltaPlan['ready_not_public_1018'] ?? []), ['count']);
+        }
         if ($declaredCount === null) {
             $blockers[] = $this->blocker('target_delta_slug_count_missing', 'Target delta plan must declare an explicit delta slug count.', []);
         }
@@ -188,9 +216,10 @@ final class CareerRuntimeArtifactRefreshPlanner
 
     /**
      * @param  array<string, mixed>|null  $candidatePrepPlan
+     * @param  array<string, mixed>  $targetConfig
      * @return array{delta_slug_count: int|null, blockers: list<array<string, mixed>>}
      */
-    private function validateCandidatePrepPlan(?array $candidatePrepPlan): array
+    private function validateCandidatePrepPlan(?array $candidatePrepPlan, array $targetConfig): array
     {
         if ($candidatePrepPlan === null) {
             return ['delta_slug_count' => null, 'blockers' => []];
@@ -209,10 +238,10 @@ final class CareerRuntimeArtifactRefreshPlanner
             ]);
         }
 
-        if (($candidatePrepPlan['target'] ?? null) !== self::TARGET) {
+        if (($candidatePrepPlan['target'] ?? null) !== $targetConfig['target']) {
             $blockers[] = $this->blocker('candidate_prep_plan_target_invalid', 'Runtime candidate preparation plan target must match the artifact refresh target.', [
                 'target' => $candidatePrepPlan['target'] ?? null,
-                'expected' => self::TARGET,
+                'expected' => $targetConfig['target'],
             ]);
         }
 
@@ -314,7 +343,7 @@ final class CareerRuntimeArtifactRefreshPlanner
     private function slugList(array $artifact, array $keys): ?array
     {
         foreach ($keys as $key) {
-            $value = $artifact[$key] ?? null;
+            $value = str_contains($key, '.') ? data_get($artifact, $key) : ($artifact[$key] ?? null);
             if (! is_array($value) || ! array_is_list($value)) {
                 continue;
             }
@@ -371,20 +400,20 @@ final class CareerRuntimeArtifactRefreshPlanner
      * @param  array<string, mixed>|null  $candidatePrepApply
      * @return list<array<string, mixed>>
      */
-    private function requiredInputs(?array $deltaPlan, ?array $candidatePrepPlan, ?array $candidatePrepApply): array
+    private function requiredInputs(array $targetConfig, ?array $deltaPlan, ?array $candidatePrepPlan, ?array $candidatePrepApply): array
     {
         return [
             [
                 'name' => 'target_delta_plan',
                 'required' => true,
                 'supplied' => $deltaPlan !== null,
-                'purpose' => 'Preserves 29 baseline plus 51 delta target accounting.',
+                'purpose' => $targetConfig['input_purpose'],
             ],
             [
                 'name' => 'runtime_candidate_prep_plan',
                 'required' => true,
                 'supplied' => $candidatePrepPlan !== null,
-                'purpose' => 'Supplies the explicit 51 delta candidate preparation plan.',
+                'purpose' => 'Supplies the explicit '.$targetConfig['expected_delta_slug_count'].' delta candidate preparation plan.',
             ],
             [
                 'name' => 'runtime_candidate_prep_apply_artifact',
@@ -399,27 +428,27 @@ final class CareerRuntimeArtifactRefreshPlanner
     /**
      * @return list<array<string, mixed>>
      */
-    private function requiredOutputs(): array
+    private function requiredOutputs(array $targetConfig): array
     {
         return [
             [
                 'kind' => 'projection',
-                'path' => self::PROJECTION_OUTPUT,
-                'required_for' => '51-delta rollout dry-run',
+                'path' => $targetConfig['outputs']['projection'],
+                'required_for' => $targetConfig['required_for'],
             ],
             [
                 'kind' => 'truth',
-                'path' => self::TRUTH_OUTPUT,
-                'required_for' => '51-delta rollout dry-run',
+                'path' => $targetConfig['outputs']['truth'],
+                'required_for' => $targetConfig['required_for'],
             ],
             [
                 'kind' => 'ledger',
-                'path' => self::LEDGER_OUTPUT,
-                'required_for' => '51-delta rollout dry-run',
+                'path' => $targetConfig['outputs']['ledger'],
+                'required_for' => $targetConfig['required_for'],
             ],
             [
                 'kind' => 'summary',
-                'path' => self::SUMMARY_OUTPUT,
+                'path' => $targetConfig['outputs']['summary'],
                 'required_for' => 'operator review and downstream artifact provenance',
             ],
         ];
@@ -428,27 +457,27 @@ final class CareerRuntimeArtifactRefreshPlanner
     /**
      * @return list<array<string, mixed>>
      */
-    private function commands(): array
+    private function commands(array $targetConfig): array
     {
         return [
             [
                 'command' => 'career:export-full-release-ledger',
-                'output' => self::LEDGER_OUTPUT,
+                'output' => $targetConfig['outputs']['ledger'],
                 'read_only' => true,
                 'execution' => 'future_read_only_run_after_candidate_prep_apply',
             ],
             [
                 'command' => 'career:export-runtime-publish-projection',
-                'output' => self::PROJECTION_OUTPUT,
+                'output' => $targetConfig['outputs']['projection'],
                 'read_only' => true,
-                'requires' => [self::LEDGER_OUTPUT],
+                'requires' => [$targetConfig['outputs']['ledger']],
                 'execution' => 'future_read_only_run_after_candidate_prep_apply',
             ],
             [
                 'command' => 'career:export-canonical-runtime-truth',
-                'output' => self::TRUTH_OUTPUT,
+                'output' => $targetConfig['outputs']['truth'],
                 'read_only' => true,
-                'requires' => [self::LEDGER_OUTPUT, self::PROJECTION_OUTPUT],
+                'requires' => [$targetConfig['outputs']['ledger'], $targetConfig['outputs']['projection']],
                 'execution' => 'future_read_only_run_after_candidate_prep_apply',
             ],
         ];
@@ -457,13 +486,13 @@ final class CareerRuntimeArtifactRefreshPlanner
     /**
      * @return list<array<string, mixed>>
      */
-    private function approvalGates(string $status, string $phase): array
+    private function approvalGates(string $status, string $phase, array $targetConfig): array
     {
         $refreshReady = $status === 'planned' && $phase === 'post_apply_ready';
 
         return [
             [
-                'id' => 'RUNTIME_CANDIDATE_PREP_APPLY_51',
+                'id' => $targetConfig['approval_gate_prefix'].'_CANDIDATE_PREP_APPLY',
                 'required_before' => 'RUNTIME_ARTIFACT_REFRESH_READ_ONLY',
                 'currently_ready' => false,
                 'satisfied' => $phase === 'post_apply_ready',
@@ -477,8 +506,8 @@ final class CareerRuntimeArtifactRefreshPlanner
                 'forbidden_actions' => ['apply', 'rollout_apply', 'db_mutation', 'deploy'],
             ],
             [
-                'id' => 'DELTA_ROLLOUT_DRY_RUN_51',
-                'required_before' => 'ROLLOUT_APPLY_51_DELTA',
+                'id' => $targetConfig['approval_gate_prefix'].'_ROLLOUT_DRY_RUN',
+                'required_before' => $targetConfig['approval_gate_prefix'].'_ROLLOUT_APPLY',
                 'currently_ready' => false,
                 'satisfied' => false,
                 'forbidden_actions' => ['rollout_apply', 'db_mutation', 'deploy'],
@@ -486,13 +515,13 @@ final class CareerRuntimeArtifactRefreshPlanner
         ];
     }
 
-    private function nextRequiredAction(string $status, string $phase): string
+    private function nextRequiredAction(string $status, string $phase, array $targetConfig): string
     {
         if ($status === 'planned' && $phase === 'post_apply_ready') {
             return 'RUNTIME_ARTIFACT_REFRESH_READ_ONLY';
         }
 
-        return 'RUNTIME_CANDIDATE_PREP_DRY_RUN';
+        return $targetConfig['candidate_prep_action'];
     }
 
     /**
@@ -505,6 +534,103 @@ final class CareerRuntimeArtifactRefreshPlanner
             'reason' => $reason,
             'message' => $message,
             'evidence' => $evidence,
+        ];
+    }
+
+    private function normalizeTarget(string $target): string
+    {
+        $normalized = strtolower(trim($target));
+        if ($normalized === '') {
+            return self::TARGET_CAREER_80_DELTA;
+        }
+
+        $key = preg_replace('/[^a-z0-9]+/', '_', $normalized) ?? $normalized;
+
+        return trim($key, '_') ?: self::TARGET_CAREER_80_DELTA;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function targetConfig(string $target): ?array
+    {
+        return match ($target) {
+            self::TARGET_CAREER_80_DELTA => [
+                'target' => self::TARGET_CAREER_80_DELTA,
+                'target_public_total' => self::TARGET_PUBLIC_TOTAL_80,
+                'expected_delta_slug_count' => self::DELTA_SLUG_COUNT_51,
+                'delta_count_blocker' => 'delta_slug_count_not_51',
+                'accepted_delta_plan_schemas' => ['career_80_target_delta.v1'],
+                'input_purpose' => 'Preserves 29 baseline plus 51 delta target accounting.',
+                'required_for' => '51-delta rollout dry-run',
+                'candidate_prep_action' => 'RUNTIME_CANDIDATE_PREP_DRY_RUN',
+                'approval_gate_prefix' => 'CAREER_80_DELTA',
+                'outputs' => [
+                    'projection' => '/tmp/career_80_delta_runtime_projection_after_candidate_prep.json',
+                    'truth' => '/tmp/career_80_delta_runtime_truth_after_candidate_prep.json',
+                    'ledger' => '/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json',
+                    'summary' => '/tmp/career_80_delta_runtime_artifact_refresh_summary.json',
+                ],
+            ],
+            self::TARGET_DETAIL_READY_1048 => [
+                'target' => self::TARGET_DETAIL_READY_1048,
+                'target_public_total' => self::TARGET_PUBLIC_TOTAL_DETAIL_READY_1048,
+                'expected_delta_slug_count' => self::DELTA_SLUG_COUNT_DETAIL_READY_1048,
+                'delta_count_blocker' => 'detail_ready_1048_delta_count_mismatch',
+                'accepted_delta_plan_schemas' => ['career_detail_ready_publication_candidates.v1'],
+                'input_purpose' => 'Preserves current public 30 plus the 1018 detail-ready delta without treating 2786 raw occupation assets as public authority.',
+                'required_for' => 'detail_ready_1048 rollout gate dry-run',
+                'candidate_prep_action' => 'DETAIL_READY_1048_RUNTIME_CANDIDATE_PREP_DRY_RUN',
+                'approval_gate_prefix' => 'DETAIL_READY_1048',
+                'outputs' => [
+                    'projection' => '/tmp/career_detail_ready_1048_runtime_projection_after_candidate_prep.json',
+                    'truth' => '/tmp/career_detail_ready_1048_runtime_truth_after_candidate_prep.json',
+                    'ledger' => '/tmp/career_detail_ready_1048_full_release_ledger_after_candidate_prep.json',
+                    'summary' => '/tmp/career_detail_ready_1048_runtime_artifact_refresh_summary.json',
+                ],
+            ],
+            default => null,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function targetAuthority(string $target): array
+    {
+        if ($target === self::TARGET_DETAIL_READY_1048) {
+            return (new CareerDetailReadyTargetAuthority)->target(self::CANONICAL_LOCALES);
+        }
+
+        return [
+            'target_key' => $target,
+            'candidate_prep_apply_allowed' => false,
+            'rollout_apply_allowed' => false,
+            'production_deploy_allowed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runtimeAuthorityContract(string $target): array
+    {
+        return [
+            'contract_version' => 'career_runtime_artifact_shared_authority.v1',
+            'target' => $target,
+            'single_runtime_authority' => true,
+            'authority_source' => 'runtime_projection_truth_ledger_refresh_after_verified_candidate_prep',
+            'consumers' => [
+                'dataset_hub',
+                'career_jobs_api',
+                'career_job_detail_api',
+                'sitemap',
+                'llms',
+                'llms_full',
+            ],
+            'must_not_publish_from_raw_assets' => true,
+            'must_not_use_fap_web_fallback_authority' => true,
+            'pre_rollout_candidate_rows_remain_hidden' => true,
         ];
     }
 }

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php
@@ -12,7 +12,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
 
     public const OVERLAY_SOURCE = 'candidate_prep_apply_overlay';
 
-    private const DEFAULT_TARGET = 'career_80_delta';
+    private const DEFAULT_TARGET = CareerRuntimeArtifactRefreshPlanner::TARGET_CAREER_80_DELTA;
 
     private const RUNTIME_STATE = 'published_candidate';
 
@@ -41,13 +41,14 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
         int $expectedSlugCount = 51,
         string $target = self::DEFAULT_TARGET,
     ): array {
+        $target = $this->target($target);
         $source = $this->verifiedSource($candidatePrepApply, $candidatePrepApplyPath, $candidatePrepApplyFileSha256, $expectedSlugCount);
         $slugs = $source['slugs'];
         $locales = $source['locales'];
 
-        $projectionArtifact = $this->projectionArtifact($projection, $slugs, $locales, $source, $projectionPath);
-        $truthArtifact = $this->truthArtifact($truth, $slugs, $locales, $source, $truthPath);
-        $ledgerArtifact = $this->ledgerArtifact($ledger, $slugs, $source, $ledgerPath);
+        $projectionArtifact = $this->projectionArtifact($projection, $slugs, $locales, $source, $projectionPath, $target);
+        $truthArtifact = $this->truthArtifact($truth, $slugs, $locales, $source, $truthPath, $target);
+        $ledgerArtifact = $this->ledgerArtifact($ledger, $slugs, $source, $ledgerPath, $target);
 
         return [
             'summary' => [
@@ -62,10 +63,12 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
                     'artifact_sha256' => $source['artifact_sha256'],
                     'file_sha256' => $candidatePrepApplyFileSha256,
                 ],
-                'target' => $this->target($target),
+                'target' => $target,
                 'delta_slug_count' => count($slugs),
                 'expected_delta_locale_rows' => count($slugs) * count($locales),
                 'locales' => $locales,
+                'target_authority' => $this->targetAuthority($target),
+                'runtime_authority_contract' => $this->runtimeAuthorityContract($target),
                 'projection' => [
                     'source_path' => $projectionPath,
                     'output_path' => $projectionOutputPath,
@@ -112,9 +115,11 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
     {
         $target = $this->target($target);
 
-        return $target === self::DEFAULT_TARGET
-            ? '51_DELTA_ROLLOUT_DRY_RUN'
-            : 'PROGRESSIVE_ROLLOUT_DRY_RUN';
+        return match ($target) {
+            self::DEFAULT_TARGET => '51_DELTA_ROLLOUT_DRY_RUN',
+            CareerRuntimeArtifactRefreshPlanner::TARGET_DETAIL_READY_1048 => 'DETAIL_READY_1048_ROLLOUT_GATE_DRY_RUN',
+            default => 'PROGRESSIVE_ROLLOUT_DRY_RUN',
+        };
     }
 
     /**
@@ -221,7 +226,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
      * @param  array{artifact_sha256: string|null, slugs: list<string>, locales: list<string>}  $source
      * @return array<string, mixed>
      */
-    private function projectionArtifact(array $projection, array $slugs, array $locales, array $source, string $sourcePath): array
+    private function projectionArtifact(array $projection, array $slugs, array $locales, array $source, string $sourcePath, string $target): array
     {
         $rows = [
             ...$this->nonOverlayRows($this->artifactRows($projection, ['items', 'rows']), $slugs),
@@ -236,6 +241,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
             'source_path' => $sourcePath,
             'canonical_ledger_authority_claimed' => false,
         ];
+        $projection['runtime_authority_contract'] = $this->runtimeAuthorityContract($target);
         $projection['candidate_aware_overlay'] = $this->overlaySummary($slugs, $locales, $source);
         $projection['items'] = $rows;
         unset($projection['rows']);
@@ -251,7 +257,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
      * @param  array{artifact_sha256: string|null, slugs: list<string>, locales: list<string>}  $source
      * @return array<string, mixed>
      */
-    private function truthArtifact(array $truth, array $slugs, array $locales, array $source, string $sourcePath): array
+    private function truthArtifact(array $truth, array $slugs, array $locales, array $source, string $sourcePath, string $target): array
     {
         $rows = [
             ...$this->nonOverlayRows($this->artifactRows($truth, ['items', 'rows']), $slugs),
@@ -266,6 +272,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
             'source_path' => $sourcePath,
             'canonical_ledger_authority_claimed' => false,
         ];
+        $truth['runtime_authority_contract'] = $this->runtimeAuthorityContract($target);
         $truth['candidate_aware_overlay'] = $this->overlaySummary($slugs, $locales, $source);
         $truth['items'] = $rows;
         unset($truth['rows']);
@@ -280,7 +287,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
      * @param  array{artifact_sha256: string|null, slugs: list<string>, locales: list<string>}  $source
      * @return array<string, mixed>
      */
-    private function ledgerArtifact(array $ledger, array $slugs, array $source, string $sourcePath): array
+    private function ledgerArtifact(array $ledger, array $slugs, array $source, string $sourcePath, string $target): array
     {
         $members = [
             ...$this->nonOverlayMembers($this->artifactRows($ledger, ['members', 'items', 'rows']), $slugs),
@@ -295,6 +302,7 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
             'source_path' => $sourcePath,
             'canonical_ledger_authority_claimed' => false,
         ];
+        $ledger['runtime_authority_contract'] = $this->runtimeAuthorityContract($target);
         $ledger['candidate_aware_overlay'] = $this->overlaySummary($slugs, [], $source);
         $ledger['members'] = $members;
         unset($ledger['items'], $ledger['rows']);
@@ -569,5 +577,46 @@ final class CareerRuntimeCandidateAwareArtifactRefresh
     private function countRows(array $rows, string $key, string $value): int
     {
         return count(array_filter($rows, static fn (array $row): bool => ($row[$key] ?? null) === $value));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function targetAuthority(string $target): array
+    {
+        if ($target === CareerRuntimeArtifactRefreshPlanner::TARGET_DETAIL_READY_1048) {
+            return (new CareerDetailReadyTargetAuthority)->target(self::DEFAULT_LOCALES);
+        }
+
+        return [
+            'target_key' => $target,
+            'candidate_prep_apply_allowed' => false,
+            'rollout_apply_allowed' => false,
+            'production_deploy_allowed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runtimeAuthorityContract(string $target): array
+    {
+        return [
+            'contract_version' => 'career_runtime_artifact_shared_authority.v1',
+            'target' => $target,
+            'single_runtime_authority' => true,
+            'authority_source' => 'candidate_aware_runtime_projection_truth_ledger_artifacts',
+            'consumers' => [
+                'dataset_hub',
+                'career_jobs_api',
+                'career_job_detail_api',
+                'sitemap',
+                'llms',
+                'llms_full',
+            ],
+            'candidate_rows_remain_hidden_until_rollout' => true,
+            'must_not_publish_from_raw_assets' => true,
+            'must_not_use_fap_web_fallback_authority' => true,
+        ];
     }
 }

--- a/backend/docs/career/audits/runtime_artifact_refresh.md
+++ b/backend/docs/career/audits/runtime_artifact_refresh.md
@@ -2,7 +2,7 @@
 
 `career:plan-canonical-runtime-artifact-refresh` defines the read-only artifact refresh sequence required after a separately approved Career runtime candidate preparation apply.
 
-The plan exists because delta slugs must first be prepared as runtime `published_candidate` inventory, then projection, truth, and ledger artifacts must be refreshed before any rollout dry-run is attempted. It supports the 51 Career 80 delta path and progressive cohort deltas such as 220, 500, and 1986 slugs.
+The plan exists because delta slugs must first be prepared as runtime `published_candidate` inventory, then projection, truth, and ledger artifacts must be refreshed before any rollout dry-run is attempted. It supports the 51 Career 80 delta path, progressive cohort deltas such as 220, 500, and 1986 slugs, and the `detail_ready_1048` target of 1018 ready-not-public slugs.
 
 ## Usage
 
@@ -63,6 +63,34 @@ php artisan career:plan-canonical-runtime-artifact-refresh \
   --output=/tmp/career_300_runtime_artifact_refresh_candidate_aware.json
 ```
 
+Detail-ready 1048 refresh uses the publication candidate scan and candidate-prep plan as authority. It keeps the 1048 target separate from 2786 raw occupation partition accounting:
+
+```bash
+php artisan career:plan-canonical-runtime-artifact-refresh \
+  --target=detail_ready_1048 \
+  --delta-plan=/tmp/career_detail_ready_publication_candidates.json \
+  --candidate-prep-plan=/tmp/career_detail_ready_1048_runtime_candidate_prep_plan.json \
+  --json \
+  --output=/tmp/career_detail_ready_1048_runtime_artifact_refresh_plan.json
+```
+
+After a separately approved and write-verified candidate-prep apply artifact exists, the read-only candidate-aware artifact refresh can be planned with the same target:
+
+```bash
+php artisan career:plan-canonical-runtime-artifact-refresh \
+  --target=detail_ready_1048 \
+  --candidate-prep-apply=/tmp/career_detail_ready_1048_runtime_candidate_prep_apply.json \
+  --projection=/tmp/career_detail_ready_1048_runtime_projection_after_candidate_prep.json \
+  --truth=/tmp/career_detail_ready_1048_runtime_truth_after_candidate_prep.json \
+  --ledger=/tmp/career_detail_ready_1048_full_release_ledger_after_candidate_prep.json \
+  --candidate-aware \
+  --projection-output=/tmp/career_detail_ready_1048_runtime_projection_candidate_aware.json \
+  --truth-output=/tmp/career_detail_ready_1048_runtime_truth_candidate_aware.json \
+  --ledger-output=/tmp/career_detail_ready_1048_full_release_ledger_candidate_aware.json \
+  --json \
+  --output=/tmp/career_detail_ready_1048_runtime_artifact_refresh_candidate_aware.json
+```
+
 ## Output
 
 The output schema is `career_runtime_artifact_refresh_plan.v1`.
@@ -72,6 +100,10 @@ Key fields:
 - `status`: `planned` only when the supplied candidate-prep apply artifact has `write_verified=true`; otherwise `blocked`.
 - `phase`: `pre_apply`, `blocked`, or `post_apply_ready`.
 - `writes_database`: always `false`.
+- `target_public_total`: `80` for `career_80_delta`, `1048` for `detail_ready_1048`.
+- `expected_locale_rows`: `delta_slug_count * 2` for the canonical `en` and `zh` locale rows.
+- `target_authority`: embeds the detail-ready 1048 guardrails when `target=detail_ready_1048`.
+- `runtime_authority_contract`: requires dataset hub, jobs API, job detail API, sitemap, `llms.txt`, and `llms-full` to consume one refreshed projection/truth/ledger authority.
 - `required_outputs`:
   - `/tmp/career_80_delta_runtime_projection_after_candidate_prep.json`
   - `/tmp/career_80_delta_runtime_truth_after_candidate_prep.json`
@@ -91,13 +123,15 @@ Candidate-aware artifact paths:
 - `/tmp/career_80_delta_full_release_ledger_candidate_aware.json`
 - `/tmp/career_80_delta_runtime_artifact_refresh_candidate_aware.json`
 
-The candidate-aware artifacts are intended for the next read-only rollout dry-run for the current delta cohort. They do not publish pages, do not run rollout, and do not mutate the database.
+The candidate-aware artifacts are intended for the next read-only rollout dry-run for the current delta cohort. They do not publish pages, do not run rollout, and do not mutate the database. For `detail_ready_1048`, overlay rows still remain hidden pre-route candidates until a later rollout gate explicitly promotes them: `detail_route_enabled=false`, `dataset_visible=false`, `sitemap_live=false`, `llms_live=false`, and `llms_full_live=false`.
 
 ## Approval Gates
 
 - `RUNTIME_CANDIDATE_PREP_APPLY_51`: creates or verifies the 51 delta `published_candidate` runtime inventory after explicit approval.
+- `DETAIL_READY_1048_CANDIDATE_PREP_APPLY`: creates or verifies the 1018 delta `published_candidate` runtime inventory after explicit approval.
 - `RUNTIME_ARTIFACT_REFRESH_READ_ONLY`: refreshes projection, truth, and ledger artifacts after candidate-prep write verification.
 - `DELTA_ROLLOUT_DRY_RUN_51`: future dry-run that consumes refreshed artifacts and the 51-delta manifest.
+- `DETAIL_READY_1048_ROLLOUT_DRY_RUN`: future dry-run that consumes refreshed artifacts and the detail-ready 1048 rollout manifest.
 
 ## Non-goals
 

--- a/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php
@@ -294,6 +294,52 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
         $this->assertSame(1986, $full['ledger']['overlay_members']);
     }
 
+    public function test_candidate_aware_mode_supports_detail_ready_1048_overlay_without_runtime_exposure(): void
+    {
+        $projectionOutput = $this->tempPath('detail-ready-1048-projection');
+        $truthOutput = $this->tempPath('detail-ready-1048-truth');
+        $ledgerOutput = $this->tempPath('detail-ready-1048-ledger');
+        $slugs = $this->slugs(1018, 'ready');
+
+        $exitCode = $this->callCommand([
+            '--target' => 'detail_ready_1048',
+            '--candidate-aware' => true,
+            '--candidate-prep-apply' => $this->writeJson('prep-apply', $this->candidatePrepApplyForSlugs($slugs)),
+            '--projection' => $this->writeJson('projection', ['items' => []]),
+            '--truth' => $this->writeJson('truth', ['items' => []]),
+            '--ledger' => $this->writeJson('ledger', ['members' => []]),
+            '--projection-output' => $projectionOutput,
+            '--truth-output' => $truthOutput,
+            '--ledger-output' => $ledgerOutput,
+        ]);
+        $payload = $this->payload();
+        $projection = json_decode((string) file_get_contents($projectionOutput), true, flags: JSON_THROW_ON_ERROR);
+        $truth = json_decode((string) file_get_contents($truthOutput), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('detail_ready_1048', $payload['target']);
+        $this->assertSame(1018, $payload['delta_slug_count']);
+        $this->assertSame(2036, $payload['expected_delta_locale_rows']);
+        $this->assertSame('detail_ready_1048', $payload['target_authority']['target_key']);
+        $this->assertSame('DETAIL_READY_1048_ROLLOUT_GATE_DRY_RUN', $payload['next_required_action']);
+        $this->assertSame([
+            'dataset_hub',
+            'career_jobs_api',
+            'career_job_detail_api',
+            'sitemap',
+            'llms',
+            'llms_full',
+        ], $payload['runtime_authority_contract']['consumers']);
+        $this->assertSame(0, $projection['counts']['dataset_visible']);
+        $this->assertSame(0, $projection['counts']['detail_route_enabled']);
+        $this->assertSame(0, $projection['counts']['sitemap_live']);
+        $this->assertSame(0, $projection['counts']['llms_live']);
+        $this->assertSame(0, $projection['counts']['llms_full_live']);
+        $this->assertSame(2036, $truth['counts']['candidate_pre_route_expected_count']);
+        $this->assertSame(0, $truth['counts']['candidate_unexpected_route_exposure_count']);
+        $this->assertSame(0, $truth['counts']['candidate_unexpected_sitemap_exposure_count']);
+    }
+
     public function test_candidate_aware_artifacts_pass_runtime_candidate_pool_synthetic_integration(): void
     {
         $slugs = ['alpha-career', 'beta-career'];
@@ -341,10 +387,14 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
             'target',
             'phase',
             'delta_slug_count',
+            'target_public_total',
+            'expected_locale_rows',
             'candidate_prep_required',
             'candidate_prep_apply_required',
             'writes_database',
             'read_only',
+            'target_authority',
+            'runtime_authority_contract',
             'required_inputs',
             'required_outputs',
             'commands',
@@ -374,6 +424,8 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
             'delta_slug_count',
             'expected_delta_locale_rows',
             'locales',
+            'target_authority',
+            'runtime_authority_contract',
             'projection',
             'truth',
             'ledger',
@@ -644,11 +696,11 @@ final class CareerPlanCanonicalRuntimeArtifactRefreshCommandTest extends TestCas
     /**
      * @return list<string>
      */
-    private function slugs(int $count = 51): array
+    private function slugs(int $count = 51, string $prefix = 'delta'): array
     {
         $slugs = [];
         for ($i = 1; $i <= $count; $i++) {
-            $slugs[] = sprintf('delta-%03d', $i);
+            $slugs[] = sprintf('%s-%04d', $prefix, $i);
         }
 
         return $slugs;

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php
@@ -19,6 +19,8 @@ final class CareerRuntimeArtifactRefreshPlannerTest extends TestCase
 
         $this->assertSame('planned', $payload['status']);
         $this->assertSame('career_runtime_artifact_refresh_plan.v1', $payload['schema_version']);
+        $this->assertSame('career_80_delta', $payload['target']);
+        $this->assertSame(80, $payload['target_public_total']);
         $this->assertSame('/tmp/career_80_delta_runtime_projection_after_candidate_prep.json', $payload['required_outputs'][0]['path']);
         $this->assertSame('/tmp/career_80_delta_runtime_truth_after_candidate_prep.json', $payload['required_outputs'][1]['path']);
         $this->assertSame('/tmp/career_80_delta_full_release_ledger_after_candidate_prep.json', $payload['required_outputs'][2]['path']);
@@ -126,6 +128,56 @@ final class CareerRuntimeArtifactRefreshPlannerTest extends TestCase
         $this->assertSame([true, true, true], array_column($payload['commands'], 'read_only'));
     }
 
+    public function test_plans_detail_ready_1048_refresh_without_writing_artifacts(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            target: 'detail_ready_1048',
+            deltaPlan: $this->detailReadyPlan(),
+            candidatePrepPlan: $this->detailReadyCandidatePrepPlan(),
+            candidatePrepApply: $this->detailReadyCandidatePrepApply(writeVerified: true),
+        )->toArray();
+
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('post_apply_ready', $payload['phase']);
+        $this->assertSame('detail_ready_1048', $payload['target']);
+        $this->assertSame(1048, $payload['target_public_total']);
+        $this->assertSame(1018, $payload['delta_slug_count']);
+        $this->assertSame(2036, $payload['expected_locale_rows']);
+        $this->assertSame('/tmp/career_detail_ready_1048_runtime_projection_after_candidate_prep.json', $payload['required_outputs'][0]['path']);
+        $this->assertSame('/tmp/career_detail_ready_1048_runtime_truth_after_candidate_prep.json', $payload['required_outputs'][1]['path']);
+        $this->assertSame('/tmp/career_detail_ready_1048_full_release_ledger_after_candidate_prep.json', $payload['required_outputs'][2]['path']);
+        $this->assertSame('detail_ready_1048', $payload['target_authority']['target_key']);
+        $this->assertSame([
+            'dataset_hub',
+            'career_jobs_api',
+            'career_job_detail_api',
+            'sitemap',
+            'llms',
+            'llms_full',
+        ], $payload['runtime_authority_contract']['consumers']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertTrue($payload['read_only']);
+    }
+
+    public function test_detail_ready_1048_blocks_wrong_delta_count_and_target_key(): void
+    {
+        $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
+            target: 'detail_ready_1048',
+            deltaPlan: [
+                ...$this->detailReadyPlan(count: 1017),
+                'target_key' => 'career_80_delta',
+            ],
+            candidatePrepPlan: [
+                ...$this->detailReadyCandidatePrepPlan(deltaCount: 1017),
+            ],
+            candidatePrepApply: $this->detailReadyCandidatePrepApply(writeVerified: true, deltaCount: 1017),
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('target_delta_plan_target_key_invalid', array_column($payload['blockers'], 'reason'));
+        $this->assertContains('detail_ready_1048_delta_count_mismatch', array_column($payload['blockers'], 'reason'));
+    }
+
     public function test_schema_is_stable(): void
     {
         $payload = (new CareerRuntimeArtifactRefreshPlanner)->plan(
@@ -139,10 +191,14 @@ final class CareerRuntimeArtifactRefreshPlannerTest extends TestCase
             'target',
             'phase',
             'delta_slug_count',
+            'target_public_total',
+            'expected_locale_rows',
             'candidate_prep_required',
             'candidate_prep_apply_required',
             'writes_database',
             'read_only',
+            'target_authority',
+            'runtime_authority_contract',
             'required_inputs',
             'required_outputs',
             'commands',
@@ -208,6 +264,72 @@ final class CareerRuntimeArtifactRefreshPlannerTest extends TestCase
         $slugs = [];
         for ($i = 1; $i <= 51; $i++) {
             $slugs[] = sprintf('delta-%03d', $i);
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function detailReadyPlan(int $count = 1018): array
+    {
+        return [
+            'schema_version' => 'career_detail_ready_publication_candidates.v1',
+            'status' => 'pass',
+            'target_key' => 'detail_ready_1048',
+            'current_public_total' => 30,
+            'target_public_total' => 1048,
+            'ready_not_public_1018' => [
+                'count' => $count,
+                'slugs' => $this->detailReadySlugs($count),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function detailReadyCandidatePrepPlan(int $deltaCount = 1018): array
+    {
+        return [
+            'schema_version' => 'career_runtime_candidate_prep_plan.v1',
+            'status' => 'planned',
+            'target' => 'detail_ready_1048',
+            'delta_slug_count' => $deltaCount,
+            'locales' => ['en', 'zh'],
+            'expected_locale_rows' => $deltaCount * 2,
+            'planned_candidate_rows_count' => $deltaCount * 2,
+            'target_public_total' => 1048,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function detailReadyCandidatePrepApply(bool $writeVerified, int $deltaCount = 1018): array
+    {
+        return [
+            'status' => $writeVerified ? 'applied' : 'blocked',
+            'writes_database' => $writeVerified,
+            'write_verified' => $writeVerified,
+            'slug_count' => $writeVerified ? $deltaCount : 0,
+            'expected_locale_rows' => $writeVerified ? $deltaCount * 2 : 0,
+            'created_count' => $writeVerified ? $deltaCount : 0,
+            'verified_count' => $writeVerified ? $deltaCount : 0,
+            'failures' => [],
+            'locales' => ['en', 'zh-CN'],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function detailReadySlugs(int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('ready-%04d', $i);
         }
 
         return $slugs;

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29145,7 +29145,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1": {
-    "status": "local_checks_passed",
+    "status": "local_commit_created",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-runtime-artifact-refresh-1",
     "base": "main",
@@ -29153,7 +29153,7 @@
       "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1"
     ],
     "title": "fix(api): refresh career detail-ready 1048 artifacts",
-    "commit_sha": null,
+    "commit_sha": "2a4e987c0d66fb2a4103b4d3a186891de4359311",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -29206,6 +29206,11 @@
         "at": "2026-05-27T19:42:47+08:00",
         "status": "scope_validation_passed",
         "summary": "Changed files are within runtime artifact refresh PR allowed paths; generated BIG5_OCEAN compiled artifacts were restored as out-of-scope CI side effects."
+      },
+      {
+        "at": "2026-05-27T19:43:24+08:00",
+        "status": "local_commit_created",
+        "summary": "Created local commit 2a4e987c0d66fb2a4103b4d3a186891de4359311 for detail-ready 1048 runtime artifact refresh planning."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29145,7 +29145,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1": {
-    "status": "local_commit_created",
+    "status": "pr_open",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-runtime-artifact-refresh-1",
     "base": "main",
@@ -29154,7 +29154,7 @@
     ],
     "title": "fix(api): refresh career detail-ready 1048 artifacts",
     "commit_sha": "2a4e987c0d66fb2a4103b4d3a186891de4359311",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1728",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -29211,6 +29211,11 @@
         "at": "2026-05-27T19:43:24+08:00",
         "status": "local_commit_created",
         "summary": "Created local commit 2a4e987c0d66fb2a4103b4d3a186891de4359311 for detail-ready 1048 runtime artifact refresh planning."
+      },
+      {
+        "at": "2026-05-27T19:44:37+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1728 for detail_ready_1048 runtime artifact refresh planning."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29022,7 +29022,7 @@
     "local_cleanup_note": "scripts/post_merge_cleanup.sh not present in fap-api; local main fast-forwarded to origin/main and task branch was not present locally after merge."
   },
   "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1": {
-    "status": "github_checks_green",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-candidate-prep-1",
     "base": "main",
@@ -29030,11 +29030,11 @@
       "REPAIR-CAREER-DETAIL-READY-TARGET-AUTHORITY-1"
     ],
     "title": "fix(api): plan career detail-ready 1018 candidate prep",
-    "commit_sha": "b7ddae6de5feb950b46ec89bae64e7029e26fbd2",
+    "commit_sha": "cbbbbb850434d79a6e042c5fbfd946fd3deb2a5f",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1726",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-05-27T10:37:37Z",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "checks": {
       "local": {
@@ -29122,6 +29122,11 @@
         "at": "2026-05-27T18:29:06+08:00",
         "status": "github_checks_green",
         "summary": "After rebasing onto origin/main with PR #1727, PR #1726 required GitHub checks passed and merge state is CLEAN."
+      },
+      {
+        "at": "2026-05-27T19:42:09+08:00",
+        "status": "ledger_reconciled_merged",
+        "summary": "Reconciled PR #1726 as merged into origin/main with merge commit cbbbbb850434d79a6e042c5fbfd946fd3deb2a5f; fap-api has no scripts/post_merge_cleanup.sh local cleanup hook."
       }
     ],
     "sidecar_blockers": [
@@ -29140,7 +29145,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1": {
-    "status": "planned",
+    "status": "local_checks_passed",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-runtime-artifact-refresh-1",
     "base": "main",
@@ -29154,11 +29159,58 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "checks": {},
-    "history": []
+    "checks": {
+      "local": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test --filter=CareerDetailReady --no-ansi",
+          "cd backend && php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi",
+          "cd backend && php artisan test tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+          "cd backend && vendor/bin/pint --test",
+          "bash backend/scripts/ci_verify_mbti.sh"
+        ],
+        "notes": "Career runtime artifact refresh and detail-ready focused tests passed. backend/scripts/ci_verify_mbti.sh passed and regenerated BIG5_OCEAN compiled artifacts as a local side effect; those generated diffs were restored because they are outside this PR scope."
+      },
+      "scope": {
+        "status": "passed",
+        "changed_files": [
+          "backend/app/Console/Commands/CareerPlanCanonicalRuntimeArtifactRefresh.php",
+          "backend/app/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlanner.php",
+          "backend/app/Domain/Career/Audit/CareerRuntimeCandidateAwareArtifactRefresh.php",
+          "backend/docs/career/audits/runtime_artifact_refresh.md",
+          "backend/tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php",
+          "backend/tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php",
+          "docs/codex/pr-train-state.json"
+        ],
+        "outside_scope": [],
+        "diff_checks": [
+          "git diff --check",
+          "git diff --cached --check"
+        ]
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T19:42:09+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started detail_ready_1048 runtime artifact refresh planner/read-only PR from latest main after PR #1726 merged."
+      },
+      {
+        "at": "2026-05-27T19:42:09+08:00",
+        "status": "local_checks_passed",
+        "summary": "CareerDetailReady, CareerRuntimeArtifactRefresh, focused command tests, route list, migrate pretend, Pint, and backend MBTI CI passed locally."
+      },
+      {
+        "at": "2026-05-27T19:42:47+08:00",
+        "status": "scope_validation_passed",
+        "summary": "Changed files are within runtime artifact refresh PR allowed paths; generated BIG5_OCEAN compiled artifacts were restored as out-of-scope CI side effects."
+      }
+    ]
   },
   "SUPPLY-CHAIN-SYMFONY-AUDIT-UNBLOCK-20260527": {
-    "status": "implementation_in_progress",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/supply-chain-symfony-audit-unblock-20260527",
     "base": "main",
@@ -29166,11 +29218,11 @@
       "REPAIR-CAREER-DETAIL-READY-CANDIDATE-PREP-1"
     ],
     "title": "fix(deps): unblock Symfony Composer audit",
-    "commit_sha": "b7833e07220c885ab9af12696323000c253a7a0b",
+    "commit_sha": "c1b708fc0d70e9f3e7124f564152b07bcdd4b797",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1727",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-05-27T10:21:24Z",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "checks": {
       "local": {
@@ -29195,6 +29247,18 @@
           "docs/codex/pr-train-state.json"
         ],
         "outside_scope": []
+      },
+      "github": {
+        "status": "passed",
+        "merge_state": "CLEAN",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "Semgrep blocking secrets",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "failure_reason": null
       }
     },
     "history": [
@@ -29222,6 +29286,11 @@
         "at": "2026-05-27T18:12:27+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1727 for the Symfony Composer audit sidecar unblocker."
+      },
+      {
+        "at": "2026-05-27T19:42:09+08:00",
+        "status": "ledger_reconciled_merged",
+        "summary": "Reconciled sidecar PR #1727 as merged into origin/main with merge commit c1b708fc0d70e9f3e7124f564152b07bcdd4b797; remote branch is deleted and fap-api has no scripts/post_merge_cleanup.sh local cleanup hook."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Extends the existing Career runtime artifact refresh planner to support `target=detail_ready_1048` with the 1018 ready-not-public delta, 1048 target public total, and 2096 expected locale rows.
- Adds a shared runtime authority contract for dataset hub, career jobs API, job detail API, sitemap, `llms`, and `llms-full` so the detail-ready target remains tied to one projection/truth/ledger authority.
- Extends candidate-aware artifact refresh summaries and generated projection/truth/ledger artifacts with the shared authority contract while keeping overlay rows hidden before rollout.
- Adds focused unit/command coverage for the detail-ready 1048 path and documents the read-only operator flow.
- Reconciles the train ledger for already-merged #1726 and #1727, then records this PR's local validation.

## Why
This is PR 4 of the `CAREER-DETAIL-READY-1048-PUBLICATION-TRAIN-01` train. It prepares the runtime artifact refresh layer for all currently detail-ready Career jobs without publishing pages, mutating production data, or using frontend fallback authority.

## Validation commands
- `cd backend && php artisan test --filter=CareerDetailReady --no-ansi`
- `cd backend && php artisan test --filter=CareerRuntimeArtifactRefresh --no-ansi`
- `cd backend && php artisan test tests/Feature/Console/CareerPlanCanonicalRuntimeArtifactRefreshCommandTest.php --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `cd backend && vendor/bin/pint --test`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- `git diff --cached --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())"`

## Intentionally deferred items
- No production artifact export/apply.
- No candidate prep apply.
- No rollout dry-run or rollout apply.
- No production DB mutation.
- No deploy.
- No fap-web change or fallback authority.
- No publication of 2289 excluded/raw assets or all 2786 occupations.
- No force-enable of `software-developers`.

## Sidecar blockers
None currently. The previous external Symfony Composer audit blocker was resolved by #1727 before this PR started.

## Repository rule impact
This PR changes Career runtime artifact planning semantics only. It preserves backend authority as the source of truth, adds no publishable content, and keeps candidate-aware artifacts read-only/planner-only until a later explicit rollout gate.
