### PR TITLE
fix(api): accept career detail-ready 1048 closeout

### DIFF
--- a/backend/app/Domain/Career/Audit/Career80TotalLiveAcceptancePlanner.php
+++ b/backend/app/Domain/Career/Audit/Career80TotalLiveAcceptancePlanner.php
@@ -128,16 +128,20 @@ final class Career80TotalLiveAcceptancePlanner
 
     private function completeAction(string $target): string
     {
-        return $target === 'career_80_total'
-            ? '80_TOTAL_LIVE_ACCEPTANCE_COMPLETE'
-            : 'PROGRESSIVE_LIVE_ACCEPTANCE_COMPLETE';
+        return match ($target) {
+            'career_80_total' => '80_TOTAL_LIVE_ACCEPTANCE_COMPLETE',
+            'detail_ready_1048' => 'DETAIL_READY_1048_LIVE_ACCEPTANCE_COMPLETE',
+            default => 'PROGRESSIVE_LIVE_ACCEPTANCE_COMPLETE',
+        };
     }
 
     private function runAction(string $target): string
     {
-        return $target === 'career_80_total'
-            ? 'RUN_80_TOTAL_LIVE_ACCEPTANCE_READ_ONLY'
-            : 'RUN_PROGRESSIVE_LIVE_ACCEPTANCE_READ_ONLY';
+        return match ($target) {
+            'career_80_total' => 'RUN_80_TOTAL_LIVE_ACCEPTANCE_READ_ONLY',
+            'detail_ready_1048' => 'RUN_DETAIL_READY_1048_LIVE_ACCEPTANCE_READ_ONLY',
+            default => 'RUN_PROGRESSIVE_LIVE_ACCEPTANCE_READ_ONLY',
+        };
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
+++ b/backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
@@ -8,7 +8,7 @@ final class CareerFullVisiblePublicationGate
 {
     public function appliesTo(int $targetPublicTotal): bool
     {
-        return $targetPublicTotal === 2786;
+        return in_array($targetPublicTotal, [1048, 2786], true);
     }
 
     /**
@@ -30,9 +30,11 @@ final class CareerFullVisiblePublicationGate
             'canonical_public_slug_count' => $this->intAtAny($liveAcceptance, [
                 'canonical_public_slug_count',
                 'product_surface.canonical_public_slug_count',
+                'validation.full_visible_publication_gate.canonical_public_slug_count',
             ]),
             'found_published_locale_rows' => $this->foundPublishedLocaleRows($liveAcceptance),
             'release_gate_pass_count' => $this->releaseGatePassCount($liveAcceptance),
+            'forbidden_exposure_counts' => $this->forbiddenExposureCounts($liveAcceptance),
             'product_claim' => $this->productClaim($liveAcceptance, $targetPublicTotal, $expectedLocaleRows),
         ];
     }
@@ -96,6 +98,14 @@ final class CareerFullVisiblePublicationGate
             ]);
         }
 
+        foreach ($summary['forbidden_exposure_counts'] as $key => $count) {
+            if ($count > 0) {
+                $blockers[] = $this->blocker('product_forbidden_'.$key.'_present', [
+                    'actual' => $count,
+                ]);
+            }
+        }
+
         if ($blockers !== [] && $this->intAtAny($liveAcceptance, [
             'partition_accounting.final_public_accounted_total',
             'final_public_accounted_total',
@@ -136,6 +146,7 @@ final class CareerFullVisiblePublicationGate
         return $this->intAtAny($payload, [
             'product_surface.directory_member_count',
             'product_surface.member_count',
+            'validation.full_visible_publication_gate.directory_member_count',
             'directory.member_count',
             'career_directory.member_count',
             'collection_summary.member_count',
@@ -153,6 +164,7 @@ final class CareerFullVisiblePublicationGate
         return $this->intAtAny($payload, [
             'product_surface.career_jobs_item_count',
             'product_surface.job_items_count',
+            'validation.full_visible_publication_gate.career_jobs_item_count',
             'career_jobs.item_count',
             'career_job_list.item_count',
             'job_items_count',
@@ -169,6 +181,7 @@ final class CareerFullVisiblePublicationGate
             'product_surface.detail_ready_count',
             'product_surface.visible_detail_count',
             'product_surface.public_detail_indexable_count',
+            'validation.full_visible_publication_gate.detail_ready_count',
             'career_jobs.detail_ready_count',
             'collection_summary.public_detail_indexable_count',
             'api_collection_summary.public_detail_indexable_count',
@@ -184,6 +197,7 @@ final class CareerFullVisiblePublicationGate
     {
         return $this->intAtAny($payload, [
             'product_surface.public_detail_indexable_count',
+            'validation.full_visible_publication_gate.public_detail_indexable_count',
             'collection_summary.public_detail_indexable_count',
             'api_collection_summary.public_detail_indexable_count',
             'public_detail_indexable_count',
@@ -199,6 +213,7 @@ final class CareerFullVisiblePublicationGate
             'found_published',
             'projection_truth.found_published',
             'acceptance_summary.found_published',
+            'validation.full_visible_publication_gate.found_published_locale_rows',
             'canonical_public_locale_rows',
         ]);
     }
@@ -212,6 +227,7 @@ final class CareerFullVisiblePublicationGate
             'release_gate_pass_count',
             'release_gate.pass_count',
             'acceptance_summary.release_gate_pass_count',
+            'validation.full_visible_publication_gate.release_gate_pass_count',
         ]);
     }
 
@@ -260,10 +276,92 @@ final class CareerFullVisiblePublicationGate
                 'partition_accounting_total' => $partitionAccountingTotal,
             ],
             'blocked_claims' => $visibleDetailClaimAllowed ? [] : [
-                '2786_visible_directory_members',
-                '2786_visible_detail_pages',
-                '2786_detail_indexable_pages',
+                $targetPublicTotal.'_visible_directory_members',
+                $targetPublicTotal.'_visible_detail_pages',
+                $targetPublicTotal.'_detail_indexable_pages',
             ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, int>
+     */
+    private function forbiddenExposureCounts(array $payload): array
+    {
+        return [
+            'sitemap_noindex_urls' => $this->intAtAny($payload, [
+                'product_surface.sitemap_noindex_url_count',
+                'product_surface.sitemap_noindex_urls',
+                'sitemap.noindex_url_count',
+                'sitemap.noindex_urls',
+                'forbidden_exposure.sitemap_noindex_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_noindex_urls',
+            ]) ?? 0,
+            'sitemap_404_urls' => $this->intAtAny($payload, [
+                'product_surface.sitemap_404_url_count',
+                'product_surface.sitemap_404_urls',
+                'sitemap.not_found_url_count',
+                'sitemap.404_urls',
+                'forbidden_exposure.sitemap_404_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_404_urls',
+            ]) ?? 0,
+            'sitemap_redirect_source_urls' => $this->intAtAny($payload, [
+                'product_surface.sitemap_redirect_source_url_count',
+                'product_surface.sitemap_redirect_source_urls',
+                'sitemap.redirect_source_url_count',
+                'sitemap.redirect_source_urls',
+                'forbidden_exposure.sitemap_redirect_source_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_redirect_source_urls',
+            ]) ?? 0,
+            'llms_noindex_urls' => $this->intAtAny($payload, [
+                'product_surface.llms_noindex_url_count',
+                'product_surface.llms_noindex_urls',
+                'llms.noindex_url_count',
+                'llms.noindex_urls',
+                'forbidden_exposure.llms_noindex_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_noindex_urls',
+            ]) ?? 0,
+            'llms_404_urls' => $this->intAtAny($payload, [
+                'product_surface.llms_404_url_count',
+                'product_surface.llms_404_urls',
+                'llms.not_found_url_count',
+                'llms.404_urls',
+                'forbidden_exposure.llms_404_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_404_urls',
+            ]) ?? 0,
+            'llms_redirect_source_urls' => $this->intAtAny($payload, [
+                'product_surface.llms_redirect_source_url_count',
+                'product_surface.llms_redirect_source_urls',
+                'llms.redirect_source_url_count',
+                'llms.redirect_source_urls',
+                'forbidden_exposure.llms_redirect_source_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_redirect_source_urls',
+            ]) ?? 0,
+            'llms_full_noindex_urls' => $this->intAtAny($payload, [
+                'product_surface.llms_full_noindex_url_count',
+                'product_surface.llms_full_noindex_urls',
+                'llms_full.noindex_url_count',
+                'llms_full.noindex_urls',
+                'forbidden_exposure.llms_full_noindex_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_noindex_urls',
+            ]) ?? 0,
+            'llms_full_404_urls' => $this->intAtAny($payload, [
+                'product_surface.llms_full_404_url_count',
+                'product_surface.llms_full_404_urls',
+                'llms_full.not_found_url_count',
+                'llms_full.404_urls',
+                'forbidden_exposure.llms_full_404_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_404_urls',
+            ]) ?? 0,
+            'llms_full_redirect_source_urls' => $this->intAtAny($payload, [
+                'product_surface.llms_full_redirect_source_url_count',
+                'product_surface.llms_full_redirect_source_urls',
+                'llms_full.redirect_source_url_count',
+                'llms_full.redirect_source_urls',
+                'forbidden_exposure.llms_full_redirect_source_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_redirect_source_urls',
+            ]) ?? 0,
         ];
     }
 

--- a/backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlanner.php
@@ -55,7 +55,7 @@ final class CareerProgressiveCohortCloseoutPlanner
             'apply_allowed' => false,
             'rollout_allowed' => false,
             'live_crawl_executed' => false,
-            'target' => $this->target($targetPublicTotal),
+            'target' => $this->target($targetPublicTotal, $liveAcceptance),
             'target_public_total' => $targetPublicTotal,
             'baseline_count' => $baselineCount,
             'delta_count' => $deltaCount,
@@ -185,8 +185,16 @@ final class CareerProgressiveCohortCloseoutPlanner
         return array_values(array_filter($sidecars, static fn (mixed $sidecar): bool => is_array($sidecar)));
     }
 
-    private function target(int $targetPublicTotal): string
+    /**
+     * @param  array<string, mixed>  $liveAcceptance
+     */
+    private function target(int $targetPublicTotal, array $liveAcceptance): string
     {
+        $target = trim((string) ($liveAcceptance['target'] ?? ''));
+        if ($targetPublicTotal === 1048 && $target === 'detail_ready_1048') {
+            return 'detail_ready_1048';
+        }
+
         return 'career_'.$targetPublicTotal.'_total';
     }
 
@@ -196,6 +204,7 @@ final class CareerProgressiveCohortCloseoutPlanner
             80 => '300_READINESS_1',
             300 => '800_READINESS_1',
             800 => '2786_READINESS_1',
+            1048 => 'CAREER_DETAIL_READY_1048_CLOSEOUT_COMPLETE',
             2786 => 'CAREER_2786_FINAL_CLOSEOUT_COMPLETE',
             default => 'NEXT_PROGRESSIVE_READINESS',
         };

--- a/backend/docs/career/audits/product_visible_claim_authority.md
+++ b/backend/docs/career/audits/product_visible_claim_authority.md
@@ -2,6 +2,8 @@
 
 Career public-resolution accounting and product-visible publication are separate claims.
 
+For the `detail_ready_1048` program, detail-ready candidate accounting may prove that 1048 slugs are eligible for publication planning. It does not prove that all 1048 are visible in the public career directory, jobs API, sitemap, `llms`, or detail pages.
+
 For the final `2786` Career program, partition accounting may prove that every source row has a governed resolution. It does not prove that every source row is visible in the public career directory or has a viewable detail page.
 
 ## Claim scopes
@@ -18,8 +20,9 @@ For the final `2786` Career program, partition accounting may prove that every s
 - career jobs index item count equals the target total;
 - detail-ready and `public_detail_indexable_count` equal the target total;
 - published locale rows and release-gate pass rows equal `target_public_total * locale_count`.
+- sitemap, `llms`, and `llms-full` have zero noindex, 404, or redirect-source URLs.
 
-Only `product_visible_detail_publication` may support a product claim that 2786 occupations are visible with detail pages.
+Only `product_visible_detail_publication` may support a product claim that the target occupations are visible with detail pages.
 
 ## Runtime artifact field
 

--- a/backend/docs/career/audits/progressive_closeout.md
+++ b/backend/docs/career/audits/progressive_closeout.md
@@ -7,6 +7,7 @@ Supported closeout targets:
 - 80: next action `300_READINESS_1`
 - 300: next action `800_READINESS_1`
 - 800: next action `2786_READINESS_1`
+- 1048 / `detail_ready_1048`: next action `CAREER_DETAIL_READY_1048_CLOSEOUT_COMPLETE`
 - 2786: next action `CAREER_2786_FINAL_CLOSEOUT_COMPLETE`
 
 Example:
@@ -32,6 +33,8 @@ The closeout artifact records:
 - sidecars carried by the acceptance artifact
 
 The command refuses closeout when the live acceptance artifact is not `status=pass`, `accepted=true`, and `writes_database=false`, when failures are present, when baseline plus delta does not equal the target total, or when the total slug artifact path is missing.
+
+For `target_public_total=1048` with `target=detail_ready_1048`, closeout refuses evidence that only proves candidate accounting. The live acceptance artifact must prove the product-visible surface: directory `member_count=1048`, career jobs item count `1048`, detail-ready / `public_detail_indexable_count=1048`, `2096` published locale rows, and zero noindex/404/redirect-source URLs in sitemap, `llms`, and `llms-full`.
 
 For `target_public_total=2786`, closeout also refuses partition-accounting-only evidence. The live acceptance artifact must prove the product-visible surface: directory `member_count=2786`, career jobs item count `2786`, detail-ready / `public_detail_indexable_count=2786`, and `5572` published locale rows. A final partition total of `2786` is not sufficient when public routes or detail pages remain disabled.
 

--- a/backend/docs/career/audits/progressive_live_acceptance.md
+++ b/backend/docs/career/audits/progressive_live_acceptance.md
@@ -6,16 +6,20 @@ Supported target totals:
 
 - 300: 600 locale rows for `en,zh`
 - 800: 1600 locale rows for `en,zh`
+- 1048 / `detail_ready_1048`: 2096 locale rows for `en,zh`
 - 2786: 5572 locale rows for `en,zh`
 
 The command consumes a progressive target-delta artifact and optional rollout manifest and live acceptance artifact. It validates that the current public cohort plus the explicit delta cohort equals the target total and that any supplied live acceptance artifact reports the expected locale row count.
 
-For the final `2786` target, the command also enforces the product-visible publication gate. A supplied live acceptance artifact cannot pass by partition accounting alone. It must prove:
+For `detail_ready_1048` and the final `2786` target, the command also enforces the product-visible publication gate. A supplied live acceptance artifact cannot pass by partition accounting alone. It must prove:
 
-- public career directory `member_count=2786`
-- career jobs index item count `2786`
-- detail-ready / `public_detail_indexable_count=2786`
-- published locale rows and release-gate pass count `5572`
+- public career directory `member_count` equals the target total
+- career jobs index item count equals the target total
+- detail-ready / `public_detail_indexable_count` equals the target total
+- published locale rows and release-gate pass count equal `target_public_total * locale_count`
+- sitemap, `llms`, and `llms-full` have zero noindex, 404, or redirect-source URLs
+
+For `detail_ready_1048`, the expected product-visible evidence is `member_count=1048`, career jobs item count `1048`, detail-ready / `public_detail_indexable_count=1048`, and `2096` published locale rows for `en,zh`.
 
 CN proxy public-owner accounting and software manual-hold accounting may be recorded as context, but they are not accepted as evidence that 2786 public detail pages are visible.
 

--- a/backend/tests/Feature/Console/CareerCloseoutCanonicalProgressiveCohortCommandTest.php
+++ b/backend/tests/Feature/Console/CareerCloseoutCanonicalProgressiveCohortCommandTest.php
@@ -63,6 +63,26 @@ final class CareerCloseoutCanonicalProgressiveCohortCommandTest extends TestCase
         $this->assertFileExists($output);
     }
 
+    public function test_writes_detail_ready_1048_closeout_artifact(): void
+    {
+        $output = $this->tempPath('closeout-1048');
+        $exitCode = $this->callCommand([
+            '--live-acceptance' => $this->writeJson('live-acceptance', $this->liveAcceptance(1048, 30, 1018)),
+            '--baseline-slugs' => '/tmp/career_current_public_30_slugs.txt',
+            '--delta-slugs' => '/tmp/career_detail_ready_1048_delta_slugs.txt',
+            '--total-slugs' => '/tmp/career_detail_ready_1048_total_slugs.txt',
+            '--output' => $output,
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('detail_ready_1048', $payload['target']);
+        $this->assertSame(1048, $payload['target_public_total']);
+        $this->assertSame(2096, $payload['expected_locale_rows']);
+        $this->assertSame('CAREER_DETAIL_READY_1048_CLOSEOUT_COMPLETE', $payload['next_required_action']);
+        $this->assertFileExists($output);
+    }
+
     public function test_failed_acceptance_artifact_blocks(): void
     {
         $artifact = $this->liveAcceptance(300, 80, 220);
@@ -104,7 +124,7 @@ final class CareerCloseoutCanonicalProgressiveCohortCommandTest extends TestCase
      */
     private function liveAcceptance(int $target, int $baseline, int $delta): array
     {
-        return [
+        $payload = [
             'status' => 'pass',
             'accepted' => true,
             'read_only' => true,
@@ -125,6 +145,21 @@ final class CareerCloseoutCanonicalProgressiveCohortCommandTest extends TestCase
             'failures' => [],
             'sidecars' => [],
         ];
+
+        if ($target === 1048) {
+            $payload['target'] = 'detail_ready_1048';
+            $payload['product_surface'] = [
+                'directory_member_count' => 1048,
+                'career_jobs_item_count' => 1048,
+                'detail_ready_count' => 1048,
+                'public_detail_indexable_count' => 1048,
+                'canonical_public_slug_count' => 1048,
+            ];
+            $payload['found_published'] = 2096;
+            $payload['release_gate']['pass_count'] = 2096;
+        }
+
+        return $payload;
     }
 
     /**

--- a/backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php
@@ -91,6 +91,23 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
         $this->assertSame(5572, $payload['expected_locale_rows']);
     }
 
+    public function test_detail_ready_1048_target_expected_rows_are_computed(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(30, 1048, 1018, 'detail_ready_1048')),
+            '--target' => 'detail_ready_1048',
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame('detail_ready_1048', $payload['target']);
+        $this->assertSame(1048, $payload['target_public_total']);
+        $this->assertSame(2096, $payload['expected_locale_rows']);
+        $this->assertTrue(data_get($payload, 'validation.full_visible_publication_gate.required'));
+        $this->assertSame('RUN_DETAIL_READY_1048_LIVE_ACCEPTANCE_READ_ONLY', $payload['next_required_action']);
+    }
+
     public function test_passes_when_accepted_live_acceptance_artifact_is_supplied(): void
     {
         $exitCode = $this->callCommand([
@@ -209,6 +226,43 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
         $this->assertSame([], data_get($payload, 'validation.full_visible_publication_gate.product_claim.blocked_claims'));
     }
 
+    public function test_detail_ready_1048_live_acceptance_passes_only_with_product_visible_counts(): void
+    {
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(30, 1048, 1018, 'detail_ready_1048')),
+            '--target' => 'detail_ready_1048',
+            '--live-acceptance' => $this->writeJson('live-acceptance', $this->fullVisible1048Acceptance()),
+        ]);
+        $payload = $this->payload();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['accepted']);
+        $this->assertSame('DETAIL_READY_1048_LIVE_ACCEPTANCE_COMPLETE', $payload['next_required_action']);
+        $this->assertSame(1048, data_get($payload, 'validation.full_visible_publication_gate.directory_member_count'));
+        $this->assertSame(2096, data_get($payload, 'validation.full_visible_publication_gate.found_published_locale_rows'));
+    }
+
+    public function test_detail_ready_1048_live_acceptance_blocks_forbidden_sitemap_llms_urls(): void
+    {
+        $artifact = $this->fullVisible1048Acceptance();
+        $artifact['product_surface']['sitemap_noindex_url_count'] = 1;
+        $artifact['product_surface']['llms_full_redirect_source_url_count'] = 1;
+
+        $exitCode = $this->callCommand([
+            '--target-delta' => $this->writeJson('target-delta', $this->progressiveTargetDelta(30, 1048, 1018, 'detail_ready_1048')),
+            '--target' => 'detail_ready_1048',
+            '--live-acceptance' => $this->writeJson('live-acceptance', $artifact),
+        ]);
+        $payload = $this->payload();
+        $reasons = array_column($payload['blockers'], 'reason');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('product_forbidden_sitemap_noindex_urls_present', $reasons);
+        $this->assertContains('product_forbidden_llms_full_redirect_source_urls_present', $reasons);
+    }
+
     /**
      * @param  array<string, mixed>  $options
      */
@@ -244,7 +298,7 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
     /**
      * @return array<string, mixed>
      */
-    private function progressiveTargetDelta(int $current, int $target, int $delta): array
+    private function progressiveTargetDelta(int $current, int $target, int $delta, ?string $targetKey = null): array
     {
         $currentSlugs = $this->slugs('current', $current);
         $deltaSlugs = $this->slugs('delta', $delta);
@@ -252,6 +306,7 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
         return [
             'schema_version' => 'career_progressive_cohort_delta_plan.v1',
             'status' => 'pass',
+            'target' => $targetKey,
             'read_only' => true,
             'writes_database' => false,
             'current_public_total' => $current,
@@ -319,6 +374,33 @@ final class CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest extends 
             'found_published' => 5572,
             'release_gate' => [
                 'pass_count' => 5572,
+                'blocked_count' => 0,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fullVisible1048Acceptance(): array
+    {
+        return [
+            'status' => 'pass',
+            'accepted' => true,
+            'expected_rows' => 2096,
+            'target_public_total' => 1048,
+            'read_only' => true,
+            'writes_database' => false,
+            'product_surface' => [
+                'directory_member_count' => 1048,
+                'career_jobs_item_count' => 1048,
+                'detail_ready_count' => 1048,
+                'public_detail_indexable_count' => 1048,
+                'canonical_public_slug_count' => 1048,
+            ],
+            'found_published' => 2096,
+            'release_gate' => [
+                'pass_count' => 2096,
                 'blocked_count' => 0,
             ],
         ];

--- a/backend/tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php
@@ -85,6 +85,23 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
         $this->assertSame(5572, $result['expected_locale_rows']);
     }
 
+    public function test_plans_detail_ready_1048_live_acceptance_rows(): void
+    {
+        $result = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->progressiveTargetDelta(current: 30, target: 1048, delta: 1018, targetKey: 'detail_ready_1048'),
+            targetPublicTotal: 1048,
+            target: 'detail_ready_1048',
+        )->toArray();
+
+        $this->assertSame('detail_ready_1048', $result['target']);
+        $this->assertSame(30, $result['baseline_count']);
+        $this->assertSame(1018, $result['delta_count']);
+        $this->assertSame(1048, $result['total_slug_count']);
+        $this->assertSame(2096, $result['expected_locale_rows']);
+        $this->assertTrue(data_get($result, 'validation.full_visible_publication_gate.required'));
+        $this->assertSame('RUN_DETAIL_READY_1048_LIVE_ACCEPTANCE_READ_ONLY', $result['next_required_action']);
+    }
+
     public function test_passes_progressive_acceptance_when_artifact_is_accepted(): void
     {
         $result = (new Career80TotalLiveAcceptancePlanner)->plan(
@@ -96,6 +113,22 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
         $this->assertSame('pass', $result['status']);
         $this->assertTrue($result['accepted']);
         $this->assertSame('PROGRESSIVE_LIVE_ACCEPTANCE_COMPLETE', $result['next_required_action']);
+    }
+
+    public function test_detail_ready_1048_acceptance_requires_product_visible_counts(): void
+    {
+        $result = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->progressiveTargetDelta(current: 30, target: 1048, delta: 1018, targetKey: 'detail_ready_1048'),
+            liveAcceptance: $this->fullVisible1048Acceptance(),
+            targetPublicTotal: 1048,
+            target: 'detail_ready_1048',
+        )->toArray();
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertTrue($result['accepted']);
+        $this->assertSame('DETAIL_READY_1048_LIVE_ACCEPTANCE_COMPLETE', $result['next_required_action']);
+        $this->assertSame(1048, data_get($result, 'validation.full_visible_publication_gate.career_jobs_item_count'));
+        $this->assertTrue(data_get($result, 'validation.full_visible_publication_gate.product_claim.visible_detail_claim_allowed'));
     }
 
     public function test_blocks_when_target_total_does_not_match_combined_slugs(): void
@@ -159,6 +192,25 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
         $this->assertContains('live_acceptance_expected_rows_mismatch', array_column($result['blockers'], 'reason'));
     }
 
+    public function test_detail_ready_1048_blocks_forbidden_sitemap_and_llms_exposure(): void
+    {
+        $artifact = $this->fullVisible1048Acceptance();
+        $artifact['product_surface']['sitemap_redirect_source_url_count'] = 1;
+        $artifact['product_surface']['llms_noindex_url_count'] = 1;
+
+        $result = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->progressiveTargetDelta(current: 30, target: 1048, delta: 1018, targetKey: 'detail_ready_1048'),
+            liveAcceptance: $artifact,
+            targetPublicTotal: 1048,
+            target: 'detail_ready_1048',
+        )->toArray();
+        $reasons = array_column($result['blockers'], 'reason');
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertContains('product_forbidden_sitemap_redirect_source_urls_present', $reasons);
+        $this->assertContains('product_forbidden_llms_noindex_urls_present', $reasons);
+    }
+
     /**
      * @return list<string>
      */
@@ -199,7 +251,7 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function progressiveTargetDelta(int $current, int $target, int $delta): array
+    private function progressiveTargetDelta(int $current, int $target, int $delta, ?string $targetKey = null): array
     {
         $currentSlugs = $this->slugs('current', $current);
         $deltaSlugs = $this->slugs('delta', $delta);
@@ -207,6 +259,7 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
         return [
             'schema_version' => 'career_progressive_cohort_delta_plan.v1',
             'status' => 'pass',
+            'target' => $targetKey,
             'read_only' => true,
             'writes_database' => false,
             'current_public_total' => $current,
@@ -252,6 +305,33 @@ final class Career80TotalLiveAcceptancePlannerTest extends TestCase
             'expected_rows' => $expectedRows,
             'read_only' => true,
             'writes_database' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fullVisible1048Acceptance(): array
+    {
+        return [
+            'status' => 'pass',
+            'accepted' => true,
+            'expected_rows' => 2096,
+            'target_public_total' => 1048,
+            'read_only' => true,
+            'writes_database' => false,
+            'product_surface' => [
+                'directory_member_count' => 1048,
+                'career_jobs_item_count' => 1048,
+                'detail_ready_count' => 1048,
+                'public_detail_indexable_count' => 1048,
+                'canonical_public_slug_count' => 1048,
+            ],
+            'found_published' => 2096,
+            'release_gate' => [
+                'pass_count' => 2096,
+                'blocked_count' => 0,
+            ],
         ];
     }
 }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerFullVisiblePublicationGateTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerFullVisiblePublicationGateTest.php
@@ -56,4 +56,59 @@ final class CareerFullVisiblePublicationGateTest extends TestCase
         $this->assertSame(2786, $summary['public_detail_indexable_count']);
         $this->assertTrue($summary['product_claim']['visible_detail_claim_allowed']);
     }
+
+    public function test_1048_gate_requires_product_visible_detail_counts(): void
+    {
+        $gate = new CareerFullVisiblePublicationGate;
+        $liveAcceptance = [
+            'product_surface' => [
+                'directory_member_count' => 1048,
+                'career_jobs_item_count' => 1048,
+                'detail_ready_count' => 1048,
+                'public_detail_indexable_count' => 1048,
+                'canonical_public_slug_count' => 1048,
+            ],
+            'found_published' => 2096,
+            'release_gate' => [
+                'pass_count' => 2096,
+            ],
+        ];
+
+        $summary = $gate->summary($liveAcceptance, 1048, 2);
+
+        $this->assertSame([], $gate->blockers($liveAcceptance, 1048, 2));
+        $this->assertTrue($summary['required']);
+        $this->assertSame(1048, $summary['directory_member_count']);
+        $this->assertTrue($summary['product_claim']['visible_detail_claim_allowed']);
+        $this->assertSame('product_visible_detail_publication', $summary['product_claim']['safe_claim_scope']);
+    }
+
+    public function test_1048_gate_blocks_sitemap_and_llms_forbidden_url_exposure(): void
+    {
+        $gate = new CareerFullVisiblePublicationGate;
+        $liveAcceptance = [
+            'product_surface' => [
+                'directory_member_count' => 1048,
+                'career_jobs_item_count' => 1048,
+                'detail_ready_count' => 1048,
+                'public_detail_indexable_count' => 1048,
+                'canonical_public_slug_count' => 1048,
+                'sitemap_noindex_url_count' => 1,
+                'llms_404_url_count' => 2,
+                'llms_full_redirect_source_url_count' => 3,
+            ],
+            'found_published' => 2096,
+            'release_gate' => [
+                'pass_count' => 2096,
+            ],
+        ];
+
+        $summary = $gate->summary($liveAcceptance, 1048, 2);
+        $reasons = array_column($gate->blockers($liveAcceptance, 1048, 2), 'reason');
+
+        $this->assertSame(1, $summary['forbidden_exposure_counts']['sitemap_noindex_urls']);
+        $this->assertContains('product_forbidden_sitemap_noindex_urls_present', $reasons);
+        $this->assertContains('product_forbidden_llms_404_urls_present', $reasons);
+        $this->assertContains('product_forbidden_llms_full_redirect_source_urls_present', $reasons);
+    }
 }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerLiveAcceptance1048CloseoutPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerLiveAcceptance1048CloseoutPlannerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Audit;
+
+use App\Domain\Career\Audit\Career80TotalLiveAcceptancePlanner;
+use App\Domain\Career\Audit\CareerProgressiveCohortCloseoutPlanner;
+use Tests\TestCase;
+
+final class CareerLiveAcceptance1048CloseoutPlannerTest extends TestCase
+{
+    public function test_detail_ready_1048_live_acceptance_and_closeout_use_product_visible_counts(): void
+    {
+        $liveAcceptance = (new Career80TotalLiveAcceptancePlanner)->plan(
+            targetDelta: $this->targetDelta(),
+            liveAcceptance: $this->acceptedLiveAcceptance(),
+            targetPublicTotal: 1048,
+            target: 'detail_ready_1048',
+        )->toArray();
+
+        $this->assertSame('pass', $liveAcceptance['status']);
+        $this->assertSame('DETAIL_READY_1048_LIVE_ACCEPTANCE_COMPLETE', $liveAcceptance['next_required_action']);
+
+        $closeout = (new CareerProgressiveCohortCloseoutPlanner)->closeout(
+            liveAcceptance: $liveAcceptance,
+            totalSlugsPath: '/tmp/career_detail_ready_1048_total_slugs.txt',
+        )->toArray();
+
+        $this->assertSame('complete', $closeout['status']);
+        $this->assertSame('detail_ready_1048', $closeout['target']);
+        $this->assertSame('CAREER_DETAIL_READY_1048_CLOSEOUT_COMPLETE', $closeout['next_required_action']);
+        $this->assertTrue(data_get($closeout, 'acceptance_summary.full_visible_publication_gate.product_claim.visible_detail_claim_allowed'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function targetDelta(): array
+    {
+        $baseline = $this->slugs('current', 30);
+        $delta = $this->slugs('delta', 1018);
+
+        return [
+            'schema_version' => 'career_progressive_cohort_delta_plan.v1',
+            'status' => 'pass',
+            'target' => 'detail_ready_1048',
+            'read_only' => true,
+            'writes_database' => false,
+            'current_public_total' => 30,
+            'target_public_total' => 1048,
+            'delta_slug_count' => 1018,
+            'current_public_slugs' => $baseline,
+            'delta_promotion_slugs' => $delta,
+            'recommended_rollout_delta_slugs' => $delta,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function acceptedLiveAcceptance(): array
+    {
+        return [
+            'status' => 'pass',
+            'accepted' => true,
+            'expected_rows' => 2096,
+            'target_public_total' => 1048,
+            'read_only' => true,
+            'writes_database' => false,
+            'product_surface' => [
+                'directory_member_count' => 1048,
+                'career_jobs_item_count' => 1048,
+                'detail_ready_count' => 1048,
+                'public_detail_indexable_count' => 1048,
+                'canonical_public_slug_count' => 1048,
+            ],
+            'found_published' => 2096,
+            'release_gate' => [
+                'pass_count' => 2096,
+                'blocked_count' => 0,
+            ],
+            'failures' => [],
+            'sidecars' => [],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(string $prefix, int $count): array
+    {
+        $slugs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $slugs[] = sprintf('%s-%04d', $prefix, $i);
+        }
+
+        return $slugs;
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php
@@ -66,6 +66,22 @@ final class CareerProgressiveCohortCloseoutPlannerTest extends TestCase
         $this->assertSame('product_visible_detail_publication', data_get($result, 'acceptance_summary.full_visible_publication_gate.product_claim.safe_claim_scope'));
     }
 
+    public function test_closes_out_detail_ready_1048_cohort(): void
+    {
+        $result = (new CareerProgressiveCohortCloseoutPlanner)->closeout(
+            liveAcceptance: $this->liveAcceptance(target: 1048, baseline: 30, delta: 1018),
+            totalSlugsPath: '/tmp/career_detail_ready_1048_total_slugs.txt',
+        )->toArray();
+
+        $this->assertSame('detail_ready_1048', $result['target']);
+        $this->assertSame(1048, $result['target_public_total']);
+        $this->assertSame(30, $result['baseline_count']);
+        $this->assertSame(1018, $result['delta_count']);
+        $this->assertSame(2096, $result['expected_locale_rows']);
+        $this->assertSame('CAREER_DETAIL_READY_1048_CLOSEOUT_COMPLETE', $result['next_required_action']);
+        $this->assertTrue(data_get($result, 'acceptance_summary.full_visible_publication_gate.product_claim.visible_detail_claim_allowed'));
+    }
+
     public function test_refuses_closeout_when_acceptance_failed(): void
     {
         $artifact = $this->liveAcceptance(target: 300, baseline: 80, delta: 220);
@@ -157,6 +173,19 @@ final class CareerProgressiveCohortCloseoutPlannerTest extends TestCase
             'failures' => [],
             'sidecars' => [],
         ];
+
+        if ($target === 1048) {
+            $artifact['target'] = 'detail_ready_1048';
+            $artifact['product_surface'] = [
+                'directory_member_count' => 1048,
+                'career_jobs_item_count' => 1048,
+                'detail_ready_count' => 1048,
+                'public_detail_indexable_count' => 1048,
+                'canonical_public_slug_count' => 1048,
+            ];
+            $artifact['found_published'] = 2096;
+            $artifact['release_gate']['pass_count'] = 2096;
+        }
 
         if ($target === 2786) {
             $artifact['product_surface'] = [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29407,7 +29407,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-LIVE-ACCEPTANCE-CLOSEOUT-1": {
-    "status": "local_commit_created",
+    "status": "pr_open",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-live-acceptance-closeout-1",
     "base": "main",
@@ -29416,7 +29416,7 @@
     ],
     "title": "fix(api): accept career detail-ready 1048 closeout",
     "commit_sha": "02411442575c3a403dce12a31779d60507cc3dd1",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1730",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -29481,6 +29481,11 @@
         "at": "2026-05-27T21:12:57+08:00",
         "status": "local_commit_created",
         "summary": "Created local commit 02411442575c3a403dce12a31779d60507cc3dd1 for detail-ready 1048 live acceptance and closeout read-only support."
+      },
+      {
+        "at": "2026-05-27T21:14:11+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #1730 for detail-ready 1048 live acceptance and closeout read-only support."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29407,7 +29407,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-LIVE-ACCEPTANCE-CLOSEOUT-1": {
-    "status": "local_checks_passed",
+    "status": "local_commit_created",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-live-acceptance-closeout-1",
     "base": "main",
@@ -29415,7 +29415,7 @@
       "REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1"
     ],
     "title": "fix(api): accept career detail-ready 1048 closeout",
-    "commit_sha": null,
+    "commit_sha": "02411442575c3a403dce12a31779d60507cc3dd1",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -29476,6 +29476,11 @@
         "at": "2026-05-27T21:12:05+08:00",
         "status": "scope_validation_passed",
         "summary": "Changed files are within live acceptance closeout PR allowed paths; generated BIG5_OCEAN compiled artifacts were restored as out-of-scope CI side effects."
+      },
+      {
+        "at": "2026-05-27T21:12:57+08:00",
+        "status": "local_commit_created",
+        "summary": "Created local commit 02411442575c3a403dce12a31779d60507cc3dd1 for detail-ready 1048 live acceptance and closeout read-only support."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29324,7 +29324,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-ROLLOUT-GATE-1": {
-    "status": "local_commit_created",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-rollout-gate-1",
     "base": "main",
@@ -29332,12 +29332,12 @@
       "REPAIR-CAREER-DETAIL-READY-RUNTIME-ARTIFACT-REFRESH-1"
     ],
     "title": "fix(api): gate career detail-ready 1048 rollout",
-    "commit_sha": "2ff39fd7a7301b985163de368081a4d36775a8a0",
-    "pr_url": null,
+    "commit_sha": "69216f556cecf0b504632f52443cc7dafda13b39",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1729",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-27T12:51:43Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "local": {
         "status": "passed",
@@ -29398,11 +29398,16 @@
         "at": "2026-05-27T20:34:00+08:00",
         "status": "local_commit_created",
         "summary": "Created local commit 2ff39fd7a7301b985163de368081a4d36775a8a0 for detail-ready 1048 rollout gate dry-run support."
+      },
+      {
+        "at": "2026-05-27T21:02:38+08:00",
+        "status": "merged_reconciled",
+        "summary": "Reconciled PR #1729 after squash merge commit 69216f556cecf0b504632f52443cc7dafda13b39; remote branch deleted and local task branch cleaned up."
       }
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-LIVE-ACCEPTANCE-CLOSEOUT-1": {
-    "status": "planned",
+    "status": "local_checks_passed",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-live-acceptance-closeout-1",
     "base": "main",
@@ -29416,7 +29421,62 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "checks": {},
-    "history": []
+    "checks": {
+      "local": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test --filter=CareerDetailReady --no-ansi",
+          "cd backend && php artisan test --filter=CareerLiveAcceptance --no-ansi",
+          "cd backend && php artisan test tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php tests/Feature/Console/CareerCloseoutCanonicalProgressiveCohortCommandTest.php tests/Unit/Domain/Career/Audit/CareerFullVisiblePublicationGateTest.php --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "bash backend/scripts/ci_verify_mbti.sh",
+          "git diff --check",
+          "git diff --cached --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+        ],
+        "notes": "DetailReady, CareerLiveAcceptance, focused live acceptance/closeout tests, route list, Pint, backend MBTI CI, diff checks, and JSON validation passed locally. backend/scripts/ci_verify_mbti.sh regenerated BIG5_OCEAN compiled artifacts as a local side effect; those generated diffs were restored because they are outside this PR scope."
+      },
+      "scope": {
+        "status": "passed",
+        "changed_files": [
+          "backend/app/Domain/Career/Audit/Career80TotalLiveAcceptancePlanner.php",
+          "backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php",
+          "backend/app/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlanner.php",
+          "backend/docs/career/audits/product_visible_claim_authority.md",
+          "backend/docs/career/audits/progressive_closeout.md",
+          "backend/docs/career/audits/progressive_live_acceptance.md",
+          "backend/tests/Feature/Console/CareerCloseoutCanonicalProgressiveCohortCommandTest.php",
+          "backend/tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php",
+          "backend/tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php",
+          "backend/tests/Unit/Domain/Career/Audit/CareerFullVisiblePublicationGateTest.php",
+          "backend/tests/Unit/Domain/Career/Audit/CareerLiveAcceptance1048CloseoutPlannerTest.php",
+          "backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php",
+          "docs/codex/pr-train-state.json"
+        ],
+        "outside_scope": [],
+        "diff_checks": [
+          "git diff --check",
+          "git diff --cached --check"
+        ]
+      }
+    },
+    "history": [
+      {
+        "at": "2026-05-27T21:02:38+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started detail_ready_1048 live acceptance and closeout read-only support from latest main; no live crawl, deploy, rollout apply, production mutation, or CMS mutation."
+      },
+      {
+        "at": "2026-05-27T21:12:05+08:00",
+        "status": "local_checks_passed",
+        "summary": "CareerDetailReady, CareerLiveAcceptance, focused 1048 live acceptance/closeout tests, route list, Pint, backend MBTI CI, diff checks, and JSON validation passed locally."
+      },
+      {
+        "at": "2026-05-27T21:12:05+08:00",
+        "status": "scope_validation_passed",
+        "summary": "Changed files are within live acceptance closeout PR allowed paths; generated BIG5_OCEAN compiled artifacts were restored as out-of-scope CI side effects."
+      }
+    ]
   }
 }


### PR DESCRIPTION
## What changed
- Adds `detail_ready_1048` support to the read-only Career progressive live acceptance and closeout planners.
- Requires product-visible evidence for the 1048 target: dataset/directory member count, jobs item count, detail-ready count, public detail-indexable count, and 2096 locale rows for `en,zh`.
- Extends the product-visible gate to reject noindex, 404, or redirect-source exposure in sitemap, `llms`, and `llms-full` evidence.
- Documents the 1048 acceptance/closeout contract and reconciles the prior rollout-gate PR state in the train ledger.

## Why
This is the final read-only closeout support PR in the Career detail-ready 1048 train. It prepares acceptance artifacts to verify product-visible counts rather than partition accounting before any later separately approved production apply/deploy step.

## Validation commands
- `cd backend && php artisan test --filter=CareerDetailReady --no-ansi`
- `cd backend && php artisan test --filter=CareerLiveAcceptance --no-ansi`
- `cd backend && php artisan test tests/Unit/Domain/Career/Audit/Career80TotalLiveAcceptancePlannerTest.php tests/Feature/Console/CareerValidateCanonicalProgressiveLiveAcceptanceCommandTest.php tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php tests/Feature/Console/CareerCloseoutCanonicalProgressiveCohortCommandTest.php tests/Unit/Domain/Career/Audit/CareerFullVisiblePublicationGateTest.php --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- `git diff --cached --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`

## Intentionally deferred
- No live crawl was executed.
- No production DB mutation, rollout apply, deploy, CMS mutation, Search Channel action, URL submission, fap-web change, or pSEO generation was performed.
- This does not publish 2289 excluded/raw assets, all 2786 occupations, or force-enable `software-developers`.

## Repository rule impact
Career publication authority remains backend/runtime-artifact authoritative. This PR adds planner and test support only; it does not move authority to frontend or CMS fallback content.

## Sidecar blockers
- None introduced by this PR.
