### PR TITLE
TAKE-EN-QUESTION-LOCALE-SCAN-00 take flow EN/ZH question locale scan

### DIFF
--- a/backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json
+++ b/backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json
@@ -1,0 +1,400 @@
+{
+  "schema_version": "take-en-question-locale-scan-00.v1",
+  "task": "TAKE-EN-QUESTION-LOCALE-SCAN-00",
+  "final_decision": "question_locale_scan_completed_ready_for_content_pack_fixes",
+  "scan_mode": "read_only_public_api_and_repo_contract_inventory",
+  "observed_at": "2026-05-27T23:11:18+08:00",
+  "no_api_mutation": true,
+  "no_cms_mutation": true,
+  "no_content_pack_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "scanned_surfaces": [
+    "public /api/v0.3/scales/{scale_code}/questions?locale=en",
+    "public /api/v0.3/scales/lookup?locale=en",
+    "backend ScalesController questions locale branches",
+    "backend content pack loaders",
+    "fap-web take clients and question normalizers"
+  ],
+  "summary": {
+    "total_cases_scanned": 12,
+    "visible_english_locale_failures": 5,
+    "visible_english_locale_passes": 7,
+    "affected_scale_codes": [
+      "MBTI",
+      "RIASEC",
+      "ENNEAGRAM"
+    ],
+    "unaffected_scale_codes": [
+      "BIG5_OCEAN",
+      "IQ_RAVEN",
+      "EQ_60",
+      "CLINICAL_COMBO_68",
+      "SDS_20"
+    ]
+  },
+  "question_locale_matrix": [
+    {
+      "scale_code": "MBTI",
+      "form_code": "mbti_93",
+      "public_slug": "mbti-personality-test-16-personality-types",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 93,
+      "visible_en_status": "fail_displayed_chinese_question_and_options",
+      "sample_displayed_text": "你经常结交新朋友。",
+      "sample_displayed_options": [
+        "非常认同",
+        "认同",
+        "不确定",
+        "不认同",
+        "非常不认同"
+      ],
+      "displayed_cjk_item_count": 93,
+      "displayed_cjk_option_count": 465,
+      "frontend_client": "QuizTakeClient",
+      "backend_authority": "QuestionsService::loadByPack via ScalesController MBTI branch",
+      "root_cause": "MBTI questions endpoint accepts locale but returns raw pack fields without locale projection; fap-web generic take client also does not pass locale for MBTI today.",
+      "required_action": "backend_mbti_locale_projection_and_fap_web_locale_contract_guard",
+      "recommended_pr": "MBTI-EN-QUESTIONS-PACK-PROJECTION-01",
+      "severity": "high"
+    },
+    {
+      "scale_code": "MBTI",
+      "form_code": "mbti_144",
+      "public_slug": "mbti-personality-test-16-personality-types",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 144,
+      "visible_en_status": "fail_displayed_chinese_question_and_options",
+      "sample_displayed_text": "你经常结交新朋友。",
+      "sample_displayed_options": [
+        "非常认同",
+        "认同",
+        "不确定",
+        "不认同",
+        "非常不认同"
+      ],
+      "displayed_cjk_item_count": 144,
+      "displayed_cjk_option_count": 720,
+      "frontend_client": "QuizTakeClient",
+      "backend_authority": "QuestionsService::loadByPack via ScalesController MBTI branch",
+      "root_cause": "MBTI questions endpoint accepts locale but returns raw pack fields without locale projection; fap-web generic take client also does not pass locale for MBTI today.",
+      "required_action": "backend_mbti_locale_projection_and_fap_web_locale_contract_guard",
+      "recommended_pr": "MBTI-EN-QUESTIONS-PACK-PROJECTION-01",
+      "severity": "high"
+    },
+    {
+      "scale_code": "BIG5_OCEAN",
+      "form_code": "big5_90",
+      "public_slug": "big-five-personality-test-ocean-model",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 90,
+      "visible_en_status": "pass_displayed_english",
+      "sample_displayed_text": "I tend to worry a lot.",
+      "sample_displayed_options": [
+        "Strongly Disagree",
+        "Disagree",
+        "Neutral",
+        "Agree",
+        "Strongly Agree"
+      ],
+      "displayed_cjk_item_count": 0,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "Big5TakeClient",
+      "backend_authority": "BigFivePackLoader locale projection",
+      "root_cause": null,
+      "required_action": "no_action",
+      "recommended_pr": null,
+      "severity": "none"
+    },
+    {
+      "scale_code": "BIG5_OCEAN",
+      "form_code": "big5_120",
+      "public_slug": "big-five-personality-test-ocean-model",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 120,
+      "visible_en_status": "pass_displayed_english",
+      "sample_displayed_text": "I tend to worry a lot.",
+      "sample_displayed_options": [
+        "Strongly Disagree",
+        "Disagree",
+        "Neutral",
+        "Agree",
+        "Strongly Agree"
+      ],
+      "displayed_cjk_item_count": 0,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "Big5TakeClient",
+      "backend_authority": "BigFivePackLoader locale projection",
+      "root_cause": null,
+      "required_action": "no_action",
+      "recommended_pr": null,
+      "severity": "none"
+    },
+    {
+      "scale_code": "RIASEC",
+      "form_code": "riasec_60",
+      "public_slug": "holland-career-interest-test-riasec",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 60,
+      "visible_en_status": "fail_displayed_chinese_question_text",
+      "sample_displayed_text": "我喜欢动手搭建、修理或改装东西。",
+      "sample_displayed_options": [
+        "Strongly dislike",
+        "Dislike",
+        "Neutral",
+        "Like",
+        "Strongly like"
+      ],
+      "displayed_cjk_item_count": 60,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "QuizTakeClient or RiasecTakeClient",
+      "backend_authority": "RiasecPackLoader questions_doc_by_locale.en",
+      "root_cause": "RIASEC English questions document exists but text_en/text display values are Chinese.",
+      "required_action": "backend_riasec_english_question_pack_translation",
+      "recommended_pr": "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02",
+      "severity": "high"
+    },
+    {
+      "scale_code": "RIASEC",
+      "form_code": "riasec_140",
+      "public_slug": "holland-career-interest-test-riasec",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 140,
+      "visible_en_status": "fail_displayed_chinese_question_text",
+      "sample_displayed_text": "我喜欢动手搭建、修理或改装东西。",
+      "sample_displayed_options": [
+        "Strongly dislike",
+        "Dislike",
+        "Neutral",
+        "Like",
+        "Strongly like"
+      ],
+      "displayed_cjk_item_count": 140,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "QuizTakeClient or RiasecTakeClient",
+      "backend_authority": "RiasecPackLoader questions_doc_by_locale.en",
+      "root_cause": "RIASEC English questions document exists but text_en/text display values are Chinese.",
+      "required_action": "backend_riasec_english_question_pack_translation",
+      "recommended_pr": "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02",
+      "severity": "high"
+    },
+    {
+      "scale_code": "ENNEAGRAM",
+      "form_code": "enneagram_likert_105",
+      "public_slug": "enneagram-personality-test-nine-types",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 105,
+      "visible_en_status": "pass_displayed_english",
+      "sample_displayed_text": "I usually strive to do things as perfectly as possible.",
+      "sample_displayed_options": [
+        "Strongly disagree",
+        "Disagree",
+        "Neutral",
+        "Agree",
+        "Strongly agree"
+      ],
+      "displayed_cjk_item_count": 0,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "EnneagramTakeClient",
+      "backend_authority": "EnneagramPackLoader questions_doc_by_locale.en",
+      "root_cause": null,
+      "required_action": "no_action",
+      "recommended_pr": null,
+      "severity": "none"
+    },
+    {
+      "scale_code": "ENNEAGRAM",
+      "form_code": "enneagram_forced_choice_144",
+      "public_slug": "enneagram-personality-test-nine-types",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 144,
+      "visible_en_status": "fail_displayed_chinese_forced_choice_options",
+      "sample_displayed_text": null,
+      "sample_displayed_options": [
+        "我会留意哪里还能再改进。",
+        "我会主动照顾别人的需要。"
+      ],
+      "displayed_cjk_item_count": 0,
+      "displayed_cjk_option_count": 288,
+      "frontend_client": "EnneagramTakeClient",
+      "backend_authority": "EnneagramPackLoader questions_doc_by_locale.en",
+      "root_cause": "Enneagram forced-choice English questions document exists but choice text_en/display values are Chinese.",
+      "required_action": "backend_enneagram_forced_choice_english_pack_translation",
+      "recommended_pr": "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03",
+      "severity": "medium"
+    },
+    {
+      "scale_code": "IQ_RAVEN",
+      "form_code": null,
+      "public_slug": "iq-test-intelligence-quotient-assessment",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 30,
+      "visible_en_status": "pass_displayed_english_with_zh_fallback_fields_present",
+      "sample_displayed_text": "Which option fits?",
+      "sample_displayed_options": [],
+      "displayed_cjk_item_count": 0,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "QuizTakeClient IQ normalization",
+      "backend_authority": "IQ_RAVEN questions payload with prompt_en/prompt_zh",
+      "root_cause": null,
+      "required_action": "no_action",
+      "recommended_pr": null,
+      "severity": "none"
+    },
+    {
+      "scale_code": "EQ_60",
+      "form_code": null,
+      "public_slug": "eq-test-emotional-intelligence-assessment",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 60,
+      "visible_en_status": "pass_displayed_english",
+      "sample_displayed_text": "I am very good at identifying the emotions I am feeling.",
+      "sample_displayed_options": [
+        "Strongly disagree",
+        "Disagree",
+        "Neutral",
+        "Agree",
+        "Strongly agree"
+      ],
+      "displayed_cjk_item_count": 0,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "QuizTakeClient",
+      "backend_authority": "Eq60PackLoader questions_doc_by_locale.en",
+      "root_cause": null,
+      "required_action": "no_action",
+      "recommended_pr": null,
+      "severity": "none"
+    },
+    {
+      "scale_code": "CLINICAL_COMBO_68",
+      "form_code": null,
+      "public_slug": "clinical-depression-anxiety-assessment-professional-edition",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 68,
+      "visible_en_status": "pass_displayed_english",
+      "sample_displayed_text": "Over the past two weeks, you felt unmotivated and had little interest in doing things.",
+      "sample_displayed_options": [
+        "Not at all",
+        "Several days",
+        "More than half the days",
+        "Nearly every day"
+      ],
+      "displayed_cjk_item_count": 0,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "ClinicalTakeClient",
+      "backend_authority": "ClinicalComboPackLoader questions_doc_by_locale.en",
+      "root_cause": null,
+      "required_action": "no_action",
+      "recommended_pr": null,
+      "severity": "none"
+    },
+    {
+      "scale_code": "SDS_20",
+      "form_code": null,
+      "public_slug": "sds-20",
+      "locale_requested": "en",
+      "locale_resolved": "en",
+      "question_count": 20,
+      "visible_en_status": "pass_displayed_english",
+      "sample_displayed_text": "I feel down-hearted and blue.",
+      "sample_displayed_options": [
+        "A little of the time",
+        "Some of the time",
+        "Good part of the time",
+        "Most of the time"
+      ],
+      "displayed_cjk_item_count": 0,
+      "displayed_cjk_option_count": 0,
+      "frontend_client": "ClinicalTakeClient",
+      "backend_authority": "Sds20PackLoader questions_doc_by_locale.en",
+      "root_cause": null,
+      "required_action": "no_action",
+      "recommended_pr": null,
+      "severity": "none"
+    }
+  ],
+  "frontend_contract_findings": [
+    {
+      "repo": "fap-web",
+      "file": "app/(localized)/[locale]/tests/[slug]/take/QuizTakeClient.tsx",
+      "finding": "fetchScaleQuestions currently passes locale only for RIASEC in the generic take client path.",
+      "impact": "MBTI can request the default backend locale from the frontend even after backend projection exists unless a contract guard is added.",
+      "required_action": "Add a small fap-web follow-up after backend pack fixes to pass locale for all generic scale questions requests and assert no English take page displays CJK in rendered question text."
+    }
+  ],
+  "recommended_pr_train": [
+    {
+      "id": "MBTI-EN-QUESTIONS-PACK-PROJECTION-01",
+      "repo": "fap-api",
+      "title": "MBTI English question locale projection",
+      "scope": "Fix MBTI mbti_93 and mbti_144 English question and option display fields from backend/content-pack authority.",
+      "likely_files": [
+        "backend/app/Http/Controllers/API/V0_3/ScalesController.php",
+        "backend/app/Services/Content/QuestionsService.php",
+        "content_packages/**/mbti*/**",
+        "backend/tests/**/Mbti*Question*Locale*Test.php"
+      ],
+      "required_checks": [
+        "cd backend && php artisan test --filter=MbtiQuestionLocale --no-ansi",
+        "cd backend && php artisan route:list --no-ansi",
+        "cd backend && vendor/bin/pint --test",
+        "git diff --check"
+      ]
+    },
+    {
+      "id": "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02",
+      "repo": "fap-api",
+      "title": "RIASEC English question pack translation",
+      "scope": "Fix RIASEC riasec_60 and riasec_140 English question stems in backend/content-pack authority.",
+      "likely_files": [
+        "content_packages/**/riasec*/**",
+        "backend/app/Services/Content/RiasecPackLoader.php",
+        "backend/tests/**/Riasec*Question*Locale*Test.php"
+      ],
+      "required_checks": [
+        "cd backend && php artisan test --filter=RiasecQuestionLocale --no-ansi",
+        "cd backend && php artisan route:list --no-ansi",
+        "cd backend && vendor/bin/pint --test",
+        "git diff --check"
+      ]
+    },
+    {
+      "id": "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03",
+      "repo": "fap-api",
+      "title": "Enneagram forced-choice English question pack translation",
+      "scope": "Fix Enneagram forced-choice 144 English option texts while preserving likert_105 behavior.",
+      "likely_files": [
+        "content_packages/**/enneagram*/**",
+        "backend/app/Services/Content/EnneagramPackLoader.php",
+        "backend/tests/**/Enneagram*Question*Locale*Test.php"
+      ],
+      "required_checks": [
+        "cd backend && php artisan test --filter=EnneagramQuestionLocale --no-ansi",
+        "cd backend && php artisan route:list --no-ansi",
+        "cd backend && vendor/bin/pint --test",
+        "git diff --check"
+      ]
+    }
+  ],
+  "future_frontend_follow_up": {
+    "id": "TAKE-FRONTEND-LOCALE-CONTRACT-04",
+    "repo": "fap-web",
+    "title": "Take flow locale contract guard",
+    "scope": "Pass locale to generic scale question fetches and add frontend contract coverage; do not add frontend translation fallback content.",
+    "dependency": "Run after backend/content-pack authority fixes are merged."
+  },
+  "next_task": "MBTI-EN-QUESTIONS-PACK-PROJECTION-01"
+}

--- a/backend/docs/seo/take-en-question-locale-scan-00.md
+++ b/backend/docs/seo/take-en-question-locale-scan-00.md
@@ -1,0 +1,129 @@
+# TAKE-EN-QUESTION-LOCALE-SCAN-00 Report
+
+## Executive Summary
+
+The English take-page Chinese question issue is real and is not limited to MBTI. The scan found five visible English-locale failures across twelve question surfaces:
+
+- MBTI `mbti_93` and `mbti_144` return Chinese displayed question text and Chinese displayed option labels for `locale=en`.
+- RIASEC `riasec_60` and `riasec_140` return Chinese displayed question stems for `locale=en`; options are already English.
+- Enneagram `enneagram_forced_choice_144` returns Chinese displayed forced-choice option text for `locale=en`.
+
+Big Five, IQ, EQ, Clinical Combo, SDS, and Enneagram `likert_105` do not show the same visible English take-page failure in the scanned displayed fields.
+
+No API behavior, content pack, CMS record, publish state, deploy state, sitemap, llms, footer/nav, or Search Channel state was changed.
+
+## Scan Scope
+
+Read-only surfaces inspected:
+
+- Public questions API behavior for `locale=en`.
+- Public lookup API form resolution.
+- Backend `ScalesController` question-loading branches.
+- Backend content pack loader boundaries.
+- fap-web take clients and question normalizers as reference-only consumer context.
+
+Scanned cases:
+
+- MBTI `mbti_93`, `mbti_144`
+- Big Five `big5_90`, `big5_120`
+- RIASEC `riasec_60`, `riasec_140`
+- Enneagram `enneagram_likert_105`, `enneagram_forced_choice_144`
+- IQ Raven
+- EQ 60
+- Clinical Combo 68
+- SDS 20
+
+## Findings
+
+| Scale | Form | EN displayed status | Required action |
+| --- | --- | --- | --- |
+| MBTI | `mbti_93` | FAIL: Chinese question and options | Backend MBTI locale projection |
+| MBTI | `mbti_144` | FAIL: Chinese question and options | Backend MBTI locale projection |
+| Big Five | `big5_90` | PASS | None |
+| Big Five | `big5_120` | PASS | None |
+| RIASEC | `riasec_60` | FAIL: Chinese question stems | Backend RIASEC English pack translation |
+| RIASEC | `riasec_140` | FAIL: Chinese question stems | Backend RIASEC English pack translation |
+| Enneagram | `enneagram_likert_105` | PASS | None |
+| Enneagram | `enneagram_forced_choice_144` | FAIL: Chinese forced-choice options | Backend Enneagram forced-choice English pack translation |
+| IQ Raven | default | PASS | None |
+| EQ 60 | default | PASS | None |
+| Clinical Combo 68 | default | PASS | None |
+| SDS 20 | default | PASS | None |
+
+## Root Cause
+
+### MBTI
+
+The backend MBTI branch resolves the form code and accepts the requested locale, but then falls through to `QuestionsService::loadByPack()`, which returns raw pack question fields. The response reports `locale=en`, but displayed fields remain Chinese. fap-web also has a generic take-flow gap: `QuizTakeClient` passes `locale` only for RIASEC today, so MBTI needs a frontend contract guard after the backend authority fix.
+
+### RIASEC
+
+The backend already uses `RiasecPackLoader::loadQuestionsDoc($locale, $version)`, and the response resolves to `locale=en`. The English questions document is present, but displayed `text` / `text_en` values are Chinese. This is a content-pack authority issue, not a frontend translation issue.
+
+### Enneagram forced-choice
+
+The backend already uses `EnneagramPackLoader::loadQuestionsDoc($locale, $version)`, and the likert 105 English form is clean. The forced-choice 144 English document contains Chinese option display text. This should be fixed in the Enneagram forced-choice pack only.
+
+## Unaffected Surfaces
+
+Big Five uses explicit backend locale projection and returns English displayed fields for `big5_90` and `big5_120`.
+
+IQ includes Chinese fallback fields in the payload, but the English displayed prompt is `prompt_en` and is rendered in English.
+
+EQ, Clinical Combo, SDS, and Enneagram likert 105 returned English displayed fields in the scanned cases.
+
+## Recommended PR Train
+
+1. `MBTI-EN-QUESTIONS-PACK-PROJECTION-01`
+   - Fix MBTI `mbti_93` and `mbti_144` English displayed question and option fields from backend/content-pack authority.
+   - Add API tests for `locale=en` and `locale=zh-CN`.
+
+2. `RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02`
+   - Fix RIASEC `riasec_60` and `riasec_140` English question stems in backend/content-pack authority.
+   - Keep option scoring, order, dimensions, and Chinese locale unchanged.
+
+3. `ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03`
+   - Fix Enneagram forced-choice 144 English option texts.
+   - Preserve Enneagram likert 105 behavior.
+
+4. Follow-up after backend fixes: `TAKE-FRONTEND-LOCALE-CONTRACT-04`
+   - fap-web only.
+   - Pass locale for generic scale question fetches and add a no-CJK contract guard.
+   - Do not add frontend hardcoded translation fallback content.
+
+## What Was Not Done
+
+- No backend API runtime behavior changed.
+- No content pack translations were changed.
+- No CMS mutation occurred.
+- No publish, deploy, Search Channel, sitemap, llms, footer/nav, or URL submission action occurred.
+- No fap-web runtime changes were made.
+
+## Validation
+
+Required validation for this scan PR:
+
+```bash
+cd backend && php artisan test --filter=TakeEnQuestionLocaleScan00 --no-ansi
+cd backend && php artisan route:list --no-ansi
+cd backend && vendor/bin/pint --test
+cd backend && composer validate --strict
+cd backend && composer audit --locked --no-interaction --ignore-unreachable
+python3 -m json.tool backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 - <<'PY'
+import yaml, pathlib
+yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
+print('yaml ok')
+PY
+git diff --check
+git diff --cached --check
+```
+
+## Final Decision
+
+`question_locale_scan_completed_ready_for_content_pack_fixes`
+
+## Next Task
+
+`MBTI-EN-QUESTIONS-PACK-PROJECTION-01`

--- a/backend/tests/Feature/SeoIntel/TakeEnQuestionLocaleScan00Test.php
+++ b/backend/tests/Feature/SeoIntel/TakeEnQuestionLocaleScan00Test.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class TakeEnQuestionLocaleScan00Test extends TestCase
+{
+    #[Test]
+    public function take_en_question_locale_scan_artifact_exists_with_expected_findings(): void
+    {
+        $reportPath = base_path('docs/seo/take-en-question-locale-scan-00.md');
+        $generatedPath = base_path('docs/seo/generated/take-en-question-locale-scan-00.v1.json');
+
+        $this->assertFileExists($reportPath);
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('take-en-question-locale-scan-00.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('TAKE-EN-QUESTION-LOCALE-SCAN-00', $generated['task'] ?? null);
+        $this->assertSame('question_locale_scan_completed_ready_for_content_pack_fixes', $generated['final_decision'] ?? null);
+
+        $matrix = $generated['question_locale_matrix'] ?? null;
+        $this->assertIsArray($matrix);
+        $this->assertCount(12, $matrix);
+
+        $caseByKey = [];
+        foreach ($matrix as $case) {
+            $this->assertIsArray($case);
+            $key = ($case['scale_code'] ?? '').'|'.($case['form_code'] ?? 'default');
+            $caseByKey[$key] = $case;
+        }
+
+        foreach ([
+            'MBTI|mbti_93',
+            'MBTI|mbti_144',
+            'RIASEC|riasec_60',
+            'RIASEC|riasec_140',
+            'ENNEAGRAM|enneagram_forced_choice_144',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $caseByKey);
+            $this->assertStringStartsWith('fail_', (string) ($caseByKey[$key]['visible_en_status'] ?? ''));
+            $this->assertNotSame('no_action', $caseByKey[$key]['required_action'] ?? null);
+        }
+
+        foreach ([
+            'BIG5_OCEAN|big5_90',
+            'BIG5_OCEAN|big5_120',
+            'ENNEAGRAM|enneagram_likert_105',
+            'IQ_RAVEN|default',
+            'EQ_60|default',
+            'CLINICAL_COMBO_68|default',
+            'SDS_20|default',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $caseByKey);
+            $this->assertStringStartsWith('pass_', (string) ($caseByKey[$key]['visible_en_status'] ?? ''));
+            $this->assertSame('no_action', $caseByKey[$key]['required_action'] ?? null);
+        }
+
+        $recommendedTrain = $generated['recommended_pr_train'] ?? null;
+        $this->assertIsArray($recommendedTrain);
+        $this->assertSame([
+            'MBTI-EN-QUESTIONS-PACK-PROJECTION-01',
+            'RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02',
+            'ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03',
+        ], array_column($recommendedTrain, 'id'));
+
+        $this->assertTrue($generated['no_api_mutation'] ?? false);
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_content_pack_mutation'] ?? false);
+        $this->assertTrue($generated['no_publish'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertSame('MBTI-EN-QUESTIONS-PACK-PROJECTION-01', $generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29557,11 +29557,11 @@
     "repo": "fap-api",
     "branch": "codex/take-en-question-locale-scan-00",
     "base": "main",
-    "status": "local_validation_passed",
+    "status": "pr_opened",
     "depends_on": [],
     "title": "TAKE-EN-QUESTION-LOCALE-SCAN-00 take flow EN/ZH question locale scan",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "75b26a54aa2e66cb892d58e88b526f7848d6ac4c",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1732",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -29605,6 +29605,10 @@
           "git diff --cached --check"
         ],
         "evidence": "Focused test, route list, Pint, composer validate, composer audit, JSON/YAML parse, and diff checks passed locally."
+      },
+      "github_required_checks": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1732"
       }
     },
     "scope": {
@@ -29640,6 +29644,11 @@
         "at": "2026-05-27T23:18:00+08:00",
         "status": "scope_validation_passed",
         "summary": "Scope is limited to scan artifacts, focused test, and manifest/state; no API runtime, content pack, CMS, publish, deploy, Search Channel, URL submission, or fap-web runtime change."
+      },
+      {
+        "at": "2026-05-27T23:22:00+08:00",
+        "status": "pr_opened",
+        "summary": "Opened PR #1732 for the read-only take EN/ZH question locale scan."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T00:00:00+08:00",
+  "updated_at": "2026-05-27T23:11:18+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -29549,6 +29549,97 @@
         "at": "2026-05-27T21:14:11+08:00",
         "status": "pr_open",
         "summary": "Opened PR #1730 for detail-ready 1048 live acceptance and closeout read-only support."
+      }
+    ]
+  },
+  "TAKE-EN-QUESTION-LOCALE-SCAN-00": {
+    "id": "TAKE-EN-QUESTION-LOCALE-SCAN-00",
+    "repo": "fap-api",
+    "branch": "codex/take-en-question-locale-scan-00",
+    "base": "main",
+    "status": "local_validation_passed",
+    "depends_on": [],
+    "title": "TAKE-EN-QUESTION-LOCALE-SCAN-00 take flow EN/ZH question locale scan",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User requested the scan PR first before the three backend content-pack fixes; only this scan item was added."
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_files": [
+          "backend/docs/seo/take-en-question-locale-scan-00.md",
+          "backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json",
+          "backend/tests/Feature/SeoIntel/TakeEnQuestionLocaleScan00Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "changed_files": [
+          "backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json",
+          "backend/docs/seo/take-en-question-locale-scan-00.md",
+          "backend/tests/Feature/SeoIntel/TakeEnQuestionLocaleScan00Test.php",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml"
+        ],
+        "outside_scope": [],
+        "evidence": "Changed files are confined to read-only scan artifacts, focused test, and PR train metadata."
+      },
+      "local_validation": {
+        "status": "pass",
+        "commands": [
+          "cd backend && php artisan test --filter=TakeEnQuestionLocaleScan00 --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nprint('yaml ok')\nPY",
+          "git diff --check",
+          "git diff --cached --check"
+        ],
+        "evidence": "Focused test, route list, Pint, composer validate, composer audit, JSON/YAML parse, and diff checks passed locally."
+      }
+    },
+    "scope": {
+      "allowed_files": [
+        "backend/docs/seo/take-en-question-locale-scan-00.md",
+        "backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json",
+        "backend/tests/Feature/SeoIntel/TakeEnQuestionLocaleScan00Test.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "api_runtime_change": false,
+      "content_pack_mutation": false,
+      "cms_mutation": false,
+      "publish": false,
+      "deploy": false,
+      "search_channel_action": false,
+      "url_submission": false,
+      "fap_web_modified": false,
+      "frontend_fallback_authority": false
+    },
+    "history": [
+      {
+        "at": "2026-05-27T23:11:18+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started read-only EN/ZH take-question locale scan from latest main; no API, content-pack, CMS, publish, deploy, Search Channel, sitemap, llms, footer, nav, or fap-web runtime changes."
+      },
+      {
+        "at": "2026-05-27T23:18:00+08:00",
+        "status": "local_validation_passed",
+        "summary": "Generated scan report/JSON/test and validated focused PHPUnit, route list, Pint, composer validate/audit, JSON/YAML parse, and diff checks."
+      },
+      {
+        "at": "2026-05-27T23:18:00+08:00",
+        "status": "scope_validation_passed",
+        "summary": "Scope is limited to scan artifacts, focused test, and manifest/state; no API runtime, content pack, CMS, publish, deploy, Search Channel, URL submission, or fap-web runtime change."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -14968,3 +14968,44 @@ prs:
     content_generation_allowed: false
     frontend_fallback_authority: false
     next_task: DEPLOY-READINESS
+
+  - id: TAKE-EN-QUESTION-LOCALE-SCAN-00
+    repo: fap-api
+    branch: codex/take-en-question-locale-scan-00
+    base: main
+    title: "TAKE-EN-QUESTION-LOCALE-SCAN-00 take flow EN/ZH question locale scan"
+    train_scope: take_question_locale_parity
+    risk_level: p1_read_only_inventory
+    allowed_paths:
+      - backend/docs/seo/take-en-question-locale-scan-00.md
+      - backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json
+      - backend/tests/Feature/SeoIntel/TakeEnQuestionLocaleScan00Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Record a read-only EN/ZH take-question locale inventory for MBTI, Big Five, RIASEC, Enneagram, IQ, EQ, Clinical Combo, and SDS.
+      - Identify backend/content-pack authority failures and affected forms without changing APIs, content packs, CMS, publish state, deploy state, Search Channel, sitemap, llms, footer, or nav.
+      - Produce the follow-up backend content-pack PR plan for MBTI, RIASEC, and Enneagram forced-choice fixes.
+    validation:
+      - cd backend && php artisan test --filter=TakeEnQuestionLocaleScan00 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    content_pack_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: MBTI-EN-QUESTIONS-PACK-PROJECTION-01


### PR DESCRIPTION
## What changed
- Added a read-only EN/ZH take-question locale scan report and generated JSON artifact.
- Added focused PHPUnit coverage that locks the scan artifact shape, affected forms, safe/no-mutation flags, and recommended follow-up PR train.
- Registered the single scan PR in `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json`.

## Why
English take pages can still display Chinese question text for some tests. This PR records the exact affected surfaces before scoped content-pack fixes:
- MBTI `mbti_93` and `mbti_144`: Chinese displayed question text and options under `locale=en`.
- RIASEC `riasec_60` and `riasec_140`: Chinese displayed question stems under `locale=en`.
- Enneagram `enneagram_forced_choice_144`: Chinese displayed forced-choice option text under `locale=en`.

## Validation
- `cd backend && php artisan test --filter=TakeEnQuestionLocaleScan00 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/take-en-question-locale-scan-00.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No API runtime changes.
- No content-pack edits or translations.
- No CMS mutation, publish, deploy, Search Channel action, URL submission, sitemap/llms/footer/nav exposure, or fap-web runtime change.
- Follow-up fixes are separated into MBTI, RIASEC, and Enneagram content-pack scopes.

## Repository rule impact
This is a scan/planning-only PR. It preserves backend/content-pack authority and does not introduce frontend fallback content.
