### PR TITLE
RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02 RIASEC English question pack translation

### DIFF
--- a/backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json
+++ b/backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json
@@ -20,11 +20,11 @@
   "source_asset": "holland_riasec_60_140_design_doc",
   "hashes": {
     "policy.compiled.json": "b07f854e261cf8913fb2dafe94255d4026e52156a78534bda056f08a1d7d5007",
-    "questions.compiled.json": "89a197bdb81453a132f8f3d2df2099d6dcffd7904fea9186ac852669107bc76c"
+    "questions.compiled.json": "a6229a7a745f53d46860737906f952380f00bccfdf46c872abce84a3684540b2"
   },
   "compiled_files": [
     "questions.compiled.json",
     "policy.compiled.json"
   ],
-  "compiled_hash": "fdfa7ebea6bd8f5572ae0d81f87dc3c5284e2bf5be3397211be7085c35809742"
+  "compiled_hash": "24820222d3ffe8904ef6a9883c68636b3ac607e0aaa8db444ff264044a21f7a7"
 }

--- a/backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json
+++ b/backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json
@@ -902,7 +902,7 @@
                     "kind": "interest",
                     "text": "我喜欢动手搭建、修理或改装东西。",
                     "text_zh": "我喜欢动手搭建、修理或改装东西。",
-                    "text_en": "我喜欢动手搭建、修理或改装东西。",
+                    "text_en": "I enjoy building, repairing, or modifying things by hand.",
                     "options": [
                         {
                             "code": "1",
@@ -949,7 +949,7 @@
                     "kind": "interest",
                     "text": "结果直观、看得见摸得着的任务会吸引我。",
                     "text_zh": "结果直观、看得见摸得着的任务会吸引我。",
-                    "text_en": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_en": "Tasks with visible, tangible results appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -996,7 +996,7 @@
                     "kind": "interest",
                     "text": "使用工具、设备或机械让我感到自在。",
                     "text_zh": "使用工具、设备或机械让我感到自在。",
-                    "text_en": "使用工具、设备或机械让我感到自在。",
+                    "text_en": "Using tools, equipment, or machinery feels comfortable to me.",
                     "options": [
                         {
                             "code": "1",
@@ -1043,7 +1043,7 @@
                     "kind": "interest",
                     "text": "比起长时间讨论，我更喜欢直接上手做。",
                     "text_zh": "比起长时间讨论，我更喜欢直接上手做。",
-                    "text_en": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_en": "Compared with long discussions, I prefer to get hands-on and do the work directly.",
                     "options": [
                         {
                             "code": "1",
@@ -1090,7 +1090,7 @@
                     "kind": "interest",
                     "text": "我喜欢解决机械、设备或技术故障。",
                     "text_zh": "我喜欢解决机械、设备或技术故障。",
-                    "text_en": "我喜欢解决机械、设备或技术故障。",
+                    "text_en": "I enjoy troubleshooting mechanical, equipment, or technical problems.",
                     "options": [
                         {
                             "code": "1",
@@ -1137,7 +1137,7 @@
                     "kind": "interest",
                     "text": "我愿意在现场完成需要操作和调整的工作。",
                     "text_zh": "我愿意在现场完成需要操作和调整的工作。",
-                    "text_en": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_en": "I am willing to complete work on site that requires operation and adjustment.",
                     "options": [
                         {
                             "code": "1",
@@ -1184,7 +1184,7 @@
                     "kind": "interest",
                     "text": "我对器材、结构或系统如何运作很感兴趣。",
                     "text_zh": "我对器材、结构或系统如何运作很感兴趣。",
-                    "text_en": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_en": "I am interested in how equipment, structures, or systems work.",
                     "options": [
                         {
                             "code": "1",
@@ -1231,7 +1231,7 @@
                     "kind": "interest",
                     "text": "需要手眼协调和实际操作的任务让我有投入感。",
                     "text_zh": "需要手眼协调和实际操作的任务让我有投入感。",
-                    "text_en": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_en": "Tasks that require hand-eye coordination and practical operation draw me in.",
                     "options": [
                         {
                             "code": "1",
@@ -1278,7 +1278,7 @@
                     "kind": "interest",
                     "text": "把想法变成实体、样品或可执行成果会让我满足。",
                     "text_zh": "把想法变成实体、样品或可执行成果会让我满足。",
-                    "text_en": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_en": "Turning ideas into physical objects, prototypes, or executable outcomes feels satisfying to me.",
                     "options": [
                         {
                             "code": "1",
@@ -1325,7 +1325,7 @@
                     "kind": "interest",
                     "text": "我愿意接触户外、工地、实验场或生产现场类情境。",
                     "text_zh": "我愿意接触户外、工地、实验场或生产现场类情境。",
-                    "text_en": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_en": "I am willing to work in settings such as outdoor sites, work sites, labs, or production environments.",
                     "options": [
                         {
                             "code": "1",
@@ -1372,7 +1372,7 @@
                     "kind": "interest",
                     "text": "我喜欢分析复杂问题并找出原因。",
                     "text_zh": "我喜欢分析复杂问题并找出原因。",
-                    "text_en": "我喜欢分析复杂问题并找出原因。",
+                    "text_en": "I enjoy analyzing complex problems and finding their causes.",
                     "options": [
                         {
                             "code": "1",
@@ -1419,7 +1419,7 @@
                     "kind": "interest",
                     "text": "数据、证据和逻辑会激发我的好奇心。",
                     "text_zh": "数据、证据和逻辑会激发我的好奇心。",
-                    "text_en": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_en": "Data, evidence, and logic spark my curiosity.",
                     "options": [
                         {
                             "code": "1",
@@ -1466,7 +1466,7 @@
                     "kind": "interest",
                     "text": "做决定前，我倾向先研究再行动。",
                     "text_zh": "做决定前，我倾向先研究再行动。",
-                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "text_en": "Before making a decision, I tend to research first and act later.",
                     "options": [
                         {
                             "code": "1",
@@ -1513,7 +1513,7 @@
                     "kind": "interest",
                     "text": "阅读和理解有难度的概念会让我投入。",
                     "text_zh": "阅读和理解有难度的概念会让我投入。",
-                    "text_en": "阅读和理解有难度的概念会让我投入。",
+                    "text_en": "Reading and understanding challenging concepts draws me in.",
                     "options": [
                         {
                             "code": "1",
@@ -1560,7 +1560,7 @@
                     "kind": "interest",
                     "text": "我喜欢从信息中识别规律或模型。",
                     "text_zh": "我喜欢从信息中识别规律或模型。",
-                    "text_en": "我喜欢从信息中识别规律或模型。",
+                    "text_en": "I enjoy identifying patterns or models in information.",
                     "options": [
                         {
                             "code": "1",
@@ -1607,7 +1607,7 @@
                     "kind": "interest",
                     "text": "需要严谨思考的工作更容易吸引我。",
                     "text_zh": "需要严谨思考的工作更容易吸引我。",
-                    "text_en": "需要严谨思考的工作更容易吸引我。",
+                    "text_en": "Work that requires rigorous thinking is more likely to attract me.",
                     "options": [
                         {
                             "code": "1",
@@ -1654,7 +1654,7 @@
                     "kind": "interest",
                     "text": "面对未知问题，我愿意先提出假设再验证。",
                     "text_zh": "面对未知问题，我愿意先提出假设再验证。",
-                    "text_en": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_en": "When facing an unfamiliar problem, I am willing to form hypotheses and then test them.",
                     "options": [
                         {
                             "code": "1",
@@ -1701,7 +1701,7 @@
                     "kind": "interest",
                     "text": "比起凭直觉判断，我更喜欢用事实推理。",
                     "text_zh": "比起凭直觉判断，我更喜欢用事实推理。",
-                    "text_en": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_en": "Compared with judging by intuition, I prefer reasoning from facts.",
                     "options": [
                         {
                             "code": "1",
@@ -1748,7 +1748,7 @@
                     "kind": "interest",
                     "text": "我喜欢把模糊问题拆解成可分析的部分。",
                     "text_zh": "我喜欢把模糊问题拆解成可分析的部分。",
-                    "text_en": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_en": "I enjoy breaking vague problems into parts that can be analyzed.",
                     "options": [
                         {
                             "code": "1",
@@ -1795,7 +1795,7 @@
                     "kind": "interest",
                     "text": "长时间独立思考、研究或探索答案不会让我厌烦。",
                     "text_zh": "长时间独立思考、研究或探索答案不会让我厌烦。",
-                    "text_en": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_en": "Long periods of independent thinking, research, or exploration do not bore me.",
                     "options": [
                         {
                             "code": "1",
@@ -1842,7 +1842,7 @@
                     "kind": "interest",
                     "text": "我喜欢创造新点子和原创成果。",
                     "text_zh": "我喜欢创造新点子和原创成果。",
-                    "text_en": "我喜欢创造新点子和原创成果。",
+                    "text_en": "I enjoy creating new ideas and original work.",
                     "options": [
                         {
                             "code": "1",
@@ -1889,7 +1889,7 @@
                     "kind": "interest",
                     "text": "表达自我是我工作动力的重要来源。",
                     "text_zh": "表达自我是我工作动力的重要来源。",
-                    "text_en": "表达自我是我工作动力的重要来源。",
+                    "text_en": "Self-expression is an important source of work motivation for me.",
                     "options": [
                         {
                             "code": "1",
@@ -1936,7 +1936,7 @@
                     "kind": "interest",
                     "text": "我喜欢尝试不同风格和表达方式。",
                     "text_zh": "我喜欢尝试不同风格和表达方式。",
-                    "text_en": "我喜欢尝试不同风格和表达方式。",
+                    "text_en": "I enjoy trying different styles and ways of expression.",
                     "options": [
                         {
                             "code": "1",
@@ -1983,7 +1983,7 @@
                     "kind": "interest",
                     "text": "相比固定流程，我更喜欢开放式任务。",
                     "text_zh": "相比固定流程，我更喜欢开放式任务。",
-                    "text_en": "相比固定流程，我更喜欢开放式任务。",
+                    "text_en": "Compared with fixed procedures, I prefer open-ended tasks.",
                     "options": [
                         {
                             "code": "1",
@@ -2030,7 +2030,7 @@
                     "kind": "interest",
                     "text": "视觉、文字、声音或概念设计类工作会吸引我。",
                     "text_zh": "视觉、文字、声音或概念设计类工作会吸引我。",
-                    "text_en": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_en": "Work involving visual, written, audio, or conceptual design appeals to me.",
                     "options": [
                         {
                             "code": "1",
@@ -2077,7 +2077,7 @@
                     "kind": "interest",
                     "text": "创造性探索会让我更有能量。",
                     "text_zh": "创造性探索会让我更有能量。",
-                    "text_en": "创造性探索会让我更有能量。",
+                    "text_en": "Creative exploration gives me more energy.",
                     "options": [
                         {
                             "code": "1",
@@ -2124,7 +2124,7 @@
                     "kind": "interest",
                     "text": "我喜欢把抽象感觉转化为作品、内容或方案。",
                     "text_zh": "我喜欢把抽象感觉转化为作品、内容或方案。",
-                    "text_en": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_en": "I enjoy turning abstract feelings into work, content, or solutions.",
                     "options": [
                         {
                             "code": "1",
@@ -2171,7 +2171,7 @@
                     "kind": "interest",
                     "text": "我愿意从零开始构思，而不是只按模板执行。",
                     "text_zh": "我愿意从零开始构思，而不是只按模板执行。",
-                    "text_en": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_en": "I am willing to develop ideas from scratch rather than only follow templates.",
                     "options": [
                         {
                             "code": "1",
@@ -2218,7 +2218,7 @@
                     "kind": "interest",
                     "text": "当一件事可以做得更有美感或更有个性时，我会更投入。",
                     "text_zh": "当一件事可以做得更有美感或更有个性时，我会更投入。",
-                    "text_en": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_en": "When something can be made more aesthetic or more personal, I become more engaged.",
                     "options": [
                         {
                             "code": "1",
@@ -2265,7 +2265,7 @@
                     "kind": "interest",
                     "text": "我享受在没有标准答案的情况下进行创作。",
                     "text_zh": "我享受在没有标准答案的情况下进行创作。",
-                    "text_en": "我享受在没有标准答案的情况下进行创作。",
+                    "text_en": "I enjoy creating when there is no single standard answer.",
                     "options": [
                         {
                             "code": "1",
@@ -2312,7 +2312,7 @@
                     "kind": "interest",
                     "text": "我喜欢帮助他人解决问题。",
                     "text_zh": "我喜欢帮助他人解决问题。",
-                    "text_en": "我喜欢帮助他人解决问题。",
+                    "text_en": "I enjoy helping others solve problems.",
                     "options": [
                         {
                             "code": "1",
@@ -2359,7 +2359,7 @@
                     "kind": "interest",
                     "text": "我重视团队氛围和人际关系。",
                     "text_zh": "我重视团队氛围和人际关系。",
-                    "text_en": "我重视团队氛围和人际关系。",
+                    "text_en": "I value team atmosphere and interpersonal relationships.",
                     "options": [
                         {
                             "code": "1",
@@ -2406,7 +2406,7 @@
                     "kind": "interest",
                     "text": "我愿意耐心倾听他人。",
                     "text_zh": "我愿意耐心倾听他人。",
-                    "text_en": "我愿意耐心倾听他人。",
+                    "text_en": "I am willing to listen to others patiently.",
                     "options": [
                         {
                             "code": "1",
@@ -2453,7 +2453,7 @@
                     "kind": "interest",
                     "text": "包含辅导、支持或服务职责的角色会吸引我。",
                     "text_zh": "包含辅导、支持或服务职责的角色会吸引我。",
-                    "text_en": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_en": "Roles that include coaching, support, or service responsibilities appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -2500,7 +2500,7 @@
                     "kind": "interest",
                     "text": "当工作能真正帮助别人时，我会更有成就感。",
                     "text_zh": "当工作能真正帮助别人时，我会更有成就感。",
-                    "text_en": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_en": "When work can genuinely help other people, I feel a stronger sense of achievement.",
                     "options": [
                         {
                             "code": "1",
@@ -2547,7 +2547,7 @@
                     "kind": "interest",
                     "text": "我喜欢协调多方协作，让事情顺利推进。",
                     "text_zh": "我喜欢协调多方协作，让事情顺利推进。",
-                    "text_en": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_en": "I enjoy coordinating collaboration among different people so things move forward smoothly.",
                     "options": [
                         {
                             "code": "1",
@@ -2594,7 +2594,7 @@
                     "kind": "interest",
                     "text": "我愿意花时间理解他人的需求、情绪或难处。",
                     "text_zh": "我愿意花时间理解他人的需求、情绪或难处。",
-                    "text_en": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_en": "I am willing to spend time understanding other people's needs, emotions, or difficulties.",
                     "options": [
                         {
                             "code": "1",
@@ -2641,7 +2641,7 @@
                     "kind": "interest",
                     "text": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
                     "text_zh": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
-                    "text_en": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_en": "I enjoy using communication to help others feel more reassured, clearer, or more directed.",
                     "options": [
                         {
                             "code": "1",
@@ -2688,7 +2688,7 @@
                     "kind": "interest",
                     "text": "看到别人因我的支持而进步，我会很满足。",
                     "text_zh": "看到别人因我的支持而进步，我会很满足。",
-                    "text_en": "看到别人因我的支持而进步，我会很满足。",
+                    "text_en": "Seeing others make progress because of my support feels satisfying to me.",
                     "options": [
                         {
                             "code": "1",
@@ -2735,7 +2735,7 @@
                     "kind": "interest",
                     "text": "我喜欢需要合作、陪伴或群体互动的工作场景。",
                     "text_zh": "我喜欢需要合作、陪伴或群体互动的工作场景。",
-                    "text_en": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_en": "I enjoy work settings that require cooperation, companionship, or group interaction.",
                     "options": [
                         {
                             "code": "1",
@@ -2782,7 +2782,7 @@
                     "kind": "interest",
                     "text": "我喜欢通过观点影响他人。",
                     "text_zh": "我喜欢通过观点影响他人。",
-                    "text_en": "我喜欢通过观点影响他人。",
+                    "text_en": "I enjoy influencing others through ideas and viewpoints.",
                     "options": [
                         {
                             "code": "1",
@@ -2829,7 +2829,7 @@
                     "kind": "interest",
                     "text": "主导推进事项会让我更有动力。",
                     "text_zh": "主导推进事项会让我更有动力。",
-                    "text_en": "主导推进事项会让我更有动力。",
+                    "text_en": "Taking the lead in moving things forward gives me more motivation.",
                     "options": [
                         {
                             "code": "1",
@@ -2876,7 +2876,7 @@
                     "kind": "interest",
                     "text": "我喜欢设定目标并推动结果达成。",
                     "text_zh": "我喜欢设定目标并推动结果达成。",
-                    "text_en": "我喜欢设定目标并推动结果达成。",
+                    "text_en": "I enjoy setting goals and driving results to completion.",
                     "options": [
                         {
                             "code": "1",
@@ -2923,7 +2923,7 @@
                     "kind": "interest",
                     "text": "我能适应谈判、争取资源或说服他人的场景。",
                     "text_zh": "我能适应谈判、争取资源或说服他人的场景。",
-                    "text_en": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_en": "I can adapt to situations involving negotiation, resource seeking, or persuasion.",
                     "options": [
                         {
                             "code": "1",
@@ -2970,7 +2970,7 @@
                     "kind": "interest",
                     "text": "偏商业导向、增长导向的挑战会吸引我。",
                     "text_zh": "偏商业导向、增长导向的挑战会吸引我。",
-                    "text_en": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_en": "Business-oriented and growth-oriented challenges appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -3017,7 +3017,7 @@
                     "kind": "interest",
                     "text": "在压力下主动承担责任会让我更有存在感。",
                     "text_zh": "在压力下主动承担责任会让我更有存在感。",
-                    "text_en": "在压力下主动承担责任会让我更有存在感。",
+                    "text_en": "Taking responsibility under pressure gives me a stronger sense of presence.",
                     "options": [
                         {
                             "code": "1",
@@ -3064,7 +3064,7 @@
                     "kind": "interest",
                     "text": "我愿意带头组织资源、人和节奏去完成目标。",
                     "text_zh": "我愿意带头组织资源、人和节奏去完成目标。",
-                    "text_en": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_en": "I am willing to lead the coordination of resources, people, and pace to achieve a goal.",
                     "options": [
                         {
                             "code": "1",
@@ -3111,7 +3111,7 @@
                     "kind": "interest",
                     "text": "我喜欢竞争、突破和把机会变成结果的过程。",
                     "text_zh": "我喜欢竞争、突破和把机会变成结果的过程。",
-                    "text_en": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_en": "I enjoy the process of competition, breakthrough, and turning opportunities into results.",
                     "options": [
                         {
                             "code": "1",
@@ -3158,7 +3158,7 @@
                     "kind": "interest",
                     "text": "当一个项目需要有人站出来拍板时，我愿意担当。",
                     "text_zh": "当一个项目需要有人站出来拍板时，我愿意担当。",
-                    "text_en": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_en": "When a project needs someone to step up and make decisions, I am willing to take that role.",
                     "options": [
                         {
                             "code": "1",
@@ -3205,7 +3205,7 @@
                     "kind": "interest",
                     "text": "我对市场、业务、创业或对外拓展类任务有兴趣。",
                     "text_zh": "我对市场、业务、创业或对外拓展类任务有兴趣。",
-                    "text_en": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving markets, business, entrepreneurship, or external development.",
                     "options": [
                         {
                             "code": "1",
@@ -3252,7 +3252,7 @@
                     "kind": "interest",
                     "text": "我偏好清晰流程和结构化工作方式。",
                     "text_zh": "我偏好清晰流程和结构化工作方式。",
-                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "I prefer clear processes and structured ways of working.",
                     "options": [
                         {
                             "code": "1",
@@ -3299,7 +3299,7 @@
                     "kind": "interest",
                     "text": "我重视细节以及质量校验。",
                     "text_zh": "我重视细节以及质量校验。",
-                    "text_en": "我重视细节以及质量校验。",
+                    "text_en": "I value details and quality checks.",
                     "options": [
                         {
                             "code": "1",
@@ -3346,7 +3346,7 @@
                     "kind": "interest",
                     "text": "我喜欢规划安排并跟踪进度。",
                     "text_zh": "我喜欢规划安排并跟踪进度。",
-                    "text_en": "我喜欢规划安排并跟踪进度。",
+                    "text_en": "I enjoy planning, arranging, and tracking progress.",
                     "options": [
                         {
                             "code": "1",
@@ -3393,7 +3393,7 @@
                     "kind": "interest",
                     "text": "对重复但重要的任务，我能稳定执行并且不排斥。",
                     "text_zh": "对重复但重要的任务，我能稳定执行并且不排斥。",
-                    "text_en": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_en": "For repetitive but important tasks, I can execute steadily and do not reject them.",
                     "options": [
                         {
                             "code": "1",
@@ -3440,7 +3440,7 @@
                     "kind": "interest",
                     "text": "规范、一致性和文档化会让我更安心。",
                     "text_zh": "规范、一致性和文档化会让我更安心。",
-                    "text_en": "规范、一致性和文档化会让我更安心。",
+                    "text_en": "Standards, consistency, and documentation make me feel more secure.",
                     "options": [
                         {
                             "code": "1",
@@ -3487,7 +3487,7 @@
                     "kind": "interest",
                     "text": "我喜欢组织、整理和运营执行类工作。",
                     "text_zh": "我喜欢组织、整理和运营执行类工作。",
-                    "text_en": "我喜欢组织、整理和运营执行类工作。",
+                    "text_en": "I enjoy work involving organization, sorting, operations, and execution.",
                     "options": [
                         {
                             "code": "1",
@@ -3534,7 +3534,7 @@
                     "kind": "interest",
                     "text": "我愿意维护台账、清单、记录或标准作业流程。",
                     "text_zh": "我愿意维护台账、清单、记录或标准作业流程。",
-                    "text_en": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_en": "I am willing to maintain ledgers, checklists, records, or standard operating procedures.",
                     "options": [
                         {
                             "code": "1",
@@ -3581,7 +3581,7 @@
                     "kind": "interest",
                     "text": "明确规则和职责边界的环境会让我更高效。",
                     "text_zh": "明确规则和职责边界的环境会让我更高效。",
-                    "text_en": "明确规则和职责边界的环境会让我更高效。",
+                    "text_en": "Environments with clear rules and responsibility boundaries make me more efficient.",
                     "options": [
                         {
                             "code": "1",
@@ -3628,7 +3628,7 @@
                     "kind": "interest",
                     "text": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
                     "text_zh": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
-                    "text_en": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_en": "I enjoy organizing messy information into clear categories and sequences.",
                     "options": [
                         {
                             "code": "1",
@@ -3675,7 +3675,7 @@
                     "kind": "interest",
                     "text": "当事情被安排得井井有条时，我会更有满足感。",
                     "text_zh": "当事情被安排得井井有条时，我会更有满足感。",
-                    "text_en": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_en": "When things are arranged in an orderly way, I feel more satisfied.",
                     "options": [
                         {
                             "code": "1",
@@ -3722,7 +3722,7 @@
                     "kind": "interest",
                     "text": "我喜欢拆解一个装置，再理解各部件如何配合。",
                     "text_zh": "我喜欢拆解一个装置，再理解各部件如何配合。",
-                    "text_en": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "text_en": "I enjoy taking a device apart and understanding how its parts work together.",
                     "options": [
                         {
                             "code": "1",
@@ -3769,7 +3769,7 @@
                     "kind": "interest",
                     "text": "我愿意通过试装、调试或校准来改进成品。",
                     "text_zh": "我愿意通过试装、调试或校准来改进成品。",
-                    "text_en": "我愿意通过试装、调试或校准来改进成品。",
+                    "text_en": "I am willing to improve finished work through trial assembly, testing, or calibration.",
                     "options": [
                         {
                             "code": "1",
@@ -3816,7 +3816,7 @@
                     "kind": "interest",
                     "text": "需要快速判断并现场处理问题的任务会让我兴奋。",
                     "text_zh": "需要快速判断并现场处理问题的任务会让我兴奋。",
-                    "text_en": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "text_en": "Tasks that require quick judgment and on-site problem handling excite me.",
                     "options": [
                         {
                             "code": "1",
@@ -3863,7 +3863,7 @@
                     "kind": "interest",
                     "text": "我喜欢把图纸、说明或想法转成实物成果。",
                     "text_zh": "我喜欢把图纸、说明或想法转成实物成果。",
-                    "text_en": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "text_en": "I enjoy turning drawings, instructions, or ideas into physical outcomes.",
                     "options": [
                         {
                             "code": "1",
@@ -3910,7 +3910,7 @@
                     "kind": "interest",
                     "text": "面对器材或流程异常，我会想亲自去排查。",
                     "text_zh": "面对器材或流程异常，我会想亲自去排查。",
-                    "text_en": "面对器材或流程异常，我会想亲自去排查。",
+                    "text_en": "When equipment or processes behave abnormally, I want to investigate them myself.",
                     "options": [
                         {
                             "code": "1",
@@ -3957,7 +3957,7 @@
                     "kind": "interest",
                     "text": "我对需要耐力、协调或空间感的实操任务有兴趣。",
                     "text_zh": "我对需要耐力、协调或空间感的实操任务有兴趣。",
-                    "text_en": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "text_en": "I am interested in hands-on tasks that require endurance, coordination, or spatial awareness.",
                     "options": [
                         {
                             "code": "1",
@@ -4004,7 +4004,7 @@
                     "kind": "interest",
                     "text": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
                     "text_zh": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
-                    "text_en": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "text_en": "I prefer work environments where I can see equipment, materials, samples, or objects of operation.",
                     "options": [
                         {
                             "code": "1",
@@ -4051,7 +4051,7 @@
                     "kind": "interest",
                     "text": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
                     "text_zh": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
-                    "text_en": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "text_en": "Compared with a purely office-based environment, I prefer settings with a sense of site work or contact with physical objects.",
                     "options": [
                         {
                             "code": "1",
@@ -4098,7 +4098,7 @@
                     "kind": "interest",
                     "text": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
                     "text_zh": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
-                    "text_en": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "text_en": "Working with real systems, real products, or real spaces makes me more engaged.",
                     "options": [
                         {
                             "code": "1",
@@ -4145,7 +4145,7 @@
                     "kind": "interest",
                     "text": "在团队中，我愿意承担安装、实施或落地执行的角色。",
                     "text_zh": "在团队中，我愿意承担安装、实施或落地执行的角色。",
-                    "text_en": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "text_en": "In a team, I am willing to take on installation, implementation, or practical execution roles.",
                     "options": [
                         {
                             "code": "1",
@@ -4192,7 +4192,7 @@
                     "kind": "interest",
                     "text": "当项目进入“把方案做出来”的阶段，我会更想参与。",
                     "text_zh": "当项目进入“把方案做出来”的阶段，我会更想参与。",
-                    "text_en": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "text_en": "When a project reaches the stage of making the plan real, I want to be more involved.",
                     "options": [
                         {
                             "code": "1",
@@ -4239,7 +4239,7 @@
                     "kind": "interest",
                     "text": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
                     "text_zh": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
-                    "text_en": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "text_en": "I prefer being the person who gets things built and stabilized, rather than staying only at the discussion level.",
                     "options": [
                         {
                             "code": "1",
@@ -4286,7 +4286,7 @@
                     "kind": "interest",
                     "text": "我喜欢阅读报告、论文或资料来建立判断。",
                     "text_zh": "我喜欢阅读报告、论文或资料来建立判断。",
-                    "text_en": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "text_en": "I enjoy reading reports, papers, or materials to build my judgment.",
                     "options": [
                         {
                             "code": "1",
@@ -4333,7 +4333,7 @@
                     "kind": "interest",
                     "text": "对一个问题进行比较、分类和验证会让我有满足感。",
                     "text_zh": "对一个问题进行比较、分类和验证会让我有满足感。",
-                    "text_en": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "text_en": "Comparing, classifying, and verifying a problem gives me a sense of satisfaction.",
                     "options": [
                         {
                             "code": "1",
@@ -4380,7 +4380,7 @@
                     "kind": "interest",
                     "text": "我乐于设计研究路径，而不只是接受现成答案。",
                     "text_zh": "我乐于设计研究路径，而不只是接受现成答案。",
-                    "text_en": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "text_en": "I enjoy designing a research path rather than only accepting ready-made answers.",
                     "options": [
                         {
                             "code": "1",
@@ -4427,7 +4427,7 @@
                     "kind": "interest",
                     "text": "我喜欢用模型、框架或假设来理解复杂现象。",
                     "text_zh": "我喜欢用模型、框架或假设来理解复杂现象。",
-                    "text_en": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "text_en": "I enjoy using models, frameworks, or hypotheses to understand complex phenomena.",
                     "options": [
                         {
                             "code": "1",
@@ -4474,7 +4474,7 @@
                     "kind": "interest",
                     "text": "需要精确推理的任务比情绪化判断更吸引我。",
                     "text_zh": "需要精确推理的任务比情绪化判断更吸引我。",
-                    "text_en": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "text_en": "Tasks that require precise reasoning appeal to me more than emotion-driven judgments.",
                     "options": [
                         {
                             "code": "1",
@@ -4521,7 +4521,7 @@
                     "kind": "interest",
                     "text": "我愿意反复核对信息，只为确认结论是否可靠。",
                     "text_zh": "我愿意反复核对信息，只为确认结论是否可靠。",
-                    "text_en": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "text_en": "I am willing to check information repeatedly to confirm whether a conclusion is reliable.",
                     "options": [
                         {
                             "code": "1",
@@ -4568,7 +4568,7 @@
                     "kind": "interest",
                     "text": "我偏好鼓励提问、质疑和求证的工作环境。",
                     "text_zh": "我偏好鼓励提问、质疑和求证的工作环境。",
-                    "text_en": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "text_en": "I prefer work environments that encourage questions, challenge, and verification.",
                     "options": [
                         {
                             "code": "1",
@@ -4615,7 +4615,7 @@
                     "kind": "interest",
                     "text": "在可以安静思考、深入研究的场景里，我通常表现更好。",
                     "text_zh": "在可以安静思考、深入研究的场景里，我通常表现更好。",
-                    "text_en": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "text_en": "I usually perform better in settings where I can think quietly and research deeply.",
                     "options": [
                         {
                             "code": "1",
@@ -4662,7 +4662,7 @@
                     "kind": "interest",
                     "text": "我喜欢重视专业判断和证据质量的组织氛围。",
                     "text_zh": "我喜欢重视专业判断和证据质量的组织氛围。",
-                    "text_en": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "text_en": "I enjoy organizational climates that value professional judgment and evidence quality.",
                     "options": [
                         {
                             "code": "1",
@@ -4709,7 +4709,7 @@
                     "kind": "interest",
                     "text": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
                     "text_zh": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
-                    "text_en": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "text_en": "In a team, I am willing to play the role of analyst, researcher, or problem diagnostician.",
                     "options": [
                         {
                             "code": "1",
@@ -4756,7 +4756,7 @@
                     "kind": "interest",
                     "text": "当别人需要把复杂问题想清楚时，我愿意接手。",
                     "text_zh": "当别人需要把复杂问题想清楚时，我愿意接手。",
-                    "text_en": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "text_en": "When others need to make sense of a complex problem, I am willing to take it on.",
                     "options": [
                         {
                             "code": "1",
@@ -4803,7 +4803,7 @@
                     "kind": "interest",
                     "text": "我更希望因“看得深、想得准”而被需要。",
                     "text_zh": "我更希望因“看得深、想得准”而被需要。",
-                    "text_en": "我更希望因“看得深、想得准”而被需要。",
+                    "text_en": "I would rather be needed for seeing deeply and thinking accurately.",
                     "options": [
                         {
                             "code": "1",
@@ -4850,7 +4850,7 @@
                     "kind": "interest",
                     "text": "我喜欢把普通内容做出独特风格。",
                     "text_zh": "我喜欢把普通内容做出独特风格。",
-                    "text_en": "我喜欢把普通内容做出独特风格。",
+                    "text_en": "I enjoy giving ordinary content a distinctive style.",
                     "options": [
                         {
                             "code": "1",
@@ -4897,7 +4897,7 @@
                     "kind": "interest",
                     "text": "我愿意为一个作品反复打磨形式、语感或审美效果。",
                     "text_zh": "我愿意为一个作品反复打磨形式、语感或审美效果。",
-                    "text_en": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "text_en": "I am willing to polish the form, wording, or aesthetic effect of a piece of work repeatedly.",
                     "options": [
                         {
                             "code": "1",
@@ -4944,7 +4944,7 @@
                     "kind": "interest",
                     "text": "我喜欢从灵感、情绪或体验中生成创意。",
                     "text_zh": "我喜欢从灵感、情绪或体验中生成创意。",
-                    "text_en": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "text_en": "I enjoy generating ideas from inspiration, emotion, or experience.",
                     "options": [
                         {
                             "code": "1",
@@ -4991,7 +4991,7 @@
                     "kind": "interest",
                     "text": "当需要打破常规、换个角度思考时，我会更兴奋。",
                     "text_zh": "当需要打破常规、换个角度思考时，我会更兴奋。",
-                    "text_en": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "text_en": "When a situation calls for breaking convention and thinking from another angle, I feel more excited.",
                     "options": [
                         {
                             "code": "1",
@@ -5038,7 +5038,7 @@
                     "kind": "interest",
                     "text": "我乐于把复杂想法转成更有感染力的表达。",
                     "text_zh": "我乐于把复杂想法转成更有感染力的表达。",
-                    "text_en": "我乐于把复杂想法转成更有感染力的表达。",
+                    "text_en": "I enjoy turning complex ideas into more compelling expression.",
                     "options": [
                         {
                             "code": "1",
@@ -5085,7 +5085,7 @@
                     "kind": "interest",
                     "text": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
                     "text_zh": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
-                    "text_en": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "text_en": "I am interested in branding, storytelling, content, visual, or experience design.",
                     "options": [
                         {
                             "code": "1",
@@ -5132,7 +5132,7 @@
                     "kind": "interest",
                     "text": "我喜欢允许试错和个性表达的工作环境。",
                     "text_zh": "我喜欢允许试错和个性表达的工作环境。",
-                    "text_en": "我喜欢允许试错和个性表达的工作环境。",
+                    "text_en": "I enjoy work environments that allow experimentation and personal expression.",
                     "options": [
                         {
                             "code": "1",
@@ -5179,7 +5179,7 @@
                     "kind": "interest",
                     "text": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
                     "text_zh": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
-                    "text_en": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "text_en": "I become more engaged in teams where aesthetics, creativity, and independent judgment are respected.",
                     "options": [
                         {
                             "code": "1",
@@ -5226,7 +5226,7 @@
                     "kind": "interest",
                     "text": "过于僵化、标准化的环境会压制我的发挥。",
                     "text_zh": "过于僵化、标准化的环境会压制我的发挥。",
-                    "text_en": "过于僵化、标准化的环境会压制我的发挥。",
+                    "text_en": "Overly rigid and standardized environments suppress my performance.",
                     "options": [
                         {
                             "code": "1",
@@ -5273,7 +5273,7 @@
                     "kind": "interest",
                     "text": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
                     "text_zh": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
-                    "text_en": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "text_en": "In a team, I am willing to take on the role of idea contributor or content shaper.",
                     "options": [
                         {
                             "code": "1",
@@ -5320,7 +5320,7 @@
                     "kind": "interest",
                     "text": "当一个项目需要“让它更有表达力”时，我会想加入。",
                     "text_zh": "当一个项目需要“让它更有表达力”时，我会想加入。",
-                    "text_en": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "text_en": "When a project needs to become more expressive, I want to join in.",
                     "options": [
                         {
                             "code": "1",
@@ -5367,7 +5367,7 @@
                     "kind": "interest",
                     "text": "我更希望因新颖、敏感和有想法而被看到。",
                     "text_zh": "我更希望因新颖、敏感和有想法而被看到。",
-                    "text_en": "我更希望因新颖、敏感和有想法而被看到。",
+                    "text_en": "I would rather be noticed for being novel, perceptive, and full of ideas.",
                     "options": [
                         {
                             "code": "1",
@@ -5414,7 +5414,7 @@
                     "kind": "interest",
                     "text": "我喜欢帮助他人厘清问题，而不只是给出答案。",
                     "text_zh": "我喜欢帮助他人厘清问题，而不只是给出答案。",
-                    "text_en": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "text_en": "I enjoy helping others clarify problems, not just giving answers.",
                     "options": [
                         {
                             "code": "1",
@@ -5461,7 +5461,7 @@
                     "kind": "interest",
                     "text": "我愿意在冲突或分歧中帮助各方恢复理解。",
                     "text_zh": "我愿意在冲突或分歧中帮助各方恢复理解。",
-                    "text_en": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "text_en": "I am willing to help different sides restore understanding during conflict or disagreement.",
                     "options": [
                         {
                             "code": "1",
@@ -5508,7 +5508,7 @@
                     "kind": "interest",
                     "text": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
                     "text_zh": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
-                    "text_en": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving training, coaching, companionship, or community support.",
                     "options": [
                         {
                             "code": "1",
@@ -5555,7 +5555,7 @@
                     "kind": "interest",
                     "text": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
                     "text_zh": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
-                    "text_en": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "text_en": "I enjoy helping others move forward with more clarity through questions and feedback.",
                     "options": [
                         {
                             "code": "1",
@@ -5602,7 +5602,7 @@
                     "kind": "interest",
                     "text": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
                     "text_zh": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
-                    "text_en": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "text_en": "I enjoy helping new members, people in weaker positions, or people who feel lost feel supported.",
                     "options": [
                         {
                             "code": "1",
@@ -5649,7 +5649,7 @@
                     "kind": "interest",
                     "text": "我愿意花时间让团队关系更顺畅、更有信任。",
                     "text_zh": "我愿意花时间让团队关系更顺畅、更有信任。",
-                    "text_en": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "text_en": "I am willing to spend time making team relationships smoother and more trusting.",
                     "options": [
                         {
                             "code": "1",
@@ -5696,7 +5696,7 @@
                     "kind": "interest",
                     "text": "我喜欢合作氛围强、彼此支持的工作环境。",
                     "text_zh": "我喜欢合作氛围强、彼此支持的工作环境。",
-                    "text_en": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "text_en": "I enjoy work environments with strong collaboration and mutual support.",
                     "options": [
                         {
                             "code": "1",
@@ -5743,7 +5743,7 @@
                     "kind": "interest",
                     "text": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
                     "text_zh": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
-                    "text_en": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "text_en": "I feel more motivated in settings where I can stay in contact with real people and real needs.",
                     "options": [
                         {
                             "code": "1",
@@ -5790,7 +5790,7 @@
                     "kind": "interest",
                     "text": "我偏好重视服务、教育、公益或社区价值的组织。",
                     "text_zh": "我偏好重视服务、教育、公益或社区价值的组织。",
-                    "text_en": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "text_en": "I prefer organizations that value service, education, public benefit, or community value.",
                     "options": [
                         {
                             "code": "1",
@@ -5837,7 +5837,7 @@
                     "kind": "interest",
                     "text": "在团队中，我愿意扮演协调者、支持者或赋能者。",
                     "text_zh": "在团队中，我愿意扮演协调者、支持者或赋能者。",
-                    "text_en": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "text_en": "In a team, I am willing to play the role of coordinator, supporter, or enabler.",
                     "options": [
                         {
                             "code": "1",
@@ -5884,7 +5884,7 @@
                     "kind": "interest",
                     "text": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
                     "text_zh": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
-                    "text_en": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "text_en": "When people need someone who can connect them, I am willing to step forward.",
                     "options": [
                         {
                             "code": "1",
@@ -5931,7 +5931,7 @@
                     "kind": "interest",
                     "text": "我更希望因“让别人变得更好”而被认可。",
                     "text_zh": "我更希望因“让别人变得更好”而被认可。",
-                    "text_en": "我更希望因“让别人变得更好”而被认可。",
+                    "text_en": "I would rather be recognized for helping others become better.",
                     "options": [
                         {
                             "code": "1",
@@ -5978,7 +5978,7 @@
                     "kind": "interest",
                     "text": "我喜欢把一个模糊机会推进成明确结果。",
                     "text_zh": "我喜欢把一个模糊机会推进成明确结果。",
-                    "text_en": "我喜欢把一个模糊机会推进成明确结果。",
+                    "text_en": "I enjoy turning a vague opportunity into a clear result.",
                     "options": [
                         {
                             "code": "1",
@@ -6025,7 +6025,7 @@
                     "kind": "interest",
                     "text": "我愿意主动争取资源、合作或支持来推动目标。",
                     "text_zh": "我愿意主动争取资源、合作或支持来推动目标。",
-                    "text_en": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "text_en": "I am willing to proactively seek resources, cooperation, or support to move goals forward.",
                     "options": [
                         {
                             "code": "1",
@@ -6072,7 +6072,7 @@
                     "kind": "interest",
                     "text": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
                     "text_zh": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
-                    "text_en": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "text_en": "When public expression, presenting a proposal, or mobilizing others is needed, I usually do not reject it.",
                     "options": [
                         {
                             "code": "1",
@@ -6119,7 +6119,7 @@
                     "kind": "interest",
                     "text": "我喜欢在不确定中判断方向并先行一步。",
                     "text_zh": "我喜欢在不确定中判断方向并先行一步。",
-                    "text_en": "我喜欢在不确定中判断方向并先行一步。",
+                    "text_en": "I enjoy judging direction amid uncertainty and taking the first step.",
                     "options": [
                         {
                             "code": "1",
@@ -6166,7 +6166,7 @@
                     "kind": "interest",
                     "text": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
                     "text_zh": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
-                    "text_en": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving sales, business development, growth, fundraising, or project expansion.",
                     "options": [
                         {
                             "code": "1",
@@ -6213,7 +6213,7 @@
                     "kind": "interest",
                     "text": "当目标清晰且有挑战时，我会自然进入推进状态。",
                     "text_zh": "当目标清晰且有挑战时，我会自然进入推进状态。",
-                    "text_en": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "text_en": "When the goal is clear and challenging, I naturally enter a drive-forward state.",
                     "options": [
                         {
                             "code": "1",
@@ -6260,7 +6260,7 @@
                     "kind": "interest",
                     "text": "我喜欢节奏快、结果导向强的工作环境。",
                     "text_zh": "我喜欢节奏快、结果导向强的工作环境。",
-                    "text_en": "我喜欢节奏快、结果导向强的工作环境。",
+                    "text_en": "I enjoy fast-paced, strongly results-oriented work environments.",
                     "options": [
                         {
                             "code": "1",
@@ -6307,7 +6307,7 @@
                     "kind": "interest",
                     "text": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
                     "text_zh": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
-                    "text_en": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "text_en": "I feel more excited in settings where I can take on greater responsibility and influence larger outcomes.",
                     "options": [
                         {
                             "code": "1",
@@ -6354,7 +6354,7 @@
                     "kind": "interest",
                     "text": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
                     "text_zh": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
-                    "text_en": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "text_en": "I prefer organizational climates that encourage experimentation, competition, and proactively seeking opportunities.",
                     "options": [
                         {
                             "code": "1",
@@ -6401,7 +6401,7 @@
                     "kind": "interest",
                     "text": "在团队中，我愿意担当负责人、发起人或对外代表。",
                     "text_zh": "在团队中，我愿意担当负责人、发起人或对外代表。",
-                    "text_en": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "text_en": "In a team, I am willing to serve as the person in charge, initiator, or external representative.",
                     "options": [
                         {
                             "code": "1",
@@ -6448,7 +6448,7 @@
                     "kind": "interest",
                     "text": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
                     "text_zh": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
-                    "text_en": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "text_en": "When a project needs someone to set direction, set pace, and push implementation, I am willing to take it on.",
                     "options": [
                         {
                             "code": "1",
@@ -6495,7 +6495,7 @@
                     "kind": "interest",
                     "text": "我更希望因“能把事做成”而被信任。",
                     "text_zh": "我更希望因“能把事做成”而被信任。",
-                    "text_en": "我更希望因“能把事做成”而被信任。",
+                    "text_en": "I would rather be trusted for being able to get things done.",
                     "options": [
                         {
                             "code": "1",
@@ -6542,7 +6542,7 @@
                     "kind": "interest",
                     "text": "我喜欢建立模板、规则或清单来减少混乱。",
                     "text_zh": "我喜欢建立模板、规则或清单来减少混乱。",
-                    "text_en": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "text_en": "I enjoy creating templates, rules, or checklists to reduce disorder.",
                     "options": [
                         {
                             "code": "1",
@@ -6589,7 +6589,7 @@
                     "kind": "interest",
                     "text": "我愿意持续维护数据、记录和文档的准确性。",
                     "text_zh": "我愿意持续维护数据、记录和文档的准确性。",
-                    "text_en": "我愿意持续维护数据、记录和文档的准确性。",
+                    "text_en": "I am willing to keep data, records, and documents accurate over time.",
                     "options": [
                         {
                             "code": "1",
@@ -6636,7 +6636,7 @@
                     "kind": "interest",
                     "text": "我喜欢把一个流程拆成可重复执行的步骤。",
                     "text_zh": "我喜欢把一个流程拆成可重复执行的步骤。",
-                    "text_en": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "text_en": "I enjoy breaking a process into repeatable steps.",
                     "options": [
                         {
                             "code": "1",
@@ -6683,7 +6683,7 @@
                     "kind": "interest",
                     "text": "当任务需要耐心校对、复核和归档时，我通常能投入。",
                     "text_zh": "当任务需要耐心校对、复核和归档时，我通常能投入。",
-                    "text_en": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "text_en": "When a task requires patient checking, review, and filing, I can usually stay engaged.",
                     "options": [
                         {
                             "code": "1",
@@ -6730,7 +6730,7 @@
                     "kind": "interest",
                     "text": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
                     "text_zh": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
-                    "text_en": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving budgeting, scheduling, ledgers, process management, or administrative operations.",
                     "options": [
                         {
                             "code": "1",
@@ -6777,7 +6777,7 @@
                     "kind": "interest",
                     "text": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
                     "text_zh": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
-                    "text_en": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "text_en": "I enjoy making collaboration more orderly, trackable, and transferable.",
                     "options": [
                         {
                             "code": "1",
@@ -6824,7 +6824,7 @@
                     "kind": "interest",
                     "text": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
                     "text_zh": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
-                    "text_en": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "text_en": "I enjoy work environments with clear responsibilities, clear standards, and a stable rhythm.",
                     "options": [
                         {
                             "code": "1",
@@ -6871,7 +6871,7 @@
                     "kind": "interest",
                     "text": "在规则清楚、资料完整的组织里，我通常更高效。",
                     "text_zh": "在规则清楚、资料完整的组织里，我通常更高效。",
-                    "text_en": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "text_en": "I am usually more efficient in organizations with clear rules and complete materials.",
                     "options": [
                         {
                             "code": "1",
@@ -6918,7 +6918,7 @@
                     "kind": "interest",
                     "text": "我偏好重视合规、准确和交付质量的团队氛围。",
                     "text_zh": "我偏好重视合规、准确和交付质量的团队氛围。",
-                    "text_en": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "text_en": "I prefer team climates that value compliance, accuracy, and delivery quality.",
                     "options": [
                         {
                             "code": "1",
@@ -6965,7 +6965,7 @@
                     "kind": "interest",
                     "text": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
                     "text_zh": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
-                    "text_en": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "text_en": "In a team, I am willing to play the role of planner, recorder, or process guardian.",
                     "options": [
                         {
                             "code": "1",
@@ -7012,7 +7012,7 @@
                     "kind": "interest",
                     "text": "当事情开始变乱时，我会想把它重新整理出秩序。",
                     "text_zh": "当事情开始变乱时，我会想把它重新整理出秩序。",
-                    "text_en": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "text_en": "When things start to become messy, I want to restore order.",
                     "options": [
                         {
                             "code": "1",
@@ -7059,7 +7059,7 @@
                     "kind": "interest",
                     "text": "我更希望因可靠、细致和可复用而被需要。",
                     "text_zh": "我更希望因可靠、细致和可复用而被需要。",
-                    "text_en": "我更希望因可靠、细致和可复用而被需要。",
+                    "text_en": "I would rather be needed for being reliable, detail-oriented, and reusable.",
                     "options": [
                         {
                             "code": "1",
@@ -7106,7 +7106,7 @@
                     "kind": 3,
                     "text": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
                     "text_zh": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
-                    "text_en": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "text_en": "To confirm that you are answering attentively, please choose '3 Unsure / neutral' for this item.",
                     "options": [
                         {
                             "code": "1",
@@ -7153,7 +7153,7 @@
                     "kind": null,
                     "text": "我对几乎所有类型的工作都同样感兴趣。",
                     "text_zh": "我对几乎所有类型的工作都同样感兴趣。",
-                    "text_en": "我对几乎所有类型的工作都同样感兴趣。",
+                    "text_en": "I am equally interested in almost every type of work.",
                     "options": [
                         {
                             "code": "1",
@@ -7200,7 +7200,7 @@
                     "kind": null,
                     "text": "我从不在任何情境下犯错。",
                     "text_zh": "我从不在任何情境下犯错。",
-                    "text_en": "我从不在任何情境下犯错。",
+                    "text_en": "I never make mistakes in any situation.",
                     "options": [
                         {
                             "code": "1",
@@ -7247,7 +7247,7 @@
                     "kind": null,
                     "text": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
                     "text_zh": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
-                    "text_en": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "text_en": "Even when work content is completely unfamiliar, I can always like it immediately.",
                     "options": [
                         {
                             "code": "1",
@@ -7294,7 +7294,7 @@
                     "kind": 2,
                     "text": "为了确认注意力，本题请选择“2 不喜欢”。",
                     "text_zh": "为了确认注意力，本题请选择“2 不喜欢”。",
-                    "text_en": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "text_en": "To confirm attention, please choose '2 Dislike' for this item.",
                     "options": [
                         {
                             "code": "1",
@@ -7341,7 +7341,7 @@
                     "kind": 13,
                     "text": "做决定前，我倾向先研究再行动。",
                     "text_zh": "做决定前，我倾向先研究再行动。",
-                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "text_en": "Before making a decision, I tend to research first and act later.",
                     "options": [
                         {
                             "code": "1",
@@ -7388,7 +7388,7 @@
                     "kind": 31,
                     "text": "我喜欢帮助他人解决问题。",
                     "text_zh": "我喜欢帮助他人解决问题。",
-                    "text_en": "我喜欢帮助他人解决问题。",
+                    "text_en": "I enjoy helping others solve problems.",
                     "options": [
                         {
                             "code": "1",
@@ -7435,7 +7435,7 @@
                     "kind": 51,
                     "text": "我偏好清晰流程和结构化工作方式。",
                     "text_zh": "我偏好清晰流程和结构化工作方式。",
-                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "I prefer clear processes and structured ways of working.",
                     "options": [
                         {
                             "code": "1",
@@ -7484,9 +7484,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢动手搭建、修理或改装东西。",
+                    "text": "I enjoy building, repairing, or modifying things by hand.",
                     "text_zh": "我喜欢动手搭建、修理或改装东西。",
-                    "text_en": "我喜欢动手搭建、修理或改装东西。",
+                    "text_en": "I enjoy building, repairing, or modifying things by hand.",
                     "options": [
                         {
                             "code": "1",
@@ -7531,9 +7531,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text": "Tasks with visible, tangible results appeal to me.",
                     "text_zh": "结果直观、看得见摸得着的任务会吸引我。",
-                    "text_en": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_en": "Tasks with visible, tangible results appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -7578,9 +7578,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "使用工具、设备或机械让我感到自在。",
+                    "text": "Using tools, equipment, or machinery feels comfortable to me.",
                     "text_zh": "使用工具、设备或机械让我感到自在。",
-                    "text_en": "使用工具、设备或机械让我感到自在。",
+                    "text_en": "Using tools, equipment, or machinery feels comfortable to me.",
                     "options": [
                         {
                             "code": "1",
@@ -7625,9 +7625,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text": "Compared with long discussions, I prefer to get hands-on and do the work directly.",
                     "text_zh": "比起长时间讨论，我更喜欢直接上手做。",
-                    "text_en": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_en": "Compared with long discussions, I prefer to get hands-on and do the work directly.",
                     "options": [
                         {
                             "code": "1",
@@ -7672,9 +7672,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢解决机械、设备或技术故障。",
+                    "text": "I enjoy troubleshooting mechanical, equipment, or technical problems.",
                     "text_zh": "我喜欢解决机械、设备或技术故障。",
-                    "text_en": "我喜欢解决机械、设备或技术故障。",
+                    "text_en": "I enjoy troubleshooting mechanical, equipment, or technical problems.",
                     "options": [
                         {
                             "code": "1",
@@ -7719,9 +7719,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意在现场完成需要操作和调整的工作。",
+                    "text": "I am willing to complete work on site that requires operation and adjustment.",
                     "text_zh": "我愿意在现场完成需要操作和调整的工作。",
-                    "text_en": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_en": "I am willing to complete work on site that requires operation and adjustment.",
                     "options": [
                         {
                             "code": "1",
@@ -7766,9 +7766,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text": "I am interested in how equipment, structures, or systems work.",
                     "text_zh": "我对器材、结构或系统如何运作很感兴趣。",
-                    "text_en": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_en": "I am interested in how equipment, structures, or systems work.",
                     "options": [
                         {
                             "code": "1",
@@ -7813,9 +7813,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text": "Tasks that require hand-eye coordination and practical operation draw me in.",
                     "text_zh": "需要手眼协调和实际操作的任务让我有投入感。",
-                    "text_en": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_en": "Tasks that require hand-eye coordination and practical operation draw me in.",
                     "options": [
                         {
                             "code": "1",
@@ -7860,9 +7860,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text": "Turning ideas into physical objects, prototypes, or executable outcomes feels satisfying to me.",
                     "text_zh": "把想法变成实体、样品或可执行成果会让我满足。",
-                    "text_en": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_en": "Turning ideas into physical objects, prototypes, or executable outcomes feels satisfying to me.",
                     "options": [
                         {
                             "code": "1",
@@ -7907,9 +7907,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text": "I am willing to work in settings such as outdoor sites, work sites, labs, or production environments.",
                     "text_zh": "我愿意接触户外、工地、实验场或生产现场类情境。",
-                    "text_en": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_en": "I am willing to work in settings such as outdoor sites, work sites, labs, or production environments.",
                     "options": [
                         {
                             "code": "1",
@@ -7954,9 +7954,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢分析复杂问题并找出原因。",
+                    "text": "I enjoy analyzing complex problems and finding their causes.",
                     "text_zh": "我喜欢分析复杂问题并找出原因。",
-                    "text_en": "我喜欢分析复杂问题并找出原因。",
+                    "text_en": "I enjoy analyzing complex problems and finding their causes.",
                     "options": [
                         {
                             "code": "1",
@@ -8001,9 +8001,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "数据、证据和逻辑会激发我的好奇心。",
+                    "text": "Data, evidence, and logic spark my curiosity.",
                     "text_zh": "数据、证据和逻辑会激发我的好奇心。",
-                    "text_en": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_en": "Data, evidence, and logic spark my curiosity.",
                     "options": [
                         {
                             "code": "1",
@@ -8048,9 +8048,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "做决定前，我倾向先研究再行动。",
+                    "text": "Before making a decision, I tend to research first and act later.",
                     "text_zh": "做决定前，我倾向先研究再行动。",
-                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "text_en": "Before making a decision, I tend to research first and act later.",
                     "options": [
                         {
                             "code": "1",
@@ -8095,9 +8095,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "阅读和理解有难度的概念会让我投入。",
+                    "text": "Reading and understanding challenging concepts draws me in.",
                     "text_zh": "阅读和理解有难度的概念会让我投入。",
-                    "text_en": "阅读和理解有难度的概念会让我投入。",
+                    "text_en": "Reading and understanding challenging concepts draws me in.",
                     "options": [
                         {
                             "code": "1",
@@ -8142,9 +8142,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢从信息中识别规律或模型。",
+                    "text": "I enjoy identifying patterns or models in information.",
                     "text_zh": "我喜欢从信息中识别规律或模型。",
-                    "text_en": "我喜欢从信息中识别规律或模型。",
+                    "text_en": "I enjoy identifying patterns or models in information.",
                     "options": [
                         {
                             "code": "1",
@@ -8189,9 +8189,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "需要严谨思考的工作更容易吸引我。",
+                    "text": "Work that requires rigorous thinking is more likely to attract me.",
                     "text_zh": "需要严谨思考的工作更容易吸引我。",
-                    "text_en": "需要严谨思考的工作更容易吸引我。",
+                    "text_en": "Work that requires rigorous thinking is more likely to attract me.",
                     "options": [
                         {
                             "code": "1",
@@ -8236,9 +8236,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "面对未知问题，我愿意先提出假设再验证。",
+                    "text": "When facing an unfamiliar problem, I am willing to form hypotheses and then test them.",
                     "text_zh": "面对未知问题，我愿意先提出假设再验证。",
-                    "text_en": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_en": "When facing an unfamiliar problem, I am willing to form hypotheses and then test them.",
                     "options": [
                         {
                             "code": "1",
@@ -8283,9 +8283,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text": "Compared with judging by intuition, I prefer reasoning from facts.",
                     "text_zh": "比起凭直觉判断，我更喜欢用事实推理。",
-                    "text_en": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_en": "Compared with judging by intuition, I prefer reasoning from facts.",
                     "options": [
                         {
                             "code": "1",
@@ -8330,9 +8330,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text": "I enjoy breaking vague problems into parts that can be analyzed.",
                     "text_zh": "我喜欢把模糊问题拆解成可分析的部分。",
-                    "text_en": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_en": "I enjoy breaking vague problems into parts that can be analyzed.",
                     "options": [
                         {
                             "code": "1",
@@ -8377,9 +8377,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text": "Long periods of independent thinking, research, or exploration do not bore me.",
                     "text_zh": "长时间独立思考、研究或探索答案不会让我厌烦。",
-                    "text_en": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_en": "Long periods of independent thinking, research, or exploration do not bore me.",
                     "options": [
                         {
                             "code": "1",
@@ -8424,9 +8424,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢创造新点子和原创成果。",
+                    "text": "I enjoy creating new ideas and original work.",
                     "text_zh": "我喜欢创造新点子和原创成果。",
-                    "text_en": "我喜欢创造新点子和原创成果。",
+                    "text_en": "I enjoy creating new ideas and original work.",
                     "options": [
                         {
                             "code": "1",
@@ -8471,9 +8471,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "表达自我是我工作动力的重要来源。",
+                    "text": "Self-expression is an important source of work motivation for me.",
                     "text_zh": "表达自我是我工作动力的重要来源。",
-                    "text_en": "表达自我是我工作动力的重要来源。",
+                    "text_en": "Self-expression is an important source of work motivation for me.",
                     "options": [
                         {
                             "code": "1",
@@ -8518,9 +8518,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢尝试不同风格和表达方式。",
+                    "text": "I enjoy trying different styles and ways of expression.",
                     "text_zh": "我喜欢尝试不同风格和表达方式。",
-                    "text_en": "我喜欢尝试不同风格和表达方式。",
+                    "text_en": "I enjoy trying different styles and ways of expression.",
                     "options": [
                         {
                             "code": "1",
@@ -8565,9 +8565,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "相比固定流程，我更喜欢开放式任务。",
+                    "text": "Compared with fixed procedures, I prefer open-ended tasks.",
                     "text_zh": "相比固定流程，我更喜欢开放式任务。",
-                    "text_en": "相比固定流程，我更喜欢开放式任务。",
+                    "text_en": "Compared with fixed procedures, I prefer open-ended tasks.",
                     "options": [
                         {
                             "code": "1",
@@ -8612,9 +8612,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text": "Work involving visual, written, audio, or conceptual design appeals to me.",
                     "text_zh": "视觉、文字、声音或概念设计类工作会吸引我。",
-                    "text_en": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_en": "Work involving visual, written, audio, or conceptual design appeals to me.",
                     "options": [
                         {
                             "code": "1",
@@ -8659,9 +8659,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "创造性探索会让我更有能量。",
+                    "text": "Creative exploration gives me more energy.",
                     "text_zh": "创造性探索会让我更有能量。",
-                    "text_en": "创造性探索会让我更有能量。",
+                    "text_en": "Creative exploration gives me more energy.",
                     "options": [
                         {
                             "code": "1",
@@ -8706,9 +8706,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text": "I enjoy turning abstract feelings into work, content, or solutions.",
                     "text_zh": "我喜欢把抽象感觉转化为作品、内容或方案。",
-                    "text_en": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_en": "I enjoy turning abstract feelings into work, content, or solutions.",
                     "options": [
                         {
                             "code": "1",
@@ -8753,9 +8753,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text": "I am willing to develop ideas from scratch rather than only follow templates.",
                     "text_zh": "我愿意从零开始构思，而不是只按模板执行。",
-                    "text_en": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_en": "I am willing to develop ideas from scratch rather than only follow templates.",
                     "options": [
                         {
                             "code": "1",
@@ -8800,9 +8800,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text": "When something can be made more aesthetic or more personal, I become more engaged.",
                     "text_zh": "当一件事可以做得更有美感或更有个性时，我会更投入。",
-                    "text_en": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_en": "When something can be made more aesthetic or more personal, I become more engaged.",
                     "options": [
                         {
                             "code": "1",
@@ -8847,9 +8847,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我享受在没有标准答案的情况下进行创作。",
+                    "text": "I enjoy creating when there is no single standard answer.",
                     "text_zh": "我享受在没有标准答案的情况下进行创作。",
-                    "text_en": "我享受在没有标准答案的情况下进行创作。",
+                    "text_en": "I enjoy creating when there is no single standard answer.",
                     "options": [
                         {
                             "code": "1",
@@ -8894,9 +8894,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢帮助他人解决问题。",
+                    "text": "I enjoy helping others solve problems.",
                     "text_zh": "我喜欢帮助他人解决问题。",
-                    "text_en": "我喜欢帮助他人解决问题。",
+                    "text_en": "I enjoy helping others solve problems.",
                     "options": [
                         {
                             "code": "1",
@@ -8941,9 +8941,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我重视团队氛围和人际关系。",
+                    "text": "I value team atmosphere and interpersonal relationships.",
                     "text_zh": "我重视团队氛围和人际关系。",
-                    "text_en": "我重视团队氛围和人际关系。",
+                    "text_en": "I value team atmosphere and interpersonal relationships.",
                     "options": [
                         {
                             "code": "1",
@@ -8988,9 +8988,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意耐心倾听他人。",
+                    "text": "I am willing to listen to others patiently.",
                     "text_zh": "我愿意耐心倾听他人。",
-                    "text_en": "我愿意耐心倾听他人。",
+                    "text_en": "I am willing to listen to others patiently.",
                     "options": [
                         {
                             "code": "1",
@@ -9035,9 +9035,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text": "Roles that include coaching, support, or service responsibilities appeal to me.",
                     "text_zh": "包含辅导、支持或服务职责的角色会吸引我。",
-                    "text_en": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_en": "Roles that include coaching, support, or service responsibilities appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -9082,9 +9082,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text": "When work can genuinely help other people, I feel a stronger sense of achievement.",
                     "text_zh": "当工作能真正帮助别人时，我会更有成就感。",
-                    "text_en": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_en": "When work can genuinely help other people, I feel a stronger sense of achievement.",
                     "options": [
                         {
                             "code": "1",
@@ -9129,9 +9129,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text": "I enjoy coordinating collaboration among different people so things move forward smoothly.",
                     "text_zh": "我喜欢协调多方协作，让事情顺利推进。",
-                    "text_en": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_en": "I enjoy coordinating collaboration among different people so things move forward smoothly.",
                     "options": [
                         {
                             "code": "1",
@@ -9176,9 +9176,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text": "I am willing to spend time understanding other people's needs, emotions, or difficulties.",
                     "text_zh": "我愿意花时间理解他人的需求、情绪或难处。",
-                    "text_en": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_en": "I am willing to spend time understanding other people's needs, emotions, or difficulties.",
                     "options": [
                         {
                             "code": "1",
@@ -9223,9 +9223,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text": "I enjoy using communication to help others feel more reassured, clearer, or more directed.",
                     "text_zh": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
-                    "text_en": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_en": "I enjoy using communication to help others feel more reassured, clearer, or more directed.",
                     "options": [
                         {
                             "code": "1",
@@ -9270,9 +9270,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "看到别人因我的支持而进步，我会很满足。",
+                    "text": "Seeing others make progress because of my support feels satisfying to me.",
                     "text_zh": "看到别人因我的支持而进步，我会很满足。",
-                    "text_en": "看到别人因我的支持而进步，我会很满足。",
+                    "text_en": "Seeing others make progress because of my support feels satisfying to me.",
                     "options": [
                         {
                             "code": "1",
@@ -9317,9 +9317,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text": "I enjoy work settings that require cooperation, companionship, or group interaction.",
                     "text_zh": "我喜欢需要合作、陪伴或群体互动的工作场景。",
-                    "text_en": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_en": "I enjoy work settings that require cooperation, companionship, or group interaction.",
                     "options": [
                         {
                             "code": "1",
@@ -9364,9 +9364,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢通过观点影响他人。",
+                    "text": "I enjoy influencing others through ideas and viewpoints.",
                     "text_zh": "我喜欢通过观点影响他人。",
-                    "text_en": "我喜欢通过观点影响他人。",
+                    "text_en": "I enjoy influencing others through ideas and viewpoints.",
                     "options": [
                         {
                             "code": "1",
@@ -9411,9 +9411,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "主导推进事项会让我更有动力。",
+                    "text": "Taking the lead in moving things forward gives me more motivation.",
                     "text_zh": "主导推进事项会让我更有动力。",
-                    "text_en": "主导推进事项会让我更有动力。",
+                    "text_en": "Taking the lead in moving things forward gives me more motivation.",
                     "options": [
                         {
                             "code": "1",
@@ -9458,9 +9458,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢设定目标并推动结果达成。",
+                    "text": "I enjoy setting goals and driving results to completion.",
                     "text_zh": "我喜欢设定目标并推动结果达成。",
-                    "text_en": "我喜欢设定目标并推动结果达成。",
+                    "text_en": "I enjoy setting goals and driving results to completion.",
                     "options": [
                         {
                             "code": "1",
@@ -9505,9 +9505,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text": "I can adapt to situations involving negotiation, resource seeking, or persuasion.",
                     "text_zh": "我能适应谈判、争取资源或说服他人的场景。",
-                    "text_en": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_en": "I can adapt to situations involving negotiation, resource seeking, or persuasion.",
                     "options": [
                         {
                             "code": "1",
@@ -9552,9 +9552,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text": "Business-oriented and growth-oriented challenges appeal to me.",
                     "text_zh": "偏商业导向、增长导向的挑战会吸引我。",
-                    "text_en": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_en": "Business-oriented and growth-oriented challenges appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -9599,9 +9599,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "在压力下主动承担责任会让我更有存在感。",
+                    "text": "Taking responsibility under pressure gives me a stronger sense of presence.",
                     "text_zh": "在压力下主动承担责任会让我更有存在感。",
-                    "text_en": "在压力下主动承担责任会让我更有存在感。",
+                    "text_en": "Taking responsibility under pressure gives me a stronger sense of presence.",
                     "options": [
                         {
                             "code": "1",
@@ -9646,9 +9646,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text": "I am willing to lead the coordination of resources, people, and pace to achieve a goal.",
                     "text_zh": "我愿意带头组织资源、人和节奏去完成目标。",
-                    "text_en": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_en": "I am willing to lead the coordination of resources, people, and pace to achieve a goal.",
                     "options": [
                         {
                             "code": "1",
@@ -9693,9 +9693,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text": "I enjoy the process of competition, breakthrough, and turning opportunities into results.",
                     "text_zh": "我喜欢竞争、突破和把机会变成结果的过程。",
-                    "text_en": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_en": "I enjoy the process of competition, breakthrough, and turning opportunities into results.",
                     "options": [
                         {
                             "code": "1",
@@ -9740,9 +9740,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text": "When a project needs someone to step up and make decisions, I am willing to take that role.",
                     "text_zh": "当一个项目需要有人站出来拍板时，我愿意担当。",
-                    "text_en": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_en": "When a project needs someone to step up and make decisions, I am willing to take that role.",
                     "options": [
                         {
                             "code": "1",
@@ -9787,9 +9787,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text": "I am interested in tasks involving markets, business, entrepreneurship, or external development.",
                     "text_zh": "我对市场、业务、创业或对外拓展类任务有兴趣。",
-                    "text_en": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving markets, business, entrepreneurship, or external development.",
                     "options": [
                         {
                             "code": "1",
@@ -9834,9 +9834,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text": "I prefer clear processes and structured ways of working.",
                     "text_zh": "我偏好清晰流程和结构化工作方式。",
-                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "I prefer clear processes and structured ways of working.",
                     "options": [
                         {
                             "code": "1",
@@ -9881,9 +9881,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我重视细节以及质量校验。",
+                    "text": "I value details and quality checks.",
                     "text_zh": "我重视细节以及质量校验。",
-                    "text_en": "我重视细节以及质量校验。",
+                    "text_en": "I value details and quality checks.",
                     "options": [
                         {
                             "code": "1",
@@ -9928,9 +9928,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢规划安排并跟踪进度。",
+                    "text": "I enjoy planning, arranging, and tracking progress.",
                     "text_zh": "我喜欢规划安排并跟踪进度。",
-                    "text_en": "我喜欢规划安排并跟踪进度。",
+                    "text_en": "I enjoy planning, arranging, and tracking progress.",
                     "options": [
                         {
                             "code": "1",
@@ -9975,9 +9975,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text": "For repetitive but important tasks, I can execute steadily and do not reject them.",
                     "text_zh": "对重复但重要的任务，我能稳定执行并且不排斥。",
-                    "text_en": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_en": "For repetitive but important tasks, I can execute steadily and do not reject them.",
                     "options": [
                         {
                             "code": "1",
@@ -10022,9 +10022,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "规范、一致性和文档化会让我更安心。",
+                    "text": "Standards, consistency, and documentation make me feel more secure.",
                     "text_zh": "规范、一致性和文档化会让我更安心。",
-                    "text_en": "规范、一致性和文档化会让我更安心。",
+                    "text_en": "Standards, consistency, and documentation make me feel more secure.",
                     "options": [
                         {
                             "code": "1",
@@ -10069,9 +10069,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢组织、整理和运营执行类工作。",
+                    "text": "I enjoy work involving organization, sorting, operations, and execution.",
                     "text_zh": "我喜欢组织、整理和运营执行类工作。",
-                    "text_en": "我喜欢组织、整理和运营执行类工作。",
+                    "text_en": "I enjoy work involving organization, sorting, operations, and execution.",
                     "options": [
                         {
                             "code": "1",
@@ -10116,9 +10116,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text": "I am willing to maintain ledgers, checklists, records, or standard operating procedures.",
                     "text_zh": "我愿意维护台账、清单、记录或标准作业流程。",
-                    "text_en": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_en": "I am willing to maintain ledgers, checklists, records, or standard operating procedures.",
                     "options": [
                         {
                             "code": "1",
@@ -10163,9 +10163,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "明确规则和职责边界的环境会让我更高效。",
+                    "text": "Environments with clear rules and responsibility boundaries make me more efficient.",
                     "text_zh": "明确规则和职责边界的环境会让我更高效。",
-                    "text_en": "明确规则和职责边界的环境会让我更高效。",
+                    "text_en": "Environments with clear rules and responsibility boundaries make me more efficient.",
                     "options": [
                         {
                             "code": "1",
@@ -10210,9 +10210,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text": "I enjoy organizing messy information into clear categories and sequences.",
                     "text_zh": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
-                    "text_en": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_en": "I enjoy organizing messy information into clear categories and sequences.",
                     "options": [
                         {
                             "code": "1",
@@ -10257,9 +10257,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text": "When things are arranged in an orderly way, I feel more satisfied.",
                     "text_zh": "当事情被安排得井井有条时，我会更有满足感。",
-                    "text_en": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_en": "When things are arranged in an orderly way, I feel more satisfied.",
                     "options": [
                         {
                             "code": "1",
@@ -10304,9 +10304,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "text": "I enjoy taking a device apart and understanding how its parts work together.",
                     "text_zh": "我喜欢拆解一个装置，再理解各部件如何配合。",
-                    "text_en": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "text_en": "I enjoy taking a device apart and understanding how its parts work together.",
                     "options": [
                         {
                             "code": "1",
@@ -10351,9 +10351,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意通过试装、调试或校准来改进成品。",
+                    "text": "I am willing to improve finished work through trial assembly, testing, or calibration.",
                     "text_zh": "我愿意通过试装、调试或校准来改进成品。",
-                    "text_en": "我愿意通过试装、调试或校准来改进成品。",
+                    "text_en": "I am willing to improve finished work through trial assembly, testing, or calibration.",
                     "options": [
                         {
                             "code": "1",
@@ -10398,9 +10398,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "text": "Tasks that require quick judgment and on-site problem handling excite me.",
                     "text_zh": "需要快速判断并现场处理问题的任务会让我兴奋。",
-                    "text_en": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "text_en": "Tasks that require quick judgment and on-site problem handling excite me.",
                     "options": [
                         {
                             "code": "1",
@@ -10445,9 +10445,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "text": "I enjoy turning drawings, instructions, or ideas into physical outcomes.",
                     "text_zh": "我喜欢把图纸、说明或想法转成实物成果。",
-                    "text_en": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "text_en": "I enjoy turning drawings, instructions, or ideas into physical outcomes.",
                     "options": [
                         {
                             "code": "1",
@@ -10492,9 +10492,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "面对器材或流程异常，我会想亲自去排查。",
+                    "text": "When equipment or processes behave abnormally, I want to investigate them myself.",
                     "text_zh": "面对器材或流程异常，我会想亲自去排查。",
-                    "text_en": "面对器材或流程异常，我会想亲自去排查。",
+                    "text_en": "When equipment or processes behave abnormally, I want to investigate them myself.",
                     "options": [
                         {
                             "code": "1",
@@ -10539,9 +10539,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "text": "I am interested in hands-on tasks that require endurance, coordination, or spatial awareness.",
                     "text_zh": "我对需要耐力、协调或空间感的实操任务有兴趣。",
-                    "text_en": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "text_en": "I am interested in hands-on tasks that require endurance, coordination, or spatial awareness.",
                     "options": [
                         {
                             "code": "1",
@@ -10586,9 +10586,9 @@
                     "dimension": "R",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "text": "I prefer work environments where I can see equipment, materials, samples, or objects of operation.",
                     "text_zh": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
-                    "text_en": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "text_en": "I prefer work environments where I can see equipment, materials, samples, or objects of operation.",
                     "options": [
                         {
                             "code": "1",
@@ -10633,9 +10633,9 @@
                     "dimension": "R",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "text": "Compared with a purely office-based environment, I prefer settings with a sense of site work or contact with physical objects.",
                     "text_zh": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
-                    "text_en": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "text_en": "Compared with a purely office-based environment, I prefer settings with a sense of site work or contact with physical objects.",
                     "options": [
                         {
                             "code": "1",
@@ -10680,9 +10680,9 @@
                     "dimension": "R",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "text": "Working with real systems, real products, or real spaces makes me more engaged.",
                     "text_zh": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
-                    "text_en": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "text_en": "Working with real systems, real products, or real spaces makes me more engaged.",
                     "options": [
                         {
                             "code": "1",
@@ -10727,9 +10727,9 @@
                     "dimension": "R",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "text": "In a team, I am willing to take on installation, implementation, or practical execution roles.",
                     "text_zh": "在团队中，我愿意承担安装、实施或落地执行的角色。",
-                    "text_en": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "text_en": "In a team, I am willing to take on installation, implementation, or practical execution roles.",
                     "options": [
                         {
                             "code": "1",
@@ -10774,9 +10774,9 @@
                     "dimension": "R",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "text": "When a project reaches the stage of making the plan real, I want to be more involved.",
                     "text_zh": "当项目进入“把方案做出来”的阶段，我会更想参与。",
-                    "text_en": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "text_en": "When a project reaches the stage of making the plan real, I want to be more involved.",
                     "options": [
                         {
                             "code": "1",
@@ -10821,9 +10821,9 @@
                     "dimension": "R",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "text": "I prefer being the person who gets things built and stabilized, rather than staying only at the discussion level.",
                     "text_zh": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
-                    "text_en": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "text_en": "I prefer being the person who gets things built and stabilized, rather than staying only at the discussion level.",
                     "options": [
                         {
                             "code": "1",
@@ -10868,9 +10868,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "text": "I enjoy reading reports, papers, or materials to build my judgment.",
                     "text_zh": "我喜欢阅读报告、论文或资料来建立判断。",
-                    "text_en": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "text_en": "I enjoy reading reports, papers, or materials to build my judgment.",
                     "options": [
                         {
                             "code": "1",
@@ -10915,9 +10915,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "text": "Comparing, classifying, and verifying a problem gives me a sense of satisfaction.",
                     "text_zh": "对一个问题进行比较、分类和验证会让我有满足感。",
-                    "text_en": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "text_en": "Comparing, classifying, and verifying a problem gives me a sense of satisfaction.",
                     "options": [
                         {
                             "code": "1",
@@ -10962,9 +10962,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "text": "I enjoy designing a research path rather than only accepting ready-made answers.",
                     "text_zh": "我乐于设计研究路径，而不只是接受现成答案。",
-                    "text_en": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "text_en": "I enjoy designing a research path rather than only accepting ready-made answers.",
                     "options": [
                         {
                             "code": "1",
@@ -11009,9 +11009,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "text": "I enjoy using models, frameworks, or hypotheses to understand complex phenomena.",
                     "text_zh": "我喜欢用模型、框架或假设来理解复杂现象。",
-                    "text_en": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "text_en": "I enjoy using models, frameworks, or hypotheses to understand complex phenomena.",
                     "options": [
                         {
                             "code": "1",
@@ -11056,9 +11056,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "text": "Tasks that require precise reasoning appeal to me more than emotion-driven judgments.",
                     "text_zh": "需要精确推理的任务比情绪化判断更吸引我。",
-                    "text_en": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "text_en": "Tasks that require precise reasoning appeal to me more than emotion-driven judgments.",
                     "options": [
                         {
                             "code": "1",
@@ -11103,9 +11103,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "text": "I am willing to check information repeatedly to confirm whether a conclusion is reliable.",
                     "text_zh": "我愿意反复核对信息，只为确认结论是否可靠。",
-                    "text_en": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "text_en": "I am willing to check information repeatedly to confirm whether a conclusion is reliable.",
                     "options": [
                         {
                             "code": "1",
@@ -11150,9 +11150,9 @@
                     "dimension": "I",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "text": "I prefer work environments that encourage questions, challenge, and verification.",
                     "text_zh": "我偏好鼓励提问、质疑和求证的工作环境。",
-                    "text_en": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "text_en": "I prefer work environments that encourage questions, challenge, and verification.",
                     "options": [
                         {
                             "code": "1",
@@ -11197,9 +11197,9 @@
                     "dimension": "I",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "text": "I usually perform better in settings where I can think quietly and research deeply.",
                     "text_zh": "在可以安静思考、深入研究的场景里，我通常表现更好。",
-                    "text_en": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "text_en": "I usually perform better in settings where I can think quietly and research deeply.",
                     "options": [
                         {
                             "code": "1",
@@ -11244,9 +11244,9 @@
                     "dimension": "I",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "text": "I enjoy organizational climates that value professional judgment and evidence quality.",
                     "text_zh": "我喜欢重视专业判断和证据质量的组织氛围。",
-                    "text_en": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "text_en": "I enjoy organizational climates that value professional judgment and evidence quality.",
                     "options": [
                         {
                             "code": "1",
@@ -11291,9 +11291,9 @@
                     "dimension": "I",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "text": "In a team, I am willing to play the role of analyst, researcher, or problem diagnostician.",
                     "text_zh": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
-                    "text_en": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "text_en": "In a team, I am willing to play the role of analyst, researcher, or problem diagnostician.",
                     "options": [
                         {
                             "code": "1",
@@ -11338,9 +11338,9 @@
                     "dimension": "I",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "text": "When others need to make sense of a complex problem, I am willing to take it on.",
                     "text_zh": "当别人需要把复杂问题想清楚时，我愿意接手。",
-                    "text_en": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "text_en": "When others need to make sense of a complex problem, I am willing to take it on.",
                     "options": [
                         {
                             "code": "1",
@@ -11385,9 +11385,9 @@
                     "dimension": "I",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "我更希望因“看得深、想得准”而被需要。",
+                    "text": "I would rather be needed for seeing deeply and thinking accurately.",
                     "text_zh": "我更希望因“看得深、想得准”而被需要。",
-                    "text_en": "我更希望因“看得深、想得准”而被需要。",
+                    "text_en": "I would rather be needed for seeing deeply and thinking accurately.",
                     "options": [
                         {
                             "code": "1",
@@ -11432,9 +11432,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把普通内容做出独特风格。",
+                    "text": "I enjoy giving ordinary content a distinctive style.",
                     "text_zh": "我喜欢把普通内容做出独特风格。",
-                    "text_en": "我喜欢把普通内容做出独特风格。",
+                    "text_en": "I enjoy giving ordinary content a distinctive style.",
                     "options": [
                         {
                             "code": "1",
@@ -11479,9 +11479,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "text": "I am willing to polish the form, wording, or aesthetic effect of a piece of work repeatedly.",
                     "text_zh": "我愿意为一个作品反复打磨形式、语感或审美效果。",
-                    "text_en": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "text_en": "I am willing to polish the form, wording, or aesthetic effect of a piece of work repeatedly.",
                     "options": [
                         {
                             "code": "1",
@@ -11526,9 +11526,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "text": "I enjoy generating ideas from inspiration, emotion, or experience.",
                     "text_zh": "我喜欢从灵感、情绪或体验中生成创意。",
-                    "text_en": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "text_en": "I enjoy generating ideas from inspiration, emotion, or experience.",
                     "options": [
                         {
                             "code": "1",
@@ -11573,9 +11573,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "text": "When a situation calls for breaking convention and thinking from another angle, I feel more excited.",
                     "text_zh": "当需要打破常规、换个角度思考时，我会更兴奋。",
-                    "text_en": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "text_en": "When a situation calls for breaking convention and thinking from another angle, I feel more excited.",
                     "options": [
                         {
                             "code": "1",
@@ -11620,9 +11620,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我乐于把复杂想法转成更有感染力的表达。",
+                    "text": "I enjoy turning complex ideas into more compelling expression.",
                     "text_zh": "我乐于把复杂想法转成更有感染力的表达。",
-                    "text_en": "我乐于把复杂想法转成更有感染力的表达。",
+                    "text_en": "I enjoy turning complex ideas into more compelling expression.",
                     "options": [
                         {
                             "code": "1",
@@ -11667,9 +11667,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "text": "I am interested in branding, storytelling, content, visual, or experience design.",
                     "text_zh": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
-                    "text_en": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "text_en": "I am interested in branding, storytelling, content, visual, or experience design.",
                     "options": [
                         {
                             "code": "1",
@@ -11714,9 +11714,9 @@
                     "dimension": "A",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我喜欢允许试错和个性表达的工作环境。",
+                    "text": "I enjoy work environments that allow experimentation and personal expression.",
                     "text_zh": "我喜欢允许试错和个性表达的工作环境。",
-                    "text_en": "我喜欢允许试错和个性表达的工作环境。",
+                    "text_en": "I enjoy work environments that allow experimentation and personal expression.",
                     "options": [
                         {
                             "code": "1",
@@ -11761,9 +11761,9 @@
                     "dimension": "A",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "text": "I become more engaged in teams where aesthetics, creativity, and independent judgment are respected.",
                     "text_zh": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
-                    "text_en": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "text_en": "I become more engaged in teams where aesthetics, creativity, and independent judgment are respected.",
                     "options": [
                         {
                             "code": "1",
@@ -11808,9 +11808,9 @@
                     "dimension": "A",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "过于僵化、标准化的环境会压制我的发挥。",
+                    "text": "Overly rigid and standardized environments suppress my performance.",
                     "text_zh": "过于僵化、标准化的环境会压制我的发挥。",
-                    "text_en": "过于僵化、标准化的环境会压制我的发挥。",
+                    "text_en": "Overly rigid and standardized environments suppress my performance.",
                     "options": [
                         {
                             "code": "1",
@@ -11855,9 +11855,9 @@
                     "dimension": "A",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "text": "In a team, I am willing to take on the role of idea contributor or content shaper.",
                     "text_zh": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
-                    "text_en": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "text_en": "In a team, I am willing to take on the role of idea contributor or content shaper.",
                     "options": [
                         {
                             "code": "1",
@@ -11902,9 +11902,9 @@
                     "dimension": "A",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "text": "When a project needs to become more expressive, I want to join in.",
                     "text_zh": "当一个项目需要“让它更有表达力”时，我会想加入。",
-                    "text_en": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "text_en": "When a project needs to become more expressive, I want to join in.",
                     "options": [
                         {
                             "code": "1",
@@ -11949,9 +11949,9 @@
                     "dimension": "A",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "我更希望因新颖、敏感和有想法而被看到。",
+                    "text": "I would rather be noticed for being novel, perceptive, and full of ideas.",
                     "text_zh": "我更希望因新颖、敏感和有想法而被看到。",
-                    "text_en": "我更希望因新颖、敏感和有想法而被看到。",
+                    "text_en": "I would rather be noticed for being novel, perceptive, and full of ideas.",
                     "options": [
                         {
                             "code": "1",
@@ -11996,9 +11996,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "text": "I enjoy helping others clarify problems, not just giving answers.",
                     "text_zh": "我喜欢帮助他人厘清问题，而不只是给出答案。",
-                    "text_en": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "text_en": "I enjoy helping others clarify problems, not just giving answers.",
                     "options": [
                         {
                             "code": "1",
@@ -12043,9 +12043,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "text": "I am willing to help different sides restore understanding during conflict or disagreement.",
                     "text_zh": "我愿意在冲突或分歧中帮助各方恢复理解。",
-                    "text_en": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "text_en": "I am willing to help different sides restore understanding during conflict or disagreement.",
                     "options": [
                         {
                             "code": "1",
@@ -12090,9 +12090,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "text": "I am interested in tasks involving training, coaching, companionship, or community support.",
                     "text_zh": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
-                    "text_en": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving training, coaching, companionship, or community support.",
                     "options": [
                         {
                             "code": "1",
@@ -12137,9 +12137,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "text": "I enjoy helping others move forward with more clarity through questions and feedback.",
                     "text_zh": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
-                    "text_en": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "text_en": "I enjoy helping others move forward with more clarity through questions and feedback.",
                     "options": [
                         {
                             "code": "1",
@@ -12184,9 +12184,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "text": "I enjoy helping new members, people in weaker positions, or people who feel lost feel supported.",
                     "text_zh": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
-                    "text_en": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "text_en": "I enjoy helping new members, people in weaker positions, or people who feel lost feel supported.",
                     "options": [
                         {
                             "code": "1",
@@ -12231,9 +12231,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "text": "I am willing to spend time making team relationships smoother and more trusting.",
                     "text_zh": "我愿意花时间让团队关系更顺畅、更有信任。",
-                    "text_en": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "text_en": "I am willing to spend time making team relationships smoother and more trusting.",
                     "options": [
                         {
                             "code": "1",
@@ -12278,9 +12278,9 @@
                     "dimension": "S",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "text": "I enjoy work environments with strong collaboration and mutual support.",
                     "text_zh": "我喜欢合作氛围强、彼此支持的工作环境。",
-                    "text_en": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "text_en": "I enjoy work environments with strong collaboration and mutual support.",
                     "options": [
                         {
                             "code": "1",
@@ -12325,9 +12325,9 @@
                     "dimension": "S",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "text": "I feel more motivated in settings where I can stay in contact with real people and real needs.",
                     "text_zh": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
-                    "text_en": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "text_en": "I feel more motivated in settings where I can stay in contact with real people and real needs.",
                     "options": [
                         {
                             "code": "1",
@@ -12372,9 +12372,9 @@
                     "dimension": "S",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "text": "I prefer organizations that value service, education, public benefit, or community value.",
                     "text_zh": "我偏好重视服务、教育、公益或社区价值的组织。",
-                    "text_en": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "text_en": "I prefer organizations that value service, education, public benefit, or community value.",
                     "options": [
                         {
                             "code": "1",
@@ -12419,9 +12419,9 @@
                     "dimension": "S",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "text": "In a team, I am willing to play the role of coordinator, supporter, or enabler.",
                     "text_zh": "在团队中，我愿意扮演协调者、支持者或赋能者。",
-                    "text_en": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "text_en": "In a team, I am willing to play the role of coordinator, supporter, or enabler.",
                     "options": [
                         {
                             "code": "1",
@@ -12466,9 +12466,9 @@
                     "dimension": "S",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "text": "When people need someone who can connect them, I am willing to step forward.",
                     "text_zh": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
-                    "text_en": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "text_en": "When people need someone who can connect them, I am willing to step forward.",
                     "options": [
                         {
                             "code": "1",
@@ -12513,9 +12513,9 @@
                     "dimension": "S",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "我更希望因“让别人变得更好”而被认可。",
+                    "text": "I would rather be recognized for helping others become better.",
                     "text_zh": "我更希望因“让别人变得更好”而被认可。",
-                    "text_en": "我更希望因“让别人变得更好”而被认可。",
+                    "text_en": "I would rather be recognized for helping others become better.",
                     "options": [
                         {
                             "code": "1",
@@ -12560,9 +12560,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把一个模糊机会推进成明确结果。",
+                    "text": "I enjoy turning a vague opportunity into a clear result.",
                     "text_zh": "我喜欢把一个模糊机会推进成明确结果。",
-                    "text_en": "我喜欢把一个模糊机会推进成明确结果。",
+                    "text_en": "I enjoy turning a vague opportunity into a clear result.",
                     "options": [
                         {
                             "code": "1",
@@ -12607,9 +12607,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "text": "I am willing to proactively seek resources, cooperation, or support to move goals forward.",
                     "text_zh": "我愿意主动争取资源、合作或支持来推动目标。",
-                    "text_en": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "text_en": "I am willing to proactively seek resources, cooperation, or support to move goals forward.",
                     "options": [
                         {
                             "code": "1",
@@ -12654,9 +12654,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "text": "When public expression, presenting a proposal, or mobilizing others is needed, I usually do not reject it.",
                     "text_zh": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
-                    "text_en": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "text_en": "When public expression, presenting a proposal, or mobilizing others is needed, I usually do not reject it.",
                     "options": [
                         {
                             "code": "1",
@@ -12701,9 +12701,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢在不确定中判断方向并先行一步。",
+                    "text": "I enjoy judging direction amid uncertainty and taking the first step.",
                     "text_zh": "我喜欢在不确定中判断方向并先行一步。",
-                    "text_en": "我喜欢在不确定中判断方向并先行一步。",
+                    "text_en": "I enjoy judging direction amid uncertainty and taking the first step.",
                     "options": [
                         {
                             "code": "1",
@@ -12748,9 +12748,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "text": "I am interested in tasks involving sales, business development, growth, fundraising, or project expansion.",
                     "text_zh": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
-                    "text_en": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving sales, business development, growth, fundraising, or project expansion.",
                     "options": [
                         {
                             "code": "1",
@@ -12795,9 +12795,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "text": "When the goal is clear and challenging, I naturally enter a drive-forward state.",
                     "text_zh": "当目标清晰且有挑战时，我会自然进入推进状态。",
-                    "text_en": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "text_en": "When the goal is clear and challenging, I naturally enter a drive-forward state.",
                     "options": [
                         {
                             "code": "1",
@@ -12842,9 +12842,9 @@
                     "dimension": "E",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我喜欢节奏快、结果导向强的工作环境。",
+                    "text": "I enjoy fast-paced, strongly results-oriented work environments.",
                     "text_zh": "我喜欢节奏快、结果导向强的工作环境。",
-                    "text_en": "我喜欢节奏快、结果导向强的工作环境。",
+                    "text_en": "I enjoy fast-paced, strongly results-oriented work environments.",
                     "options": [
                         {
                             "code": "1",
@@ -12889,9 +12889,9 @@
                     "dimension": "E",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "text": "I feel more excited in settings where I can take on greater responsibility and influence larger outcomes.",
                     "text_zh": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
-                    "text_en": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "text_en": "I feel more excited in settings where I can take on greater responsibility and influence larger outcomes.",
                     "options": [
                         {
                             "code": "1",
@@ -12936,9 +12936,9 @@
                     "dimension": "E",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "text": "I prefer organizational climates that encourage experimentation, competition, and proactively seeking opportunities.",
                     "text_zh": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
-                    "text_en": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "text_en": "I prefer organizational climates that encourage experimentation, competition, and proactively seeking opportunities.",
                     "options": [
                         {
                             "code": "1",
@@ -12983,9 +12983,9 @@
                     "dimension": "E",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "text": "In a team, I am willing to serve as the person in charge, initiator, or external representative.",
                     "text_zh": "在团队中，我愿意担当负责人、发起人或对外代表。",
-                    "text_en": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "text_en": "In a team, I am willing to serve as the person in charge, initiator, or external representative.",
                     "options": [
                         {
                             "code": "1",
@@ -13030,9 +13030,9 @@
                     "dimension": "E",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "text": "When a project needs someone to set direction, set pace, and push implementation, I am willing to take it on.",
                     "text_zh": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
-                    "text_en": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "text_en": "When a project needs someone to set direction, set pace, and push implementation, I am willing to take it on.",
                     "options": [
                         {
                             "code": "1",
@@ -13077,9 +13077,9 @@
                     "dimension": "E",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "我更希望因“能把事做成”而被信任。",
+                    "text": "I would rather be trusted for being able to get things done.",
                     "text_zh": "我更希望因“能把事做成”而被信任。",
-                    "text_en": "我更希望因“能把事做成”而被信任。",
+                    "text_en": "I would rather be trusted for being able to get things done.",
                     "options": [
                         {
                             "code": "1",
@@ -13124,9 +13124,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "text": "I enjoy creating templates, rules, or checklists to reduce disorder.",
                     "text_zh": "我喜欢建立模板、规则或清单来减少混乱。",
-                    "text_en": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "text_en": "I enjoy creating templates, rules, or checklists to reduce disorder.",
                     "options": [
                         {
                             "code": "1",
@@ -13171,9 +13171,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意持续维护数据、记录和文档的准确性。",
+                    "text": "I am willing to keep data, records, and documents accurate over time.",
                     "text_zh": "我愿意持续维护数据、记录和文档的准确性。",
-                    "text_en": "我愿意持续维护数据、记录和文档的准确性。",
+                    "text_en": "I am willing to keep data, records, and documents accurate over time.",
                     "options": [
                         {
                             "code": "1",
@@ -13218,9 +13218,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "text": "I enjoy breaking a process into repeatable steps.",
                     "text_zh": "我喜欢把一个流程拆成可重复执行的步骤。",
-                    "text_en": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "text_en": "I enjoy breaking a process into repeatable steps.",
                     "options": [
                         {
                             "code": "1",
@@ -13265,9 +13265,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "text": "When a task requires patient checking, review, and filing, I can usually stay engaged.",
                     "text_zh": "当任务需要耐心校对、复核和归档时，我通常能投入。",
-                    "text_en": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "text_en": "When a task requires patient checking, review, and filing, I can usually stay engaged.",
                     "options": [
                         {
                             "code": "1",
@@ -13312,9 +13312,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "text": "I am interested in tasks involving budgeting, scheduling, ledgers, process management, or administrative operations.",
                     "text_zh": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
-                    "text_en": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving budgeting, scheduling, ledgers, process management, or administrative operations.",
                     "options": [
                         {
                             "code": "1",
@@ -13359,9 +13359,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "text": "I enjoy making collaboration more orderly, trackable, and transferable.",
                     "text_zh": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
-                    "text_en": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "text_en": "I enjoy making collaboration more orderly, trackable, and transferable.",
                     "options": [
                         {
                             "code": "1",
@@ -13406,9 +13406,9 @@
                     "dimension": "C",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "text": "I enjoy work environments with clear responsibilities, clear standards, and a stable rhythm.",
                     "text_zh": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
-                    "text_en": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "text_en": "I enjoy work environments with clear responsibilities, clear standards, and a stable rhythm.",
                     "options": [
                         {
                             "code": "1",
@@ -13453,9 +13453,9 @@
                     "dimension": "C",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "text": "I am usually more efficient in organizations with clear rules and complete materials.",
                     "text_zh": "在规则清楚、资料完整的组织里，我通常更高效。",
-                    "text_en": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "text_en": "I am usually more efficient in organizations with clear rules and complete materials.",
                     "options": [
                         {
                             "code": "1",
@@ -13500,9 +13500,9 @@
                     "dimension": "C",
                     "subscale": "environment",
                     "kind": "interest",
-                    "text": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "text": "I prefer team climates that value compliance, accuracy, and delivery quality.",
                     "text_zh": "我偏好重视合规、准确和交付质量的团队氛围。",
-                    "text_en": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "text_en": "I prefer team climates that value compliance, accuracy, and delivery quality.",
                     "options": [
                         {
                             "code": "1",
@@ -13547,9 +13547,9 @@
                     "dimension": "C",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "text": "In a team, I am willing to play the role of planner, recorder, or process guardian.",
                     "text_zh": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
-                    "text_en": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "text_en": "In a team, I am willing to play the role of planner, recorder, or process guardian.",
                     "options": [
                         {
                             "code": "1",
@@ -13594,9 +13594,9 @@
                     "dimension": "C",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "text": "When things start to become messy, I want to restore order.",
                     "text_zh": "当事情开始变乱时，我会想把它重新整理出秩序。",
-                    "text_en": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "text_en": "When things start to become messy, I want to restore order.",
                     "options": [
                         {
                             "code": "1",
@@ -13641,9 +13641,9 @@
                     "dimension": "C",
                     "subscale": "role",
                     "kind": "interest",
-                    "text": "我更希望因可靠、细致和可复用而被需要。",
+                    "text": "I would rather be needed for being reliable, detail-oriented, and reusable.",
                     "text_zh": "我更希望因可靠、细致和可复用而被需要。",
-                    "text_en": "我更希望因可靠、细致和可复用而被需要。",
+                    "text_en": "I would rather be needed for being reliable, detail-oriented, and reusable.",
                     "options": [
                         {
                             "code": "1",
@@ -13688,9 +13688,9 @@
                     "dimension": "quality_attention",
                     "subscale": "attention",
                     "kind": 3,
-                    "text": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "text": "To confirm that you are answering attentively, please choose '3 Unsure / neutral' for this item.",
                     "text_zh": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
-                    "text_en": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "text_en": "To confirm that you are answering attentively, please choose '3 Unsure / neutral' for this item.",
                     "options": [
                         {
                             "code": "1",
@@ -13735,9 +13735,9 @@
                     "dimension": "quality_broad_agreement",
                     "subscale": "broad_agreement",
                     "kind": null,
-                    "text": "我对几乎所有类型的工作都同样感兴趣。",
+                    "text": "I am equally interested in almost every type of work.",
                     "text_zh": "我对几乎所有类型的工作都同样感兴趣。",
-                    "text_en": "我对几乎所有类型的工作都同样感兴趣。",
+                    "text_en": "I am equally interested in almost every type of work.",
                     "options": [
                         {
                             "code": "1",
@@ -13782,9 +13782,9 @@
                     "dimension": "quality_idealization",
                     "subscale": "idealization",
                     "kind": null,
-                    "text": "我从不在任何情境下犯错。",
+                    "text": "I never make mistakes in any situation.",
                     "text_zh": "我从不在任何情境下犯错。",
-                    "text_en": "我从不在任何情境下犯错。",
+                    "text_en": "I never make mistakes in any situation.",
                     "options": [
                         {
                             "code": "1",
@@ -13829,9 +13829,9 @@
                     "dimension": "quality_unrealistic",
                     "subscale": "idealization",
                     "kind": null,
-                    "text": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "text": "Even when work content is completely unfamiliar, I can always like it immediately.",
                     "text_zh": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
-                    "text_en": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "text_en": "Even when work content is completely unfamiliar, I can always like it immediately.",
                     "options": [
                         {
                             "code": "1",
@@ -13876,9 +13876,9 @@
                     "dimension": "quality_attention",
                     "subscale": "attention",
                     "kind": 2,
-                    "text": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "text": "To confirm attention, please choose '2 Dislike' for this item.",
                     "text_zh": "为了确认注意力，本题请选择“2 不喜欢”。",
-                    "text_en": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "text_en": "To confirm attention, please choose '2 Dislike' for this item.",
                     "options": [
                         {
                             "code": "1",
@@ -13923,9 +13923,9 @@
                     "dimension": "quality_consistency",
                     "subscale": "consistency",
                     "kind": 13,
-                    "text": "做决定前，我倾向先研究再行动。",
+                    "text": "Before making a decision, I tend to research first and act later.",
                     "text_zh": "做决定前，我倾向先研究再行动。",
-                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "text_en": "Before making a decision, I tend to research first and act later.",
                     "options": [
                         {
                             "code": "1",
@@ -13970,9 +13970,9 @@
                     "dimension": "quality_consistency",
                     "subscale": "consistency",
                     "kind": 31,
-                    "text": "我喜欢帮助他人解决问题。",
+                    "text": "I enjoy helping others solve problems.",
                     "text_zh": "我喜欢帮助他人解决问题。",
-                    "text_en": "我喜欢帮助他人解决问题。",
+                    "text_en": "I enjoy helping others solve problems.",
                     "options": [
                         {
                             "code": "1",
@@ -14017,9 +14017,9 @@
                     "dimension": "quality_consistency",
                     "subscale": "consistency",
                     "kind": 51,
-                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text": "I prefer clear processes and structured ways of working.",
                     "text_zh": "我偏好清晰流程和结构化工作方式。",
-                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "I prefer clear processes and structured ways of working.",
                     "options": [
                         {
                             "code": "1",

--- a/backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json
+++ b/backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json
@@ -20,11 +20,11 @@
   "source_asset": "holland_riasec_60_140_design_doc",
   "hashes": {
     "policy.compiled.json": "9aed5b4d61d3054fab3bc5f0e65dc62d98eae4e18034f2ee4f4771b5807c0522",
-    "questions.compiled.json": "26aed11c0de43d59396820d842c50861a61354ca931ee913a20c8a3bcfac9d91"
+    "questions.compiled.json": "9c2f236931416bd676d2543ad8f14b824184179b3071b9a740d35e8cec8a8f9b"
   },
   "compiled_files": [
     "questions.compiled.json",
     "policy.compiled.json"
   ],
-  "compiled_hash": "27c24c1022d5897c3201a667e2af358a01d195777f527d6ded8c446e935edc79"
+  "compiled_hash": "7ace460d7886eb5b79152df53dedfc5e6c52b5aec865552f0464aa9840eebdd2"
 }

--- a/backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json
+++ b/backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json
@@ -422,7 +422,7 @@
                     "kind": "interest",
                     "text": "我喜欢动手搭建、修理或改装东西。",
                     "text_zh": "我喜欢动手搭建、修理或改装东西。",
-                    "text_en": "我喜欢动手搭建、修理或改装东西。",
+                    "text_en": "I enjoy building, repairing, or modifying things by hand.",
                     "options": [
                         {
                             "code": "1",
@@ -469,7 +469,7 @@
                     "kind": "interest",
                     "text": "结果直观、看得见摸得着的任务会吸引我。",
                     "text_zh": "结果直观、看得见摸得着的任务会吸引我。",
-                    "text_en": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_en": "Tasks with visible, tangible results appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -516,7 +516,7 @@
                     "kind": "interest",
                     "text": "使用工具、设备或机械让我感到自在。",
                     "text_zh": "使用工具、设备或机械让我感到自在。",
-                    "text_en": "使用工具、设备或机械让我感到自在。",
+                    "text_en": "Using tools, equipment, or machinery feels comfortable to me.",
                     "options": [
                         {
                             "code": "1",
@@ -563,7 +563,7 @@
                     "kind": "interest",
                     "text": "比起长时间讨论，我更喜欢直接上手做。",
                     "text_zh": "比起长时间讨论，我更喜欢直接上手做。",
-                    "text_en": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_en": "Compared with long discussions, I prefer to get hands-on and do the work directly.",
                     "options": [
                         {
                             "code": "1",
@@ -610,7 +610,7 @@
                     "kind": "interest",
                     "text": "我喜欢解决机械、设备或技术故障。",
                     "text_zh": "我喜欢解决机械、设备或技术故障。",
-                    "text_en": "我喜欢解决机械、设备或技术故障。",
+                    "text_en": "I enjoy troubleshooting mechanical, equipment, or technical problems.",
                     "options": [
                         {
                             "code": "1",
@@ -657,7 +657,7 @@
                     "kind": "interest",
                     "text": "我愿意在现场完成需要操作和调整的工作。",
                     "text_zh": "我愿意在现场完成需要操作和调整的工作。",
-                    "text_en": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_en": "I am willing to complete work on site that requires operation and adjustment.",
                     "options": [
                         {
                             "code": "1",
@@ -704,7 +704,7 @@
                     "kind": "interest",
                     "text": "我对器材、结构或系统如何运作很感兴趣。",
                     "text_zh": "我对器材、结构或系统如何运作很感兴趣。",
-                    "text_en": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_en": "I am interested in how equipment, structures, or systems work.",
                     "options": [
                         {
                             "code": "1",
@@ -751,7 +751,7 @@
                     "kind": "interest",
                     "text": "需要手眼协调和实际操作的任务让我有投入感。",
                     "text_zh": "需要手眼协调和实际操作的任务让我有投入感。",
-                    "text_en": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_en": "Tasks that require hand-eye coordination and practical operation draw me in.",
                     "options": [
                         {
                             "code": "1",
@@ -798,7 +798,7 @@
                     "kind": "interest",
                     "text": "把想法变成实体、样品或可执行成果会让我满足。",
                     "text_zh": "把想法变成实体、样品或可执行成果会让我满足。",
-                    "text_en": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_en": "Turning ideas into physical objects, prototypes, or executable outcomes feels satisfying to me.",
                     "options": [
                         {
                             "code": "1",
@@ -845,7 +845,7 @@
                     "kind": "interest",
                     "text": "我愿意接触户外、工地、实验场或生产现场类情境。",
                     "text_zh": "我愿意接触户外、工地、实验场或生产现场类情境。",
-                    "text_en": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_en": "I am willing to work in settings such as outdoor sites, work sites, labs, or production environments.",
                     "options": [
                         {
                             "code": "1",
@@ -892,7 +892,7 @@
                     "kind": "interest",
                     "text": "我喜欢分析复杂问题并找出原因。",
                     "text_zh": "我喜欢分析复杂问题并找出原因。",
-                    "text_en": "我喜欢分析复杂问题并找出原因。",
+                    "text_en": "I enjoy analyzing complex problems and finding their causes.",
                     "options": [
                         {
                             "code": "1",
@@ -939,7 +939,7 @@
                     "kind": "interest",
                     "text": "数据、证据和逻辑会激发我的好奇心。",
                     "text_zh": "数据、证据和逻辑会激发我的好奇心。",
-                    "text_en": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_en": "Data, evidence, and logic spark my curiosity.",
                     "options": [
                         {
                             "code": "1",
@@ -986,7 +986,7 @@
                     "kind": "interest",
                     "text": "做决定前，我倾向先研究再行动。",
                     "text_zh": "做决定前，我倾向先研究再行动。",
-                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "text_en": "Before making a decision, I tend to research first and act later.",
                     "options": [
                         {
                             "code": "1",
@@ -1033,7 +1033,7 @@
                     "kind": "interest",
                     "text": "阅读和理解有难度的概念会让我投入。",
                     "text_zh": "阅读和理解有难度的概念会让我投入。",
-                    "text_en": "阅读和理解有难度的概念会让我投入。",
+                    "text_en": "Reading and understanding challenging concepts draws me in.",
                     "options": [
                         {
                             "code": "1",
@@ -1080,7 +1080,7 @@
                     "kind": "interest",
                     "text": "我喜欢从信息中识别规律或模型。",
                     "text_zh": "我喜欢从信息中识别规律或模型。",
-                    "text_en": "我喜欢从信息中识别规律或模型。",
+                    "text_en": "I enjoy identifying patterns or models in information.",
                     "options": [
                         {
                             "code": "1",
@@ -1127,7 +1127,7 @@
                     "kind": "interest",
                     "text": "需要严谨思考的工作更容易吸引我。",
                     "text_zh": "需要严谨思考的工作更容易吸引我。",
-                    "text_en": "需要严谨思考的工作更容易吸引我。",
+                    "text_en": "Work that requires rigorous thinking is more likely to attract me.",
                     "options": [
                         {
                             "code": "1",
@@ -1174,7 +1174,7 @@
                     "kind": "interest",
                     "text": "面对未知问题，我愿意先提出假设再验证。",
                     "text_zh": "面对未知问题，我愿意先提出假设再验证。",
-                    "text_en": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_en": "When facing an unfamiliar problem, I am willing to form hypotheses and then test them.",
                     "options": [
                         {
                             "code": "1",
@@ -1221,7 +1221,7 @@
                     "kind": "interest",
                     "text": "比起凭直觉判断，我更喜欢用事实推理。",
                     "text_zh": "比起凭直觉判断，我更喜欢用事实推理。",
-                    "text_en": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_en": "Compared with judging by intuition, I prefer reasoning from facts.",
                     "options": [
                         {
                             "code": "1",
@@ -1268,7 +1268,7 @@
                     "kind": "interest",
                     "text": "我喜欢把模糊问题拆解成可分析的部分。",
                     "text_zh": "我喜欢把模糊问题拆解成可分析的部分。",
-                    "text_en": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_en": "I enjoy breaking vague problems into parts that can be analyzed.",
                     "options": [
                         {
                             "code": "1",
@@ -1315,7 +1315,7 @@
                     "kind": "interest",
                     "text": "长时间独立思考、研究或探索答案不会让我厌烦。",
                     "text_zh": "长时间独立思考、研究或探索答案不会让我厌烦。",
-                    "text_en": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_en": "Long periods of independent thinking, research, or exploration do not bore me.",
                     "options": [
                         {
                             "code": "1",
@@ -1362,7 +1362,7 @@
                     "kind": "interest",
                     "text": "我喜欢创造新点子和原创成果。",
                     "text_zh": "我喜欢创造新点子和原创成果。",
-                    "text_en": "我喜欢创造新点子和原创成果。",
+                    "text_en": "I enjoy creating new ideas and original work.",
                     "options": [
                         {
                             "code": "1",
@@ -1409,7 +1409,7 @@
                     "kind": "interest",
                     "text": "表达自我是我工作动力的重要来源。",
                     "text_zh": "表达自我是我工作动力的重要来源。",
-                    "text_en": "表达自我是我工作动力的重要来源。",
+                    "text_en": "Self-expression is an important source of work motivation for me.",
                     "options": [
                         {
                             "code": "1",
@@ -1456,7 +1456,7 @@
                     "kind": "interest",
                     "text": "我喜欢尝试不同风格和表达方式。",
                     "text_zh": "我喜欢尝试不同风格和表达方式。",
-                    "text_en": "我喜欢尝试不同风格和表达方式。",
+                    "text_en": "I enjoy trying different styles and ways of expression.",
                     "options": [
                         {
                             "code": "1",
@@ -1503,7 +1503,7 @@
                     "kind": "interest",
                     "text": "相比固定流程，我更喜欢开放式任务。",
                     "text_zh": "相比固定流程，我更喜欢开放式任务。",
-                    "text_en": "相比固定流程，我更喜欢开放式任务。",
+                    "text_en": "Compared with fixed procedures, I prefer open-ended tasks.",
                     "options": [
                         {
                             "code": "1",
@@ -1550,7 +1550,7 @@
                     "kind": "interest",
                     "text": "视觉、文字、声音或概念设计类工作会吸引我。",
                     "text_zh": "视觉、文字、声音或概念设计类工作会吸引我。",
-                    "text_en": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_en": "Work involving visual, written, audio, or conceptual design appeals to me.",
                     "options": [
                         {
                             "code": "1",
@@ -1597,7 +1597,7 @@
                     "kind": "interest",
                     "text": "创造性探索会让我更有能量。",
                     "text_zh": "创造性探索会让我更有能量。",
-                    "text_en": "创造性探索会让我更有能量。",
+                    "text_en": "Creative exploration gives me more energy.",
                     "options": [
                         {
                             "code": "1",
@@ -1644,7 +1644,7 @@
                     "kind": "interest",
                     "text": "我喜欢把抽象感觉转化为作品、内容或方案。",
                     "text_zh": "我喜欢把抽象感觉转化为作品、内容或方案。",
-                    "text_en": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_en": "I enjoy turning abstract feelings into work, content, or solutions.",
                     "options": [
                         {
                             "code": "1",
@@ -1691,7 +1691,7 @@
                     "kind": "interest",
                     "text": "我愿意从零开始构思，而不是只按模板执行。",
                     "text_zh": "我愿意从零开始构思，而不是只按模板执行。",
-                    "text_en": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_en": "I am willing to develop ideas from scratch rather than only follow templates.",
                     "options": [
                         {
                             "code": "1",
@@ -1738,7 +1738,7 @@
                     "kind": "interest",
                     "text": "当一件事可以做得更有美感或更有个性时，我会更投入。",
                     "text_zh": "当一件事可以做得更有美感或更有个性时，我会更投入。",
-                    "text_en": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_en": "When something can be made more aesthetic or more personal, I become more engaged.",
                     "options": [
                         {
                             "code": "1",
@@ -1785,7 +1785,7 @@
                     "kind": "interest",
                     "text": "我享受在没有标准答案的情况下进行创作。",
                     "text_zh": "我享受在没有标准答案的情况下进行创作。",
-                    "text_en": "我享受在没有标准答案的情况下进行创作。",
+                    "text_en": "I enjoy creating when there is no single standard answer.",
                     "options": [
                         {
                             "code": "1",
@@ -1832,7 +1832,7 @@
                     "kind": "interest",
                     "text": "我喜欢帮助他人解决问题。",
                     "text_zh": "我喜欢帮助他人解决问题。",
-                    "text_en": "我喜欢帮助他人解决问题。",
+                    "text_en": "I enjoy helping others solve problems.",
                     "options": [
                         {
                             "code": "1",
@@ -1879,7 +1879,7 @@
                     "kind": "interest",
                     "text": "我重视团队氛围和人际关系。",
                     "text_zh": "我重视团队氛围和人际关系。",
-                    "text_en": "我重视团队氛围和人际关系。",
+                    "text_en": "I value team atmosphere and interpersonal relationships.",
                     "options": [
                         {
                             "code": "1",
@@ -1926,7 +1926,7 @@
                     "kind": "interest",
                     "text": "我愿意耐心倾听他人。",
                     "text_zh": "我愿意耐心倾听他人。",
-                    "text_en": "我愿意耐心倾听他人。",
+                    "text_en": "I am willing to listen to others patiently.",
                     "options": [
                         {
                             "code": "1",
@@ -1973,7 +1973,7 @@
                     "kind": "interest",
                     "text": "包含辅导、支持或服务职责的角色会吸引我。",
                     "text_zh": "包含辅导、支持或服务职责的角色会吸引我。",
-                    "text_en": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_en": "Roles that include coaching, support, or service responsibilities appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -2020,7 +2020,7 @@
                     "kind": "interest",
                     "text": "当工作能真正帮助别人时，我会更有成就感。",
                     "text_zh": "当工作能真正帮助别人时，我会更有成就感。",
-                    "text_en": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_en": "When work can genuinely help other people, I feel a stronger sense of achievement.",
                     "options": [
                         {
                             "code": "1",
@@ -2067,7 +2067,7 @@
                     "kind": "interest",
                     "text": "我喜欢协调多方协作，让事情顺利推进。",
                     "text_zh": "我喜欢协调多方协作，让事情顺利推进。",
-                    "text_en": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_en": "I enjoy coordinating collaboration among different people so things move forward smoothly.",
                     "options": [
                         {
                             "code": "1",
@@ -2114,7 +2114,7 @@
                     "kind": "interest",
                     "text": "我愿意花时间理解他人的需求、情绪或难处。",
                     "text_zh": "我愿意花时间理解他人的需求、情绪或难处。",
-                    "text_en": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_en": "I am willing to spend time understanding other people's needs, emotions, or difficulties.",
                     "options": [
                         {
                             "code": "1",
@@ -2161,7 +2161,7 @@
                     "kind": "interest",
                     "text": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
                     "text_zh": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
-                    "text_en": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_en": "I enjoy using communication to help others feel more reassured, clearer, or more directed.",
                     "options": [
                         {
                             "code": "1",
@@ -2208,7 +2208,7 @@
                     "kind": "interest",
                     "text": "看到别人因我的支持而进步，我会很满足。",
                     "text_zh": "看到别人因我的支持而进步，我会很满足。",
-                    "text_en": "看到别人因我的支持而进步，我会很满足。",
+                    "text_en": "Seeing others make progress because of my support feels satisfying to me.",
                     "options": [
                         {
                             "code": "1",
@@ -2255,7 +2255,7 @@
                     "kind": "interest",
                     "text": "我喜欢需要合作、陪伴或群体互动的工作场景。",
                     "text_zh": "我喜欢需要合作、陪伴或群体互动的工作场景。",
-                    "text_en": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_en": "I enjoy work settings that require cooperation, companionship, or group interaction.",
                     "options": [
                         {
                             "code": "1",
@@ -2302,7 +2302,7 @@
                     "kind": "interest",
                     "text": "我喜欢通过观点影响他人。",
                     "text_zh": "我喜欢通过观点影响他人。",
-                    "text_en": "我喜欢通过观点影响他人。",
+                    "text_en": "I enjoy influencing others through ideas and viewpoints.",
                     "options": [
                         {
                             "code": "1",
@@ -2349,7 +2349,7 @@
                     "kind": "interest",
                     "text": "主导推进事项会让我更有动力。",
                     "text_zh": "主导推进事项会让我更有动力。",
-                    "text_en": "主导推进事项会让我更有动力。",
+                    "text_en": "Taking the lead in moving things forward gives me more motivation.",
                     "options": [
                         {
                             "code": "1",
@@ -2396,7 +2396,7 @@
                     "kind": "interest",
                     "text": "我喜欢设定目标并推动结果达成。",
                     "text_zh": "我喜欢设定目标并推动结果达成。",
-                    "text_en": "我喜欢设定目标并推动结果达成。",
+                    "text_en": "I enjoy setting goals and driving results to completion.",
                     "options": [
                         {
                             "code": "1",
@@ -2443,7 +2443,7 @@
                     "kind": "interest",
                     "text": "我能适应谈判、争取资源或说服他人的场景。",
                     "text_zh": "我能适应谈判、争取资源或说服他人的场景。",
-                    "text_en": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_en": "I can adapt to situations involving negotiation, resource seeking, or persuasion.",
                     "options": [
                         {
                             "code": "1",
@@ -2490,7 +2490,7 @@
                     "kind": "interest",
                     "text": "偏商业导向、增长导向的挑战会吸引我。",
                     "text_zh": "偏商业导向、增长导向的挑战会吸引我。",
-                    "text_en": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_en": "Business-oriented and growth-oriented challenges appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -2537,7 +2537,7 @@
                     "kind": "interest",
                     "text": "在压力下主动承担责任会让我更有存在感。",
                     "text_zh": "在压力下主动承担责任会让我更有存在感。",
-                    "text_en": "在压力下主动承担责任会让我更有存在感。",
+                    "text_en": "Taking responsibility under pressure gives me a stronger sense of presence.",
                     "options": [
                         {
                             "code": "1",
@@ -2584,7 +2584,7 @@
                     "kind": "interest",
                     "text": "我愿意带头组织资源、人和节奏去完成目标。",
                     "text_zh": "我愿意带头组织资源、人和节奏去完成目标。",
-                    "text_en": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_en": "I am willing to lead the coordination of resources, people, and pace to achieve a goal.",
                     "options": [
                         {
                             "code": "1",
@@ -2631,7 +2631,7 @@
                     "kind": "interest",
                     "text": "我喜欢竞争、突破和把机会变成结果的过程。",
                     "text_zh": "我喜欢竞争、突破和把机会变成结果的过程。",
-                    "text_en": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_en": "I enjoy the process of competition, breakthrough, and turning opportunities into results.",
                     "options": [
                         {
                             "code": "1",
@@ -2678,7 +2678,7 @@
                     "kind": "interest",
                     "text": "当一个项目需要有人站出来拍板时，我愿意担当。",
                     "text_zh": "当一个项目需要有人站出来拍板时，我愿意担当。",
-                    "text_en": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_en": "When a project needs someone to step up and make decisions, I am willing to take that role.",
                     "options": [
                         {
                             "code": "1",
@@ -2725,7 +2725,7 @@
                     "kind": "interest",
                     "text": "我对市场、业务、创业或对外拓展类任务有兴趣。",
                     "text_zh": "我对市场、业务、创业或对外拓展类任务有兴趣。",
-                    "text_en": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving markets, business, entrepreneurship, or external development.",
                     "options": [
                         {
                             "code": "1",
@@ -2772,7 +2772,7 @@
                     "kind": "interest",
                     "text": "我偏好清晰流程和结构化工作方式。",
                     "text_zh": "我偏好清晰流程和结构化工作方式。",
-                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "I prefer clear processes and structured ways of working.",
                     "options": [
                         {
                             "code": "1",
@@ -2819,7 +2819,7 @@
                     "kind": "interest",
                     "text": "我重视细节以及质量校验。",
                     "text_zh": "我重视细节以及质量校验。",
-                    "text_en": "我重视细节以及质量校验。",
+                    "text_en": "I value details and quality checks.",
                     "options": [
                         {
                             "code": "1",
@@ -2866,7 +2866,7 @@
                     "kind": "interest",
                     "text": "我喜欢规划安排并跟踪进度。",
                     "text_zh": "我喜欢规划安排并跟踪进度。",
-                    "text_en": "我喜欢规划安排并跟踪进度。",
+                    "text_en": "I enjoy planning, arranging, and tracking progress.",
                     "options": [
                         {
                             "code": "1",
@@ -2913,7 +2913,7 @@
                     "kind": "interest",
                     "text": "对重复但重要的任务，我能稳定执行并且不排斥。",
                     "text_zh": "对重复但重要的任务，我能稳定执行并且不排斥。",
-                    "text_en": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_en": "For repetitive but important tasks, I can execute steadily and do not reject them.",
                     "options": [
                         {
                             "code": "1",
@@ -2960,7 +2960,7 @@
                     "kind": "interest",
                     "text": "规范、一致性和文档化会让我更安心。",
                     "text_zh": "规范、一致性和文档化会让我更安心。",
-                    "text_en": "规范、一致性和文档化会让我更安心。",
+                    "text_en": "Standards, consistency, and documentation make me feel more secure.",
                     "options": [
                         {
                             "code": "1",
@@ -3007,7 +3007,7 @@
                     "kind": "interest",
                     "text": "我喜欢组织、整理和运营执行类工作。",
                     "text_zh": "我喜欢组织、整理和运营执行类工作。",
-                    "text_en": "我喜欢组织、整理和运营执行类工作。",
+                    "text_en": "I enjoy work involving organization, sorting, operations, and execution.",
                     "options": [
                         {
                             "code": "1",
@@ -3054,7 +3054,7 @@
                     "kind": "interest",
                     "text": "我愿意维护台账、清单、记录或标准作业流程。",
                     "text_zh": "我愿意维护台账、清单、记录或标准作业流程。",
-                    "text_en": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_en": "I am willing to maintain ledgers, checklists, records, or standard operating procedures.",
                     "options": [
                         {
                             "code": "1",
@@ -3101,7 +3101,7 @@
                     "kind": "interest",
                     "text": "明确规则和职责边界的环境会让我更高效。",
                     "text_zh": "明确规则和职责边界的环境会让我更高效。",
-                    "text_en": "明确规则和职责边界的环境会让我更高效。",
+                    "text_en": "Environments with clear rules and responsibility boundaries make me more efficient.",
                     "options": [
                         {
                             "code": "1",
@@ -3148,7 +3148,7 @@
                     "kind": "interest",
                     "text": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
                     "text_zh": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
-                    "text_en": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_en": "I enjoy organizing messy information into clear categories and sequences.",
                     "options": [
                         {
                             "code": "1",
@@ -3195,7 +3195,7 @@
                     "kind": "interest",
                     "text": "当事情被安排得井井有条时，我会更有满足感。",
                     "text_zh": "当事情被安排得井井有条时，我会更有满足感。",
-                    "text_en": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_en": "When things are arranged in an orderly way, I feel more satisfied.",
                     "options": [
                         {
                             "code": "1",
@@ -3244,9 +3244,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢动手搭建、修理或改装东西。",
+                    "text": "I enjoy building, repairing, or modifying things by hand.",
                     "text_zh": "我喜欢动手搭建、修理或改装东西。",
-                    "text_en": "我喜欢动手搭建、修理或改装东西。",
+                    "text_en": "I enjoy building, repairing, or modifying things by hand.",
                     "options": [
                         {
                             "code": "1",
@@ -3291,9 +3291,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text": "Tasks with visible, tangible results appeal to me.",
                     "text_zh": "结果直观、看得见摸得着的任务会吸引我。",
-                    "text_en": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_en": "Tasks with visible, tangible results appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -3338,9 +3338,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "使用工具、设备或机械让我感到自在。",
+                    "text": "Using tools, equipment, or machinery feels comfortable to me.",
                     "text_zh": "使用工具、设备或机械让我感到自在。",
-                    "text_en": "使用工具、设备或机械让我感到自在。",
+                    "text_en": "Using tools, equipment, or machinery feels comfortable to me.",
                     "options": [
                         {
                             "code": "1",
@@ -3385,9 +3385,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text": "Compared with long discussions, I prefer to get hands-on and do the work directly.",
                     "text_zh": "比起长时间讨论，我更喜欢直接上手做。",
-                    "text_en": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_en": "Compared with long discussions, I prefer to get hands-on and do the work directly.",
                     "options": [
                         {
                             "code": "1",
@@ -3432,9 +3432,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢解决机械、设备或技术故障。",
+                    "text": "I enjoy troubleshooting mechanical, equipment, or technical problems.",
                     "text_zh": "我喜欢解决机械、设备或技术故障。",
-                    "text_en": "我喜欢解决机械、设备或技术故障。",
+                    "text_en": "I enjoy troubleshooting mechanical, equipment, or technical problems.",
                     "options": [
                         {
                             "code": "1",
@@ -3479,9 +3479,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意在现场完成需要操作和调整的工作。",
+                    "text": "I am willing to complete work on site that requires operation and adjustment.",
                     "text_zh": "我愿意在现场完成需要操作和调整的工作。",
-                    "text_en": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_en": "I am willing to complete work on site that requires operation and adjustment.",
                     "options": [
                         {
                             "code": "1",
@@ -3526,9 +3526,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text": "I am interested in how equipment, structures, or systems work.",
                     "text_zh": "我对器材、结构或系统如何运作很感兴趣。",
-                    "text_en": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_en": "I am interested in how equipment, structures, or systems work.",
                     "options": [
                         {
                             "code": "1",
@@ -3573,9 +3573,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text": "Tasks that require hand-eye coordination and practical operation draw me in.",
                     "text_zh": "需要手眼协调和实际操作的任务让我有投入感。",
-                    "text_en": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_en": "Tasks that require hand-eye coordination and practical operation draw me in.",
                     "options": [
                         {
                             "code": "1",
@@ -3620,9 +3620,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text": "Turning ideas into physical objects, prototypes, or executable outcomes feels satisfying to me.",
                     "text_zh": "把想法变成实体、样品或可执行成果会让我满足。",
-                    "text_en": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_en": "Turning ideas into physical objects, prototypes, or executable outcomes feels satisfying to me.",
                     "options": [
                         {
                             "code": "1",
@@ -3667,9 +3667,9 @@
                     "dimension": "R",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text": "I am willing to work in settings such as outdoor sites, work sites, labs, or production environments.",
                     "text_zh": "我愿意接触户外、工地、实验场或生产现场类情境。",
-                    "text_en": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_en": "I am willing to work in settings such as outdoor sites, work sites, labs, or production environments.",
                     "options": [
                         {
                             "code": "1",
@@ -3714,9 +3714,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢分析复杂问题并找出原因。",
+                    "text": "I enjoy analyzing complex problems and finding their causes.",
                     "text_zh": "我喜欢分析复杂问题并找出原因。",
-                    "text_en": "我喜欢分析复杂问题并找出原因。",
+                    "text_en": "I enjoy analyzing complex problems and finding their causes.",
                     "options": [
                         {
                             "code": "1",
@@ -3761,9 +3761,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "数据、证据和逻辑会激发我的好奇心。",
+                    "text": "Data, evidence, and logic spark my curiosity.",
                     "text_zh": "数据、证据和逻辑会激发我的好奇心。",
-                    "text_en": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_en": "Data, evidence, and logic spark my curiosity.",
                     "options": [
                         {
                             "code": "1",
@@ -3808,9 +3808,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "做决定前，我倾向先研究再行动。",
+                    "text": "Before making a decision, I tend to research first and act later.",
                     "text_zh": "做决定前，我倾向先研究再行动。",
-                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "text_en": "Before making a decision, I tend to research first and act later.",
                     "options": [
                         {
                             "code": "1",
@@ -3855,9 +3855,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "阅读和理解有难度的概念会让我投入。",
+                    "text": "Reading and understanding challenging concepts draws me in.",
                     "text_zh": "阅读和理解有难度的概念会让我投入。",
-                    "text_en": "阅读和理解有难度的概念会让我投入。",
+                    "text_en": "Reading and understanding challenging concepts draws me in.",
                     "options": [
                         {
                             "code": "1",
@@ -3902,9 +3902,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢从信息中识别规律或模型。",
+                    "text": "I enjoy identifying patterns or models in information.",
                     "text_zh": "我喜欢从信息中识别规律或模型。",
-                    "text_en": "我喜欢从信息中识别规律或模型。",
+                    "text_en": "I enjoy identifying patterns or models in information.",
                     "options": [
                         {
                             "code": "1",
@@ -3949,9 +3949,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "需要严谨思考的工作更容易吸引我。",
+                    "text": "Work that requires rigorous thinking is more likely to attract me.",
                     "text_zh": "需要严谨思考的工作更容易吸引我。",
-                    "text_en": "需要严谨思考的工作更容易吸引我。",
+                    "text_en": "Work that requires rigorous thinking is more likely to attract me.",
                     "options": [
                         {
                             "code": "1",
@@ -3996,9 +3996,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "面对未知问题，我愿意先提出假设再验证。",
+                    "text": "When facing an unfamiliar problem, I am willing to form hypotheses and then test them.",
                     "text_zh": "面对未知问题，我愿意先提出假设再验证。",
-                    "text_en": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_en": "When facing an unfamiliar problem, I am willing to form hypotheses and then test them.",
                     "options": [
                         {
                             "code": "1",
@@ -4043,9 +4043,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text": "Compared with judging by intuition, I prefer reasoning from facts.",
                     "text_zh": "比起凭直觉判断，我更喜欢用事实推理。",
-                    "text_en": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_en": "Compared with judging by intuition, I prefer reasoning from facts.",
                     "options": [
                         {
                             "code": "1",
@@ -4090,9 +4090,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text": "I enjoy breaking vague problems into parts that can be analyzed.",
                     "text_zh": "我喜欢把模糊问题拆解成可分析的部分。",
-                    "text_en": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_en": "I enjoy breaking vague problems into parts that can be analyzed.",
                     "options": [
                         {
                             "code": "1",
@@ -4137,9 +4137,9 @@
                     "dimension": "I",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text": "Long periods of independent thinking, research, or exploration do not bore me.",
                     "text_zh": "长时间独立思考、研究或探索答案不会让我厌烦。",
-                    "text_en": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_en": "Long periods of independent thinking, research, or exploration do not bore me.",
                     "options": [
                         {
                             "code": "1",
@@ -4184,9 +4184,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢创造新点子和原创成果。",
+                    "text": "I enjoy creating new ideas and original work.",
                     "text_zh": "我喜欢创造新点子和原创成果。",
-                    "text_en": "我喜欢创造新点子和原创成果。",
+                    "text_en": "I enjoy creating new ideas and original work.",
                     "options": [
                         {
                             "code": "1",
@@ -4231,9 +4231,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "表达自我是我工作动力的重要来源。",
+                    "text": "Self-expression is an important source of work motivation for me.",
                     "text_zh": "表达自我是我工作动力的重要来源。",
-                    "text_en": "表达自我是我工作动力的重要来源。",
+                    "text_en": "Self-expression is an important source of work motivation for me.",
                     "options": [
                         {
                             "code": "1",
@@ -4278,9 +4278,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢尝试不同风格和表达方式。",
+                    "text": "I enjoy trying different styles and ways of expression.",
                     "text_zh": "我喜欢尝试不同风格和表达方式。",
-                    "text_en": "我喜欢尝试不同风格和表达方式。",
+                    "text_en": "I enjoy trying different styles and ways of expression.",
                     "options": [
                         {
                             "code": "1",
@@ -4325,9 +4325,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "相比固定流程，我更喜欢开放式任务。",
+                    "text": "Compared with fixed procedures, I prefer open-ended tasks.",
                     "text_zh": "相比固定流程，我更喜欢开放式任务。",
-                    "text_en": "相比固定流程，我更喜欢开放式任务。",
+                    "text_en": "Compared with fixed procedures, I prefer open-ended tasks.",
                     "options": [
                         {
                             "code": "1",
@@ -4372,9 +4372,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text": "Work involving visual, written, audio, or conceptual design appeals to me.",
                     "text_zh": "视觉、文字、声音或概念设计类工作会吸引我。",
-                    "text_en": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_en": "Work involving visual, written, audio, or conceptual design appeals to me.",
                     "options": [
                         {
                             "code": "1",
@@ -4419,9 +4419,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "创造性探索会让我更有能量。",
+                    "text": "Creative exploration gives me more energy.",
                     "text_zh": "创造性探索会让我更有能量。",
-                    "text_en": "创造性探索会让我更有能量。",
+                    "text_en": "Creative exploration gives me more energy.",
                     "options": [
                         {
                             "code": "1",
@@ -4466,9 +4466,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text": "I enjoy turning abstract feelings into work, content, or solutions.",
                     "text_zh": "我喜欢把抽象感觉转化为作品、内容或方案。",
-                    "text_en": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_en": "I enjoy turning abstract feelings into work, content, or solutions.",
                     "options": [
                         {
                             "code": "1",
@@ -4513,9 +4513,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text": "I am willing to develop ideas from scratch rather than only follow templates.",
                     "text_zh": "我愿意从零开始构思，而不是只按模板执行。",
-                    "text_en": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_en": "I am willing to develop ideas from scratch rather than only follow templates.",
                     "options": [
                         {
                             "code": "1",
@@ -4560,9 +4560,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text": "When something can be made more aesthetic or more personal, I become more engaged.",
                     "text_zh": "当一件事可以做得更有美感或更有个性时，我会更投入。",
-                    "text_en": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_en": "When something can be made more aesthetic or more personal, I become more engaged.",
                     "options": [
                         {
                             "code": "1",
@@ -4607,9 +4607,9 @@
                     "dimension": "A",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我享受在没有标准答案的情况下进行创作。",
+                    "text": "I enjoy creating when there is no single standard answer.",
                     "text_zh": "我享受在没有标准答案的情况下进行创作。",
-                    "text_en": "我享受在没有标准答案的情况下进行创作。",
+                    "text_en": "I enjoy creating when there is no single standard answer.",
                     "options": [
                         {
                             "code": "1",
@@ -4654,9 +4654,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢帮助他人解决问题。",
+                    "text": "I enjoy helping others solve problems.",
                     "text_zh": "我喜欢帮助他人解决问题。",
-                    "text_en": "我喜欢帮助他人解决问题。",
+                    "text_en": "I enjoy helping others solve problems.",
                     "options": [
                         {
                             "code": "1",
@@ -4701,9 +4701,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我重视团队氛围和人际关系。",
+                    "text": "I value team atmosphere and interpersonal relationships.",
                     "text_zh": "我重视团队氛围和人际关系。",
-                    "text_en": "我重视团队氛围和人际关系。",
+                    "text_en": "I value team atmosphere and interpersonal relationships.",
                     "options": [
                         {
                             "code": "1",
@@ -4748,9 +4748,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意耐心倾听他人。",
+                    "text": "I am willing to listen to others patiently.",
                     "text_zh": "我愿意耐心倾听他人。",
-                    "text_en": "我愿意耐心倾听他人。",
+                    "text_en": "I am willing to listen to others patiently.",
                     "options": [
                         {
                             "code": "1",
@@ -4795,9 +4795,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text": "Roles that include coaching, support, or service responsibilities appeal to me.",
                     "text_zh": "包含辅导、支持或服务职责的角色会吸引我。",
-                    "text_en": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_en": "Roles that include coaching, support, or service responsibilities appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -4842,9 +4842,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text": "When work can genuinely help other people, I feel a stronger sense of achievement.",
                     "text_zh": "当工作能真正帮助别人时，我会更有成就感。",
-                    "text_en": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_en": "When work can genuinely help other people, I feel a stronger sense of achievement.",
                     "options": [
                         {
                             "code": "1",
@@ -4889,9 +4889,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text": "I enjoy coordinating collaboration among different people so things move forward smoothly.",
                     "text_zh": "我喜欢协调多方协作，让事情顺利推进。",
-                    "text_en": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_en": "I enjoy coordinating collaboration among different people so things move forward smoothly.",
                     "options": [
                         {
                             "code": "1",
@@ -4936,9 +4936,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text": "I am willing to spend time understanding other people's needs, emotions, or difficulties.",
                     "text_zh": "我愿意花时间理解他人的需求、情绪或难处。",
-                    "text_en": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_en": "I am willing to spend time understanding other people's needs, emotions, or difficulties.",
                     "options": [
                         {
                             "code": "1",
@@ -4983,9 +4983,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text": "I enjoy using communication to help others feel more reassured, clearer, or more directed.",
                     "text_zh": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
-                    "text_en": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_en": "I enjoy using communication to help others feel more reassured, clearer, or more directed.",
                     "options": [
                         {
                             "code": "1",
@@ -5030,9 +5030,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "看到别人因我的支持而进步，我会很满足。",
+                    "text": "Seeing others make progress because of my support feels satisfying to me.",
                     "text_zh": "看到别人因我的支持而进步，我会很满足。",
-                    "text_en": "看到别人因我的支持而进步，我会很满足。",
+                    "text_en": "Seeing others make progress because of my support feels satisfying to me.",
                     "options": [
                         {
                             "code": "1",
@@ -5077,9 +5077,9 @@
                     "dimension": "S",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text": "I enjoy work settings that require cooperation, companionship, or group interaction.",
                     "text_zh": "我喜欢需要合作、陪伴或群体互动的工作场景。",
-                    "text_en": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_en": "I enjoy work settings that require cooperation, companionship, or group interaction.",
                     "options": [
                         {
                             "code": "1",
@@ -5124,9 +5124,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢通过观点影响他人。",
+                    "text": "I enjoy influencing others through ideas and viewpoints.",
                     "text_zh": "我喜欢通过观点影响他人。",
-                    "text_en": "我喜欢通过观点影响他人。",
+                    "text_en": "I enjoy influencing others through ideas and viewpoints.",
                     "options": [
                         {
                             "code": "1",
@@ -5171,9 +5171,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "主导推进事项会让我更有动力。",
+                    "text": "Taking the lead in moving things forward gives me more motivation.",
                     "text_zh": "主导推进事项会让我更有动力。",
-                    "text_en": "主导推进事项会让我更有动力。",
+                    "text_en": "Taking the lead in moving things forward gives me more motivation.",
                     "options": [
                         {
                             "code": "1",
@@ -5218,9 +5218,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢设定目标并推动结果达成。",
+                    "text": "I enjoy setting goals and driving results to completion.",
                     "text_zh": "我喜欢设定目标并推动结果达成。",
-                    "text_en": "我喜欢设定目标并推动结果达成。",
+                    "text_en": "I enjoy setting goals and driving results to completion.",
                     "options": [
                         {
                             "code": "1",
@@ -5265,9 +5265,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text": "I can adapt to situations involving negotiation, resource seeking, or persuasion.",
                     "text_zh": "我能适应谈判、争取资源或说服他人的场景。",
-                    "text_en": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_en": "I can adapt to situations involving negotiation, resource seeking, or persuasion.",
                     "options": [
                         {
                             "code": "1",
@@ -5312,9 +5312,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text": "Business-oriented and growth-oriented challenges appeal to me.",
                     "text_zh": "偏商业导向、增长导向的挑战会吸引我。",
-                    "text_en": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_en": "Business-oriented and growth-oriented challenges appeal to me.",
                     "options": [
                         {
                             "code": "1",
@@ -5359,9 +5359,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "在压力下主动承担责任会让我更有存在感。",
+                    "text": "Taking responsibility under pressure gives me a stronger sense of presence.",
                     "text_zh": "在压力下主动承担责任会让我更有存在感。",
-                    "text_en": "在压力下主动承担责任会让我更有存在感。",
+                    "text_en": "Taking responsibility under pressure gives me a stronger sense of presence.",
                     "options": [
                         {
                             "code": "1",
@@ -5406,9 +5406,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text": "I am willing to lead the coordination of resources, people, and pace to achieve a goal.",
                     "text_zh": "我愿意带头组织资源、人和节奏去完成目标。",
-                    "text_en": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_en": "I am willing to lead the coordination of resources, people, and pace to achieve a goal.",
                     "options": [
                         {
                             "code": "1",
@@ -5453,9 +5453,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text": "I enjoy the process of competition, breakthrough, and turning opportunities into results.",
                     "text_zh": "我喜欢竞争、突破和把机会变成结果的过程。",
-                    "text_en": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_en": "I enjoy the process of competition, breakthrough, and turning opportunities into results.",
                     "options": [
                         {
                             "code": "1",
@@ -5500,9 +5500,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text": "When a project needs someone to step up and make decisions, I am willing to take that role.",
                     "text_zh": "当一个项目需要有人站出来拍板时，我愿意担当。",
-                    "text_en": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_en": "When a project needs someone to step up and make decisions, I am willing to take that role.",
                     "options": [
                         {
                             "code": "1",
@@ -5547,9 +5547,9 @@
                     "dimension": "E",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text": "I am interested in tasks involving markets, business, entrepreneurship, or external development.",
                     "text_zh": "我对市场、业务、创业或对外拓展类任务有兴趣。",
-                    "text_en": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_en": "I am interested in tasks involving markets, business, entrepreneurship, or external development.",
                     "options": [
                         {
                             "code": "1",
@@ -5594,9 +5594,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text": "I prefer clear processes and structured ways of working.",
                     "text_zh": "我偏好清晰流程和结构化工作方式。",
-                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "I prefer clear processes and structured ways of working.",
                     "options": [
                         {
                             "code": "1",
@@ -5641,9 +5641,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我重视细节以及质量校验。",
+                    "text": "I value details and quality checks.",
                     "text_zh": "我重视细节以及质量校验。",
-                    "text_en": "我重视细节以及质量校验。",
+                    "text_en": "I value details and quality checks.",
                     "options": [
                         {
                             "code": "1",
@@ -5688,9 +5688,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢规划安排并跟踪进度。",
+                    "text": "I enjoy planning, arranging, and tracking progress.",
                     "text_zh": "我喜欢规划安排并跟踪进度。",
-                    "text_en": "我喜欢规划安排并跟踪进度。",
+                    "text_en": "I enjoy planning, arranging, and tracking progress.",
                     "options": [
                         {
                             "code": "1",
@@ -5735,9 +5735,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text": "For repetitive but important tasks, I can execute steadily and do not reject them.",
                     "text_zh": "对重复但重要的任务，我能稳定执行并且不排斥。",
-                    "text_en": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_en": "For repetitive but important tasks, I can execute steadily and do not reject them.",
                     "options": [
                         {
                             "code": "1",
@@ -5782,9 +5782,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "规范、一致性和文档化会让我更安心。",
+                    "text": "Standards, consistency, and documentation make me feel more secure.",
                     "text_zh": "规范、一致性和文档化会让我更安心。",
-                    "text_en": "规范、一致性和文档化会让我更安心。",
+                    "text_en": "Standards, consistency, and documentation make me feel more secure.",
                     "options": [
                         {
                             "code": "1",
@@ -5829,9 +5829,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢组织、整理和运营执行类工作。",
+                    "text": "I enjoy work involving organization, sorting, operations, and execution.",
                     "text_zh": "我喜欢组织、整理和运营执行类工作。",
-                    "text_en": "我喜欢组织、整理和运营执行类工作。",
+                    "text_en": "I enjoy work involving organization, sorting, operations, and execution.",
                     "options": [
                         {
                             "code": "1",
@@ -5876,9 +5876,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text": "I am willing to maintain ledgers, checklists, records, or standard operating procedures.",
                     "text_zh": "我愿意维护台账、清单、记录或标准作业流程。",
-                    "text_en": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_en": "I am willing to maintain ledgers, checklists, records, or standard operating procedures.",
                     "options": [
                         {
                             "code": "1",
@@ -5923,9 +5923,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "明确规则和职责边界的环境会让我更高效。",
+                    "text": "Environments with clear rules and responsibility boundaries make me more efficient.",
                     "text_zh": "明确规则和职责边界的环境会让我更高效。",
-                    "text_en": "明确规则和职责边界的环境会让我更高效。",
+                    "text_en": "Environments with clear rules and responsibility boundaries make me more efficient.",
                     "options": [
                         {
                             "code": "1",
@@ -5970,9 +5970,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text": "I enjoy organizing messy information into clear categories and sequences.",
                     "text_zh": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
-                    "text_en": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_en": "I enjoy organizing messy information into clear categories and sequences.",
                     "options": [
                         {
                             "code": "1",
@@ -6017,9 +6017,9 @@
                     "dimension": "C",
                     "subscale": "activity",
                     "kind": "interest",
-                    "text": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text": "When things are arranged in an orderly way, I feel more satisfied.",
                     "text_zh": "当事情被安排得井井有条时，我会更有满足感。",
-                    "text_en": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_en": "When things are arranged in an orderly way, I feel more satisfied.",
                     "options": [
                         {
                             "code": "1",

--- a/backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php
+++ b/backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class RiasecQuestionLocaleTranslationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+    }
+
+    public function test_riasec_60_english_questions_are_translated_without_changing_count_or_scoring(): void
+    {
+        $response = $this->getJson('/api/v0.3/scales/RIASEC/questions?locale=en&form_code=riasec_60');
+
+        $response->assertOk();
+        $response->assertJsonPath('locale', 'en');
+        $response->assertJsonPath('form_code', 'riasec_60');
+        $response->assertJsonPath('dir_version', 'v1-standard-60');
+
+        $items = (array) data_get($response->json(), 'questions.items', []);
+        $this->assertCount(60, $items);
+        $this->assertSame('I enjoy building, repairing, or modifying things by hand.', data_get($items, '0.text'));
+        $this->assertSame('我喜欢动手搭建、修理或改装东西。', data_get($items, '0.text_zh'));
+        $this->assertSame('Strongly dislike', data_get($items, '0.options.0.text'));
+        $this->assertSame('非常不喜欢', data_get($items, '0.options.0.text_zh'));
+        $this->assertSame(1, data_get($items, '0.options.0.score'));
+
+        $this->assertDisplayedFieldsDoNotContainChinese($items);
+    }
+
+    public function test_riasec_140_english_questions_are_translated_without_changing_count_or_scoring(): void
+    {
+        $response = $this->getJson('/api/v0.3/scales/RIASEC/questions?locale=en&form_code=riasec_140');
+
+        $response->assertOk();
+        $response->assertJsonPath('locale', 'en');
+        $response->assertJsonPath('form_code', 'riasec_140');
+        $response->assertJsonPath('dir_version', 'v1-enhanced-140');
+
+        $items = (array) data_get($response->json(), 'questions.items', []);
+        $this->assertCount(140, $items);
+        $this->assertSame('I enjoy building, repairing, or modifying things by hand.', data_get($items, '0.text'));
+        $this->assertSame("To confirm that you are answering attentively, please choose '3 Unsure / neutral' for this item.", data_get($items, '132.text'));
+        $this->assertSame('Dislike', data_get($items, '136.options.1.text'));
+        $this->assertSame(2, data_get($items, '136.options.1.score'));
+
+        $this->assertDisplayedFieldsDoNotContainChinese($items);
+    }
+
+    public function test_riasec_zh_locale_keeps_chinese_display_fields(): void
+    {
+        $response = $this->getJson('/api/v0.3/scales/RIASEC/questions?locale=zh-CN&form_code=riasec_60');
+
+        $response->assertOk();
+        $response->assertJsonPath('locale', 'zh-CN');
+        $response->assertJsonPath('form_code', 'riasec_60');
+
+        $items = (array) data_get($response->json(), 'questions.items', []);
+        $this->assertCount(60, $items);
+        $this->assertSame('我喜欢动手搭建、修理或改装东西。', data_get($items, '0.text'));
+        $this->assertSame('非常不喜欢', data_get($items, '0.options.0.text'));
+        $this->assertSame('I enjoy building, repairing, or modifying things by hand.', data_get($items, '0.text_en'));
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     */
+    private function assertDisplayedFieldsDoNotContainChinese(array $items): void
+    {
+        foreach ($items as $item) {
+            $this->assertDoesNotMatchRegularExpression('/\\p{Han}/u', (string) ($item['text'] ?? ''));
+
+            foreach ((array) ($item['options'] ?? []) as $option) {
+                if (! is_array($option)) {
+                    continue;
+                }
+
+                $this->assertDoesNotMatchRegularExpression('/\\p{Han}/u', (string) ($option['text'] ?? ''));
+            }
+        }
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1624,6 +1624,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_question_pack_translation_changes(): void
+    {
+        $changed = [
+            'backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json',
+            'backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json',
+            'backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json',
+            'backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -2567,6 +2579,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecQuestionPackTranslationFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -3291,6 +3307,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php',
             'backend/app/Services/Riasec/RiasecPublicProjectionService.php',
         ], true);
+    }
+
+    private function isRiasecQuestionPackTranslationFile(string $file): bool
+    {
+        return preg_match('#^backend/content_packs/RIASEC/v1-(?:standard-60|enhanced-140)/compiled/(?:questions\\.compiled|manifest)\\.json$#', $file) === 1;
     }
 
     private function isIqReportFoundationFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29800,13 +29800,13 @@
     "repo": "fap-api",
     "branch": "codex/riasec-en-questions-pack-translation-02",
     "base": "main",
-    "status": "local_validation_passed",
+    "status": "pr_opened",
     "depends_on": [
       "MBTI-EN-QUESTIONS-PACK-PROJECTION-01"
     ],
     "title": "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02 RIASEC English question pack translation",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "17bbb89e6ac290115c0811ceacf724c64caf9376",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1734",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -29876,7 +29876,7 @@
       },
       "github_required_checks": {
         "status": "pending",
-        "pr_url": null
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1734"
       }
     },
     "scope": {
@@ -29909,6 +29909,11 @@
         "at": "2026-05-28T00:45:00+08:00",
         "status": "local_validation_passed",
         "summary": "Translated RIASEC 60/140 English question stems in backend content packs, updated manifest hashes, added focused locale test, and passed local validation."
+      },
+      {
+        "at": "2026-05-28T00:48:00+08:00",
+        "status": "pr_opened",
+        "summary": "Opened PR #1734 for RIASEC English question pack translation; GitHub checks pending."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29800,7 +29800,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-en-questions-pack-translation-02",
     "base": "main",
-    "status": "pr_opened",
+    "status": "local_validation_passed",
     "depends_on": [
       "MBTI-EN-QUESTIONS-PACK-PROJECTION-01"
     ],
@@ -29828,20 +29828,17 @@
           "backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json",
           "backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json",
           "backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
         "outside_scope": [],
         "changed_files": [
-          "backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json",
-          "backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json",
-          "backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json",
-          "backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "docs/codex/pr-train-state.json",
-          "docs/codex/pr-train.yaml",
-          "backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php"
+          "docs/codex/pr-train.yaml"
         ],
-        "evidence": "Changed files are confined to RIASEC compiled question packs/manifests, focused RIASEC locale test, and authorized PR-train metadata."
+        "evidence": "Changed files are confined to RIASEC compiled question packs/manifests, focused RIASEC locale test, Big Five freeze classifier test-only allowance for the RIASEC pack files, and authorized PR-train metadata."
       },
       "focused_test": {
         "status": "pass",
@@ -29856,6 +29853,7 @@
       "local_validation": {
         "status": "pass",
         "commands": [
+          "cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi",
           "cd backend && php artisan test --filter=RiasecQuestionLocaleTranslation --no-ansi",
           "cd backend && php artisan test --filter=RiasecAssessmentFlow --no-ansi",
           "cd backend && php artisan route:list --no-ansi",
@@ -29872,11 +29870,20 @@
           "git diff --cached --check",
           "git -C /Users/rainie/Desktop/GitHub/fap-web status --short"
         ],
-        "evidence": "Focused RIASEC locale test, RIASEC assessment flow regression, route list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference status passed locally."
+        "evidence": "After CI fix, Big Five freeze classifier test passed, RIASEC focused and flow tests passed, and route list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference status passed locally."
       },
       "github_required_checks": {
-        "status": "pending",
-        "pr_url": "https://github.com/fermatmind/fap-api/pull/1734"
+        "status": "pending_rerun",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1734",
+        "previous_failed_checks": [
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "fix_evidence": "Local BigFiveResultPageV2CoreBodyPreviewTest now passes with the RIASEC question-pack-only allowance."
+      },
+      "ci_fix_scope": {
+        "status": "pass",
+        "evidence": "Added a focused test-only freeze classifier allowance for backend/content_packs/RIASEC v1-standard-60 and v1-enhanced-140 compiled questions/manifests; no runtime code changed."
       }
     },
     "scope": {
@@ -29886,6 +29893,7 @@
         "backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json",
         "backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json",
         "backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
         "docs/codex/pr-train.yaml",
         "docs/codex/pr-train-state.json"
       ],
@@ -29914,6 +29922,16 @@
         "at": "2026-05-28T00:48:00+08:00",
         "status": "pr_opened",
         "summary": "Opened PR #1734 for RIASEC English question pack translation; GitHub checks pending."
+      },
+      {
+        "at": "2026-05-28T00:56:00+08:00",
+        "status": "ci_fix_in_progress",
+        "summary": "GitHub required checks failed on the Big Five runtime freeze classifier; adding a focused test-only allowance for RIASEC question-pack translation files within current PR scope."
+      },
+      {
+        "at": "2026-05-28T01:03:00+08:00",
+        "status": "local_validation_passed_after_ci_fix",
+        "summary": "Added focused Big Five freeze classifier allowance for RIASEC question-pack translation files and reran Big Five freeze, RIASEC focused/flow, route list, Pint, composer validate/audit, JSON/YAML parse, and diff checks successfully."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29657,17 +29657,17 @@
     "repo": "fap-api",
     "branch": "codex/mbti-en-questions-pack-projection-01",
     "base": "main",
-    "status": "local_validation_passed",
+    "status": "merged",
     "depends_on": [
       "TAKE-EN-QUESTION-LOCALE-SCAN-00"
     ],
     "title": "MBTI-EN-QUESTIONS-PACK-PROJECTION-01 MBTI English question locale projection",
-    "commit_sha": "956221fe825ce36dd27ca933e047780ad441cf26",
+    "commit_sha": "a6a271c86aa86b2c6ae89bd51c3e4d6d096e687d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1733",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-27T23:57:05Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -29724,17 +29724,18 @@
         "evidence": "After the CI fix, MBTI focused tests passed, the Big Five runtime freeze test passed, MBTI compatibility tests passed, and route list, Pint, composer validate/audit, JSON/YAML parse, and diff checks passed locally."
       },
       "github_required_checks": {
-        "status": "pending_rerun",
+        "status": "pass",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/1733",
-        "previous_failed_checks": [
-          "verify-mbti-legacy",
-          "verify-mbti-v2"
-        ],
-        "fix_evidence": "Local BigFiveResultPageV2CoreBodyPreviewTest now passes and final branch diff no longer includes QuestionsService.php."
+        "evidence": "GitHub check rollup passed for hygiene, supply-chain, Semgrep, verify-mbti-legacy, and verify-mbti-v2; mergeStateStatus was CLEAN before squash merge."
       },
       "ci_fix_scope": {
         "status": "pass",
         "evidence": "Projection remains MBTI-scoped in ScalesController; backend/app/Services/Content/QuestionsService.php was removed from the final branch diff."
+      },
+      "post_merge_focused_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=MbtiQuestionLocaleProjection --no-ansi",
+        "evidence": "3 tests passed, 1444 assertions after main fast-forwarded to merge commit a6a271c86aa86b2c6ae89bd51c3e4d6d096e687d."
       }
     },
     "scope": {
@@ -29786,6 +29787,128 @@
         "at": "2026-05-28T00:23:00+08:00",
         "status": "local_validation_passed_after_ci_fix",
         "summary": "Committed MBTI-scoped CI fix, removed QuestionsService.php from the final diff, and reran MBTI focused tests, Big Five runtime freeze test, compatibility tests, route list, Pint, composer validate/audit, JSON/YAML parse, and diff checks successfully."
+      },
+      {
+        "at": "2026-05-28T00:34:00+08:00",
+        "status": "merged_reconciled",
+        "summary": "Reconciled PR #1733 as merged with squash commit a6a271c86aa86b2c6ae89bd51c3e4d6d096e687d; origin/main contains the merge commit, local main is synced, branch cleanup is complete, and post-merge focused test passed."
+      }
+    ]
+  },
+  "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02": {
+    "id": "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02",
+    "repo": "fap-api",
+    "branch": "codex/riasec-en-questions-pack-translation-02",
+    "base": "main",
+    "status": "local_validation_passed",
+    "depends_on": [
+      "MBTI-EN-QUESTIONS-PACK-PROJECTION-01"
+    ],
+    "title": "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02 RIASEC English question pack translation",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "TAKE-EN-QUESTION-LOCALE-SCAN-00 recommended RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02 and the user instructed the three backend content-pack fixes to proceed sequentially."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "MBTI-EN-QUESTIONS-PACK-PROJECTION-01 merged as PR #1733 with merge commit a6a271c86aa86b2c6ae89bd51c3e4d6d096e687d."
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_files": [
+          "backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json",
+          "backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json",
+          "backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json",
+          "backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json",
+          "backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "outside_scope": [],
+        "changed_files": [
+          "backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json",
+          "backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json",
+          "backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json",
+          "backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml",
+          "backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php"
+        ],
+        "evidence": "Changed files are confined to RIASEC compiled question packs/manifests, focused RIASEC locale test, and authorized PR-train metadata."
+      },
+      "focused_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=RiasecQuestionLocaleTranslation --no-ansi",
+        "evidence": "3 tests passed, 1226 assertions."
+      },
+      "riasec_flow_regression": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=RiasecAssessmentFlow --no-ansi",
+        "evidence": "5 tests passed, 820 assertions."
+      },
+      "local_validation": {
+        "status": "pass",
+        "commands": [
+          "cd backend && php artisan test --filter=RiasecQuestionLocaleTranslation --no-ansi",
+          "cd backend && php artisan test --filter=RiasecAssessmentFlow --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json >/dev/null",
+          "python3 -m json.tool backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json >/dev/null",
+          "python3 -m json.tool backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json >/dev/null",
+          "python3 -m json.tool backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nprint('yaml ok')\nPY",
+          "git diff --check",
+          "git diff --cached --check",
+          "git -C /Users/rainie/Desktop/GitHub/fap-web status --short"
+        ],
+        "evidence": "Focused RIASEC locale test, RIASEC assessment flow regression, route list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference status passed locally."
+      },
+      "github_required_checks": {
+        "status": "pending",
+        "pr_url": null
+      }
+    },
+    "scope": {
+      "allowed_files": [
+        "backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json",
+        "backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json",
+        "backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json",
+        "backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json",
+        "backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "api_runtime_change": false,
+      "content_pack_mutation": true,
+      "cms_mutation": false,
+      "publish": false,
+      "deploy": false,
+      "search_channel_action": false,
+      "url_submission": false,
+      "fap_web_modified": false,
+      "frontend_fallback_authority": false
+    },
+    "history": [
+      {
+        "at": "2026-05-28T00:35:00+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started RIASEC English question pack translation after MBTI PR merge; scope is RIASEC compiled question packs, manifest hashes, focused test, and train metadata only."
+      },
+      {
+        "at": "2026-05-28T00:45:00+08:00",
+        "status": "local_validation_passed",
+        "summary": "Translated RIASEC 60/140 English question stems in backend content packs, updated manifest hashes, added focused locale test, and passed local validation."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15070,6 +15070,7 @@ prs:
       - backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json
       - backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json
       - backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     scope:
@@ -15079,6 +15080,7 @@ prs:
     validation:
       - cd backend && php artisan test --filter=RiasecQuestionLocaleTranslation --no-ansi
       - cd backend && php artisan test --filter=RiasecAssessmentFlow --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi
       - cd backend && php artisan route:list --no-ansi
       - cd backend && vendor/bin/pint --test
       - cd backend && composer validate --strict

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15054,3 +15054,52 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02
+
+  - id: RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02
+    repo: fap-api
+    depends_on:
+      - MBTI-EN-QUESTIONS-PACK-PROJECTION-01
+    branch: codex/riasec-en-questions-pack-translation-02
+    base: main
+    title: "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02 RIASEC English question pack translation"
+    train_scope: take_question_locale_parity
+    risk_level: p1_content_pack_translation
+    allowed_paths:
+      - backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json
+      - backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json
+      - backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json
+      - backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json
+      - backend/tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Translate RIASEC riasec_60 and riasec_140 English displayed question stems in backend content pack authority.
+      - Preserve zh-CN displayed question text, English option labels, scores, option codes, question counts, form routing, and RIASEC measurement semantics.
+      - Do not change MBTI, Enneagram, Big Five, IQ, EQ, Clinical Combo, SDS, fap-web runtime, CMS, publish state, deploy state, Search Channel, sitemap, llms, footer, or nav.
+    validation:
+      - cd backend && php artisan test --filter=RiasecQuestionLocaleTranslation --no-ansi
+      - cd backend && php artisan test --filter=RiasecAssessmentFlow --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json >/dev/null
+      - python3 -m json.tool backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json >/dev/null
+      - python3 -m json.tool backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json >/dev/null
+      - python3 -m json.tool backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    content_pack_mutation: true
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03


### PR DESCRIPTION
## What changed
- Translated backend-authoritative RIASEC `riasec_60` and `riasec_140` English question stems in compiled content packs.
- Preserved zh-CN displayed stems, option codes, scores, form counts, and existing English option labels.
- Updated RIASEC compiled manifest hashes and added focused locale regression coverage.
- Reconciled the merged MBTI predecessor in the PR train state and registered the current RIASEC scope.

## Why
`TAKE-EN-QUESTION-LOCALE-SCAN-00` found that RIASEC `locale=en` rendered Chinese question stems on the take page even though option labels were already English.

## Validation
- `cd backend && php artisan test --filter=RiasecQuestionLocaleTranslation --no-ansi`
- `cd backend && php artisan test --filter=RiasecAssessmentFlow --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- JSON parse for touched RIASEC compiled packs/manifests and `docs/codex/pr-train-state.json`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`
- `git -C /Users/rainie/Desktop/GitHub/fap-web status --short`

## Intentionally deferred
- Enneagram forced-choice English options remain for `ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03`.
- No CMS, publish, deploy, Search Channel, sitemap, llms, footer/nav, or fap-web runtime changes.

## Repository rule impact
Content ownership stays backend/content-pack authoritative. No frontend fallback content was added.
